### PR TITLE
Add Support for IGMP snooping on-off in eos_l3ls_evpn

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -187,10 +187,13 @@ vlan_internal_allocation_policy:
 
 ```yaml
 ip_igmp_snooping:
+  globally_enabled: < true | false (default is true) >
   vlans:
     < vlan_id >:
       enabled: < true | false >
 ```
+
+`globally_enabled` allows to activate or deactivate IGMP snooping for all vlans where `vlans` allows user to activate / deactivate IGMP snooping per vlan.
 
 ### Event Monitor
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-igmp-snooping.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-igmp-snooping.j2
@@ -1,7 +1,9 @@
 {# eos - IP IGMP Snooping #}
 {% if ip_igmp_snooping is defined and ip_igmp_snooping is not none %}
 !
-{%    if ip_igmp_snooping.vlans is defined and ip_igmp_snooping.vlans is not none %}
+{%    if ip_igmp_snooping.globally_enabled is defined and ip_igmp_snooping.globally_enabled == false %}
+no ip igmp snooping
+{%    elif ip_igmp_snooping.vlans is defined and ip_igmp_snooping.vlans is not none %}
 {%       for vlan in ip_igmp_snooping.vlans | arista.avd.natural_sort %}
 {%          if ip_igmp_snooping.vlans[vlan].enabled is defined and ip_igmp_snooping.vlans[vlan].enabled == false %}
 no ip igmp snooping vlan {{ vlan }}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
@@ -517,6 +517,9 @@ l3leaf:
     # Virtual router mac address for anycast gateway | Required.
     virtual_router_mac_address: < mac address >
 
+    # Activate or deactivate IGMP snooping for all l3leaf devices | Optional default is true
+    igmp_snooping_enabled: < true | false >
+
   # The node groups are group of one or two nodes where specific variables can be defined related to the topology
   # and allowed L3 and L2 network services.
   # All variables defined under `defaults` dictionary can be defined under each node group to override it.
@@ -533,6 +536,9 @@ l3leaf:
       filter:
         tenants: [ < tenant_1 >, < tenant_2 > | default all ]
         tags: [ < tag_1 >, < tag_2 > | default -> all ]]
+
+      # Activate or deactivate IGMP snooping for node groups devices
+      igmp_snooping_enabled: < true | false >
 
       # Define one or two nodes - same name as inventory_hostname | Required
       # When two nodes are defined, this will create an MLAG pair.
@@ -660,6 +666,9 @@ l2leaf:
     # Spanning tree priority | Required.
     spanning_tree_priority: < spanning-tree priority >
 
+    # Activate or deactivate IGMP snooping for all l2leaf devices | Optional default is true
+    igmp_snooping_enabled: < true | false >
+
   # The node groups are group of one or two nodes where specific variables can be defined related to the topology
   # and allowed L3 and L2 network services.
   # All variables defined under `defaults` dictionary can be defined under each node group to override it.
@@ -673,6 +682,9 @@ l2leaf:
       filter:
         tenants: [ < tenant_1 >, < tenant_2 > | default all ]
         tags: [ < tag_1 >, < tag_2 > | default -> all ]]
+
+      # Activate or deactivate IGMP snooping for node groups devices
+      igmp_snooping_enabled: < true | false >
 
       # Define one or two nodes - same name as inventory_hostname.
       # When two nodes are defined, this will create an MLAG pair.

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
@@ -321,6 +321,10 @@ leaf_bgp_defaults:
 # Enable vlan aware bundles for EVPN MAC-VRF | Required.
 vxlan_vlan_aware_bundles: < boolean | default -> false >
 
+# Disable IGMP snooping at fabric level.
+# If set, it overrides per vlan settings
+default_igmp_snooping: < boolean | default -> true >
+
 # BFD Multihop tunning | Required.
 bfd_multihop:
   interval: < | default -> 300 >

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
@@ -830,7 +830,7 @@ tenants:
             enabled: < true | false >
 
             # Enable IGMP Snooping
-            igmp_snooping: < true | false | default true (eos) >
+            igmp_snooping_enabled: < true | false | default true (eos) >
 
             # ip address virtual to configure VXLAN Anycast IP address
             # Conserves IP addresses in VXLAN deployments as it doesn't require unique IP addresses on each node.

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
@@ -813,6 +813,9 @@ tenants:
             # Enable or disable interface
             enabled: < true | false >
 
+            # Enable IGMP Snooping
+            ip_igmp_snooping: < true | false | default true (eos) >
+
             # ip address virtual to configure VXLAN Anycast IP address
             # Conserves IP addresses in VXLAN deployments as it doesn't require unique IP addresses on each node.
             # Optional

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
@@ -814,7 +814,7 @@ tenants:
             enabled: < true | false >
 
             # Enable IGMP Snooping
-            ip_igmp_snooping: < true | false | default true (eos) >
+            igmp_snooping: < true | false | default true (eos) >
 
             # ip address virtual to configure VXLAN Anycast IP address
             # Conserves IP addresses in VXLAN deployments as it doesn't require unique IP addresses on each node.

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/defaults/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/defaults/main.yml
@@ -50,7 +50,7 @@ leaf_bgp_defaults:
 
 vxlan_vlan_aware_bundles: false
 
-default_igmp_snooping: false
+default_igmp_snooping_enabled: true
 
 bfd_multihop:
   interval: 300

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/defaults/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/defaults/main.yml
@@ -50,6 +50,8 @@ leaf_bgp_defaults:
 
 vxlan_vlan_aware_bundles: false
 
+default_igmp_snooping: false
+
 bfd_multihop:
   interval: 300
   min_rx: 300

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l2leaf-yml.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l2leaf-yml.j2
@@ -17,6 +17,13 @@
 {%             else %}
 {%                 set switch.spanning_tree_mode = l2leaf.defaults.spanning_tree_mode %}
 {%             endif %}
+{%             if l2leaf.node_groups[l2leaf_node_group].igmp_snooping_enabled is defined %}
+{%                 set leaf.igmp_snooping_enabled = l2leaf.node_groups[l2leaf_node_group].igmp_snooping_enabled %}
+{%             elif l2leaf.defaults.igmp_snooping_enabled is defined %}
+{%                 set leaf.igmp_snooping_enabled = l2leaf.defaults.igmp_snooping_enabled %}
+{%             else %}
+{%                 set leaf.igmp_snooping_enabled = default_igmp_snooping_enabled %}
+{%             endif %}
 {%             if l2leaf.node_groups[l2leaf_node_group].spanning_tree_priority is defined %}
 {%                 set switch.spanning_tree_priority = l2leaf.node_groups[l2leaf_node_group].spanning_tree_priority %}
 {%             else %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l2leaf-yml.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l2leaf-yml.j2
@@ -288,6 +288,10 @@ tcam_profile:
 mac_address_table:
 {% include 'base/mac-address-table.j2' %}
 
+{# Tenant ip-igmp-snooping #}
+ip_igmp_snooping:
+{% include 'tenant_evpn_vxlan/leaf-tenant-igmp-snooping.j2' %}
+
 {# static_routes #}
 ### static routes ###
 static_routes:

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l3leaf-yml.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l3leaf-yml.j2
@@ -18,6 +18,13 @@
 {%             else %}
 {%                 set leaf.filter_tenants = [ 'all' ] %}
 {%             endif %}
+{%             if l3leaf.node_groups[l3leaf_node_group].igmp_snooping_enabled is defined %}
+{%                 set leaf.igmp_snooping_enabled = l3leaf.node_groups[l3leaf_node_group].igmp_snooping_enabled %}
+{%             elif l3leaf.defaults.igmp_snooping_enabled is defined %}
+{%                 set leaf.igmp_snooping_enabled = l3leaf.defaults.igmp_snooping_enabled %}
+{%             else %}
+{%                 set leaf.igmp_snooping_enabled = default_igmp_snooping_enabled %}
+{%             endif %}
 {%             if l3leaf.node_groups[l3leaf_node_group].filter.tags is defined %}
 {%                 set leaf.filter_tags = l3leaf.node_groups[l3leaf_node_group].filter.tags %}
 {%             else %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l3leaf-yml.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l3leaf-yml.j2
@@ -322,6 +322,10 @@ ip_virtual_router_mac_address: {{ leaf.virtual_router_mac_address | lower }}
 virtual_source_nat_vrfs:
 {% include 'tenant_evpn_vxlan/leaf-tenant-virtual-source-nat-vrfs.j2' %}
 
+{# Tenant ip-igmp-snooping #}
+ip_igmp_snooping:
+{% include 'tenant_evpn_vxlan/leaf-tenant-igmp-snooping.j2' %}
+
 {# static_routes #}
 ### static routes ###
 static_routes:

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-igmp-snooping.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-igmp-snooping.j2
@@ -1,7 +1,7 @@
 {# Leaf tenant IGMP snooping #}
 {% set igmp_snooping = namespace() %}
 {% set igmp_snooping.configured = false %}
-{% if default_igmp_snooping == false %}
+{% if leaf.igmp_snooping_enabled == true %}
 {% set igmp_snooping.configured = true %}
 {% endif %}
 {% for tenant in tenants | arista.avd.natural_sort if tenant in leaf.filter_tenants or "all" in leaf.filter_tenants %}
@@ -22,7 +22,8 @@
 {%         endfor %}
 {%     endif %}
 {% endfor %}
-{% if igmp_snooping.configured == true %}
+  globally_enabled: {{ leaf.igmp_snooping_enabled }}
+{% if igmp_snooping.configured == true and leaf.igmp_snooping_enabled == true %}
   vlans:
 {# ---------------------------- #}
 {# SVI & L3VLANs services       #}
@@ -33,10 +34,7 @@
 {%              for vrf in tenants[tenant].vrfs | arista.avd.natural_sort if leaf.vrfs is not none and vrf in leaf.vrfs %}
 {# Tenant VLANs w/SVIs #}
 {%                  for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if leaf.svis is not none and svi in leaf.svis %}
-{%                      if default_igmp_snooping == false %}
-    {{ svi|int }}:
-      enabled: false
-{%                      elif tenants[tenant].vrfs[vrf].svis[svi].igmp_snooping is not defined %}
+{%                      if tenants[tenant].vrfs[vrf].svis[svi].igmp_snooping is not defined %}
     {{ svi|int }}:
       enabled: true
 {%                      elif tenants[tenant].vrfs[vrf].svis[svi].igmp_snooping == true %}
@@ -54,10 +52,7 @@
 {# ---------------------------- #}
 {%          if tenants[tenant].l2vlans is defined %}
 {%              for l2vlan in tenants[tenant].l2vlans | arista.avd.natural_sort %}
-{%                      if default_igmp_snooping == false %}
-    {{ l2vlan|int }}:
-      enabled: false
-{%                      elif tenants[tenant].l2vlans[l2vlan].igmp_snooping is not defined %}
+{%                      if tenants[tenant].l2vlans[l2vlan].igmp_snooping is not defined %}
     {{ l2vlan|int }}:
       enabled: true
 {%                      elif tenants[tenant].l2vlans[l2vlan].igmp_snooping == true %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-igmp-snooping.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-igmp-snooping.j2
@@ -1,0 +1,37 @@
+{# Leaf tenant IGMP snooping #}
+{% set igmp_snooping = namespace() %}
+{% set igmp_snooping.configured = false %}
+{% for tenant in tenants | arista.avd.natural_sort if tenant in leaf.filter_tenants or "all" in leaf.filter_tenants %}
+{%     if tenants[tenant].vrfs is defined %}
+{%         for vrf in tenants[tenant].vrfs | arista.avd.natural_sort if leaf.vrfs is not none and vrf in leaf.vrfs %}
+{%             for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if leaf.svis is not none and svi in leaf.svis %}
+{%                  if tenants[tenant].vrfs[vrf].svis[svi].ip_igmp_snooping is defined %}
+{%                      set igmp_snooping.configured = true %}
+{%                  endif %}
+{%             endfor %}
+{%         endfor %}
+{%     endif %}
+{% endfor %}
+{% if igmp_snooping.configured == true %}
+  vlans:
+{%      for tenant in tenants | arista.avd.natural_sort if tenant in leaf.filter_tenants or "all" in leaf.filter_tenants %}
+## {{ tenant }} ##
+{%          if tenants[tenant].vrfs is defined %}
+{%              for vrf in tenants[tenant].vrfs | arista.avd.natural_sort if leaf.vrfs is not none and vrf in leaf.vrfs %}
+{# Tenant VLANs w/SVIs #}
+{%                  for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if leaf.svis is not none and svi in leaf.svis %}
+{%                      if tenants[tenant].vrfs[vrf].svis[svi].ip_igmp_snooping is not defined %}
+    {{ svi|int }}:
+      enabled: true
+{%                      elif tenants[tenant].vrfs[vrf].svis[svi].ip_igmp_snooping == true %}
+    {{ svi|int }}:
+      enabled: true
+{%                      elif tenants[tenant].vrfs[vrf].svis[svi].ip_igmp_snooping == false %}
+    {{ svi|int }}:
+      enabled: false
+{%                      endif %}
+{%                  endfor %}
+{%              endfor %}
+{%          endif %}
+{%      endfor %}
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-igmp-snooping.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-igmp-snooping.j2
@@ -35,10 +35,7 @@
 {# Tenant VLANs w/SVIs #}
 {%                  for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if leaf.svis is not none and svi in leaf.svis %}
 {%                      if tenants[tenant].vrfs[vrf].svis[svi].igmp_snooping_enabled is defined %}
-{%                          if tenants[tenant].vrfs[vrf].svis[svi].igmp_snooping_enabled == true and leaf.igmp_snooping_enabled == false %}
-    {{ svi|int }}:
-      enabled: true
-{%                          elif tenants[tenant].vrfs[vrf].svis[svi].igmp_snooping_enabled == false and leaf.igmp_snooping_enabled == true %}
+{%                          if tenants[tenant].vrfs[vrf].svis[svi].igmp_snooping_enabled == false and leaf.igmp_snooping_enabled == true %}
     {{ svi|int }}:
       enabled: false
 {%                          endif %}
@@ -52,10 +49,7 @@
 {%          if tenants[tenant].l2vlans is defined %}
 {%              for l2vlan in tenants[tenant].l2vlans | arista.avd.natural_sort %}
 {%                  if tenants[tenant].l2vlans[l2vlan].igmp_snooping_enabled is defined %}
-{%                      if tenants[tenant].l2vlans[l2vlan].igmp_snooping_enabled == true and leaf.igmp_snooping_enabled == false %}
-    {{ l2vlan|int }}:
-      enabled: true
-{%                      elif tenants[tenant].l2vlans[l2vlan].igmp_snooping_enabled == false and leaf.igmp_snooping_enabled == true %}
+{%                      if tenants[tenant].l2vlans[l2vlan].igmp_snooping_enabled == false and leaf.igmp_snooping_enabled == true %}
     {{ l2vlan|int }}:
       enabled: false
 {%                      endif %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-igmp-snooping.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-igmp-snooping.j2
@@ -34,13 +34,13 @@
 {%              for vrf in tenants[tenant].vrfs | arista.avd.natural_sort if leaf.vrfs is not none and vrf in leaf.vrfs %}
 {# Tenant VLANs w/SVIs #}
 {%                  for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if leaf.svis is not none and svi in leaf.svis %}
-{%                      if tenants[tenant].vrfs[vrf].svis[svi].igmp_snooping is not defined %}
+{%                      if tenants[tenant].vrfs[vrf].svis[svi].igmp_snooping_enabled is not defined %}
     {{ svi|int }}:
       enabled: true
-{%                      elif tenants[tenant].vrfs[vrf].svis[svi].igmp_snooping == true %}
+{%                      elif tenants[tenant].vrfs[vrf].svis[svi].igmp_snooping_enabled == true %}
     {{ svi|int }}:
       enabled: true
-{%                      elif tenants[tenant].vrfs[vrf].svis[svi].igmp_snooping == false %}
+{%                      elif tenants[tenant].vrfs[vrf].svis[svi].igmp_snooping_enabled == false %}
     {{ svi|int }}:
       enabled: false
 {%                      endif %}
@@ -52,13 +52,13 @@
 {# ---------------------------- #}
 {%          if tenants[tenant].l2vlans is defined %}
 {%              for l2vlan in tenants[tenant].l2vlans | arista.avd.natural_sort %}
-{%                      if tenants[tenant].l2vlans[l2vlan].igmp_snooping is not defined %}
+{%                      if tenants[tenant].l2vlans[l2vlan].igmp_snooping_enabled is not defined %}
     {{ l2vlan|int }}:
       enabled: true
-{%                      elif tenants[tenant].l2vlans[l2vlan].igmp_snooping == true %}
+{%                      elif tenants[tenant].l2vlans[l2vlan].igmp_snooping_enabled == true %}
     {{ l2vlan|int }}:
       enabled: true
-{%                      elif tenants[tenant].l2vlans[l2vlan].igmp_snooping == false %}
+{%                      elif tenants[tenant].l2vlans[l2vlan].igmp_snooping_enabled == false %}
     {{ l2vlan|int }}:
       enabled: false
 {%                      endif %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-igmp-snooping.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-igmp-snooping.j2
@@ -1,6 +1,9 @@
 {# Leaf tenant IGMP snooping #}
 {% set igmp_snooping = namespace() %}
 {% set igmp_snooping.configured = false %}
+{% if default_igmp_snooping == false %}
+{% set igmp_snooping.configured = true %}
+{% endif %}
 {% for tenant in tenants | arista.avd.natural_sort if tenant in leaf.filter_tenants or "all" in leaf.filter_tenants %}
 {%     if tenants[tenant].vrfs is defined %}
 {%         for vrf in tenants[tenant].vrfs | arista.avd.natural_sort if leaf.vrfs is not none and vrf in leaf.vrfs %}
@@ -21,13 +24,19 @@
 {% endfor %}
 {% if igmp_snooping.configured == true %}
   vlans:
+{# ---------------------------- #}
+{# SVI & L3VLANs services       #}
+{# ---------------------------- #}
 {%      for tenant in tenants | arista.avd.natural_sort if tenant in leaf.filter_tenants or "all" in leaf.filter_tenants %}
 ## {{ tenant }} ##
 {%          if tenants[tenant].vrfs is defined %}
 {%              for vrf in tenants[tenant].vrfs | arista.avd.natural_sort if leaf.vrfs is not none and vrf in leaf.vrfs %}
 {# Tenant VLANs w/SVIs #}
 {%                  for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if leaf.svis is not none and svi in leaf.svis %}
-{%                      if tenants[tenant].vrfs[vrf].svis[svi].igmp_snooping is not defined %}
+{%                      if default_igmp_snooping == false %}
+    {{ svi|int }}:
+      enabled: false
+{%                      elif tenants[tenant].vrfs[vrf].svis[svi].igmp_snooping is not defined %}
     {{ svi|int }}:
       enabled: true
 {%                      elif tenants[tenant].vrfs[vrf].svis[svi].igmp_snooping == true %}
@@ -40,10 +49,15 @@
 {%                  endfor %}
 {%              endfor %}
 {%          endif %}
+{# ---------------------------- #}
+{# L2VLANs services             #}
+{# ---------------------------- #}
 {%          if tenants[tenant].l2vlans is defined %}
 {%              for l2vlan in tenants[tenant].l2vlans | arista.avd.natural_sort %}
-{# Tenant VLANs w/o SVIs #}
-{%                      if tenants[tenant].l2vlans[l2vlan].igmp_snooping is not defined %}
+{%                      if default_igmp_snooping == false %}
+    {{ l2vlan|int }}:
+      enabled: false
+{%                      elif tenants[tenant].l2vlans[l2vlan].igmp_snooping is not defined %}
     {{ l2vlan|int }}:
       enabled: true
 {%                      elif tenants[tenant].l2vlans[l2vlan].igmp_snooping == true %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-igmp-snooping.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-igmp-snooping.j2
@@ -23,7 +23,7 @@
 {%     endif %}
 {% endfor %}
   globally_enabled: {{ leaf.igmp_snooping_enabled }}
-{% if igmp_snooping.configured == true and leaf.igmp_snooping_enabled == true %}
+{% if igmp_snooping.configured == true %}
   vlans:
 {# ---------------------------- #}
 {# SVI & L3VLANs services       #}
@@ -34,15 +34,14 @@
 {%              for vrf in tenants[tenant].vrfs | arista.avd.natural_sort if leaf.vrfs is not none and vrf in leaf.vrfs %}
 {# Tenant VLANs w/SVIs #}
 {%                  for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if leaf.svis is not none and svi in leaf.svis %}
-{%                      if tenants[tenant].vrfs[vrf].svis[svi].igmp_snooping_enabled is not defined %}
+{%                      if tenants[tenant].vrfs[vrf].svis[svi].igmp_snooping_enabled is defined %}
+{%                          if tenants[tenant].vrfs[vrf].svis[svi].igmp_snooping_enabled == true and leaf.igmp_snooping_enabled == false %}
     {{ svi|int }}:
       enabled: true
-{%                      elif tenants[tenant].vrfs[vrf].svis[svi].igmp_snooping_enabled == true %}
-    {{ svi|int }}:
-      enabled: true
-{%                      elif tenants[tenant].vrfs[vrf].svis[svi].igmp_snooping_enabled == false %}
+{%                          elif tenants[tenant].vrfs[vrf].svis[svi].igmp_snooping_enabled == false and leaf.igmp_snooping_enabled == true %}
     {{ svi|int }}:
       enabled: false
+{%                          endif %}
 {%                      endif %}
 {%                  endfor %}
 {%              endfor %}
@@ -52,16 +51,15 @@
 {# ---------------------------- #}
 {%          if tenants[tenant].l2vlans is defined %}
 {%              for l2vlan in tenants[tenant].l2vlans | arista.avd.natural_sort %}
-{%                      if tenants[tenant].l2vlans[l2vlan].igmp_snooping_enabled is not defined %}
+{%                  if tenants[tenant].l2vlans[l2vlan].igmp_snooping_enabled is defined %}
+{%                      if tenants[tenant].l2vlans[l2vlan].igmp_snooping_enabled == true and leaf.igmp_snooping_enabled == false %}
     {{ l2vlan|int }}:
       enabled: true
-{%                      elif tenants[tenant].l2vlans[l2vlan].igmp_snooping_enabled == true %}
-    {{ l2vlan|int }}:
-      enabled: true
-{%                      elif tenants[tenant].l2vlans[l2vlan].igmp_snooping_enabled == false %}
+{%                      elif tenants[tenant].l2vlans[l2vlan].igmp_snooping_enabled == false and leaf.igmp_snooping_enabled == true %}
     {{ l2vlan|int }}:
       enabled: false
 {%                      endif %}
+{%                  endif %}
 {%              endfor %}
 {%          endif %}
 {%      endfor %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-igmp-snooping.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-igmp-snooping.j2
@@ -5,10 +5,17 @@
 {%     if tenants[tenant].vrfs is defined %}
 {%         for vrf in tenants[tenant].vrfs | arista.avd.natural_sort if leaf.vrfs is not none and vrf in leaf.vrfs %}
 {%             for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if leaf.svis is not none and svi in leaf.svis %}
-{%                  if tenants[tenant].vrfs[vrf].svis[svi].ip_igmp_snooping is defined %}
+{%                  if tenants[tenant].vrfs[vrf].svis[svi].igmp_snooping is defined %}
 {%                      set igmp_snooping.configured = true %}
 {%                  endif %}
 {%             endfor %}
+{%         endfor %}
+{%     endif %}
+{%     if tenants[tenant].l2vlans is defined %}
+{%         for l2vlan in tenants[tenant].l2vlans | arista.avd.natural_sort  %}
+{%             if tenants[tenant].l2vlans[l2vlan].igmp_snooping is defined %}
+{%                set igmp_snooping.configured = true %}
+{%             endif %}
 {%         endfor %}
 {%     endif %}
 {% endfor %}
@@ -20,17 +27,32 @@
 {%              for vrf in tenants[tenant].vrfs | arista.avd.natural_sort if leaf.vrfs is not none and vrf in leaf.vrfs %}
 {# Tenant VLANs w/SVIs #}
 {%                  for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if leaf.svis is not none and svi in leaf.svis %}
-{%                      if tenants[tenant].vrfs[vrf].svis[svi].ip_igmp_snooping is not defined %}
+{%                      if tenants[tenant].vrfs[vrf].svis[svi].igmp_snooping is not defined %}
     {{ svi|int }}:
       enabled: true
-{%                      elif tenants[tenant].vrfs[vrf].svis[svi].ip_igmp_snooping == true %}
+{%                      elif tenants[tenant].vrfs[vrf].svis[svi].igmp_snooping == true %}
     {{ svi|int }}:
       enabled: true
-{%                      elif tenants[tenant].vrfs[vrf].svis[svi].ip_igmp_snooping == false %}
+{%                      elif tenants[tenant].vrfs[vrf].svis[svi].igmp_snooping == false %}
     {{ svi|int }}:
       enabled: false
 {%                      endif %}
 {%                  endfor %}
+{%              endfor %}
+{%          endif %}
+{%          if tenants[tenant].l2vlans is defined %}
+{%              for l2vlan in tenants[tenant].l2vlans | arista.avd.natural_sort %}
+{# Tenant VLANs w/o SVIs #}
+{%                      if tenants[tenant].l2vlans[l2vlan].igmp_snooping is not defined %}
+    {{ l2vlan|int }}:
+      enabled: true
+{%                      elif tenants[tenant].l2vlans[l2vlan].igmp_snooping == true %}
+    {{ l2vlan|int }}:
+      enabled: true
+{%                      elif tenants[tenant].l2vlans[l2vlan].igmp_snooping == false %}
+    {{ l2vlan|int }}:
+      enabled: false
+{%                      endif %}
 {%              endfor %}
 {%          endif %}
 {%      endfor %}


### PR DESCRIPTION
Add a key to support to enable/disable igmp-snopping per SVI in tenant
section.

If variable is unset, we apply default EOS config (enable). Then we follow user definition

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

## Related Issue(s)

Fixes #315

## Component(s) name

`eos_l3ls_evpn`

## Proposed changes
<!--- Describe your changes in detail -->

```yaml
l3leaf:
  node_groups:
    DC1_LEAF2:
      bgp_as: 65102
      igmp_snooping_enabled: false

[ ... output trunctaed ... ]

l2leaf:
  defaults:
    igmp_snooping_enabled: false

[ ... output trunctaed ... ]

tenants:
  Tenant_A:
    vrfs:
      TENANT_A_PROJECT01:
        svis:
          110:
            igmp_snooping_enabled: false
  Tenant_B:
    l2vlans:
      201:
        igmp_snooping_enabled: false
```

## How to test

In group_vars:

```yaml
l3leaf:
  defaults:
    # virtual router mac for VNIs assigned to Leaf switches
    # format: xx:xx:xx:xx:xx:xx
    virtual_router_mac_address: 00:1c:73:00:dc:01
    platform: vEOS-LAB
    bgp_as: 65100
    spines: [DC1-SPINE1, DC1-SPINE2]
    uplink_to_spine_interfaces: [Ethernet1, Ethernet2]
    mlag_interfaces: [Ethernet3, Ethernet4]
    spanning_tree_priority: 4096
    spanning_tree_mode: mstp
  node_groups:
    DC1_LEAF1:
      bgp_as: 65101
      filter:
        tenants: [ 'Tenant_A', 'Tenant_B' ]
        tags: [ 'POD01', 'DC1' ]
        # tags: [ border ]
      nodes:
        DC1-LEAF1A:
          id: 1
          mgmt_ip: 10.73.255.111/24
          spine_interfaces: [Ethernet1, Ethernet1]
        DC1-LEAF1B:
          id: 2
          mgmt_ip: 10.73.255.112/24
          spine_interfaces: [Ethernet2, Ethernet2]
    DC1_LEAF2:
      bgp_as: 65102
      igmp_snooping_enabled: false
      filter:
        tenants: [ 'Tenant_A', 'Tenant_B' ]
        tags: [ 'POD02', 'DC1' ]
        # tags: [ border ]
      nodes:
        DC1-LEAF2A:
          id: 3
          mgmt_ip: 10.73.255.113/24
          spine_interfaces: [Ethernet3, Ethernet3]
        DC1-LEAF2B:
          id: 4
          mgmt_ip: 10.73.255.114/24
          spine_interfaces: [Ethernet4, Ethernet4]

# DC1 Tenants Networks
# Documentation of Tenant specific information - Vlans/VRFs
tenants:
  # Tenant A Specific Information - VRFs / VLANs
  Tenant_A:
    mac_vrf_vni_base: 10000
    vrfs:
      TENANT_A_PROJECT01:
        vrf_vni: 11
        svis:
          110:
            name: 'PR01-DMZ'
            tags: [DC1]
            enabled: true
            ip_address_virtual: 10.1.10.254/24
            igmp_snooping: false
          111:
            name: 'PR01-TRUST'
            tags: [POD02]
            enabled: true
            ip_address_virtual: 10.1.11.254/24
  Tenant_B:
    mac_vrf_vni_base: 20000
    l2vlans:
      201:
        name: 'B-ELAN-201'
        tags: [DC1]
        igmp_snooping: false
```

Check output on EOS:

```
DC1-LEAF1A(config-if-Vl101)#show ip igmp snooping vlan 110
   Global IGMP Snooping configuration:
-------------------------------------------
IGMP snooping                  : Enabled
IGMPv2 immediate leave         : Enabled
Robustness variable            : 2
Report flooding                : Disabled

Vlan 110 :
----------
IGMP snooping                  : Disabled
IGMPv2 immediate leave         : Default
Multicast router learning mode : pim-dvmrp
IGMP max group limit           : No limit set
Recent attempt to exceed limit : No
Report flooding                : Default
IGMP snooping pruning active   : False
Flooding traffic to VLAN       : True
IGMP snooping proxy active     : False
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
