### PR TITLE
Support setting hardware specific speed-groups for SERDES links

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -31,6 +31,7 @@
     - [Sflow](#sflow)
     - [Redundancy](#redundancy)
     - [SNMP Settings](#snmp-settings)
+    - [Hardware Speed-Group Settings](#speed-group-settings)
     - [Spanning Tree](#spanning-tree)
     - [Platform](#platform)
     - [Tacacs+ Servers](#tacacs-servers)
@@ -428,6 +429,18 @@ snmp_server:
       enable: < true | false >
     - name: < vrf_name >
       enable: < true | false >
+```
+
+### Speed-Group Settings
+
+```yaml
+hardware:
+  speed_groups:
+    1:
+      serdes: <10g | 25g>
+    2:
+      serdes: <10g | 25g>
+    ...
 ```
 
 ### Spanning Tree

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
@@ -53,6 +53,8 @@ hostname {{ inventory_hostname }}
 {% include 'eos/redundancy.j2' %}
 {# snmp settings #}
 {% include 'eos/snmp-settings.j2' %}
+{# hardware speed-group configuration #}
+{% include 'eos/speed-group.j2' %}
 {# spanning-tree #}
 {% include 'eos/spanning-tree.j2' %}
 {# platform #}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/speed-group.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/speed-group.j2
@@ -1,0 +1,7 @@
+{# eos - interface speed-group #}
+{% if hardware is defined and hardware.speed_groups is defined and hardware.speed_groups is not none %}
+!
+{%   for speed_group in hardware.speed_groups %}
+hardware speed-group{{ speed_group }} serdes {{ hardware.speed_groups[speed_group].serdes }}
+{%   endfor %}
+{% endif %}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
## Change Summary
Setting to operation a new DCS-7280SR2-48YC6-F system I've noticed that I need to explicitly configure either the port speed on my individual interfaces or use the global `hardware speed-group12 serdes` command.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [x] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #346 

## Component(s) name

## Proposed changes
**Proposed Data-Model**
```
speed_group:
  - id: 1
    serdes: <10g | 25g>
```

Using the following YAML statement:
```
speed_group:
  - id: 1
    serdes: 10g
  - id: 2
    serdes: 10g
  - id: 3
    serdes: 25g
```

will render the EOS configuration:
```
hardware speed-group1 serdes 10g
hardware speed-group2 serdes 10g
hardware speed-group3 serdes 25g
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
