### PR TITLE
Fix #125 - Add support for tag with no VNI

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vxlan-interface.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vxlan-interface.j2
@@ -8,9 +8,13 @@
 
 | VLAN | VNI |
 | ---- | --- |
-{%     for vlan in vxlan_tunnel_interface.Vxlan1.vxlan_vni_mappings.vlans | arista.avd.natural_sort %}
+{%     if vxlan_tunnel_interface.Vxlan1.vxlan_vni_mappings.vlans is iterable %}
+{%          for vlan in vxlan_tunnel_interface.Vxlan1.vxlan_vni_mappings.vlans | arista.avd.natural_sort %}
 | {{ vlan }} | {{ vxlan_tunnel_interface.Vxlan1.vxlan_vni_mappings.vlans[vlan].vni }} |
-{%     endfor %}
+{%          endfor %}
+{% else %}
+| N/A | N/A |
+{%      endif %}
 {% if vxlan_tunnel_interface.Vxlan1.vxlan_vni_mappings.vrfs is defined and vxlan_tunnel_interface.Vxlan1.vxlan_vni_mappings.vrfs is not none %}
 
 **VRF to VNI Mappings:**

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vxlan-interface.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vxlan-interface.j2
@@ -6,10 +6,12 @@ interface Vxlan1
    vxlan virtual-router encapsulation mac-address {{ vxlan_tunnel_interface.Vxlan1.virtual_router.encapsulation_mac_address }}
 {%     endif %}
    vxlan udp-port {{ vxlan_tunnel_interface.Vxlan1.vxlan_udp_port }}
-{%     for vlan in vxlan_tunnel_interface.Vxlan1.vxlan_vni_mappings.vlans | arista.avd.natural_sort %}
+{%     if vxlan_tunnel_interface.Vxlan1.vxlan_vni_mappings.vlans is iterable %}
+{%          for vlan in vxlan_tunnel_interface.Vxlan1.vxlan_vni_mappings.vlans | arista.avd.natural_sort %}
    vxlan vlan {{ vlan }} vni {{ vxlan_tunnel_interface.Vxlan1.vxlan_vni_mappings.vlans[vlan].vni }}
-{%     endfor %}
-{% if vxlan_tunnel_interface.Vxlan1.vxlan_vni_mappings.vrfs is defined and 
+{%          endfor %}
+{%     endif %}
+{% if vxlan_tunnel_interface.Vxlan1.vxlan_vni_mappings.vrfs is defined and
 vxlan_tunnel_interface.Vxlan1.vxlan_vni_mappings.vrfs is not none %}
 {%     for vrf in vxlan_tunnel_interface.Vxlan1.vxlan_vni_mappings.vrfs | arista.avd.natural_sort %}
    vxlan vrf {{ vrf }} vni {{ vxlan_tunnel_interface.Vxlan1.vxlan_vni_mappings.vrfs[vrf].vni }}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant-evpn-vxlan/leaf-tenant-router-bgp-evpn-vlan-aware-bundles.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant-evpn-vxlan/leaf-tenant-router-bgp-evpn-vlan-aware-bundles.j2
@@ -3,7 +3,7 @@
 {%     for tenant in tenants | arista.avd.natural_sort if tenant in leaf.filter_tenants or "all" in leaf.filter_tenants %}
 ## {{ tenant }} ##
 {%         if tenants[tenant].vrfs is defined %}
-{%             for vrf in tenants[tenant].vrfs | arista.avd.natural_sort if vrf in leaf.vrfs %}
+{%             for vrf in tenants[tenant].vrfs | arista.avd.natural_sort if leaf.vrfs is not none and vrf in leaf.vrfs %}
     {{ vrf }}:
       rd: "{{ overlay_loopback_network_summary | ipaddr('network') | ipmath(leaf.id + spine.nodes | length) }}:{{ tenants[tenant].vrfs[vrf].vrf_vni }}"
       route_targets:
@@ -12,14 +12,14 @@
       redistribute_routes:
         - learned
 {%                 set vlan_range = [] %}
-{%                 for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if svi in leaf.svis %}
+{%                 for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if leaf.svis is not none and svi in leaf.svis %}
 {%                     do vlan_range.append( svi ) %}
 {%                 endfor %}
       vlan: {{ vlan_range | arista.avd.list_compress }}
 {%             endfor %}
 {%         endif %}
 {%         if tenants[tenant].l2vlans is defined %}
-{%             for l2vlan in tenants[tenant].l2vlans | arista.avd.natural_sort if l2vlan in leaf.vlans %}
+{%             for l2vlan in tenants[tenant].l2vlans | arista.avd.natural_sort if leaf.vlans is not none and l2vlan in leaf.vlans %}
     {{ tenants[tenant].l2vlans[l2vlan].name }}:
       tenant: {{ tenant }}
 {%                 if tenants[tenant].l2vlans[l2vlan].vni_override is defined %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant-evpn-vxlan/leaf-tenant-router-bgp-evpn-vlans.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant-evpn-vxlan/leaf-tenant-router-bgp-evpn-vlans.j2
@@ -3,7 +3,7 @@
 {%     for tenant in tenants | arista.avd.natural_sort if tenant in leaf.filter_tenants or "all" in leaf.filter_tenants %}
 ## {{ tenant }} ##
 {%         if tenants[tenant].vrfs is defined %}
-{%             for vrf in tenants[tenant].vrfs | arista.avd.natural_sort if vrf in leaf.vrfs %}
+{%             for vrf in tenants[tenant].vrfs | arista.avd.natural_sort if leaf.vrfs is not none and vrf in leaf.vrfs %}
 {%                 for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if svi in leaf.svis %}
     {{ svi }}:
       tenant: {{ tenant }}
@@ -25,7 +25,7 @@
 {%             endfor %}
 {%         endif %}
 {%         if tenants[tenant].l2vlans is defined %}
-{%             for l2vlan in tenants[tenant].l2vlans | arista.avd.natural_sort if l2vlan in leaf.vlans %}
+{%             for l2vlan in tenants[tenant].l2vlans | arista.avd.natural_sort if leaf.vlans is not none and l2vlan in leaf.vlans %}
     {{ l2vlan }}:
       tenant: {{ tenant }}
 {%                     if tenants[tenant].l2vlans[l2vlan].vni_override is defined %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant-evpn-vxlan/leaf-tenant-router-bgp-evpn-vrfs.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant-evpn-vxlan/leaf-tenant-router-bgp-evpn-vrfs.j2
@@ -2,7 +2,7 @@
 {% for tenant in tenants | arista.avd.natural_sort if tenant in leaf.filter_tenants or "all" in leaf.filter_tenants %}
 ## {{ tenant }} ##
 {%     if tenants[tenant].vrfs is defined %}
-{%         for vrf in tenants[tenant].vrfs | arista.avd.natural_sort if vrf in leaf.vrfs %}
+{%         for vrf in tenants[tenant].vrfs | arista.avd.natural_sort if leaf.vrfs is not none and vrf in leaf.vrfs %}
     {{ vrf }}:
       router_id: {{ overlay_loopback_network_summary | ipaddr('network') | ipmath(leaf.id + spine.nodes | length) }}
       rd: "{{ overlay_loopback_network_summary | ipaddr('network') | ipmath(leaf.id + spine.nodes | length) }}:{{ tenants[tenant].vrfs[vrf].vrf_vni }}"

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant-evpn-vxlan/leaf-tenant-virtual-source-nat-vrfs.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant-evpn-vxlan/leaf-tenant-virtual-source-nat-vrfs.j2
@@ -1,7 +1,7 @@
 {# Tenant virtual source NAT vrfs #}
 {% for tenant in tenants | arista.avd.natural_sort if tenant in leaf.filter_tenants or "all" in leaf.filter_tenants %}
 {%     if tenants[tenant].vrfs is defined %}
-{%         for vrf in tenants[tenant].vrfs | arista.avd.natural_sort if vrf in leaf.vrfs %}
+{%         for vrf in tenants[tenant].vrfs | arista.avd.natural_sort if leaf.vrfs is not none and vrf in leaf.vrfs %}
 {%             if tenants[tenant].vrfs[vrf].vtep_diagnostic is defined %}
 {%                 if loop.first %}
 ## {{ tenant }} ##

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant-evpn-vxlan/leaf-tenant-vlans.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant-evpn-vxlan/leaf-tenant-vlans.j2
@@ -2,9 +2,9 @@
 {% for tenant in tenants | arista.avd.natural_sort if tenant in leaf.filter_tenants or "all" in leaf.filter_tenants %}
 ## {{ tenant }} ##
 {%     if tenants[tenant].vrfs is defined %}
-{%         for vrf in tenants[tenant].vrfs | arista.avd.natural_sort if vrf in leaf.vrfs %}
+{%         for vrf in tenants[tenant].vrfs | arista.avd.natural_sort if leaf.vrfs is not none and vrf in leaf.vrfs %}
 {# Tenant VLANs w/SVIs #}
-{%             for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if svi in leaf.svis %}
+{%             for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if leaf.svis is not none and svi in leaf.svis %}
   {{ svi }}:
     tenant: {{ tenant }}
     name: {{ tenants[tenant].vrfs[vrf].svis[svi].name }}
@@ -21,7 +21,7 @@
 {%     endif %}
 {# Tenant L2 VLANs #}
 {%     if tenants[tenant].l2vlans is defined %}
-{%         for l2vlan in tenants[tenant].l2vlans | arista.avd.natural_sort if l2vlan in leaf.vlans %}
+{%         for l2vlan in tenants[tenant].l2vlans | arista.avd.natural_sort if leaf.vlans is not none and l2vlan in leaf.vlans %}
   {{ l2vlan }}:
     tenant: {{ tenant }}
     name: {{ tenants[tenant].l2vlans[l2vlan].name }}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant-evpn-vxlan/leaf-tenant-vrf-loopbacks.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant-evpn-vxlan/leaf-tenant-vrf-loopbacks.j2
@@ -1,7 +1,7 @@
 {# Leaf Tenant vrf loopback interfaces for VTEP diagnostic #}
 {% for tenant in tenants | arista.avd.natural_sort if tenant in leaf.filter_tenants or "all" in leaf.filter_tenants %}
 {%     if tenants[tenant].vrfs is defined %}
-{%         for vrf in tenants[tenant].vrfs | arista.avd.natural_sort if vrf in leaf.vrfs %}
+{%         for vrf in tenants[tenant].vrfs | arista.avd.natural_sort if leaf.vrfs is not none and vrf in leaf.vrfs %}
 {%             if tenants[tenant].vrfs[vrf].vtep_diagnostic is defined %}
 {%                 if loop.first %}
 ## {{ tenant }} ##

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant-evpn-vxlan/leaf-vxlan-vtep-interface.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant-evpn-vxlan/leaf-vxlan-vtep-interface.j2
@@ -12,8 +12,8 @@
 {% for tenant in tenants | arista.avd.natural_sort if tenant in leaf.filter_tenants or "all" in leaf.filter_tenants %}
 ## {{ tenant }} ##
 {%     if tenants[tenant].vrfs is defined %}
-{%         for vrf in tenants[tenant].vrfs | arista.avd.natural_sort if vrf in leaf.vrfs %}
-{%             for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if svi in leaf.svis %}
+{%         for vrf in tenants[tenant].vrfs | arista.avd.natural_sort if leaf.vrfs is not none and vrf in leaf.vrfs %}
+{%             for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if leaf.svis is not none and svi in leaf.svis %}
         {{ svi }}:
 {%                 if tenants[tenant].vrfs[vrf].svis[svi].vni_override is defined %}
           vni: {{ tenants[tenant].vrfs[vrf].svis[svi].vni_override }}
@@ -24,7 +24,7 @@
 {%         endfor %}
 {%     endif %}
 {%     if tenants[tenant].l2vlans is defined %}
-{%         for l2vlan in tenants[tenant].l2vlans | arista.avd.natural_sort if l2vlan in leaf.vlans %}
+{%         for l2vlan in tenants[tenant].l2vlans | arista.avd.natural_sort if leaf.vlans is not none and l2vlan in leaf.vlans %}
         {{ l2vlan }}:
 {%              if tenants[tenant].l2vlans[l2vlan].vni_override is defined %}
           vni: {{ tenants[tenant].l2vlans[l2vlan].vni_override }}
@@ -38,7 +38,7 @@
 {% for tenant in tenants | arista.avd.natural_sort if tenant in leaf.filter_tenants or "all" in leaf.filter_tenants %}
 ## {{ tenant }} ##
 {%     if tenants[tenant].vrfs is defined %}
-{%         for vrf in tenants[tenant].vrfs | arista.avd.natural_sort if vrf in leaf.vrfs %}
+{%         for vrf in tenants[tenant].vrfs | arista.avd.natural_sort if leaf.vrfs is not none and vrf in leaf.vrfs %}
         {{ vrf }}:
           vni: {{ tenants[tenant].vrfs[vrf].vrf_vni }}
 {%         endfor %}

--- a/testing/avd-no-svi-in-tag-125/ansible.cfg
+++ b/testing/avd-no-svi-in-tag-125/ansible.cfg
@@ -1,0 +1,17 @@
+[defaults]
+host_key_checking = False
+inventory =./inventory.yml
+gathering = explicit
+retry_files_enabled = False
+collections_paths = ../../
+jinja2_extensions =  jinja2.ext.loopcontrols,jinja2.ext.do,jinja2.ext.i18n
+# enable the YAML callback plugin.
+stdout_callback = yaml
+# enable the stdout_callback when running ad-hoc commands.
+bin_ansible_callbacks = True
+forks = 15
+callback_whitelist = profile_roles, profile_tasks, timer
+
+[persistent_connection]
+connect_timeout = 120
+command_timeout = 120

--- a/testing/avd-no-svi-in-tag-125/group_vars/AVD_LAB.yml
+++ b/testing/avd-no-svi-in-tag-125/group_vars/AVD_LAB.yml
@@ -1,0 +1,31 @@
+# Nashua EVE-NG LAB shared attributes
+
+# local users
+local_users:
+  admin:
+    privilege: 15
+    role: network-admin
+    sha512_password: "$6$Df86J4/SFMDE3/1K$Hef4KstdoxNDaami37cBquTWOTplC.miMPjXVgQxMe92.e5wxlnXOLlebgPj8Fz1KO0za/RCO7ZIs4Q6Eiq1g1"
+
+  cvpadmin:
+    privilege: 15
+    role: network-admin
+    sha512_password: "$6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj."
+
+# Cloud Vision server
+cvp_instance_ips:
+  - 192.168.200.11
+
+cvp_ingestauth_key: telarista
+
+# OOB Management network default gateway.
+mgmt_gateway: 192.168.200.5
+
+# dns servers.
+name_servers:
+ - 192.168.200.5
+ - 8.8.8.8
+
+# NTP Servers IP or DNS name, first NTP server will be prefered, and sourced from Managment
+ntp_servers:
+  - 192.168.200.5

--- a/testing/avd-no-svi-in-tag-125/group_vars/DC1_FABRIC.yml
+++ b/testing/avd-no-svi-in-tag-125/group_vars/DC1_FABRIC.yml
@@ -1,0 +1,175 @@
+---
+
+# L3LS Fabric Values - update these values with caution, some changes could be disruptive.
+
+fabric_name: DC1_FABRIC
+
+# Point to Point Network Summary range, assigned as /31 for each uplink interfaces
+# Assign range larger then total [ spines * total potential leafs * 2 ]
+underlay_p2p_network_summary: 172.31.255.0/24
+
+# IP address range for evpn loopback for all switches in fabric, assigned as /32s
+# Assign range larger then total spines + total leafs switches
+overlay_loopback_network_summary: 192.168.255.0/24
+
+# VTEP VXLAN Tunnel source loopback IP for leaf switches, assigned in /32s
+# Assign range larger then total leaf switches
+vtep_loopback_network_summary: 192.168.254.0/24
+
+# mlag pair IP assignment - assign blocks - Assign range larger then total spines + total leafs switches
+mlag_ips:
+  leaf_peer_l3: 10.255.251.0/24
+  mlag_peer: 10.255.252.0/24
+
+# Enable vlan aware bundles
+vxlan_vlan_aware_bundles: true
+
+# bgp peer groups passwords
+bgp_peer_groups:
+  IPv4_UNDERLAY_PEERS:
+    password: "AQQvKeimxJu+uGQ/yYvv9w=="
+  EVPN_OVERLAY_PEERS:
+      password: "q+VNViP5i4rVjW1cxFv2wA=="
+  MLAG_IPv4_UNDERLAY_PEER:
+      password: "vnEaG8gMeQf3d3cN6PktXQ=="
+
+# Spine Switches
+spine:
+  platform: vEOS-LAB
+  bgp_as: 65001
+  leaf_as_range: 65101-65132
+  nodes:
+    DC1-SPINE1:
+      id: 1
+      mgmt_ip: 192.168.200.101/24
+    DC1-SPINE2:
+      id: 2
+      mgmt_ip: 192.168.200.102/24
+    DC1-SPINE3:
+      id: 3
+      mgmt_ip: 192.168.200.103/24
+    DC1-SPINE4:
+      id: 4
+      mgmt_ip: 192.168.200.104/24
+
+# Leaf switch groups
+# A maximum of two nodes can form a leaf group
+# When two nodes are in a leaf group this will automatically form mlag pair
+
+l3leaf:
+  defaults:
+    platform: vEOS-LAB
+    bgp_as: 65100
+    spines: [ DC1-SPINE1, DC1-SPINE2, DC1-SPINE3, DC1-SPINE4 ]
+    uplink_to_spine_interfaces: [ Ethernet1, Ethernet2, Ethernet3, Ethernet4 ]
+    mlag_interfaces: [ Ethernet5, Ethernet6 ]
+    spanning_tree_mode: mstp
+    spanning_tree_priority: 4096
+    virtual_router_mac_address : 00:dc:00:00:00:0a
+  node_groups:
+    DC1_LEAF1:
+      bgp_as: 65101
+      filter:
+        tenants: [ all ]
+        tags: [ web, app ]
+      nodes:
+        DC1-LEAF1A:
+          id: 1
+          mgmt_ip: 192.168.200.105/24
+          spine_interfaces: [ Ethernet1, Ethernet1, Ethernet1, Ethernet1 ]
+    DC1_LEAF2:
+      bgp_as: 65102
+      filter:
+        tenants: [ Tenant_A, Tenant_B, Tenant_C ]
+        tags: [ opzone, web, app, db, vmotion, nfs ]
+      nodes:
+        DC1-LEAF2A:
+          id: 2
+          mgmt_ip: 192.168.200.106/24
+          spine_interfaces: [ Ethernet2, Ethernet2, Ethernet2, Ethernet2 ]
+        DC1-LEAF2B:
+          id: 3
+          mgmt_ip: 192.168.200.107/24
+          spine_interfaces: [ Ethernet3, Ethernet3, Ethernet3, Ethernet3 ]
+    DC1_SVC3:
+      bgp_as: 65103
+      filter:
+        tenants: [ Tenant_A, Tenant_B, Tenant_C ]
+        tags: [ opzone, web, app, db, vmotion, nfs, wan ]
+      nodes:
+        DC1-SVC3A:
+          id: 4
+          mgmt_ip: 192.168.200.108/24
+          spine_interfaces: [ Ethernet4, Ethernet4, Ethernet4, Ethernet4 ]
+        DC1-SVC3B:
+          id: 5
+          mgmt_ip: 192.168.200.109/24
+          spine_interfaces: [ Ethernet5, Ethernet5, Ethernet5, Ethernet5 ]
+    DC1_BL1:
+      bgp_as: 65104
+      filter:
+        tenants: [ all ]
+        tags: [ border ]
+      nodes:
+        DC1-BL1A:
+          id: 6
+          mgmt_ip: 192.168.200.110/24
+          spine_interfaces: [ Ethernet6, Ethernet6, Ethernet6, Ethernet6 ]
+        DC1-BL1B:
+          id: 7
+          mgmt_ip: 192.168.200.111/24
+          spine_interfaces: [ Ethernet7, Ethernet7, Ethernet7, Ethernet7 ]
+
+l2leaf:
+  defaults:
+    platform: vEOS-LAB
+    parent_l3leafs: [ DC1-SVC3A, DC1-SVC3B ]
+    uplink_interfaces: [ Ethernet1, Ethernet2 ]
+    mlag_interfaces: [ Ethernet3, Ethernet4 ]
+    spanning_tree_mode: mstp
+    spanning_tree_priority: 16384
+  node_groups:
+    DC1_L2LEAF1:
+      parent_l3leafs: [ DC1-LEAF2A, DC1-LEAF2B ]
+      filter:
+        tenants: [ Tenant_A ]
+        tags: [ opzone, web, app ]
+      nodes:
+        DC1-L2LEAF1A:
+          id: 8
+          mgmt_ip: 192.168.200.112/24
+          l3leaf_interfaces: [ Ethernet7, Ethernet7 ]
+    DC1_L2LEAF2:
+      nodes:
+        DC1-L2LEAF2A:
+          id: 9
+          mgmt_ip: 192.168.200.113/24
+          l3leaf_interfaces: [ Ethernet7, Ethernet7 ]
+        DC1-L2LEAF2B:
+          id: 10
+          mgmt_ip: 192.168.200.114/24
+          l3leaf_interfaces: [ Ethernet8, Ethernet8 ]
+
+#### Override for vEOS Lab Caveats ####
+
+# Disable update wait-for-convergence and update wait-for-install, which is not supported in vEOS-LAB.
+
+spine_bgp_defaults:
+#  - update wait-for-convergence
+#  - update wait-install
+  - no bgp default ipv4-unicast
+  - distance bgp 20 200 200
+
+leaf_bgp_defaults:
+#  - update wait-install
+  - no bgp default ipv4-unicast
+  - distance bgp 20 200 200
+
+# Upodate p2p mtu 9000 -> 1500
+p2p_uplinks_mtu: 1500
+
+# Adjust default bfd values
+bfd_multihop:
+  interval: 1200
+  min_rx: 1200
+  multiplier: 3

--- a/testing/avd-no-svi-in-tag-125/group_vars/DC1_L2LEAFS.yml
+++ b/testing/avd-no-svi-in-tag-125/group_vars/DC1_L2LEAFS.yml
@@ -1,0 +1,1 @@
+type: l2leaf

--- a/testing/avd-no-svi-in-tag-125/group_vars/DC1_LEAFS.yml
+++ b/testing/avd-no-svi-in-tag-125/group_vars/DC1_LEAFS.yml
@@ -1,0 +1,1 @@
+type: l3leaf

--- a/testing/avd-no-svi-in-tag-125/group_vars/DC1_SERVERS.yml
+++ b/testing/avd-no-svi-in-tag-125/group_vars/DC1_SERVERS.yml
@@ -1,0 +1,72 @@
+port_profiles:
+
+  TENANT_A_B:
+    mode: trunk
+    vlans: "110-111,210-211"
+
+  TENANT_A:
+    mode: trunk
+    vlans: "110"
+
+  TENANT_B:
+    mode: trunk
+    vlans: "210-211"
+
+
+servers:
+
+  server01:
+    rack: RackB
+    adapters:
+      - server_ports: [ Eth1 ]
+        switch_ports: [ Ethernet5 ]
+        switches: [ DC1-LEAF1A ]
+        profile: TENANT_A
+      - server_ports: [ Eth2, Eth3 ]
+        switch_ports: [ Ethernet10, Ethernet10 ]
+        switches: [ DC1-LEAF2A, DC1-LEAF2B ]
+        profile: TENANT_B
+        port_channel:
+          state: present
+          description: PortChanne1
+          mode: active
+
+  server02:
+    rack: RackB
+    adapters:
+      - server_ports: [ Eth1 ]
+        switch_ports: [ Ethernet6 ]
+        switches: [ DC1-LEAF1A ]
+        profile: TENANT_A
+      - server_ports: [ Eth2, Eth3 ]
+        switch_ports: [ Ethernet11, Ethernet11 ]
+        switches: [ DC1-LEAF2A, DC1-LEAF2B ]
+        profile: TENANT_B
+        port_channel:
+          state: present
+          description: PortChanne1
+          mode: active
+
+  server03:
+    rack: RackC
+    adapters:
+      - server_ports: [ Eth1, Eth2 ]
+        switch_ports: [ Ethernet10, Ethernet10 ]
+        switches: [ DC1-SVC3A, DC1-SVC3B ]
+        profile: TENANT_A_B
+        port_channel:
+          state: present
+          description: PortChanne1
+          mode: active
+
+  server04:
+    rack: RackC
+    adapters:
+      - server_ports: [ Eth1, Eth2 ]
+        switch_ports: [ Ethernet11, Ethernet11 ]
+        switches: [ DC1-SVC3A, DC1-SVC3B ]
+        profile: TENANT_A_B
+        port_channel:
+          state: present
+          description: PortChanne1
+          mode: active

--- a/testing/avd-no-svi-in-tag-125/group_vars/DC1_SPINES.yml
+++ b/testing/avd-no-svi-in-tag-125/group_vars/DC1_SPINES.yml
@@ -1,0 +1,2 @@
+type: spine
+

--- a/testing/avd-no-svi-in-tag-125/group_vars/DC1_TENANTS_NETWORKS.yml
+++ b/testing/avd-no-svi-in-tag-125/group_vars/DC1_TENANTS_NETWORKS.yml
@@ -1,0 +1,164 @@
+# DC1 Tenants Networks
+# Documentation of Tenant specific information - Vlans/VRFs
+
+tenants:
+
+# Tenant A Specific Information - VRFs / VLANs
+  Tenant_A:
+    mac_vrf_vni_base: 10000
+    vrfs:
+      Tenant_A_OP_Zone:
+        vrf_vni: 10
+        vtep_diagnostic:
+          loopback: 100
+          loopback_ip_range: 10.255.1.0/24
+        svis:
+          110:
+            name: Tenant_A_OP_Zone_1
+            tags: [ opzone ]
+            enabled: true
+            ip_subnet: 10.1.10.0/24
+          111:
+            vni_override: 50111
+            name: Tenant_A_OP_Zone_2
+            tags: [ opzone ]
+            enabled: true
+            ip_subnet: 10.1.11.0/24
+      Tenant_A_WEB_Zone:
+        vrf_vni: 11
+        svis:
+          120:
+            name: Tenant_A_WEB_Zone_1
+            tags: [ web, erp1 ]
+            enabled: true
+            ip_subnet: 10.1.20.0/24
+          121:
+            name: Tenant_A_WEBZone_2
+            tags: [ web ]
+            enabled: true
+            ip_subnet: 10.1.21.0/24
+      Tenant_A_APP_Zone:
+        vrf_vni: 12
+        svis:
+          130:
+            name: Tenant_A_APP_Zone_1
+            tags: [ app, erp1 ]
+            enabled: true
+            ip_subnet: 10.1.30.0/24
+          131:
+            name: Tenant_A_APP_Zone_2
+            tags: [ app ]
+            enabled: true
+            ip_subnet: 10.1.31.0/24
+      Tenant_A_DB_Zone:
+        vrf_vni: 13
+        svis:
+          140:
+            name: Tenant_A_DB_BZone_1
+            tags: [ db, erp1 ]
+            enabled: true
+            ip_subnet: 10.1.40.0/24
+          141:
+            name: Tenant_A_DB_Zone_2
+            tags: [ db ]
+            enabled: true
+            ip_subnet: 10.1.41.0/24
+      Tenant_A_WAN_Zone:
+        vrf_vni: 14
+        svis:
+          150:
+            name: Tenant_A_WAN_Zone_1
+            tags: [ wan ]
+            enabled: true
+            ip_subnet: 10.1.40.0/24
+    l2vlans:
+      160:
+        vni_override: 50160
+        name: Tenant_A_VMOTION
+        tags: [ vmotion ]
+      161:
+        name: Tenant_A_NFS
+        tags: [ nfs ]
+
+
+# Tenant B Specific Information - VRFs / VLANs
+  Tenant_B:
+    mac_vrf_vni_base: 20000
+    vrfs:
+      Tenant_B_OP_Zone:
+        vrf_vni: 20
+        svis:
+          210:
+            name: Tenant_B_OP_Zone_1
+            tags: [ opzone ]
+            enabled: true
+            ip_subnet: 10.2.10.0/24
+          211:
+            name: Tenant_B_OP_Zone_2
+            tags: [ opzone ]
+            enabled: true
+            ip_subnet: 10.2.11.0/24
+      Tenant_B_WAN_Zone:
+        vrf_vni: 21
+        svis:
+          250:
+            name: Tenant_B_WAN_Zone_1
+            tags: [ wan ]
+            enabled: true
+            ip_subnet: 10.2.50.0/24
+
+
+# Tenant C Specific Information - VRFs / VLANs
+  Tenant_C:
+    mac_vrf_vni_base: 30000
+    vrfs:
+      Tenant_C_OP_Zone:
+        vrf_vni: 30
+        svis:
+          310:
+            name: Tenant_C_OP_Zone_1
+            tags: [ opzone ]
+            enabled: true
+            ip_subnet: 10.3.10.0/24
+          311:
+            name: Tenant_C_OP_Zone_2
+            tags: [ opzone ]
+            enabled: true
+            ip_subnet: 10.3.11.0/24
+      Tenant_C_WAN_Zone:
+        vrf_vni: 31
+        svis:
+          350:
+            name: Tenant_C_WAN_Zone_1
+            tags: [ wan ]
+            enabled: true
+            ip_subnet: 10.3.50.0/24
+  # ansible_demo:
+  #   mac_vrf_vni_base: 40000
+  #   vrfs:
+  #     ansible_web_zone:
+  #       vrf_vni: 30
+  #       svis:
+  #         410:
+  #           name: ansible_demo_app_1
+  #           tags: [ app ]
+  #           enabled: true
+  #           ip_subnet: 10.4.10.0/24
+  #         411:
+  #           name: ansible_demo_app_2
+  #           tags: [ app ]
+  #           enabled: true
+  #           ip_subnet: 10.4.11.0/24
+  #     ansible_db_zone:
+  #       vrf_vni: 31
+  #       svis:
+  #         420:
+  #           name: ansible_demo_db_1
+  #           tags: [ db ]
+  #           enabled: true
+  #           ip_subnet: 10.4.20.0/24
+  #         421:
+  #           name: ansible_demo_db_2
+  #           tags: [ db ]
+  #           enabled: true
+  #           ip_subnet: 10.4.21.0/24

--- a/testing/avd-no-svi-in-tag-125/inventory.yml
+++ b/testing/avd-no-svi-in-tag-125/inventory.yml
@@ -1,0 +1,76 @@
+all:
+  children:
+    AVD_LAB:
+      children:
+        CVP:
+          hosts:
+            AVD-CVP-1:
+# DC1 Fabric
+        DC1_FABRIC:
+          children:
+            DC1_SPINES:
+              hosts:
+                DC1-SPINE1:
+                  ansible_host: 192.168.200.101
+                DC1-SPINE2:
+                  ansible_host: 192.168.200.102
+                DC1-SPINE3:
+                  ansible_host: 192.168.200.103
+                DC1-SPINE4:
+                  ansible_host: 192.168.200.104
+            DC1_LEAFS:
+              children:
+                DC1_LEAF1:
+                  hosts:
+                    DC1-LEAF1A:
+                      ansible_host: 192.168.200.105
+                DC1_LEAF2:
+                  hosts:
+                    DC1-LEAF2A:
+                      ansible_host: 192.168.200.106
+                    DC1-LEAF2B:
+                      ansible_host: 192.168.200.107
+                DC1_SVC3:
+                  hosts:
+                    DC1-SVC3A:
+                      ansible_host: 192.168.200.108
+                    DC1-SVC3B:
+                      ansible_host: 192.168.200.109
+                DC1_BL1:
+                  hosts:
+                    DC1-BL1A:
+                      ansible_host: 192.168.200.110
+                    DC1-BL1B:
+                      ansible_host: 192.168.200.111
+            DC1_L2LEAFS:
+              children:
+                DC1_L2LEAF1:
+                  hosts:
+                    DC1-L2LEAF1A:
+                      ansible_host: 192.168.200.112
+                DC1_L2LEAF2:
+                  hosts:
+                    DC1-L2LEAF2A:
+                      ansible_host: 192.168.200.113
+                    DC1-L2LEAF2B:
+                      ansible_host: 192.168.200.114
+          vars:
+            ansible_connection: httpapi
+            ansible_network_os: eos
+            ansible_user: admin
+            # should use vault for passwords - leaving un-encrypted for ease of sharing for labs
+            ansible_ssh_pass: arista123
+            ansible_become: yes
+            ansible_become_method: enable
+            ansible_httpapi_use_ssl: true
+            ansible_httpapi_validate_certs: false
+
+        DC1_TENANTS_NETWORKS:
+          children:
+            DC1_LEAFS:
+            DC1_L2LEAFS:
+
+        DC1_SERVERS:
+          children:
+            DC1_LEAFS:
+            DC1_L2LEAFS:

--- a/testing/avd-no-svi-in-tag-125/playbook-validation.yml
+++ b/testing/avd-no-svi-in-tag-125/playbook-validation.yml
@@ -1,0 +1,15 @@
+- hosts: DC1_FABRIC
+  tasks:
+    - name: create local output folders
+      tags: build
+      import_role:
+         name: arista.avd.build_output_folders
+      run_once: true
+
+    - name: generate intented variables
+      import_role:
+         name: arista.avd.eos_l3ls_evpn
+
+    - name: generate device intended config and documention
+      import_role:
+         name: arista.avd.eos_cli_config_gen


### PR DESCRIPTION
Implement template protections to allow {{filter.tags}} defined with no
VNIs attached.

Changes
-------

- eos_l3ls_evpn:
  - for leaf.(vrfs|svis|vlans), add protection

```
if leaf.vrfs is not none and vrf in leaf.vrfs
```

- eos_cli_config_gen:
  - Implement protection in vxlan-interface.j2 for intended
  configuration:
```
if vxlan_tunnel_interface.Vxlan1.vxlan_vni_mappings.vlans is iterable
```
  - implement a switch for documentation in vxlan-interface.j2

```
{%     if vxlan_tunnel_interface.Vxlan1.vxlan_vni_mappings.vlans is iterable %}
{%          for vlan in vxlan_tunnel_interface.Vxlan1.vxlan_vni_mappings.vlans | arista.avd.natural_sort %}
| {{ vlan }} | {{ vxlan_tunnel_interface.Vxlan1.vxlan_vni_mappings.vlans[vlan].vni }} |
{%          endfor %}
{% else %}
| N/A | N/A |
{%      endif %}
```

Tests cases:
------------

- Only L#LEAF with a tag set to `border` and neither SVI nor l2vlans: OK
- L3LEAF and L2LEAF with tag set to `border` and neither SVI nor
l2vlans: OK

Test Report
-----------

- __Group_vars overview__

```yaml
l3leaf:
  defaults:
    # virtual router mac for VNIs assigned to Leaf switches
    # format: xx:xx:xx:xx:xx:xx
    virtual_router_mac_address: 00:1c:73:00:dc:01
    platform: vEOS-LAB
    bgp_as: 65100
    spines: [DC1-SPINE1, DC1-SPINE2]
    uplink_to_spine_interfaces: [Ethernet1, Ethernet2]
    mlag_interfaces: [Ethernet3, Ethernet4]
    spanning_tree_priority: 4096
    spanning_tree_mode: mstp
  node_groups:
    DC1_LEAF1:
      bgp_as: 65101
      filter:
        tenants: [ Tenant_A ]
        # tags: [ opzone, web, app ]
        tags: [ border ]
```

- __Intended structured configuration for VXLAN__

```yaml
### VLANs ###
vlans:
## mlag vlans ##
  4093:
    tenant: system
    name: LEAF_PEER_L3
    trunk_groups:
      - LEAF_PEER_L3
  4094:
    tenant: system
    name: MLAG_PEER
    trunk_groups:
      - MLAG

## Tenant_A ##

### VRFs ###
vrfs:
  MGMT:
    ip_routing: False

### VxLAN interface ###
vxlan_tunnel_interface:
  Vxlan1:
    description: DC1-LEAF1A_VTEP
    source_interface: Loopback1
    virtual_router:
      encapsulation_mac_address: "mlag-system-id"
    vxlan_udp_port: 4789
    vxlan_vni_mappings:
      vlans:
## Tenant_A ##
      vrfs:
## Tenant_A ##

```

- __VXLAN Interface configuration__

```
interface Vxlan1
   vxlan source-interface Loopback1
   vxlan virtual-router encapsulation mac-address mlag-system-id
   vxlan udp-port 4789
!
```
