### PR TITLE
Add BFD for OSPF

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1277,6 +1277,7 @@ router_ospf:
       passive_interface_default: < true | false >
       router_id: < IPv4_address >
       log_adjacency_changes_detail: < true | false >
+      bfd_enable: < true | false >
       no_passive_interfaces:
         - < interface_1 >
         - < interface_2 >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-ospf.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-ospf.j2
@@ -26,6 +26,9 @@ router ospf {{ process_id }}
    network {{ network_prefix }} area {{ router_ospf.process_ids[process_id].network_prefixes[network_prefix].area }}
 {%             endfor %}
 {%         endif %}
+{%         if router_ospf.bfd_enable is defined and router_isis.bfd_enable %}
+   bfd default
+{%         endif %}
 {%         if router_ospf.process_ids[process_id].max_lsa is defined %}
    max-lsa {{ router_ospf.process_ids[process_id].max_lsa }}
 {%         endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-ospf.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-ospf.j2
@@ -26,7 +26,7 @@ router ospf {{ process_id }}
    network {{ network_prefix }} area {{ router_ospf.process_ids[process_id].network_prefixes[network_prefix].area }}
 {%             endfor %}
 {%         endif %}
-{%         if router_ospf.bfd_enable is defined and router_isis.bfd_enable %}
+{%         if router_ospf.process_ids[process_id].bfd_enable is defined and router_ospf.process_ids[process_id].bfd_enable %}
    bfd default
 {%         endif %}
 {%         if router_ospf.process_ids[process_id].max_lsa is defined %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
@@ -256,6 +256,7 @@ underlay_routing_protocol: < BGP or OSPF or ISIS | Default -> BGP >
 underlay_ospf_process_id: < process_id | Default -> 100 >
 underlay_ospf_area: < ospf_area | Default -> 0.0.0.0 >
 underlay_ospf_max_lsa: < lsa | Default -> 12000 >
+underlay_ospf_bfd_enable: < true | false | Default -> false >
 
 # Underlay OSFP | Required when < underlay_routing_protocol > == ISIS
 isis_area_id: < isis area | Default -> "49.0001" >
@@ -341,6 +342,7 @@ fabric_name: DC1_FABRIC
 # underlay_ospf_process_id: 100
 # underlay_ospf_area: 0.0.0.0
 # underlay_ospf_max_lsa: 12000
+# underlay_ospf_bfd_enable: true
 
 # p2p_uplinks_mtu: 9000
 

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/defaults/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/defaults/main.yml
@@ -31,6 +31,7 @@ underlay_routing_protocol: BGP
 underlay_ospf_process_id: 100
 underlay_ospf_area: 0.0.0.0
 underlay_ospf_max_lsa: 12000
+underlay_ospf_bfd_enable: false
 
 spine_bgp_defaults:
   - update wait-for-convergence

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/underlay-overlay/router-ospf.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/underlay-overlay/router-ospf.j2
@@ -37,5 +37,8 @@
         - Vlan4093
 {%         endif %}
 {%     endif %}
+{%     if underlay_ospf_bfd_enable is defined and underlay_ospf_bfd_enable %}
+      bfd_enable: true
+{%     endif %}
       max_lsa: {{ underlay_ospf_max_lsa }}
 {% endif %}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

## Related Issue(s)

Fixes #55

## Component(s) name

Roles:

- `eos_l3ls_evpn`
- `eos_cli_config_gen`

## Proposed changes

__eos_l3ls_evpn__

```yaml
# Underlay OSFP | Required when < underlay_routing_protocol > == OSPF
underlay_ospf_process_id: < process_id | Default -> 100 >
underlay_ospf_area: < ospf_area | Default -> 0.0.0.0 >
underlay_ospf_max_lsa: < lsa | Default -> 12000 >
underlay_ospf_bfd_enable: < true | false | Default -> false >
```

__eos_cli_config_gen__

```yaml
router_ospf:
  process_ids:
    100:
      passive_interface_default: true
      router_id: 192.168.255.7
      no_passive_interfaces:
        - Ethernet1
        - Ethernet2
      bfd_enable: true
      max_lsa: 12000
```


## How to test

Iterate one of these data

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
