### PR TITLE
Introduce enable password to eos_cli_config_gen Closes #202

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -38,6 +38,7 @@
     - [AAA Authorization](#aaa-authorization)
     - [AAA Accounting](#aaa-accounting)
     - [AAA Root](#aaa-root)
+    - [Enable Password](#enable-password)
     - [Local Users](#local-users)
     - [Clock Timezone](#clock-timezone)
     - [VLANs](#vlans)
@@ -507,6 +508,14 @@ aaa_accounting:
 aaa_root:
   secret:
     sha512_password: "< sha_512_password >"
+```
+
+### Enable Password
+
+```yaml
+enable_password:
+  encryption: < md5 | sha512 >
+  hash: "< hashed_password >"
 ```
 
 ### Local Users

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/enable-password.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/enable-password.j2
@@ -1,0 +1,12 @@
+{% if enable_password is defined and enable_password is not none %}
+{%     if enable_password.hash is defined and enable_password.hash is not none %}
+{%         if enable_password.encryption is defined and enable_password.encryption is not none and enable_password.encryption == "md5" %}
+MD5 Encrypted Enable Password Set
+{%         elif enable_password.encryption is defined and enable_password.encryption is not none and enable_password.encryption == "sha512" %}
+SHA512 Encrypted Enable Password Set
+{%         endif %}
+{%     endif %}
+!
+{%- else %}
+Enable Password not defined
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-device-documentation.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-device-documentation.j2
@@ -81,6 +81,10 @@
 
 {% include 'documentation/aaa-accounting.j2' %}
 
+## Enable Password
+
+{% include 'documentation/enable-password.j2' %}
+
 ## Local Users
 
 {% include 'documentation/local-users.j2' %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
@@ -67,6 +67,8 @@ hostname {{ inventory_hostname }}
 {% include 'eos/aaa-accounting.j2' %}
 {# aaa root #}
 {% include 'eos/aaa-root.j2' %}
+{# enable password #}
+{% include 'eos/enable-password.j2' %}
 {# users #}
 {% include 'eos/local-users.j2' %}
 {# clock timezone #}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/enable-password.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/enable-password.j2
@@ -1,0 +1,10 @@
+{% if enable_password is defined and enable_password is not none %}
+{%     if enable_password.hash is defined and enable_password.hash is not none %}
+{%         if enable_password.encryption is defined and enable_password.encryption is not none and enable_password.encryption == "md5" %}
+enable password 5 {{ enable_password.hash }}
+{%         elif enable_password.encryption is defined and enable_password.encryption is not none and enable_password.encryption == "sha512" %}
+enable password sha512 {{ enable_password.hash }}
+{%         endif %}
+no enable password
+{%     endif %}
+{% endif %}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
## Change Summary
New Template for domain-lists.  See Issues #202

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [x] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
#200

## Component(s) name
ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/enable_password.j2
ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/enable_password.j2
ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-device-documentation.j2
ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md

## Proposed changes
<!--- Describe your changes in detail -->

Updated above components to expand data model and templates to handle domain-list.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

leverage iterations of 

```yaml
enable_password:
  encryption: < md5 | sha512 >
  hash: "< hashed_password >"
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
