### PR TITLE
Add CI workflow to validate documentation content

### DIFF
--- a/.github/workflows/documentation-build.yml
+++ b/.github/workflows/documentation-build.yml
@@ -1,4 +1,4 @@
-name: Mkdocs
+name: Deploy_mkdoc
 on:
   push:
     branches:
@@ -8,7 +8,7 @@ on:
       - 'ansible_collections/arista/avd/docs/**'
       - 'ansible_collections/arista/avd/roles/**/README.md'
 jobs:
-  'doc':
+  publish:
     name: 'Update Public documentation'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/documentation-build.yml
+++ b/.github/workflows/documentation-build.yml
@@ -1,4 +1,4 @@
-name: Deploy_mkdoc
+name: mkdoc_deploy
 on:
   push:
     branches:

--- a/.github/workflows/documentation-check.yml
+++ b/.github/workflows/documentation-check.yml
@@ -18,7 +18,7 @@ jobs:
       - name: 'start docker-compose stack'
         run: |
           cp development/docker-compose.yml .
-          sed -i {} 's/ansible-avd\///g' docker-compose.yml
+          sed -i 's/ansible-avd\///g' docker-compose.yml
           docker-compose -f docker-compose.yml up -d webdoc_avd
           docker-compose -f docker-compose.yml ps
 

--- a/.github/workflows/documentation-check.yml
+++ b/.github/workflows/documentation-check.yml
@@ -1,0 +1,37 @@
+name: Check_mkdoc
+on:
+  pull_request:
+    branches:
+      - 'devel'
+    paths:
+      - 'mkdocs.yml'
+      - 'ansible_collections/arista/avd/docs/**'
+      - 'ansible_collections/arista/avd/roles/**/README.md'
+      - '.github/workflows/documentation-check.yml'
+      - '.github/workflows/documentation-build.yml'
+jobs:
+  offline_validation:
+    name: 'Validate mkdoc content'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: 'start docker-compose stack'
+        run: |
+          cp development/docker-compose.yml .
+          sed -i {} 's/ansible-avd\///g' docker-compose.yml
+          docker-compose -f docker-compose.yml up -d webdoc_avd
+          docker-compose -f docker-compose.yml ps
+
+      - name: 'test connectivity to mkdoc server'
+        run: |
+          sleep 30
+          docker run --network container:webdoc_avd appropriate/curl -s -I --retry 10 --retry-connrefused http://localhost:8000/
+          docker ps
+
+      - name: check links for 404
+        run: |
+          docker run --network container:webdoc_avd raviqqe/muffet http://127.0.0.1:8000 -e ".*fonts.gstatic.com.*" -e ".*edit.*" -f --limit-redirections=3 --timeout=30
+
+      - name: 'start docker-compose stack'
+        run: |
+          docker-compose -f docker-compose.yml down

--- a/.github/workflows/documentation-check.yml
+++ b/.github/workflows/documentation-check.yml
@@ -1,4 +1,4 @@
-name: Check_mkdoc
+name: mkdoc_check
 on:
   pull_request:
     branches:

--- a/.github/workflows/documentation-check.yml
+++ b/.github/workflows/documentation-check.yml
@@ -32,6 +32,6 @@ jobs:
         run: |
           docker run --network container:webdoc_avd raviqqe/muffet http://127.0.0.1:8000 -e ".*fonts.gstatic.com.*" -e ".*edit.*" -f --limit-redirections=3 --timeout=30
 
-      - name: 'start docker-compose stack'
+      - name: 'stop docker-compose stack'
         run: |
           docker-compose -f docker-compose.yml down

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ webdoc: ## Build documentation to publish static content
 
 .PHONY: check-avd-404
 check-avd-404: ## Check local 404 links for AVD documentation
-	docker run --network container:webdoc_avd raviqqe/muffet http://127.0.0.1:8000 -e ".*fonts.gstatic.com.*" -e ".*edit.*" -f --limit-redirections=3 --timeout=$(MUFFET_TIMEOUT)
+	docker run --rm --network container:webdoc_avd raviqqe/muffet http://127.0.0.1:8000 -e ".*fonts.gstatic.com.*" -e ".*edit.*" -f --limit-redirections=3 --timeout=$(MUFFET_TIMEOUT)
 
 #########################################
 # Misc Actions (configure CI runner) 	#

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ ANSIBLE_TEST ?= $(shell which ansible-test)
 ANSIBLE_TEST_MODE ?= docker
 # Root path for MKDOCS content
 WEBDOC_BUILD = ansible_collections/arista/avd/docs/_build
+COMPOSE_FILE ?= development/docker-compose.yml
+MUFFET_TIMEOUT ?= 60
 
 .PHONY: help
 help: ## Display help message
@@ -83,6 +85,9 @@ webdoc: ## Build documentation to publish static content
 	cd $(CURRENT_DIR)
 	mkdocs build -f mkdocs.yml
 
+.PHONY: check-avd-404
+check-avd-404: ## Check local 404 links for AVD documentation
+	docker run --network container:webdoc_avd raviqqe/muffet http://127.0.0.1:8000 -e ".*fonts.gstatic.com.*" -e ".*edit.*" -f --limit-redirections=3 --timeout=$(MUFFET_TIMEOUT)
 
 #########################################
 # Misc Actions (configure CI runner) 	#

--- a/ansible_collections/arista/avd/docs/how-to/first-project.md
+++ b/ansible_collections/arista/avd/docs/how-to/first-project.md
@@ -18,7 +18,7 @@ You can organize your work in many different way, but a structure we find useful
 $ tree -L 3 -d
 .
 ├── inventories
-│   └── topology01
+│   └── eapi-example
 │       ├── group_vars
 │       ├── host_vars
 │       └── inventory.yml
@@ -53,7 +53,7 @@ In our inventory, let's list our devices:
 - `AVD_SERVERS` as similar behavior to previous group. Its goal is to configure downlinks to compute nodes.
 
 ```yaml
-# vim inventories/topology01/inventory.yml
+# vim inventories/eapi-example/inventory.yml
 ---
 AVD:
   children:
@@ -126,7 +126,7 @@ Based on inventory we did in the previous section, it is time to create `group_v
 All the documentation is available here, but below is a short example. All this information will be configured on all devices.
 
 ```yaml
-# vim inventories/inetsix-eapi/group_vars/AVD.yml
+# vim inventories/eapi-example/group_vars/AVD.yml
 ---
 # local users
 local_users:
@@ -162,7 +162,7 @@ ntp_servers:
 
 #### Configure Fabric topology
 
-Fabric topology is configured under `inventories/inetsix-eapi/group_vars/AVD_FABRIC.yml` which is file that covers `AVD_FABRIC` group we defined in [inventory](#inventory-file). This file contains all the base information to create initial configuration:
+Fabric topology is configured under `inventories/eapi-example/group_vars/AVD_FABRIC.yml` which is file that covers `AVD_FABRIC` group we defined in [inventory](#inventory-file). This file contains all the base information to create initial configuration:
 
 You can also refer to [__Arista Validated Design__ documentation](https://github.com/aristanetworks/ansible-avd/blob/devel/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md#fabric-topology-variables) to get a description of every single option available.
 

--- a/ansible_collections/arista/avd/docs/how-to/first-project.md
+++ b/ansible_collections/arista/avd/docs/how-to/first-project.md
@@ -162,7 +162,7 @@ ntp_servers:
 
 #### Configure Fabric topology
 
-Fabric topology is configured in [`inventories/inetsix-eapi/group_vars/AVD_FABRIC.yml`](https://github.com/inetsix/demo-avd-evpn-eve-ng/blob/master/inventories/inetsix-eapi/group_vars/AVD_FABRIC.yml) which is file that covers `AVD_FABRIC` group we defined in [inventory](#inventory-file). This file contains all the base information to create initial configuration:
+Fabric topology is configured under `inventories/inetsix-eapi/group_vars/AVD_FABRIC.yml` which is file that covers `AVD_FABRIC` group we defined in [inventory](#inventory-file). This file contains all the base information to create initial configuration:
 
 You can also refer to [__Arista Validated Design__ documentation](https://github.com/aristanetworks/ansible-avd/blob/devel/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md#fabric-topology-variables) to get a description of every single option available.
 
@@ -243,7 +243,7 @@ l3leaf:
 [... output truncated ...]
 ```
 
-Complete documentation of all available variables is available in [__Arista Validated Design documentation__](../roles/../../roles/eos_l3ls_evpn/README.md). You can also look at [variables part of the demo repo](https://github.com/arista-netdevops-community/ansible-avd-cloudvision-demo/blob/master/inventory/group_vars/DC1_FABRIC.yml).
+Complete documentation of all available variables is available in [__Arista Validated Design documentation__](../../roles/eos_l3ls_evpn/README.md). You can also look at [variables part of the demo repo](https://github.com/arista-netdevops-community/ansible-avd-cloudvision-demo/blob/master/inventory/group_vars/DC1_FABRIC.yml).
 
 #### Configure device type
 
@@ -263,7 +263,7 @@ AVD supports mechanism to create VLANs and VNIs and enable traffic forwarding in
 
 Model defines a set of tenants (user's defined) where you can configure VRF or `l2vlans` or a mix of them. Let's take a look at how we configure such services.
 
-All these configurations shall be configured in file [`AVD_TENANTS_NETWORKS.yml`](https://github.com/inetsix/demo-avd-evpn-eve-ng/blob/3a461e0ce25afb25d4e51f620bafd324018c1189/inventories/inetsix-eapi/group_vars/AVD_L3LEAFS.yml)
+All these configurations shall be configured in file `AVD_TENANTS_NETWORKS.yml`
 
 #### L2 Services
 
@@ -400,7 +400,7 @@ In `TENANT_A_PROJECT02`, we can also see an optional feature named __`vtep_diagn
 
 #### Configure downlinks
 
-As we have configured L3LS fabric, EVPN/VXLAN overlay, services, it is now time to configure ports to connect servers. Ports should be configured in [`AVD_SERVERS.yml`](https://github.com/inetsix/demo-avd-evpn-eve-ng/blob/3a461e0ce25afb25d4e51f620bafd324018c1189/inventories/inetsix-eapi/group_vars/AVD_SERVERS.yml).
+As we have configured L3LS fabric, EVPN/VXLAN overlay, services, it is now time to configure ports to connect servers. Ports should be configured in `AVD_SERVERS.yml`.
 
 You first have to configure port profile. it is basically a description of how the port will be configured (`access` or `trunk`) and which set of vlan(s) will be configured
 

--- a/ansible_collections/arista/avd/docs/installation/development.md
+++ b/ansible_collections/arista/avd/docs/installation/development.md
@@ -23,8 +23,8 @@ Please refer to [Setup environment page](./setup-environement.md)
 
 Once installed, use `dev-start` command to bring up all the required containers:
 
-- An [mkdoc](https://hub.docker.com/repository/docker/titom73/mkdocs) for AVD documentation listening on port `8000`
-- An [mkdoc](https://hub.docker.com/repository/docker/titom73/mkdocs) or AVD documentation listening on port `8001`
+- An [mkdoc](https://hub.docker.com/repository/docker/titom73/mkdocs) for AVD documentation listening on port `localhost:8000`
+- An [mkdoc](https://hub.docker.com/repository/docker/titom73/mkdocs) or AVD documentation listening on port `localhost:8001`
 - An [AVD runner](https://hub.docker.com/repository/docker/avdteam/base) with a pseudo terminal connected to shell for ansible execution
 
 ## Development tools
@@ -77,6 +77,8 @@ Check for ansible-lint errors............................................Passed
 
 Command will automatically detect changed files using git status and run tests according their type.
 
+> This process is also implemented in project CI to ensure code quality and compliance with ansible development process.
+
 ### Configure git hook
 
 To automatically run tests when running a commit, configure your repository whit command:
@@ -87,3 +89,24 @@ pre-commit installed at .git/hooks/pre-commit
 ```
 
 To remove installation, use `uninstall` option.
+
+### Check 404 links
+
+To validate documentation, you should check for _not found_ links in your local version of the documentation. This test requires to run mkdocs container as explained in [installation documentation](./setup-environement.md).
+
+In a shell, run the following make command. It starts a container in AVD documentation network and leverage [`muffet`](https://github.com/raviqqe/muffet) tool to check 404 HTTP code:
+
+```shell
+$ check-avd-404
+docker run --network container:webdoc_avd raviqqe/muffet \
+    http://127.0.0.1:8000 \
+    -e ".*fonts.gstatic.com.*" \
+    -e ".*edit.*" \
+    -f --limit-redirections=3 \
+    --timeout=60
+http://127.0.0.1:8000/docs/installation/development/
+        404     http://127.0.0.1:8000/docs/installation/development/setup-environement2.md
+make: *** [check-avd-404] Error 1
+```
+
+> This process is also implemented in project CI to protect documentation against dead links.

--- a/ansible_collections/arista/avd/docs/installation/development.md
+++ b/ansible_collections/arista/avd/docs/installation/development.md
@@ -24,7 +24,7 @@ Please refer to [Setup environment page](./setup-environement.md)
 Once installed, use `dev-start` command to bring up all the required containers:
 
 - An [mkdoc](https://hub.docker.com/repository/docker/titom73/mkdocs) for AVD documentation listening on port `localhost:8000`
-- An [mkdoc](https://hub.docker.com/repository/docker/titom73/mkdocs) or AVD documentation listening on port `localhost:8001`
+- An [mkdoc](https://hub.docker.com/repository/docker/titom73/mkdocs) or CVP documentation listening on port `localhost:8001`
 - An [AVD runner](https://hub.docker.com/repository/docker/avdteam/base) with a pseudo terminal connected to shell for ansible execution
 
 ## Development tools

--- a/ansible_collections/arista/avd/docs/installation/development.md
+++ b/ansible_collections/arista/avd/docs/installation/development.md
@@ -27,6 +27,60 @@ Once installed, use `dev-start` command to bring up all the required containers:
 - An [mkdoc](https://hub.docker.com/repository/docker/titom73/mkdocs) or CVP documentation listening on port `localhost:8001`
 - An [AVD runner](https://hub.docker.com/repository/docker/avdteam/base) with a pseudo terminal connected to shell for ansible execution
 
+## Docker things
+
+he docker container approach for development can be used to ensure that everybody is using the same development environment while still being flexible enough to use the repo you are making changes in. You can inspect the Dockerfile to see what packages have been installed.
+The container will mount the current working directory, so you can work with your local files.
+
+The ansible version is passed in with the docker build command using **`ANSIBLE_VERSION`** variable.  If the ***ANSIBLE*** variable is not used the Dockerfile will by default set the ansible version to describe in AVD requirements.
+
+Before you can use a container, you must install [__Docker CE__](https://www.docker.com/products/docker-desktop) and [__docker-compose__](https://docs.docker.com/compose/) on your workstation.
+
+Since docker image is now automatically published on [__docker-hub__](https://hub.docker.com/repository/docker/avdteam/base), a dedicated repository is available on [__Arista Netdevops Community__](https://github.com/arista-netdevops-community/docker-avd-base).
+
+```shell
+# Start development stack
+$ make dev-start
+docker-compose -f ansible-avd/development/docker-compose.yml up -d
+Recreating development_ansible_1    ... done
+Recreating development_webdoc_cvp_1 ... done
+Recreating development_webdoc_avd_1 ... done
+
+# List containers started with stack
+$ docker-compose -f ansible-avd/development/docker-compose.yml ps
+        Name                       Command               State           Ports
+-----------------------------------------------------------------------------
+ansible_avd   /bin/sh -c while true; do  ...   Up
+webdoc_avd    sh -c pip install -r ansib ...   Up      0.0.0.0:8000->8000/tcp
+webdoc_cvp    sh -c pip install -r ansib ...   Up      0.0.0.0:8001->8000/tcp
+
+# Get a shell with ansible (if not in shell from previous command)
+$ make dev-run
+docker-compose -f ansible-avd/development/docker-compose.yml exec ansible zsh
+Agent pid 52
+➜  /projects
+
+# Test MKDOCS access (outside of development container)
+$ curl -s http://127.0.0.1:8000 | head -n 10
+<!doctype html>
+<html lang="en" class="no-js">
+  <head>
+
+      <meta charset="utf-8">
+      <meta name="viewport" content="width=device-width,initial-scale=1">
+
+# Stop development stack
+$ make dev-stop
+docker-compose -f ansible-avd/development/docker-compose.yml kill &&\
+        docker-compose -f ansible-avd/development/docker-compose.yml rm -f
+Killing development_ansible_1 ... done
+Killing development_webdoc_1  ... done
+Going to remove development_ansible_1, development_webdoc_1
+Removing development_ansible_1 ... done
+Removing development_webdoc_1  ... done
+```
+
+
 ## Development tools
 
 ### Pre-commit hook

--- a/ansible_collections/arista/avd/docs/installation/development.md
+++ b/ansible_collections/arista/avd/docs/installation/development.md
@@ -1,20 +1,5 @@
 # Development Process
 
-- [Development Process](#development-process)
-  - [Overview](#overview)
-  - [Build local environment](#build-local-environment)
-    - [Python Virtual Environment](#python-virtual-environment)
-      - [Install Python3 Virtual Environment](#install-python3-virtual-environment)
-    - [Docker Container for Ansible Testing and Development](#docker-container-for-ansible-testing-and-development)
-  - [Getting started Script](#getting-started-script)
-    - [Step by step installation process](#step-by-step-installation-process)
-    - [One liner installation](#one-liner-installation)
-  - [Development tools](#development-tools)
-    - [Pre-commit hook](#pre-commit-hook)
-      - [Installation](#installation)
-      - [Run pre-commit manually](#run-pre-commit-manually)
-    - [Configure git hook](#configure-git-hook)
-
 ## Overview
 
 Two methods can be used get Ansible up and running quickly with all the requirements to leverage ansible-avd.

--- a/development/Makefile
+++ b/development/Makefile
@@ -7,6 +7,7 @@ ANSIBLE_VERSION ?=
 HOME_DIR = $(shell pwd)
 UID = $(shell id -u)
 GID = $(shell id -g)
+MUFFET_TIMEOUT ?= 60
 
 .PHONY: help
 help: ## Display help message
@@ -72,3 +73,15 @@ ansible-upgrade: ## Run a shell attached to ansible container
 
 .PHONY: dev-reload
 dev-reload: dev-stop dev-start  ## Stop and Start docker-compose stack
+
+
+.PHONY: check-404
+check-404: check-avd-404 check-cvp-404 ## Check local 404 links in both AVD and CVP documentation
+
+,PHONY: check-avd-404
+check-avd-404: ## Check local 404 links for AVD documentation
+	docker run --network container:webdoc_avd raviqqe/muffet http://127.0.0.1:8000 -e ".*fonts.gstatic.com.*" -e ".*edit.*" -f --limit-redirections=3 --timeout=$(MUFFET_TIMEOUT)
+
+,PHONY: check-cvp-404
+check-cvp-404: ## Check local 404 links for AVD documentation
+	docker run --network container:webdoc_cvp raviqqe/muffet http://127.0.0.1:8000 -e ".*fonts.gstatic.com.*" -e ".*edit.*" -f --limit-redirections=3 --timeout=$(MUFFET_TIMEOUT)

--- a/development/Makefile
+++ b/development/Makefile
@@ -78,10 +78,10 @@ dev-reload: dev-stop dev-start  ## Stop and Start docker-compose stack
 .PHONY: check-404
 check-404: check-avd-404 check-cvp-404 ## Check local 404 links in both AVD and CVP documentation
 
-,PHONY: check-avd-404
+.PHONY: check-avd-404
 check-avd-404: ## Check local 404 links for AVD documentation
 	docker run --network container:webdoc_avd raviqqe/muffet http://127.0.0.1:8000 -e ".*fonts.gstatic.com.*" -e ".*edit.*" -f --limit-redirections=3 --timeout=$(MUFFET_TIMEOUT)
 
-,PHONY: check-cvp-404
+.PHONY: check-cvp-404
 check-cvp-404: ## Check local 404 links for AVD documentation
 	docker run --network container:webdoc_cvp raviqqe/muffet http://127.0.0.1:8000 -e ".*fonts.gstatic.com.*" -e ".*edit.*" -f --limit-redirections=3 --timeout=$(MUFFET_TIMEOUT)

--- a/development/Makefile
+++ b/development/Makefile
@@ -87,8 +87,8 @@ check-404: check-avd-404 check-cvp-404 ## Check local 404 links in both AVD and 
 
 .PHONY: check-avd-404
 check-avd-404: ## Check local 404 links for AVD documentation
-	docker run --network container:webdoc_avd raviqqe/muffet http://127.0.0.1:8000 -e ".*fonts.gstatic.com.*" -e ".*edit.*" -f --limit-redirections=3 --timeout=$(MUFFET_TIMEOUT)
+	docker run --rm --network container:webdoc_avd raviqqe/muffet http://127.0.0.1:8000 -e ".*fonts.gstatic.com.*" -e ".*edit.*" -f --limit-redirections=3 --timeout=$(MUFFET_TIMEOUT)
 
 .PHONY: check-cvp-404
 check-cvp-404: ## Check local 404 links for AVD documentation
-	docker run --network container:webdoc_cvp raviqqe/muffet http://127.0.0.1:8000 -e ".*fonts.gstatic.com.*" -e ".*edit.*" -f --limit-redirections=3 --timeout=$(MUFFET_TIMEOUT)
+	docker run --rm --network container:webdoc_cvp raviqqe/muffet http://127.0.0.1:8000 -e ".*fonts.gstatic.com.*" -e ".*edit.*" -f --limit-redirections=3 --timeout=$(MUFFET_TIMEOUT)

--- a/development/Makefile
+++ b/development/Makefile
@@ -13,6 +13,10 @@ MUFFET_TIMEOUT ?= 60
 help: ## Display help message
 	@grep -E '^[0-9a-zA-Z_-]+\.*[0-9a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
+###############################################################################
+# 			docker containers target									      #
+###############################################################################
+
 .PHONY: update
 update: ## Get latest version of AVD runner and MKDOCs server
 	docker pull $(CONTAINER_NAME):$(DOCKER_TAG) && \
@@ -74,6 +78,9 @@ ansible-upgrade: ## Run a shell attached to ansible container
 .PHONY: dev-reload
 dev-reload: dev-stop dev-start  ## Stop and Start docker-compose stack
 
+###############################################################################
+# 			Documentation target											  #
+###############################################################################
 
 .PHONY: check-404
 check-404: check-avd-404 check-cvp-404 ## Check local 404 links in both AVD and CVP documentation

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -2,12 +2,14 @@ version: "3"
 services:
   ansible:
     image: avdteam/base:3.6
+    container_name: ansible_avd
     volumes:
       - ./../../:/projects
     command: [ "/bin/sh", "-c", "while true; do sleep 30; done;" ]
 
   webdoc_cvp:
     image: titom73/mkdocs:latest
+    container_name: webdoc_cvp
     volumes:
       - ${PWD}:/docs
     ports:
@@ -17,6 +19,7 @@ services:
 
   webdoc_avd:
     image: titom73/mkdocs:latest
+    container_name: webdoc_avd
     volumes:
       - ${PWD}:/docs
     ports:


### PR DESCRIPTION
Implement new github actions workflow to validate mkdoc content is valid and reduce risk of dead links

- Start compose container for webdoc_avd
- Test mkdoc server is working (correct mkdocs.yml file)
- Test all links configured in documentation

Same commands are available in makefile to allow commiter to pre-check

__Makefile updated and it requires to update already deployed Makefile with installation script__