### PR TITLE
Issue #75 - Fix execute_tasks in eos_config_deploy_cvp

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/present.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/present.yml
@@ -5,6 +5,12 @@
   arista.cvp.cv_facts:
   register: CVP_FACTS
 
+- name: "Execute pending tasks on {{inventory_hostname}}"
+  tags: [apply]
+  arista.cvp.cv_task:
+    tasks: "{{ CVP_FACTS.ansible_facts.tasks }}"
+  when: execute_tasks|bool
+
 - name: 'Create configlets on CVP {{inventory_hostname}}.'
   tags: [provision]
   arista.cvp.cv_configlet:
@@ -14,12 +20,13 @@
   register: CVP_CONFIGLETS_STATUS
 
 - name: 'Execute any configlet generated tasks to update configuration on {{inventory_hostname}}'
+  tags: [apply]
   arista.cvp.cv_task:
     tasks: "{{ CVP_CONFIGLETS_STATUS.data.tasks }}"
     wait: 90
   when:
     - CVP_CONFIGLETS_STATUS.data.tasks | length > 0
-    - execute_tasks == true
+    - execute_tasks|bool
 
 - name: "Building Containers topology on {{inventory_hostname}}"
   tags: [provision]
@@ -47,4 +54,4 @@
     tasks: "{{ CVP_DEVICES_RESULTS.data.tasks }}"
     wait: 720
   when:
-    - execute_tasks == true
+    - execute_tasks|bool


### PR DESCRIPTION
Implement correct boolean WHEN check for `execute_tasks` option.
Tested in GNS3 lab