### PR TITLE
Create role to build & cleanup output folders

### DIFF
--- a/ansible_collections/arista/avd/roles/build_output_folders/README.md
+++ b/ansible_collections/arista/avd/roles/build_output_folders/README.md
@@ -1,0 +1,57 @@
+# Build Output Folders
+
+Role to cleanup and create local folder structure to save roles' outputs
+
+## Requirements
+
+None
+
+## Role Variables
+
+Role support following variables:
+
+```yaml
+# Root directory where to build output structure
+root_dir: '{{playbook_dir}}'
+# Main output directory
+output_dir_name: 'intended'
+# Output for structured YAML files:
+structured_dir_name: 'structured_configs'
+# EOS Configuration Directory name
+eos_config_dir_name: 'configs'
+```
+
+Role will create following structure:
+
+```
+intended
+├── configs
+└── structured_configs
+```
+
+If folders already exists, role will delete them and recreate structure.
+
+## Dependencies
+
+None
+
+## Example Playbook
+
+Below is an example to use in your playbook to build output folders using default values.
+
+```yaml
+- name: Build Switch configuration
+  hosts: DC1_FABRIC
+  connection: local
+  gather_facts: no
+  tasks:
+    - name: 'Reset local folders for output'
+      tags: [build]
+      import_role:
+        name: arista.avd.build_output_folders
+```
+
+## License
+
+Project is published under [Apache 2.0 License](../../../../../LICENSE)
+

--- a/ansible_collections/arista/avd/roles/build_output_folders/README.md
+++ b/ansible_collections/arista/avd/roles/build_output_folders/README.md
@@ -19,6 +19,12 @@ output_dir_name: 'intended'
 structured_dir_name: 'structured_configs'
 # EOS Configuration Directory name
 eos_config_dir_name: 'configs'
+# Main documentation folder
+documentation_dir_name: 'documentation'
+# Fabric Documentation
+fabric_dir_name: 'DC1_FABRIC'
+# Device documentation
+devices_dir_name: 'devices'
 ```
 
 Role will create following structure:
@@ -27,6 +33,10 @@ Role will create following structure:
 intended
 ├── configs
 └── structured_configs
+|
+documentation
+├── DC1_FABRIC
+└── devices
 ```
 
 If folders already exists, role will delete them and recreate structure.

--- a/ansible_collections/arista/avd/roles/build_output_folders/defaults/main.yml
+++ b/ansible_collections/arista/avd/roles/build_output_folders/defaults/main.yml
@@ -1,0 +1,15 @@
+---
+# defaults file for build_directories
+
+# Root directory where to build output structure
+root_dir: '{{playbook_dir}}'
+
+# Main output directory
+output_dir_name: 'intended'
+output_dir: '{{root_dir}}/{{output_dir_name}}'
+# Output for structured YAML files:
+structured_dir_name: 'structured_configs'
+structured_dir: '{{output_dir}}/{{structured_dir_name}}'
+# EOS Configuration Directory name
+eos_config_dir_name: 'configs'
+eos_config_dir: '{{output_dir}}/{{eos_config_dir_name}}'

--- a/ansible_collections/arista/avd/roles/build_output_folders/defaults/main.yml
+++ b/ansible_collections/arista/avd/roles/build_output_folders/defaults/main.yml
@@ -4,12 +4,28 @@
 # Root directory where to build output structure
 root_dir: '{{playbook_dir}}'
 
+# AVD configurations output
 # Main output directory
 output_dir_name: 'intended'
 output_dir: '{{root_dir}}/{{output_dir_name}}'
+
 # Output for structured YAML files:
 structured_dir_name: 'structured_configs'
 structured_dir: '{{output_dir}}/{{structured_dir_name}}'
+
 # EOS Configuration Directory name
 eos_config_dir_name: 'configs'
 eos_config_dir: '{{output_dir}}/{{eos_config_dir_name}}'
+
+# Documentation folders
+# Main documentation folder
+documentation_dir_name: 'documentation'
+documentation_dir: '{{root_dir}}/{{documentation_dir_name}}'
+
+# Fabric Documentation
+fabric_dir_name: 'DC1_FABRIC'
+fabric_dir: '{{documentation_dir}}/{{fabric_dir_name}}'
+
+# Device documentation
+devices_dir_name: 'devices'
+devices_dir: '{{documentation_dir}}/{{devices_dir_name}}'

--- a/ansible_collections/arista/avd/roles/build_output_folders/handlers/main.yml
+++ b/ansible_collections/arista/avd/roles/build_output_folders/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for build_directories

--- a/ansible_collections/arista/avd/roles/build_output_folders/meta/main.yml
+++ b/ansible_collections/arista/avd/roles/build_output_folders/meta/main.yml
@@ -1,0 +1,8 @@
+galaxy_info:
+  author: Arista Ansible Team <ansible@arista.com>
+  description: Generates Output folders for arista.avd collection.
+  company: Arista Networks
+  license: Apache-2.0
+  min_ansible_version: 2.9
+  galaxy_tags: ['arista', 'network', 'networking', 'eos', 'avd', 'cloudvision', 'cvp']
+dependencies: []

--- a/ansible_collections/arista/avd/roles/build_output_folders/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/build_output_folders/tasks/main.yml
@@ -1,0 +1,27 @@
+---
+# tasks file for build_directories
+
+- name: 'Cleanup existing folders in {{output_dir}}'
+  file:
+    path: '{{output_dir}}'
+    state: absent 
+    mode: 0755
+  delegate_to: localhost
+- name: 'Create folder {{output_dir}}'
+  file:
+    path: '{{output_dir}}'
+    state: directory
+    mode: 0755
+  delegate_to: localhost
+- name: 'Create folder {{structured_dir_name}} for structued YAML files'
+  file:
+    path: '{{structured_dir}}'
+    state: directory
+    mode: 0755
+  delegate_to: localhost
+- name: 'Create folder {{eos_config_dir_name}} for EOS Configuration files'
+  file:
+    path: '{{eos_config_dir}}'
+    state: directory
+    mode: 0755
+  delegate_to: localhost

--- a/ansible_collections/arista/avd/roles/build_output_folders/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/build_output_folders/tasks/main.yml
@@ -7,21 +7,45 @@
     state: absent 
     mode: 0755
   delegate_to: localhost
+
 - name: 'Create folder {{output_dir}}'
   file:
     path: '{{output_dir}}'
     state: directory
     mode: 0755
   delegate_to: localhost
+
 - name: 'Create folder {{structured_dir_name}} for structued YAML files'
   file:
     path: '{{structured_dir}}'
     state: directory
     mode: 0755
   delegate_to: localhost
+
 - name: 'Create folder {{eos_config_dir_name}} for EOS Configuration files'
   file:
     path: '{{eos_config_dir}}'
+    state: directory
+    mode: 0755
+  delegate_to: localhost
+
+- name: 'Create documentation folder: {{documentation_dir_name}}'
+  file:
+    path: '{{documentation_dir}}'
+    state: directory
+    mode: 0755
+  delegate_to: localhost
+
+- name: 'Create folder {{fabric_dir_name}} for Fabric documentation'
+  file:
+    path: '{{fabric_dir}}'
+    state: directory
+    mode: 0755
+  delegate_to: localhost
+
+- name: 'Create folder {{devices_dir_name}} for EOS documentation'
+  file:
+    path: '{{devices_dir}}'
     state: directory
     mode: 0755
   delegate_to: localhost


### PR DESCRIPTION
Simple role to create/cleanup output folders:

By default, user has to create output folders meaning he must know and
create structure prior to run any playbook.

To make it part of playbook execution, role will delete any existing
folder defined as output and recreate structure.

Default values are those currently in place in repository but it can be
changed by user as described in README

Complete documentation in role's README