### PR TITLE
Support EOS Event Handlers

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -11,6 +11,7 @@
     - [Daemon TerminAttr](#daemon-terminattr)
     - [Internal VLAN Allocation Policy](#internal-vlan-allocation-policy)
     - [Event Monitor](#event-monitor)
+    - [Event Handler](#event-handler)
     - [Load Interval](#load-interval)
     - [Queue Monitor Length](#queue-monitor-length)
     - [Logging](#logging)
@@ -127,6 +128,20 @@ vlan_internal_allocation_policy:
 ```yaml
 event_monitor:
   enabled: < true | false >
+```
+
+### Event Handler
+
+```yaml
+### Event Handler ###
+event_handler:
+  evpn-blacklist-recovery:
+    action_type: < Type of action. [bash, increment, log]>
+    action: < Command to execute >
+    delay: < Event-handler delay in seconds >
+    trigger: < Configure event trigger condition. Only supports on-logging >
+    regex: < Regular expression to use for searching log messages. Required for on-logging trigger >
+    asynchronous: < Set the action to be non-blocking. Boolean True or False. If unset, default is False >
 ```
 
 ### Load Interval

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -141,7 +141,7 @@ event_handler:
     delay: < Event-handler delay in seconds >
     trigger: < Configure event trigger condition. Only supports on-logging >
     regex: < Regular expression to use for searching log messages. Required for on-logging trigger >
-    asynchronous: < Set the action to be non-blocking. Boolean True or False. If unset, default is False >
+    asynchronous: < Set the action to be non-blocking. if unset, default is False >
 ```
 
 ### Load Interval

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/event-handler.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/event-handler.j2
@@ -1,0 +1,18 @@
+{# eos - event-handler #}
+{% if event_handler is defined and event_handler is iterable %}
+### Event Handler Summary
+
+| Handler | Action Type | Action | Trigger |
+| ------- | ----------- | ------ | ------- |
+{%     for handler in event_handler | arista.avd.natural_sort %}
+| {{ handler }} | {{ event_handler[handler].action_type }} | {{ event_handler[handler].action }} | {{ event_handler[handler].trigger }} |
+{%     endfor %}
+
+### Event Handler Device Configuration
+
+```eos
+{% include 'eos/event-handler.j2' %}
+```
+{% else %}
+No Event Handler Defined
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-device-documentation.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-device-documentation.j2
@@ -76,6 +76,10 @@
 
 {% include 'documentation/static-routes.j2' %}
 
+## Event Handler
+
+{% include 'documentation/event-handler.j2' %}
+
 ## IP Routing
 
 {% include 'documentation/ip-routing.j2' %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
@@ -60,6 +60,8 @@ hostname {{ inventory_hostname }}
 {% include 'eos/mac-address-table.j2' %}
 {# router virtual mac address #}
 {% include 'eos/virtual-router-mac-address-virtual-source-nat.j2' %}
+{# event handler #}
+{% include 'eos/event-handler.j2' %}
 {# Static Route #}
 {% include 'eos/static-routes.j2' %}
 {# IP Routing #}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/event-handler.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/event-handler.j2
@@ -1,0 +1,22 @@
+{% if event_handler is defined and event_handler is iterable %}
+{%     for handler in event_handler %}
+event-handler {{ handler }}
+{%         if event_handler[handler].action is defined and event_handler[handler].action_type is defined %}
+   action {{ event_handler[handler].action_type }} {{ event_handler[handler].action }}
+{%         endif %}
+{%         if event_handler[handler].delay is defined %}
+   delay {{ event_handler[handler].delay }}
+{%         endif %}
+{%         if event_handler[handler].asynchronous is defined and event_handler[handler].asynchronous is true %}
+   asynchronous
+{%         endif %}
+   !
+{%         if event_handler[handler].trigger is defined %}
+   trigger {{ event_handler[handler].trigger }}
+{%             if event_handler[handler].regex is defined %}
+      regex {{ event_handler[handler].regex }}
+{%             endif %}
+{%         endif %}
+!
+{%    endfor %}
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/base/event-handler.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/base/event-handler.j2
@@ -1,0 +1,21 @@
+{% if event_handler is defined and event_handler is iterable %}
+{%     for handler in event_handler %}
+  {{ handler }}:
+{%         if event_handler[handler].action is defined and event_handler[handler].action_type is defined %}
+    action_type: {{ event_handler[handler].action_type }}
+    action: {{ event_handler[handler].action }}
+{%         endif %}
+{%         if event_handler[handler].delay is defined %}
+    delay: {{ event_handler[handler].delay }}
+{%         endif %}
+{%         if event_handler[handler].asynchronous is defined and event_handler[handler].asynchronous is true %}
+    asynchronous: event_handler[handler].asynchronous
+{%         endif %}
+{%         if event_handler[handler].trigger is defined %}
+    trigger: {{ event_handler[handler].trigger }}
+{%             if event_handler[handler].regex is defined %}
+    regex: {{ event_handler[handler].regex }}
+{%             endif %}
+{%         endif %}
+{%    endfor %}
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l2leaf-yml.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l2leaf-yml.j2
@@ -167,6 +167,11 @@ vlan_internal_order:
 event_monitor:
 {% include 'base/event-monitor.j2' %}
 
+{# event handler #}
+### Event Handler ###
+event_handler:
+{% include 'base/event-handler.j2' %}
+
 {# load interval #}
 ### Load Interval ###
 load_interval:

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l3leaf-yml.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l3leaf-yml.j2
@@ -165,6 +165,11 @@ vlan_internal_order:
 event_monitor:
 {% include 'base/event-monitor.j2' %}
 
+{# event handler #}
+### Event Handler ###
+event_handler:
+{% include 'base/event-handler.j2' %}
+
 {# load interval #}
 ### Load Interval ###
 load_interval:

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-spine-yml.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-spine-yml.j2
@@ -26,11 +26,15 @@ daemon_terminattr:
 vlan_internal_order:
 {% include 'base/vlan-internal-order.j2' %}
 
-
 {# event monitor #}
 ### Event Monitor ###
 event_monitor:
 {% include 'base/event-monitor.j2' %}
+
+{# event handler #}
+### Event Handler ###
+event_handler:
+{% include 'base/event-handler.j2' %}
 
 {# load interval #}
 ### Load Interval ###

--- a/development/README.md
+++ b/development/README.md
@@ -90,6 +90,8 @@ CONTAINER ID        IMAGE               COMMAND             CREATED             
 
 ## Getting started Script
 
+### Step by step installation process
+
 ```shell
 mkdir git_projects
 cd git_projects
@@ -99,4 +101,10 @@ git clone https://github.com/aristanetworks/netdevops-examples.git
 cp ansible-avd/development/* ./
 make build
 make run
+```
+
+### One liner installation
+
+```shell
+$ sh -c "$(curl -fsSL https://raw.githubusercontent.com/aristanetworks/ansible-avd/master/development/install.sh)"
 ```

--- a/development/install.sh
+++ b/development/install.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Local Installation Path
+_ROOT_INSTALLATION_DIR="${PWD}/arista-ansible"
+
+# List of Arista Repositories
+_REPO_AVD="https://github.com/aristanetworks/ansible-avd.git"
+_REPO_CVP="https://github.com/aristanetworks/ansible-cvp.git"
+_REPO_EXAMPLES="https://github.com/aristanetworks/ansible-avd.git"
+
+# Path for local repositories
+_LOCAL_AVD="${_ROOT_INSTALLATION_DIR}/ansible-avd"
+_LOCAL_CVP="${_ROOT_INSTALLATION_DIR}/ansible-cvp"
+_LOCAL_EXAMPLES="${_ROOT_INSTALLATION_DIR}/netdevops-examples"
+
+# Folder where Dockerfile and Makefile are located
+_DEV_FOLDER="${_LOCAL_AVD}/development/"
+
+echo "Arista Ansible installation is starting"
+
+# Test if git is installed
+if hash git 2>/dev/null; then
+    echo "  * git has been found here: " $(which git)
+else
+    echo "  ! git is not installed, installation aborted"
+    exit 1
+fi
+
+if [ ! -d "${_ROOT_INSTALLATION_DIR}" ]; then 
+    echo "  * creating local installation folder: ${_ROOT_INSTALLATION_DIR}"
+    mkdir -p ${_ROOT_INSTALLATION_DIR}
+    echo "  * cloning ansible-avd collections to ${_LOCAL_AVD}"
+    git clone ${_REPO_AVD} ${_LOCAL_AVD}
+    echo "  * cloning ansible-cvp collections to ${_LOCAL_CVP}"
+    git clone ${_REPO_CVP} ${_LOCAL_CVP}
+    echo "  * cloning netdevops-examples collections to ${_LOCAL_EXAMPLES}"
+    git clone ${_REPO_EXAMPLES} ${_LOCAL_EXAMPLES}
+    if [ -d ${_DEV_FOLDER} ]; then
+        echo "deploying development content to ${_ROOT_INSTALLATION_DIR}"
+        cp ${_DEV_FOLDER}/* ${_ROOT_INSTALLATION_DIR}
+    else
+        echo "  ! error: development folder is missing"
+    fi
+else
+    echo "  ! local installation folder already exists - ${_ROOT_INSTALLATION_DIR}"
+fi


### PR DESCRIPTION
Summary
-------

Add support of `event-handler` in following roles:

- `eos_l3ls_evpn`
- `eos_cli_config_gen`

Inputs:
-------

```yaml
event_handler:
  evpn-blacklist-recovery:
    action_type: bash
    action: FastCli -p 15 -c “clear bgp evpn host-flap”
    delay: 300
    trigger: on-logging
    regex:  EVPN-3-BLACKLISTED_DUPLICATE_MAC
    asynchronous: true
```

Generated outputs:
------------------

- EOS Configuration:

```
event-handler evpn-blacklist-recovery
   action bash FastCli -p 15 -c “clear bgp evpn host-flap”
   delay 300
   asynchronous
   !
   trigger on-logging
      regex EVPN-3-BLACKLISTED_DUPLICATE_MAC
!
```

Todo:
-----

- [x] Update documentation templates
- [x] Report to EVPN data model (eos_l3ls_evpn)
- [x] Update roles documentation