### PR TITLE
Features/refactor tenant networking 1

### DIFF
--- a/.github/workflows/ansible_test.yml
+++ b/.github/workflows/ansible_test.yml
@@ -1,8 +1,10 @@
 name: Ansible Test
-on: 
+on:
   pull_request:
     branches:
-      - master
+      - 'devel'
+      - 'master'
+      - 'releases/*'
 jobs:
   'ansible-test':
     name: Run ansible-test validation
@@ -11,7 +13,7 @@ jobs:
       - uses: actions/checkout@master
       - name: Setup Python 3 on runner
         uses: actions/setup-python@v1.2.0
-        with: 
+        with:
           python-version: '3.x'
       - name: 'Install requirements'
         run: make github-configure-ci

--- a/.github/workflows/playbook_validation.yml
+++ b/.github/workflows/playbook_validation.yml
@@ -2,6 +2,7 @@ name: Ansible Execution
 on:
   pull_request:
     branches:
+      - 'devel'
       - 'master'
       - 'releases/*'
 jobs:
@@ -12,7 +13,7 @@ jobs:
       - uses: actions/checkout@master
       - name: Setup Python 3 on runner
         uses: actions/setup-python@v1.2.0
-        with: 
+        with:
           python-version: '3.x'
       - name: 'Install requirements'
         run: make install-requirements-generic

--- a/Makefile
+++ b/Makefile
@@ -35,13 +35,13 @@ sanity-info: ## Show information about ansible-test
 .PHONY: sanity-lint
 sanity-lint: ## Run ansible-test sanity for code sanity
 	cd ansible_collections/arista/avd/ ; \
-	mkdir tests \
+	mkdir tests ; \
 	ansible-test sanity --requirements --$(ANSIBLE_TEST_MODE) --skip-test import
 
 .PHONY: sanity-import
 sanity-import: ## Run ansible-test sanity for code import
 	cd ansible_collections/arista/avd/ ; \
-	mkdir tests \
+	mkdir tests ; \
 	ansible-test sanity --requirements --$(ANSIBLE_TEST_MODE) --test import
 
 #########################################

--- a/Makefile
+++ b/Makefile
@@ -35,11 +35,13 @@ sanity-info: ## Show information about ansible-test
 .PHONY: sanity-lint
 sanity-lint: ## Run ansible-test sanity for code sanity
 	cd ansible_collections/arista/avd/ ; \
+	mkdir tests \
 	ansible-test sanity --requirements --$(ANSIBLE_TEST_MODE) --skip-test import
 
 .PHONY: sanity-import
 sanity-import: ## Run ansible-test sanity for code import
 	cd ansible_collections/arista/avd/ ; \
+	mkdir tests \
 	ansible-test sanity --requirements --$(ANSIBLE_TEST_MODE) --test import
 
 #########################################

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -344,7 +344,9 @@ vlan_interfaces:
     vrf: < vrf_name >
     ip_address: < IPv4_address/Mask >
     ip_address_secondary: < IPv4_address/Mask >
-    virtual: < true | false >
+    ip_router_virtual_address: < IPv4_address >
+    ip_router_virtual_address_secondary: < IPv4_address >
+    ip_address_virtual: < IPv4_address/Mask >
     ospf_network_point_to_point: < true | false >
     ospf_area: < ospf_area >
     mtu: < mtu >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vlan-interfaces.j2
@@ -1,14 +1,14 @@
 {% if vlan_interfaces is defined and vlan_interfaces is not none %}
 ### VLAN Interfaces Summary
 
-| Interface | Description | VRF | IP Address | Virtual | IP Address Secondary | Virtual |
-| --------- | ----------- | --- | ---------- | ------- | -------------------- | ------- |
+| Interface | Description | VRF | IP Address | IP Address Virtual | IP Router Virtual Address (vARP) |
+| --------- | ----------- | --- | ---------- | ------------------ | -------------------------------- |
 {%     for vlan_interface in vlan_interfaces | arista.avd.natural_sort %}
 | {{ vlan_interface }} | {{ vlan_interfaces[vlan_interface].description }} |
-{%-        if vlan_interfaces[vlan_interface].vrf is defined %} {{ vlan_interfaces[vlan_interface].vrf }} {% else %} Global Routing Table {% endif %} | {{ vlan_interfaces[vlan_interface].ip_address }} |
-{%-        if vlan_interfaces[vlan_interface].ip_address is defined and vlan_interfaces[vlan_interface].virtual is defined and vlan_interfaces[vlan_interface].virtual == true  %} True {% else %} - {% endif -%} |
-{%-        if vlan_interfaces[vlan_interface].ip_address_secondary is defined %} {{ vlan_interfaces[vlan_interface].ip_address_secondary }} {% else %} - {% endif -%} |
-{%-        if vlan_interfaces[vlan_interface].ip_address_secondary is defined and vlan_interfaces[vlan_interface].virtual is defined and vlan_interfaces[vlan_interface].virtual == true  %} True {% else %} - {% endif -%} |
+{%-        if vlan_interfaces[vlan_interface].vrf is defined %} {{ vlan_interfaces[vlan_interface].vrf }} {% else %} Global Routing Table {% endif -%} |
+{%-        if vlan_interfaces[vlan_interface].ip_address is defined %} {{ vlan_interfaces[vlan_interface].ip_address }} {% else %} - {% endif -%} |
+{%-        if vlan_interfaces[vlan_interface].ip_address_virtual is defined %} {{ vlan_interfaces[vlan_interface].ip_address_virtual }} {% else %} - {% endif -%} |
+{%-        if vlan_interfaces[vlan_interface].ip_virtual_router_address is defined %} {{ vlan_interfaces[vlan_interface].ip_virtual_router_address  }} {% else %} - {% endif -%} |
 {%     endfor %}
 
 ### VLAN Interfaces Device Configuration

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/mlag-configuration.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/mlag-configuration.j2
@@ -4,7 +4,8 @@ mlag configuration
    domain-id {{ mlag_configuration.domain_id }}
    local-interface {{ mlag_configuration.local_interface }}
    peer-address {{ mlag_configuration.peer_address }}
-   peer-address heartbeat {{ mlag_configuration.peer_address_heartbeat.peer_ip }} {% if mlag_configuration.peer_address_heartbeat.vrf is ne 'default'%}vrf {{ mlag_configuration.peer_address_heartbeat.vrf }}{% endif %} 
+   peer-address heartbeat {{ mlag_configuration.peer_address_heartbeat.peer_ip }} {% if mlag_configuration.peer_address_heartbeat.vrf is ne 'default'%}vrf {{ mlag_configuration.peer_address_heartbeat.vrf }}
+   {% endif -%}
    peer-link {{ mlag_configuration.peer_link }}
    dual-primary detection delay {{ mlag_configuration.dual_primary_detection_delay }} action errdisable all-interfaces
    reload-delay mlag {{ mlag_configuration.reload_delay_mlag }}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
@@ -12,15 +12,20 @@ interface {{ vlan_interface }}
 {%         if vlan_interfaces[vlan_interface].vrf is defined %}
    vrf {{ vlan_interfaces[vlan_interface].vrf }}
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].ip_address is defined and vlan_interfaces[vlan_interface].virtual is defined and vlan_interfaces[vlan_interface].virtual == true  %}
-   ip address virtual {{ vlan_interfaces[vlan_interface].ip_address }}
-{%         elif vlan_interfaces[vlan_interface].ip_address is defined %}
+{%         if vlan_interfaces[vlan_interface].ip_address is defined %}
    ip address {{ vlan_interfaces[vlan_interface].ip_address }}
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].ip_address_secondary is defined and vlan_interfaces[vlan_interface].virtual is defined and vlan_interfaces[vlan_interface].virtual == true  %}
-   ip address virtual {{ vlan_interfaces[vlan_interface].ip_address_secondary }} secondary
-{%         elif vlan_interfaces[vlan_interface].ip_address_secondary is defined %}
+{%         if vlan_interfaces[vlan_interface].ip_address_secondary is defined %}
    ip address {{ vlan_interfaces[vlan_interface].ip_address_secondary }} secondary
+{%         endif %}
+{%         if vlan_interfaces[vlan_interface].ip_virtual_router_address is defined %}
+   ip virtual-router address {{ vlan_interfaces[vlan_interface].ip_virtual_router_address }}
+{%         endif %}
+{%         if vlan_interfaces[vlan_interface].ip_address_virtual is defined %}
+   ip address virtual {{ vlan_interfaces[vlan_interface].ip_address_virtual }}
+{%         endif %}
+{%         if vlan_interfaces[vlan_interface].ip_address_virtual_secondary is defined %}
+   ip address virtual {{ vlan_interfaces[vlan_interface].ip_address_virtual_secondary }} secondary
 {%         endif %}
 {%         if vlan_interfaces[vlan_interface].ospf_network_point_to_point is defined and vlan_interfaces[vlan_interface].ospf_network_point_to_point == true %}
    ip ospf network point-to-point

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
@@ -802,15 +802,30 @@ tenants:
             # Enable or disable interface
             enabled: < true | false >
 
-            # Ip subnet of vlan. the first IP address will be assigned as the anycast address
-            # to each svi interface. | Required
-            ip_subnet: < IPv4_address/Mask >
+            # ip address virtual to configure VXLAN Anycast IP address
+            # Conserves IP addresses in VXLAN deployments as it doesn't require unique IP addresses on each node.
+            # Optional
+            ip_address_virtual:: < IPv4_address/Mask >
+
+            # ip virtual-router address
+            # note, also requires an IP address to be configured on the SVI where it is applied.
+            # Optional
+            ip_virtual_router_address: < IPv4_address/Mask >
+
+            # Define node specific configuration, such as unique IP addresses.
+            nodes:
+              < l3_leaf_inventory_hostname_1 >:
+                # device unique IP address for node.
+                ip_address: < IPv4_address/Mask >
+
+              < l3_leaf_inventory_hostname_2 >:
+                ip_address: < IPv4_address/Mask >
 
           < 1-4096 >:
             name: < description >
             tags: [ < tag_1 >, < tag_2 > ]
             enabled: < true | false >
-            ip_subnet: < IPv4_address/Mask >
+            ip_address_virtual: < IPv4_address/Mask >
 
       < tenant_a_vrf_2 >:
         vrf_vni: <1-1024>
@@ -819,12 +834,12 @@ tenants:
             name: < description >
             tags: [ < tag_1 >, < tag_2 > ]
             enabled: < true | false >
-            ip_subnet: < IPv4_address/Mask >
+            ip_address_virtual: < IPv4_address/Mask >
           < 1-4096 >:
             name: < description >
             tags: [ < tag_1 >, < tag_2 > ]
             enabled: < true | false >
-            ip_subnet: < IPv4_address/Mask >
+            ip_address_virtual: < IPv4_address/Mask >
 
    # Define L2 network services organized by vlan id.
     l2vlans:
@@ -839,6 +854,7 @@ tenants:
         name: < description >
 
         # Tags leveraged for networks services filtering.
+        # 
         tags: [ < tag_1 >, < tag_2 > ]
 
       < 1-4096 >:
@@ -859,13 +875,13 @@ tenants:
             name: < description >
             tags: [ < tag_1 >, < tag_2 > ]
             enabled: < true | false >
-            ip_subnet: < IPv4_address/Mask >
+            ip_address_virtual: < IPv4_address/Mask >
           < 1-4096 >:
             vni_override: < 1-16777215 >
             name: < description >
             tags: [ < tag_1 >, < tag_2 > ]
             enabled: < true | false >
-            ip_subnet: < IPv4_address/Mask >
+            ip_address_virtual: < IPv4_address/Mask >
     l2vlans:
       < 1-4096 >:
         vni_override: < 1-16777215 >
@@ -897,13 +913,32 @@ tenants:
             name: Tenant_A_OP_Zone_1
             tags: [ opzone ]
             enabled: true
-            ip_subnet: 10.1.10.0/24
+            ip_address_virtual: 10.1.10.0/24
           111:
             vni_override: 50111
             name: Tenant_A_OP_Zone_2
             tags: [ opzone ]
             enabled: true
-            ip_subnet: 10.1.11.0/24
+            ip_address_virtual: 10.1.11.0/24
+          112:
+            name: Tenant_A_OP_Zone_3
+            tags: [ DC1_LEAF2 ]
+            enabled: true
+            ip_virtual_router_address: 10.1.12.1/24
+            nodes:
+              DC1-LEAF2A:
+                ip_address: 10.1.12.2/24
+              DC1-LEAF2B:
+                ip_address: 10.1.12.3/24
+          113:
+            name: Tenant_A_OP_Zone_WAN
+            tags: [ DC1_BL1 ]
+            enabled: true
+            nodes:
+              DC1-BL1A:
+                ip_address: 10.1.13.1/24
+              DC1-BL1B:
+                ip_address: 10.1.13.2/24
       Tenant_A_WEB_Zone:
         vrf_vni: 11
         svis:
@@ -911,12 +946,12 @@ tenants:
             name: Tenant_A_WEB_Zone_1
             tags: [ web, erp1 ]
             enabled: true
-            ip_subnet: 10.1.20.0/24
+            ip_address_virtual: 10.1.20.0/24
           121:
             name: Tenant_A_WEBZone_2
             tags: [ web ]
             enabled: true
-            ip_subnet: 10.1.21.0/24
+            ip_address_virtual: 10.1.21.0/24
       Tenant_A_APP_Zone:
         vrf_vni: 12
         svis:
@@ -924,12 +959,12 @@ tenants:
             name: Tenant_A_APP_Zone_1
             tags: [ app, erp1 ]
             enabled: true
-            ip_subnet: 10.1.30.0/24
+            ip_address_virtual: 10.1.30.0/24
           131:
             name: Tenant_A_APP_Zone_2
             tags: [ app ]
             enabled: true
-            ip_subnet: 10.1.31.0/24
+            ip_address_virtual: 10.1.31.0/24
       Tenant_A_DB_Zone:
         vrf_vni: 13
         svis:
@@ -937,12 +972,12 @@ tenants:
             name: Tenant_A_DB_BZone_1
             tags: [ db, erp1 ]
             enabled: true
-            ip_subnet: 10.1.40.0/24
+            ip_address_virtual: 10.1.40.0/24
           141:
             name: Tenant_A_DB_Zone_2
             tags: [ db ]
             enabled: true
-            ip_subnet: 10.1.41.0/24
+            ip_address_virtual: 10.1.41.0/24
       Tenant_A_WAN_Zone:
         vrf_vni: 14
         svis:
@@ -950,7 +985,7 @@ tenants:
             name: Tenant_A_WAN_Zone_1
             tags: [ wan ]
             enabled: true
-            ip_subnet: 10.1.40.0/24
+            ip_address_virtual: 10.1.40.0/24
     l2vlans:
       160:
         vni_override: 55160
@@ -970,12 +1005,12 @@ tenants:
             name: Tenant_B_OP_Zone_1
             tags: [ opzone ]
             enabled: true
-            ip_subnet: 10.2.10.0/24
+            ip_address_virtual: 10.2.10.0/24
           211:
             name: Tenant_B_OP_Zone_2
             tags: [ opzone ]
             enabled: true
-            ip_subnet: 10.2.11.0/24
+            ip_address_virtual: 10.2.11.0/24
       Tenant_B_WAN_Zone:
         vrf_vni: 21
         svis:
@@ -983,7 +1018,7 @@ tenants:
             name: Tenant_B_WAN_Zone_1
             tags: [ wan ]
             enabled: true
-            ip_subnet: 10.2.50.0/24
+            ip_address_virtual: 10.2.50.0/24
 ```
 
 ### Server Edge Port Connectivity

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
@@ -854,7 +854,6 @@ tenants:
         name: < description >
 
         # Tags leveraged for networks services filtering.
-        # 
         tags: [ < tag_1 >, < tag_2 > ]
 
       < 1-4096 >:
@@ -1216,7 +1215,7 @@ event_handlers:
 event_handlers:
   evpn-blacklist-recovery:
     action_type: bash
-    action: FastCli -p 15 -c “clear bgp evpn host-flap”
+    action: FastCli -p 15 -c "clear bgp evpn host-flap"
     delay: 300
     trigger: on-logging
     regex:  EVPN-3-BLACKLISTED_DUPLICATE_MAC

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l2leaf-yml.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l2leaf-yml.j2
@@ -99,8 +99,8 @@
 {%             for vrf in tenants[tenant].vrfs | arista.avd.natural_sort %}
 {%                 for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort %}
 {%                     for svi_tag in tenants[tenant].vrfs[vrf].svis[svi].tags %}
-{%                         if svi_tag in leaf.filter_tags or "all" in leaf.filter_tags %}
-{%                             if svi_tag in parentl3leaf.filter_tags or "all" in parentl3leaf.filter_tags %}
+{%                         if svi_tag in leaf.filter_tags or svi_tag == leaf.group or "all" in leaf.filter_tags %}
+{%                             if svi_tag in parentl3leaf.filter_tags or svi_tag == leaf.group or "all" in parentl3leaf.filter_tags %}
 {%                                 do leaf.vrfs.append( vrf ) %}
 {%                                 do leaf.svis.append( svi ) %}
 {%                                 do leaf.vlans.append( svi ) %}
@@ -114,8 +114,8 @@
 {%         if tenants[tenant].l2vlans is defined %}
 {%             for l2vlan in tenants[tenant].l2vlans | arista.avd.natural_sort %}
 {%                 for vlan_tag in tenants[tenant].l2vlans[l2vlan].tags %}
-{%                     if vlan_tag in leaf.filter_tags or "all" in leaf.filter_tags %}
-{%                         if vlan_tag in parentl3leaf.filter_tags or "all" in parentl3leaf.filter_tags %}
+{%                     if vlan_tag in leaf.filter_tags or vlan_tag == leaf.group or "all" in leaf.filter_tags %}
+{%                         if vlan_tag in parentl3leaf.filter_tags or vlan_tag == leaf.group or "all" in parentl3leaf.filter_tags %}
 {%                             do leaf.vlans.append( l2vlan ) %}
 {%                             break %}
 {%                         endif %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l2leaf-yml.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l2leaf-yml.j2
@@ -76,6 +76,7 @@
 {% for l3leaf_node_group in l3leaf.node_groups | arista.avd.natural_sort %}
 {%     for node in l3leaf.node_groups[l3leaf_node_group].nodes | arista.avd.natural_sort %}
 {%         if node == leaf.parent_l3leafs[0] %}
+{%             set parentl3leaf.group = l3leaf_node_group %}
 {%             if l3leaf.node_groups[l3leaf_node_group].filter.tenants is defined %}
 {%                 set parentl3leaf.filter_tenants = l3leaf.node_groups[l3leaf_node_group].filter.tenants %}
 {%             else %}
@@ -100,7 +101,7 @@
 {%                 for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort %}
 {%                     for svi_tag in tenants[tenant].vrfs[vrf].svis[svi].tags %}
 {%                         if svi_tag in leaf.filter_tags or svi_tag == leaf.group or "all" in leaf.filter_tags %}
-{%                             if svi_tag in parentl3leaf.filter_tags or svi_tag == leaf.group or "all" in parentl3leaf.filter_tags %}
+{%                             if svi_tag in parentl3leaf.filter_tags or svi_tag == parentl3leaf.group or "all" in parentl3leaf.filter_tags %}
 {%                                 do leaf.vrfs.append( vrf ) %}
 {%                                 do leaf.svis.append( svi ) %}
 {%                                 do leaf.vlans.append( svi ) %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l3leaf-yml.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l3leaf-yml.j2
@@ -101,7 +101,7 @@
 {%         for vrf in tenants[tenant].vrfs | arista.avd.natural_sort %}
 {%             for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort %}
 {%                 for svi_tag in tenants[tenant].vrfs[vrf].svis[svi].tags %}
-{%                     if svi_tag in leaf.filter_tags or "all" in leaf.filter_tags %}
+{%                     if svi_tag in leaf.filter_tags or svi_tag == leaf.group or "all" in leaf.filter_tags %}
 {%                         do leaf.vrfs.append( vrf ) %}
 {%                         do leaf.svis.append( svi ) %}
 {%                         do leaf.vlans.append( svi ) %}
@@ -114,7 +114,7 @@
 {%     if tenants[tenant].l2vlans is defined %}
 {%         for l2vlan in tenants[tenant].l2vlans | arista.avd.natural_sort %}
 {%             for vlan_tag in tenants[tenant].l2vlans[l2vlan].tags %}
-{%                 if vlan_tag in leaf.filter_tags or "all" in leaf.filter_tags %}
+{%                 if vlan_tag in leaf.filter_tags or vlan_tag == leaf.group or "all" in leaf.filter_tags %}
 {%                     do leaf.vlans.append( l2vlan ) %}
 {%                     break %}
 {%                 endif %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/l3leaf-l2leafs-uplinks/l3leaf-port-channel-uplinks.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/l3leaf-l2leafs-uplinks/l3leaf-port-channel-uplinks.j2
@@ -38,8 +38,8 @@
 {%                         for vrf in tenants[tenant].vrfs | arista.avd.natural_sort %}
 {%                             for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort %}
 {%                                 for svi_tag in tenants[tenant].vrfs[vrf].svis[svi].tags %}
-{%                                     if svi_tag in leaf.filter_tags or "all" in leaf.filter_tags %}
-{%                                         if svi_tag in l2_leaf.filter_tags or "all" in l2_leaf.filter_tags %}
+{%                                     if svi_tag in leaf.filter_tags or svi_tag == leaf.group or "all" in leaf.filter_tags %}
+{%                                         if svi_tag in l2_leaf.filter_tags or svi_tag == leaf.group or "all" in l2_leaf.filter_tags %}
 {%                                             do l2_leaf.vlans.append( svi ) %}
 {%                                             break %}
 {%                                         endif %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/l3leaf-l2leafs-uplinks/l3leaf-port-channel-uplinks.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/l3leaf-l2leafs-uplinks/l3leaf-port-channel-uplinks.j2
@@ -39,7 +39,7 @@
 {%                             for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort %}
 {%                                 for svi_tag in tenants[tenant].vrfs[vrf].svis[svi].tags %}
 {%                                     if svi_tag in leaf.filter_tags or svi_tag == leaf.group or "all" in leaf.filter_tags %}
-{%                                         if svi_tag in l2_leaf.filter_tags or svi_tag == leaf.group or "all" in l2_leaf.filter_tags %}
+{%                                         if svi_tag in l2_leaf.filter_tags or svi_tag == l2leaf_node_group or "all" in l2_leaf.filter_tags %}
 {%                                             do l2_leaf.vlans.append( svi ) %}
 {%                                             break %}
 {%                                         endif %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant-evpn-vxlan/leaf-tenant-vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant-evpn-vxlan/leaf-tenant-vlan-interfaces.j2
@@ -12,11 +12,24 @@
     tags: {{ tenants[tenant].vrfs[vrf].svis[svi].tags }}
     description: {{ tenants[tenant].vrfs[vrf].svis[svi].name }}
     vrf: {{ vrf }}
-    ip_address: {{ tenants[tenant].vrfs[vrf].svis[svi].ip_subnet | ipaddr('network') | ipmath(1) }}/{{ tenants[tenant].vrfs[vrf].svis[svi].ip_subnet | ipaddr('prefix') }}
-{%                 if tenants[tenant].vrfs[vrf].svis[svi].ip_subnet_secondary is defined %}
-    ip_address_secondary: {{ tenants[tenant].vrfs[vrf].svis[svi].ip_subnet_secondary | ipaddr('network') | ipmath(1) }}/{{ tenants[tenant].vrfs[vrf].svis[svi].ip_subnet_secondary | ipaddr('prefix') }}
+{%                 if tenants[tenant].vrfs[vrf].svis[svi].nodes is defined %}
+{%                     for node in tenants[tenant].vrfs[vrf].svis[svi].nodes %}
+{%                          if node == inventory_hostname %}
+{%                              if tenants[tenant].vrfs[vrf].svis[svi].nodes[inventory_hostname].ip_address is defined %}
+    ip_address: {{ tenants[tenant].vrfs[vrf].svis[svi].nodes[inventory_hostname].ip_address }}
+{%                              endif %}
+{%                          endif %}
+{%                     endfor %}
 {%                 endif %}
-    virtual: true
+{%                 if tenants[tenant].vrfs[vrf].svis[svi].ip_virtual_router_address is defined %}
+    ip_virtual_router_address: {{ tenants[tenant].vrfs[vrf].svis[svi].ip_virtual_router_address | ipaddr('address') }}
+{%                 endif %}
+{%                 if tenants[tenant].vrfs[vrf].svis[svi].ip_address_virtual is defined %}
+    ip_address_virtual: {{ tenants[tenant].vrfs[vrf].svis[svi].ip_address_virtual }}
+{%                 endif %}
+{%                 if tenants[tenant].vrfs[vrf].svis[svi].ip_address_virtual_secondary is defined %}
+    ip_address_virtual_secondary: {{ tenants[tenant].vrfs[vrf].svis[svi].ip_address_virtual_secondary }}
+{%                 endif %}
 {%                 if tenants[tenant].vrfs[vrf].svis[svi].mtu is defined %}
     mtu: {{ tenants[tenant].vrfs[vrf].svis[svi].mtu }}
 {%                 endif %}

--- a/testing/avd-eos-only-generic/group_vars/AVD_LAB.yml
+++ b/testing/avd-eos-only-generic/group_vars/AVD_LAB.yml
@@ -19,7 +19,7 @@ cvp_instance_ips:
 cvp_ingestauth_key: telarista
 
 # OOB Management network default gateway.
-mgmt_gateway: 192.168.200.5
+mgmt_gateway: 192.168.200.1
 
 # dns servers.
 name_servers:
@@ -28,4 +28,5 @@ name_servers:
 
 # NTP Servers IP or DNS name, first NTP server will be prefered, and sourced from Managment
 ntp_servers:
-  - 192.168.200.5
+  - 0.north-america.pool.ntp.org
+  - 1.north-america.pool.ntp.org

--- a/testing/avd-eos-only-generic/group_vars/DC1_TENANTS_NETWORKS.yml
+++ b/testing/avd-eos-only-generic/group_vars/DC1_TENANTS_NETWORKS.yml
@@ -17,13 +17,35 @@ tenants:
             name: Tenant_A_OP_Zone_1
             tags: [ opzone ]
             enabled: true
-            ip_subnet: 10.1.10.0/24
+            ip_address_virtual: 10.1.10.1/24
           111:
             vni_override: 50111
             name: Tenant_A_OP_Zone_2
             tags: [ opzone ]
             enabled: true
-            ip_subnet: 10.1.11.0/24
+            ip_address_virtual: 10.1.11.1/24
+# virtual ip address router-virtual
+          112:
+            name: Tenant_A_OP_Zone_3
+            tags: [ DC1_LEAF2 ]
+            enabled: true
+            ip_virtual_router_address: 10.1.12.1/24
+            nodes:
+              DC1-LEAF2A:
+                ip_address: 10.1.12.2/24
+              DC1-LEAF2B:
+                ip_address: 10.1.12.3/24
+# # SVI IP address (no virtual)
+          113:
+            name: Tenant_A_OP_Zone_WAN
+            tags: [ DC1_BL1 ]
+            enabled: true
+            nodes:
+              DC1-BL1A:
+                ip_address: 10.1.13.1/24
+              DC1-BL1B:
+                ip_address: 10.1.13.2/24
+
       Tenant_A_WEB_Zone:
         vrf_vni: 11
         svis:
@@ -31,12 +53,12 @@ tenants:
             name: Tenant_A_WEB_Zone_1
             tags: [ web, erp1 ]
             enabled: true
-            ip_subnet: 10.1.20.0/24
+            ip_address_virtual: 10.1.20.1/24
           121:
             name: Tenant_A_WEBZone_2
             tags: [ web ]
             enabled: true
-            ip_subnet: 10.1.21.0/24
+            ip_address_virtual: 10.1.21.1/24
       Tenant_A_APP_Zone:
         vrf_vni: 12
         svis:
@@ -44,12 +66,12 @@ tenants:
             name: Tenant_A_APP_Zone_1
             tags: [ app, erp1 ]
             enabled: true
-            ip_subnet: 10.1.30.0/24
+            ip_address_virtual: 10.1.30.1/24
           131:
             name: Tenant_A_APP_Zone_2
             tags: [ app ]
             enabled: true
-            ip_subnet: 10.1.31.0/24
+            ip_address_virtual: 10.1.31.1/24
       Tenant_A_DB_Zone:
         vrf_vni: 13
         svis:
@@ -57,12 +79,12 @@ tenants:
             name: Tenant_A_DB_BZone_1
             tags: [ db, erp1 ]
             enabled: true
-            ip_subnet: 10.1.40.0/24
+            ip_address_virtual: 10.1.40.1/24
           141:
             name: Tenant_A_DB_Zone_2
             tags: [ db ]
             enabled: true
-            ip_subnet: 10.1.41.0/24
+            ip_address_virtual: 10.1.41.1/24
       Tenant_A_WAN_Zone:
         vrf_vni: 14
         svis:
@@ -70,7 +92,7 @@ tenants:
             name: Tenant_A_WAN_Zone_1
             tags: [ wan ]
             enabled: true
-            ip_subnet: 10.1.40.0/24
+            ip_address_virtual: 10.1.40.1/24
     l2vlans:
       160:
         vni_override: 50160
@@ -92,12 +114,12 @@ tenants:
             name: Tenant_B_OP_Zone_1
             tags: [ opzone ]
             enabled: true
-            ip_subnet: 10.2.10.0/24
+            ip_address_virtual: 10.2.10.1/24
           211:
             name: Tenant_B_OP_Zone_2
             tags: [ opzone ]
             enabled: true
-            ip_subnet: 10.2.11.0/24
+            ip_address_virtual: 10.2.11.1/24
       Tenant_B_WAN_Zone:
         vrf_vni: 21
         svis:
@@ -105,7 +127,7 @@ tenants:
             name: Tenant_B_WAN_Zone_1
             tags: [ wan ]
             enabled: true
-            ip_subnet: 10.2.50.0/24
+            ip_address_virtual: 10.2.50.1/24
 
 
 # Tenant C Specific Information - VRFs / VLANs
@@ -119,12 +141,12 @@ tenants:
             name: Tenant_C_OP_Zone_1
             tags: [ opzone ]
             enabled: true
-            ip_subnet: 10.3.10.0/24
+            ip_address_virtual: 10.3.10.1/24
           311:
             name: Tenant_C_OP_Zone_2
             tags: [ opzone ]
             enabled: true
-            ip_subnet: 10.3.11.0/24
+            ip_address_virtual: 10.3.11.1/24
       Tenant_C_WAN_Zone:
         vrf_vni: 31
         svis:
@@ -132,33 +154,4 @@ tenants:
             name: Tenant_C_WAN_Zone_1
             tags: [ wan ]
             enabled: true
-            ip_subnet: 10.3.50.0/24
-  # ansible_demo:
-  #   mac_vrf_vni_base: 40000
-  #   vrfs:
-  #     ansible_web_zone:
-  #       vrf_vni: 30
-  #       svis:
-  #         410:
-  #           name: ansible_demo_app_1
-  #           tags: [ app ]
-  #           enabled: true
-  #           ip_subnet: 10.4.10.0/24
-  #         411:
-  #           name: ansible_demo_app_2
-  #           tags: [ app ]
-  #           enabled: true
-  #           ip_subnet: 10.4.11.0/24
-  #     ansible_db_zone:
-  #       vrf_vni: 31
-  #       svis:
-  #         420:
-  #           name: ansible_demo_db_1
-  #           tags: [ db ]
-  #           enabled: true
-  #           ip_subnet: 10.4.20.0/24
-  #         421:
-  #           name: ansible_demo_db_2
-  #           tags: [ db ]
-  #           enabled: true
-  #           ip_subnet: 10.4.21.0/24
+            ip_address_virtual: 10.3.50.1/24

--- a/testing/avd-eos-only-generic/inventory.yml
+++ b/testing/avd-eos-only-generic/inventory.yml
@@ -4,7 +4,7 @@ all:
       children:
         CVP:
           hosts:
-            AVD-CVP-1:
+            CVP-1:
 # DC1 Fabric
         DC1_FABRIC:
           children:


### PR DESCRIPTION
# Add the capability to define different types of IP addresses when defining network services
   
- ip router virtual address
- ip router virtual address secondary
- ip address virtual
- unique ip addresses on nodes SVI interfaces

## Tasks:

- [x] update documentation
- [x] update templates
- [x] update CI test with new data model


## Sample Inputs

```yaml
  Tenant_A:
    mac_vrf_vni_base: 10000
    vrfs:
      Tenant_A_OP_Zone:
        vrf_vni: 10
        vtep_diagnostic:
          loopback: 100
          loopback_ip_range: 10.255.1.0/24
        svis:
          111:
            vni_override: 50111
            name: Tenant_A_OP_Zone_2
            tags: [ opzone ]
            enabled: true
            ip_address_virtual: 10.1.11.1/24
# virtual ip address router-virtual
          112:
            name: Tenant_A_OP_Zone_3
            tags: [ DC1_LEAF2 ]
            enabled: true
            ip_virtual_router_address: 10.1.12.1/24
            nodes:
              DC1-LEAF2A:
                ip_address: 10.1.12.2/24
              DC1-LEAF2B:
                ip_address: 10.1.12.3/24
# # SVI IP address (no virtual)
          113:
            name: Tenant_A_OP_Zone_WAN
            tags: [ DC1_BL1 ]
            enabled: true
            nodes:
              DC1-BL1A:
                ip_address: 10.1.13.1/24
              DC1-BL1B:
                ip_address: 10.1.13.2/24
```

## Outputs generated (truncated):

DC1-LEAF2A:

```eos
interface Vlan111
   description Tenant_A_OP_Zone_2
   vrf Tenant_A_OP_Zone
   ip address virtual 10.1.11.1/24
!
interface Vlan112
   description Tenant_A_OP_Zone_3
   vrf Tenant_A_OP_Zone
   ip address 10.1.12.2/24
   ip virtual-router address 10.1.12.1
```

DC1-LEAF2B:

```eos
interface Vlan111
   description Tenant_A_OP_Zone_2
   vrf Tenant_A_OP_Zone
   ip address virtual 10.1.11.1/24
!
interface Vlan112
   description Tenant_A_OP_Zone_3
   vrf Tenant_A_OP_Zone
   ip address 10.1.12.3/24
   ip virtual-router address 10.1.12.1
```

DC1-BL1A:
```eos
interface Vlan113
   description Tenant_A_OP_Zone_WAN
   vrf Tenant_A_OP_Zone
   ip address 10.1.13.1/24
```

DC1-BL1B:

```eos
interface Vlan113
   description Tenant_A_OP_Zone_WAN
   vrf Tenant_A_OP_Zone
   ip address 10.1.13.2/24
```






