### PR TITLE
Fix issue when devices are part of inventory and not managed by Cloudvision

### DIFF
--- a/ansible_collections/arista/avd/plugins/filter/is_in_filter.py
+++ b/ansible_collections/arista/avd/plugins/filter/is_in_filter.py
@@ -1,0 +1,27 @@
+#
+# device-filter filter
+#
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from jinja2 import TemplateError
+from itertools import count, groupby
+from ansible.errors import AnsibleFilterError
+import re
+
+
+class FilterModule(object):
+
+    def is_in_filter(self, hostname, hostname_filter):
+        if hostname_filter is None:
+            hostname_filter = ["all"]
+        if "all" in hostname_filter:
+            return True
+        elif any(element in hostname for element in hostname_filter):
+            return True
+        return False
+
+    def filters(self):
+        return {
+            'is_in_filter': self.is_in_filter,
+        }

--- a/ansible_collections/arista/avd/plugins/filter/is_in_filter.py
+++ b/ansible_collections/arista/avd/plugins/filter/is_in_filter.py
@@ -25,3 +25,4 @@ class FilterModule(object):
         return {
             'is_in_filter': self.is_in_filter,
         }
+    

--- a/ansible_collections/arista/avd/plugins/filter/is_in_filter.py
+++ b/ansible_collections/arista/avd/plugins/filter/is_in_filter.py
@@ -25,4 +25,3 @@ class FilterModule(object):
         return {
             'is_in_filter': self.is_in_filter,
         }
-    

--- a/ansible_collections/arista/avd/plugins/modules/inventory_to_container.py
+++ b/ansible_collections/arista/avd/plugins/modules/inventory_to_container.py
@@ -56,8 +56,8 @@ options:
     description: Optional path to save variable.
     required: false
     type: str
-    device_filter:
-  description: Filter to apply intended mode on a set of configlet.
+  device_filter:
+    description: Filter to apply intended mode on a set of configlet.
                  If not used, then module only uses ADD mode. device_filter
                  list devices that can be modified or deleted based
                  on configlets entries.
@@ -147,6 +147,7 @@ def is_in_filter(hostname_filter=None, hostname="eos"):
     elif any(element in hostname for element in hostname_filter):
         return True
     return False
+
 
 def isIterable(testing_object=None):
     """
@@ -299,7 +300,8 @@ def get_devices(dict_inventory, search_container=None, devices=None, device_filt
             for dev, data in v1['hosts'].items():
                 if is_in_filter(
                     hostname_filter=device_filter,
-                    hostname=dev):
+                    hostname=dev
+                ):
                     devices.append(dev)
         # If subgroup has kids
         if isIterable(v1) and 'children' in v1:

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/main.yml
@@ -8,6 +8,7 @@
     configlet_dir: '{{inventory_dir}}/intended/configs'
     configlet_prefix: '{{ configlets_prefix }}'
     destination: '{{inventory_dir}}/intended/structured_configs/cvp/{{inventory_hostname}}_configlets.yml'
+    device_filter: ['{{ device_filter }}']
   register: CVP_VARS
 
 - name: 'Build DEVICES and CONTAINER definition for {{inventory_hostname}}'

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/templates/cvp-devices.j2
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/templates/cvp-devices.j2
@@ -1,6 +1,7 @@
 ---
 CVP_DEVICES:
 {% for device in groups[container_root] %}
+{% if device | arista.avd.is_in_filter([device_filter]) %}
   {{device}}:
     name: {{device}}
 {%     for container_name, container in CVP_VARS.CVP_TOPOLOGY.items() %}
@@ -20,6 +21,7 @@ CVP_DEVICES:
 {%      endif %}
       - {{configlets_prefix}}_{{device}}
     imageBundle: []
+{% endif %}
 {% endfor %}
 CVP_CONTAINERS:
 {% for container_name, container in CVP_VARS.CVP_TOPOLOGY.items() %}


### PR DESCRIPTION
## Description

Generate a `intended/structured_configs/cvp/cv_server.yml` with only devices managed by AVD even if more devices are part of inventory file.

- Create a new custom filter: `arista.avd.is_in_filter`
- Update `ansible_collections/arista/avd/roles/eos_config_deploy_cvp/templates/cvp-devices.j2` to add new constraint.

## Validation

- Implement a restrictive filter in your playbook

```yaml
- name: Configuration deployment with CVP
  hosts: cv_server
  connection: local
  gather_facts: false
  collections:
    - arista.avd
    - arista.cvp
  vars:
    run_tasks: false
  tasks:
    - name: run CVP provisioning
      import_role:
        name: eos_config_deploy_cvp
      vars:
        container_root: 'DC1_FABRIC'
        configlets_prefix: 'AVD'
        device_filter: 'DC1-LE'
        execute_tasks: false
        state: present
```

- Check result under `intended/structured_configs/cvp/cv_server.yml`
- Validate only devices part of your filter are listed.