### PR TITLE
Add support for non-MLAG Port-Channels

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/edge-ports/leaf-server-port-channels.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/edge-ports/leaf-server-port-channels.j2
@@ -9,8 +9,9 @@
     description: {{ server }}_{{ adapter.port_channel.description }}
     vlans: {{ port_profiles[adapter.profile].vlans }}
     mode: {{ port_profiles[adapter.profile].mode }}
-{# place holder add logic to handle no mlag #}
+{%                     if adapter.switches | unique| list | length > 1 %}
     mlag: {{ channel_group_id }}
+{%                     endif %}
 {%                 break %}
 {%                 endif %}
 {%             endfor %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/edge-ports/leaf-server-port-channels.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/edge-ports/leaf-server-port-channels.j2
@@ -9,7 +9,7 @@
     description: {{ server }}_{{ adapter.port_channel.description }}
     vlans: {{ port_profiles[adapter.profile].vlans }}
     mode: {{ port_profiles[adapter.profile].mode }}
-{%                     if adapter.switches | unique| list | length > 1 %}
+{%                     if adapter.switches | unique | list | length > 1 %}
     mlag: {{ channel_group_id }}
 {%                     endif %}
 {%                 break %}


### PR DESCRIPTION
If a server has a port-channel defined, but the connections are on only one leaf MLAG is not needed. 

This PR handles that case both for single link port-channels and multiples as shown below.

```
  server01:
    rack: RackA
    adapters:
      - server_ports: [ Eth1, Eth2 ]
        switch_ports: [ Ethernet11, Ethernet11 ]
        switches: [ DC1-SVC3A, DC1-SVC3A ]
        profile: TENANT_A_B
        port_channel:
          state: present
          description: PortChanne1
          mode: active
```