### PR TITLE
Create a role to deploy additional configlets

### DIFF
--- a/ansible_collections/arista/avd/README.md
+++ b/ansible_collections/arista/avd/README.md
@@ -19,6 +19,7 @@ This repository provides roles for Ansible's collection __arista.avd__ with the 
 - [__arista.avd.eos_cli_config_gen__](roles/eos_cli_config_gen/README.md) - Generate Arista EOS cli syntax and device documentation.
 - [__arista.avd.eos_config_deploy_cvp__](roles/eos_config_deploy_cvp/README.md) - deploys intended configuration via CloudVision.
 - [__arista.avd.eos_config_deploy_eapi__](roles/eos_config_deploy_eapi/README.md) - deploys intended configuration via eAPI.
+- [__arista.avd.cvp_configlet_upload__](roles/cvp_configlet_upload/README.md) - Uploades configlets from a local folder to Cloudvision Server.
 
 ## Custom Plugins
 

--- a/ansible_collections/arista/avd/plugins/modules/configlet_build_config.py
+++ b/ansible_collections/arista/avd/plugins/modules/configlet_build_config.py
@@ -1,0 +1,136 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# FIXME: required to pass ansible-test
+# GNU General Public License v3.0+
+#
+# Copyright 2019 Arista Networks AS-EMEA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.0.0',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: configlet_build_config
+version_added: "2.9"
+author: EMEA AS Team (@aristanetworks)
+short_description: Build arista.cvp.configlet configuration.
+description:
+  - Build configuration to publish configlets on Cloudvision.
+options:
+  configlet_dir:
+    description: Directory where configlets are located.
+    required: true
+    type: str
+  configlet_prefix:
+    description: Prefix to append on configlet.
+    required: true
+    type: str
+  destination:
+    description: File where to save information.
+    required: false
+    type: str
+    default: none
+  extension:
+    description: File extensio to look for.
+    required: false
+    type: str
+    default: conf
+'''
+
+EXAMPLES = r'''
+# tasks file for cvp_configlet_upload
+- name: generate intented variables
+  tags: [build, provision]
+  configlet_build_config:
+    configlet_dir: '{{ configlet_dir }}'
+    configlet_prefix: '{{ configlets_prefix }}'
+    configlet_extension: '{{configlet_extension}}'
+'''
+
+import glob
+import os
+import json
+import yaml
+import traceback
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.connection import Connection, ConnectionError
+
+
+def get_configlet(src_folder=str(), prefix='AVD', extension='cfg'):
+    """
+    Get available configlets to deploy to CVP.
+
+    Parameters
+    ----------
+    src_folder : str, optional
+        Path where to find configlet, by default str()
+    prefix : str, optional
+        Prefix to append to configlet name, by default 'AVD'
+    extension : str, optional
+        File extension to lookup configlet file, by default 'cfg'
+
+    Returns
+    -------
+    dict
+        Dictionary of configlets found in source folder.
+    """
+    src_configlets = glob.glob(src_folder + '/*.' + extension)
+    configlets = dict()
+    for file in src_configlets:
+        if prefix != 'none':
+            name = prefix + '_' + os.path.splitext(os.path.basename(file))[0]
+        else:
+            name = os.path.splitext(os.path.basename(file))[0]
+        with open(file, 'r') as file:
+            data = file.read()
+        configlets[name] = data
+    return configlets
+
+
+def main():
+    """ Main entry point for module execution."""
+    argument_spec = dict(
+        configlet_dir=dict(type='str', required=True),
+        configlet_prefix=dict(type='str', required=True),
+        configlet_extension=dict(type='str', required=False, default='conf'),
+        destination=dict(type='str', required=False, default=None)
+    )
+
+    module = AnsibleModule(argument_spec=argument_spec,
+                           supports_check_mode=False)
+    result = dict(changed=False)
+
+    # If set, build configlet topology
+    if module.params['configlet_dir'] is not None:
+        result['CVP_CONFIGLETS'] = get_configlet(src_folder=module.params['configlet_dir'],
+                                                 prefix=module.params['configlet_prefix'],
+                                                 extension=module.params['configlet_extension'])
+
+    # Write vars to file if set by user
+    if module.params['destination'] is not None:
+        with open(module.params['destination'], 'w') as file:
+            documents = yaml.dump(result, file)
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/ansible_collections/arista/avd/plugins/modules/configlet_build_config.py
+++ b/ansible_collections/arista/avd/plugins/modules/configlet_build_config.py
@@ -68,11 +68,16 @@ EXAMPLES = r'''
 import glob
 import os
 import json
-import yaml
 import traceback
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.connection import Connection, ConnectionError
-
+YAML_IMP_ERR = None
+try:
+    import yaml
+    HAS_YAML = True
+except ImportError:
+    HAS_YAML = False
+    YAML_IMP_ERR = traceback.format_exc()
 
 def get_configlet(src_folder=str(), prefix='AVD', extension='cfg'):
     """

--- a/ansible_collections/arista/avd/plugins/modules/configlet_build_config.py
+++ b/ansible_collections/arista/avd/plugins/modules/configlet_build_config.py
@@ -47,12 +47,12 @@ options:
     description: File where to save information.
     required: false
     type: str
-    default: none
-  extension:
+    default: ''
+  configlet_extension:
     description: File extensio to look for.
     required: false
     type: str
-    default: conf
+    default: 'conf'
 '''
 
 EXAMPLES = r'''

--- a/ansible_collections/arista/avd/plugins/modules/inventory_to_container.py
+++ b/ansible_collections/arista/avd/plugins/modules/inventory_to_container.py
@@ -108,7 +108,6 @@ except ImportError:
     YAML_IMP_ERR = traceback.format_exc()
 
 
-
 # Root container on CloudVision.
 # Shall not be changed unless CloudVision changes it in the core.
 CVP_ROOT_CONTAINER = 'Tenant'

--- a/ansible_collections/arista/avd/roles/cvp_configlet_upload/README.md
+++ b/ansible_collections/arista/avd/roles/cvp_configlet_upload/README.md
@@ -1,0 +1,99 @@
+# Ansible Role: cvp_configlet_upload
+
+**Table of Contents:**
+
+- [Ansible Role: cvp_configlet_upload](#ansible-role-cvpconfigletupload)
+  - [Overview](#overview)
+  - [Role requirements](#role-requirements)
+  - [Role Inputs and Outputs](#role-inputs-and-outputs)
+  - [Requirements](#requirements)
+  - [License](#license)
+
+## Overview
+
+**cvp_configlet_upload**, is a role that deploys configlets stored in a local folder to Cloudvision server.
+
+## Role requirements
+
+This role requires to install `arista.cvp` collection to support CloudVision interactions.
+
+```shell
+$ ansible-galaxy collection install arista.cvp
+```
+
+## Role Inputs and Outputs
+
+1. Read content of `{{configlet_directory}}` and create **cv_configlet** input structure.
+2. Collect Cloudvision facts.
+3. Create or update configlets on Cloudvision server with content from `{{configlet_directory}}`
+
+**Inputs:**
+
+__Inventory configuration:__
+
+An entry must be part of the inventory to describe CloudVision server. `arista.cvp` modules use httpapi approach. Example below provides framework to use in your inventory.
+
+```yaml
+all:
+  children:
+    cloudvision:
+      hosts:
+        cv_server01:
+          ansible_httpapi_host: 10.83.28.164
+          ansible_host: 10.83.28.164
+          ansible_user: ansible
+          ansible_password: ansible
+          ansible_connection: httpapi
+          ansible_httpapi_use_ssl: True
+          ansible_httpapi_validate_certs: False
+          ansible_network_os: eos
+          ansible_httpapi_port: 443
+          # Configuration to get Virtual Env information
+          ansible_python_interpreter: $(which python3)
+```
+
+__Module variables:__
+
+- __`configlet_directory`__: Folder where local configlets are stored. Default: `configlets`.
+- __`file_extension`__: File extension to look for configlet in their local folder. Default: `conf`.
+- __`configlets_cvp_prefix`__: Prefix to use for configlet on CV side. Default: `none`.
+
+_Example_:
+
+```yaml
+tasks:
+  - name: run CVP provisioning
+    import_role:
+        name: cvp_configlet_upload
+    vars:
+      configlet_directory: 'configlets/'
+      file_extension: 'txt'
+      configlets_cvp_prefix: 'DC1-AVD'
+```
+
+This module also supports tags to run a subset of ansible tasks:
+
+- __`build`__: Generate `cv_configlet` input structure.
+- __`provision`__: Run `build` tags + configure Cloudvision with information generated in previous tasks
+
+```shell
+$ ansible-playbook playbook.to.deploy.with.cvp.yml --tags "provision"
+```
+
+**Outputs:**
+
+- None.
+
+**Tasks:**
+
+1. Read content of `{{configlet_directory}}` and create **cv_configlet** input structure.
+2. Collect Cloudvision facts.
+3. Create or update configlets on Cloudvision server with content from `{{configlet_directory}}`
+
+## Requirements
+
+Requirements are located here: [avd-requirements](../../README.md#Requirements)
+
+## License
+
+Project is published under [Apache 2.0 License](../../LICENSE)

--- a/ansible_collections/arista/avd/roles/cvp_configlet_upload/defaults/main.yml
+++ b/ansible_collections/arista/avd/roles/cvp_configlet_upload/defaults/main.yml
@@ -1,0 +1,11 @@
+---
+# defaults file for cvp_configlet_upload
+
+# Directory where configlets are stored.
+configlet_directory: 'configlets/'
+
+# File extension to look for configlets
+file_extension: 'conf'
+
+# Prefix to add to configlets name on Cloudvision
+configlets_cvp_prefix: ''

--- a/ansible_collections/arista/avd/roles/cvp_configlet_upload/meta/main.yml
+++ b/ansible_collections/arista/avd/roles/cvp_configlet_upload/meta/main.yml
@@ -1,0 +1,9 @@
+galaxy_info:
+  author: Arista Ansible Team <ansible@arista.com>
+  description: Publish AVD configuration to CloudVision
+  issue_tracker_url: https://github.com/aristanetworks/ansible-avd/issues
+  company: Arista Networks
+  license: Apache-2.0
+  min_ansible_version: 2.9
+  galaxy_tags: ['arista', 'network', 'networking', 'eos', 'avd', 'cloudvision', 'cvp']
+dependencies: ['']

--- a/ansible_collections/arista/avd/roles/cvp_configlet_upload/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/cvp_configlet_upload/tasks/main.yml
@@ -1,0 +1,21 @@
+---
+# tasks file for cvp_configlet_upload
+- name: generate intented variables
+  tags: [build, provision]
+  arista.avd.configlet_build_config:
+    configlet_dir: '{{ configlet_directory }}'
+    configlet_prefix: '{{ configlets_cvp_prefix }}'
+    configlet_extension: '{{file_extension}}'
+  register: CVP_VARS
+
+- name: 'collecting facts from CVP {{inventory_hostname}}.'
+  tags: [provision]
+  arista.cvp.cv_facts:
+  register: CVP_FACTS
+
+- name: 'create configlets on CVP {{inventory_hostname}}.'
+  tags: [provision]
+  arista.cvp.cv_configlet:
+    cvp_facts: "{{CVP_FACTS.ansible_facts}}"
+    configlets: "{{CVP_VARS.CVP_CONFIGLETS}}"
+    configlet_filter: ["{{ configlets_cvp_prefix }}"]

--- a/ansible_collections/arista/avd/roles/cvp_configlet_upload/tests/inventory
+++ b/ansible_collections/arista/avd/roles/cvp_configlet_upload/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/ansible_collections/arista/avd/roles/cvp_configlet_upload/tests/test.yml
+++ b/ansible_collections/arista/avd/roles/cvp_configlet_upload/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - cvp_configlet_upload

--- a/ansible_collections/arista/avd/roles/cvp_configlet_upload/vars/main.yml
+++ b/ansible_collections/arista/avd/roles/cvp_configlet_upload/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for cvp_configlet_upload


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**

In some cases, it is required to use additional configlets not generated by AVD. Main use case is when AVD has a feature gap. Having configlets in git for versioning may be a good solution.

**Describe the solution you'd like**

Create a role and a playbook to upload a set of configlets to CloudVision. This role should not take care of binding to device/container as it will remain part of AVD playbooks.

**Describe alternatives you've considered**

N/A

**Additional context**

N/A