### PR TITLE
Update development tool for docker image

### DIFF
--- a/development/Makefile
+++ b/development/Makefile
@@ -10,11 +10,6 @@ GID = $(shell id -g)
 help: ## Display help message
 	@grep -E '^[0-9a-zA-Z_-]+\.*[0-9a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-.PHONY: build
-build: ## Build a new image of avd container
-	#docker build --no-cache -t $(CONTAINER) .
-	docker build -t $(CONTAINER) . --build-arg UID=$(UID) --build-arg GID=$(GID)
-
 .PHONY: run
 run: ## Run ansible-avd container
 	docker run --rm -it \
@@ -26,3 +21,8 @@ run: ## Run ansible-avd container
 .PHONY: clean
 clean: ## Remove avd image from local repository
 	docker rmi $(CONTAINER_NAME):$(DOCKER_TAG)
+
+.PHONY: build
+build: ## [DEPRECATED] visit https://github.com/arista-netdevops-community/docker-avd-base to build image
+	#docker build --no-cache -t $(CONTAINER) .
+	echo ''; echo 'Deprecated command -- visit https://github.com/arista-netdevops-community/docker-avd-base to build image'; echo ''

--- a/development/Makefile
+++ b/development/Makefile
@@ -1,6 +1,6 @@
-CONTAINER_NAME = ansible_avd
-ANSIBLE_VERSION = 2.9.6
-CONTAINER = $(CONTAINER_NAME):$(ANSIBLE_VERSION)
+CONTAINER_NAME = avdteam/base
+DOCKER_TAG = centos-7
+CONTAINER = $(CONTAINER_NAME):$(DOCKER_TAG)
 HOME_DIR = $(shell pwd)
 HOME_DIR_DOCKER = '/home/docker'
 UID = $(shell id -u)
@@ -17,7 +17,7 @@ build: ## Build a new image of avd container
 
 .PHONY: run
 run: ## Run ansible-avd container
-	docker run --rm -it --name $(CONTAINER_NAME)_$(ANSIBLE_VERSION) \
+	docker run --rm -it \
 		-v $(HOME)/.ssh:$(HOME_DIR_DOCKER)/.ssh \
 		-v $(HOME)/.gitconfig:$(HOME_DIR_DOCKER)/.gitconfig \
 		-v $(HOME_DIR)/:/projects \

--- a/development/Makefile
+++ b/development/Makefile
@@ -25,4 +25,4 @@ run: ## Run ansible-avd container
 
 .PHONY: clean
 clean: ## Remove avd image from local repository
-	docker rmi $(CONTAINER_NAME):$(ANSIBLE_VERSION)
+	docker rmi $(CONTAINER_NAME):$(DOCKER_TAG)

--- a/development/README.md
+++ b/development/README.md
@@ -6,9 +6,6 @@
     - [Python Virtual Environment](#python-virtual-environment)
       - [Install Python3 Virtual Environment](#install-python3-virtual-environment)
     - [Docker Container for Ansible Testing and Development](#docker-container-for-ansible-testing-and-development)
-      - [Build Docker Container](#build-docker-container)
-      - [Run Docker Container](#run-docker-container)
-      - [Stop Docker Container](#stop-docker-container)
   - [Getting started Script](#getting-started-script)
     - [Step by step installation process](#step-by-step-installation-process)
   - [Development tools](#development-tools)
@@ -70,43 +67,9 @@ The ansible version is passed in with the docker build command using ***ANSIBLE*
 
 Before you can use a container, you must install Docker CE on your workstation: https://www.docker.com/products/docker-desktop
 
-#### Build Docker Container
+Since docker image is now automatically published on [__docker-hub__](https://hub.docker.com/repository/docker/avdteam/base), a dedicated repository is available on [__Arista Netdevops Community__](https://github.com/arista-netdevops-community/docker-avd-base).
 
-In addition to the `Dockerfile`, a `Makefile` is provided to help provision the container a single step. A user can pass the ansible version number to make and alter the default ansible-version number.  This allows a user to setup multiple containers running differing versions of ansible.
-
-```shell
-make build                        # Use default version of Ansible
-make build ANSIBLE_VERSION=2.9.5  # Explicitly set Ansible version to 2.9.5
-
-docker images
-REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
-ansible_avd         2.9.6               5291937a2214        33 minutes ago      795MB
-ansible_avd         2.9.5               27f648c4c249        46 hours ago        912MB
-```
-
-#### Run Docker Container
-
-```shell
-make run                        # Use default version of Ansible
-make run ANSIBLE_VERSION=2.9.5  # Explicitly set Ansible version to 2.9.5
-
-docker ps
-CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
-e682058d7dae        ansible_avd:2.9.5   "/bin/sh"           6 seconds ago       Up 5 seconds                            ansible_avd_2.9.5
-540a8e778907        ansible_avd:2.9.6   "/bin/sh"           38 seconds ago      Up 37 seconds                           ansible_avd_2.9.6
-```
-
-#### Stop Docker Container
-
-Another make target (clean) has been created to stop and remove the container once the user is finished with it.
-
-```shell
-make clean                       # Clean default version of Ansible
-make clean ANSIBLE_VERSION=2.9.5 # Explicitly clean Ansible version to 2.9.5
-
-docker ps
-CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
-```
+If you want to test a specific ansible version, you can refer to this [dedicated page](https://github.com/arista-netdevops-community/docker-avd-base/blob/master/USAGE.md) to build your own docker image.
 
 ## Getting started Script
 
@@ -118,8 +81,7 @@ cd git_projects
 git clone https://github.com/aristanetworks/ansible-avd.git
 git clone https://github.com/aristanetworks/ansible-cvp.git
 git clone https://github.com/aristanetworks/netdevops-examples.git
-cp ansible-avd/development/* ./
-make build
+cp ansible-avd/development/Makefile ./
 make run
 ```
 

--- a/development/install.sh
+++ b/development/install.sh
@@ -26,7 +26,7 @@ else
     exit 1
 fi
 
-if [ ! -d "${_ROOT_INSTALLATION_DIR}" ]; then 
+if [ ! -d "${_ROOT_INSTALLATION_DIR}" ]; then
     echo "  * creating local installation folder: ${_ROOT_INSTALLATION_DIR}"
     mkdir -p ${_ROOT_INSTALLATION_DIR}
     echo "  * cloning ansible-avd collections to ${_LOCAL_AVD}"
@@ -37,7 +37,7 @@ if [ ! -d "${_ROOT_INSTALLATION_DIR}" ]; then
     git clone ${_REPO_EXAMPLES} ${_LOCAL_EXAMPLES}
     if [ -d ${_DEV_FOLDER} ]; then
         echo "deploying development content to ${_ROOT_INSTALLATION_DIR}"
-        cp ${_DEV_FOLDER}/* ${_ROOT_INSTALLATION_DIR}
+        cp ${_DEV_FOLDER}/Makefile ${_ROOT_INSTALLATION_DIR}
     else
         echo "  ! error: development folder is missing"
     fi


### PR DESCRIPTION
Refactor docker information to use a published docker image:

- [Repository to build image](https://github.com/arista-netdevops-community/docker-avd-base)

- [Build process](https://github.com/arista-netdevops-community/docker-avd-base/blob/master/USAGE.md)

- [Docker Hub page](https://hub.docker.com/repository/docker/avdteam/base)

With this change, no need to build image locally for every user.

Besides that, it will give us option to use a standard image for all our test in CI instead of bootstrapping runner all time.