### PR TITLE
Add auto-generated folder to git for documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,5 +116,4 @@ examples/evpn-l3ls-cvp-deployment/collections
 ansible_collections/arista/avd/docs/_build/*.rst
 ansible_collections/arista/avd/docs/media/*
 ansible_collections/arista/avd/docs/contributing.md
-ansible_collections/arista/avd/docs/modules/*
 ansible_collections/arista/avd/docs/*.rst

--- a/ansible_collections/arista/avd/docs/modules/README.md
+++ b/ansible_collections/arista/avd/docs/modules/README.md
@@ -1,0 +1,1 @@
+# Modules documentation

--- a/ansible_collections/arista/avd/docs/modules/configlet_build_config.rst.md
+++ b/ansible_collections/arista/avd/docs/modules/configlet_build_config.rst.md
@@ -1,0 +1,94 @@
+# configlet\_build\_config
+
+Build arista.cvp.configlet configuration.
+
+Module added in version 2.9
+
+<div class="contents" data-local="" data-depth="2">
+
+</div>
+
+## Synopsis
+
+Build configuration to publish configlets on Cloudvision.
+
+## Module-specific Options
+
+The following options may be specified for this module:
+
+<table border=1 cellpadding=4>
+
+<tr>
+<th class="head">parameter</th>
+<th class="head">type</th>
+<th class="head">required</th>
+<th class="head">default</th>
+<th class="head">choices</th>
+<th class="head">comments</th>
+</tr>
+
+<tr>
+<td>configlet_dir<br/><div style="font-size: small;"></div></td>
+<td>str</td>
+<td>yes</td>
+<td></td>
+<td></td>
+<td>
+    <div>Directory where configlets are located.</div>
+</td>
+</tr>
+
+<tr>
+<td>configlet_extension<br/><div style="font-size: small;"></div></td>
+<td>str</td>
+<td>no</td>
+<td>conf</td>
+<td></td>
+<td>
+    <div>File extensio to look for.</div>
+</td>
+</tr>
+
+<tr>
+<td>configlet_prefix<br/><div style="font-size: small;"></div></td>
+<td>str</td>
+<td>yes</td>
+<td></td>
+<td></td>
+<td>
+    <div>Prefix to append on configlet.</div>
+</td>
+</tr>
+
+<tr>
+<td>destination<br/><div style="font-size: small;"></div></td>
+<td>str</td>
+<td>no</td>
+<td></td>
+<td></td>
+<td>
+    <div>File where to save information.</div>
+</td>
+</tr>
+
+</table>
+</br>
+
+## Examples:
+
+    # tasks file for cvp_configlet_upload
+    - name: generate intented variables
+      tags: [build, provision]
+      configlet_build_config:
+        configlet_dir: '{{ configlet_dir }}'
+        configlet_prefix: '{{ configlets_prefix }}'
+        configlet_extension: '{{configlet_extension}}'
+
+### Author
+
+  - EMEA AS Team (@aristanetworks)
+
+### Status
+
+This module is flagged as **preview** which means that it is not
+guaranteed to have a backwards compatible interface.

--- a/ansible_collections/arista/avd/docs/modules/index.rst.md
+++ b/ansible_collections/arista/avd/docs/modules/index.rst.md
@@ -1,0 +1,21 @@
+# Arista Cloudvision Ansible Modules
+
+<div id="mastertoc::" class="toctree" data-caption="Project Documentation" data-maxdepth="1">
+
+Collection Overview \<../README.md\>
+
+</div>
+
+<div id="roletoc::" class="toctree" data-caption="Roles List" data-maxdepth="1">
+
+DHCP Configuration
+\<../ansible\_collections/arista/cvp/roles/dhcp\_configuration/README.md\>
+
+</div>
+
+<div id="moduletoc::" class="toctree" data-caption="Modules List" data-maxdepth="1">
+
+Module arista.cvp.configlet\_build\_config \<configlet\_build\_config\>
+Module arista.cvp.inventory\_to\_container \<inventory\_to\_container\>
+
+</div>

--- a/ansible_collections/arista/avd/docs/modules/inventory_to_container.rst.md
+++ b/ansible_collections/arista/avd/docs/modules/inventory_to_container.rst.md
@@ -1,0 +1,136 @@
+# inventory\_to\_container
+
+Transform information from inventory to arista.cvp collection
+
+Module added in version 2.9
+
+<div class="contents" data-local="" data-depth="2">
+
+</div>
+
+## Synopsis
+
+Transform information from ansible inventory to be able to provision
+CloudVision Platform using arista.cvp collection and its specific data
+structure.
+
+## Module-specific Options
+
+The following options may be specified for this module:
+
+<table border=1 cellpadding=4>
+
+<tr>
+<th class="head">parameter</th>
+<th class="head">type</th>
+<th class="head">required</th>
+<th class="head">default</th>
+<th class="head">choices</th>
+<th class="head">comments</th>
+</tr>
+
+<tr>
+<td>configlet_dir<br/><div style="font-size: small;"></div></td>
+<td>str</td>
+<td>no</td>
+<td></td>
+<td></td>
+<td>
+    <div>Directory where intended configurations are located.</div>
+</td>
+</tr>
+
+<tr>
+<td>configlet_prefix<br/><div style="font-size: small;"></div></td>
+<td>str</td>
+<td>no</td>
+<td></td>
+<td></td>
+<td>
+    <div>Prefix to put on configlet.</div>
+</td>
+</tr>
+
+<tr>
+<td>container_root<br/><div style="font-size: small;"></div></td>
+<td>str</td>
+<td>yes</td>
+<td></td>
+<td></td>
+<td>
+    <div>Ansible group name to consider to be Root of our topology.</div>
+</td>
+</tr>
+
+<tr>
+<td>destination<br/><div style="font-size: small;"></div></td>
+<td>str</td>
+<td>no</td>
+<td></td>
+<td></td>
+<td>
+    <div>Optional path to save variable.</div>
+</td>
+</tr>
+
+<tr>
+<td>device_filter<br/><div style="font-size: small;"></div></td>
+<td>list</td>
+<td>no</td>
+<td>[&#x27;all&#x27;]</td>
+<td></td>
+<td>
+    <div>Filter to apply intended mode on a set of configlet. If not used, then module only uses ADD mode. device_filter list devices that can be modified or deleted based on configlets entries.</div>
+</td>
+</tr>
+
+<tr>
+<td>inventory<br/><div style="font-size: small;"></div></td>
+<td>str</td>
+<td>yes</td>
+<td></td>
+<td></td>
+<td>
+    <div>YAML inventory file</div>
+</td>
+</tr>
+
+</table>
+</br>
+
+## Examples:
+
+    - name: generate intented variables
+      inventory_to_container:
+        inventory: 'inventory.yml'
+        container_root: 'DC1_FABRIC'
+        configlet_dir: 'intended_configs'
+        configlet_prefix: 'AVD'
+        device_filter: ['DC1-LE']
+        # destination: 'generated_vars/{{inventory_hostname}}.yml'
+      register: CVP_VARS
+
+    - name: 'Collecting facts from CVP {{inventory_hostname}}.'
+      arista.cvp.cv_facts:
+      register: CVP_FACTS
+
+    - name: 'Create configlets on CVP {{inventory_hostname}}.'
+      arista.cvp.cv_configlet:
+        cvp_facts: "{{CVP_FACTS.ansible_facts}}"
+        configlets: "{{CVP_VARS.CVP_CONFIGLETS}}"
+        configlet_filter: ["AVD"]
+
+    - name: "Building Container topology on {{inventory_hostname}}"
+      arista.cvp.cv_container:
+        topology: '{{CVP_VARS.CVP_TOPOLOGY}}'
+        cvp_facts: '{{CVP_FACTS.ansible_facts}}'
+        save_topology: true
+
+### Author
+
+  - Ansible Arista Team (@aristanetworks)
+
+### Status
+
+This module is flagged as **preview** which means that it is not
+guaranteed to have a backwards compatible interface.


### PR DESCRIPTION
All folders to publish must be part of the git process and not autogenrated during the build.

modules/ folder was auto generated and not tracked in git. This PR changes this behavior
