### PR TITLE
eos_validate_state not properly reporting bgp evpn results

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_validate_state/templates/validate_state_report-csv.j2
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/templates/validate_state_report-csv.j2
@@ -145,7 +145,7 @@ test_id,node,test_category,test_description,test,result,failure_reason
 
 {%    endif %}
 {% endfor %}
-{# ip bgp neighbors peer state - IPv4-UNDERLAY-PEERS Results #}
+{# ip bgp neighbors peer state type: "ipv4" Results #}
 {% for node in groups[fabric_name] | arista.avd.natural_sort %}
 {%     if hostvars[node].ip_bgp_peer_state_results is defined and hostvars[node].ip_bgp_peer_state_results.results is defined %}
 {%         for result in hostvars[node].ip_bgp_peer_state_results.results %}
@@ -157,10 +157,10 @@ test_id,node,test_category,test_description,test,result,failure_reason
 {%         endfor %}
 {%    endif %}
 {% endfor %}
-{# bgp evpn neighbors peer state - IPv4-UNDERLAY-PEERS Results #}
+{# bgp evpn neighbors peer state type: "evpn" Results #}
 {% for node in groups[fabric_name] | arista.avd.natural_sort %}
-{%     if hostvars[node].ip_bgp_peer_state_results is defined and hostvars[node].ip_bgp_peer_state_results.results is defined %}
-{%         for result in hostvars[node].ip_bgp_peer_state_results.results %}
+{%     if hostvars[node].bgp_evpn_peer_state_results is defined and hostvars[node].bgp_evpn_peer_state_results.results is defined %}
+{%         for result in hostvars[node].bgp_evpn_peer_state_results.results %}
 {%             if result.skipped is not defined %}
 {%                 set test_id.value = test_id.value + 1 %}
 {{ test_id.value }},{{ node }},BGP,bgp evpn peer state established (evpn),bgp_neighbor: {{ result.bgp_neighbor.key }},{% if result.failed == false %}PASS{% else %}FAIL,{{ result.msg }}{% endif %}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
- eos_validate_state not properly reporting bgp evpn results.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

## Component(s) name
role: eos_validate_state

## Proposed changes
Update csv template accordingly: https://github.com/aristanetworks/ansible-avd/blob/devel/ansible_collections/arista/avd/roles/eos_validate_state/templates/validate_state_report-csv.j2

## How to test
Run the eos_validate_state role with a fabric in a degraded state and validate the report output.
This can be done by setting one of the spine switches operating routing protocol model to `ribd` as opposed to multi-agent

