### PR TITLE
add support to enter multiple cvp ips

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -100,7 +100,10 @@ hardware_counters:
 ```yaml
 daemon_terminattr:
   ingestgrpcurl:
-    ip: < IPv4_address >
+    ips:
+      - < IPv4_address >
+      - < IPv4_address >
+      - < IPv4_address >
     port: < port_id >
   ingestauth_key: < ingest_key >
   ingestvrf: < vrf_name >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/daemon-terminattr.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/daemon-terminattr.j2
@@ -3,7 +3,7 @@
 
 | CV Compression | Ingest gRPC URL | Ingest Authentication Key | Smash Excludes | Ingest Exclude | Ingest VRF |  NTP VRF |
 | -------------- | --------------- | ------------------------- | -------------- | -------------- | ---------- | -------- |
-| gzip | {{ daemon_terminattr.ingestgrpcurl.ip }}:{{ daemon_terminattr.ingestgrpcurl.port }} | {{ daemon_terminattr.ingestauth_key }} | {{ daemon_terminattr.smashexcludes }} | {{ daemon_terminattr.ingestexclude }} | {{ daemon_terminattr.ingestvrf }} | {{ daemon_terminattr.ingestvrf }} |
+| gzip | {% for cvp_ip in daemon_terminattr.ingestgrpcurl.ips %}{{ cvp_ip }}:{{ daemon_terminattr.ingestgrpcurl.port }}{% if not loop.last %},{% endif %}{% endfor %} | {{ daemon_terminattr.ingestauth_key }} | {{ daemon_terminattr.smashexcludes }} | {{ daemon_terminattr.ingestexclude }} | {{ daemon_terminattr.ingestvrf }} | {{ daemon_terminattr.ingestvrf }} |
 
 ### TerminAttr Daemon Device Configuration
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/daemon-terminattr.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/daemon-terminattr.j2
@@ -1,6 +1,6 @@
 {% if daemon_terminattr is defined and daemon_terminattr is not none %}
 daemon TerminAttr
-   exec /usr/bin/TerminAttr -ingestgrpcurl={{ daemon_terminattr.ingestgrpcurl.ip }}:{{ daemon_terminattr.ingestgrpcurl.port }} -cvcompression=gzip -ingestauth=key,{{ daemon_terminattr.ingestauth_key }} -smashexcludes={{ daemon_terminattr.smashexcludes }} -ingestexclude={{ daemon_terminattr.ingestexclude }} -ingestvrf={{ daemon_terminattr.ingestvrf }} -taillogs
+   exec /usr/bin/TerminAttr -ingestgrpcurl={% for cvp_ip in daemon_terminattr.ingestgrpcurl.ips %}{{ cvp_ip }}:{{ daemon_terminattr.ingestgrpcurl.port }}{% if not loop.last %},{% endif %}{% endfor %} -cvcompression=gzip -ingestauth=key,{{ daemon_terminattr.ingestauth_key }} -smashexcludes={{ daemon_terminattr.smashexcludes }} -ingestexclude={{ daemon_terminattr.ingestexclude }} -ingestvrf={{ daemon_terminattr.ingestvrf }} -taillogs
    no shutdown
 !
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
@@ -105,6 +105,11 @@ management_eapi:
 
 # CloudVision - Telemetry Agent (TerminAttr) configuration | Optional
 cvp_instance_ip: < IPv4 address >
+or
+cvp_instance_ips:
+  - < IPv4 address >
+  - < IPv4 address >
+  - < IPv4 address >
 cvp_ingestauth_key: < CloudVision Ingest Authentication key >
 terminattr_ingestgrpcurl_port: < port_number | default -> 9910 >
 terminattr_smashexcludes: "< smash excludes | default -> ale,flexCounter,hardware,kni,pulse,strata >"

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
@@ -180,7 +180,10 @@ local_users:
 #   enable_https: true
 
 # Cloud Vision server information
-cvp_instance_ip: 192.168.2.201
+cvp_instance_ips:
+ - 192.168.2.201
+ - 192.168.2.202
+ - 192.168.2.203
 cvp_ingestauth_key: telarista
 # terminattr_ingestgrpcurl_port: 9910
 # terminattr_smashexcludes: "ale,flexCounter,hardware,kni,pulse,strata"

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/base/daemon-terminattr.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/base/daemon-terminattr.j2
@@ -1,7 +1,14 @@
 {# daemon TerminAttr #}
-{% if cvp_instance_ip is defined %}
+{% if cvp_instance_ip is defined or cvp_instance_ips is defined %}
   ingestgrpcurl:
-    ip: {{ cvp_instance_ip }}
+    ips:
+{%     if cvp_instance_ip is defined %}
+      - {{ cvp_instance_ip }}
+{%     elif cvp_instance_ips is defined %}
+{%         for cvp_instance_ip in cvp_instance_ips %}
+      - {{ cvp_instance_ip }}
+{%         endfor %}
+{%     endif %}
     port: {{ terminattr_ingestgrpcurl_port }}
   ingestauth_key: {{ cvp_ingestauth_key }}
   ingestvrf: {{ mgmt_interface_vrf }}


### PR DESCRIPTION
resolves #17

**example input:**
```yaml
cvp_instance_ips:
  - 192.168.200.11
  - 192.168.200.12
  - 192.168.200.13
``` 

**example output:**
```eos
daemon TerminAttr
   exec /usr/bin/TerminAttr -ingestgrpcurl=192.168.200.11:9910,192.168.200.12:9910,192.168.200.13:9910 -cvcompression=gzip -ingestauth=key,telarista -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -ingestvrf=MGMT -taillogs
   no shutdown
```