### PR TITLE
Fix and optimize ansible-test CI execution

### DIFF
--- a/.github/workflows/ansible_test.yml
+++ b/.github/workflows/ansible_test.yml
@@ -32,6 +32,9 @@ jobs:
       - name: 'Install requirements'
         run: make github-configure-ci
 
+      - name: 'Install docker'
+        run: make install-docker
+
       - name: 'Install Python requirements'
         run: make install-requirements
 

--- a/.github/workflows/ansible_test.yml
+++ b/.github/workflows/ansible_test.yml
@@ -19,6 +19,13 @@ jobs:
         uses: actions/setup-python@v1.2.0
         with:
           python-version: '3.x'
+
+      - name: 'Install sudo'
+        run: apt-get -q -y install sudo
+
+      - name: 'Install build essentials'
+        run: sudo apt-get install -q -y build-essential
+
       - name: 'Install requirements'
         run: make github-configure-ci
 

--- a/.github/workflows/ansible_test.yml
+++ b/.github/workflows/ansible_test.yml
@@ -1,5 +1,6 @@
 name: Ansible Test
 on:
+  push:
   pull_request:
     branches:
       - 'devel'
@@ -8,6 +9,7 @@ jobs:
   'ansible-test':
     name: Run ansible-test validation
     runs-on: ubuntu-latest
+    container: ubuntu/ubuntu:18.04
     env:
       PY_COLORS: 1 # allows molecule colors to be passed to GitHub Actions
       ANSIBLE_FORCE_COLOR: 1 # allows ansible colors to be passed to GitHub Actions

--- a/.github/workflows/ansible_test.yml
+++ b/.github/workflows/ansible_test.yml
@@ -9,7 +9,7 @@ jobs:
   'ansible-test':
     name: Run ansible-test validation
     runs-on: ubuntu-latest
-    container: ubuntu/ubuntu:18.04
+    container: ubuntu:18.04
     env:
       PY_COLORS: 1 # allows molecule colors to be passed to GitHub Actions
       ANSIBLE_FORCE_COLOR: 1 # allows ansible colors to be passed to GitHub Actions

--- a/.github/workflows/ansible_test.yml
+++ b/.github/workflows/ansible_test.yml
@@ -1,6 +1,5 @@
 name: Ansible Test
 on:
-  push:
   pull_request:
     branches:
       - 'devel'

--- a/.github/workflows/ansible_test.yml
+++ b/.github/workflows/ansible_test.yml
@@ -20,6 +20,9 @@ jobs:
         with:
           python-version: '3.x'
 
+      - name: update packages
+        run: apt-get update
+
       - name: 'Install sudo'
         run: apt-get -q -y install sudo
 

--- a/Makefile
+++ b/Makefile
@@ -113,3 +113,11 @@ install-requirements: ## Install python requirements for generic purpose
 	pip3 install --upgrade wheel
 	pip3 install -r development/requirements.txt
 	pip3 install -r development/requirements-dev.txt
+
+.PHONY: install-docker
+install-docker: ## Install docker
+	sudo apt install -q -y apt-transport-https ca-certificates curl software-properties-common
+	curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+	sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable"
+	sudo apt update
+	sudo apt install -q -y docker-ce

--- a/Makefile
+++ b/Makefile
@@ -92,12 +92,12 @@ webdoc: ## Build documentation to publish static content
 github-configure-ci: github-configure-ci-python3 github-configure-ci-ansible ## Configure CI environment to run GA (Ubuntu:latest LTS)
 
 .PHONY: github-configure-ci-ansible
-github-configure-ci-ansible: ## Install Ansible Test on GA (Ubuntu:latest LTS)
+github-configure-ci-ansible: ## Install Ansible Test 2.9 on GA (Ubuntu:latest LTS)
 	sudo apt-get update
 	sudo apt-get install -y gnupg2
 	sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367
-	sudo echo "deb http://ppa.launchpad.net/ansible/ansible/ubuntu bionic main" | sudo tee /etc/apt/sources.list.d/ansible.list
-	sudo echo "deb-src http://ppa.launchpad.net/ansible/ansible/ubuntu bionic main" | sudo tee -a /etc/apt/sources.list.d/ansible.list
+	sudo echo "deb http://ppa.launchpad.net/ansible/ansible-2.9/ubuntu bionic main" | sudo tee /etc/apt/sources.list.d/ansible.list
+	sudo echo "deb-src http://ppa.launchpad.net/ansible/ansible-2.9/ubuntu bionic main" | sudo tee -a /etc/apt/sources.list.d/ansible.list
 	sudo apt-get update
 	sudo DEBIAN_FRONTEND=noninteractive apt-get install -q -y ansible-test
 


### PR DESCRIPTION
- Fix issue where host VM had more recent version of ansible repository (latest/2.10) and cause the pipeline to fail. 
- Move to docker in docker approach for ansible-test, to help with the consistency of applications installed and speed up CI execution.

**Useful information on ubuntu-latest host VM application and scripts:**

- https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu1804-README.md
- https://github.com/actions/virtual-environments/tree/main/images/linux/scripts/installers

