### PR TITLE
eos_cli_config_gen fixes + new features : community-lists, dhcp option 82, route-map enhancement

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -648,7 +648,6 @@ vlan_interfaces:
     shutdown: < true | false >
     vrf: < vrf_name >
     ip_address: < IPv4_address/Mask >
-    ip_address_virtual: < IPv4_address/Mask >
     ip_address_secondary: < IPv4_address/Mask >
     ip_router_virtual_address: < IPv4_address >
     ip_router_virtual_address_secondary: < IPv4_address >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -300,11 +300,23 @@ router_l2_vpn:
 
 ```yaml
 sflow:
+  sample: < sample_rate >
+  dangerous: < true | false >
+  vrfs:
+    <vrf_name_1>:
+      destinations:
+        < sflow_destination_ip_1>:
+        < sflow_destination_ip_2>:
+          port: < port_number >
+      source_interface: < source_interface >
+    <vrf_name_2>:
+      destinations:
+        < sflow_destination_ip_1>:
+      source_interface: < source_interface >
   destinations:
     < sflow_destination_ip_1 >:
     < sflow_destination_ip_2 >:
-  source_interface: < source_interface_name >
-  sample: < sample_rate >
+  source_interface: < source_interface >
   run: < true | false >
 ```
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -922,17 +922,23 @@ route_maps:
       < sequence_id_1 >:
         type: < permit | deny >
         description: < description >
-        match: "< match as string >"
-        set: "< set as string >"
+        match:
+          - "< match rule 1 as string >"
+          - "< match rule 2 as string >"
+        set:
+          - "< set as string >"
       < sequence_id_2 >:
         type: < permit | deny >
-        match: "< match as string >"
+        match:
+          - "< match as string >"
   < route_map_name_2 >:
     sequence_numbers:
       < sequence_id_1 >:
         type: < permit | deny >
         description: < description >
-        set: "< set as string >"
+        set:
+          - "< set rule 1 as string >"
+          - "< set rule 2 as string >"
 ```
 
 ### Peer Filters

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -11,6 +11,7 @@
     - [Aliases](#aliases)
     - [Hardware Counters](#hardware-counters)
     - [Daemon TerminAttr](#daemon-terminattr)
+    - [IP DHCP Relay](#ip-dhcp-relay)
     - [Internal VLAN Allocation Policy](#internal-vlan-allocation-policy)
     - [IP IGMP Snooping](#ip_igmp_snooping#)
     - [Event Monitor](#event-monitor)
@@ -155,6 +156,15 @@ daemon_terminattr:
   ingestexclude: "< list as string >"
 
 ```
+
+### IP DHCP Relay
+
+```yaml
+ip_dhcp_relay:
+  information_option: true
+  
+```
+
 
 ### Internal VLAN Allocation Policy
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -2,7 +2,7 @@
 
 **Table of Contents:**
 
-- [Ansible Role: eos_cli_config_gen](#ansible-role-eoscliconfiggen)
+- [Ansible Role: eos_cli_config_gen](#ansible-role-eos_cli_config_gen)
   - [Overview](#overview)
   - [Role Inputs and Outputs](#role-inputs-and-outputs)
   - [Requirements](#requirements)
@@ -13,13 +13,13 @@
     - [Daemon TerminAttr](#daemon-terminattr)
     - [IP DHCP Relay](#ip-dhcp-relay)
     - [Internal VLAN Allocation Policy](#internal-vlan-allocation-policy)
-    - [IP IGMP Snooping](#ip_igmp_snooping#)
+    - [IP IGMP Snooping](#ip-igmp-snooping)
     - [Event Monitor](#event-monitor)
     - [Event Handler](#event-handler)
     - [Load Interval](#load-interval)
     - [Queue Monitor Length](#queue-monitor-length)
-    - [Logging](#logging)
     - [Service Routing Protocols Model](#service-routing-protocols-model)
+    - [Logging](#logging)
     - [Domain Lookup](#domain-lookup)
     - [Name Servers](#name-servers)
     - [DNS Domain](#dns-domain)
@@ -27,7 +27,7 @@
     - [Router L2 VPN](#router-l2-vpn)
     - [Sflow](#sflow)
     - [Redundancy](#redundancy)
-    - [SNMP Settings](#snmp-settings)
+    - [Snmp Settings](#snmp-settings)
     - [Spanning Tree](#spanning-tree)
     - [Platform](#platform)
     - [Tacacs+ Servers](#tacacs-servers)
@@ -50,25 +50,27 @@
     - [MAC Address-table](#mac-address-table)
     - [Router Virtual MAC Address](#router-virtual-mac-address)
     - [Virtual Source NAT](#virtual-source-nat)
-    - [IPv6 Extended ACL](#ipv6-access-lists)
-    - [IPv6 Standard ACL](#ipv6-standard-access-lists)
-    - [Extended ACL](#access-lists)
-    - [Standard ACL](#standard-access-lists)
+    - [IPv6 Extended Access-Lists](#ipv6-extended-access-lists)
+    - [IPv6 Standard Access-Lists](#ipv6-standard-access-lists)
+    - [IP Extended Access-Lists](#ip-extended-access-lists)
+    - [IP Standard Access-Lists](#ip-standard-access-lists)
     - [Static Routes](#static-routes)
     - [IPv6 Static Routes](#ipv6-static-routes)
     - [IP Routing](#ip-routing)
     - [Prefix Lists](#prefix-lists)
     - [IPv6 Prefix Lists](#ipv6-prefix-lists)
-    - [IPv6 Routing](#ipv6-unicast-routing)
+    - [IPv6 Routing](#ipv6-routing)
     - [MLAG Configuration](#mlag-configuration)
     - [Community Lists](#community-lists)
     - [Route Maps](#route-maps)
     - [Peer Filters](#peer-filters)
     - [Router BGP Configuration](#router-bgp-configuration)
+    - [Routing - Multicast](#routing---multicast)
     - [Router OSPF Configuration](#router-ospf-configuration)
+    - [Routing PIM Sparse Mode](#routing-pim-sparse-mode)
     - [Queue Monitor Streaming](#queue-monitor-streaming)
     - [IP TACACS+ Source Interfaces](#ip-tacacs-source-interfaces)
-    - [VM Tracer Sessions](#vmtracer-sessions)
+    - [VM Tracer Sessions](#vm-tracer-sessions)
     - [Banners](#banners)
     - [HTTP Management API](#http-management-api)
     - [Management Console](#management-console)
@@ -896,7 +898,8 @@ ipv6_prefix_lists:
         action: "< action as string >"
 ```
 
-### IPv6 Routing ###
+### IPv6 Routing
+
 ipv6_unicast_routing: < true | false >
 
 ### MLAG Configuration

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -648,11 +648,11 @@ vlan_interfaces:
     shutdown: < true | false >
     vrf: < vrf_name >
     ip_address: < IPv4_address/Mask >
+    ip_address_virtual: < IPv4_address/Mask >
     ip_address_secondary: < IPv4_address/Mask >
     ip_router_virtual_address: < IPv4_address >
     ip_router_virtual_address_secondary: < IPv4_address >
     ip_address_virtual: < IPv4_address/Mask >
-    virtual: < true | false >
     mtu: < mtu >
     ip_helpers:
       < ip_helper_address_1 >:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1269,12 +1269,12 @@ management_security:
 ```yaml
 management_ssh:
   access_groups:
-    < standard_acl_name_1 >:
-    < standard_acl_name_2 >:
+    - name: < standard_acl_name_1 >:
+    - name: < standard_acl_name_2 >:
       vrf: < vrf name >
   ipv6_access_groups:
-    < standard_acl_name_1 >:
-    < standard_acl_name_2 >:
+    - name: < standard_acl_name_1 >:
+    - name: < standard_acl_name_2 >:
       vrf: < vrf name >
   idle_timeout: < 0-86400 in minutes >
   enable: < true | false >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -61,6 +61,7 @@
     - [IPv6 Prefix Lists](#ipv6-prefix-lists)
     - [IPv6 Routing](#ipv6-unicast-routing)
     - [MLAG Configuration](#mlag-configuration)
+    - [Community Lists](#community-lists)
     - [Route Maps](#route-maps)
     - [Peer Filters](#peer-filters)
     - [Router BGP Configuration](#router-bgp-configuration)
@@ -164,7 +165,6 @@ ip_dhcp_relay:
   information_option: < true | false >
 
 ```
-
 
 ### Internal VLAN Allocation Policy
 
@@ -901,6 +901,16 @@ mlag_configuration:
   peer_link: < Port-Channel_id >
   reload_delay_mlag: < seconds >
   reload_delay_non_mlag: < seconds >
+```
+
+### Community Lists
+
+```yaml
+community_lists:
+  < community_list_name_1 >:
+    action: "< action as string >"
+  < community_list_name_2 >:
+    action: "< action as string >"
 ```
 
 ### Route Maps

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -161,8 +161,8 @@ daemon_terminattr:
 
 ```yaml
 ip_dhcp_relay:
-  information_option: true
-  
+  information_option: < true | false >
+
 ```
 
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/community-lists.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/community-lists.j2
@@ -1,0 +1,17 @@
+{% if community_lists is defined and community_lists is not none %}
+### Community Lists Summary
+
+| Name | Action |
+| -------- | ------ |
+{%     for community_list in community_lists | arista.avd.natural_sort %}
+| {{ community_list }} | {{ community_lists[community_list].action }} |
+{%     endfor %}
+
+### Community Lists Device Configuration
+
+```eos
+{% include 'eos/community-lists.j2' %}
+```
+{% else %}
+Community Lists not defined
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ip-dhcp-relay.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ip-dhcp-relay.j2
@@ -1,0 +1,15 @@
+{% if ip_dhcp_relay is defined and ip_dhcp_relay is not none %}
+### IP DHCP Relay
+{%    if ip_dhcp_relay.information_option is defined and ip_dhcp_relay.information_option == true %}
+
+IP DHCP Relay Option 82 is enabled.
+{%    endif %}
+
+### IP DHCP Relay Configuration
+
+```eos
+{% include 'eos/ip-dhcp-relay.j2' %}
+```
+{% else %}
+IP DHCP Relay not defined
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/route-maps.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/route-maps.j2
@@ -8,10 +8,13 @@
 | -------- | ---- | ---------------- |
 {%         for sequence in route_maps[route_map].sequence_numbers | arista.avd.natural_sort %}
 {%              if route_maps[route_map].sequence_numbers[sequence].match is defined and route_maps[route_map].sequence_numbers[sequence].match is not none %}
-| {{ sequence }} | {{ route_maps[route_map].sequence_numbers[sequence].type }} | match {{ route_maps[route_map].sequence_numbers[sequence].match }} |
+{%                for match_rule in route_maps[route_map].sequence_numbers[sequence].match | arista.avd.natural_sort %}
+| {{ sequence }} | {{ route_maps[route_map].sequence_numbers[sequence].type }} | match {{ match_rule }} |
+{%                endfor %}
 {%              endif %}
-{%              if route_maps[route_map].sequence_numbers[sequence].set is defined and route_maps[route_map].sequence_numbers[sequence].set is not none %}
-| {{ sequence }} | {{ route_maps[route_map].sequence_numbers[sequence].type }} | set {{ route_maps[route_map].sequence_numbers[sequence].set }} |
+{%              if route_maps[route_map].sequence_numbers[sequence].set is defined and route_maps[route_map].sequence_numbers[sequence].set is not none %}{%                for set_rule in route_maps[route_map].sequence_numbers[sequence].set | arista.avd.natural_sort %}
+| {{ sequence }} | {{ route_maps[route_map].sequence_numbers[sequence].type }} | set {{ set_rule }} |
+{%                endfor %}
 {%              endif %}
 {%         endfor %}
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/sflow.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/sflow.j2
@@ -1,17 +1,30 @@
 {% if sflow is defined and sflow is not none %}
 ### SFlow Summary
 
-{%     if sflow.destinations is defined and sflow.destinations is not none %}
-| SFlow Destination | Port |
-| ----------------- | --- |
-{%      for destination in sflow.destinations %}
-| {{ destination }} | {% if sflow.destinations[destination].port is defined and sflow.destinations[destination].port is not none %} {{ sflow.destinations[destination].port }} {% else %} 6343 {% endif %} |
-{%      endfor %}
+{%   if ( (sflow.vrfs is defined and sflow.vrfs is not none) or (sflow.destinations is defined and sflow.destinations is not none) or (sflow.source_interface is defined and sflow.source_interface is not none) ) %}
+| VRF | SFlow Source Interface | SFlow Destination | Port |
+| --- | ---------------------- | ----------------- | ---- |
+{%      if sflow.vrfs is defined and sflow.vrfs is not none %}
+{%          for vrf in sflow.vrfs | arista.avd.natural_sort %}
+{%              if sflow.vrfs[vrf].destinations is defined and sflow.vrfs[vrf].destinations is not none %}
+{%                  for destination in sflow.vrfs[vrf].destinations | arista.avd.natural_sort %}
+| {{ vrf }} | - | {{ destination }} |{% if sflow.vrfs[vrf].destinations[destination].port is defined and sflow.vrfs[vrf].destinations[destination].port is not none %} {{ sflow.vrfs[vrf].destinations[destination].port }}{% else %} 6343 {% endif %} |
+{%                  endfor %}
+{%              endif %}
+{%              if sflow.vrfs[vrf].source_interface is defined and sflow.vrfs[vrf].source_interface is not none %}
+| {{ vrf }} | {{ sflow.vrfs[vrf].source_interface }} | - | - |
+{%              endif %}
+{%          endfor %}
+{%      endif %}
+{%      if sflow.destinations is defined and sflow.destinations is not none %}
+{%          for destination in sflow.destinations %}
+| GRT | - | {{ destination }} |{% if sflow.destinations[destination].port is defined and sflow.destinations[destination].port is not none %} {{ sflow.destinations[destination].port }} {% else %} 6343 {% endif %} |
+{%          endfor %}
 {%     endif %}
-
 {%     if sflow.source_interface is defined and sflow.source_interface is not none %}
-sFlow Source Interface: {{ sflow.source_interface }}
+| GRT | {{ sflow.source_interface }} | - | - |
 {%     endif %}
+{%   endif %}
 
 {%     if sflow.sample is defined and sflow.sample is not none %}
 sFlow Sample Rate: {{ sflow.sample }}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-device-documentation.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-device-documentation.j2
@@ -161,6 +161,10 @@
 
 {% include 'documentation/mlag-configuration.j2' %}
 
+## Community Lists
+
+{% include 'documentation/community-lists.j2' %}
+
 ## Route Maps
 
 {% include 'documentation/route-maps.j2' %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-device-documentation.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-device-documentation.j2
@@ -13,6 +13,10 @@
 
 {% include 'documentation/daemon-terminattr.j2' %}
 
+## IP DHCP Relay
+
+{% include 'documentation/ip-dhcp-relay.j2' %}
+
 ## Internal VLAN allocation Policy
 
 {% include 'documentation/vlan-internal-order.j2' %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
@@ -9,6 +9,8 @@
 {% include 'eos/hardware-counters.j2' %}
 {# daemon TerminAttr #}
 {% include 'eos/daemon-terminattr.j2' %}
+{# ip dhcp relay #}
+{% include 'eos/ip-dhcp-relay.j2' %}
 {# internal vlan allocation policy #}
 {% include 'eos/vlan-internal-order.j2' %}
 {# ip igmp snooping #}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
@@ -112,6 +112,8 @@ hostname {{ inventory_hostname }}
 {% include 'eos/static-routes.j2' %}
 {# IPv6 Static Route #}
 {% include 'eos/ipv6-static-routes.j2' %}
+{# Community-lists #}
+{% include 'eos/community-lists.j2' %}
 {# route-maps #}
 {% include 'eos/route-maps.j2' %}
 {# router bfd #}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/community-lists.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/community-lists.j2
@@ -1,0 +1,7 @@
+{# eos - community-lists #}
+{% if community_lists is defined and community_lists is not none %}
+{%     for community_list in community_lists | arista.avd.natural_sort %}
+ip community-list {{ community_list }} {{ community_lists[community_list].action }}
+{%     endfor %}
+!
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-dhcp-relay.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-dhcp-relay.j2
@@ -1,0 +1,7 @@
+{# eos - ip dhcp relay #}
+{% if ip_dhcp_relay is defined and ip_dhcp_relay is not none %}
+{%    if ip_dhcp_relay.information_option is defined and ip_dhcp_relay.information_option == true %}
+ip dhcp relay information option
+!
+{%    endif %}
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ipv6-static-routes.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ipv6-static-routes.j2
@@ -2,7 +2,7 @@
 {% if ipv6_static_routes is defined and ipv6_static_routes is not none %}
 {%     for ipv6_static_route in ipv6_static_routes %}
 ipv6 route
-{%- if ipv6_static_route['vrf'] is defined and ipv6_static_route['vrf'] != 'default' %} vrf {{ ipv6_static_route['vrf'] }}{% endif -%} {{ ipv6_static_route['destination_address_prefix'] }} {{ ipv6_static_route['gateway'] }}
+{%- if ipv6_static_route['vrf'] is defined and ipv6_static_route['vrf'] != 'default' %} vrf {{ ipv6_static_route['vrf'] }}{% endif %} {{ ipv6_static_route['destination_address_prefix'] }} {{ ipv6_static_route['gateway'] }}
 {%- if ipv6_static_route['distance'] is defined and ipv6_static_route['distance'] is not none %} {{ ipv6_static_route['distance'] }}{% endif -%}
 {%- if ipv6_static_route['tag'] is defined and ipv6_static_route['tag'] is not none %} tag {{ ipv6_static_route['tag'] }}{% endif -%}
 {%- if ipv6_static_route['name'] is defined and ipv6_static_route['name'] is not none %} name {{ ipv6_static_route['name'] }}{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-ssh.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-ssh.j2
@@ -3,12 +3,12 @@
 management ssh
 {%     if management_ssh.access_groups is defined and management_ssh.access_groups is not none %}
 {%         for access_group in management_ssh.access_groups %}
-   ip access-group {{ access_group }} {% if management_ssh.access_groups[access_group].vrf is defined and management_ssh.access_groups[access_group].vrf is not none %}vrf {{ management_ssh.access_groups[access_group].vrf }} {% endif %}in
+   ip access-group {{ access_group.name }}{% if management_ssh.access_groups[access_group].vrf is defined and management_ssh.access_groups[access_group].vrf is not none %} vrf {{ access_group.vrf }}{% endif %} in
 {%         endfor %}
 {%     endif %}
 {%     if management_ssh.ipv6_access_groups is defined and management_ssh.ipv6_access_groups is not none %}
-{%         for ipv6_access_group in management_ssh.ipv6_access_groups %}
-   ipv6 access-group {{ ipv6_access_group }} {% if management_ssh.ipv6_access_groups[ipv6_access_group].vrf is defined and management_ssh.ipv6_access_groups[ipv6_access_group].vrf is not none %}vrf {{ management_ssh.ipv6_access_groups[ipv6_access_group].vrf }} {% endif %}in
+{%         for access_group in management_ssh.ipv6_access_groups %}
+   ipv6 access-group {{ access_group.name }}{% if management_ssh.ipv6_access_groups[access_group].vrf is defined and management_ssh.ipv6_access_groups[access_group].vrf is not none %} vrf {{ access_group.vrf }}{% endif %} in
 {%         endfor %}
 {%     endif %}
 {%     if management_ssh.idle_timeout is defined and management_ssh.idle_timeout is not none %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/route-maps.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/route-maps.j2
@@ -7,10 +7,14 @@ route-map {{ route_map }} {{ route_maps[route_map].sequence_numbers[sequence].ty
    description {{ route_maps[route_map].sequence_numbers[sequence].description }}
 {%             endif %}
 {%             if route_maps[route_map].sequence_numbers[sequence].match is defined and route_maps[route_map].sequence_numbers[sequence].match is not none %}
-   match {{ route_maps[route_map].sequence_numbers[sequence].match }}
+{%                for match_rule in route_maps[route_map].sequence_numbers[sequence].match | arista.avd.natural_sort %}
+   match {{ match_rule }}
+{%                endfor %}
 {%             endif %}
 {%             if route_maps[route_map].sequence_numbers[sequence].set is defined and route_maps[route_map].sequence_numbers[sequence].set is not none %}
-   set {{ route_maps[route_map].sequence_numbers[sequence].set }}
+{%                for set_rule in route_maps[route_map].sequence_numbers[sequence].set | arista.avd.natural_sort %}
+   set {{ set_rule }}
+{%                endfor %}
 {%             endif %}
 !
 {%         endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -63,8 +63,8 @@ router bgp {{ router_bgp.as }}
 {%     endif %}
 {%     if router_bgp.redistribute_routes is defined and router_bgp.redistribute_routes is not none %}
 {%         for redistribute_route in router_bgp.redistribute_routes | arista.avd.natural_sort %}
-   redistribute {{ redistribute_route }} {% if router_bgp.redistribute_routes[redistribute_route].route_map is defined and router_bgp.redistribute_routes[redistribute_route].route_map is not none %}route-map {{ router_bgp.redistribute_routes[redistribute_route].route_map }}
-{%             endif %}
+   redistribute {{ redistribute_route }}{% if router_bgp.redistribute_routes[redistribute_route].route_map is defined and router_bgp.redistribute_routes[redistribute_route].route_map is not none %} route-map {{ router_bgp.redistribute_routes[redistribute_route].route_map }}{% endif %}
+
 {%         endfor %}
 {%     endif %}
 {# L2VPNs - (vxlan) vlan based #}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/sflow.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/sflow.j2
@@ -1,21 +1,31 @@
 {# eos - SFlow #}
 {% if sflow is defined and sflow is not none %}
+{%     if sflow.sample is defined and sflow.sample is not none %}
+sflow sample{% if sflow.dangerous is defined and sflow.dangerous == true %} dangerous{% endif %} {{ sflow.sample }}
+{%     endif %}
+{%   if sflow.vrfs is defined and sflow.vrfs is not none %}
+{%     for vrf in sflow.vrfs | arista.avd.natural_sort %}
+{%       if sflow.vrfs[vrf].destinations is defined and sflow.vrfs[vrf].destinations is not none %}
+{%          for destination in sflow.vrfs[vrf].destinations | arista.avd.natural_sort %}
+sflow vrf {{ vrf }} destination {{ destination }}{% if sflow.vrfs[vrf].destinations[destination].port is defined and sflow.vrfs[vrf].destinations[destination].port is not none %} {{ sflow.vrfs[vrf].destinations[destination].port }}{% endif %}
+
+{%          endfor %}
+{%       endif %}
+{%       if sflow.vrfs[vrf].source_interface is defined and sflow.vrfs[vrf].source_interface is not none %}
+sflow vrf {{ vrf }} source-interface {{ sflow.vrfs[vrf].source_interface }}
+{%       endif %}
+{%     endfor %}
+{%   endif %}
 {%     if sflow.destinations is defined and sflow.destinations is not none %}
-{%      for destination in sflow.destinations %}
-{%          if sflow.destinations[destination].port is defined and sflow.destinations[destination].port is not none %}
-sflow destination {{ destination }} {{ sflow.destinations[destination].port }}
-{%          else %}
-sflow destination {{ destination }}
-{%          endif %}
+{%      for destination in sflow.destinations | arista.avd.natural_sort %}
+sflow destination {{ destination }}{% if sflow.destinations[destination].port is defined and sflow.destinations[destination].port is not none %} {{ sflow.destinations[destination].port }}{% endif %}
+
 {%      endfor %}
 {%     endif %}
 {%     if sflow.source_interface is defined and sflow.source_interface is not none %}
 sflow source-interface {{ sflow.source_interface }}
 {%     endif %}
-{%     if sflow.sample is defined and sflow.sample is not none %}
-sflow sample dangerous {{ sflow.sample }}
-{%     endif %}
-{%     if sflow.run is defined and sflow.run == True %}
+{%     if sflow.run is defined and sflow.run == true %}
 sflow run
 {%     endif %}
 !

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
@@ -20,14 +20,6 @@ interface {{ vlan_interface }}
 {%         if vlan_interfaces[vlan_interface].ip_address is defined %}
    ip address {{ vlan_interfaces[vlan_interface].ip_address }}
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].ip_address is defined and vlan_interfaces[vlan_interface].virtual is defined and vlan_interfaces[vlan_interface].virtual == true %}
-   ip address virtual {{ vlan_interfaces[vlan_interface].ip_address }}
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].ip_address_secondary is defined and vlan_interfaces[vlan_interface].virtual is defined and vlan_interfaces[vlan_interface].virtual == true %}
-   ip address virtual {{ vlan_interfaces[vlan_interface].ip_address_secondary }} secondary
-{%         elif vlan_interfaces[vlan_interface].ip_address_secondary is defined %}
-   ip address {{ vlan_interfaces[vlan_interface].ip_address_secondary }} secondary
-{%         endif %}
 {%         if vlan_interfaces[vlan_interface].ip_virtual_router_address is defined %}
    ip virtual-router address {{ vlan_interfaces[vlan_interface].ip_virtual_router_address }}
 {%         endif %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/underlay-overlay/route-maps.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/underlay-overlay/route-maps.j2
@@ -3,4 +3,5 @@
     sequence_numbers:
       10:
         type: permit
-        match: "ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY"
+        match:
+          - "ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY"


### PR DESCRIPTION
- [x] fixing redistribute return on line in bgp
- [x] fix white space when vrf in static route
- [x] fix ip_address_virtual
- [x] eos_cli_config_gen Readme correction
- [x] add possibility to have several match/set rules in route-maps
- [x] add support for dhcp relay option 82 
- [x] add support for community-lists
- [x] refactor SFlow and include VRF support
- [x] refactor SSH management