### PR TITLE
Fix inventory_to_container - incorrect parameter in get_devices

### DIFF
--- a/ansible_collections/arista/avd/plugins/modules/inventory_to_container.py
+++ b/ansible_collections/arista/avd/plugins/modules/inventory_to_container.py
@@ -272,7 +272,7 @@ def get_devices(dict_inventory, search_container=None, devices=None):
                 get_devices(
                     dict_inventory=v2,
                     search_container=search_container,
-                    devcices=devices
+                    devices=devices
                 )
     return devices
 


### PR DESCRIPTION
`inventory_to-container` module uses an incorrect parameter to call `get_device` function for a [specific scenario](https://github.com/aristanetworks/ansible-avd/blob/3ec68bfadaa4d121f894b6930f5a73058a9317c1/ansible_collections/arista/avd/plugins/modules/inventory_to_container.py#L275)

No execution error has been reported yet, but should be fixed to protect unexpected situation.


```python
// get_device definition
def get_devices(dict_inventory, search_container=None, devices=None)

// get_device call:
# Extract sub-group information
for k2, v2 in v1.items():
    get_devices(
        dict_inventory=v2,
        search_container=search_container,
        devcices=devices
    )

```

Commit should be cherry-picked to __`releases/v1.0.x`__