### PR TITLE
Provide installation script for development environment

### DIFF
--- a/development/README.md
+++ b/development/README.md
@@ -90,6 +90,8 @@ CONTAINER ID        IMAGE               COMMAND             CREATED             
 
 ## Getting started Script
 
+### Step by step installation process
+
 ```shell
 mkdir git_projects
 cd git_projects
@@ -99,4 +101,10 @@ git clone https://github.com/aristanetworks/netdevops-examples.git
 cp ansible-avd/development/* ./
 make build
 make run
+```
+
+### One liner installation
+
+```shell
+$ sh -c "$(curl -fsSL https://raw.githubusercontent.com/aristanetworks/ansible-avd/master/development/install.sh)"
 ```

--- a/development/install.sh
+++ b/development/install.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Local Installation Path
+_ROOT_INSTALLATION_DIR="${PWD}/arista-ansible"
+
+# List of Arista Repositories
+_REPO_AVD="https://github.com/aristanetworks/ansible-avd.git"
+_REPO_CVP="https://github.com/aristanetworks/ansible-cvp.git"
+_REPO_EXAMPLES="https://github.com/aristanetworks/ansible-avd.git"
+
+# Path for local repositories
+_LOCAL_AVD="${_ROOT_INSTALLATION_DIR}/ansible-avd"
+_LOCAL_CVP="${_ROOT_INSTALLATION_DIR}/ansible-cvp"
+_LOCAL_EXAMPLES="${_ROOT_INSTALLATION_DIR}/netdevops-examples"
+
+# Folder where Dockerfile and Makefile are located
+_DEV_FOLDER="${_LOCAL_AVD}/development/"
+
+echo "Arista Ansible installation is starting"
+
+# Test if git is installed
+if hash git 2>/dev/null; then
+    echo "  * git has been found here: " $(which git)
+else
+    echo "  ! git is not installed, installation aborted"
+    exit 1
+fi
+
+if [ ! -d "${_ROOT_INSTALLATION_DIR}" ]; then 
+    echo "  * creating local installation folder: ${_ROOT_INSTALLATION_DIR}"
+    mkdir -p ${_ROOT_INSTALLATION_DIR}
+    echo "  * cloning ansible-avd collections to ${_LOCAL_AVD}"
+    git clone ${_REPO_AVD} ${_LOCAL_AVD}
+    echo "  * cloning ansible-cvp collections to ${_LOCAL_CVP}"
+    git clone ${_REPO_CVP} ${_LOCAL_CVP}
+    echo "  * cloning netdevops-examples collections to ${_LOCAL_EXAMPLES}"
+    git clone ${_REPO_EXAMPLES} ${_LOCAL_EXAMPLES}
+    if [ -d ${_DEV_FOLDER} ]; then
+        echo "deploying development content to ${_ROOT_INSTALLATION_DIR}"
+        cp ${_DEV_FOLDER}/* ${_ROOT_INSTALLATION_DIR}
+    else
+        echo "  ! error: development folder is missing"
+    fi
+else
+    echo "  ! local installation folder already exists - ${_ROOT_INSTALLATION_DIR}"
+fi


### PR DESCRIPTION
## Feature

Create installation script to automatically configure a local development environment:

- Create local development folder
- Clone AVD collection
- Clone CVP collection
- Clone netdevops examples
- Deploy `Dockerfile` and `Makefile` to local development folder

## Usage

Once merged in `master`, usage will be: 

```shell
$ sh -c "$(curl -fsSL https://raw.githubusercontent.com/aristanetworks/ansible-avd/master/development/install.sh)"
```

Current PR validation:

```
$ sh -c "$(curl -fsSL https://raw.githubusercontent.com/titom73/ansible-avd/features/installation-script/development/install.sh)"
Arista Ansible installation is starting
  * git has been found here:  /usr/bin/git
  * creating local installation folder: ~/arista-ansible-dev-toolkit/arista-ansible
  * cloning ansible-avd collections to ~/arista-ansible-dev-toolkit/arista-ansible/ansible-avd
Cloning into '~/arista-ansible-dev-toolkit/arista-ansible/ansible-avd'...
remote: Enumerating objects: 4428, done.
remote: Total 4428 (delta 0), reused 0 (delta 0), pack-reused 4428
Receiving objects: 100% (4428/4428), 1.66 MiB | 2.83 MiB/s, done.
Resolving deltas: 100% (2902/2902), done.
  * cloning ansible-cvp collections to ~/arista-ansible-dev-toolkit/arista-ansible/ansible-cvp
Cloning into '~/arista-ansible-dev-toolkit/arista-ansible/ansible-cvp'...
remote: Enumerating objects: 2245, done.
remote: Total 2245 (delta 0), reused 0 (delta 0), pack-reused 2245
Receiving objects: 100% (2245/2245), 817.75 KiB | 1.67 MiB/s, done.
Resolving deltas: 100% (1271/1271), done.
  * cloning netdevops-examples collections to ~/arista-ansible-dev-toolkit/arista-ansible/netdevops-examples
Cloning into '~/arista-ansible-dev-toolkit/arista-ansible/netdevops-examples'...
remote: Enumerating objects: 4428, done.
remote: Total 4428 (delta 0), reused 0 (delta 0), pack-reused 4428
Receiving objects: 100% (4428/4428), 1.66 MiB | 3.01 MiB/s, done.
Resolving deltas: 100% (2902/2902), done.
deploying development content to ~/arista-ansible-dev-toolkit/arista-ansible
```