### PR TITLE
Remove export for Point to Point links

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/underlay-overlay/route-maps.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/underlay-overlay/route-maps.j2
@@ -4,6 +4,3 @@
       10:
         type: permit
         match: "ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY"
-      20:
-        type: permit
-        match: "ip address prefix-list PL-P2P-UNDERLAY"

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/underlay-overlay/spine-prefix-lists.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/underlay-overlay/spine-prefix-lists.j2
@@ -3,7 +3,3 @@
     sequence_numbers:
       10:
         action: "permit {{ overlay_loopback_network_summary }} le 32"
-  PL-P2P-UNDERLAY:
-    sequence_numbers:
-      10:
-        action: "permit {{ underlay_p2p_network_summary }} le 31"


### PR DESCRIPTION
__Issue__: #113 

## Changes

- Remove prefix-list to export prefixes part of `{{ underlay_p2p_network_summary }}`
- Remove rout-map related to underlay prefix export.

## Config Result

```
ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
   seq 10 permit 192.168.255.0/24 le 32
!
route-map RM-CONN-2-BGP permit 10
   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
!
```

## EOS result

```
DC1-LEAF1B#show ip interface br | grep Ethernet
Ethernet1       172.31.255.5/31      up         up              1500
Ethernet2       172.31.255.7/31      up         up              1500
DC1-LEAF1B#show bgp neighbors 172.31.255.4 received-routes
BGP routing table information for VRF default
Router identifier 192.168.255.4, local AS number 65101
Route status codes: s - suppressed, * - valid, > - active, # - not installed, E - ECMP head, e - ECMP
                    S - Stale, c - Contributing to ECMP, b - backup, L - labeled-unicast
                    % - Pending BGP convergence
Origin codes: i - IGP, e - EGP, ? - incomplete
AS Path Attributes: Or-ID - Originator ID, C-LST - Cluster List, LL Nexthop - Link Local Nexthop

         Network                Next Hop              Metric  LocPref Weight  Path
 * >Ec   192.168.254.5/32       172.31.255.4          -       -       0       65001 65102 i
 * >     192.168.255.1/32       172.31.255.4          -       -       0       65001 i
 * >Ec   192.168.255.5/32       172.31.255.4          -       -       0       65001 65102 i
 * >Ec   192.168.255.6/32       172.31.255.4          -       -       0       65001 65102 i
```