### PR TITLE
ip name-server - sort to match EOS output

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/name-servers.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/name-servers.j2
@@ -1,6 +1,6 @@
 {# eos - name-server #}
 {% if name_server is defined and name_server is not none %}
-{%     for node in name_server.nodes %}
+{%     for node in name_server.nodes | sort %}
 ip name-server vrf {{ name_server.source.vrf }} {{ node }}
 {%     endfor %}
 {% endif %}


### PR DESCRIPTION
After further review, noticed the ip name-server is sorted in EOS, just not naturally.

the jinja2 `| sort` filter provides the desired results.
