### PR TITLE
#329 update the template that generates the ipv6 routing doc

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ipv6-routing.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ipv6-routing.j2
@@ -1,21 +1,25 @@
-{% if vrfs is defined and vrfs is not none %}
 ### IPv6 Routing Summary
 
-| VRF | IPv6 Routing Enabled |
-| --- | -------------------- |
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | {% if ipv6_unicast_routing is defined and ipv6_unicast_routing == true %} True | {% else %} False | {% endif %}
+
+{% set IPv6_configured_in_vrf = false %}
+{% if vrfs is defined and vrfs is not none %}
 {%     for vrf in vrfs | arista.avd.natural_sort %}
 {%         if vrfs[vrf].ipv6_routing is defined and vrfs[vrf].ipv6_routing == true %}
+{% set IPv6_configured_in_vrf = true %}
 | {{ vrf }} | True |
 {%         else %}
 | {{ vrf }} | False |
 {%         endif %}
 {%     endfor %}
+{% endif %} 
 
+{% if (ipv6_unicast_routing is defined and ipv6_unicast_routing == true) or (IPv6_configured_in_vrf == true) %}
 ### IPv6 Routing Device Configuration
 
 ```eos
 {% include 'eos/ipv6-routing.j2' %}
 ```
-{% else %}
-IPv6 routing not defined
 {% endif %}


### PR DESCRIPTION
## Related Issue(s)
 
fix #329 

## Component(s) name

`eos_cli_config_gen role`

## Change Summary

update the template to generate ipv6 routing documentation for devices 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [x] Documentation content changes
- [ ] Other (please describe):

## How to test

execute the role `eos_cli_config_gen role` and check the generated doc for devices. 


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
