### PR TITLE
consolidate backup handler to 1 task instead of 2

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_config_deploy_eapi/handlers/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_eapi/handlers/main.yml
@@ -1,7 +1,2 @@
-- name: show running config
-  eos_config:
-    backup: yes
-    backup_options:
-      filename: "{{ inventory_hostname }}_running-config.conf"
-      dir_path: "{{ inventory_dir }}/config_backup/"
-  listen: "backup config"
+---
+  # handlers file for eos_config_deploy_eapi

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_eapi/handlers/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_eapi/handlers/main.yml
@@ -1,11 +1,7 @@
 - name: show running config
-  eos_command:
-    commands: "show running-config"
-  register: backup
-  listen: "backup config"
-
-- name: backup running config
-  copy:
-    content: "{{ backup.stdout[0] }}"
-    dest: "{{inventory_dir}}/config_backup/{{ inventory_hostname }}_running-config.conf"
+  eos_config:
+    backup: yes
+    backup_options:
+      filename: "{{ inventory_hostname }}_running-config.conf"
+      dir_path: "{{ inventory_dir }}/config_backup/"
   listen: "backup config"

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_eapi/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_eapi/tasks/main.yml
@@ -5,6 +5,9 @@
     src: '{{inventory_dir}}/intended/configs/{{ inventory_hostname }}.cfg'
     replace: config
     save_when: modified
+    backup: yes
+    backup_options:
+      filename: "{{ inventory_hostname }}_running-config.conf"
+      dir_path: "{{ inventory_dir }}/config_backup/"
   when: eosconfig.changed
-  notify: "backup config"
   tags: [provision]


### PR DESCRIPTION
- Eliminate the need for 2 separate handler tasks to handle eos config backups.

- Closes #166