### PR TITLE
Fix #65 - Implement router_id for BGP in VRFs

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -108,6 +108,9 @@ router bgp {{ router_bgp.as }}
 {%         for vrf in router_bgp.vrfs | arista.avd.natural_sort %}
    !
    vrf {{ vrf }}
+{%             if router_bgp.vrfs[vrf].router_id is defined %}
+      router-id {{ router_bgp.vrfs[vrf].router_id }}
+{%             endif %}
       rd {{ router_bgp.vrfs[vrf].rd }}
 {%             if router_bgp.vrfs[vrf].route_targets.import is defined %}
       route-target import {{ router_bgp.vrfs[vrf].route_targets.import.address_family }} {{ router_bgp.vrfs[vrf].route_targets.import.asn }}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant-evpn-vxlan/leaf-tenant-router-bgp-evpn-vrfs.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant-evpn-vxlan/leaf-tenant-router-bgp-evpn-vrfs.j2
@@ -4,6 +4,7 @@
 {%     if tenants[tenant].vrfs is defined %}
 {%         for vrf in tenants[tenant].vrfs | arista.avd.natural_sort if vrf in leaf.vrfs %}
     {{ vrf }}:
+      router_id: {{ overlay_loopback_network_summary | ipaddr('network') | ipmath(leaf.id + spine.nodes | length) }}
       rd: "{{ overlay_loopback_network_summary | ipaddr('network') | ipmath(leaf.id + spine.nodes | length) }}:{{ tenants[tenant].vrfs[vrf].vrf_vni }}"
       route_targets:
         import:


### PR DESCRIPTION
Configure VRF with router-id computed by AVD for global BGP process.

## Implementation

- Implement a new `router_id` key for structured_configs for every VRF annunced with BGP

```
Tenant_A_WEB_Zone:
  router_id: 192.168.255.3
  rd: "192.168.255.3:111"
```

- Implement router-id in configuration if router_id is configured in VRF
BGP VRF stanza.

```
router bgp 65101
   vrf Tenant_A_WEB_Zone
      router-id 192.168.255.3
      rd 192.168.255.3:111
```

## Test & Validation

### Cloudvision Change Control check

![image](https://user-images.githubusercontent.com/4608573/79985636-2f88f400-84ab-11ea-8a32-8c8d8fdffdf7.png)

### EOS side

Topology was running for 40 minutes before applying new code.

```
DC1-LEAF1A#show ip bgp summary vrf all | grep 10.255
  10.255.251.1     4  65101             62        60    0    0 00:41:41 Estab   15     15
  10.255.251.1     4  65101             63        62    0    0 00:06:30 Estab   4      4
  10.255.251.1     4  65101             61        60    0    0 00:06:30 Estab   4      4
  10.255.251.1     4  65101             60        61    0    0 00:06:30 Estab   8      8
  10.255.251.1     4  65101             36        62    0    0 00:04:03 Estab   3      3
  10.255.251.1     4  65101             35        60    0    0 00:03:43 Estab   4      4
  10.255.251.1     4  65101             35        58    0    0 00:03:35 Estab   4      4
  10.255.251.1     4  65101             61        60    0    0 00:06:30 Estab   3      3
  10.255.251.1     4  65101             61        61    0    0 00:06:30 Estab   4      4
  10.255.251.1     4  65101             60        59    0    0 00:06:30 Estab   3      3
```
