### PR TITLE
Add CI action to build docker image

### DIFF
--- a/.github/workflows/ansible_test.yml
+++ b/.github/workflows/ansible_test.yml
@@ -3,7 +3,9 @@ on:
   pull_request:
     branches:
       - 'devel'
-      - 'releases/*'
+      - 'releases/**'
+    paths:
+      - 'ansible_collections/arista/avd/**'
 jobs:
   'ansible-test':
     name: Run ansible-test validation

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - devel
       - 'releases/**'
-      - 'features/ci-build-docker-224'
+      # - 'features/ci-build-docker-224'
     paths:
       - '.github/workflows/docker_build.yml'
       - 'development/requirements.txt'

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -1,4 +1,4 @@
-name: Commit check
+name: Docker Build
 on:
   push:
     branches:

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -1,0 +1,23 @@
+name: Commit check
+on:
+  push:
+    branches:
+      - devel
+      - 'releases/**'
+      - 'features/ci-build-docker-224'
+    paths:
+      - '.github/workflows/docker_build.yml'
+      - 'development/requirements.txt'
+      - 'development/requirements-dev.txt'
+jobs:
+  'rebuild-docker-avd':
+    name: Instruct Docker Hub to build image
+    runs-on: ubuntu-latest
+    container: avdteam/base:3.6
+    steps:
+      - uses: actions/checkout@master
+      - name: 'Send Webhook'
+        env:
+          DOCKER_WEBHOOK: ${{secrets.DOCKER_WEBHOOK}}
+        run: |
+          curl  -H "Content-Type: application/json" --data '{}' -X POST $DOCKER_WEBHOOK

--- a/.github/workflows/installation-test.yml
+++ b/.github/workflows/installation-test.yml
@@ -6,7 +6,7 @@ jobs:
   'setup':
     name: 'One liner installation'
     runs-on: ubuntu-latest
-    container: avdteam/base:centos-8
+    container: avdteam/base:3.6
     steps:
       - uses: actions/checkout@master
       - name: Execute one-liner installation

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -6,7 +6,7 @@ jobs:
   'pre-commit':
     name: Run pre-commit validation hooks
     runs-on: ubuntu-latest
-    container: avdteam/base:centos-8
+    container: avdteam/base:3.6
     steps:
       - uses: actions/checkout@master
       - name: 'Pre Commit run'

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,7 +1,7 @@
 name: Commit check
 on:
   push:
-
+  pull_request:
 jobs:
   'pre-commit':
     name: Run pre-commit validation hooks
@@ -9,6 +9,9 @@ jobs:
     container: avdteam/base:3.6
     steps:
       - uses: actions/checkout@master
+      - name: Install Pre Commit
+        run: |
+          pip --no-cache-dir install -r development/requirements-dev.txt
       - name: 'Pre Commit run'
         run: |
           make pre-commit

--- a/development/requirements.txt
+++ b/development/requirements.txt
@@ -3,8 +3,4 @@ netaddr==0.7.19
 Jinja2==2.10.3
 requests==2.22.0
 treelib==1.5.5
-pytest==5.4.2
-pytest-html==2.1.1
-ward==0.46.0b0
-git+https://github.com/batfish/pybatfish.git
 cvprac==1.0.4


### PR DESCRIPTION
Implement a specific action to trigger a docker build of avdteam/base (Issue #224 )

Action is executed only when:

- Push commit on:
      - `devel`
      - `releases/**`
- Files changed: 
      - `.github/workflows/docker_build.yml`
      - `development/requirements.txt`
      - `development/requirements-dev.txt`

Docker Webhook is saved under `Settings/Secrets` and it is not available for CI running in forks

Also update runner to use `avdteam/base:3.6` instead of `avdteam/base:centos8`