### PR TITLE
#328 add IPv4 global configuration status in the IP Routing Summary r…

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ip-routing.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ip-routing.j2
@@ -1,6 +1,14 @@
-{% if vrfs is defined and vrfs is not none %}
 ### IP Routing Summary
 
+{% if ip_routing is defined and ip_routing is not none %}
+{%     if ip_routing == true %} 
+IPv4 Routing is enabled
+{%         else %} 
+IPv4 Routing is disabled
+{%     endif %}
+{% endif %}
+
+{% if vrfs is defined and vrfs is not none %}
 | VRF | Routing Enabled |
 | --- | --------------- |
 {%     for vrf in vrfs | arista.avd.natural_sort %}
@@ -10,10 +18,10 @@
 | {{ vrf }} | False |
 {%         endif %}
 {%     endfor %}
+{% endif %}
 
 ### IP Routing Device Configuration
 
 ```eos
 {% include 'eos/ip-routing.j2' %}
 ```
-{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ip-routing.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ip-routing.j2
@@ -2,7 +2,7 @@
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| Default | {% if ip_routing is defined and ip_routing is not none and ip_routing == true %} True | {% else %} False | {% endif %}
+| default | {% if ip_routing is defined and ip_routing is not none and ip_routing == true %} True | {% else %} False | {% endif %}
 
 {% if vrfs is defined and vrfs is not none %}
 {%     for vrf in vrfs | arista.avd.natural_sort %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ip-routing.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ip-routing.j2
@@ -1,16 +1,10 @@
 ### IP Routing Summary
 
-{% if ip_routing is defined and ip_routing is not none %}
-{%     if ip_routing == true %} 
-IPv4 Routing is enabled
-{%         else %} 
-IPv4 Routing is disabled
-{%     endif %}
-{% endif %}
-
-{% if vrfs is defined and vrfs is not none %}
 | VRF | Routing Enabled |
 | --- | --------------- |
+| Default | {% if ip_routing is defined and ip_routing is not none and ip_routing == true %} True | {% else %} False | {% endif %}
+
+{% if vrfs is defined and vrfs is not none %}
 {%     for vrf in vrfs | arista.avd.natural_sort %}
 {%         if vrfs[vrf].ip_routing == true %}
 | {{ vrf }} | True |


### PR DESCRIPTION
## Related Issue(s)

fix #328  

## Component(s) name

`eos_cli_config_gen role`

## Change Summary

update the template [ip-routing.j2](https://github.com/aristanetworks/ansible-avd/blob/devel/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ip-routing.j2) in order to include also the global IP routing status in the `IP Routing Summary` section

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [x] Documentation content changes
- [ ] Other (please describe):

## How to test

execute the role `eos_cli_config_gen role` and check the generated doc for devices. 


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
