### PR TITLE
Update TerminAttr template in eos_cli_config_gen for CVaaS

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos-cli-config-gen/intended/structured_configs/DC1-SP1.yml
+++ b/ansible_collections/arista/avd/molecule/eos-cli-config-gen/intended/structured_configs/DC1-SP1.yml
@@ -36,10 +36,8 @@ aliases: |
 daemon_terminattr:
   ingestgrpcurl:
     ips:
-      - 10.10.10.8
-      - 10.10.10.9
-      - 10.10.10.10
-    port: 9910
+      - test-cvp.arista.io
+    port: 443
   ingestauth_key: magickey
   ingestvrf: mgt
   smashexcludes: ale,flexCounter,hardware,kni,pulse,strata

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -165,6 +165,8 @@ daemon_terminattr:
 
 ```
 
+You can either provide a list of IPs to target on-premise Cloudvision cluster or either use DNS name for your Cloudvision as a Service instance. If you have both on-prem and CVaaS defined, only on-prem is going to be configured.
+
 ### IP DHCP Relay
 
 ```yaml

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/daemon-terminattr.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/daemon-terminattr.j2
@@ -17,7 +17,7 @@ daemon TerminAttr
 {% if cvp_on_prem.ips|length > 0 %}
    exec /usr/bin/TerminAttr -ingestgrpcurl={% for cvp_ip in cvp_on_prem.ips %}{{ cvp_ip }}:{{ daemon_terminattr.ingestgrpcurl.port }}{% if not loop.last %},{% endif %}{% endfor %} -cvcompression=gzip -ingestauth=key,{{ daemon_terminattr.ingestauth_key }} -smashexcludes={{ daemon_terminattr.smashexcludes }} -ingestexclude={{ daemon_terminattr.ingestexclude }}{% if daemon_terminattr.ingestvrf is ne 'default'%} -ingestvrf={{ daemon_terminattr.ingestvrf }}{% endif %} -taillogs
 {% elif cvaas.ips|length > 0 %}
-   exec /usr/bin/TerminAttr -cvaddr={% for cvp_ip in cvaas.ips %}{{ cvp_ip }}:443{% if not loop.last %},{% endif %}{% endfor %} -cvcompression=gzip -taillogs -cvauth=token-secure,/tmp/onboardingtoken1 -smashexcludes={{ daemon_terminattr.smashexcludes }} -ingestexclude={{ daemon_terminattr.ingestexclude }}  -cvvrf={{ daemon_terminattr.ingestvrf }}
+   exec /usr/bin/TerminAttr -cvaddr={% for cvp_ip in cvaas.ips %}{{ cvp_ip }}:{{ daemon_terminattr.ingestgrpcurl.port }}{% if not loop.last %},{% endif %}{% endfor %} -cvcompression=gzip -taillogs -cvauth=token-secure,/tmp/onboardingtoken1 -smashexcludes={{ daemon_terminattr.smashexcludes }} -ingestexclude={{ daemon_terminattr.ingestexclude }}  -cvvrf={{ daemon_terminattr.ingestvrf }}
 {% endif %}
    no shutdown
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/daemon-terminattr.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/daemon-terminattr.j2
@@ -12,7 +12,6 @@
 {%             do cvaas.ips.append( cvp_ip ) %}
 {%    endif %}
 {% endfor %}
-
 daemon TerminAttr
 {% if cvp_on_prem.ips|length > 0 %}
    exec /usr/bin/TerminAttr -ingestgrpcurl={% for cvp_ip in cvp_on_prem.ips %}{{ cvp_ip }}:{{ daemon_terminattr.ingestgrpcurl.port }}{% if not loop.last %},{% endif %}{% endfor %} -cvcompression=gzip -ingestauth=key,{{ daemon_terminattr.ingestauth_key }} -smashexcludes={{ daemon_terminattr.smashexcludes }} -ingestexclude={{ daemon_terminattr.ingestexclude }}{% if daemon_terminattr.ingestvrf is ne 'default'%} -ingestvrf={{ daemon_terminattr.ingestvrf }}{% endif %} -taillogs

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/daemon-terminattr.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/daemon-terminattr.j2
@@ -1,6 +1,24 @@
 {% if daemon_terminattr is defined and daemon_terminattr is not none %}
 !
+{# Create list of non CVaaS server #}
+{% set cvp_on_prem = namespace() %}
+{% set cvp_on_prem.ips = [] %}
+{% set cvaas = namespace() %}
+{% set cvaas.ips = [] %}
+{% for cvp_ip in daemon_terminattr.ingestgrpcurl.ips %}
+{%       if "arista.io" not in cvp_ip %}
+{%             do cvp_on_prem.ips.append( cvp_ip ) %}
+{%       elif "arista.io" in cvp_ip %}
+{%             do cvaas.ips.append( cvp_ip ) %}
+{%    endif %}
+{% endfor %}
+
 daemon TerminAttr
-   exec /usr/bin/TerminAttr -ingestgrpcurl={% for cvp_ip in daemon_terminattr.ingestgrpcurl.ips %}{{ cvp_ip }}:{{ daemon_terminattr.ingestgrpcurl.port }}{% if not loop.last %},{% endif %}{% endfor %} -cvcompression=gzip -ingestauth=key,{{ daemon_terminattr.ingestauth_key }} -smashexcludes={{ daemon_terminattr.smashexcludes }} -ingestexclude={{ daemon_terminattr.ingestexclude }}{% if daemon_terminattr.ingestvrf is ne 'default'%} -ingestvrf={{ daemon_terminattr.ingestvrf }}{% endif %} -taillogs
+{% if cvp_on_prem.ips|length > 0 %}
+   exec /usr/bin/TerminAttr -ingestgrpcurl={% for cvp_ip in cvp_on_prem.ips %}{{ cvp_ip }}:{{ daemon_terminattr.ingestgrpcurl.port }}{% if not loop.last %},{% endif %}{% endfor %} -cvcompression=gzip -ingestauth=key,{{ daemon_terminattr.ingestauth_key }} -smashexcludes={{ daemon_terminattr.smashexcludes }} -ingestexclude={{ daemon_terminattr.ingestexclude }}{% if daemon_terminattr.ingestvrf is ne 'default'%} -ingestvrf={{ daemon_terminattr.ingestvrf }}{% endif %} -taillogs
+{% endif %}
+{% if cvaas.ips|length > 0 %}
+   exec /usr/bin/TerminAttr -cvaddr={% for cvp_ip in cvaas.ips %}{{ cvp_ip }}:443{% if not loop.last %},{% endif %}{% endfor %} -cvcompression=gzip -taillogs -cvauth=token-secure,/tmp/onboardingtoken1 -smashexcludes={{ daemon_terminattr.smashexcludes }} -ingestexclude={{ daemon_terminattr.ingestexclude }}  -cvvrf={{ daemon_terminattr.ingestvrf }}
+{% endif %}
    no shutdown
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/daemon-terminattr.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/daemon-terminattr.j2
@@ -16,8 +16,7 @@
 daemon TerminAttr
 {% if cvp_on_prem.ips|length > 0 %}
    exec /usr/bin/TerminAttr -ingestgrpcurl={% for cvp_ip in cvp_on_prem.ips %}{{ cvp_ip }}:{{ daemon_terminattr.ingestgrpcurl.port }}{% if not loop.last %},{% endif %}{% endfor %} -cvcompression=gzip -ingestauth=key,{{ daemon_terminattr.ingestauth_key }} -smashexcludes={{ daemon_terminattr.smashexcludes }} -ingestexclude={{ daemon_terminattr.ingestexclude }}{% if daemon_terminattr.ingestvrf is ne 'default'%} -ingestvrf={{ daemon_terminattr.ingestvrf }}{% endif %} -taillogs
-{% endif %}
-{% if cvaas.ips|length > 0 %}
+{% elif cvaas.ips|length > 0 %}
    exec /usr/bin/TerminAttr -cvaddr={% for cvp_ip in cvaas.ips %}{{ cvp_ip }}:443{% if not loop.last %},{% endif %}{% endfor %} -cvcompression=gzip -taillogs -cvauth=token-secure,/tmp/onboardingtoken1 -smashexcludes={{ daemon_terminattr.smashexcludes }} -ingestexclude={{ daemon_terminattr.ingestexclude }}  -cvvrf={{ daemon_terminattr.ingestvrf }}
 {% endif %}
    no shutdown

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
@@ -117,6 +117,7 @@ cvp_instance_ips:
   - < IPv4 address >
   - < IPv4 address >
   - < IPv4 address >
+  - < CV as a Service hostname >
 cvp_ingestauth_key: < CloudVision Ingest Authentication key >
 terminattr_ingestgrpcurl_port: < port_number | default -> 9910 >
 terminattr_smashexcludes: "< smash excludes | default -> ale,flexCounter,hardware,kni,pulse,strata >"

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
@@ -162,6 +162,8 @@ mac_address_table:
   aging_time: < time_in_seconds >
 ```
 
+> In `cvp_instance_ips` you can either provide a list of IPs to target on-premise Cloudvision cluster or either use DNS name for your Cloudvision as a Service instance. If you have both on-prem and CVaaS defined, only on-prem is going to be configured.
+
 **Example:**
 
 note: Default values are commented

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/base/daemon-terminattr.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/base/daemon-terminattr.j2
@@ -6,23 +6,12 @@
 {% set cvaas = namespace() %}
 {% set cvaas.ips = [] %}
 {%     if cvp_instance_ip is defined %}
-{%          for cvp_ip in cvp_instance_ip %}
-{%              if "arista.io" not in cvp_ip %}
-{%                  do cvp_on_prem.ips.append( cvp_ip ) %}
-{%              elif "arista.io" in cvp_ip %}
-{%                  do cvaas.ips.append( cvp_ip ) %}
-{%              endif %}
-{%          endfor %}
+{%          if "arista.io" not in cvp_instance_ip %}
+{%              do cvp_on_prem.ips.append( cvp_instance_ip ) %}
+{%          elif "arista.io" in cvp_ip %}
+{%              do cvaas.ips.append( cvp_ip ) %}
+{%          endif %}
 {%     elif cvp_instance_ips is defined %}
-{%          for cvp_ip in cvp_instance_ips %}
-{%              if "arista.io" not in cvp_ip %}
-{%                  do cvp_on_prem.ips.append( cvp_ip ) %}
-{%              elif "arista.io" in cvp_ip %}
-{%                  do cvaas.ips.append( cvp_ip ) %}
-{%              endif %}
-{%          endfor %}
-{%     endif %}
-{%     if cvp_instance_ips is defined %}
 {%          for cvp_ip in cvp_instance_ips %}
 {%              if "arista.io" not in cvp_ip %}
 {%                  do cvp_on_prem.ips.append( cvp_ip ) %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/base/daemon-terminattr.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/base/daemon-terminattr.j2
@@ -1,15 +1,49 @@
 {# daemon TerminAttr #}
 {% if cvp_instance_ip is defined or cvp_instance_ips is defined %}
+{# Create list of non CVaaS server #}
+{% set cvp_on_prem = namespace() %}
+{% set cvp_on_prem.ips = [] %}
+{% set cvaas = namespace() %}
+{% set cvaas.ips = [] %}
+{%     if cvp_instance_ip is defined %}
+{%          for cvp_ip in cvp_instance_ip %}
+{%              if "arista.io" not in cvp_ip %}
+{%                  do cvp_on_prem.ips.append( cvp_ip ) %}
+{%              elif "arista.io" in cvp_ip %}
+{%                  do cvaas.ips.append( cvp_ip ) %}
+{%              endif %}
+{%          endfor %}
+{%     elif cvp_instance_ips is defined %}
+{%          for cvp_ip in cvp_instance_ips %}
+{%              if "arista.io" not in cvp_ip %}
+{%                  do cvp_on_prem.ips.append( cvp_ip ) %}
+{%              elif "arista.io" in cvp_ip %}
+{%                  do cvaas.ips.append( cvp_ip ) %}
+{%              endif %}
+{%          endfor %}
+{%     endif %}
+{%     if cvp_instance_ips is defined %}
+{%          for cvp_ip in cvp_instance_ips %}
+{%              if "arista.io" not in cvp_ip %}
+{%                  do cvp_on_prem.ips.append( cvp_ip ) %}
+{%              elif "arista.io" in cvp_ip %}
+{%                  do cvaas.ips.append( cvp_ip ) %}
+{%              endif %}
+{%          endfor %}
+{%     endif %}
   ingestgrpcurl:
     ips:
-{%     if cvp_instance_ip is defined %}
+{% if cvp_on_prem.ips|length > 0 %}
+{%    for cvp_instance_ip in cvp_on_prem.ips %}
       - {{ cvp_instance_ip }}
-{%     elif cvp_instance_ips is defined %}
-{%         for cvp_instance_ip in cvp_instance_ips %}
-      - {{ cvp_instance_ip }}
-{%         endfor %}
-{%     endif %}
+{%    endfor %}
     port: {{ terminattr_ingestgrpcurl_port }}
+{% elif cvaas.ips|length > 0 %}
+{%    for cvp_instance_ip in cvaas.ips %}
+      - {{ cvp_instance_ip }}
+{%    endfor %}
+    port: {{ terminattr_ingestgrpcurl_port }}
+{% endif %}
   ingestauth_key: {{ cvp_ingestauth_key }}
   ingestvrf: {{ mgmt_interface_vrf }}
   smashexcludes: "{{ terminattr_smashexcludes }}"


### PR DESCRIPTION
Description
-----------

- Build list of IPs for on-prem CV
- Build list of CVaaS server based on FQDN `arista.io`
- Generate configuration for both on-prem and cvaas

Requirements
------------

TerminAttr 1.7.1 if streaming to on-prem and CVaaS is required

## Configuration Example using AVD for on-prem

```
cvp_instance_ips:
  - 10.83.28.164
cvp_ingestauth_key: ''
```

### Configuration with eos_cli_config_gen:

```
daemon_terminattr:
  ingestgrpcurl:
    ips:
      - 10.83.28.164
    port: 9910
  ingestauth_key:
  ingestvrf: MGMT
  smashexcludes: "ale,flexCounter,hardware,kni,pulse,strata"
  ingestexclude: "/Sysdb/cell/1/agent,/Sysdb/cell/2/agent"
```

### Configuration generated

```
daemon TerminAttr
   exec /usr/bin/TerminAttr -ingestgrpcurl=10.83.28.164:9910 \
-cvcompression=gzip -ingestauth=key, -smashexcludes=ale,flexCounter,\
hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/\
cell/2/agent -ingestvrf=MGMT -taillogs
   no shutdown
!
```

## Configuration Example using AVD for CVaaS

```
cvp_instance_ips:
  - apiserver.corp.arista.io
cvp_ingestauth_key: ''
```

### Configuration with eos_cli_config_gen:

```
daemon_terminattr:
  ingestgrpcurl:
    ips:
      - apiserver.corp.arista.io
    port: 9910
  ingestauth_key:
  ingestvrf: MGMT
  smashexcludes: "ale,flexCounter,hardware,kni,pulse,strata"
  ingestexclude: "/Sysdb/cell/1/agent,/Sysdb/cell/2/agent"
```

### Configuration generated

```
daemon TerminAttr
   exec /usr/bin/TerminAttr -cvaddr=apiserver.corp.arista.io:443 \
-cvcompression=gzip -taillogs -cvauth=token-secure,/tmp/onboardingtoken1 \
-smashexcludes=ale,flexCounter,hardware,kni,pulse,strata \
-ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent  -cvvrf=MGMT
   no shutdown
!
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Fixes #257

## Component(s) name

Role: `eos_cli_config_gen`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
