### PR TITLE
Make server block optional in eos_l3ls_evpn

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/edge_ports/leaf-server-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/edge_ports/leaf-server-interfaces.j2
@@ -1,4 +1,5 @@
 {# Leaf server interfaces #}
+{% if servers is defined and servers is not none %}
 {% for server in servers | arista.avd.natural_sort() %}
 {%     for adapter in servers[server].adapters %}
 {%         for switch in adapter.switches %}
@@ -39,3 +40,4 @@
 {%         endfor %}
 {%     endfor %}
 {% endfor %}
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/edge_ports/leaf-server-port-channels.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/edge_ports/leaf-server-port-channels.j2
@@ -1,5 +1,6 @@
 {# Leaf server port-channels #}
-{% for server in servers | arista.avd.natural_sort() %}
+{% if servers is defined and servers is not none %}
+{%  for server in servers | arista.avd.natural_sort() %}
 {%     for adapter in servers[server].adapters %}
 {%         if adapter.port_channel is defined and adapter.port_channel.state == "present" %}
 {%             for switch in adapter.switches %}
@@ -36,4 +37,5 @@
 {%             endfor %}
 {%         endif %}
 {%     endfor %}
-{% endfor %}
+{%  endfor %}
+{% endif %}


### PR DESCRIPTION
Fixes #333

Add if statement to make `servers` section optional.

