### PR TITLE
When setting execute_tasks, tasks are not executing

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/present.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/present.yml
@@ -5,6 +5,12 @@
   arista.cvp.cv_facts:
   register: CVP_FACTS
 
+- name: "Execute pending tasks on {{inventory_hostname}}"
+  tags: [apply]
+  arista.cvp.cv_task:
+    tasks: "{{ CVP_FACTS.ansible_facts.tasks }}"
+  when: execute_tasks|bool
+
 - name: 'Create configlets on CVP {{inventory_hostname}}.'
   tags: [provision]
   arista.cvp.cv_configlet:
@@ -14,12 +20,13 @@
   register: CVP_CONFIGLETS_STATUS
 
 - name: 'Execute any configlet generated tasks to update configuration on {{inventory_hostname}}'
+  tags: [apply]
   arista.cvp.cv_task:
     tasks: "{{ CVP_CONFIGLETS_STATUS.data.tasks }}"
     wait: 90
   when:
     - CVP_CONFIGLETS_STATUS.data.tasks | length > 0
-    - execute_tasks == true
+    - execute_tasks|bool
 
 - name: "Building Containers topology on {{inventory_hostname}}"
   tags: [provision]
@@ -47,4 +54,4 @@
     tasks: "{{ CVP_DEVICES_RESULTS.data.tasks }}"
     wait: 720
   when:
-    - execute_tasks == true
+    - execute_tasks|bool


### PR DESCRIPTION
Description
-----------

Role `eos_config_deploy_cvp` supports an option to automatically execute pending tasks at different stages like: pending tasks, updated configlets, devices changes: 

```yaml
  tasks:
    - name: run CVP provisioning
      import_role:
        name: eos_config_deploy_cvp
      vars:
        container_root: 'DC1_FABRIC'
        configlets_prefix: 'DC1-AVD'
        device_filter: 'DC1'
        execute_tasks: false
        state: present
```

By settings `execute_tasks` to true, it is expected tasks to be executed during playbook execution and it is actually not:

```
TASK [eos_config_deploy_cvp : Execute pending tasks on cv_server] 
skipping: [cv_server]
```

Fix
----

Tasks conditionals do not use Ansible bool checks whereas variable is set as a boolean.

Fix will come in a PR.

```
- name: "Execute pending tasks on {{inventory_hostname}}"
  tags: [apply]
  arista.cvp.cv_task:
    tasks: "{{ CVP_FACTS.ansible_facts.tasks }}"
  when: execute_tasks|bool
```
