### PR TITLE
Fix incorrect configlet lookup path

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/main.yml
@@ -5,9 +5,9 @@
   inventory_to_container:
     inventory: '{{ inventory_file }}'
     container_root: '{{ container_root }}'
-    configlet_dir: '{{playbook_dir}}/intended/configs'
+    configlet_dir: '{{inventory_dir}}/intended/configs'
     configlet_prefix: '{{ configlets_prefix }}'
-    destination: '{{inventory_dir}}/intended/structured_configs/cvp/{{inventory_hostname}}.yml'
+    destination: '{{inventory_dir}}/intended/structured_configs/cvp/{{inventory_hostname}}_2.yml'
   register: CVP_VARS
 
 - name: 'Build DEVICES and CONTAINER definition for {{inventory_hostname}}'

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/main.yml
@@ -7,7 +7,7 @@
     container_root: '{{ container_root }}'
     configlet_dir: '{{inventory_dir}}/intended/configs'
     configlet_prefix: '{{ configlets_prefix }}'
-    destination: '{{inventory_dir}}/intended/structured_configs/cvp/{{inventory_hostname}}_2.yml'
+    destination: '{{inventory_dir}}/intended/structured_configs/cvp/{{inventory_hostname}}_configlets.yml'
   register: CVP_VARS
 
 - name: 'Build DEVICES and CONTAINER definition for {{inventory_hostname}}'


### PR DESCRIPTION
Fix an incorrect path feading inventory_to_container looking for wrong
place for configlets upload.

It only impact if inventories and playbooks are not in same folder.
