### PR TITLE
Update build_output_dir documentation

### DIFF
--- a/ansible_collections/arista/avd/roles/build_output_folders/README.md
+++ b/ansible_collections/arista/avd/roles/build_output_folders/README.md
@@ -12,7 +12,9 @@ Role support following variables:
 
 ```yaml
 # Root directory where to build output structure
-root_dir: '{{playbook_dir}}'
+# All folder below will be created in this directory folder.
+root_dir: '{{inventory_dir}}'
+
 # Main output directory
 output_dir_name: 'intended'
 # Output for structured YAML files:
@@ -25,11 +27,13 @@ documentation_dir_name: 'documentation'
 fabric_dir_name: 'DC1_FABRIC'
 # Device documentation
 devices_dir_name: 'devices'
+# EOS State Validation Directory name
+eos_validate_state_name: 'report'
 ```
 
 Role will create following structure:
 
-```
+```shell
 intended
 ├── configs
 └── structured_configs
@@ -64,4 +68,3 @@ Below is an example to use in your playbook to build output folders using defaul
 ## License
 
 Project is published under [Apache 2.0 License](../../../../../LICENSE)
-

--- a/ansible_collections/arista/avd/roles/build_output_folders/README.md
+++ b/ansible_collections/arista/avd/roles/build_output_folders/README.md
@@ -28,7 +28,7 @@ fabric_dir_name: 'DC1_FABRIC'
 # Device documentation
 devices_dir_name: 'devices'
 # EOS State Validation Directory name
-eos_validate_state_name: 'report'
+eos_validate_state_name: 'reports'
 ```
 
 Role will create following structure:

--- a/ansible_collections/arista/avd/roles/eos_validate_state/README.md
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/README.md
@@ -5,6 +5,7 @@
 - [Ansible Role: eos_validate_state](#ansible-role-eos_validate_state)
   - [Overview](#overview)
   - [Role Inputs and Outputs](#role-inputs-and-outputs)
+  - [Default Variables](#default-variables)
   - [Requirements](#requirements)
   - [Example Playbook](#example-playbook)
   - [Input example](#input-example)
@@ -67,6 +68,24 @@ Figure 1 below provides a visualization of the roles inputs, and outputs and tas
 3. Create CSV report.
 4. Read CSV file (leveraged to generate summary report).
 5. Create Markdown Summary report.
+
+## Default Variables
+
+The following default variables are defined, and can be modified as desired:
+
+```yaml
+# configure playbook to ingnore errors and continue testing.
+eos_validate_state_validation_mode_loose: true
+
+# Format for path to r/w reports. Sync with default values configured in arista.avd.build_output_folders
+root_dir: '{{ inventory_dir }}'
+eos_validate_state_name: 'reports'
+eos_validate_state_dir: '{{ root_dir }}/{{ eos_validate_state_name }}'
+
+# Reports name
+eos_validate_state_md_report_path: '{{ eos_validate_state_dir }}/{{ fabric_name }}-state.md'
+eos_validate_state_csv_report_path: '{{ eos_validate_state_dir }}/{{ fabric_name }}-state.csv'
+```
 
 ## Requirements
 

--- a/ansible_collections/arista/avd/roles/eos_validate_state/defaults/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/defaults/main.yml
@@ -2,7 +2,7 @@ eos_validate_state_validation_mode_loose: true
 
 # Format for path to r/w reports. Sync with default values configured in arista.avd.build_output_folders
 root_dir: '{{ inventory_dir }}'
-eos_validate_state_name: 'report'
+eos_validate_state_name: 'reports'
 eos_validate_state_dir: '{{ root_dir }}/{{ eos_validate_state_name }}'
 
 # Reports name


### PR DESCRIPTION
Update `build_output_dir` documentation to add information about `eos_validate_states` structure.
