### PR TITLE
ethernet: extend speed options

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -632,7 +632,9 @@ ethernet_interfaces:
   <Ethernet_interface_1 >:
     description: < description >
     shutdown: < true | false >
-    speed: < interface_speed >
+    speed:
+      mode: < no-auto | forced | auto >
+      speed: < interface_speed >
     mtu: < mtu >
     type: < routed | switched >
     vrf: < vrf_name >
@@ -672,7 +674,9 @@ ethernet_interfaces:
   <Ethernet_interface_2 >:
     description: < description >
     shutdown: < true | false >
-    speed: < interface_speed >
+    speed:
+      mode: < no-auto | forced | auto >
+      speed: < interface_speed >
     mtu: < mtu >
     vlans: "< list of vlans as string >"
     native_vlan: <native vlan number>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -9,8 +9,17 @@ interface {{ ethernet_interface }}
 {%         if ethernet_interfaces[ethernet_interface].shutdown is defined and ethernet_interfaces[ethernet_interface].shutdown == true %}
    shutdown
 {%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].speed is defined and ethernet_interfaces[ethernet_interface].speed is not none %}
-   speed forced {{ ethernet_interfaces[ethernet_interface].speed }}
+{%         if ethernet_interfaces[ethernet_interface].speed is defined and ethernet_interfaces[ethernet_interface].speed.mode is defined and ethernet_interfaces[ethernet_interface].speed.mode == 'no-auto' %}
+{%           if ethernet_interfaces[ethernet_interface].speed.speed is defined and ethernet_interfaces[ethernet_interface].speed.speed is not none %}
+   speed {{ ethernet_interfaces[ethernet_interface].speed.speed }}
+{%           endif %}
+{%         elif ethernet_interfaces[ethernet_interface].speed is defined and ethernet_interfaces[ethernet_interface].speed.mode is defined and ethernet_interfaces[ethernet_interface].speed.mode == 'forced' %}
+{%           if ethernet_interfaces[ethernet_interface].speed.speed is defined and ethernet_interfaces[ethernet_interface].speed.speed is not none %}
+   speed forced {{ ethernet_interfaces[ethernet_interface].speed.speed }}
+{%           endif %}
+{%         elif ethernet_interfaces[ethernet_interface].speed is defined and ethernet_interfaces[ethernet_interface].speed.mode is defined and ethernet_interfaces[ethernet_interface].speed.mode == 'auto' %}
+   speed auto {% if ethernet_interfaces[ethernet_interface].speed.speed is defined and ethernet_interfaces[ethernet_interface].speed.speed is not none %}{{ ethernet_interfaces[ethernet_interface].speed.speed }}{% endif %}
+
 {%         endif %}
 {%         if ethernet_interfaces[ethernet_interface].channel_group is defined and ethernet_interfaces[ethernet_interface].channel_group is not none %}
    channel-group {{ ethernet_interfaces[ethernet_interface].channel_group.id }} mode {{ ethernet_interfaces[ethernet_interface].channel_group.mode }}


### PR DESCRIPTION
Change datamodel as described in https://github.com/aristanetworks/ansible-avd/issues/319
to support additional speed options per ethernet interface.

```
  speed:
    mode: < no-auto | forced | auto >
    speed: < interface_speed >
```

<!-- All PR should follow this template to allow a clean and transparent review -->
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [x] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
 https://github.com/aristanetworks/ansible-avd/issues/319

## Component(s) name
* eos_cli_config_gen

## Proposed changes
Change datamodel to support additional link-speed options.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
