### PR TITLE
Add pre-commit tool

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,42 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.4.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+      - id: check-merge-conflict
+  - repo: https://github.com/pre-commit/mirrors-pylint
+    rev: 'v2.5.0'
+    hooks:
+    - id: pylint # Use pylintrc file in repository
+      name: Check for Linting error on Python files
+      description: This hook runs pylint.
+  - repo: https://github.com/adrienverge/yamllint.git
+    rev: 'v1.23.0'
+    hooks:
+    - id: yamllint
+      name: Check for Linting error on YAML files
+      description: This hook runs yamllint.
+      entry: yamllint
+      language: python
+      types: [file, yaml]
+      args: [-c=.github/yamllintrc]
+  - repo: https://github.com/ansible/ansible-lint.git
+    rev: v4.2.0
+    hooks:
+      - id: ansible-lint
+        name: Check for ansible-lint errors
+        files: \.(yaml|yml)$
+  # - repo: https://github.com/markdownlint/markdownlint.git
+  #   rev: v0.9.0
+  #   hooks:
+  #     - id: markdownlint
+  #       name: Markdownlint
+  #       description: Run markdownlint on your Markdown files
+  #       entry: mdl
+  #       language: ruby
+  #       files: \.(md|mdown|markdown)$

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,10 @@ linting: ## Run pre-commit script for python code linting using pylint
 	sh .github/lint-yaml
 	sh .github/lint-python
 
+.PHONY: pre-commit
+pre-commit: ## Execute pre-commit validation
+	pre-commit run --all-files
+
 .PHONY: github-configure-ci
 github-configure-ci: github-configure-ci-python3 github-configure-ci-ansible ## Configure CI environment to run GA (Ubuntu:latest LTS)
 

--- a/development/Makefile
+++ b/development/Makefile
@@ -13,7 +13,7 @@ help: ## Display help message
 .PHONY: build
 build: ## Build a new image of avd container
 	#docker build --no-cache -t $(CONTAINER) .
-	docker build -t $(CONTAINER) . --build-arg UID=$(UID) --build-arg GID=$(GID) 
+	docker build -t $(CONTAINER) . --build-arg UID=$(UID) --build-arg GID=$(GID)
 
 .PHONY: run
 run: ## Run ansible-avd container

--- a/development/README.md
+++ b/development/README.md
@@ -1,4 +1,24 @@
-# Development Tool
+# Development Process
+
+- [Development Process](#development-process)
+  - [Overview](#overview)
+  - [Build local environment](#build-local-environment)
+    - [Python Virtual Environment](#python-virtual-environment)
+      - [Install Python3 Virtual Environment](#install-python3-virtual-environment)
+    - [Docker Container for Ansible Testing and Development](#docker-container-for-ansible-testing-and-development)
+      - [Build Docker Container](#build-docker-container)
+      - [Run Docker Container](#run-docker-container)
+      - [Stop Docker Container](#stop-docker-container)
+  - [Getting started Script](#getting-started-script)
+    - [Step by step installation process](#step-by-step-installation-process)
+  - [Development tools](#development-tools)
+    - [One liner installation](#one-liner-installation)
+    - [Pre-commit hook](#pre-commit-hook)
+      - [Installation](#installation)
+      - [Run pre-commit manually](#run-pre-commit-manually)
+    - [Configure git hook](#configure-git-hook)
+
+## Overview
 
 Two methods can be used get Ansible up and running quickly with all the requirements to leverage ansible-avd.
 A Python Virtual Environment or Docker container.
@@ -12,7 +32,6 @@ For example, see the file/folder structure below.
 │   ├── ansible-cvp
 │   ├── ansible-eos
 │   ├── netdevops-examples
-│   │
 │   ├── Dockerfile
 │   ├── Makefile
 │   ├── requirements-dev.txt
@@ -20,9 +39,11 @@ For example, see the file/folder structure below.
 
 ```
 
-## Python Virtual Environment
+## Build local environment
 
-### Install Python3 Virtual Environment
+### Python Virtual Environment
+
+#### Install Python3 Virtual Environment
 
 ```shell
 # install virtualenv via pip3
@@ -40,7 +61,7 @@ $ pip install -r requirements.txt
 
 ```
 
-## Docker Container for Ansible Testing and Development
+### Docker Container for Ansible Testing and Development
 
 The docker container approach for development can be used to ensure that everybody is using the same development environment while still being flexible enough to use the repo you are making changes in. You can inspect the Dockerfile to see what packages have been installed.
 The container will mount the current working directory, so you can work with your local files.
@@ -49,7 +70,7 @@ The ansible version is passed in with the docker build command using ***ANSIBLE*
 
 Before you can use a container, you must install Docker CE on your workstation: https://www.docker.com/products/docker-desktop
 
-### Build Docker Container
+#### Build Docker Container
 
 In addition to the `Dockerfile`, a `Makefile` is provided to help provision the container a single step. A user can pass the ansible version number to make and alter the default ansible-version number.  This allows a user to setup multiple containers running differing versions of ansible.
 
@@ -63,7 +84,7 @@ ansible_avd         2.9.6               5291937a2214        33 minutes ago      
 ansible_avd         2.9.5               27f648c4c249        46 hours ago        912MB
 ```
 
-### Run Docker Container
+#### Run Docker Container
 
 ```shell
 make run                        # Use default version of Ansible
@@ -75,7 +96,7 @@ e682058d7dae        ansible_avd:2.9.5   "/bin/sh"           6 seconds ago       
 540a8e778907        ansible_avd:2.9.6   "/bin/sh"           38 seconds ago      Up 37 seconds                           ansible_avd_2.9.6
 ```
 
-### Stop Docker Container
+#### Stop Docker Container
 
 Another make target (clean) has been created to stop and remove the container once the user is finished with it.
 
@@ -102,13 +123,15 @@ make build
 make run
 ```
 
+## Development tools
+
 ### One liner installation
 
 ```shell
 $ sh -c "$(curl -fsSL https://raw.githubusercontent.com/aristanetworks/ansible-avd/master/development/install.sh)"
 ```
 
-## Pre-commit hook
+### Pre-commit hook
 
 [`pre-commit`](../.pre-commit-config.yaml) can run standard hooks on every commit to automatically point out issues in code such as missing semicolons, trailing whitespace, and debug statements. By pointing these issues out before code review, this allows a code reviewer to focus on the architecture of a change while not wasting time with trivial style nitpicks.
 
@@ -123,7 +146,7 @@ Repository implements following hooks:
 - `yamllint`: Validate all YAML files using configuration from [`yamllintrc`](../.github/yamllintrc)
 - `ansible-lint`: Validate yaml files are valid against ansible rules.
 
-### Installation
+#### Installation
 
 `pre-commit` is part of [__developement requirememnts__](./requirements-dev.txt). To install, run `pip command`:
 
@@ -132,7 +155,7 @@ $ pip install -r requirements-dev.txt
 ...
 ```
 
-### Run pre-commit manually
+#### Run pre-commit manually
 
 To run `pre-commit` manually before your commit, use this command:
 

--- a/development/README.md
+++ b/development/README.md
@@ -107,3 +107,62 @@ make run
 ```shell
 $ sh -c "$(curl -fsSL https://raw.githubusercontent.com/aristanetworks/ansible-avd/master/development/install.sh)"
 ```
+
+## Pre-commit hook
+
+[`pre-commit`](../.pre-commit-config.yaml) can run standard hooks on every commit to automatically point out issues in code such as missing semicolons, trailing whitespace, and debug statements. By pointing these issues out before code review, this allows a code reviewer to focus on the architecture of a change while not wasting time with trivial style nitpicks.
+
+Repository implements following hooks:
+
+- `trailing-whitespace`: Fix trailing whitespace. if found, commit is stopped and you must run commit process again.
+- `end-of-file-fixer`: Like `trailing-whitespace`, this hook fix wrong end of file and stop your commit.
+- `check-yaml`: Check all YAML files ares valid
+- `check-added-large-files`: Check if there is no large file included in repository
+- `check-merge-conflict`: Validate there is no `MERGE` syntax related to a invalid merge process.
+- `pylint`: Run python linting with settings defined in [`pylintrc`](../pylintrc)
+- `yamllint`: Validate all YAML files using configuration from [`yamllintrc`](../.github/yamllintrc)
+- `ansible-lint`: Validate yaml files are valid against ansible rules.
+
+### Installation
+
+`pre-commit` is part of [__developement requirememnts__](./requirements-dev.txt). To install, run `pip command`:
+
+```shell
+$ pip install -r requirements-dev.txt
+...
+```
+
+### Run pre-commit manually
+
+To run `pre-commit` manually before your commit, use this command:
+
+```shell
+pre-commit run
+[WARNING] Unstaged files detected.
+
+[INFO] Stashing unstaged files to /Users/xxx/.cache/pre-commit/patch1590742434.
+
+Trim Trailing Whitespace.............................(no files to check)Skipped
+Fix End of Files.....................................(no files to check)Skipped
+Check Yaml...........................................(no files to check)Skipped
+Check for added large files..........................(no files to check)Skipped
+Check for merge conflicts............................(no files to check)Skipped
+Check for Linting error on Python files..............(no files to check)Skipped
+Check for Linting error on YAML files................(no files to check)Skipped
+Check for ansible-lint errors............................................Passed
+
+[INFO] Restored changes from /Users/xxx/.cache/pre-commit/patch1590742434.
+```
+
+Command will automatically detect changed files using git status and run tests according their type.
+
+### Configure git hook
+
+To automatically run tests when running a commit, configure your repository whit command:
+
+```shell
+$ pre-commit install
+pre-commit installed at .git/hooks/pre-commit
+```
+
+To remove installation, use `uninstall` option.


### PR DESCRIPTION
Add a pre-commit configuration with following hooks:

- `trailing-whitespace`: Fix trailing whitespace. if found, commit is stopped and you must run commit process again.
- `end-of-file-fixer`: Like `trailing-whitespace`, this hook fix wrong end of file and stop your commit.
- `check-yaml`: Check all YAML files ares valid
- `check-added-large-files`: Check if there is no large file included in repository
- `check-merge-conflict`: Validate there is no `MERGE` syntax related to a invalid merge process.
- `pylint`: Run python linting with settings defined in `pylintrc`
- `yamllint`: Validate all YAML files using configuration from `yamllintrc`
- `ansible-lint`: Validate yaml files are valid against ansible rules.

Documentation has been updated in development/README.md
