### PR TITLE
Fix for issues 199 and 204

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-routing.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-routing.j2
@@ -1,14 +1,19 @@
 {# eos - IP Routing #}
-{% if ip_routing is defined and ip_routing == true %}
+{% if ip_routing is defined and ip_routing is not none %}
+{%     if ip_routing == true %}
 !
 ip routing
-{%     if vrfs is defined %}
-{%         for vrf in vrfs | arista.avd.natural_sort %}
-{%             if vrfs[vrf].ip_routing == true %}
+{%     else %}
+!
+no ip routing
+{%     endif %}
+{% endif %}
+{% if vrfs is defined and vrfs is not none %}
+{%     for vrf in vrfs | arista.avd.natural_sort %}
+{%             if vrfs[vrf].ip_routing == true and vrf is ne 'default' %}
 ip routing vrf {{ vrf }}
 {%             elif vrfs[vrf].ip_routing == false and vrf is ne 'default' %}
 no ip routing vrf {{ vrf }}
 {%             endif %}
-{%         endfor %}
-{%     endif %}
+{%     endfor %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ipv6-routing.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ipv6-routing.j2
@@ -2,11 +2,12 @@
 {% if ipv6_unicast_routing is defined and ipv6_unicast_routing == true %}
 !
 ipv6 unicast-routing
-{%     if vrfs is defined %}
-{%         for vrf in vrfs | arista.avd.natural_sort %}
-{%             if vrfs[vrf].ipv6_routing is defined and vrfs[vrf].ipv6_routing == true %}
+{% endif %}
+{% if vrfs is defined and vrfs is not none %}
+!
+{%       for vrf in vrfs | arista.avd.natural_sort %}
+{%           if vrfs[vrf].ipv6_routing is defined and vrfs[vrf].ipv6_routing == true %}
 ipv6 unicast-routing vrf {{ vrf }}
-{%             endif %}
-{%         endfor %}
-{%     endif %}
+{%           endif %}
+{%       endfor %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/name-servers.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/name-servers.j2
@@ -1,6 +1,6 @@
 {# eos - name-server #}
-{% if name_server is defined %}
-{%     for node in name_server.nodes %}
-ip name-server{% if name_server.source.vrf is ne 'default'%} vrf {{ name_server.source.vrf }}{% endif %} {{ node }}
+{% if name_server is defined and name_server is not none %}
+{%     for node in name_server.nodes | arista.avd.natural_sort %}
+ip name-server vrf {{ name_server.source.vrf }} {{ node }}
 {%     endfor %}
 {% endif %}


### PR DESCRIPTION
- #199 : Syntax change of domain-name server declaration in default VRF in eos_cli_config_gen
- #204: Removal of VRF IP routing dependency with ip routing in GRT
- Removal of VRF IPv6 routing dependency with ipv6 routing in GRT