### PR TITLE
Add support for no_password for local users

### DIFF
--- a/ansible_collections/arista/avd/molecule/avd-l3ls-ebgp/inventory/group_vars/AVD_LAB.yml
+++ b/ansible_collections/arista/avd/molecule/avd-l3ls-ebgp/inventory/group_vars/AVD_LAB.yml
@@ -6,7 +6,7 @@ local_users:
   admin:
     privilege: 15
     role: network-admin
-    sha512_password: "$6$Df86J4/SFMDE3/1K$Hef4KstdoxNDaami37cBquTWOTplC.miMPjXVgQxMe92.e5wxlnXOLlebgPj8Fz1KO0za/RCO7ZIs4Q6Eiq1g1"
+    no_password: true
 
   cvpadmin:
     privilege: 15

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -19,8 +19,8 @@
     - [Load Interval](#load-interval)
     - [Queue Monitor Length](#queue-monitor-length)
     - [Service Routing Protocols Model](#service-routing-protocols-model)
-    - [Logging](#logging)
     - [LLDP](#lldp)
+    - [Logging](#logging)
     - [Domain Lookup](#domain-lookup)
     - [Name Servers](#name-servers)
     - [DNS Domain](#dns-domain)
@@ -495,10 +495,12 @@ local_users:
     privilege: < 1-15 >
     role: < role >
     sha512_password: "< sha_512_password >"
+    no_password: < true | do not configure a password for given username. sha512_password MUST not be defined for this user. >
   < user_2 >:
     privilege: < 1-15 >
     role: < role >
     sha512_password: "< sha_512_password >"
+    no_password: < true | do not configure a password for given username. sha512_password MUST not be defined for this user. >
 ```
 
 ### Clock Timezone

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/local-users.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/local-users.j2
@@ -1,7 +1,11 @@
 {# eos - local users #}
 {% if local_users is defined %}
 {%     for local_user in local_users | arista.avd.natural_sort %}
+{%         if local_users[local_user].sha512_password is defined %}
 username {{ local_user }} privilege {{ local_users[local_user].privilege }} role {{ local_users[local_user].role }} secret sha512 {{ local_users[local_user].sha512_password }}
+{%         elif local_users[local_user].no_password is defined and local_users[local_user].no_password == True %}
+username {{ local_user }} privilege {{ local_users[local_user].privilege }} role {{ local_users[local_user].role }} nopassword
+{%         endif  %}
 {%     endfor %}
 !
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/local-users.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/local-users.j2
@@ -8,5 +8,4 @@ username {{ local_user }} privilege {{ local_users[local_user].privilege }}{% if
 username {{ local_user }} privilege {{ local_users[local_user].privilege }} role {{ local_users[local_user].role }} nopassword
 {%         endif  %}
 {%     endfor %}
-!
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
@@ -95,6 +95,7 @@ local_users:
   < username_1 >:
     privilege: < (1-15) Initial privilege level with local EXEC authorization >
     role: < Specify a role for the user >
+    no_password: < true | do not configure a password for given username. sha512_password MUST not be defined for this user. >
     sha512_password: "< SHA512 ENCRYPTED password >"
 
   < username_2 >:

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/base/local-users.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/base/local-users.j2
@@ -2,5 +2,9 @@
   {{ local_user }}:
     privilege: {{ local_users[local_user].privilege }}
     role: {{ local_users[local_user].role }}
+{%    if local_users[local_user].sha512_password is defined %}
     sha512_password: {{ local_users[local_user].sha512_password }}
+{%     elif local_users[local_user].no_password is defined and local_users[local_user].no_password == True %}
+    no_password: {{local_users[local_user].no_password}}
+{%      endif %}
 {% endfor %}


### PR DESCRIPTION
Add verb in eos_cli_config_gen to support user with no password

```
local_users:
  < user_1 >:
    privilege: < 1-15 >
    role: < role >
    sha512_password: "< sha_512_password >"
    no_password: < true | do not configure a password for given username. sha512_password MUST not be defined for this user. >
```

Add verb in datamodel for eos_l3ls_evpn to configure username with no
password:

```
local_users:
  < username_1 >:
    privilege: < (1-15) Initial privilege level with local EXEC authorization >
    role: < Specify a role for the user >
    no_password: < true | do not configure a password for given username. sha512_password MUST not be defined for this user. >
    sha512_password: "< SHA512 ENCRYPTED password >"
```

CLI output is the following:

```
username admin privilege 15 role network-admin nopassword
```