### PR TITLE
vrrp: initial support for redundancy of vlan interfaces

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -730,11 +730,11 @@ vlan_interfaces:
     vrrp:
       virtual_router: < virtual_router_id >
       priority: < instance_priority >
+      advertisement_interval: < advertisement_interval>
+      preempt_delay_minimum: < minimum_preemption_delay >
       ipv4: < virtual_ip_address >
       ipv6: < virtual_ip_address >
-      interval: < advertisement_interval>
-      preempt_delay: < minimum_preemption_delay >
-  < Vlan_id_2 >:
+< Vlan_id_2 >:
     description: < description >
     ip_address: < IPv4_address/Mask >
 ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -727,6 +727,13 @@ vlan_interfaces:
     isis_metric: < integer >
     isis_network_point_to_point: < boolean >
     mtu: < mtu >
+    vrrp:
+      virtual_router: < virtual_router_id >
+      priority: < instance_priority >
+      ipv4: < virtual_ip_address >
+      ipv6: < virtual_ip_address >
+      interval: < advertisement_interval>
+      preempt_delay: < minimum_preemption_delay >
   < Vlan_id_2 >:
     description: < description >
     ip_address: < IPv4_address/Mask >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
@@ -100,20 +100,20 @@ interface {{ vlan_interface }}
 {%         endif %}
 {%         if vlan_interfaces[vlan_interface].vrrp is defined and vlan_interfaces[vlan_interface].vrrp is not none %}
 {%           if vlan_interfaces[vlan_interface].vrrp.virtual_router is defined and vlan_interfaces[vlan_interface].vrrp.virtual_router is not none %}
+{%             if vlan_interfaces[vlan_interface].vrrp.priority is defined and vlan_interfaces[vlan_interface].vrrp.priority is not none and vlan_interfaces[vlan_interface].vrrp.priority > 1 %}
+   vrrp {{ vlan_interfaces[vlan_interface].vrrp.virtual_router }} priority {{ vlan_interfaces[vlan_interface].vrrp.priority }}
+{%             endif %}
+{%             if vlan_interfaces[vlan_interface].vrrp.advertisement_interval is defined and vlan_interfaces[vlan_interface].vrrp.advertisement_interval is not none %}
+   vrrp {{ vlan_interfaces[vlan_interface].vrrp.virtual_router }} advertisement interval {{ vlan_interfaces[vlan_interface].vrrp.advertisement_interval }}
+{%             endif %}
+{%             if vlan_interfaces[vlan_interface].vrrp.preempt_delay_minimum is defined and vlan_interfaces[vlan_interface].vrrp.preempt_delay_minimum is not none %}
+   vrrp {{ vlan_interfaces[vlan_interface].vrrp.virtual_router }} preempt delay minimum {{ vlan_interfaces[vlan_interface].vrrp.preempt_delay_minimum }}
+{%             endif %}
 {%             if vlan_interfaces[vlan_interface].vrrp.ipv4 is defined and vlan_interfaces[vlan_interface].vrrp.ipv4 is not none %}
    vrrp {{ vlan_interfaces[vlan_interface].vrrp.virtual_router }} ipv4 {{ vlan_interfaces[vlan_interface].vrrp.ipv4 }}
 {%             endif %}
 {%             if vlan_interfaces[vlan_interface].vrrp.ipv6 is defined and vlan_interfaces[vlan_interface].vrrp.ipv6 is not none %}
    vrrp {{ vlan_interfaces[vlan_interface].vrrp.virtual_router }} ipv6 {{ vlan_interfaces[vlan_interface].vrrp.ipv6 }}
-{%             endif %}
-{%             if vlan_interfaces[vlan_interface].vrrp.priority is defined and vlan_interfaces[vlan_interface].vrrp.priority is not none %}
-   vrrp {{ vlan_interfaces[vlan_interface].vrrp.virtual_router }} priority {{ vlan_interfaces[vlan_interface].vrrp.priority }}
-{%             endif %}
-{%             if vlan_interfaces[vlan_interface].vrrp.interval is defined and vlan_interfaces[vlan_interface].vrrp.interval is not none %}
-   vrrp {{ vlan_interfaces[vlan_interface].vrrp.virtual_router }} advertisement interval {{ vlan_interfaces[vlan_interface].vrrp.interval }}
-{%             endif %}
-{%             if vlan_interfaces[vlan_interface].vrrp.preempt_delay is defined and vlan_interfaces[vlan_interface].vrrp.preempt_delay is not none %}
-   vrrp {{ vlan_interfaces[vlan_interface].vrrp.virtual_router }} preempt delay minimum {{ vlan_interfaces[vlan_interface].vrrp.preempt_delay }}
 {%             endif %}
 {%           endif %}
 {%         endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
@@ -98,6 +98,25 @@ interface {{ vlan_interface }}
 {%         if vlan_interfaces[vlan_interface].isis_network_point_to_point is defined and vlan_interfaces[vlan_interface].isis_network_point_to_point == true %}
    isis network point-to-point
 {%         endif %}
+{%         if vlan_interfaces[vlan_interface].vrrp is defined and vlan_interfaces[vlan_interface].vrrp is not none %}
+{%           if vlan_interfaces[vlan_interface].vrrp.virtual_router is defined and vlan_interfaces[vlan_interface].vrrp.virtual_router is not none %}
+{%             if vlan_interfaces[vlan_interface].vrrp.ipv4 is defined and vlan_interfaces[vlan_interface].vrrp.ipv4 is not none %}
+   vrrp {{ vlan_interfaces[vlan_interface].vrrp.virtual_router }} ipv4 {{ vlan_interfaces[vlan_interface].vrrp.ipv4 }}
+{%             endif %}
+{%             if vlan_interfaces[vlan_interface].vrrp.ipv6 is defined and vlan_interfaces[vlan_interface].vrrp.ipv6 is not none %}
+   vrrp {{ vlan_interfaces[vlan_interface].vrrp.virtual_router }} ipv6 {{ vlan_interfaces[vlan_interface].vrrp.ipv6 }}
+{%             endif %}
+{%             if vlan_interfaces[vlan_interface].vrrp.priority is defined and vlan_interfaces[vlan_interface].vrrp.priority is not none %}
+   vrrp {{ vlan_interfaces[vlan_interface].vrrp.virtual_router }} priority {{ vlan_interfaces[vlan_interface].vrrp.priority }}
+{%             endif %}
+{%             if vlan_interfaces[vlan_interface].vrrp.interval is defined and vlan_interfaces[vlan_interface].vrrp.interval is not none %}
+   vrrp {{ vlan_interfaces[vlan_interface].vrrp.virtual_router }} advertisement interval {{ vlan_interfaces[vlan_interface].vrrp.interval }}
+{%             endif %}
+{%             if vlan_interfaces[vlan_interface].vrrp.preempt_delay is defined and vlan_interfaces[vlan_interface].vrrp.preempt_delay is not none %}
+   vrrp {{ vlan_interfaces[vlan_interface].vrrp.virtual_router }} preempt delay minimum {{ vlan_interfaces[vlan_interface].vrrp.preempt_delay }}
+{%             endif %}
+{%           endif %}
+{%         endif %}
 !
 {%     endfor %}
 {% endif %}


### PR DESCRIPTION
proposed interface vlan vrrp data model

```yaml
vlan_interfaces:
  Vlan10:
    description: vrrp test
    ip_address: 192.0.2.2/24
    vrrp:
      virtual_router: 10
      advertisement_interval: 2
      preempt_delay_minimum: 30
      ipv4: 192.0.2.1
      ipv6: 2001:db8::2
```

Will generate the following EOS configuration:

```eos
interface Vlan10
   description vrrp test
   ip address 192.0.2.2/24
   vrrp 10 advertisement interval 2
   vrrp 10 preempt delay minimum 30
   vrrp 10 ipv4 192.0.2.1
   vrrp 10 ipv6 2001:db8::2
```