### PR TITLE
Fix issue in doucmentation for logging when VRF is missing

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/logging.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/logging.j2
@@ -51,6 +51,7 @@
 
 | VRF | Hosts |
 | --- | ---------------- |
+{%     if logging.vrfs is defined and logging.vrfs is not none %}
 {%          for vrf in logging.vrfs | arista.avd.natural_sort %}
 {%              if logging.vrfs[vrf].hosts is defined and logging.vrfs[vrf].hosts is not none %}
 {%                  for host in logging.vrfs[vrf].hosts | arista.avd.natural_sort %}
@@ -58,6 +59,7 @@
 {%                  endfor %}
 {%              endif %}
 {%          endfor %}
+{%     endif %}
 
 ### Logging Servers and Features Device Configuration
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
## Change Summary

## Summary

When `logging` is set without VRF, `arista.avd.eos_cli_config_gen` fails to generate documentation with the following error message

```shell
fatal: [DC1-AGG01 -> localhost]: FAILED! => changed=false
  msg: 'AnsibleUndefinedVariable: ''dict object'' has no attribute ''vrfs'''
```

Reported by @mpergament

## Role or Module Name

<!--- Insert, BELOW THIS COMMENT, the name of the module, plugin, task or feature
-->

`arista.avd.eos_cli_config_gen` 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Fixes #378

## Component(s) name

## Proposed changes
<!--- Describe your changes in detail -->

## How to test

Host variable for logging part:

```yaml
### Logging ###
logging:
  console: informational
  monitor: debugging
```

<!--- What did you expect to happen when running the steps above? -->

```shell
TASK [eos_cli_config_gen : Generate device documentation] 
...
changed: [DC1-AGG01 -> localhost]
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
