### PR TITLE
Development stack with docker-compose

### DIFF
--- a/.github/workflows/installation-test.yml
+++ b/.github/workflows/installation-test.yml
@@ -8,8 +8,8 @@ jobs:
     steps:
       - name: Execute one-liner installation
         run: |
-          echo 'Test installation script from: ${GITHUB_REPOSITORY}'
-          echo 'Use content from commit: ${GITHUB_SHA}'
+          echo "Test installation script from: ${GITHUB_REPOSITORY}"
+          echo "Use content from commit: ${GITHUB_SHA}"
           sh -c "$(curl -fsSL https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${GITHUB_SHA}/development/install.sh)"
       - name: Run Makefile commands
         run: |

--- a/.github/workflows/installation-test.yml
+++ b/.github/workflows/installation-test.yml
@@ -11,12 +11,8 @@ jobs:
           echo "Test installation script from: ${GITHUB_REPOSITORY}"
           echo "Use content from commit: ${GITHUB_SHA}"
           sh -c "$(curl -fsSL https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${GITHUB_SHA}/development/install.sh)"
-          cat arista-ansible/Makefile
       - name: Run Makefile commands
         run: |
           cd arista-ansible/
+          cat Makefile
           make
-      - name: Start docker shell
-        run: |
-          cd arista-ansible
-          make run

--- a/.github/workflows/installation-test.yml
+++ b/.github/workflows/installation-test.yml
@@ -13,7 +13,9 @@ jobs:
           sh -c "$(curl -fsSL https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${GITHUB_SHA}/development/install.sh)"
       - name: Run Makefile commands
         run: |
+          cd arista-ansible/
           make
       - name: Start docker shell
         run: |
+          cd arista-ansible
           make run

--- a/.github/workflows/installation-test.yml
+++ b/.github/workflows/installation-test.yml
@@ -11,6 +11,7 @@ jobs:
           echo "Test installation script from: ${GITHUB_REPOSITORY}"
           echo "Use content from commit: ${GITHUB_SHA}"
           sh -c "$(curl -fsSL https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${GITHUB_SHA}/development/install.sh)"
+          cat arista-ansible/Makefile
       - name: Run Makefile commands
         run: |
           cd arista-ansible/

--- a/.github/workflows/installation-test.yml
+++ b/.github/workflows/installation-test.yml
@@ -1,0 +1,11 @@
+name: Test Installation
+on:
+  push:
+jobs:
+  'setup':
+    name: 'One liner installation'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Execute one-liner installation
+        run: |
+          sh -c "$(curl -fsSL https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${GITHUB_SHA}/development/install.sh)"

--- a/.github/workflows/installation-test.yml
+++ b/.github/workflows/installation-test.yml
@@ -8,4 +8,12 @@ jobs:
     steps:
       - name: Execute one-liner installation
         run: |
+          echo 'Test installation script from: ${GITHUB_REPOSITORY}'
+          echo 'Use content from commit: ${GITHUB_SHA}'
           sh -c "$(curl -fsSL https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${GITHUB_SHA}/development/install.sh)"
+      - name: Run Makefile commands
+        run: |
+          make
+      - name: Start docker shell
+        run: |
+          make run

--- a/ansible_collections/arista/avd/docs/Dockerfile
+++ b/ansible_collections/arista/avd/docs/Dockerfile
@@ -1,0 +1,32 @@
+FROM python:3.8-alpine
+
+# Set build directory
+WORKDIR /tmp
+
+# Copy files necessary for build
+# COPY material material
+# COPY MANIFEST.in MANIFEST.in
+# COPY package.json package.json
+# COPY README.md README.md
+COPY requirements.txt requirements.txt
+# COPY setup.py setup.py
+
+# Perform build and cleanup artifacts
+RUN apk add --no-cache \
+    git \
+    && apk add --no-cache --virtual .build gcc musl-dev \
+    && pip install --user -r requirements.txt \
+    && apk del .build gcc musl-dev \
+    && rm -rf /tmp/*
+
+ENV PATH=$PATH:/root/.local/bin
+# Set working directory
+
+WORKDIR /docs
+
+# Expose MkDocs development server port
+EXPOSE 8000
+
+# Start development server by default
+ENTRYPOINT ["mkdocs"]
+CMD ["serve", "--dev-addr=0.0.0.0:8000"]

--- a/development/Makefile
+++ b/development/Makefile
@@ -1,8 +1,10 @@
 CONTAINER_NAME = avdteam/base
-DOCKER_TAG = centos-8
+DOCKER_TAG = 3.6
 CONTAINER = $(CONTAINER_NAME):$(DOCKER_TAG)
+COMPOSE_FILE ?= ansible-avd/development/docker-compose.yml
+PIP_REQ ?=
+ANSIBLE_VERSION ?=
 HOME_DIR = $(shell pwd)
-HOME_DIR_DOCKER = '/home/docker'
 UID = $(shell id -u)
 GID = $(shell id -g)
 
@@ -10,10 +12,16 @@ GID = $(shell id -g)
 help: ## Display help message
 	@grep -E '^[0-9a-zA-Z_-]+\.*[0-9a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
+.PHONY: update
+update: ## Get latest version of AVD runner and MKDOCs server
+	docker pull $(CONTAINER_NAME):$(DOCKER_TAG) && \
+	docker-compose -f ansible-avd/development/docker-compose.yml pull
+
 .PHONY: run
 run: ## Run ansible-avd container
 	docker run --rm -it \
-		-v $(HOME)/.ssh:$(HOME_DIR_DOCKER)/.ssh \
+		-e AVD_REQUIREMENTS=$(PIP_REQ) \
+		-e AVD_ANSIBLE=$(ANSIBLE_VERSION) \
 		-v $(HOME)/.gitconfig:$(HOME_DIR_DOCKER)/.gitconfig \
 		-v $(HOME_DIR)/:/projects \
 		-v /etc/hosts:/etc/hosts $(CONTAINER)
@@ -26,3 +34,18 @@ clean: ## Remove avd image from local repository
 build: ## [DEPRECATED] visit https://github.com/arista-netdevops-community/docker-avd-base to build image
 	#docker build --no-cache -t $(CONTAINER) .
 	echo ''; echo 'Deprecated command -- visit https://github.com/arista-netdevops-community/docker-avd-base to build image'; echo ''
+
+.PHONY: dev-start
+dev-start: ## Start docker compose stack to develop with AVD and CVP collection
+	docker-compose -f $(COMPOSE_FILE) up -d
+
+.PHONY: dev-stop
+dev-stop: ## Stop docker compose stack and remove containers
+	docker-compose -f $(COMPOSE_FILE) kill && docker-compose -f $(COMPOSE_FILE) rm -f
+
+.PHONY: dev-run
+dev-run: ## Run a shell attached to ansible container
+	docker-compose -f $(COMPOSE_FILE) exec ansible zsh
+
+.PHONY: dev-reload
+dev-reload: dev-stop dev-start  ## Stop and Start docker-compose stack

--- a/development/README.md
+++ b/development/README.md
@@ -2,14 +2,16 @@
 
 - [Development Process](#development-process)
   - [Overview](#overview)
-  - [Build local environment](#build-local-environment)
-    - [Python Virtual Environment](#python-virtual-environment)
-      - [Install Python3 Virtual Environment](#install-python3-virtual-environment)
-    - [Docker Container for Ansible Testing and Development](#docker-container-for-ansible-testing-and-development)
   - [Getting started Script](#getting-started-script)
     - [Step by step installation process](#step-by-step-installation-process)
     - [One liner installation](#one-liner-installation)
-  - [Development tools](#development-tools)
+  - [Build local environment](#build-local-environment)
+    - [Docker Container for Ansible Testing and Development](#docker-container-for-ansible-testing-and-development)
+      - [Development containers](#development-containers)
+      - [Container commands](#container-commands)
+    - [Python Virtual Environment](#python-virtual-environment)
+      - [Install Python3 Virtual Environment](#install-python3-virtual-environment)
+  - [Development & test tools](#development--test-tools)
     - [Pre-commit hook](#pre-commit-hook)
       - [Installation](#installation)
       - [Run pre-commit manually](#run-pre-commit-manually)
@@ -27,45 +29,11 @@ For example, see the file/folder structure below.
 ├── git_projects
 │   ├── ansible-avd
 │   ├── ansible-cvp
-│   ├── ansible-eos
-│   ├── netdevops-examples
+│   ├── ansible-avd-cloudvision-demo
+│   ├── <your-own-test-folder>
 │   ├── Makefile
+...
 ```
-
-## Build local environment
-
-### Python Virtual Environment
-
-#### Install Python3 Virtual Environment
-
-```shell
-# install virtualenv via pip3
-$ sudo pip3 install virtualenv
-
-```
-
-```shell
-# Configure Python virtual environment
-$ virtualenv -p python3 .venv
-$ source .venv/bin/activate
-
-# Install Python requirements
-$ pip install -r requirements.txt
-
-```
-
-### Docker Container for Ansible Testing and Development
-
-The docker container approach for development can be used to ensure that everybody is using the same development environment while still being flexible enough to use the repo you are making changes in. You can inspect the Dockerfile to see what packages have been installed.
-The container will mount the current working directory, so you can work with your local files.
-
-The ansible version is passed in with the docker build command using ***ANSIBLE*** variable.  If the ***ANSIBLE*** variable is not used the Dockerfile will by default set the ansible version to 2.9.2
-
-Before you can use a container, you must install Docker CE on your workstation: https://www.docker.com/products/docker-desktop
-
-Since docker image is now automatically published on [__docker-hub__](https://hub.docker.com/repository/docker/avdteam/base), a dedicated repository is available on [__Arista Netdevops Community__](https://github.com/arista-netdevops-community/docker-avd-base).
-
-If you want to test a specific ansible version, you can refer to this [dedicated page](https://github.com/arista-netdevops-community/docker-avd-base/blob/master/USAGE.md) to build your own docker image.
 
 ## Getting started Script
 
@@ -76,7 +44,7 @@ mkdir git_projects
 cd git_projects
 git clone https://github.com/aristanetworks/ansible-avd.git
 git clone https://github.com/aristanetworks/ansible-cvp.git
-git clone https://github.com/aristanetworks/netdevops-examples.git
+git clone https://github.com/arista-netdevops-community/ansible-avd-cloudvision-demo.git
 cp ansible-avd/development/Makefile ./
 make run
 ```
@@ -91,10 +59,59 @@ One liner script to setup a development environment. it does following actions:
 - Deploy Makefile
 
 ```shell
-$ sh -c "$(curl -fsSL https://raw.githubusercontent.com/aristanetworks/ansible-avd/master/development/install.sh)"
+$ sh -c "$(curl -fsSL https://raw.githubusercontent.com/aristanetworks/ansible-avd/devel/development/install.sh)"
 ```
 
-## Development tools
+## Build local environment
+
+### Docker Container for Ansible Testing and Development
+
+The docker container approach for development can be used to ensure that everybody is using the same development environment while still being flexible enough to use the repo you are making changes in. You can inspect the Dockerfile to see what packages have been installed.
+The container will mount the current working directory, so you can work with your local files.
+
+The ansible version is passed in with the docker build command using ***ANSIBLE*** variable.  If the ***ANSIBLE*** variable is not used the Dockerfile will by default set the ansible version to 2.9.2
+
+Before you can use a container, you must install [__Docker CE__](https://www.docker.com/products/docker-desktop) and [__docker-compose__](https://docs.docker.com/compose/) on your workstation.
+
+#### Development containers
+
+- [Ansible shell](https://hub.docker.com/repository/docker/avdteam/base): provide a built-in container with all AVD and CVP requirements already installed.
+- [MKDOCS](https://github.com/titom73/docker-mkdocs) for documentation update: Run MKDOCS in a container and expose port `8000` to test and validate markdown rendering for AVD site.
+
+#### Container commands
+
+In this folder you have a [`Makefile`](./Makefile) providing a list of commands to start a development environment:
+
+- `run`: Start a shell within a container and local folder mounted in `/projects`
+- `dev-start`: Start a stack of containers based on docker-compose: 1 container for ansible playbooks and 1 container for mkdocs
+- `dev-stop`: Stop compose stack and remove containers.
+- `dev-run`: Connect to ansible container to run your test playbooks.
+- `dev-reload`: Run stop and start.
+
+If you want to test a specific ansible version, you can refer to this [dedicated page](https://github.com/arista-netdevops-community/docker-avd-base/blob/master/USAGE.md) to start your own docker image. You can also use following make command: `make ANSIBLE_VERSION=2.9.3 run`
+
+Since docker image is now automatically published on [__docker-hub__](https://hub.docker.com/repository/docker/avdteam/base), a dedicated repository is available on [__Arista Netdevops Community__](https://github.com/arista-netdevops-community/docker-avd-base).
+
+### Python Virtual Environment
+
+#### Install Python3 Virtual Environment
+
+```shell
+# install virtualenv via pip3
+$ sudo pip3 install virtualenv
+...
+```
+
+```shell
+# Configure Python virtual environment
+$ virtualenv -p python3 .venv
+$ source .venv/bin/activate
+
+# Install Python requirements
+$ pip install -r requirements.txt
+```
+
+## Development & test tools
 
 ### Pre-commit hook
 

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -1,0 +1,16 @@
+version: "3"
+services:
+  ansible:
+    image: avdteam/base:3.6
+    volumes:
+      - ./../../:/projects
+    entrypoint: [ "/bin/sh", "-c", "while true; do sleep 30; done;" ]
+
+  webdoc:
+    image: titom73/mkdocs:latest
+    volumes:
+      - ${PWD}:/docs
+    ports:
+      - 8000:8000
+    entrypoint: ""
+    command: ["sh", "-c", "pip install -r ansible-avd/ansible_collections/arista/avd/docs/requirements.txt && mkdocs serve --dev-addr=0.0.0.0:8000 -f ansible-avd/mkdocs.yml"]

--- a/development/install.sh
+++ b/development/install.sh
@@ -6,7 +6,7 @@ _ROOT_INSTALLATION_DIR="${PWD}/arista-ansible"
 # List of Arista Repositories
 _REPO_AVD="https://github.com/aristanetworks/ansible-avd.git"
 _REPO_CVP="https://github.com/aristanetworks/ansible-cvp.git"
-_REPO_EXAMPLES="https://github.com/aristanetworks/ansible-avd.git"
+_REPO_EXAMPLES="https://github.com/arista-netdevops-community/ansible-avd-cloudvision-demo"
 
 # Path for local repositories
 _LOCAL_AVD="${_ROOT_INSTALLATION_DIR}/ansible-avd"

--- a/development/install.sh
+++ b/development/install.sh
@@ -3,8 +3,15 @@
 # Local Installation Path
 _ROOT_INSTALLATION_DIR="${PWD}/arista-ansible"
 
+if [[ -z GITHUB_REPOSITORY ]]; then
+    export GITHUB_REPOSITORY="aristanetworks/ansible-avd"
+fi
+if [[ -z GITHUB_SHA ]]; then
+    export GITHUB_SHA="devel"
+fi
+
 # List of Arista Repositories
-_REPO_AVD="https://github.com/aristanetworks/ansible-avd.git"
+_REPO_AVD="https://github.com/${GITHUB_REPOSITORY}.git"
 _REPO_CVP="https://github.com/aristanetworks/ansible-cvp.git"
 _REPO_EXAMPLES="https://github.com/arista-netdevops-community/ansible-avd-cloudvision-demo"
 


### PR DESCRIPTION
# Build a docker-compose stack to support development.

Fix: #164 

## Containers

- ansible: use `avdteam/base` to expose ansible shell for testing
- mkdocs: use `titom73/mkdocs` to expose AVD documentation for repository update

## Installation

Docker Compose is required: https://docs.docker.com/compose/install/

## Usage

```
~/Projects/arista-ansible env:(arista-ansible-stable)
➜ make update
docker pull avdteam/base:3.6 && \
        docker-compose -f ansible-avd/development/docker-compose.yml pull
3.6: Pulling from avdteam/base
Digest: sha256:a4a25b40a712644b2f594b86f260823082660999c7806b97b3ff2a0e5a933654
Status: Image is up to date for avdteam/base:3.6
docker.io/avdteam/base:3.6
Pulling ansible ... done
Pulling webdoc  ... done

~/Projects/arista-ansible env:(arista-ansible-stable)
➜ make dev-start
docker-compose -f ansible-avd/development/docker-compose.yml up -d
Creating development_webdoc_1  ... done
Creating development_ansible_1 ... done

~/Projects/arista-ansible env:(arista-ansible-stable)
➜ make dev-run
docker-compose -f ansible-avd/development/docker-compose.yml exec ansible zsh
Agent pid 49
➜  /projects exit

~/Projects/arista-ansible env:(arista-ansible-stable)
➜ make dev-stop
docker-compose -f ansible-avd/development/docker-compose.yml kill && docker-compose -f ansible-avd/development/docker-compose.yml rm -f
Killing development_ansible_1 ... done
Killing development_webdoc_1  ... done
Going to remove development_ansible_1, development_webdoc_1
Removing development_ansible_1 ... done
Removing development_webdoc_1  ... done
```

You can also open http:127.0.0.1:8000

### Instalaltion script

- Updated to support CI
- Add task to test installation script

## Documentation

- Developement Readme updated
