### PR TITLE
BGP: OSPF: routing extensions to eos_cli_config_ren role

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1011,6 +1011,7 @@ router_bgp:
   peer_groups:
     < peer_group_name_1>:
       type: < ipv4 | evpn >
+      description: "< description as string >"
       shutdown: < true | false >
       peer_filter: < peer_filter >
       next_hop_unchanged: < true | false >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1011,6 +1011,7 @@ router_bgp:
   peer_groups:
     < peer_group_name_1>:
       type: < ipv4 | evpn >
+      shutdown: < true | false >
       peer_filter: < peer_filter >
       next_hop_unchanged: < true | false >
       update_source: < interface >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1135,6 +1135,9 @@ router_bgp:
         prefix_list_out: < prefix_list_name >
       < neighbor_ip_address>:
         activate: < true | false >
+        default_originate:
+          always: < true | false >
+          route_map: < route_map_name >
   address_family_ipv4_multicast:
     peer_groups:
       < peer_group_name >:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1131,6 +1131,8 @@ router_bgp:
     neighbors:
       < neighbor_ip_address>:
         activate: < true | false >
+        prefix_list_in: < prefix_list_name >
+        prefix_list_out: < prefix_list_name >
       < neighbor_ip_address>:
         activate: < true | false >
   address_family_ipv4_multicast:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1216,6 +1216,9 @@ router_ospf:
       max_lsa: < integer >
       default_information_originate:
         always: true
+      redistribute:
+        static:
+         route_map: < route_map_name >
 ```
 
 ### Routing PIM Sparse Mode

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -20,6 +20,7 @@
     - [Queue Monitor Length](#queue-monitor-length)
     - [Service Routing Protocols Model](#service-routing-protocols-model)
     - [Logging](#logging)
+    - [LLDP](#lldp)
     - [Domain Lookup](#domain-lookup)
     - [Name Servers](#name-servers)
     - [DNS Domain](#dns-domain)
@@ -229,6 +230,16 @@ queue_monitor_length:
 
 ```yaml
 service_routing_protocols_model: < multi-agent | ribd >
+```
+
+### LLDP
+
+```yaml
+lldp:
+  timer: < transmission_time >
+  holdtime: < hold_time_period >
+  management_address: < all | ethernetN | loopbackN | managementN | port-channelN | vlanN >
+  vrf: < vrf_name >
 ```
 
 ### Logging

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1022,6 +1022,7 @@ router_bgp:
       password: "< encrypted_password >"
       send_community: < true | false >
       maximum_routes: < integer >
+      weight: < weight_value >
     < peer_group_name_2 >:
       type: < ipv4 | evpn >
       bgp_listen_range_prefix: < IP prefix range >
@@ -1034,6 +1035,7 @@ router_bgp:
       remote_as: < bgp_as >
       description: "< description as string >"
       shutdown: < true | false >
+      weight: < weight_value >
     < IPv4_address_2 >:
       remote_as: < bgp_as >
       next_hop_self: < true | false >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -240,6 +240,7 @@ lldp:
   holdtime: < hold_time_period >
   management_address: < all | ethernetN | loopbackN | managementN | port-channelN | vlanN >
   vrf: < vrf_name >
+  run: < true | false >
 ```
 
 ### Logging

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1036,6 +1036,7 @@ router_bgp:
       shutdown: < true | false >
     < IPv4_address_2 >:
       remote_as: < bgp_as >
+      next_hop_self: < true | false >
       password: "< encrypted_password >"
     < IPv6_address_1 >:
       remote_as: < bgp_as >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1236,7 +1236,9 @@ router_ospf:
         always: true
       redistribute:
         static:
-         route_map: < route_map_name >
+          route_map: < route_map_name >
+        connected:
+          route_map: < route_map_name >
 ```
 
 ### Routing PIM Sparse Mode

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1036,6 +1036,7 @@ router_bgp:
       remote_as: < bgp_as >
       description: "< description as string >"
       shutdown: < true | false >
+      update_source: < interface >
       weight: < weight_value >
       timers: < keepalive_hold_timer_values >
     < IPv4_address_2 >:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1023,6 +1023,7 @@ router_bgp:
       send_community: < true | false >
       maximum_routes: < integer >
       weight: < weight_value >
+      timers: < keepalive_hold_timer_values >
     < peer_group_name_2 >:
       type: < ipv4 | evpn >
       bgp_listen_range_prefix: < IP prefix range >
@@ -1036,6 +1037,7 @@ router_bgp:
       description: "< description as string >"
       shutdown: < true | false >
       weight: < weight_value >
+      timers: < keepalive_hold_timer_values >
     < IPv4_address_2 >:
       remote_as: < bgp_as >
       next_hop_self: < true | false >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1214,6 +1214,8 @@ router_ospf:
         - < interface_1 >
         - < interface_2 >
       max_lsa: < integer >
+      default_information_originate:
+        always: true
 ```
 
 ### Routing PIM Sparse Mode

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1101,6 +1101,9 @@ router_bgp:
       < peer_group_name >:
         activate: < true | false >
   address_family_ipv4:
+    networks:
+      < prefix_ipv4 >:
+        route_map: < route_map_name >
     peer_groups:
       < peer_group_name >:
         route_map_in: < route_map_name >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
@@ -26,6 +26,8 @@ transceiver qsfp default-mode 4x10G
 {% include 'eos/service-routing-protocols-model.j2' %}
 {# queue monitor length #}
 {% include 'eos/queue-monitor-length.j2' %}
+{# lldp #}
+{% include 'eos/lldp.j2' %}
 {# logging #}
 {% include 'eos/logging.j2' %}
 hostname {{ inventory_hostname }}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/lldp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/lldp.j2
@@ -1,5 +1,8 @@
 {# eos - lldp #}
 {% if lldp is defined and lldp is not none %}
+{%   if lldp.run is defined and lldp.run == false %}
+no lldp run
+{%   endif %}
 {%   if lldp.timer is defined and lldp.timer is not none %}
 lldp timer {{ lldp.timer }}
 {%   endif %}
@@ -12,9 +15,5 @@ lldp management-address {{ lldp.management_address }}
 {%   if lldp.vrf is defined and lldp.vrf is not none %}
 lldp management-address vrf {{ lldp.vrf }}
 {%   endif %}
-lldp run
-!
-{% else %}
-no lldp run
 !
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/lldp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/lldp.j2
@@ -1,0 +1,20 @@
+{# eos - lldp #}
+{% if lldp is defined and lldp is not none %}
+{%   if lldp.timer is defined and lldp.timer is not none %}
+lldp timer {{ lldp.timer }}
+{%   endif %}
+{%   if lldp.holdtime is defined and lldp.holdtime is not none %}
+lldp hold-time {{ lldp.holdtime }}
+{%   endif %}
+{%   if lldp.management_address is defined and lldp.management_address is not none %}
+lldp management-address {{ lldp.management_address }}
+{%   endif %}
+{%   if lldp.vrf is defined and lldp.vrf is not none %}
+lldp management-address vrf {{ lldp.vrf }}
+{%   endif %}
+lldp run
+!
+{% else %}
+no lldp run
+!
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -201,6 +201,10 @@ router bgp {{ router_bgp.as }}
 {%             if router_bgp.address_family_ipv4.neighbors[neighbor].prefix_list_out is defined and router_bgp.address_family_ipv4.neighbors[neighbor].prefix_list_out is not none %}
       neighbor {{ neighbor }} prefix-list {{ router_bgp.address_family_ipv4.neighbors[neighbor].prefix_list_out }} out
 {%             endif %}
+{%             if router_bgp.address_family_ipv4.neighbors[neighbor].default_originate is defined %}
+      neighbor {{ neighbor }} default-originate{%if router_bgp.address_family_ipv4.neighbors[neighbor].default_originate.route_map is defined and router_bgp.address_family_ipv4.neighbors[neighbor].default_originate.route_map is not none %} route-map {{ router_bgp.address_family_ipv4.neighbors[neighbor].default_originate.route_map }}{% endif %}{%if router_bgp.address_family_ipv4.neighbors[neighbor].default_originate.always is defined and router_bgp.address_family_ipv4.neighbors[neighbor].default_originate.always == true %} always{% endif %}
+
+{%             endif %}
 {%             if router_bgp.address_family_ipv4.neighbors[neighbor].activate == true %}
       neighbor {{ neighbor }} activate
 {%             elif router_bgp.address_family_ipv4.neighbors[neighbor].activate == false %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -56,6 +56,9 @@ router bgp {{ router_bgp.as }}
 {%             if router_bgp.neighbors[neighbor].remote_as is defined and router_bgp.neighbors[neighbor].remote_as is not none %}
    neighbor {{ neighbor }} remote-as {{ router_bgp.neighbors[neighbor].remote_as }}
 {%             endif %}
+{%             if router_bgp.neighbors[neighbor].next_hop_self is defined and router_bgp.neighbors[neighbor].next_hop_self == true %}
+   neighbor {{ neighbor }} next-hop-self
+{%             endif %}
 {%             if router_bgp.neighbors[neighbor].shutdown is defined and router_bgp.neighbors[neighbor].shutdown == true %}
    neighbor {{ neighbor }} shutdown
 {%             endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -148,6 +148,15 @@ router bgp {{ router_bgp.as }}
 {%     if router_bgp.address_family_ipv4 is defined and router_bgp.address_family_ipv4 is not none %}
    !
    address-family ipv4
+{%       if router_bgp.address_family_ipv4.networks is defined and router_bgp.address_family_ipv4.networks is not none %}
+{%          for network in router_bgp.address_family_ipv4.networks | arista.avd.natural_sort %}
+{%             if router_bgp.address_family_ipv4.networks[network].route_map is defined and router_bgp.address_family_ipv4.networks[network].route_map is not none %}
+      network {{ network }} route-map {{ router_bgp.address_family_ipv4.networks[network].route_map }}
+{%             else %}
+      network {{ network }}
+{%             endif %}
+{%          endfor %}
+{%       endif %}
 {%       if router_bgp.address_family_ipv4.peer_groups is defined and router_bgp.address_family_ipv4.peer_groups is not none %}
 {%          for peer_group in router_bgp.address_family_ipv4.peer_groups | arista.avd.natural_sort %}
 {%             if router_bgp.address_family_ipv4.peer_groups[peer_group].route_map_in is defined and router_bgp.address_family_ipv4.peer_groups[peer_group].route_map_in is not none %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -195,6 +195,12 @@ router bgp {{ router_bgp.as }}
 {%             if router_bgp.address_family_ipv4.neighbors[neighbor].route_map_out is defined and router_bgp.address_family_ipv4.neighbors[neighbor].route_map_out is not none %}
       neighbor {{ neighbor }} route-map {{ router_bgp.address_family_ipv4.neighbors[neighbor].route_map_out }} out
 {%             endif %}
+{%             if router_bgp.address_family_ipv4.neighbors[neighbor].prefix_list_in is defined and router_bgp.address_family_ipv4.neighbors[neighbor].prefix_list_in is not none %}
+      neighbor {{ neighbor }} prefix-list {{ router_bgp.address_family_ipv4.neighbors[neighbor].prefix_list_in }} in
+{%             endif %}
+{%             if router_bgp.address_family_ipv4.neighbors[neighbor].prefix_list_out is defined and router_bgp.address_family_ipv4.neighbors[neighbor].prefix_list_out is not none %}
+      neighbor {{ neighbor }} prefix-list {{ router_bgp.address_family_ipv4.neighbors[neighbor].prefix_list_out }} out
+{%             endif %}
 {%             if router_bgp.address_family_ipv4.neighbors[neighbor].activate == true %}
       neighbor {{ neighbor }} activate
 {%             elif router_bgp.address_family_ipv4.neighbors[neighbor].activate == false %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -12,6 +12,9 @@ router bgp {{ router_bgp.as }}
 {%          endif %}
 {%       endfor %}
 {%       for peer_group in router_bgp.peer_groups | arista.avd.natural_sort %}
+{%             if router_bgp.peer_groups[peer_group].description is defined and router_bgp.peer_groups[peer_group].description is not none %}
+   neighbor {{ peer_group }} description {{ router_bgp.peer_groups[peer_group].description }}
+{%             endif %}
 {%             if router_bgp.peer_groups[peer_group].shutdown is defined and router_bgp.peer_groups[peer_group].shutdown == true %}
    neighbor {{ peer_group }} shutdown
 {%             endif %}
@@ -42,9 +45,6 @@ router bgp {{ router_bgp.as }}
 {%             endif %}
 {%             if router_bgp.peer_groups[peer_group].maximum_routes is defined and router_bgp.peer_groups[peer_group].maximum_routes is not none %}
    neighbor {{ peer_group }} maximum-routes {{ router_bgp.peer_groups[peer_group].maximum_routes }}
-{%             endif %}
-{%             if router_bgp.peer_groups[peer_group].shutdown is defined and router_bgp.peer_groups[peer_group].shutdown is not none %}
-   neighbor {{ peer_group }} shutdown
 {%             endif %}
 {%       endfor %}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -46,6 +46,9 @@ router bgp {{ router_bgp.as }}
 {%             if router_bgp.peer_groups[peer_group].maximum_routes is defined and router_bgp.peer_groups[peer_group].maximum_routes is not none %}
    neighbor {{ peer_group }} maximum-routes {{ router_bgp.peer_groups[peer_group].maximum_routes }}
 {%             endif %}
+{%             if router_bgp.peer_groups[peer_group].weight is defined and router_bgp.peer_groups[peer_group].weight is not none %}
+   neighbor {{ peer_group }} weight {{ router_bgp.peer_groups[peer_group].weight }}
+{%             endif %}
 {%       endfor %}
 {%     endif %}
 {%     if router_bgp.neighbors is defined and router_bgp.neighbors is not none %}
@@ -67,6 +70,9 @@ router bgp {{ router_bgp.as }}
 {%             endif %}
 {%             if router_bgp.neighbors[neighbor].password is defined and router_bgp.neighbors[neighbor].password is not none %}
    neighbor {{ neighbor }} password 7 {{ router_bgp.neighbors[neighbor].password }}
+{%             endif %}
+{%             if router_bgp.neighbors[neighbor].weight is defined and router_bgp.neighbors[neighbor].weight is not none %}
+   neighbor {{ neighbor }} weight {{ router_bgp.neighbors[neighbor].weight }}
 {%             endif %}
 {%         endfor %}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -71,6 +71,9 @@ router bgp {{ router_bgp.as }}
 {%             if router_bgp.neighbors[neighbor].description is defined and router_bgp.neighbors[neighbor].description is not none %}
    neighbor {{ neighbor }} description {{ router_bgp.neighbors[neighbor].description }}
 {%             endif %}
+{%             if router_bgp.neighbors[neighbor].update_source is defined and router_bgp.neighbors[neighbor].update_source is not none %}
+   neighbor {{ neighbor }} update-source {{ router_bgp.neighbors[neighbor].update_source }}
+{%             endif %}
 {%             if router_bgp.neighbors[neighbor].password is defined and router_bgp.neighbors[neighbor].password is not none %}
    neighbor {{ neighbor }} password 7 {{ router_bgp.neighbors[neighbor].password }}
 {%             endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -49,6 +49,9 @@ router bgp {{ router_bgp.as }}
 {%             if router_bgp.peer_groups[peer_group].weight is defined and router_bgp.peer_groups[peer_group].weight is not none %}
    neighbor {{ peer_group }} weight {{ router_bgp.peer_groups[peer_group].weight }}
 {%             endif %}
+{%             if router_bgp.peer_groups[peer_group].timers is defined and router_bgp.peer_groups[peer_group].timers is not none %}
+   neighbor {{ peer_group }} timers {{ router_bgp.peer_groups[peer_group].timers }}
+{%             endif %}
 {%       endfor %}
 {%     endif %}
 {%     if router_bgp.neighbors is defined and router_bgp.neighbors is not none %}
@@ -73,6 +76,9 @@ router bgp {{ router_bgp.as }}
 {%             endif %}
 {%             if router_bgp.neighbors[neighbor].weight is defined and router_bgp.neighbors[neighbor].weight is not none %}
    neighbor {{ neighbor }} weight {{ router_bgp.neighbors[neighbor].weight }}
+{%             endif %}
+{%             if router_bgp.neighbors[neighbor].timers is defined and router_bgp.neighbors[neighbor].timers is not none %}
+   neighbor {{ neighbor }} timers {{ router_bgp.neighbors[neighbor].timers }}
 {%             endif %}
 {%         endfor %}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -12,6 +12,9 @@ router bgp {{ router_bgp.as }}
 {%          endif %}
 {%       endfor %}
 {%       for peer_group in router_bgp.peer_groups | arista.avd.natural_sort %}
+{%             if router_bgp.peer_groups[peer_group].shutdown is defined and router_bgp.peer_groups[peer_group].shutdown == true %}
+   neighbor {{ peer_group }} shutdown
+{%             endif %}
    neighbor {{ peer_group }} peer group
 {%             if router_bgp.peer_groups[peer_group].remote_as is defined and router_bgp.peer_groups[peer_group].remote_as is not none %}
    neighbor {{ peer_group }} remote-as {{ router_bgp.peer_groups[peer_group].remote_as }}
@@ -39,6 +42,9 @@ router bgp {{ router_bgp.as }}
 {%             endif %}
 {%             if router_bgp.peer_groups[peer_group].maximum_routes is defined and router_bgp.peer_groups[peer_group].maximum_routes is not none %}
    neighbor {{ peer_group }} maximum-routes {{ router_bgp.peer_groups[peer_group].maximum_routes }}
+{%             endif %}
+{%             if router_bgp.peer_groups[peer_group].shutdown is defined and router_bgp.peer_groups[peer_group].shutdown is not none %}
+   neighbor {{ peer_group }} shutdown
 {%             endif %}
 {%       endfor %}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-ospf.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-ospf.j2
@@ -25,6 +25,10 @@ router ospf {{ process_id }}
 {%         if router_ospf.process_ids[process_id].max_lsa is defined %}
    max-lsa {{ router_ospf.process_ids[process_id].max_lsa }}
 {%         endif %}
+{%         if router_ospf.process_ids[process_id].default_information_originate is defined %}
+   default-information originate{% if router_ospf.process_ids[process_id].default_information_originate.always == true %} always{% endif %}
+
+{%         endif %}
 !
 {%     endfor %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-ospf.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-ospf.j2
@@ -29,6 +29,13 @@ router ospf {{ process_id }}
    default-information originate{% if router_ospf.process_ids[process_id].default_information_originate.always == true %} always{% endif %}
 
 {%         endif %}
+{%         if router_ospf.process_ids[process_id].redistribute.static is defined %}
+{%           if router_ospf.process_ids[process_id].redistribute.static.route_map is defined %}
+   redistribute static route-map {{ router_ospf.process_ids[process_id].redistribute.static.route_map }}
+{%           else %}
+   redistribute static
+{%           endif %}
+{%         endif %}
 !
 {%     endfor %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-ospf.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-ospf.j2
@@ -36,6 +36,13 @@ router ospf {{ process_id }}
    redistribute static
 {%           endif %}
 {%         endif %}
+{%         if router_ospf.process_ids[process_id].redistribute.connected is defined %}
+{%           if router_ospf.process_ids[process_id].redistribute.connected.route_map is defined %}
+   redistribute connected route-map {{ router_ospf.process_ids[process_id].redistribute.connected.route_map }}
+{%           else %}
+   redistribute connected
+{%           endif %}
+{%         endif %}
 !
 {%     endfor %}
 {% endif %}


### PR DESCRIPTION
# BGP
* peer-groups can be shutdown for maintenance
* peer-groups can have a description
* neighbors can be configured with next-hop-self for iBGP
* prefixes to announce can be specified
* peer-groups and neighbors support weight attribute
* peer-groups and neighbors support configurable timer values
* neighbor update-source can be set individually (required for iBGP neighborship using loopback addresses learned from OSPF)
* bgp: ipv4: add prefix-list support

# OSPF:
* support for originating a default route
* support redistributing static routes into OSPF process

# LLDP:
* add initial LLDP support to eos_cli_config_gen role