### PR TITLE
cli_config_gen: support bpduguard on ethernet-interface and port-channel interfaces

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -527,6 +527,7 @@ port_channel_interfaces:
     vlans: "< list of vlans as string >"
     mode: < access | dot1q-tunnel | trunk >
     spanning_tree_bpdufilter: < true | false >
+    spanning_tree_bpduguard: < true | false >
     spanning_tree_portfast: < portfast_mode >
     vmtracer: < true | false >
   < Port-Channel_interface_3 >:
@@ -604,6 +605,7 @@ ethernet_interfaces:
     qos:
       trust: < cos | dscp >
     spanning_tree_bpdufilter: < true | false >
+    spanning_tree_bpduguard: < true | false >
     spanning_tree_portfast: < portfast_mode >
     vmtracer: < true | false >
 ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -50,6 +50,9 @@ interface {{ ethernet_interface }}
 {%             if ethernet_interfaces[ethernet_interface].spanning_tree_bpdufilter is defined and ethernet_interfaces[ethernet_interface].spanning_tree_bpdufilter == true %}
    spanning-tree bpdufilter enable
 {%             endif%}
+{%             if ethernet_interfaces[ethernet_interface].spanning_tree_bpduguard is defined and ethernet_interfaces[ethernet_interface].spanning_tree_bpduguard == true %}
+   spanning-tree bpduguard enable
+{%             endif%}
 {%             if ethernet_interfaces[ethernet_interface].vrf is defined and ethernet_interfaces[ethernet_interface].vrf is not none %}
    vrf {{ ethernet_interfaces[ethernet_interface].vrf }}
 {%             endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
@@ -42,6 +42,9 @@ interface {{ port_channel_interface }}
 {%         if port_channel_interfaces[port_channel_interface].spanning_tree_bpdufilter is defined and port_channel_interfaces[port_channel_interface].spanning_tree_bpdufilter == true %}
    spanning-tree bpdufilter enable
 {%         endif%}
+{%         if port_channel_interfaces[port_channel_interface].spanning_tree_bpduguard is defined and port_channel_interfaces[port_channel_interface].spanning_tree_bpduguard == true %}
+   spanning-tree bpduguard enable
+{%         endif%}
 {%         if port_channel_interfaces[port_channel_interface].vrf is defined and port_channel_interfaces[port_channel_interface].vrf is not none %}
    vrf {{ port_channel_interfaces[port_channel_interface].vrf }}
 {%         endif %}


### PR DESCRIPTION
Add implementation (same as spanning_tree_bpdufilter) to configure an switch
port ot port-channel with the "spanning-tree bpduguard enable" option.

This implements https://github.com/aristanetworks/ansible-avd/issues/148