### PR TITLE
Fix python 3 setup for continuous testing

### DIFF
--- a/.github/workflows/ansible_test.yml
+++ b/.github/workflows/ansible_test.yml
@@ -9,10 +9,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+      - name: Setup Python 3 on runner
+        uses: actions/setup-python@v1.2.0
+        with: 
+          python-version: '3.x'
       - name: 'Install requirements'
         run: make github-configure-ci
       - name: 'Install Python requirements'
-        run: make setup-repository
+        run: make install-requirements
       - name: 'ansible-test linting'
         run: make sanity-lint
       - name: 'ansible-test import'

--- a/.github/workflows/docker
+++ b/.github/workflows/docker
@@ -1,0 +1,25 @@
+name: Docker Build
+on:
+  push:
+    paths: 
+      - 'developement/Dockerfile'
+    tags:
+      - 'v**'
+  pull_request:
+    branches:
+      - 'master'
+      - 'releases/*'
+jobs:
+  'docker_image':
+    name: Build Local Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Execute testing playbook
+        run: |
+          cd development
+          make build
+          echo '-----------------------'
+          echo 'Image information: '
+          docker images | grep avd
+          echo '-----------------------'

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -14,6 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+      - name: Setup Python 3 on runner
+        uses: actions/setup-python@v1.2.0
+        with: 
+          python-version: '3.x'
       - name: 'Lint YAML Content'
         run: |
           sudo apt-get install -y yamllint
@@ -23,8 +27,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+      - name: Setup Python 3 on runner
+        uses: actions/setup-python@v1.2.0
+        with: 
+          python-version: '3.x'
       - name: 'Lint Python code in plugins'
         run: |
-          pip install wheel
-          pip install pylint
+          pip3 install wheel
+          pip3 install pylint
           sh .github/lint-python

--- a/.github/workflows/playbook_validation.yml
+++ b/.github/workflows/playbook_validation.yml
@@ -10,8 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+      - name: Setup Python 3 on runner
+        uses: actions/setup-python@v1.2.0
+        with: 
+          python-version: '3.x'
       - name: 'Install requirements'
-        run: make setup-repository
+        run: make install-requirements-generic
       - name: Execute testing playbook
         run: |
           cd testing

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ ANSIBLE_TEST ?= $(shell which ansible-test)
 ANSIBLE_TEST_MODE ?= docker
 
 .PHONY: help
-help: ## Display help message (*: main entry points / []: part of an entry point)
+help: ## Display help message
 	@grep -E '^[0-9a-zA-Z_-]+\.*[0-9a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 #########################################
@@ -52,19 +52,36 @@ linting: ## Run pre-commit script for python code linting using pylint
 	sh .github/lint-python
 
 .PHONY: github-configure-ci
-github-configure-ci: ## Configure CI environment to run GA (Ubuntu:latest LTS)
+github-configure-ci: github-configure-ci-python3 github-configure-ci-ansible ## Configure CI environment to run GA (Ubuntu:latest LTS)
+
+.PHONY: github-configure-ci-python3
+github-configure-ci-python3: ## Configure Python3 environment to run GA (Ubuntu:latest LTS)
+	sudo apt-get update
+	sudo apt-get upgrade -y
+	sudo apt-get install -y python3 python3-pip git python3-setuptools
+	sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 10
+	pip3 install --upgrade wheel
+	pip3 install -r development/requirements.txt
+
+.PHONY: github-configure-ci-ansible
+github-configure-ci-ansible: ## Install Ansible Test on GA (Ubuntu:latest LTS)
 	sudo apt-get update
 	sudo apt-get install -y gnupg2
 	sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367
 	sudo echo "deb http://ppa.launchpad.net/ansible/ansible/ubuntu bionic main" | sudo tee /etc/apt/sources.list.d/ansible.list
 	sudo echo "deb-src http://ppa.launchpad.net/ansible/ansible/ubuntu bionic main" | sudo tee -a /etc/apt/sources.list.d/ansible.list
 	sudo apt-get update
-	sudo apt-get install ansible-test
-	sudo pip install --upgrade wheel
-	sudo pip install -r development/requirements.txt
+	sudo apt-get install -y ansible-test
 
-.PHONY: setup-repository
-setup-repository: ## Install python requirements
-	pip install --upgrade wheel
-	pip install -r development/requirements.txt
-	pip install -r development/requirements-dev.txt
+.PHONY: install-requirements
+install-requirements: install-requirements-generic install-requirements-dev ## Install python requirements (normal + dev)
+
+.PHONY: install-requirements-generic
+install-requirements-generic: ## Install python requirements for generic purpose
+	pip3 install --upgrade wheel
+	pip3 install -r development/requirements.txt
+
+.PHONY: install-requirements-dev
+install-requirements-dev: ## Install python requirements for development purpose
+	pip3 install --upgrade wheel
+	pip3 install -r development/requirements-dev.txt

--- a/ansible_collections/arista/avd/plugins/modules/configlet_build_config.py
+++ b/ansible_collections/arista/avd/plugins/modules/configlet_build_config.py
@@ -79,6 +79,7 @@ except ImportError:
     HAS_YAML = False
     YAML_IMP_ERR = traceback.format_exc()
 
+
 def get_configlet(src_folder=str(), prefix='AVD', extension='cfg'):
     """
     Get available configlets to deploy to CVP.


### PR DESCRIPTION
Enable Py3 configuration prior to any custom job:

```yaml
- name: Setup Python 3 on runner
   uses: actions/setup-python@v1.2.0
   with: 
     python-version: '3.x'
```

Some `Makefile` targets have been update as well:

- `setup-repository` --> `install-requirements`
- `install-requirements-generic`
- `install-requirements-dev`