### PR TITLE
Add support for event-handler

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -11,6 +11,7 @@
     - [Daemon TerminAttr](#daemon-terminattr)
     - [Internal VLAN Allocation Policy](#internal-vlan-allocation-policy)
     - [Event Monitor](#event-monitor)
+    - [Event Handler](#event-handler)
     - [Load Interval](#load-interval)
     - [Queue Monitor Length](#queue-monitor-length)
     - [Logging](#logging)
@@ -127,6 +128,20 @@ vlan_internal_allocation_policy:
 ```yaml
 event_monitor:
   enabled: < true | false >
+```
+
+### Event Handler
+
+```yaml
+### Event Handler ###
+event_handler:
+  evpn-blacklist-recovery:
+    action_type: < Type of action. [bash, increment, log]>
+    action: < Command to execute >
+    delay: < Event-handler delay in seconds >
+    trigger: < Configure event trigger condition. Only supports on-logging >
+    regex: < Regular expression to use for searching log messages. Required for on-logging trigger >
+    asynchronous: < Set the action to be non-blocking. Boolean True or False. If unset, default is False >
 ```
 
 ### Load Interval

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -141,7 +141,7 @@ event_handler:
     delay: < Event-handler delay in seconds >
     trigger: < Configure event trigger condition. Only supports on-logging >
     regex: < Regular expression to use for searching log messages. Required for on-logging trigger >
-    asynchronous: < Set the action to be non-blocking. Boolean True or False. If unset, default is False >
+    asynchronous: < Set the action to be non-blocking. if unset, default is False >
 ```
 
 ### Load Interval

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -134,7 +134,7 @@ event_monitor:
 
 ```yaml
 ### Event Handler ###
-event_handler:
+event_handlers:
   evpn-blacklist-recovery:
     action_type: < Type of action. [bash, increment, log]>
     action: < Command to execute >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/event-handler.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/event-handler.j2
@@ -1,11 +1,11 @@
 {# eos - event-handler #}
-{% if event_handler is defined and event_handler is iterable %}
+{% if event_handlers is defined and event_handlers is iterable %}
 ### Event Handler Summary
 
 | Handler | Action Type | Action | Trigger |
 | ------- | ----------- | ------ | ------- |
-{%     for handler in event_handler | arista.avd.natural_sort %}
-| {{ handler }} | {{ event_handler[handler].action_type }} | {{ event_handler[handler].action }} | {{ event_handler[handler].trigger }} |
+{%     for handler in event_handlers | arista.avd.natural_sort %}
+| {{ handler }} | {{ event_handlers[handler].action_type }} | {{ event_handlers[handler].action }} | {{ event_handlers[handler].trigger }} |
 {%     endfor %}
 
 ### Event Handler Device Configuration

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/event-handler.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/event-handler.j2
@@ -1,0 +1,18 @@
+{# eos - event-handler #}
+{% if event_handler is defined and event_handler is iterable %}
+### Event Handler Summary
+
+| Handler | Action Type | Action | Trigger |
+| ------- | ----------- | ------ | ------- |
+{%     for handler in event_handler | arista.avd.natural_sort %}
+| {{ handler }} | {{ event_handler[handler].action_type }} | {{ event_handler[handler].action }} | {{ event_handler[handler].trigger }} |
+{%     endfor %}
+
+### Event Handler Device Configuration
+
+```eos
+{% include 'eos/event-handler.j2' %}
+```
+{% else %}
+No Event Handler Defined
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-device-documentation.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-device-documentation.j2
@@ -76,6 +76,10 @@
 
 {% include 'documentation/static-routes.j2' %}
 
+## Event Handler
+
+{% include 'documentation/event-handler.j2' %}
+
 ## IP Routing
 
 {% include 'documentation/ip-routing.j2' %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
@@ -60,6 +60,8 @@ hostname {{ inventory_hostname }}
 {% include 'eos/mac-address-table.j2' %}
 {# router virtual mac address #}
 {% include 'eos/virtual-router-mac-address-virtual-source-nat.j2' %}
+{# event handler #}
+{% include 'eos/event-handler.j2' %}
 {# Static Route #}
 {% include 'eos/static-routes.j2' %}
 {# IP Routing #}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/event-handler.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/event-handler.j2
@@ -7,7 +7,7 @@ event-handler {{ handler }}
 {%         if event_handler[handler].delay is defined %}
    delay {{ event_handler[handler].delay }}
 {%         endif %}
-{%         if event_handler[handler].asynchronous is defined and event_handler[handler].asynchronous is true %}
+{%         if event_handler[handler].asynchronous is defined and event_handlers[handler].asynchronous == true %}
    asynchronous
 {%         endif %}
    !

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/event-handler.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/event-handler.j2
@@ -1,0 +1,22 @@
+{% if event_handler is defined and event_handler is iterable %}
+{%     for handler in event_handler %}
+event-handler {{ handler }}
+{%         if event_handler[handler].action is defined and event_handler[handler].action_type is defined %}
+   action {{ event_handler[handler].action_type }} {{ event_handler[handler].action }}
+{%         endif %}
+{%         if event_handler[handler].delay is defined %}
+   delay {{ event_handler[handler].delay }}
+{%         endif %}
+{%         if event_handler[handler].asynchronous is defined and event_handler[handler].asynchronous is true %}
+   asynchronous
+{%         endif %}
+   !
+{%         if event_handler[handler].trigger is defined %}
+   trigger {{ event_handler[handler].trigger }}
+{%             if event_handler[handler].regex is defined %}
+      regex {{ event_handler[handler].regex }}
+{%             endif %}
+{%         endif %}
+!
+{%    endfor %}
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/event-handler.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/event-handler.j2
@@ -1,20 +1,20 @@
-{% if event_handler is defined and event_handler is iterable %}
-{%     for handler in event_handler %}
+{% if event_handlers is defined and event_handlers is not none %}
+{%     for handler in event_handlers %}
 event-handler {{ handler }}
-{%         if event_handler[handler].action is defined and event_handler[handler].action_type is defined %}
-   action {{ event_handler[handler].action_type }} {{ event_handler[handler].action }}
+{%         if event_handlers[handler].action is defined and event_handlers[handler].action_type is defined %}
+   action {{ event_handlers[handler].action_type }} {{ event_handlers[handler].action }}
 {%         endif %}
-{%         if event_handler[handler].delay is defined %}
-   delay {{ event_handler[handler].delay }}
+{%         if event_handlers[handler].delay is defined %}
+   delay {{ event_handlers[handler].delay }}
 {%         endif %}
-{%         if event_handler[handler].asynchronous is defined and event_handlers[handler].asynchronous == true %}
+{%         if event_handlers[handler].asynchronous is defined and event_handlers[handler].asynchronous == true %}
    asynchronous
 {%         endif %}
    !
-{%         if event_handler[handler].trigger is defined %}
-   trigger {{ event_handler[handler].trigger }}
-{%             if event_handler[handler].regex is defined %}
-      regex {{ event_handler[handler].regex }}
+{%         if event_handlers[handler].trigger is defined %}
+   trigger {{ event_handlers[handler].trigger }}
+{%             if event_handlers[handler].regex is defined %}
+      regex {{ event_handlers[handler].regex }}
 {%             endif %}
 {%         endif %}
 !

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
@@ -1164,7 +1164,7 @@ Gives ability to monitor and react to Syslog messages provides a powerful and fl
 **Variables and Options:**
 
 ```yaml
-event_handler:
+event_handlers:
   evpn-blacklist-recovery:    # Name of the event-handler
     action_type: < bash, increment >
     action: < Command to run when handler is triggered >
@@ -1178,7 +1178,7 @@ event_handler:
 **Example:**
 
 ```yaml
-event_handler:
+event_handlers:
   evpn-blacklist-recovery:
     action_type: bash
     action: FastCli -p 15 -c “clear bgp evpn host-flap”

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
@@ -17,6 +17,7 @@
     - [Network Services Variables - VRFs/VLANs](#network-services-variables---vrfsvlans)
     - [Server Edge Port Connectivity](#server-edge-port-connectivity)
     - [Variable to attach additional configlets](#variable-to-attach-additional-configlets)
+    - [Event Handlers](#event-handlers)
     - [vEOS-LAB Know Caveats and Recommendations](#veos-lab-know-caveats-and-recommendations)
   - [License](#license)
 
@@ -1154,6 +1155,37 @@ cv_configlets:
       - GLOBAL-ALIASES
     DC1-L2LEAF2B:
       - GLOBAL-ALIASES
+```
+
+### Event Handlers
+
+Gives ability to monitor and react to Syslog messages provides a powerful and flexible tool that can be used to apply self-healing actions, customize the system behavior, and implement workarounds to problems discovered in the field.
+
+**Variables and Options:**
+
+```yaml
+event_handler:
+  evpn-blacklist-recovery:    # Name of the event-handler
+    action_type: < bash, increment >
+    action: < Command to run when handler is triggered >
+    delay: < int / delay in sec between 2 triggers >
+    trigger: < on-logging >
+    regex:  < string to trigger handler >
+    asynchronous: < true, false >
+
+```
+
+**Example:**
+
+```yaml
+event_handler:
+  evpn-blacklist-recovery:
+    action_type: bash
+    action: FastCli -p 15 -c “clear bgp evpn host-flap”
+    delay: 300
+    trigger: on-logging
+    regex:  EVPN-3-BLACKLISTED_DUPLICATE_MAC
+    asynchronous: true
 ```
 
 ### vEOS-LAB Know Caveats and Recommendations

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/base/event-handler.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/base/event-handler.j2
@@ -1,0 +1,21 @@
+{% if event_handler is defined and event_handler is iterable %}
+{%     for handler in event_handler %}
+  {{ handler }}:
+{%         if event_handler[handler].action is defined and event_handler[handler].action_type is defined %}
+    action_type: {{ event_handler[handler].action_type }}
+    action: {{ event_handler[handler].action }}
+{%         endif %}
+{%         if event_handler[handler].delay is defined %}
+    delay: {{ event_handler[handler].delay }}
+{%         endif %}
+{%         if event_handler[handler].asynchronous is defined and event_handler[handler].asynchronous is true %}
+    asynchronous: event_handler[handler].asynchronous
+{%         endif %}
+{%         if event_handler[handler].trigger is defined %}
+    trigger: {{ event_handler[handler].trigger }}
+{%             if event_handler[handler].regex is defined %}
+    regex: {{ event_handler[handler].regex }}
+{%             endif %}
+{%         endif %}
+{%    endfor %}
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/base/event-handler.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/base/event-handler.j2
@@ -1,20 +1,20 @@
-{% if event_handler is defined and event_handler is iterable %}
-{%     for handler in event_handler %}
+{% if event_handlers is defined and event_handlers is iterable %}
+{%     for handler in event_handlers %}
   {{ handler }}:
-{%         if event_handler[handler].action is defined and event_handler[handler].action_type is defined %}
-    action_type: {{ event_handler[handler].action_type }}
-    action: {{ event_handler[handler].action }}
+{%         if event_handlers[handler].action is defined and event_handlers[handler].action_type is defined %}
+    action_type: {{ event_handlers[handler].action_type }}
+    action: {{ event_handlers[handler].action }}
 {%         endif %}
-{%         if event_handler[handler].delay is defined %}
-    delay: {{ event_handler[handler].delay }}
+{%         if event_handlers[handler].delay is defined %}
+    delay: {{ event_handlers[handler].delay }}
 {%         endif %}
-{%         if event_handler[handler].asynchronous is defined and event_handlers[handler].asynchronous == true %}
-    asynchronous: event_handler[handler].asynchronous
+{%         if event_handlers[handler].asynchronous is defined and event_handlers[handler].asynchronous == true %}
+    asynchronous: event_handlers[handler].asynchronous
 {%         endif %}
-{%         if event_handler[handler].trigger is defined %}
-    trigger: {{ event_handler[handler].trigger }}
-{%             if event_handler[handler].regex is defined %}
-    regex: {{ event_handler[handler].regex }}
+{%         if event_handlers[handler].trigger is defined %}
+    trigger: {{ event_handlers[handler].trigger }}
+{%             if event_handlers[handler].regex is defined %}
+    regex: {{ event_handlers[handler].regex }}
 {%             endif %}
 {%         endif %}
 {%    endfor %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/base/event-handler.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/base/event-handler.j2
@@ -8,7 +8,7 @@
 {%         if event_handler[handler].delay is defined %}
     delay: {{ event_handler[handler].delay }}
 {%         endif %}
-{%         if event_handler[handler].asynchronous is defined and event_handler[handler].asynchronous is true %}
+{%         if event_handler[handler].asynchronous is defined and event_handlers[handler].asynchronous == true %}
     asynchronous: event_handler[handler].asynchronous
 {%         endif %}
 {%         if event_handler[handler].trigger is defined %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l2leaf-yml.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l2leaf-yml.j2
@@ -169,7 +169,7 @@ event_monitor:
 
 {# event handler #}
 ### Event Handler ###
-event_handler:
+event_handlers:
 {% include 'base/event-handler.j2' %}
 
 {# load interval #}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l2leaf-yml.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l2leaf-yml.j2
@@ -167,6 +167,11 @@ vlan_internal_order:
 event_monitor:
 {% include 'base/event-monitor.j2' %}
 
+{# event handler #}
+### Event Handler ###
+event_handler:
+{% include 'base/event-handler.j2' %}
+
 {# load interval #}
 ### Load Interval ###
 load_interval:

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l3leaf-yml.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l3leaf-yml.j2
@@ -167,7 +167,7 @@ event_monitor:
 
 {# event handler #}
 ### Event Handler ###
-event_handler:
+event_handlers:
 {% include 'base/event-handler.j2' %}
 
 {# load interval #}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l3leaf-yml.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l3leaf-yml.j2
@@ -165,6 +165,11 @@ vlan_internal_order:
 event_monitor:
 {% include 'base/event-monitor.j2' %}
 
+{# event handler #}
+### Event Handler ###
+event_handler:
+{% include 'base/event-handler.j2' %}
+
 {# load interval #}
 ### Load Interval ###
 load_interval:

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-spine-yml.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-spine-yml.j2
@@ -26,11 +26,15 @@ daemon_terminattr:
 vlan_internal_order:
 {% include 'base/vlan-internal-order.j2' %}
 
-
 {# event monitor #}
 ### Event Monitor ###
 event_monitor:
 {% include 'base/event-monitor.j2' %}
+
+{# event handler #}
+### Event Handler ###
+event_handler:
+{% include 'base/event-handler.j2' %}
 
 {# load interval #}
 ### Load Interval ###

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-spine-yml.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-spine-yml.j2
@@ -33,7 +33,7 @@ event_monitor:
 
 {# event handler #}
 ### Event Handler ###
-event_handler:
+event_handlers:
 {% include 'base/event-handler.j2' %}
 
 {# load interval #}


### PR DESCRIPTION
Summary
-------

Add support of `event-handler` in following roles:

- `eos_l3ls_evpn`
- `eos_cli_config_gen`

In order to make data model easier to maintain, when it is used with __`eos_l3ls_evpn`__ role, `event_handler` block should be placed on group_vars targeting set of expecting devices:
- `group_vars/DC1_FABRIC.yml` to apply on all eos devices
- `group_vars/DC1_SPINES.yml` to apply on all spine devices
- `group_vars/DC1_L3LEAFS.yml` to apply on all l3leaf devices

Inputs:
-------

```yaml
event_handler:
  evpn-blacklist-recovery:
    action_type: bash
    action: FastCli -p 15 -c “clear bgp evpn host-flap”
    delay: 300
    trigger: on-logging
    regex:  EVPN-3-BLACKLISTED_DUPLICATE_MAC
    asynchronous: true
```

Generated outputs:
------------------

- EOS Configuration:

```
event-handler evpn-blacklist-recovery
   action bash FastCli -p 15 -c “clear bgp evpn host-flap”
   delay 300
   asynchronous
   !
   trigger on-logging
      regex EVPN-3-BLACKLISTED_DUPLICATE_MAC
!
```

- EOS Documentation:

![](https://user-images.githubusercontent.com/4608573/78972960-3741b380-7b0f-11ea-83c7-10758b607b62.png)

- Documentation Update

	- eos_cli_config_gen: [README file](https://github.com/aristanetworks/ansible-avd/tree/issues/84-event-handler-implementation/ansible_collections/arista/avd/roles/eos_cli_config_gen#event-handler)
	- eos_l3ls_config_gen: [README file](https://github.com/aristanetworks/ansible-avd/tree/issues/84-event-handler-implementation/ansible_collections/arista/avd/roles/eos_l3ls_evpn#event-handlers)
