### PR TITLE
Implement IS-IS as underlay option in eos_l3ls_evpn

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -27,7 +27,7 @@
     - [Router L2 VPN](#router-l2-vpn)
     - [Sflow](#sflow)
     - [Redundancy](#redundancy)
-    - [Snmp Settings](#snmp-settings)
+    - [SNMP Settings](#snmp-settings)
     - [Spanning Tree](#spanning-tree)
     - [Platform](#platform)
     - [Tacacs+ Servers](#tacacs-servers)
@@ -68,6 +68,21 @@
     - [Routing - Multicast](#routing---multicast)
     - [Router OSPF Configuration](#router-ospf-configuration)
     - [Routing PIM Sparse Mode](#routing-pim-sparse-mode)
+    - [Router ISIS Configuration](#router-isis-configuration)
+    - [Queue Monitor Streaming](#queue-monitor-streaming)
+    - [IP TACACS+ Source Interfaces](#ip-tacacs-source-interfaces)
+    - [VM Tracer Sessions](#vm-tracer-sessions)
+    - [Banners](#banners)
+    - [HTTP Management API](#http-management-api)
+    - [Management Console](#management-console)
+    - [Management Security](#management-security)
+    - [Management SSH](#management-ssh)
+  - [License](#license)
+<<<<<<< HEAD
+    - [Routing PIM Sparse Mode](#routing-pim-sparse-mode)
+=======
+    - [Router ISIS Configuration](#router-isis-configuration)
+>>>>>>> 6062c69... Implement ISIS in eos_cli_config_gen (#127)
     - [Queue Monitor Streaming](#queue-monitor-streaming)
     - [IP TACACS+ Source Interfaces](#ip-tacacs-source-interfaces)
     - [VM Tracer Sessions](#vm-tracer-sessions)
@@ -609,9 +624,16 @@ ethernet_interfaces:
     ipv6_access_group_out: < ipv6_access_list_name >
     ospf_network_point_to_point: < true | false >
     ospf_area: < ospf_area >
+<<<<<<< HEAD
     pim:
       ipv4:
         sparse_mode: < true | false >
+=======
+    isis_enable: < ISIS Instance >
+    isis_passive: < boolean >
+    isis_metric: < integer >
+    isis_network_point_to_point: < boolean >
+>>>>>>> 6062c69... Implement ISIS in eos_cli_config_gen (#127)
 
 # Switched Interfaces
   <Ethernet_interface_2 >:
@@ -650,6 +672,10 @@ loopback_interfaces:
   < Loopback_interface_2 >:
     description: < description >
     ip_address: < IPv4_address/Mask >
+    isis_enable: < ISIS Instance >
+    isis_passive: < boolean >
+    isis_metric: < integer >
+    isis_network_point_to_point: < boolean >
 ```
 
 ### Management Interfaces
@@ -708,11 +734,19 @@ vlan_interfaces:
           administrative_distance: < 1-255 >
     ospf_network_point_to_point: < true | false >
     ospf_area: < ospf_area >
+<<<<<<< HEAD
     pim:
       ipv4:
         sparse_mode: < true | false >
         local_interface: < local_interface_name >
     ipv6_virtual_router_address: < IPv6_address >
+=======
+    isis_enable: < ISIS Instance >
+    isis_passive: < boolean >
+    isis_metric: < integer >
+    isis_network_point_to_point: < boolean >
+    mtu: < mtu >
+>>>>>>> 6062c69... Implement ISIS in eos_cli_config_gen (#127)
   < Vlan_id_2 >:
     description: < description >
     ip_address: < IPv4_address/Mask >
@@ -1198,6 +1232,19 @@ router_pim_sparse_mode:
         other_anycast_rp_addresses:
           < ip_address_other_anycast_rp_1 >:
             register_count: < register_count_nb >
+```
+
+### Router ISIS Configuration
+
+```yaml
+
+router_isis:
+  instance: <ISIS Instance Name>
+  net: < CLNS Address to run ISIS | format 49.0001.0001.0000.0001.00 >
+  router_id: < IPv4_address >
+  no_passive_interfaces: < List no-passive-interface >
+  is_type: < level-1 | level-1-2 | level-2 >
+  address_family: < List of Address Families >
 ```
 
 ### Queue Monitor Streaming

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1245,6 +1245,8 @@ router_isis:
   no_passive_interfaces: < List no-passive-interface >
   is_type: < level-1 | level-1-2 | level-2 >
   address_family: < List of Address Families >
+  isis_af_defaults:
+      - maximum-paths < Integer 1-64 >
 ```
 
 ### Queue Monitor Streaming

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -78,20 +78,6 @@
     - [Management Security](#management-security)
     - [Management SSH](#management-ssh)
   - [License](#license)
-<<<<<<< HEAD
-    - [Routing PIM Sparse Mode](#routing-pim-sparse-mode)
-=======
-    - [Router ISIS Configuration](#router-isis-configuration)
->>>>>>> 6062c69... Implement ISIS in eos_cli_config_gen (#127)
-    - [Queue Monitor Streaming](#queue-monitor-streaming)
-    - [IP TACACS+ Source Interfaces](#ip-tacacs-source-interfaces)
-    - [VM Tracer Sessions](#vm-tracer-sessions)
-    - [Banners](#banners)
-    - [HTTP Management API](#http-management-api)
-    - [Management Console](#management-console)
-    - [Management Security](#management-security)
-    - [Management SSH](#management-ssh)
-  - [License](#license)
 
 ## Overview
 
@@ -624,16 +610,13 @@ ethernet_interfaces:
     ipv6_access_group_out: < ipv6_access_list_name >
     ospf_network_point_to_point: < true | false >
     ospf_area: < ospf_area >
-<<<<<<< HEAD
     pim:
       ipv4:
         sparse_mode: < true | false >
-=======
     isis_enable: < ISIS Instance >
     isis_passive: < boolean >
     isis_metric: < integer >
     isis_network_point_to_point: < boolean >
->>>>>>> 6062c69... Implement ISIS in eos_cli_config_gen (#127)
 
 # Switched Interfaces
   <Ethernet_interface_2 >:
@@ -734,19 +717,16 @@ vlan_interfaces:
           administrative_distance: < 1-255 >
     ospf_network_point_to_point: < true | false >
     ospf_area: < ospf_area >
-<<<<<<< HEAD
     pim:
       ipv4:
         sparse_mode: < true | false >
         local_interface: < local_interface_name >
     ipv6_virtual_router_address: < IPv6_address >
-=======
     isis_enable: < ISIS Instance >
     isis_passive: < boolean >
     isis_metric: < integer >
     isis_network_point_to_point: < boolean >
     mtu: < mtu >
->>>>>>> 6062c69... Implement ISIS in eos_cli_config_gen (#127)
   < Vlan_id_2 >:
     description: < description >
     ip_address: < IPv4_address/Mask >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-isis.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-isis.j2
@@ -1,0 +1,27 @@
+{% if router_isis is defined and router_isis is not none %}
+### Router ISIS Summary
+
+| Settings | Value |
+| -------- | ----- |
+{%     if router_isis.instance is defined %}
+| Instance | {{ router_isis.instance }} |
+{%     endif %}
+{%     if router_isis.net is defined %}
+| Net-ID | {{ router_isis.net }} |
+{%     endif %}
+{%     if router_isis.is_type is defined %}
+| Type | {{ router_isis.is_type }} |
+{%     endif %}
+{%     if router_isis.address_family is defined %}
+| Address Family | {% for af in router_isis.address_family %}{{ af }} {% endfor %}|
+{%     endif %}
+
+### Router ISIS Device Configuration
+
+```eos
+{% include 'eos/router-isis.j2' %}
+```
+
+{% else %}
+Router ISIS not defined
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-device-documentation.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-device-documentation.j2
@@ -200,6 +200,7 @@
 ## Platform
 
 {% include 'documentation/platform.j2' %}
+
 ## Router ISIS
 
 {% include 'documentation/router-isis.j2' %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-device-documentation.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-device-documentation.j2
@@ -200,3 +200,6 @@
 ## Platform
 
 {% include 'documentation/platform.j2' %}
+## Router ISIS
+
+{% include 'documentation/router-isis.j2' %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
@@ -128,6 +128,8 @@ hostname {{ inventory_hostname }}
 {% include 'eos/router-ospf.j2' %}
 {# router pim sparse mode configuration #}
 {% include 'eos/router-pim-sparse-mode.j2' %}
+{# router isis configuration #}
+{% include 'eos/router-isis.j2' %}
 {# queue monitor streaming #}
 {% include 'eos/queue-monitor-streaming.j2' %}
 {# ip tacacs+ source interfaces #}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -106,6 +106,7 @@ interface {{ ethernet_interface }}
 {%             endif %}
 {%             if ethernet_interfaces[ethernet_interface].vmtracer is defined and ethernet_interfaces[ethernet_interface].vmtracer == true %}
    vmtracer vmware-esx
+{%             endif %}
 {%             if ethernet_interfaces[ethernet_interface].isis_enable is defined %}
    isis enable {{ ethernet_interfaces[ethernet_interface].isis_enable }}
 {%             endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -106,6 +106,17 @@ interface {{ ethernet_interface }}
 {%             endif %}
 {%             if ethernet_interfaces[ethernet_interface].vmtracer is defined and ethernet_interfaces[ethernet_interface].vmtracer == true %}
    vmtracer vmware-esx
+{%             if ethernet_interfaces[ethernet_interface].isis_enable is defined %}
+   isis enable {{ ethernet_interfaces[ethernet_interface].isis_enable }}
+{%             endif %}
+{%             if ethernet_interfaces[ethernet_interface].isis_passive is defined and ethernet_interfaces[ethernet_interface].isis_passive == true %}
+   isis passive
+{%             endif %}
+{%             if ethernet_interfaces[ethernet_interface].isis_metric is defined %}
+   isis metric {{ ethernet_interfaces[ethernet_interface].isis_metric }}
+{%             endif %}
+{%             if ethernet_interfaces[ethernet_interface].isis_network_point_to_point is defined and ethernet_interfaces[ethernet_interface].isis_network_point_to_point == true %}
+   isis network point-to-point
 {%             endif %}
 {%         endif %}
 !

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -118,6 +118,12 @@ interface {{ ethernet_interface }}
 {%             if ethernet_interfaces[ethernet_interface].isis_network_point_to_point is defined and ethernet_interfaces[ethernet_interface].isis_network_point_to_point == true %}
    isis network point-to-point
 {%             endif %}
+{%             if ethernet_interfaces[ethernet_interface].pim.ipv4.sparse_mode is defined and ethernet_interfaces[ethernet_interface].pim.ipv4.sparse_mode == true %}
+   pim ipv4 sparse-mode
+{%             endif %}
+{%             if ethernet_interfaces[ethernet_interface].vmtracer is defined and ethernet_interfaces[ethernet_interface].vmtracer == true %}
+   vmtracer vmware-esx
+{%             endif %}
 {%         endif %}
 !
 {%     endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/loopback-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/loopback-interfaces.j2
@@ -23,6 +23,18 @@ interface {{ loopback_interface }}
 {%         if loopback_interfaces[loopback_interface].ospf_area is defined and loopback_interfaces[loopback_interface].ospf_area is not none %}
    ip ospf area {{ loopback_interfaces[loopback_interface].ospf_area }}
 {%         endif %}
+{%         if loopback_interfaces[loopback_interface].isis_enable is defined %}
+   isis enable {{ loopback_interfaces[loopback_interface].isis_enable }}
+{%         endif %}
+{%         if loopback_interfaces[loopback_interface].isis_passive is defined and loopback_interfaces[loopback_interface].isis_passive == true %}
+   isis passive
+{%         endif %}
+{%         if loopback_interfaces[loopback_interface].isis_metric is defined %}
+   isis metric {{ loopback_interfaces[loopback_interface].isis_metric }}
+{%         endif %}
+{%         if loopback_interfaces[loopback_interface].isis_network_point_to_point is defined and loopback_interfaces[loopback_interface].isis_network_point_to_point == true %}
+   isis network point-to-point
+{%         endif %}
 !
 {%     endfor %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-isis.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-isis.j2
@@ -1,0 +1,23 @@
+{# eos - router ospf #}
+{% if router_isis is defined and router_isis is not none %}
+router isis {{ router_isis.instance }}
+   net {{ router_isis.net }}
+   is-type {{ router_isis.is_type }}
+   router-id ipv4 {{ router_isis.router_id }}
+   log-adjacency-changes
+   !
+{%     if router_isis.address_family is defined and router_isis.address_family is iterable %}
+{%          for address_family in router_isis.address_family %}
+   address-family {{ address_family }}
+{%          endfor %}
+{%     endif %}
+   !
+{%     if router_isis.segment_routing_mpls is defined %}
+   segment-routing mpls
+{%         if router_isis.segment_routing_mpls.router_id is defined %}
+      router-id {{ router_isis.segment_routing_mpls.router_id }}
+{%         endif %}
+      no shutdown
+{%     endif %}
+!
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-isis.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-isis.j2
@@ -9,6 +9,9 @@ router isis {{ router_isis.instance }}
 {%     if router_isis.address_family is defined and router_isis.address_family is iterable %}
 {%          for address_family in router_isis.address_family %}
    address-family {{ address_family }}
+{%             for af_default in router_isis.isis_af_defaults %}
+      {{af_default}}
+{%             endfor %}
 {%          endfor %}
 {%     endif %}
    !

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
@@ -97,6 +97,17 @@ interface {{ vlan_interface }}
 {%         if vlan_interfaces[vlan_interface].isis_network_point_to_point is defined and vlan_interfaces[vlan_interface].isis_network_point_to_point == true %}
    isis network point-to-point
 {%         endif %}
+{%         if vlan_interfaces[vlan_interface].pim is defined and vlan_interfaces[vlan_interface].pim is not none %}
+{%            if vlan_interfaces[vlan_interface].pim.ipv4.sparse_mode is defined and vlan_interfaces[vlan_interface].pim.ipv4.sparse_mode == true %}
+   pim ipv4 sparse-mode
+{%            endif %}
+{%            if vlan_interfaces[vlan_interface].pim.ipv4.local_interface is defined and vlan_interfaces[vlan_interface].pim.ipv4.local_interface is not none %}
+   pim ipv4 local-interface {{ vlan_interfaces[vlan_interface].pim.ipv4.local_interface }}
+{%            endif %}
+{%         endif %}
+{%         if vlan_interfaces[vlan_interface].ipv6_virtual_router_address is defined and vlan_interfaces[vlan_interface].ipv6_virtual_router_address is not none %}
+   ipv6 virtual-router address {{ vlan_interfaces[vlan_interface].ipv6_virtual_router_address }}
+{%         endif %}
 !
 {%     endfor %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
@@ -85,6 +85,17 @@ interface {{ vlan_interface }}
 {%         endif %}
 {%         if vlan_interfaces[vlan_interface].ipv6_virtual_router_address is defined and vlan_interfaces[vlan_interface].ipv6_virtual_router_address is not none %}
    ipv6 virtual-router address {{ vlan_interfaces[vlan_interface].ipv6_virtual_router_address }}
+{%         if vlan_interfaces[vlan_interface].isis_enable is defined %}
+   isis enable {{ vlan_interfaces[vlan_interface].isis_enable }}
+{%         endif %}
+{%         if vlan_interfaces[vlan_interface].isis_passive is defined and vlan_interfaces[vlan_interface].isis_passive == true %}
+   isis passive
+{%         endif %}
+{%         if vlan_interfaces[vlan_interface].isis_metric is defined %}
+   isis metric {{ vlan_interfaces[vlan_interface].isis_metric }}
+{%         endif %}
+{%         if vlan_interfaces[vlan_interface].isis_network_point_to_point is defined and vlan_interfaces[vlan_interface].isis_network_point_to_point == true %}
+   isis network point-to-point
 {%         endif %}
 !
 {%     endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
@@ -85,6 +85,7 @@ interface {{ vlan_interface }}
 {%         endif %}
 {%         if vlan_interfaces[vlan_interface].ipv6_virtual_router_address is defined and vlan_interfaces[vlan_interface].ipv6_virtual_router_address is not none %}
    ipv6 virtual-router address {{ vlan_interfaces[vlan_interface].ipv6_virtual_router_address }}
+{%         endif %}
 {%         if vlan_interfaces[vlan_interface].isis_enable is defined %}
    isis enable {{ vlan_interfaces[vlan_interface].isis_enable }}
 {%         endif %}
@@ -96,17 +97,6 @@ interface {{ vlan_interface }}
 {%         endif %}
 {%         if vlan_interfaces[vlan_interface].isis_network_point_to_point is defined and vlan_interfaces[vlan_interface].isis_network_point_to_point == true %}
    isis network point-to-point
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].pim is defined and vlan_interfaces[vlan_interface].pim is not none %}
-{%            if vlan_interfaces[vlan_interface].pim.ipv4.sparse_mode is defined and vlan_interfaces[vlan_interface].pim.ipv4.sparse_mode == true %}
-   pim ipv4 sparse-mode
-{%            endif %}
-{%            if vlan_interfaces[vlan_interface].pim.ipv4.local_interface is defined and vlan_interfaces[vlan_interface].pim.ipv4.local_interface is not none %}
-   pim ipv4 local-interface {{ vlan_interfaces[vlan_interface].pim.ipv4.local_interface }}
-{%            endif %}
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].ipv6_virtual_router_address is defined and vlan_interfaces[vlan_interface].ipv6_virtual_router_address is not none %}
-   ipv6 virtual-router address {{ vlan_interfaces[vlan_interface].ipv6_virtual_router_address }}
 {%         endif %}
 !
 {%     endfor %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
@@ -234,8 +234,8 @@ mac_address_table:
 - The fabric underlay and overlay topology variables, define the elements related to build the L3 Leaf and Spine fabric.
 - The following underlay routing protocols are supported:
   - BGP (default)
-  - OSPF
-  - ISIS is planned for a future release.
+  - OSPF.
+  - ISIS.
 - Only summary network addresses need to be defined. IP addresses are then assigned to each node, based on its unique device id.
   - To view IP address allocation and consumption, a summary is provided in the auto-generated fabric documentation in Markdown format.
 - The variables should be applied to all devices in the fabric.
@@ -248,12 +248,16 @@ mac_address_table:
 fabric_name: < Fabric_Name >
 
 # Underlay routing protocol | Required.
-underlay_routing_protocol: < BGP or OSPF | Default -> BGP >
+underlay_routing_protocol: < BGP or OSPF or ISIS | Default -> BGP >
 
 # Underlay OSFP | Required when < underlay_routing_protocol > == OSPF
 underlay_ospf_process_id: < process_id | Default -> 100 >
 underlay_ospf_area: < ospf_area | Default -> 0.0.0.0 >
-underlay_ospf_max_lsa: < lsa | default -> 12000 >
+underlay_ospf_max_lsa: < lsa | Default -> 12000 >
+
+# Underlay OSFP | Required when < underlay_routing_protocol > == ISIS
+isis_area_id: < isis area | Default -> "49.0001" >
+isis_site_id: < isis site ID | Default -> "0001" >
 
 # Point to Point Links MTU | Required.
 p2p_uplinks_mtu: < 0-9216 | default -> 9000 >

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/documentation/dc-fabric-documentation.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/documentation/dc-fabric-documentation.j2
@@ -15,6 +15,9 @@
     - [Point-To-Point Links Node Allocation](#point-to-point-links-node-allocation)
     - [Overlay Loopback Interfaces (BGP EVPN Peering)](#overlay-loopback-interfaces-bgp-evpn-peering)
     - [Loopback0 Interfaces Node Allocation](#loopback0-interfaces-node-allocation)
+{% if underlay_routing_protocol == "ISIS" %}
+    - [CLNS Interfaces](#isis-clns-interfaces)
+{% endif %}
     - [VTEP Loopback VXLAN Tunnel Source Interfaces (Leafs Only)](#vtep-loopback-vxlan-tunnel-source-interfaces-leafs-only)
     - [VTEP Loopback Node allocation](#vtep-loopback-node-allocation)
 
@@ -143,6 +146,23 @@
 {%     endif %}
 {% endfor %}
 
+{% if underlay_routing_protocol == "ISIS" %}
+### ISIS CLNS interfaces
+
+| Node | CLNS Address |
+| ---- | ------------ |
+{% for node in groups[fabric_name] | arista.avd.natural_sort %}
+{%     if hostvars[node].type == "spine" %}
+| {{ node }} | {{ hostvars[node].router_isis.net }} |
+{% endif %}
+{% endfor %}
+{% for node in groups[fabric_name] | arista.avd.natural_sort %}
+{%     if hostvars[node].type == "l3leaf" %}
+| {{ node }} | {{ hostvars[node].router_isis.net }} |
+{% endif %}
+{% endfor %}
+
+{% endif %}
 ### VTEP Loopback VXLAN Tunnel Source Interfaces (Leafs Only)
 
 | VTEP Loopback Summary | Available Addresses | Assigned addresses | Assigned Address % |

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l3leaf-yml.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l3leaf-yml.j2
@@ -369,6 +369,12 @@ router_ospf:
 {# underlay #}
 {% include 'underlay-overlay/router-ospf.j2' %}
 
+{# OSPF Configurartion #}
+### Routing - ISIS ###
+router_isis:
+{# underlay #}
+{% include 'underlay-overlay/router-isis.j2' %}
+
 {# queue monitor streaming #}
 ### Queue Monitor Streaming ###
 queue_monitor_streaming:

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-spine-yml.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-spine-yml.j2
@@ -176,6 +176,12 @@ router_ospf:
 {# underlay #}
 {% include 'underlay-overlay/router-ospf.j2' %}
 
+{# OSPF Configurartion #}
+### Routing - ISIS ###
+router_isis:
+{# underlay #}
+{% include 'underlay-overlay/router-isis.j2' %}
+
 {# queue monitor streaming #}
 ### Queue Monitor Streaming ###
 queue_monitor_streaming:

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/mlag/leaf-mlag-vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/mlag/leaf-mlag-vlan-interfaces.j2
@@ -9,6 +9,11 @@
     ospf_area: {{ underlay_ospf_area }}
     mtu: {{ p2p_uplinks_mtu }}
 {%         endif %}
+{%         if underlay_routing_protocol == "ISIS" %}
+    isis_enable: EVPN_UNDERLAY
+    isis_metric: 50
+    isis_network_point_to_point: true
+{%         endif %}
 {%     endif %}
   Vlan4094:
     description: MLAG_PEER

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/underlay-overlay/leaf-overlay-loopback.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/underlay-overlay/leaf-overlay-loopback.j2
@@ -5,3 +5,7 @@
 {% if underlay_routing_protocol == "OSPF" %}
     ospf_area: {{ underlay_ospf_area }}
 {% endif %}
+{% if underlay_routing_protocol == "ISIS" %}
+    isis_enable: EVPN_UNDERLAY
+    isis_passive: true
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/underlay-overlay/leaf-p2p-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/underlay-overlay/leaf-p2p-interfaces.j2
@@ -15,4 +15,9 @@
     ospf_network_point_to_point: true
     ospf_area: {{ underlay_ospf_area }}
 {%     endif %}
+{%     if underlay_routing_protocol == "ISIS" %}
+    isis_enable: EVPN_UNDERLAY
+    isis_metric: 50
+    isis_network_point_to_point: true
+{%     endif %}
 {% endfor %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/underlay-overlay/leaf-router-bgp-address-family-evpn.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/underlay-overlay/leaf-router-bgp-address-family-evpn.j2
@@ -7,7 +7,7 @@
       IPv4-UNDERLAY-PEERS:
         activate: false
 {%     endif %}
-{%     if leaf.mlag == true %}
+{%     if leaf.mlag == true and underlay_routing_protocol == "BGP" %}
       MLAG-IPv4-UNDERLAY-PEER:
         activate: false
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/underlay-overlay/leaf-router-bgp-address-family-evpn.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/underlay-overlay/leaf-router-bgp-address-family-evpn.j2
@@ -7,7 +7,7 @@
       IPv4-UNDERLAY-PEERS:
         activate: false
 {%     endif %}
-{%     if leaf.mlag == true and underlay_routing_protocol == "BGP" %}
+{%     if leaf.mlag == true %}
       MLAG-IPv4-UNDERLAY-PEER:
         activate: false
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/underlay-overlay/leaf-router-bgp-address-family-ipv4.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/underlay-overlay/leaf-router-bgp-address-family-ipv4.j2
@@ -7,7 +7,7 @@
       IPv4-UNDERLAY-PEERS:
         activate: true
 {%     endif %}
-{%     if leaf.mlag == true and underlay_routing_protocol == "BGP" %}
+{%     if leaf.mlag == true %}
       MLAG-IPv4-UNDERLAY-PEER:
         activate: true
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/underlay-overlay/leaf-router-bgp-address-family-ipv4.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/underlay-overlay/leaf-router-bgp-address-family-ipv4.j2
@@ -7,7 +7,7 @@
       IPv4-UNDERLAY-PEERS:
         activate: true
 {%     endif %}
-{%     if leaf.mlag == true %}
+{%     if leaf.mlag == true and underlay_routing_protocol == "BGP" %}
       MLAG-IPv4-UNDERLAY-PEER:
         activate: true
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/underlay-overlay/leaf-router-bgp-peer-groups.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/underlay-overlay/leaf-router-bgp-peer-groups.j2
@@ -20,7 +20,7 @@
       send_community: true
       maximum_routes: 0
 {# MLAG iBGP peering #}
-{%     if leaf.mlag == true %}
+{%     if leaf.mlag == true and underlay_routing_protocol == 'BGP' %}
     MLAG-IPv4-UNDERLAY-PEER:
       type: ipv4
       remote_as: {{ leaf.bgp_as }}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/underlay-overlay/leaf-router-bgp-peer-groups.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/underlay-overlay/leaf-router-bgp-peer-groups.j2
@@ -20,7 +20,7 @@
       send_community: true
       maximum_routes: 0
 {# MLAG iBGP peering #}
-{%     if leaf.mlag == true and underlay_routing_protocol == 'BGP' %}
+{%     if leaf.mlag == true %}
     MLAG-IPv4-UNDERLAY-PEER:
       type: ipv4
       remote_as: {{ leaf.bgp_as }}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/underlay-overlay/leaf-vtep-vxlan-tunnel-loopback.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/underlay-overlay/leaf-vtep-vxlan-tunnel-loopback.j2
@@ -11,3 +11,7 @@
 {% if underlay_routing_protocol == "OSPF" %}
     ospf_area: {{ underlay_ospf_area }}
 {% endif %}
+{% if underlay_routing_protocol == "ISIS" %}
+    isis_enable: EVPN_UNDERLAY
+    isis_passive: true
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/underlay-overlay/router-isis.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/underlay-overlay/router-isis.j2
@@ -38,4 +38,6 @@
 {% endif %}
   is_type: level-2
   address_family: ['ipv4 unicast']
+  isis_af_defaults:
+    - maximum-paths {{ spine.nodes | length * max_l3leaf_to_spine_links }}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/underlay-overlay/router-isis.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/underlay-overlay/router-isis.j2
@@ -35,7 +35,7 @@
 {%         if leaf.mlag == true %}
     - Vlan4093
 {%         endif %}
-{% endif %}
+{%    endif %}
   is_type: level-2
   address_family: ['ipv4 unicast']
   isis_af_defaults:

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/underlay-overlay/router-isis.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/underlay-overlay/router-isis.j2
@@ -34,6 +34,7 @@
 {%         endfor %}
 {%         if leaf.mlag == true %}
     - Vlan4093
+    - Loopback1
 {%         endif %}
 {%    endif %}
   is_type: level-2

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/underlay-overlay/router-isis.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/underlay-overlay/router-isis.j2
@@ -1,0 +1,41 @@
+{% if underlay_routing_protocol == "ISIS" %}
+  instance: EVPN_UNDERLAY
+{%     if type == "spine" %}
+  net: {{ isis_area_id | default('49.0001') }}.{{ isis_site_id | default('0001') }}.0000.{{ '%04d' | format(spine.nodes[inventory_hostname].id) }}.00
+  router_id: {{ overlay_loopback_network_summary | ipaddr('network') | ipmath(spine.nodes[inventory_hostname].id) }}
+  no_passive_interfaces:
+{# Point-to-Point Interfaces to Leaf Switches #}
+{%         for l3leaf_node_group in l3leaf.node_groups | arista.avd.natural_sort %}
+{%             if l3leaf.node_groups[l3leaf_node_group].spines is defined %}
+{%                 set leaf_spines = l3leaf.node_groups[l3leaf_node_group].spines %}
+{%             else %}
+{%                 set leaf_spines = l3leaf.defaults.spines %}
+{%             endif %}
+{%             for node in l3leaf.node_groups[l3leaf_node_group].nodes | arista.avd.natural_sort %}
+{%                 set spine_interfaces = l3leaf.node_groups[l3leaf_node_group].nodes[node].spine_interfaces %}
+{%                 if l3leaf.node_groups[l3leaf_node_group].uplink_to_spine_interfaces is defined %}
+{%                     set uplink_to_spine_interfaces = l3leaf.node_groups[l3leaf_node_group].uplink_to_spine_interfaces %}
+{%                 else %}
+{%                     set uplink_to_spine_interfaces = l3leaf.defaults.uplink_to_spine_interfaces %}
+{%                 endif %}
+{%                 for leaf_spine in leaf_spines %}
+{%                     if leaf_spine == inventory_hostname %}
+    - {{ spine_interfaces[loop.index0] }}
+{%                     endif %}
+{%                 endfor %}
+{%             endfor %}
+{%         endfor %}
+{%     elif type == "l3leaf" %}
+  net: {{ isis_area_id }}.{{ isis_site_id }}.0001.{{ '%04d' | format(leaf.id) }}.00
+  router_id: {{ overlay_loopback_network_summary | ipaddr('network') | ipmath(leaf.id + spine.nodes | length) }}
+  no_passive_interfaces:
+{%         for uplink_to_spine_interface in leaf.uplink_to_spine_interfaces %}
+    - {{ uplink_to_spine_interface }}
+{%         endfor %}
+{%         if leaf.mlag == true %}
+    - Vlan4093
+{%         endif %}
+{% endif %}
+  is_type: level-2
+  address_family: ['ipv4 unicast']
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/underlay-overlay/spine-overlay-loopback.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/underlay-overlay/spine-overlay-loopback.j2
@@ -5,3 +5,7 @@
 {% if underlay_routing_protocol == "OSPF" %}
     ospf_area: {{ underlay_ospf_area }}
 {% endif %}
+{% if underlay_routing_protocol == "ISIS" %}
+    isis_enable: EVPN_UNDERLAY
+    isis_passive: true
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/underlay-overlay/spine-p2p-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/underlay-overlay/spine-p2p-interfaces.j2
@@ -34,6 +34,11 @@
     ospf_network_point_to_point: true
     ospf_area: {{ underlay_ospf_area }}
 {%                 endif %}
+{%                 if underlay_routing_protocol == "ISIS" %}
+    isis_enable: EVPN_UNDERLAY
+    isis_metric: 50
+    isis_network_point_to_point: true
+{%                 endif %}
 {%             endif %}
 {%         endfor %}
 {%     endfor %}

--- a/testing/avd-underlay-isis/ansible.cfg
+++ b/testing/avd-underlay-isis/ansible.cfg
@@ -1,0 +1,17 @@
+[defaults]
+host_key_checking = False
+inventory =./inventory.yml
+gathering = explicit
+retry_files_enabled = False
+collections_paths = ../../
+jinja2_extensions =  jinja2.ext.loopcontrols,jinja2.ext.do,jinja2.ext.i18n
+# enable the YAML callback plugin.
+stdout_callback = yaml
+# enable the stdout_callback when running ad-hoc commands.
+bin_ansible_callbacks = True
+forks = 15
+callback_whitelist = profile_roles, profile_tasks, timer
+
+[persistent_connection]
+connect_timeout = 120
+command_timeout = 120

--- a/testing/avd-underlay-isis/group_vars/CVP.yml
+++ b/testing/avd-underlay-isis/group_vars/CVP.yml
@@ -1,0 +1,63 @@
+---
+ztp:
+  default:
+    registration: 'http://10.255.0.1/ztp/bootstrap'
+    gateway: 10.255.0.3
+    nameservers: 
+      - '10.255.0.3'
+  general:
+    subnets:
+      - network: 10.255.0.0
+        netmask: 255.255.255.0
+        gateway: 10.255.0.3
+        nameservers: 
+          - '10.255.0.3'
+        start: 10.255.0.200
+        end: 10.255.0.250
+        lease_time: 300
+  clients:
+  # AVD/CVP Integration
+    - name: DC1-SPINE1
+      mac: 0c:1d:c0:1d:62:01
+      ip4: 10.255.0.11
+    - name: DC1-SPINE2
+      mac: 0c:1d:c0:1d:62:02
+      ip4: 10.255.0.12
+    - name: DC1-LEAF1A
+      mac: 0c:1d:c0:1d:62:11
+      ip4: 10.255.0.13
+    - name: DC1-LEAF1B
+      mac: 0c:1d:c0:1d:62:12
+      ip4: 10.255.0.14
+    - name: DC1-LEAF2A
+      mac: 0c:1d:c0:1d:62:21
+      ip4: 10.255.0.15
+    - name: DC1-LEAF2B
+      mac: 0c:1d:c0:1d:62:22
+      ip4: 10.255.0.16
+    - name: DC1-L2LEAF1A
+      mac: 0c:1d:c0:1d:62:13
+      ip4: 10.255.0.17
+    - name: DC1-L2LEAF2A
+      mac: 0c:1d:c0:1d:62:23
+      ip4: 10.255.0.18
+  # Ansible CVP Development
+    - name: veos-01
+      mac: 0c:30:ae:7d:e6:01
+      ip4: 10.255.0.21
+    - name: veos-02
+      mac: 0c:30:ae:7d:e6:02
+      ip4: 10.255.0.22
+  # Ansible CVP TOI
+    - name: TEAM01-DEVICE01
+      mac: 0c:1a:c1:00:00:01
+      ip4: 10.255.0.31
+    - name: TEAM02-DEVICE01
+      mac: 0c:1a:c1:00:00:02
+      ip4: 10.255.0.32
+    - name: TEAM03-DEVICE01
+      mac: 0c:1a:c1:00:00:03
+      ip4: 10.255.0.33
+    - name: TEAM04-DEVICE01
+      mac: 0c:1a:c1:00:00:04
+      ip4: 10.255.0.34

--- a/testing/avd-underlay-isis/group_vars/DC1.yml
+++ b/testing/avd-underlay-isis/group_vars/DC1.yml
@@ -1,0 +1,40 @@
+---
+# Validation lab
+# local users
+local_users:
+  admin:
+    privilege: 15
+    role: network-admin
+    sha512_password: "$6$Df86J4/SFMDE3/1K$Hef4KstdoxNDaami37cBquTWOTplC.miMPjXVgQxMe92.e5wxlnXOLlebgPj8Fz1KO0za/RCO7ZIs4Q6Eiq1g1"
+
+  cvpadmin:
+    privilege: 15
+    role: network-admin
+    sha512_password: "$6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj."
+
+  ansible:
+    privilege: 15
+    role: network-admin
+    sha512_password: "$6$Dzu11L7yp9j3nCM9$FSptxMPyIL555OMO.ldnjDXgwZmrfMYwHSr0uznE5Qoqvd9a6UdjiFcJUhGLtvXVZR1r.A/iF5aAt50hf/EK4/"
+
+  demo:
+    privilege: 15
+    role: network-admin
+    sha512_password: "$6$Dzu11L7yp9j3nCM9$FSptxMPyIL555OMO.ldnjDXgwZmrfMYwHSr0uznE5Qoqvd9a6UdjiFcJUhGLtvXVZR1r.A/iF5aAt50hf/EK4/"
+
+
+# Cloud Vision server information
+cvp_instance_ip: 10.255.0.1
+cvp_ingestauth_key: ''
+# cvp_ingestauth_key: telarista
+
+# OOB Management network default gateway.
+mgmt_gateway: 10.255.0.3
+
+# dns servers.
+name_servers:
+  - 10.255.0.3
+
+# NTP Servers IP or DNS name, first NTP server will be prefered, and sourced from Managment VRF
+ntp_servers:
+  - 10.255.0.3

--- a/testing/avd-underlay-isis/group_vars/DC1_FABRIC.yml
+++ b/testing/avd-underlay-isis/group_vars/DC1_FABRIC.yml
@@ -1,0 +1,171 @@
+---
+# L3LS Fabric Values - update these values with caution,
+# SOME CHANGES COULD BE DISRUPTIVE.
+
+fabric_name: DC1_FABRIC
+
+underlay_routing_protocol: ISIS
+isis_area_id: "49.0001"
+isis_site_id: "0001"
+
+# Point to Point Network Summary range, assigned as /31 for each
+# uplink interfaces
+# Assign range larger then total [spines * total potential leafs * 2]
+underlay_p2p_network_summary: 172.31.255.0/24
+
+# IP address range for evpn loopback for all switches in fabric,
+# assigned as /32s
+# Assign range larger then total spines + total leafs switches
+overlay_loopback_network_summary: 192.168.255.0/24
+
+# VTEP VXLAN Tunnel source loopback IP for leaf switches, assigned in /32s
+# Assign range larger then total leaf switches
+vtep_loopback_network_summary: 192.168.254.0/24
+
+# mlag pair IP assignment - assign blocks - Assign range larger then
+# total spines + total leafs switches
+mlag_ips:
+  leaf_peer_l3: 10.255.251.0/24
+  mlag_peer: 10.255.252.0/24
+
+# Enable vlan aware bundles
+vxlan_vlan_aware_bundles: true
+
+# bgp peer groups passwords
+bgp_peer_groups:
+  IPv4_UNDERLAY_PEERS:
+    password: "AQQvKeimxJu+uGQ/yYvv9w=="
+  EVPN_OVERLAY_PEERS:
+    password: "q+VNViP5i4rVjW1cxFv2wA=="
+  MLAG_IPv4_UNDERLAY_PEER:
+    password: "vnEaG8gMeQf3d3cN6PktXQ=="
+
+# Spine Switches
+spine:
+  platform: vEOS-LAB
+  bgp_as: 65001
+  # defines the range of acceptable remote ASNs from leaf switches
+  leaf_as_range: 65101-65132
+  nodes:
+    DC1-SPINE1:
+      id: 1
+      mgmt_ip: 10.255.0.11/24
+    DC1-SPINE2:
+      id: 2
+      mgmt_ip: 10.255.0.12/24
+
+# Leaf switch groups
+# A maximum of two nodes can form a leaf group
+# When two nodes are in a leaf group this will automatically form mlag pair
+
+l3leaf:
+  defaults:
+    # virtual router mac for VNIs assigned to Leaf switches
+    # format: xx:xx:xx:xx:xx:xx
+    virtual_router_mac_address: 00:1c:73:00:dc:01
+    platform: vEOS-LAB
+    bgp_as: 65100
+    spines: [DC1-SPINE1, DC1-SPINE2]
+    uplink_to_spine_interfaces: [Ethernet1, Ethernet2]
+    mlag_interfaces: [Ethernet3, Ethernet4]
+    spanning_tree_priority: 4096
+    spanning_tree_mode: mstp
+  node_groups:
+    DC1_LEAF1:
+      bgp_as: 65101
+      filter:
+        tenants: [ Tenant_A ]
+        tags: [ opzone, web, app ]
+        # tags: [ border ]
+      nodes:
+        DC1-LEAF1A:
+          id: 1
+          mgmt_ip: 10.255.0.13/24
+          spine_interfaces: [Ethernet1, Ethernet1]
+        DC1-LEAF1B:
+          id: 2
+          mgmt_ip: 10.255.0.14/24
+          spine_interfaces: [Ethernet2, Ethernet2]
+    DC1_LEAF2:
+      bgp_as: 65102
+      nodes:
+        DC1-LEAF2A:
+          id: 3
+          mgmt_ip: 10.255.0.15/24
+          spine_interfaces: [Ethernet3, Ethernet3]
+        DC1-LEAF2B:
+          id: 4
+          mgmt_ip: 10.255.0.16/24
+          spine_interfaces: [Ethernet4, Ethernet4]
+
+
+l2leaf:
+  defaults:
+    platform: vEOS-LAB
+    parent_l3leafs: [ DC1-LEAF1A, DC1-LEAF1B ]
+    uplink_interfaces: [ Ethernet1, Ethernet2 ]
+    mlag_interfaces: [ Ethernet3, Ethernet4 ]
+    spanning_tree_mode: mstp
+    spanning_tree_priority: 16384
+  node_groups:
+    DC1_L2LEAF1:
+      parent_l3leafs: [ DC1-LEAF1A, DC1-LEAF1B ]
+      filter:
+        tenants: [ Tenant_A ]
+        tags: [ opzone, web, app ]
+        # tags: [ border ]
+      nodes:
+        DC1-L2LEAF1A:
+          id: 5
+          mgmt_ip: 10.255.0.17/24
+          l3leaf_interfaces: [ Ethernet5, Ethernet5 ]
+    DC1_L2LEAF2:
+      parent_l3leafs: [ DC1-LEAF2A, DC1-LEAF2B ]
+      filter:
+        tenants: [ Tenant_A ]
+        tags: [ opzone, web, app ]
+      nodes:
+        DC1-L2LEAF2A:
+          id: 7
+          mgmt_ip: 10.255.0.18/24
+          l3leaf_interfaces: [ Ethernet5, Ethernet5 ]
+
+#### Override for vEOS Lab Caveats ####
+
+# Disable update wait-for-convergence and update wait-for-install,
+# which is not supported in vEOS-LAB.
+# Refer to design guide
+
+spine_bgp_defaults:
+  #  - update wait-for-convergence
+  #  - update wait-install
+  - no bgp default ipv4-unicast
+  - distance bgp 20 200 200
+  - graceful-restart restart-time 300
+  - graceful-restart
+
+leaf_bgp_defaults:
+  #  - update wait-install
+  - no bgp default ipv4-unicast
+  - distance bgp 20 200 200
+  - graceful-restart restart-time 300
+  - graceful-restart
+
+# Update p2p mtu 9000 -> 1500
+p2p_uplinks_mtu: 1500
+
+# Adjust default bfd values
+bfd_multihop:
+  interval: 1200
+  min_rx: 1200
+  multiplier: 3
+
+# List of additional CVP configlets to bind to devices and containers
+# Configlets MUST be configured on CVP before running AVD playbooks.
+cv_configlets:
+  containers:
+    DC1_L3LEAFS:
+      - ASE_GLOBAL-ALIASES
+#   devices:
+#     DC1-L2LEAF1A:
+#       - ASE_DEVICE-ALIASES.conf

--- a/testing/avd-underlay-isis/group_vars/DC1_L2LEAFS.yml
+++ b/testing/avd-underlay-isis/group_vars/DC1_L2LEAFS.yml
@@ -1,0 +1,2 @@
+---
+type: l2leaf

--- a/testing/avd-underlay-isis/group_vars/DC1_L3LEAFS.yml
+++ b/testing/avd-underlay-isis/group_vars/DC1_L3LEAFS.yml
@@ -1,0 +1,2 @@
+---
+type: l3leaf

--- a/testing/avd-underlay-isis/group_vars/DC1_SERVERS.yml
+++ b/testing/avd-underlay-isis/group_vars/DC1_SERVERS.yml
@@ -1,0 +1,29 @@
+---
+port_profiles:
+  TENANT_A_B:
+    mode: trunk
+    vlans: "110-111,210-211"
+  TENANT_A:
+    mode: access
+    vlans: "110"
+  TENANT_B:
+    mode: trunk
+    vlans: "210-211"
+
+servers:
+  server01:
+    rack: RackA
+    adapters:
+      - type: nic
+        server_ports: [Eth0]
+        switch_ports: [Ethernet5]
+        switches: [DC1-L2LEAF1A]
+        profile: TENANT_A
+  server02:
+    rack: RackA
+    adapters:
+      - type: nic
+        server_ports: [Eth0]
+        switch_ports: [Ethernet5]
+        switches: [DC1-L2LEAF2A]
+        profile: TENANT_A

--- a/testing/avd-underlay-isis/group_vars/DC1_SPINES.yml
+++ b/testing/avd-underlay-isis/group_vars/DC1_SPINES.yml
@@ -1,0 +1,11 @@
+---
+type: spine
+
+event_handler:
+  evpn-blacklist-recovery:
+    action_type: bash
+    action: FastCli -p 15 -c “clear bgp evpn host-flap”
+    delay: 300
+    trigger: on-logging
+    regex:  EVPN-3-BLACKLISTED_DUPLICATE_MAC
+    asynchronous: true

--- a/testing/avd-underlay-isis/group_vars/DC1_TENANTS_NETWORKS.yml
+++ b/testing/avd-underlay-isis/group_vars/DC1_TENANTS_NETWORKS.yml
@@ -1,0 +1,42 @@
+---
+# DC1 Tenants Networks
+# Documentation of Tenant specific information - Vlans/VRFs
+tenants:
+  # Tenant A Specific Information - VRFs / VLANs
+  Tenant_A:
+    mac_vrf_vni_base: 10000
+    vrfs:
+      Tenant_A_OP_Zone:
+        vrf_vni: 10
+        vtep_diagnostic:
+          loopback: 100
+          loopback_ip_range: 10.255.1.0/24
+        svis:
+          110:
+            name: Tenant_A_OP_Zone_1
+            tags: [opzone]
+            enabled: true
+            ip_subnet: 10.1.10.0/24
+  #         111:
+  #           vni_override: 50111
+  #           name: Tenant_A_OP_Zone_2
+  #           tags: [opzone]
+  #           enabled: true
+  #           ip_subnet: 10.1.11.0/24
+  #         114:
+  #           vni_override: 50114
+  #           name: Tenant_A_OP_Zone_3
+  #           tags: [opzone]
+  #           enabled: true
+  #           ip_subnet: 10.1.14.0/24
+
+# Tenant D Specific Information - Pure L2 tenant
+  Tenant_D:
+    mac_vrf_vni_base: 40000
+    l2vlans:
+      411:
+        name: 'Tenant_D_OP_Zone_1'
+        tags: [opzone]
+      412:
+        name: 'Tenant_D_OP_Zone_2'
+        tags: [opzone]

--- a/testing/avd-underlay-isis/group_vars/all.yml
+++ b/testing/avd-underlay-isis/group_vars/all.yml
@@ -1,0 +1,7 @@
+---
+ansible_user: ansible
+# should use vault for passwords
+ansible_ssh_pass: ansible
+ansible_become: true
+ansible_become_method: enable
+ansible_httpapi_validate_certs: false

--- a/testing/avd-underlay-isis/group_vars/cvp_sync.yml
+++ b/testing/avd-underlay-isis/group_vars/cvp_sync.yml
@@ -1,0 +1,9 @@
+---
+ansible_httpapi_host: '{{ ansible_host }}'
+ansible_connection: httpapi
+ansible_httpapi_use_ssl: true
+ansible_httpapi_validate_certs: false
+ansible_network_os: eos
+ansible_httpapi_port: 443
+# Configuration to get Virtual Env information
+ansible_python_interpreter: $(which python)

--- a/testing/avd-underlay-isis/inventory.yml
+++ b/testing/avd-underlay-isis/inventory.yml
@@ -1,0 +1,69 @@
+---
+all:
+  children:
+    cvp_sync:
+      hosts:
+        cv_server1:
+          ansible_host: 3.101.72.76
+          ansible_user: arista
+          ansible_password: arista
+        cv_server2:
+          ansible_host: 13.57.219.206
+          ansible_user: arista
+          ansible_password: arista
+    CVP:
+      hosts:
+        cv_ztp:
+          ansible_host: 10.83.28.164
+          ansible_user: root
+          ansible_password: ansible
+        cv_server:
+          ansible_host: 10.83.28.164
+          ansible_user: ansible
+          ansible_password: ansible
+    # DC1_Fabric - EVPN Fabric running in home lab
+    DC1:
+      vars:
+        ansible_user: admin
+        ansible_ssh_pass: arista123
+      children:
+        DC1_FABRIC:
+          children:
+            DC1_SPINES:
+              hosts:
+                DC1-SPINE1:
+                  ansible_host: 10.255.0.11
+                DC1-SPINE2:
+                  ansible_host: 10.255.0.12
+            DC1_L3LEAFS:
+              children:
+                DC1_LEAF1:
+                  hosts:
+                    DC1-LEAF1A:
+                      ansible_host: 10.255.0.13
+                    DC1-LEAF1B:
+                      ansible_host: 10.255.0.14
+                DC1_LEAF2:
+                  hosts:
+                    DC1-LEAF2A:
+                      ansible_host: 10.255.0.15
+                    DC1-LEAF2B:
+                      ansible_host: 10.255.0.16
+            DC1_L2LEAFS:
+              children:
+                DC1_L2LEAF1:
+                  hosts:
+                    DC1-L2LEAF1A:
+                      ansible_host: 10.255.0.17
+                DC1_L2LEAF2:
+                  hosts:
+                    DC1-L2LEAF2A:
+                      ansible_host: 10.255.0.18
+        DC1_TENANTS_NETWORKS:
+          children:
+            DC1_L3LEAFS:
+            DC1_L2LEAFS:
+        DC1_SERVERS:
+          children:
+            DC1_L3LEAFS:
+            DC1_L2LEAFS:

--- a/testing/avd-underlay-isis/playbook-validation.yml
+++ b/testing/avd-underlay-isis/playbook-validation.yml
@@ -1,0 +1,15 @@
+- hosts: DC1_FABRIC
+  tasks:
+    - name: create local output folders
+      tags: build
+      import_role:
+         name: arista.avd.build_output_folders
+      run_once: true
+
+    - name: generate intented variables
+      import_role:
+         name: arista.avd.eos_l3ls_evpn
+
+    - name: generate device intended config and documention
+      import_role:
+         name: arista.avd.eos_cli_config_gen


### PR DESCRIPTION
Initial Implementation for ISIS as underlay (#127)

## EOS_L3LS_EVPN

### Inputs:

DC1_FABRIC.yml

```yaml
underlay_routing_protocol: ISIS
isis_area_id: "49.0001"
isis_site_id: "0001"
```

### Outputs:

- Data structure compatible with eos_cli_config_gen role

```yaml
router_isis:
    instance: EVPN_UNDERLAY
    net: 49.0001.0001.0001.0001.00
    router_id: 192.168.255.3
    no_passive_interfaces:
    - Ethernet1
    - Ethernet2
    - Vlan4093
    is_type: level-2
    address_family: ['ipv4 unicast']
    isis_af_defaults:
      - maximum-paths 2
```

- Fabric documentation: List of CLNS addresses configured on devices.

## EOS_CLI_CONFIG_GEN


Initial implementation of ISIS to support protocol as underlay in L3LS
environment.

### Supported options:

- ISIS Router options:

```yaml
router_isis:
    instance: <ISIS Instance Name>
    net: < CLNS Address to run ISIS | format 49.0001.0001.0000.0001.00 >
    router_id: < IPv4_address >
    no_passive_interfaces: < List no-passive-interface >
    is_type: < level-1 | level-1-2 | level-2 >
    address_family: < List of Address Families >
    isis_af_defaults:
      - maximum-paths < Integer 1-64 >
```

- ISIS Interface confituguration (Ethernet / Loopback / Vlans)

```yaml
isis_enable: < ISIS Instance >
isis_passive: < boolean >
isis_metric: < integer >
isis_network_point_to_point: < boolean >
```

### Outputs:

- Device documentation
- Device Configuration

```
interface Loopback0
    description EVPN_Overlay_Peering
    ip address 192.168.255.3/32
    isis enable EVPN_UNDERLAY
    isis passive
!
interface Vlan4093
    description MLAG_PEER_L3_PEERING
    ip address 10.255.251.0/31
    isis enable EVPN_UNDERLAY
    isis metric 50
    isis network point-to-point
!
router isis EVPN_UNDERLAY
    net 49.0001.0001.0001.0001.00
    is-type level-2
    router-id ipv4 192.168.255.3
    log-adjacency-changes
    !
    address-family ipv4 unicast
      maximum-paths 2
    !
!
```

## Review

- `eos_l3ls_evpn` [readme file](https://github.com/titom73/ansible-avd/blob/features/underlay-isis-127/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md#fabric-underlay-and-overlay-topology-variables)
- `eos_cli_config_gen` [readme file](https://github.com/titom73/ansible-avd/blob/features/underlay-isis-127/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md#router-isis-configuration)
- [Testing for CI](testing/avd-underlay-isis)
