### PR TITLE
Logging extension for format option in eos and doc jinja templates

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -256,6 +256,10 @@ logging:
     size: < messages_nb (minimum of 10) >
     level: < severity_level >
   trap: < severity_level >
+  format:
+    timestamp: < high-resolution | traditional >
+    hostname: < fqdn | ipv4 >
+    sequence_numbers: < true | false >
   source_interface: < source_interface_name >
   vrfs:
     < vrf_name >:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/logging.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/logging.j2
@@ -25,11 +25,7 @@
 | Timestamp | traditional |
 {%        endif %}
 {%        if logging.format.hostname is defined and logging.format.hostname is not none %}
-{%              if logging.format.hostname is defined and logging.format.hostname == 'fqdn' %}
-| Hostname | fqdn |
-{%              elif logging.format.hostname is defined and logging.format.hostname == 'ipv4' %}
-| Hostname | ipv4 |
-{%              endif %}
+| Hostname | {{ logging.format.hostname }} |
 {%        else %}
 | Hostname | hostname |
 {%        endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/logging.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/logging.j2
@@ -15,6 +15,30 @@
 {%     if logging.trap is defined and logging.trap is not none %}
 | Trap | {{ logging.trap }} |
 {%     endif %}
+{%     if logging.format is defined and logging.format is not none %}
+
+| Format Type | Setting |
+| ----------- | ------- |
+{%        if logging.format.timestamp is defined and logging.format.timestamp == 'high-resolution' %}
+| Timestamp | high-resolution |
+{%        else %}
+| Timestamp | traditional |
+{%        endif %}
+{%        if logging.format.hostname is defined and logging.format.hostname is not none %}
+{%              if logging.format.hostname is defined and logging.format.hostname == 'fqdn' %}
+| Hostname | fqdn |
+{%              elif logging.format.hostname is defined and logging.format.hostname == 'ipv4' %}
+| Hostname | ipv4 |
+{%              endif %}
+{%        else %}
+| Hostname | hostname |
+{%        endif %}
+{%        if logging.format.sequence_numbers is defined and logging.format.sequence_numbers == true %}
+| Sequence-numbers | true |
+{%        else %}
+| Sequence-numbers | false |
+{%        endif %}
+{%     endif %}
 
 | VRF | Source Interface |
 | --- | ---------------- |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/logging.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/logging.j2
@@ -13,6 +13,21 @@ logging buffered {{ logging.buffered.size }} {{ logging.buffered.level }}
 {%     if logging.trap is defined and logging.trap is not none %}
 logging trap {{ logging.trap }}
 {%     endif %}
+{%     if logging.format is defined and logging.format is not none %}
+{%        if logging.format.timestamp is defined and logging.format.timestamp == 'high-resolution' %}
+logging format timestamp high-resolution
+{%        endif %}
+{%        if logging.format.hostname is defined and logging.format.hostname is not none %}
+{%              if logging.format.hostname is defined and logging.format.hostname == 'fqdn' %}
+logging format hostname fqdn
+{%              elif logging.format.hostname is defined and logging.format.hostname == 'ipv4' %}
+logging format hostname ipv4
+{%              endif %}
+{%        endif %}
+{%        if logging.format.sequence_numbers is defined and logging.format.sequence_numbers == true %}
+logging format sequence-numbers
+{%        endif %}
+{%     endif %}
 {%     if logging.source_interface is defined and logging.source_interface is not none %}
 logging source-interface {{ logging.source_interface }}
 {%     endif %}


### PR DESCRIPTION
#197 -  Logging extension for format option in eos and doc jinja templates

New Logging sub-feature:
```yaml
logging:
  format:
    timestamp: < high-resolution | traditional >
    hostname: < fqdn | ipv4 >
    sequence_numbers: < true | false >
```

## Related Issue(s)
Issue #197 

Tested with 4.24.2F