### PR TITLE
Implement ip-helper for dhcp-relay

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
@@ -782,6 +782,12 @@ tenants:
         # The VRF VNI range is limited.
         vrf_vni: <1-1024>
 
+        # IP Helper for DHCP relay
+        ip_helpers:
+          < IPv4 dhcp server IP >:
+            source_interface: < interface-name >
+            source_vrf: < VRF to originate DHCP relay packets to DHCP server. If not set, uses current VRF >
+
         # Enable VTEP Network diagnostics | Optional.
         # This will create a loopback with virtual source-nat enable to perform diagnostics from the switch.
         vtep_diagnostic:
@@ -827,6 +833,7 @@ tenants:
             ip_helpers:
               < IPv4 dhcp server IP >:
                 source_interface: < interface-name >
+                source_vrf: < VRF to originate DHCP relay packets to DHCP server. If not set, uses current VRF >
 
             # Define node specific configuration, such as unique IP addresses.
             nodes:

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
@@ -823,6 +823,11 @@ tenants:
             # Optional
             ip_virtual_router_address: < IPv4_address/Mask >
 
+            # IP Helper for DHCP relay
+            ip_helpers:
+              < IPv4 dhcp server IP >:
+                source_interface: < interface-name >
+
             # Define node specific configuration, such as unique IP addresses.
             nodes:
               < l3_leaf_inventory_hostname_1 >:

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-vlan-interfaces.j2
@@ -33,6 +33,14 @@
 {%                 if tenants[tenant].vrfs[vrf].svis[svi].mtu is defined %}
     mtu: {{ tenants[tenant].vrfs[vrf].svis[svi].mtu }}
 {%                 endif %}
+{%                 if tenants[tenant].vrfs[vrf].svis[svi].ip_helpers is defined and tenants[tenant].vrfs[vrf].svis[svi].ip_helpers is not none %}
+    ip_helpers:
+{%                     for helper_ip in tenants[tenant].vrfs[vrf].svis[svi].ip_helpers %}
+      {{ helper_ip }}:
+        source_interface: {{ tenants[tenant].vrfs[vrf].svis[svi].ip_helpers[helper_ip].source_interface }}
+        vrf: {{ vrf }}
+{%                     endfor %}
+{%                 endif %}
 {# VLAN interface for iBGP peering in overlay VRFs #}
 {%                 if loop.last and type == "l3leaf" and leaf.mlag == true %}
   Vlan{{ mlag_ibgp_peering_vrfs.base_vlan + (tenants[tenant].vrfs[vrf].vrf_vni - 1) }}:

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-vlan-interfaces.j2
@@ -33,7 +33,14 @@
 {%                 if tenants[tenant].vrfs[vrf].svis[svi].mtu is defined %}
     mtu: {{ tenants[tenant].vrfs[vrf].svis[svi].mtu }}
 {%                 endif %}
-{%                 if tenants[tenant].vrfs[vrf].svis[svi].ip_helpers is defined and tenants[tenant].vrfs[vrf].svis[svi].ip_helpers is not none %}
+{%                 if tenants[tenant].vrfs[vrf].ip_helpers is defined and tenants[tenant].vrfs[vrf].ip_helpers is not none %}
+    ip_helpers:
+{%                     for helper_ip in tenants[tenant].vrfs[vrf].ip_helpers %}
+      {{ helper_ip }}:
+        source_interface: {{ tenants[tenant].vrfs[vrf].ip_helpers[helper_ip].source_interface }}
+        vrf: {{ vrf }}
+{%                     endfor %}
+{%                 elif tenants[tenant].vrfs[vrf].svis[svi].ip_helpers is defined and tenants[tenant].vrfs[vrf].svis[svi].ip_helpers is not none %}
     ip_helpers:
 {%                     for helper_ip in tenants[tenant].vrfs[vrf].svis[svi].ip_helpers %}
       {{ helper_ip }}:

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-vlan-interfaces.j2
@@ -38,7 +38,11 @@
 {%                     for helper_ip in tenants[tenant].vrfs[vrf].ip_helpers %}
       {{ helper_ip }}:
         source_interface: {{ tenants[tenant].vrfs[vrf].ip_helpers[helper_ip].source_interface }}
+{%                          if tenants[tenant].vrfs[vrf].ip_helpers[helper_ip].source_vrf is defined and tenants[tenant].vrfs[vrf].ip_helpers[helper_ip].source_vrf is not none %}
+        vrf: {{ tenants[tenant].vrfs[vrf].ip_helpers[helper_ip].source_vrf }}
+{%                          else %}
         vrf: {{ vrf }}
+{%                          endif %}
 {%                     endfor %}
 {%                 elif tenants[tenant].vrfs[vrf].svis[svi].ip_helpers is defined and tenants[tenant].vrfs[vrf].svis[svi].ip_helpers is not none %}
     ip_helpers:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
## Change Summary

Apply data model from eos_cli_config_gen in eos_l3ls_evpn

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Fixes #312

## Component(s) name

`eos_l3ls_evpn`

## Proposed changes

Apply data model from `eos_cli_config_gen` in `eos_l3ls_evpn`

```yaml
tenants:
  # Tenant A Specific Information - VRFs / VLANs
  Tenant_A:
    mac_vrf_vni_base: 10000
    vrfs:
      TENANT_A_PROJECT01:
        vrf_vni: 11
        svis:
          311:
            name: 'PR01-TRUST-DHCP'
            tags: [POD01]
            enabled: true
            ip_address_virtual: 10.1.31.254/24
            ip_helpers:
              1.1.1.1:
                source_interface: lo100
  Tenant_B:
    mac_vrf_vni_base: 11000
    vrfs:
      ip_helpers:
        1.1.1.1:
          source_interface: lo100
      TENANT_B_PROJECT01:
        vrf_vni: 12
        svis:
          311:
            name: 'PR01-TRUST-DHCP'
            tags: [POD01]
            enabled: true
            ip_address_virtual: 10.2.31.254/24

```

## How to test

Rendering is as below for `eos_cli_config_gen`:

```yaml
  Vlan311:
    tenant: Tenant_A
    tags: ['POD01']
    description: PR01-TRUST-DHCP
    vrf: TENANT_A_PROJECT01
    ip_address_virtual: 10.1.31.254/24
    ip_helpers:
      1.1.1.1:
        source_interface: lo100
        vrf: TENANT_A_PROJECT01
```

And EOS configuration:

```eos
interface Vlan311
   description PR01-TRUST-DHCP
   vrf TENANT_A_PROJECT01
   ip address virtual 10.1.31.254/24
   ip helper-address 1.1.1.1 vrf TENANT_A_PROJECT01  source-interface lo100
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
