### PR TITLE
Add constraints on VRF in VXLAN IFL

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vxlan-interface.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vxlan-interface.j2
@@ -11,7 +11,8 @@
 {%     for vlan in vxlan_tunnel_interface.Vxlan1.vxlan_vni_mappings.vlans | arista.avd.natural_sort %}
 | {{ vlan }} | {{ vxlan_tunnel_interface.Vxlan1.vxlan_vni_mappings.vlans[vlan].vni }} |
 {%     endfor %}
-
+{% if vxlan_tunnel_interface.Vxlan1.vxlan_vni_mappings.vrfs is defined and 
+vxlan_tunnel_interface.Vxlan1.vxlan_vni_mappings.vrfs is not none %}
 **VRF to VNI Mappings:**
 
 | VLAN | VNI |
@@ -19,7 +20,7 @@
 {%     for vrf in vxlan_tunnel_interface.Vxlan1.vxlan_vni_mappings.vrfs | arista.avd.natural_sort %}
 | {{ vrf }} | {{ vxlan_tunnel_interface.Vxlan1.vxlan_vni_mappings.vrfs[vrf].vni }} |
 {%     endfor %}
-
+{% endif %}
 ### VXLAN Interface Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vxlan-interface.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vxlan-interface.j2
@@ -11,8 +11,8 @@
 {%     for vlan in vxlan_tunnel_interface.Vxlan1.vxlan_vni_mappings.vlans | arista.avd.natural_sort %}
 | {{ vlan }} | {{ vxlan_tunnel_interface.Vxlan1.vxlan_vni_mappings.vlans[vlan].vni }} |
 {%     endfor %}
-{% if vxlan_tunnel_interface.Vxlan1.vxlan_vni_mappings.vrfs is defined and 
-vxlan_tunnel_interface.Vxlan1.vxlan_vni_mappings.vrfs is not none %}
+{% if vxlan_tunnel_interface.Vxlan1.vxlan_vni_mappings.vrfs is defined and vxlan_tunnel_interface.Vxlan1.vxlan_vni_mappings.vrfs is not none %}
+
 **VRF to VNI Mappings:**
 
 | VLAN | VNI |
@@ -21,6 +21,7 @@ vxlan_tunnel_interface.Vxlan1.vxlan_vni_mappings.vrfs is not none %}
 | {{ vrf }} | {{ vxlan_tunnel_interface.Vxlan1.vxlan_vni_mappings.vrfs[vrf].vni }} |
 {%     endfor %}
 {% endif %}
+
 ### VXLAN Interface Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vxlan-interface.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vxlan-interface.j2
@@ -9,8 +9,11 @@ interface Vxlan1
 {%     for vlan in vxlan_tunnel_interface.Vxlan1.vxlan_vni_mappings.vlans | arista.avd.natural_sort %}
    vxlan vlan {{ vlan }} vni {{ vxlan_tunnel_interface.Vxlan1.vxlan_vni_mappings.vlans[vlan].vni }}
 {%     endfor %}
+{% if vxlan_tunnel_interface.Vxlan1.vxlan_vni_mappings.vrfs is defined and 
+vxlan_tunnel_interface.Vxlan1.vxlan_vni_mappings.vrfs is not none %}
 {%     for vrf in vxlan_tunnel_interface.Vxlan1.vxlan_vni_mappings.vrfs | arista.avd.natural_sort %}
    vxlan vrf {{ vrf }} vni {{ vxlan_tunnel_interface.Vxlan1.vxlan_vni_mappings.vrfs[vrf].vni }}
 {%     endfor %}
+{% endif %}
 !
 {% endif %}


### PR DESCRIPTION
In case of a pure L2 environment, templates failed to generate VXLAN
interface because VRF was missing.

Fixes:
- Add constraint on VRF for CLI config gen in VXLAN interface section.
- Add constraint on VRF for documentation purpose in VXLAN section.

Fixes can be tested with following `DC1_TENANTS_NETWORKS.yml` file:

```yaml
---
# DC1 Tenants Networks
# Documentation of Tenant specific information - Vlans/VRFs
tenants:
  Tenant_D:
    mac_vrf_vni_base: 40000
    l2vlans:
      411:
        name: 'Tenant_D_OP_Zone_1'
        tags: [opzone]
      412:
        name: 'Tenant_D_OP_Zone_2'
        tags: [opzone]
```

Resolves #78 