### PR TITLE
Github Actions fails to deploy documentation

### DIFF
--- a/.github/workflows/documentation-build.yml
+++ b/.github/workflows/documentation-build.yml
@@ -13,7 +13,6 @@ jobs:
           python-version: '3.x'
       - name: 'Build mkdocs content to site folder'
         run: |
-            pip install -r requirements.txt
             pip install -r ansible_collections/arista/avd/docs/requirements.txt
             make webdoc
       - name: 'Deploy last version to gh-pages'


### PR DESCRIPTION
Fix #167 - Github Actions fails to deploy doc
