### PR TITLE
cli_config_gen: sFlow: add VRF awareness

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -292,8 +292,16 @@ router_l2_vpn:
 sflow:
   destinations:
     < sflow_destination_ip_1 >:
+      port: < sflow_destination_port >
     < sflow_destination_ip_2 >:
   source_interface: < source_interface_name >
+  vrfs:
+    name: < vrf_name >
+    destinations:
+      < sflow_destination_ip_1 >:
+        port: < sflow_destination_port >
+      < sflow_destination_ip_2 >:
+    source_interface: < source_interface_name >
   sample: < sample_rate >
   run: < true | false >
 ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/sflow.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/sflow.j2
@@ -1,22 +1,31 @@
 {# eos - SFlow #}
 {% if sflow is defined and sflow is not none %}
-{%     if sflow.destinations is defined and sflow.destinations is not none %}
-{%      for destination in sflow.destinations %}
-{%          if sflow.destinations[destination].port is defined and sflow.destinations[destination].port is not none %}
-sflow destination {{ destination }} {{ sflow.destinations[destination].port }}
-{%          else %}
-sflow destination {{ destination }}
-{%          endif %}
-{%      endfor %}
-{%     endif %}
-{%     if sflow.source_interface is defined and sflow.source_interface is not none %}
+{# eos - VRF based SFlow #}
+{%   if sflow.vrfs is defined and sflow.vrfs is not none %}
+{%     for vrf in sflow.vrfs %}
+{%       for destination in vrf.destinations %}
+{%         set port = vrf.destinations[destination].port if vrf.destinations[destination].port is defined else '' %}
+sflow vrf {{ vrf.name }} destination {{ destination }} {{ port }}
+{%       endfor %}
+{%       if vrf.source_interface is defined and vrf.source_interface is not none %}
+sflow vrf {{ vrf.name }} source-interface {{ vrf.source_interface }}
+{%       endif %}
+{%     endfor %}
+{%   endif %}
+{%   if sflow.destinations is defined and sflow.destinations is not none %}
+{%     for destination in sflow.destinations %}
+{%       set port = sflow.destinations[destination].port if sflow.destinations[destination].port is defined else '' %}
+sflow destination {{ destination }} {{ port }}
+{%     endfor %}
+{%   endif %}
+{%   if sflow.source_interface is defined and sflow.source_interface is not none %}
 sflow source-interface {{ sflow.source_interface }}
-{%     endif %}
-{%     if sflow.sample is defined and sflow.sample is not none %}
+{%   endif %}
+{%   if sflow.sample is defined and sflow.sample is not none %}
 sflow sample dangerous {{ sflow.sample }}
-{%     endif %}
-{%     if sflow.run is defined and sflow.run == True %}
+{%   endif %}
+{%   if sflow.run is defined and sflow.run == True %}
 sflow run
-{%     endif %}
+{%   endif %}
 !
 {% endif %}


### PR DESCRIPTION
The following YAML statement should render a proper EOS configureation
```
### sFlow ###
  sflow:
    vrfs:
      - name: MGMT
        destinations:
          192.0.2.1:
            port: 2222
          192.0.2.2:
        source_interface: Management1
    destinations:
      192.0.2.3:
        port: 3333
      192.0.2.4:
    source_interface: Eth11
    run: true
```
Will render:
```
!
sflow vrf MGMT destination 192.0.2.1 2222
sflow vrf MGMT destination 192.0.2.2
sflow vrf MGMT source-interface Management1
sflow destination 192.0.2.3 3333
sflow destination 192.0.2.4
sflow source-interface Eth11
sflow run
!
```