### PR TITLE
refactor platform specific settings

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
@@ -18,6 +18,7 @@
     - [Server Edge Port Connectivity](#server-edge-port-connectivity)
     - [Variable to attach additional configlets](#variable-to-attach-additional-configlets)
     - [Event Handlers](#event-handlers)
+    - [Platform Specific settings](#platform-specific-settings)
     - [vEOS-LAB Know Caveats and Recommendations](#veos-lab-know-caveats-and-recommendations)
   - [License](#license)
 
@@ -1220,6 +1221,45 @@ event_handlers:
     trigger: on-logging
     regex:  EVPN-3-BLACKLISTED_DUPLICATE_MAC
     asynchronous: true
+```
+
+### Platform Specific settings
+
+- Set platform specific settings, TCAM profile and reload delay.
+- The reload delay values should be reviewed and tuned to the specific environment.
+- If the platform is not defined, it will load parameters from the platform tagged `default`.
+
+**Variables and Options:**
+
+```yaml
+platform_settings:
+  - platforms: [ default ]
+    reload_delay:
+      mlag: < seconds >
+      non_mlag: < seconds >
+  - platforms: [ < Arista Platform Family >, < Arista Platform Family > ]
+    tcam_profile: < tcam_profile >
+    reload_delay:
+      mlag: < seconds >
+      non_mlag: < seconds >
+
+```
+
+note: Recommended default values for Jericho based platform, and all other platforms `default` tag.
+
+**Example:**
+
+```yaml
+# platform_settings:
+#   - platforms: [ default ]
+#     reload_delay:
+#       mlag: 300
+#       non_mlag: 330
+#   - platforms: [ 7800R3, 7500R3, 7500R, 7280R3, 7280R2, 7280R ]
+#     tcam_profile: vxlan-routing
+#     reload_delay:
+#       mlag: 780
+#       non_mlag: 1020
 ```
 
 ### vEOS-LAB Know Caveats and Recommendations

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
@@ -20,6 +20,7 @@
       - [MLAG dual-attached server scenario](#mlag-dual-attached-server-scenario)
     - [Variable to attach additional configlets](#variable-to-attach-additional-configlets)
     - [Event Handlers](#event-handlers)
+    - [Platform Specific settings](#platform-specific-settings)
     - [vEOS-LAB Know Caveats and Recommendations](#veos-lab-know-caveats-and-recommendations)
   - [License](#license)
 
@@ -1267,6 +1268,45 @@ event_handlers:
     trigger: on-logging
     regex:  EVPN-3-BLACKLISTED_DUPLICATE_MAC
     asynchronous: true
+```
+
+### Platform Specific settings
+
+- Set platform specific settings, TCAM profile and reload delay.
+- The reload delay values should be reviewed and tuned to the specific environment.
+- If the platform is not defined, it will load parameters from the platform tagged `default`.
+
+**Variables and Options:**
+
+```yaml
+platform_settings:
+  - platforms: [ default ]
+    reload_delay:
+      mlag: < seconds >
+      non_mlag: < seconds >
+  - platforms: [ < Arista Platform Family >, < Arista Platform Family > ]
+    tcam_profile: < tcam_profile >
+    reload_delay:
+      mlag: < seconds >
+      non_mlag: < seconds >
+
+```
+
+note: Recommended default values for Jericho based platform, and all other platforms `default` tag.
+
+**Example:**
+
+```yaml
+# platform_settings:
+#   - platforms: [ default ]
+#     reload_delay:
+#       mlag: 300
+#       non_mlag: 330
+#   - platforms: [ 7800R3, 7500R3, 7500R, 7280R3, 7280R2, 7280R ]
+#     tcam_profile: vxlan-routing
+#     reload_delay:
+#       mlag: 780
+#       non_mlag: 1020
 ```
 
 ### vEOS-LAB Know Caveats and Recommendations

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/defaults/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/defaults/main.yml
@@ -55,11 +55,17 @@ bfd_multihop:
 mlag_ibgp_peering_vrfs:
   base_vlan: 3000
 
-# Set TCAM profile to Vxlan-Routing (R-Series / Jericho Platforms Only)
-tcam_profile:
-  vxlan_routing:
-    - 7500R
-    - 7500R3
-    - 7280R
-    - 7280R2
-    - 7280R3
+# Set platform specific settings, TCAM profile and reload delay.
+# The reload delay values should be reviewed and tuned to the specific environment.
+# Recommended default values for Jericho based platform, and all other platforms default tag.
+
+platform_settings:
+  - platforms: [ default ]
+    reload_delay:
+      mlag: 300
+      non_mlag: 330
+  - platforms: [ 7800R3, 7500R3, 7500R, 7280R3, 7280R2, 7280R ]
+    tcam_profile: vxlan-routing
+    reload_delay:
+      mlag: 780
+      non_mlag: 1020

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/base/tcam-profile.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/base/tcam-profile.j2
@@ -1,3 +1,20 @@
-{% if switch.platform in tcam_profile.vxlan_routing %}
-  - vxlan-routing
-{% endif %}
+{# tcam-profile #}
+{% set ns = namespace() %}
+{% for platform_setting in platform_settings %}
+{%     set ns.platform_defined = false %}
+{%     if switch.platform in platform_setting.platforms %}
+{%         set ns.platform_defined = true %}
+{%         if platform_setting.tcam_profile is defined %}
+  - {{ platform_setting.tcam_profile }}
+{%         endif %}
+{%         break %}
+{%     endif %}
+{% endfor %}
+{% for platform_setting in platform_settings if ns.platform_defined == false %}
+{%     if 'default' in platform_setting.platforms %}
+{%         if platform_setting.tcam_profile is defined %}
+  - {{ platform_setting.tcam_profile }}
+{%         endif %}
+{%         break %}
+{%     endif %}
+{% endfor %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/mlag/leaf-mlag-configuration.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/mlag/leaf-mlag-configuration.j2
@@ -1,4 +1,5 @@
 {# Leaf mlag configuration #}
+{% set ns = namespace() %}
 {% if leaf.mlag == true %}
 ### MLAG Configuration ###
 mlag_configuration:
@@ -10,11 +11,25 @@ mlag_configuration:
     vrf: {{ mgmt_interface_vrf }}
   dual_primary_detection_delay: 5
   peer_link: Port-Channel{{ leaf.mlag_interfaces[0] | regex_findall("\d") | join }}
-{%     if switch.platform in tcam_profile.vxlan_routing %}
-  reload_delay_mlag: 1020
-  reload_delay_non_mlag: 780
-{%     else %}
-  reload_delay_mlag: 360
-  reload_delay_non_mlag: 300
-{%     endif %}
+{%     set ns = namespace() %}
+{%     for platform_setting in platform_settings %}
+{%         set ns.platform_defined = false %}
+{%         if switch.platform in platform_setting.platforms %}
+{%             set ns.platform_defined = true %}
+{%             if platform_setting.reload_delay is defined %}
+  reload_delay_mlag: {{ platform_setting.reload_delay.mlag }}
+  reload_delay_non_mlag: {{ platform_setting.reload_delay.non_mlag }}
+{%             endif %}
+{%             break %}
+{%         endif %}
+{%     endfor %}
+{%     for platform_setting in platform_settings if ns.platform_defined == false %}
+{%         if 'default' in platform_setting.platforms %}
+{%             if platform_setting.reload_delay is defined %}
+  reload_delay_mlag: {{ platform_setting.reload_delay.mlag }}
+  reload_delay_non_mlag: {{ platform_setting.reload_delay.non_mlag }}
+{%             endif %}
+{%             break %}
+{%         endif %}
+{%     endfor %}
 {% endif %}


### PR DESCRIPTION
Refactoring of templates to allow customization of platform specific settings from both TCAM profile and reload delay.

## Tasks:

- [x] Refactor platform specific settings to allow custom tuning based on the deployment scenario.
- [x] New default values for mlag / non mlag reload_delay, based on updates to EVPN design guide.
- [x] updated role documentation (eos_l3ls_evpn)

## EOS_L3LS_EVPN

### Inputs:

Proposed new input data model, and updated default settting:

```yaml
platform_settings:
  - platforms: [ default ]
    reload_delay:
      mlag: 300
      non_mlag: 330
  - platforms: [ 7800R3, 7500R3, 7500R, 7280R3, 7280R2, 7280R ]
    tcam_profile: vxlan-routing
    reload_delay:
      mlag: 780
      non_mlag: 1020
```

### Outputs

- No change to the output format

## Review

- `eos_l3ls_evpn` [readme file](https://github.com/carlbuchmann/ansible-avd/tree/refactor-platform-settings/ansible_collections/arista/avd/roles/eos_l3ls_evpn#platform-specific-settings)
- `eos_l3ls_evpn`[defaults\main.yml](https://github.com/carlbuchmann/ansible-avd/blob/refactor-platform-settings/ansible_collections/arista/avd/roles/eos_l3ls_evpn/defaults/main.yml)

## Notes

- resolves #137 




 