### PR TITLE
Add lacp fallback

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -596,6 +596,8 @@ port_channel_interfaces:
     trunk_groups:
       - < trunk_group_name_1 >
       - < trunk_group_name_2 >
+    lacp_fallback_timeout: <timeout in seconds, 0-300 (default 90) >
+    lacp_fallback_mode: < individual | static >
     qos:
       trust: < cos | dscp >
   < Port-Channel_interface_2 >:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/port-channel-interfaces.j2
@@ -1,8 +1,8 @@
 {% if port_channel_interfaces is defined and port_channel_interfaces is not none %}
 ### Port-Channel Interfaces Summary
 
-| Interface | Description | MTU | Type | Mode | Allowed VLANs (trunk) | Trunk Group | MLAG ID | EVPN ESI | VRF | IP Address | IPv6 Address |
-| --------- | ----------- | --- | ---- | ---- | --------------------- | ----------- | ------- | -------- | --- | ---------- | ------------ |
+| Interface | Description | MTU | Type | Mode | Allowed VLANs (trunk) | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI | VRF | IP Address | IPv6 Address |
+| --------- | ----------- | --- | ---- | ---- | --------------------- | ----------- | --------------------- ! ------------------ | ------- | -------- | --- | ---------- | ------------ |
 {%   for port_channel_interface in port_channel_interfaces | arista.avd.natural_sort %}
 | {{ port_channel_interface }} | {{ port_channel_interfaces[port_channel_interface].description }} |
 {%-    if port_channel_interfaces[port_channel_interface].mtu is defined and port_channel_interfaces[port_channel_interface].mtu  != 1500  %} {{ port_channel_interfaces[port_channel_interface].mtu }} {% else %} 1500 {% endif -%} |
@@ -10,6 +10,8 @@
 {%-    if port_channel_interfaces[port_channel_interface].mode is defined %} {{ port_channel_interfaces[port_channel_interface].mode }} {% else %} access {% endif -%} |
 {%-    if port_channel_interfaces[port_channel_interface].vlans is defined %} {{ port_channel_interfaces[port_channel_interface].vlans }} {% else %} - {% endif -%} |
 {%-    if port_channel_interfaces[port_channel_interface].trunk_groups is defined %} {% for  trunk_group in port_channel_interfaces[port_channel_interface].trunk_groups | arista.avd.natural_sort %}{{ trunk_group }}{% if not loop.last %}<br>{% endif %} {% endfor %}{% else %} - {% endif -%} |
+{%-    if port_channel_interfaces[port_channel_interface].lacp_fallback_timeout is defined %} {{ port_channel_interfaces[port_channel_interface].lacp_fallback_timeout }} {% else %} - {% endif -%} |
+{%-    if port_channel_interfaces[port_channel_interface].lacp_fallback_mode is defined %} {{ port_channel_interfaces[port_channel_interface].lacp_fallback_mode }} {% else %} - {% endif -%} |
 {%-    if port_channel_interfaces[port_channel_interface].mlag is defined %} {{ port_channel_interfaces[port_channel_interface].mlag }} {% else %} - {% endif -%} |
 {%-    if port_channel_interfaces[port_channel_interface].esi is defined %} {{ port_channel_interfaces[port_channel_interface].esi }} {% else %} - {% endif -%} |
 {%-    if port_channel_interfaces[port_channel_interface].vrf is defined %} {{ port_channel_interfaces[port_channel_interface].vrf }} {% else %} - {% endif -%} |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
@@ -47,6 +47,12 @@ interface {{ port_channel_interface }}
 {%         if port_channel_interfaces[port_channel_interface].lacp_id is defined and port_channel_interfaces[port_channel_interface].lacp_id is not none %}
    lacp system-id {{ port_channel_interfaces[port_channel_interface].lacp_id }}
 {%         endif %}
+{%         if port_channel_interfaces[port_channel_interface].lacp_fallback_timeout is defined and port_channel_interfaces[port_channel_interface].lacp_fallback_timeout is not none %}
+   port-channel lacp fallback timeout {{ lacp_fallback_timeout }}
+{%         endif %}
+{%         if port_channel_interfaces[port_channel_interface].lacp_fallback_mode is defined and port_channel_interfaces[port_channel_interface].lacp_fallback_mode is not none %}
+   port-channel lacp fallback {{ lacp_fallback_mode }}
+{%         endif %}
 {%         if port_channel_interfaces[port_channel_interface].qos.trust is defined and port_channel_interfaces[port_channel_interface].qos.trust is not none %}
    qos trust {{ port_channel_interfaces[port_channel_interface].qos.trust }}
 {%         endif %}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

## Component(s) name
`eos_cli_config_gen`

## Proposed changes
Add LACP fallback support to port-channel-interfaces.j2.
The port-profile data model can look like:
```yml
lacp_fallback_mode: <individual | static>
lacp_fallback_timeout: <timeout in seconds>
```
## How to test
Update template to support following data-model:
```yml
<port_channel_interfaces.#>
   lacp_fallback_mode: <individual | static>
   lacp_fallback_timeout: <seconds>
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [ ] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
