### PR TITLE
Fix for Issue #28 - Add missing netaddr requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ cvprac==1.0.1
 enum34==1.1.6
 idna==2.8
 ipaddress==1.0.22
+netaddr==0.7.19
 Jinja2==2.10.1
 MarkupSafe==1.1.1
 pycparser==2.19


### PR DESCRIPTION
Add missing requirement for `netaddr==0.7.19`