### PR TITLE
Fix an issue where cvp structured folder was not created

### DIFF
--- a/ansible_collections/arista/avd/plugins/modules/configlet_build_config.py
+++ b/ansible_collections/arista/avd/plugins/modules/configlet_build_config.py
@@ -79,6 +79,7 @@ except ImportError:
     HAS_YAML = False
     YAML_IMP_ERR = traceback.format_exc()
 
+
 def get_configlet(src_folder=str(), prefix='AVD', extension='cfg'):
     """
     Get available configlets to deploy to CVP.

--- a/ansible_collections/arista/avd/roles/build_output_folders/defaults/main.yml
+++ b/ansible_collections/arista/avd/roles/build_output_folders/defaults/main.yml
@@ -13,6 +13,10 @@ output_dir: '{{root_dir}}/{{output_dir_name}}'
 structured_dir_name: 'structured_configs'
 structured_dir: '{{output_dir}}/{{structured_dir_name}}'
 
+# Output for structured YAML files for CVP:
+structured_cvp_name: 'cvp'
+structured_cvp: '{{structured_dir}}/{{structured_cvp_name}}'
+
 # EOS Configuration Directory name
 eos_config_dir_name: 'configs'
 eos_config_dir: '{{output_dir}}/{{eos_config_dir_name}}'

--- a/ansible_collections/arista/avd/roles/build_output_folders/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/build_output_folders/tasks/main.yml
@@ -7,6 +7,7 @@
     state: absent
     mode: 0755
   delegate_to: localhost
+  run_once: True
 
 - name: 'Create folder {{output_dir}}'
   file:
@@ -14,13 +15,15 @@
     state: directory
     mode: 0755
   delegate_to: localhost
+  run_once: True
 
-- name: 'Create folder {{structured_dir_name}} for structued YAML files'
+- name: 'Create folder {{structured_dir_name}} for structured YAML files'
   file:
     path: '{{structured_dir}}'
     state: directory
     mode: 0755
   delegate_to: localhost
+  run_once: True
 
 - name: 'Create folder {{eos_config_dir_name}} for EOS Configuration files'
   file:
@@ -28,6 +31,15 @@
     state: directory
     mode: 0755
   delegate_to: localhost
+  run_once: True
+
+- name: 'Create folder {{structured_cvp_name}} for CVP structured YAML files'
+  file:
+    path: '{{structured_cvp}}'
+    state: directory
+    mode: 0755
+  delegate_to: localhost
+  run_once: True
 
 - name: 'Create documentation folder: {{documentation_dir_name}}'
   file:
@@ -35,6 +47,7 @@
     state: directory
     mode: 0755
   delegate_to: localhost
+  run_once: True
 
 - name: 'Create folder {{fabric_dir_name}} for Fabric documentation'
   file:
@@ -42,6 +55,7 @@
     state: directory
     mode: 0755
   delegate_to: localhost
+  run_once: True
 
 - name: 'Create folder {{devices_dir_name}} for EOS documentation'
   file:
@@ -49,3 +63,4 @@
     state: directory
     mode: 0755
   delegate_to: localhost
+  run_once: True


### PR DESCRIPTION
Types of changes
----------------

- [x] Bug fix (non-breaking change which fixes an issue)

Related issue(s)
----------------

N/A

Proposed changes
----------------

Fix an issue in build_dir_outputs role where structured folder for CVP
was not created by role

Also implement a `run_once: true` to not optimize execution time

Fix a linting issue in python module

How to test
-----------

Playbook with following task:

```yaml
    - name: 'reset local folders for output'
      tags: [build, generate]
      import_role:
        name: arista.avd.build_output_folders
```

Checklist:
-----------

- [x] I have read the [**CONTRIBUTING**](https://github.com/aristanetworks/ansible-cvp/blob/master/contributing.md#branches) document.
- [x] All new and existing tests passed (`make linting` and `make sanity-lint`).