### PR TITLE
LLDP support for eos_cli_config_gen role

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -229,6 +229,7 @@ lldp:
   holdtime: < hold_time_period >
   management_address: < all | ethernetN | loopbackN | managementN | port-channelN | vlanN >
   vrf: < vrf_name >
+  run: < true | false >
 ```
 
 ### Logging

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -19,6 +19,7 @@
     - [Queue Monitor Length](#queue-monitor-length)
     - [Service Routing Protocols Model](#service-routing-protocols-model)
     - [Logging](#logging)
+    - [LLDP](#lldp)
     - [Domain Lookup](#domain-lookup)
     - [Name Servers](#name-servers)
     - [DNS Domain](#dns-domain)
@@ -218,6 +219,16 @@ queue_monitor_length:
 
 ```yaml
 service_routing_protocols_model: < multi-agent | ribd >
+```
+
+### LLDP
+
+```yaml
+lldp:
+  timer: < transmission_time >
+  holdtime: < hold_time_period >
+  management_address: < all | ethernetN | loopbackN | managementN | port-channelN | vlanN >
+  vrf: < vrf_name >
 ```
 
 ### Logging

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
@@ -24,6 +24,8 @@ transceiver qsfp default-mode 4x10G
 {% include 'eos/service-routing-protocols-model.j2' %}
 {# queue monitor length #}
 {% include 'eos/queue-monitor-length.j2' %}
+{# lldp #}
+{% include 'eos/lldp.j2' %}
 {# logging #}
 {% include 'eos/logging.j2' %}
 hostname {{ inventory_hostname }}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/lldp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/lldp.j2
@@ -1,0 +1,20 @@
+{# eos - lldp #}
+{% if lldp is defined and lldp is not none %}
+{%   if lldp.timer is defined and lldp.timer is not none %}
+lldp timer {{ lldp.timer }}
+{%   endif %}
+{%   if lldp.holdtime is defined and lldp.holdtime is not none %}
+lldp hold-time {{ lldp.holdtime }}
+{%   endif %}
+{%   if lldp.management_address is defined and lldp.management_address is not none %}
+lldp management-address {{ lldp.management_address }}
+{%   endif %}
+{%   if lldp.vrf is defined and lldp.vrf is not none %}
+lldp management-address vrf {{ lldp.vrf }}
+{%   endif %}
+lldp run
+!
+{% else %}
+no lldp run
+!
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/lldp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/lldp.j2
@@ -12,9 +12,10 @@ lldp management-address {{ lldp.management_address }}
 {%   if lldp.vrf is defined and lldp.vrf is not none %}
 lldp management-address vrf {{ lldp.vrf }}
 {%   endif %}
+{%   if lldp.run is defined and lldp.run == true %}
 lldp run
-!
-{% else %}
+{%   else %}
 no lldp run
+{%   endif %}
 !
 {% endif %}


### PR DESCRIPTION
The following YAML representation should render the switch config:
```
  ### LLDP ###
  lldp:
    timer: 120
    holdtime: 240
    management_address: Management1
    vrf: MGMT
  !
  lldp timer 120
  lldp hold-time 240
  lldp management-address Management1
  lldp management-address vrf MGMT
  lldp run
  !
```
This implements GitHub PullRequest aristanetworks/ansible-avd#155