### PR TITLE
eos_validate_state - Add Check box for test result

### DIFF
--- a/ansible_collections/arista/avd/plugins/filter/markdown_rendering.py
+++ b/ansible_collections/arista/avd/plugins/filter/markdown_rendering.py
@@ -1,0 +1,41 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from jinja2 import TemplateError
+from ansible.errors import AnsibleFilterError
+import re
+
+
+class FilterModule(object):
+    # STATIC EMOJI CODE
+    GH_CODE = dict()
+    # Github MD code for Emoji checked box
+    GH_CODE['PASS'] = ':white_check_mark:'
+    # GH MD code for Emoji Fail
+    GH_CODE['FAIL'] = ':x:'
+
+    def status_render(self, state_string, rendering):
+        """
+        status_render Convert Text to EMOJI code
+
+        Parameters
+        ----------
+        state_string : str
+            Text to convert in EMOJI
+        rendering : string
+            Markdown Flavor to use for Emoji rendering.
+
+        Returns
+        -------
+        str
+            Value to render in markdown
+        """
+        if rendering == 'github':
+            return self.GH_CODE[state_string.upper()]
+        else:
+            return state_string
+
+    def filters(self):
+        return {
+            'status_render': self.status_render
+        }

--- a/ansible_collections/arista/avd/roles/eos_validate_state/README.md
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/README.md
@@ -87,7 +87,7 @@ eos_validate_state_md_report_path: '{{ eos_validate_state_dir }}/{{ fabric_name 
 eos_validate_state_csv_report_path: '{{ eos_validate_state_dir }}/{{ fabric_name }}-state.csv'
 
 # Markdown flavor to support non-text rendering
-# Only support default ang github
+# Only support default and github
 validate_state_markdown_flavor: "default"
 ```
 

--- a/ansible_collections/arista/avd/roles/eos_validate_state/README.md
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/README.md
@@ -85,6 +85,10 @@ eos_validate_state_dir: '{{ root_dir }}/{{ eos_validate_state_name }}'
 # Reports name
 eos_validate_state_md_report_path: '{{ eos_validate_state_dir }}/{{ fabric_name }}-state.md'
 eos_validate_state_csv_report_path: '{{ eos_validate_state_dir }}/{{ fabric_name }}-state.csv'
+
+# Markdown flavor to support non-text rendering
+# Only support default ang github
+validate_state_markdown_flavor: "default"
 ```
 
 ## Requirements

--- a/ansible_collections/arista/avd/roles/eos_validate_state/defaults/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/defaults/main.yml
@@ -10,5 +10,5 @@ eos_validate_state_md_report_path: '{{ eos_validate_state_dir }}/{{ fabric_name 
 eos_validate_state_csv_report_path: '{{ eos_validate_state_dir }}/{{ fabric_name }}-state.csv'
 
 # Markdown flavor to support non-text rendering
-# Only support default ang github
+# Only support default and github
 validate_state_markdown_flavor: "default"

--- a/ansible_collections/arista/avd/roles/eos_validate_state/defaults/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/defaults/main.yml
@@ -8,3 +8,7 @@ eos_validate_state_dir: '{{ root_dir }}/{{ eos_validate_state_name }}'
 # Reports name
 eos_validate_state_md_report_path: '{{ eos_validate_state_dir }}/{{ fabric_name }}-state.md'
 eos_validate_state_csv_report_path: '{{ eos_validate_state_dir }}/{{ fabric_name }}-state.csv'
+
+# Markdown flavor to support non-text rendering
+# Only support default ang github
+validate_state_markdown_flavor: "default"

--- a/ansible_collections/arista/avd/roles/eos_validate_state/templates/validate_state_report-md.j2
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/templates/validate_state_report-md.j2
@@ -85,7 +85,7 @@
 | ------- | ---- | ------------- | ---------------- | ---- | ----------- | -------------- |
 {% for test_id in validation_report_csv.dict %}
 {%     if validation_report_csv.dict[test_id].result == "FAIL" %}
-| {{ test_id }} | {{ validation_report_csv.dict[test_id].node }} | {{ validation_report_csv.dict[test_id].test_category }} | {{ validation_report_csv.dict[test_id].test_description }} | {{ validation_report_csv.dict[test_id].test }} | {{ validation_report_csv.dict[test_id].result }} | {{ validation_report_csv.dict[test_id].failure_reason }} |
+| {{ test_id }} | {{ validation_report_csv.dict[test_id].node }} | {{ validation_report_csv.dict[test_id].test_category }} | {{ validation_report_csv.dict[test_id].test_description }} | {{ validation_report_csv.dict[test_id].test }} | {{ validation_report_csv.dict[test_id].result|arista.avd.status_render(validate_state_markdown_flavor) }} | {{ validation_report_csv.dict[test_id].failure_reason }} |
 {%     endif %}
 {% endfor %}
 
@@ -94,5 +94,5 @@
 | Test ID | Node | Test Category | Test Description | Test | Test Result | Failure Reason |
 | ------- | ---- | ------------- | ---------------- | ---- | ----------- | -------------- |
 {% for test_id in validation_report_csv.dict %}
-| {{ test_id }} | {{ validation_report_csv.dict[test_id].node }} | {{ validation_report_csv.dict[test_id].test_category }} | {{ validation_report_csv.dict[test_id].test_description }} | {{ validation_report_csv.dict[test_id].test }} | {{ validation_report_csv.dict[test_id].result }} | {{ validation_report_csv.dict[test_id].failure_reason }} |
+| {{ test_id }} | {{ validation_report_csv.dict[test_id].node }} | {{ validation_report_csv.dict[test_id].test_category }} | {{ validation_report_csv.dict[test_id].test_description }} | {{ validation_report_csv.dict[test_id].test }} | {{ validation_report_csv.dict[test_id].result|arista.avd.status_render(validate_state_markdown_flavor) }} | {{ validation_report_csv.dict[test_id].failure_reason }} |
 {% endfor %}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] New feature (non-breaking change which adds functionality)

## Related Issue(s)

Fixes #293 

## Component(s) name

Role: `eos_validate_state`

## Proposed changes

- Implement a plugin filter for string conversion
- Implement a new variable (set in default) to select Markdown flavor to use for rendering
- Update template to use plugin filter in result status

## How to test

Run any existing playbook with `eos_validate_state` after creating a variable in your group_vars like:

```yaml
# Markdown flavor to support non-text rendering
# Only support default ang github
validate_state_markdown_flavor: "github"
```

Rendering is:

![](https://user-images.githubusercontent.com/4608573/96087687-8b659000-0ec4-11eb-858c-d1ae29a68d66.png)


> Your MD preview __must__ support Github flavor. Tested in VSCODE with [Markdown Preview Enhanced](https://marketplace.visualstudio.com/items?itemName=shd101wyy.markdown-preview-enhanced)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
