### PR TITLE
Fix empty vlan_interfaces and port_channel_interfaces

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l2leaf-yml.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l2leaf-yml.j2
@@ -273,10 +273,12 @@ management_interfaces:
 {% include 'base/mgmt-interface.j2' %}
 
 {# vlan interfaces #}
+{% if leaf.mlag == true %}
 ### VLAN Interfaces ###
 vlan_interfaces:
 {# mlag vlan interfaces #}
 {% include 'mlag/leaf-mlag-vlan-interfaces.j2' %}
+{% endif %}
 
 {# TCAM Profiles #}
 ### TCAM Profiles ###

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l3leaf-yml.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l3leaf-yml.j2
@@ -92,6 +92,26 @@
 {%         endif %}
 {%     endfor %}
 {% endfor %}
+
+{% set leaf.has_port__channel=false %}
+{# If l3leaf hostname is in l2leaf default uplink list and 2 neighbors are defined #}
+{# We consider there is a PO to configure on L3LEAF                               #}
+{% for l3leaf in l2leaf.defaults.parent_l3leafs | arista.avd.natural_sort %}
+{%    if l3leaf == inventory_hostname and l2leaf.defaults.parent_l3leafs | length > 1%}
+{%        set leaf.has_port__channel=true %}
+{%    endif %}
+{% endfor %}
+{% for l2leaf_node_group in l2leaf.node_groups | arista.avd.natural_sort %}
+{# If l3leaf hostname is in l2leaf node specific uplink list and 2 neighbors are defined #}
+{# We consider there is a PO to configure on L3LEAF                                      #}
+{%      for l3leaf in l2leaf.node_groups[l2leaf_node_group].parent_l3leafs | arista.avd.natural_sort %}
+{%              if l3leaf == inventory_hostname and l2leaf.node_groups[l2leaf_node_group].parent_l3leafs | length > 1%}
+{%                  set leaf.has_port__channel=true %}
+{%              endif %}
+{%      endfor %}
+{% endfor %}
+
+
 {# set leaf allowed vrfs, svis and vlans #}
 {% set leaf.vrfs = []  %}
 {% set leaf.svis = []  %}
@@ -253,7 +273,7 @@ bfd_multihop:
 {% include 'base/bfd-multihop.j2' %}
 
 {# Port-Channel Interfaces #}
-{% if leaf.mlag == true %}
+{% if leaf.mlag == true or leaf.has_port__channel == true %}
 ### Port-Channel Interfaces ###
 port_channel_interfaces:
 {# L2 Leaf uplinks #}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l3leaf-yml.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l3leaf-yml.j2
@@ -253,6 +253,7 @@ bfd_multihop:
 {% include 'base/bfd-multihop.j2' %}
 
 {# Port-Channel Interfaces #}
+{% if leaf.mlag == true %}
 ### Port-Channel Interfaces ###
 port_channel_interfaces:
 {# L2 Leaf uplinks #}
@@ -261,6 +262,7 @@ port_channel_interfaces:
 {% include 'mlag/leaf-mlag-peer-link.j2' %}
 {# Server - Port Channel Interfaces #}
 {% include 'edge-ports/leaf-server-port-channels.j2' %}
+{% endif %}
 
 {# Ethernet Interfaces #}
 ### Ethernet Interfaces ###


### PR DESCRIPTION
Provides fixes to not generate empty variables for both port_channel_interfaces and vlan_interfaces.

## Fix

Issue: #213

## Description

- Add condition to only generate vlan_interfaces on l2leaf when they are running in MLAG since AVD does not generate SVI for tenant vlans
- Add condition to only generate port_channel_interfaces on l3leaf when they are running in MLAG mode. We assume l2leaf are only using PO to l3leafs in MLAG and do not leverage PO on a single l3leaf


