### PR TITLE
updated the template that generates managenent interface documentation

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-interfaces.j2
@@ -1,29 +1,31 @@
-
+{% if management_interfaces is defined and management_interfaces is not none %}
 ### Management Interfaces Summary
 
 IPv4
 
 | Management Interface | description | VRF | IP Address | Gateway |
 | -------------------- | ----------- | --- | ---------- | ------- |
-{% for management_interface in management_interfaces | arista.avd.natural_sort %}
+{%     for management_interface in management_interfaces | arista.avd.natural_sort %}
 | {{ management_interface }} | {{ management_interfaces[management_interface].description }} |
-{%- if management_interfaces[management_interface].vrf is defined %} {{ management_interfaces[management_interface].vrf }} {% else %} not defined / default {% endif -%}
+{%- if management_interfaces[management_interface].vrf is defined and management_interfaces[management_interface].vrf is not none %} {{ management_interfaces[management_interface].vrf }} {% else %} default {% endif -%}
 | {{ management_interfaces[management_interface].ip_address }} | {{ management_interfaces[management_interface].gateway }} |
-{% endfor %}
+{%     endfor %}
 
 IPv6
 
 | Management Interface | description | VRF | IPv6 Address | IPv6 Gateway |
 | -------------------- | ----------- | --- | ------------ | ------------ |
-{% for management_interface in management_interfaces | arista.avd.natural_sort %}
+{%     for management_interface in management_interfaces | arista.avd.natural_sort %}
 | {{ management_interface }} | {{ management_interfaces[management_interface].description }} |
-{%- if management_interfaces[management_interface].vrf is defined %} {{ management_interfaces[management_interface].vrf }} {% else %} not defined / default {% endif -%}
-| {%- if management_interfaces[management_interface].ipv6_address is defined and management_interfaces[management_interface].ipv6_address is not none %} {{ management_interfaces[management_interface].ipv6_address }} {% endif %} | {%- if management_interfaces[management_interface].ipv6_gateway is defined and management_interfaces[management_interface].ipv6_gateway is not none %} {{ management_interfaces[management_interface].ipv6_gateway }} {% endif -%} |
-{% endfor %}
+{%- if management_interfaces[management_interface].vrf is defined and management_interfaces[management_interface].vrf is not none %} {{ management_interfaces[management_interface].vrf }} {% else %} default {% endif -%}
+| {%- if management_interfaces[management_interface].ipv6_address is defined and management_interfaces[management_interface].ipv6_address is not none %} {{ management_interfaces[management_interface].ipv6_address }} {% else %} not configured {% endif %} | {%- if management_interfaces[management_interface].ipv6_gateway is defined and management_interfaces[management_interface].ipv6_gateway is not none %} {{ management_interfaces[management_interface].ipv6_gateway }} {% else %} not configured {% endif -%} |
+{%     endfor %}
 
 ### Management Interfaces Device Configuration
 
 ```eos
 {% include 'eos/management-interfaces.j2' %}
 ```
-
+{% else %}
+Management interfaces not defined
+{% endif %}


### PR DESCRIPTION
## Related Issue(s)
 
fix #325 

## Component(s) name

`eos_cli_config_gen role`

## Change Summary

updated the template that generates managenent interface documentation

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [x] Documentation content changes
- [ ] Other (please describe):

## How to test

execute the role `eos_cli_config_gen role` and check the generated doc for devices. 


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
