### PR TITLE
Add first molecule scenario for avd-build

### DIFF
--- a/ansible_collections/arista/avd/.yamllint
+++ b/ansible_collections/arista/avd/.yamllint
@@ -1,0 +1,33 @@
+---
+# Based on ansible-lint config
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  colons:
+    max-spaces-after: -1
+    level: error
+  commas:
+    max-spaces-after: -1
+    level: error
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  empty-lines:
+    max: 3
+    level: error
+  hyphens:
+    level: error
+  indentation: disable
+  key-duplicates: enable
+  line-length: disable
+  new-line-at-end-of-file: disable
+  new-lines:
+    type: unix
+  trailing-spaces: disable
+  truthy: disable

--- a/ansible_collections/arista/avd/molecule/avd-build/INSTALL.rst
+++ b/ansible_collections/arista/avd/molecule/avd-build/INSTALL.rst
@@ -1,0 +1,22 @@
+*******
+Docker driver installation guide
+*******
+
+Requirements
+============
+
+* Docker Engine
+
+Install
+=======
+
+Please refer to the `Virtual environment`_ documentation for installation best
+practices. If not using a virtual environment, please consider passing the
+widely recommended `'--user' flag`_ when invoking ``pip``.
+
+.. _Virtual environment: https://virtualenv.pypa.io/en/latest/
+.. _'--user' flag: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site
+
+.. code-block:: bash
+
+    $ python3 -m pip install 'molecule[docker]'

--- a/ansible_collections/arista/avd/molecule/avd-build/converge.yml
+++ b/ansible_collections/arista/avd/molecule/avd-build/converge.yml
@@ -1,0 +1,16 @@
+---
+- name: Converge
+  hosts: all
+  gather_facts: false
+  connection: local
+  tasks:
+
+    - name: generate intented variables
+      delegate_to: 127.0.0.1
+      import_role:
+         name: arista.avd.eos_l3ls_evpn
+
+    - name: generate device intended config and documention
+      delegate_to: 127.0.0.1
+      import_role:
+         name: arista.avd.eos_cli_config_gen

--- a/ansible_collections/arista/avd/molecule/avd-build/create.yml
+++ b/ansible_collections/arista/avd/molecule/avd-build/create.yml
@@ -1,0 +1,11 @@
+---
+- name: Configure local folders
+  hosts: all
+  gather_facts: false
+  connection: local
+  tasks:
+    - name: create local output folders
+      delegate_to: 127.0.0.1
+      import_role:
+         name: arista.avd.build_output_folders
+      run_once: true

--- a/ansible_collections/arista/avd/molecule/avd-build/destroy.yml
+++ b/ansible_collections/arista/avd/molecule/avd-build/destroy.yml
@@ -1,0 +1,15 @@
+---
+- name: Remove output folders
+  hosts: all
+  gather_facts: false
+  connection: local
+  tasks:
+    - name: delete local folders
+      delegate_to: 127.0.0.1
+      run_once: true
+      file:
+        path: "{{ item }}"
+        state: absent
+      with_items:
+        - documentation
+        - intended

--- a/ansible_collections/arista/avd/molecule/avd-build/inventory/group_vars/AVD_LAB.yml
+++ b/ansible_collections/arista/avd/molecule/avd-build/inventory/group_vars/AVD_LAB.yml
@@ -1,0 +1,31 @@
+# Nashua EVE-NG LAB shared attributes
+
+# local users
+local_users:
+  admin:
+    privilege: 15
+    role: network-admin
+    sha512_password: "$6$Df86J4/SFMDE3/1K$Hef4KstdoxNDaami37cBquTWOTplC.miMPjXVgQxMe92.e5wxlnXOLlebgPj8Fz1KO0za/RCO7ZIs4Q6Eiq1g1"
+
+  cvpadmin:
+    privilege: 15
+    role: network-admin
+    sha512_password: "$6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj."
+
+# Cloud Vision server
+cvp_instance_ips:
+  - 192.168.200.11
+
+cvp_ingestauth_key: telarista
+
+# OOB Management network default gateway.
+mgmt_gateway: 192.168.200.5
+
+# dns servers.
+name_servers:
+ - 192.168.200.5
+ - 8.8.8.8
+
+# NTP Servers IP or DNS name, first NTP server will be prefered, and sourced from Managment
+ntp_servers:
+  - 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/avd-build/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/avd-build/inventory/group_vars/DC1_FABRIC.yml
@@ -1,0 +1,175 @@
+---
+
+# L3LS Fabric Values - update these values with caution, some changes could be disruptive.
+
+fabric_name: DC1_FABRIC
+
+# Point to Point Network Summary range, assigned as /31 for each uplink interfaces
+# Assign range larger then total [ spines * total potential leafs * 2 ]
+underlay_p2p_network_summary: 172.31.255.0/24
+
+# IP address range for evpn loopback for all switches in fabric, assigned as /32s
+# Assign range larger then total spines + total leafs switches
+overlay_loopback_network_summary: 192.168.255.0/24
+
+# VTEP VXLAN Tunnel source loopback IP for leaf switches, assigned in /32s
+# Assign range larger then total leaf switches
+vtep_loopback_network_summary: 192.168.254.0/24
+
+# mlag pair IP assignment - assign blocks - Assign range larger then total spines + total leafs switches
+mlag_ips:
+  leaf_peer_l3: 10.255.251.0/24
+  mlag_peer: 10.255.252.0/24
+
+# Enable vlan aware bundles
+vxlan_vlan_aware_bundles: true
+
+# bgp peer groups passwords
+bgp_peer_groups:
+  IPv4_UNDERLAY_PEERS:
+    password: "AQQvKeimxJu+uGQ/yYvv9w=="
+  EVPN_OVERLAY_PEERS:
+      password: "q+VNViP5i4rVjW1cxFv2wA=="
+  MLAG_IPv4_UNDERLAY_PEER:
+      password: "vnEaG8gMeQf3d3cN6PktXQ=="
+
+# Spine Switches
+spine:
+  platform: vEOS-LAB
+  bgp_as: 65001
+  leaf_as_range: 65101-65132
+  nodes:
+    DC1-SPINE1:
+      id: 1
+      mgmt_ip: 192.168.200.101/24
+    DC1-SPINE2:
+      id: 2
+      mgmt_ip: 192.168.200.102/24
+    DC1-SPINE3:
+      id: 3
+      mgmt_ip: 192.168.200.103/24
+    DC1-SPINE4:
+      id: 4
+      mgmt_ip: 192.168.200.104/24
+
+# Leaf switch groups
+# A maximum of two nodes can form a leaf group
+# When two nodes are in a leaf group this will automatically form mlag pair
+
+l3leaf:
+  defaults:
+    platform: vEOS-LAB
+    bgp_as: 65100
+    spines: [ DC1-SPINE1, DC1-SPINE2, DC1-SPINE3, DC1-SPINE4 ]
+    uplink_to_spine_interfaces: [ Ethernet1, Ethernet2, Ethernet3, Ethernet4 ]
+    mlag_interfaces: [ Ethernet5, Ethernet6 ]
+    spanning_tree_mode: mstp
+    spanning_tree_priority: 4096
+    virtual_router_mac_address : 00:dc:00:00:00:0a
+  node_groups:
+    DC1_LEAF1:
+      bgp_as: 65101
+      filter:
+        tenants: [ all ]
+        tags: [ web, app ]
+      nodes:
+        DC1-LEAF1A:
+          id: 1
+          mgmt_ip: 192.168.200.105/24
+          spine_interfaces: [ Ethernet1, Ethernet1, Ethernet1, Ethernet1 ]
+    DC1_LEAF2:
+      bgp_as: 65102
+      filter:
+        tenants: [ Tenant_A, Tenant_B, Tenant_C ]
+        tags: [ opzone, web, app, db, vmotion, nfs ]
+      nodes:
+        DC1-LEAF2A:
+          id: 2
+          mgmt_ip: 192.168.200.106/24
+          spine_interfaces: [ Ethernet2, Ethernet2, Ethernet2, Ethernet2 ]
+        DC1-LEAF2B:
+          id: 3
+          mgmt_ip: 192.168.200.107/24
+          spine_interfaces: [ Ethernet3, Ethernet3, Ethernet3, Ethernet3 ]
+    DC1_SVC3:
+      bgp_as: 65103
+      filter:
+        tenants: [ Tenant_A, Tenant_B, Tenant_C ]
+        tags: [ opzone, web, app, db, vmotion, nfs, wan ]
+      nodes:
+        DC1-SVC3A:
+          id: 4
+          mgmt_ip: 192.168.200.108/24
+          spine_interfaces: [ Ethernet4, Ethernet4, Ethernet4, Ethernet4 ]
+        DC1-SVC3B:
+          id: 5
+          mgmt_ip: 192.168.200.109/24
+          spine_interfaces: [ Ethernet5, Ethernet5, Ethernet5, Ethernet5 ]
+    DC1_BL1:
+      bgp_as: 65104
+      filter:
+        tenants: [ all ]
+        tags: [ wan ]
+      nodes:
+        DC1-BL1A:
+          id: 6
+          mgmt_ip: 192.168.200.110/24
+          spine_interfaces: [ Ethernet6, Ethernet6, Ethernet6, Ethernet6 ]
+        DC1-BL1B:
+          id: 7
+          mgmt_ip: 192.168.200.111/24
+          spine_interfaces: [ Ethernet7, Ethernet7, Ethernet7, Ethernet7 ]
+
+l2leaf:
+  defaults:
+    platform: vEOS-LAB
+    parent_l3leafs: [ DC1-SVC3A, DC1-SVC3B ]
+    uplink_interfaces: [ Ethernet1, Ethernet2 ]
+    mlag_interfaces: [ Ethernet3, Ethernet4 ]
+    spanning_tree_mode: mstp
+    spanning_tree_priority: 16384
+  node_groups:
+    DC1_L2LEAF1:
+      parent_l3leafs: [ DC1-LEAF2A, DC1-LEAF2B ]
+      filter:
+        tenants: [ Tenant_A ]
+        tags: [ opzone, web, app ]
+      nodes:
+        DC1-L2LEAF1A:
+          id: 8
+          mgmt_ip: 192.168.200.112/24
+          l3leaf_interfaces: [ Ethernet7, Ethernet7 ]
+    DC1_L2LEAF2:
+      nodes:
+        DC1-L2LEAF2A:
+          id: 9
+          mgmt_ip: 192.168.200.113/24
+          l3leaf_interfaces: [ Ethernet7, Ethernet7 ]
+        DC1-L2LEAF2B:
+          id: 10
+          mgmt_ip: 192.168.200.114/24
+          l3leaf_interfaces: [ Ethernet8, Ethernet8 ]
+
+#### Override for vEOS Lab Caveats ####
+
+# Disable update wait-for-convergence and update wait-for-install, which is not supported in vEOS-LAB.
+
+spine_bgp_defaults:
+#  - update wait-for-convergence
+#  - update wait-install
+  - no bgp default ipv4-unicast
+  - distance bgp 20 200 200
+
+leaf_bgp_defaults:
+#  - update wait-install
+  - no bgp default ipv4-unicast
+  - distance bgp 20 200 200
+
+# Upodate p2p mtu 9000 -> 1500
+p2p_uplinks_mtu: 1500
+
+# Adjust default bfd values
+bfd_multihop:
+  interval: 1200
+  min_rx: 1200
+  multiplier: 3

--- a/ansible_collections/arista/avd/molecule/avd-build/inventory/group_vars/DC1_L2LEAFS.yml
+++ b/ansible_collections/arista/avd/molecule/avd-build/inventory/group_vars/DC1_L2LEAFS.yml
@@ -1,0 +1,1 @@
+type: l2leaf

--- a/ansible_collections/arista/avd/molecule/avd-build/inventory/group_vars/DC1_LEAFS.yml
+++ b/ansible_collections/arista/avd/molecule/avd-build/inventory/group_vars/DC1_LEAFS.yml
@@ -1,0 +1,1 @@
+type: l3leaf

--- a/ansible_collections/arista/avd/molecule/avd-build/inventory/group_vars/DC1_SERVERS.yml
+++ b/ansible_collections/arista/avd/molecule/avd-build/inventory/group_vars/DC1_SERVERS.yml
@@ -1,0 +1,72 @@
+port_profiles:
+
+  TENANT_A_B:
+    mode: trunk
+    vlans: "110-111,210-211"
+
+  TENANT_A:
+    mode: trunk
+    vlans: "110"
+
+  TENANT_B:
+    mode: trunk
+    vlans: "210-211"
+
+
+servers:
+
+  server01:
+    rack: RackB
+    adapters:
+      - server_ports: [ Eth1 ]
+        switch_ports: [ Ethernet5 ]
+        switches: [ DC1-LEAF1A ]
+        profile: TENANT_A
+      - server_ports: [ Eth2, Eth3 ]
+        switch_ports: [ Ethernet10, Ethernet10 ]
+        switches: [ DC1-LEAF2A, DC1-LEAF2B ]
+        profile: TENANT_B
+        port_channel:
+          state: present
+          description: PortChanne1
+          mode: active
+
+  server02:
+    rack: RackB
+    adapters:
+      - server_ports: [ Eth1 ]
+        switch_ports: [ Ethernet6 ]
+        switches: [ DC1-LEAF1A ]
+        profile: TENANT_A
+      - server_ports: [ Eth2, Eth3 ]
+        switch_ports: [ Ethernet11, Ethernet11 ]
+        switches: [ DC1-LEAF2A, DC1-LEAF2B ]
+        profile: TENANT_B
+        port_channel:
+          state: present
+          description: PortChanne1
+          mode: active
+
+  server03:
+    rack: RackC
+    adapters:
+      - server_ports: [ Eth1, Eth2 ]
+        switch_ports: [ Ethernet10, Ethernet10 ]
+        switches: [ DC1-SVC3A, DC1-SVC3B ]
+        profile: TENANT_A_B
+        port_channel:
+          state: present
+          description: PortChanne1
+          mode: active
+
+  server04:
+    rack: RackC
+    adapters:
+      - server_ports: [ Eth1, Eth2 ]
+        switch_ports: [ Ethernet11, Ethernet11 ]
+        switches: [ DC1-SVC3A, DC1-SVC3B ]
+        profile: TENANT_A_B
+        port_channel:
+          state: present
+          description: PortChanne1
+          mode: active

--- a/ansible_collections/arista/avd/molecule/avd-build/inventory/group_vars/DC1_SPINES.yml
+++ b/ansible_collections/arista/avd/molecule/avd-build/inventory/group_vars/DC1_SPINES.yml
@@ -1,0 +1,2 @@
+type: spine
+

--- a/ansible_collections/arista/avd/molecule/avd-build/inventory/group_vars/DC1_TENANTS_NETWORKS.yml
+++ b/ansible_collections/arista/avd/molecule/avd-build/inventory/group_vars/DC1_TENANTS_NETWORKS.yml
@@ -1,0 +1,164 @@
+# DC1 Tenants Networks
+# Documentation of Tenant specific information - Vlans/VRFs
+
+tenants:
+
+# Tenant A Specific Information - VRFs / VLANs
+  Tenant_A:
+    mac_vrf_vni_base: 10000
+    vrfs:
+      Tenant_A_OP_Zone:
+        vrf_vni: 10
+        vtep_diagnostic:
+          loopback: 100
+          loopback_ip_range: 10.255.1.0/24
+        svis:
+          110:
+            name: Tenant_A_OP_Zone_1
+            tags: [ opzone ]
+            enabled: true
+            ip_subnet: 10.1.10.0/24
+          111:
+            vni_override: 50111
+            name: Tenant_A_OP_Zone_2
+            tags: [ opzone ]
+            enabled: true
+            ip_subnet: 10.1.11.0/24
+      Tenant_A_WEB_Zone:
+        vrf_vni: 11
+        svis:
+          120:
+            name: Tenant_A_WEB_Zone_1
+            tags: [ web, erp1 ]
+            enabled: true
+            ip_subnet: 10.1.20.0/24
+          121:
+            name: Tenant_A_WEBZone_2
+            tags: [ web ]
+            enabled: true
+            ip_subnet: 10.1.21.0/24
+      Tenant_A_APP_Zone:
+        vrf_vni: 12
+        svis:
+          130:
+            name: Tenant_A_APP_Zone_1
+            tags: [ app, erp1 ]
+            enabled: true
+            ip_subnet: 10.1.30.0/24
+          131:
+            name: Tenant_A_APP_Zone_2
+            tags: [ app ]
+            enabled: true
+            ip_subnet: 10.1.31.0/24
+      Tenant_A_DB_Zone:
+        vrf_vni: 13
+        svis:
+          140:
+            name: Tenant_A_DB_BZone_1
+            tags: [ db, erp1 ]
+            enabled: true
+            ip_subnet: 10.1.40.0/24
+          141:
+            name: Tenant_A_DB_Zone_2
+            tags: [ db ]
+            enabled: true
+            ip_subnet: 10.1.41.0/24
+      Tenant_A_WAN_Zone:
+        vrf_vni: 14
+        svis:
+          150:
+            name: Tenant_A_WAN_Zone_1
+            tags: [ wan ]
+            enabled: true
+            ip_subnet: 10.1.40.0/24
+    l2vlans:
+      160:
+        vni_override: 50160
+        name: Tenant_A_VMOTION
+        tags: [ vmotion ]
+      161:
+        name: Tenant_A_NFS
+        tags: [ nfs ]
+
+
+# Tenant B Specific Information - VRFs / VLANs
+  Tenant_B:
+    mac_vrf_vni_base: 20000
+    vrfs:
+      Tenant_B_OP_Zone:
+        vrf_vni: 20
+        svis:
+          210:
+            name: Tenant_B_OP_Zone_1
+            tags: [ opzone ]
+            enabled: true
+            ip_subnet: 10.2.10.0/24
+          211:
+            name: Tenant_B_OP_Zone_2
+            tags: [ opzone ]
+            enabled: true
+            ip_subnet: 10.2.11.0/24
+      Tenant_B_WAN_Zone:
+        vrf_vni: 21
+        svis:
+          250:
+            name: Tenant_B_WAN_Zone_1
+            tags: [ wan ]
+            enabled: true
+            ip_subnet: 10.2.50.0/24
+
+
+# Tenant C Specific Information - VRFs / VLANs
+  Tenant_C:
+    mac_vrf_vni_base: 30000
+    vrfs:
+      Tenant_C_OP_Zone:
+        vrf_vni: 30
+        svis:
+          310:
+            name: Tenant_C_OP_Zone_1
+            tags: [ opzone ]
+            enabled: true
+            ip_subnet: 10.3.10.0/24
+          311:
+            name: Tenant_C_OP_Zone_2
+            tags: [ opzone ]
+            enabled: true
+            ip_subnet: 10.3.11.0/24
+      Tenant_C_WAN_Zone:
+        vrf_vni: 31
+        svis:
+          350:
+            name: Tenant_C_WAN_Zone_1
+            tags: [ wan ]
+            enabled: true
+            ip_subnet: 10.3.50.0/24
+  # ansible_demo:
+  #   mac_vrf_vni_base: 40000
+  #   vrfs:
+  #     ansible_web_zone:
+  #       vrf_vni: 30
+  #       svis:
+  #         410:
+  #           name: ansible_demo_app_1
+  #           tags: [ app ]
+  #           enabled: true
+  #           ip_subnet: 10.4.10.0/24
+  #         411:
+  #           name: ansible_demo_app_2
+  #           tags: [ app ]
+  #           enabled: true
+  #           ip_subnet: 10.4.11.0/24
+  #     ansible_db_zone:
+  #       vrf_vni: 31
+  #       svis:
+  #         420:
+  #           name: ansible_demo_db_1
+  #           tags: [ db ]
+  #           enabled: true
+  #           ip_subnet: 10.4.20.0/24
+  #         421:
+  #           name: ansible_demo_db_2
+  #           tags: [ db ]
+  #           enabled: true
+  #           ip_subnet: 10.4.21.0/24

--- a/ansible_collections/arista/avd/molecule/avd-build/inventory/hosts
+++ b/ansible_collections/arista/avd/molecule/avd-build/inventory/hosts
@@ -1,0 +1,61 @@
+all:
+  children:
+    AVD_LAB:
+      children:
+        DC1_FABRIC:
+          children:
+            DC1_SPINES:
+              hosts:
+                DC1-SPINE1:
+                  ansible_host: 192.168.200.101
+                DC1-SPINE2:
+                  ansible_host: 192.168.200.102
+                DC1-SPINE3:
+                  ansible_host: 192.168.200.103
+                DC1-SPINE4:
+                  ansible_host: 192.168.200.104
+            DC1_LEAFS:
+              children:
+                DC1_LEAF1:
+                  hosts:
+                    DC1-LEAF1A:
+                      ansible_host: 192.168.200.105
+                DC1_LEAF2:
+                  hosts:
+                    DC1-LEAF2A:
+                      ansible_host: 192.168.200.106
+                    DC1-LEAF2B:
+                      ansible_host: 192.168.200.107
+                DC1_SVC3:
+                  hosts:
+                    DC1-SVC3A:
+                      ansible_host: 192.168.200.108
+                    DC1-SVC3B:
+                      ansible_host: 192.168.200.109
+                DC1_BL1:
+                  hosts:
+                    DC1-BL1A:
+                      ansible_host: 192.168.200.110
+                    DC1-BL1B:
+                      ansible_host: 192.168.200.111
+            DC1_L2LEAFS:
+              children:
+                DC1_L2LEAF1:
+                  hosts:
+                    DC1-L2LEAF1A:
+                      ansible_host: 192.168.200.112
+                DC1_L2LEAF2:
+                  hosts:
+                    DC1-L2LEAF2A:
+                      ansible_host: 192.168.200.113
+                    DC1-L2LEAF2B:
+                      ansible_host: 192.168.200.114
+        DC1_TENANTS_NETWORKS:
+          children:
+            DC1_LEAFS:
+            DC1_L2LEAFS:
+
+        DC1_SERVERS:
+          children:
+            DC1_LEAFS:
+            DC1_L2LEAFS:

--- a/ansible_collections/arista/avd/molecule/avd-build/molecule.yml
+++ b/ansible_collections/arista/avd/molecule/avd-build/molecule.yml
@@ -1,0 +1,67 @@
+---
+scenario:
+  create_sequence:
+    # - dependency
+    - create
+    - prepare
+  check_sequence:
+    # - dependency
+    # - cleanup
+    - destroy
+    - create
+    - prepare
+    - converge
+    - check
+    - destroy
+  converge_sequence:
+    # - dependency
+    - create
+    - prepare
+    - converge
+    - idempotence
+  destroy_sequence:
+    # - dependency
+    # - cleanup
+    - destroy
+  test_sequence:
+    # - dependency
+    # - lint
+    # - cleanup
+    - destroy
+    - syntax
+    - create
+    # - prepare
+    - converge
+    - idempotence
+    # - side_effect
+    - verify
+    - cleanup
+    - destroy
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: DC1-LEAF1A
+    image: centos:7
+    pre_build_image: true
+    managed: false
+    groups:
+      - DC1_LEAF1
+      - DC1_LEAFS
+      - DC1_FABRIC
+      - AVD_LAB
+provisioner:
+  name: ansible
+  env:
+    ANSIBLE_COLLECTIONS_PATHS: ~/Projects/arista-ansible/ansible-avd/
+  config_options:
+    defaults:
+      jinja2_extensions: 'jinja2.ext.loopcontrols,jinja2.ext.do,jinja2.ext.i18n'
+      gathering: explicit
+  inventory:
+    links:
+      hosts: 'inventory/hosts'
+      group_vars: 'inventory/group_vars/'
+verifier:
+  name: ansible

--- a/ansible_collections/arista/avd/molecule/avd-build/verify.yml
+++ b/ansible_collections/arista/avd/molecule/avd-build/verify.yml
@@ -1,0 +1,9 @@
+---
+# This is an example playbook to execute Ansible tests.
+
+- name: Verify
+  hosts: all
+  tasks:
+  - name: Example assertion
+    assert:
+      that: true


### PR DESCRIPTION
# Implement Molecule for role testing:

## Summary

- scenario: avd-build
- platforms: Not Applicable

Similar mechanism is in test in CVP as well (PR https://github.com/aristanetworks/ansible-cvp/pull/192)

Would help to run unit testing in CI

__Documentation__

- Molecule documentation [website](https://molecule.readthedocs.io/en/latest/)
- Ansible/Red Hat [presentation](https://www.ansible.com/hubfs//AnsibleFest%20ATL%20Slide%20Decks/Practical%20Ansible%20Testing%20with%20Molecule.pdf)

## Types of changes

- [x] Other (please describe): Unit testing

## Proposed changes

Implement a basic testing phase with molecule to validate AVD build process

- Create phase: create local output folders (considering role has been validated in a dedicated molecule)
- Run standard avd playbook to validate execution
- Idempotency test feature enable
- Destroy: remove output folders

__Todo:__

- Create ansible and/or pytest validation.
- Create more scenario to cover all use cases.
- If accepted, update dev requirements to install molecule

## How to test

To install:

```
$ pip install molecule docker
```

To test:

```
$ cd ansible_collections/arista/avd
$ molecule test -s avd-build
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/aristanetworks/ansible-cvp/blob/master/contributing.md#branches) document.
- [x] All new and existing tests passed (`make linting` and `make sanity-lint`).