### PR TITLE
Fix issue where installation script failed to clone AVD

### DIFF
--- a/.github/workflows/installation-test.yml
+++ b/.github/workflows/installation-test.yml
@@ -5,14 +5,16 @@ jobs:
   'setup':
     name: 'One liner installation'
     runs-on: ubuntu-latest
+    container: avdteam/base:centos-8
     steps:
+      - uses: actions/checkout@master
       - name: Execute one-liner installation
         run: |
-          echo "Test installation script from: ${GITHUB_REPOSITORY}"
-          echo "Use content from commit: ${GITHUB_SHA}"
-          sh -c "$(curl -fsSL https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${GITHUB_SHA}/development/install.sh)"
+          cp development/install.sh /tmp/
+          cd /tmp/
+          sh install.sh
       - name: Run Makefile commands
         run: |
-          cd arista-ansible/
+          cd /tmp/arista-ansible/
           cat Makefile
           make

--- a/.github/workflows/installation-test.yml
+++ b/.github/workflows/installation-test.yml
@@ -1,6 +1,7 @@
 name: Test Installation
 on:
   push:
+  pull_request:
 jobs:
   'setup':
     name: 'One liner installation'

--- a/development/install.sh
+++ b/development/install.sh
@@ -33,7 +33,6 @@ if [ ! -d "${_ROOT_INSTALLATION_DIR}" ]; then
     echo "  * creating local installation folder: ${_ROOT_INSTALLATION_DIR}"
     mkdir -p ${_ROOT_INSTALLATION_DIR}
     echo "  * cloning ansible-avd collections to ${_LOCAL_AVD}"
-    echo "! ${_REPO_AVD}"
     git clone ${_REPO_AVD} ${_LOCAL_AVD}
     echo "  * cloning ansible-cvp collections to ${_LOCAL_CVP}"
     git clone ${_REPO_CVP} ${_LOCAL_CVP}

--- a/development/install.sh
+++ b/development/install.sh
@@ -3,12 +3,8 @@
 # Local Installation Path
 _ROOT_INSTALLATION_DIR="${PWD}/arista-ansible"
 
-if [[ -z GITHUB_REPOSITORY ]]; then
-    export GITHUB_REPOSITORY="aristanetworks/ansible-avd"
-fi
-if [[ -z GITHUB_SHA ]]; then
-    export GITHUB_SHA="devel"
-fi
+GITHUB_REPOSITORY="aristanetworks/ansible-avd"
+GITHUB_SHA="devel"
 
 # List of Arista Repositories
 _REPO_AVD="https://github.com/${GITHUB_REPOSITORY}.git"
@@ -37,6 +33,7 @@ if [ ! -d "${_ROOT_INSTALLATION_DIR}" ]; then
     echo "  * creating local installation folder: ${_ROOT_INSTALLATION_DIR}"
     mkdir -p ${_ROOT_INSTALLATION_DIR}
     echo "  * cloning ansible-avd collections to ${_LOCAL_AVD}"
+    echo "! ${_REPO_AVD}"
     git clone ${_REPO_AVD} ${_LOCAL_AVD}
     echo "  * cloning ansible-cvp collections to ${_LOCAL_CVP}"
     git clone ${_REPO_CVP} ${_LOCAL_CVP}
@@ -46,8 +43,13 @@ if [ ! -d "${_ROOT_INSTALLATION_DIR}" ]; then
         echo "deploying development content to ${_ROOT_INSTALLATION_DIR}"
         cp ${_DEV_FOLDER}/Makefile ${_ROOT_INSTALLATION_DIR}
     else
-        echo "  ! error: development folder is missing"
+        echo "  ! error: development folder is missing: ${_DEV_FOLDER}"
+        exit 1
     fi
+    echo ""
+    echo "Installtion done. You can access setup at ${_ROOT_INSTALLATION_DIR}"
+    echo ""
 else
     echo "  ! local installation folder already exists - ${_ROOT_INSTALLATION_DIR}"
+    exit 1
 fi


### PR DESCRIPTION
Fix an issue (#185) where a variable was not set correctly leading to an error to clone AVD and then retrieve make file.

Also add a strep in CI to test installation file.