### PR TITLE
Fix #135 - Configure explicicit root folder for intended, documentation, config_backup folders

### DIFF
--- a/ansible_collections/arista/avd/roles/build_output_folders/defaults/main.yml
+++ b/ansible_collections/arista/avd/roles/build_output_folders/defaults/main.yml
@@ -33,3 +33,7 @@ fabric_dir: '{{documentation_dir}}/{{fabric_dir_name}}'
 # Device documentation
 devices_dir_name: 'devices'
 devices_dir: '{{documentation_dir}}/{{devices_dir_name}}'
+
+# Backup config dir for eos_config_deploy_eaopi
+running_config_backup_dir_name: 'config_backup'
+running_config_backup_dir: '{{root_dir}}/{{running_config_backup_dir_name}}'

--- a/ansible_collections/arista/avd/roles/build_output_folders/defaults/main.yml
+++ b/ansible_collections/arista/avd/roles/build_output_folders/defaults/main.yml
@@ -2,7 +2,7 @@
 # defaults file for build_directories
 
 # Root directory where to build output structure
-root_dir: '{{playbook_dir}}'
+root_dir: '{{inventory_dir}}'
 
 # AVD configurations output
 # Main output directory

--- a/ansible_collections/arista/avd/roles/build_output_folders/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/build_output_folders/tasks/main.yml
@@ -64,3 +64,11 @@
     mode: 0755
   delegate_to: localhost
   run_once: True
+
+- name: 'Create folder {{running_config_backup_dir_name}} for EOS documentation'
+  file:
+    path: '{{running_config_backup_dir}}'
+    state: directory
+    mode: 0755
+  delegate_to: localhost
+  run_once: True

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/tasks/main.yml
@@ -1,14 +1,14 @@
 ---
 
 - name: include device intended structure configuration variables
-  include_vars: ./intended/structured_configs//{{ inventory_hostname }}.yml
+  include_vars: '{{inventory_dir}}/intended/structured_configs//{{ inventory_hostname }}.yml'
   delegate_to: localhost
   tags: [build, provision]
 
 - name: Generate eos intended configuration
   template:
     src: eos-intended-config.j2
-    dest: ./intended/configs/{{ inventory_hostname }}.cfg
+    dest: '{{inventory_dir}}/intended/configs/{{ inventory_hostname }}.cfg'
   delegate_to: localhost
   register: eosconfig
   tags: [build, provision]
@@ -16,6 +16,6 @@
 - name: Generate device documentation
   template:
     src: eos-device-documentation.j2
-    dest: ./documentation/devices/{{ inventory_hostname }}.md
+    dest: '{{inventory_dir}}/documentation/devices/{{ inventory_hostname }}.md'
   delegate_to: localhost
   tags: [build, provision]

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/main.yml
@@ -5,7 +5,7 @@
   inventory_to_container:
     inventory: '{{ inventory_file }}'
     container_root: '{{ container_root }}'
-    configlet_dir: 'intended/configs'
+    configlet_dir: '{{playbook_dir}}/intended/configs'
     configlet_prefix: '{{ configlets_prefix }}'
     destination: '{{playbook_dir}}/intended/structured_configs/cvp/{{inventory_hostname}}.yml'
   register: CVP_VARS
@@ -14,7 +14,7 @@
   tags: [build, provision]
   template:
     src: "cvp-devices.j2"
-    dest: './intended/structured_configs/cvp/{{inventory_hostname}}.yml'
+    dest: '{{playbook_dir}}/intended/structured_configs/cvp/{{inventory_hostname}}_2.yml'
   delegate_to: localhost
   run_once: true
 

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/main.yml
@@ -7,20 +7,20 @@
     container_root: '{{ container_root }}'
     configlet_dir: '{{playbook_dir}}/intended/configs'
     configlet_prefix: '{{ configlets_prefix }}'
-    destination: '{{playbook_dir}}/intended/structured_configs/cvp/{{inventory_hostname}}.yml'
+    destination: '{{inventory_dir}}/intended/structured_configs/cvp/{{inventory_hostname}}.yml'
   register: CVP_VARS
 
 - name: 'Build DEVICES and CONTAINER definition for {{inventory_hostname}}'
   tags: [build, provision]
   template:
     src: "cvp-devices.j2"
-    dest: '{{playbook_dir}}/intended/structured_configs/cvp/{{inventory_hostname}}_2.yml'
+    dest: '{{inventory_dir}}/intended/structured_configs/cvp/{{inventory_hostname}}.yml'
   delegate_to: localhost
   run_once: true
 
 - name: "Load CVP device information for {{inventory_hostname}}"
   tags: [build, provision]
-  include_vars: '{{playbook_dir}}/intended/structured_configs/cvp/{{inventory_hostname}}.yml'
+  include_vars: '{{inventory_dir}}/intended/structured_configs/cvp/{{inventory_hostname}}.yml'
   # delegate_to: localhost
 
 #################################################

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_eapi/handlers/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_eapi/handlers/main.yml
@@ -7,5 +7,5 @@
 - name: backup running config
   copy:
     content: "{{ backup.stdout[0] }}"
-    dest: "./config_backup/{{ inventory_hostname }}_running-config.conf"
+    dest: "{{inventory_dir}}/config_backup/{{ inventory_hostname }}_running-config.conf"
   listen: "backup config"

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_eapi/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_eapi/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: replace configuration with intended configuration
   eos_config:
-    src: ./intended/configs/{{ inventory_hostname }}.cfg
+    src: '{{inventory_dir}}/intended/configs/{{ inventory_hostname }}.cfg'
     replace: config
     save_when: modified
   when: eosconfig.changed

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/tasks/main.yml
@@ -3,20 +3,20 @@
 - name: Generate device configuration in structured format (yaml).
   template:
     src: "evpn-fabric-{{ type }}-yml.j2"
-    dest: ./intended/structured_configs//{{ inventory_hostname }}.yml
+    dest: '{{inventory_dir}}/intended/structured_configs//{{ inventory_hostname }}.yml'
   delegate_to: localhost
   check_mode: no
   tags: [build, provision]
 
 - name: Include device structured configuration, that was previously generated.
-  include_vars: ./intended/structured_configs//{{ inventory_hostname }}.yml
+  include_vars: '{{inventory_dir}}/intended/structured_configs//{{ inventory_hostname }}.yml'
   delegate_to: localhost
   tags: [build, provision]
 
 - name: Generate EVPN fabric documentation in Markdown Format.
   template:
     src: documentation/dc-fabric-documentation.j2
-    dest: ./documentation/{{ fabric_name }}/{{ fabric_name }}.md
+    dest: '{{inventory_dir}}/documentation/{{ fabric_name }}/{{ fabric_name }}.md'
   delegate_to: localhost
   run_once: true
   check_mode: no
@@ -25,7 +25,7 @@
 - name: Generate Leaf and Spine Point-To-Point Links summary in csv format.
   template:
     src: documentation/dc-fabric-p2p-links.j2
-    dest: ./documentation/{{ fabric_name }}/{{ fabric_name }}-p2p-links.csv
+    dest: '{{inventory_dir}}/documentation/{{ fabric_name }}/{{ fabric_name }}-p2p-links.csv'
   delegate_to: localhost
   run_once: true
   check_mode: no
@@ -34,7 +34,7 @@
 - name: Generate Fabric Topology in csv format.
   template:
     src: documentation/dc-fabric-topology.j2
-    dest: ./documentation/{{ fabric_name }}/{{ fabric_name }}-topology.csv
+    dest: '{{inventory_dir}}/documentation/{{ fabric_name }}/{{ fabric_name }}-topology.csv'
   delegate_to: localhost
   run_once: true
   check_mode: no


### PR DESCRIPTION
Current implementation of roles uses either `{{playbook_dir}}` or implicit folder paths to access AVD generated files.

In scenario where inventory data and playbook are not part of the same folder, it is easier to use `{{inventory_dir}}` as root directory for all folders generated by AVD

Roles impacted:
---------------

- eos_l3ls_evpn
- eos_config_deploy_eapi
- eos_config_deploy_cvp
- eos_cli_config_gen
- build_output_folders
 