### PR TITLE
Enhance logging to include format settings Closes #197

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -255,6 +255,10 @@ logging:
   buffered:
     size: < messages_nb (minimum of 10) >
     level: < severity_level >
+  format:
+    hostname: < false | fqdn | ipv4 >
+    sequence_numbers: < true | false >
+    timestamp: < high_resolution | traditional >
   trap: < severity_level >
   source_interface: < source_interface_name >
   vrfs:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/logging.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/logging.j2
@@ -12,6 +12,11 @@
 {%     if logging.buffered is defined and logging.buffered is not none %}
 | Buffer |{% if logging.buffered.level is defined and logging.buffered.level is not none %} {{ logging.buffered.level }} {% else %} - {% endif %} |
 {%     endif %}
+{%     if logging.format is defined and logging.format is not none %}
+| Format - Hostname | {{ logging.format.hostname | default("default") }} |
+| Format - Sequence Numbers | {{ logging.format.sequence_numbers | default(False) }} |
+| Format - Timestamp | {{ logging.format.timestamp | default("traditional") }} |
+{%     endif %}
 {%     if logging.trap is defined and logging.trap is not none %}
 | Trap | {{ logging.trap }} |
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/logging.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/logging.j2
@@ -10,6 +10,23 @@ logging monitor {{ logging.monitor }}
 {%     if logging.buffered is defined and logging.buffered is not none %}
 logging buffered {{ logging.buffered.size }} {{ logging.buffered.level }}
 {%     endif %}
+{%     if logging.format is defined and logging.format is not none %}
+{%         if logging.format.hostname is not defined or logging.format.hostname is none or logging.format.hostname == false %}
+no logging format hostname
+{%         else %}
+logging format hostname {{ logging.format.hostname }}
+{%         endif %}
+{%         if logging.format.sequence_numbers is not defined or logging.format.sequence_numbers is none or logging.format.sequence_numbers == false %}
+no logging format sequence-numbers
+{%         elif logging.format.sequence_numbers is defined and logging.format.sequence_numbers is not none and logging.format.sequence_numbers == true %}
+logging format sequence-numbers
+{%         endif %}
+{%         if logging.format.sequence_numbers is not defined or logging.format.sequence_numbers is none or logging.format.sequence_numbers == "traditional" %}
+logging format timestamp traditional
+{%         elif logging.format.sequence_numbers is defined and logging.format.sequence_numbers is not none and logging.format.sequence_numbers == "high-resolution" %}
+logging format timestamp high-resolution
+{%         endif %}
+{%     endif %}
 {%     if logging.trap is defined and logging.trap is not none %}
 logging trap {{ logging.trap }}
 {%     endif %}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
## Change Summary
Template enhancement for logging format.  See Issues #197 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [x] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
#197 

## Component(s) name
ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/logging.j2
ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/logging.j2
ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md

## Proposed changes
<!--- Describe your changes in detail -->

Updated above components to expand data model to handle logging format.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

leverage iterations of 

```yaml
logging:
  console: < severity_level >
  monitor: < severity_level >
  buffered:
    size: < messages_nb (minimum of 10) >
    level: < severity_level >
  format:
    hostname: < fqdn | ipv4 >
    sequence_numbers: < true | false >
    timestamp: < high_resolution | traditional >
  trap: < severity_level >
  source_interface: < source_interface_name >
  vrfs:
    < vrf_name >:
      source_interface: < source_interface_name >
      hosts:
        - < syslog_server_1>
        - < syslog_server_2>
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
