### PR TITLE
Support for Overlay Controllers / EVPN Route servers & Flexible EVPN Overlay Peerings (Take 2)

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
@@ -422,7 +422,7 @@ The variables should be applied to all devices in the fabric.
 
 ```yaml
 # define the layer type
-type: < spine | l3leaf | l2leaf >
+type: < spine | l3leaf | l2leaf | super-spine | overlay-controller >
 ```
 
 **Example:**
@@ -436,6 +436,12 @@ type: l3leaf
 
 # Defined in L2LEAFS.yml
 type: l2leaf
+
+# Defined in SUPER-SPINES.yml
+type: super-spine
+
+# Defined in ROUTE-SERVERS.yml
+type: overlay-controller
 ```
 
 #### Spine Variables
@@ -1563,6 +1569,129 @@ Following variables must be now defined on DC and not POD level:
 
 - `p2p_uplinks_mtu`
 - `bgp_peer_groups`
+
+## Role Enchancements for dedicated Overlay Controllers
+
+This enhancement will allow support for dedicated Overlay Controllers connected to fabric nodes.
+Overlay Controllers can be connected to any other device type.
+Overlay Controllers can currently only be used as EVPN Overlay Controllers
+
+### Inventory Structure
+
+The inventory must have a dedicated group for Overlay Controllers. Example:
+
+```yaml
+all:
+  children:
+    < DC-group-name >:
+      children:
+        < Overlay Controllers group name >:
+          hosts:
+            < Overlay Controller name >:
+              ansible_host: < management IP >
+            < Overlay Controller name >:
+              ansible_host: < management IP >
+            ...
+```
+
+### Additional Variables Required For Overlay Controllers Deployment
+
+Defaults:
+```yaml
+max_overlay_controller_to_switch_links: 1
+```
+
+Assigned to the DC group:
+
+```yaml
+overlay_controller:
+  platform: <platform>   # overlay-controller platform
+  defaults: #Default variables, can be overridden when defined under each node
+    remote_switches: [ <switch_inventory_hostname> , <switch_inventory_hostname> ] #Remote Switches connected to uplink interfaces
+    uplink_to_remote_switches: [ <uplink_interface> , <uplink_interface> ]
+    bgp_as: <BGP AS>
+  nodes:
+    <inventory_hostname>:
+      id: <number> # Starting from 1
+      mgmt_ip: < IPv4_address/Mask >
+      remote_switches_interfaces: [ <remote_switch_interface> , <remote_switch_interface> ] # Interfaces on remote switch
+# Point to Point Network Summary range, assigned as /31 for each uplink interfaces
+# Assign range larger than [ total overlay_controllers * max_overlay_controller_to_switch_links * 2]
+overlay_controller_p2p_network_summary: < IPv4_network/Mask >
+# IP address summary for BGP evpn overlay peering loopback for Overlay Controllers | Required
+# Assigned as /32 to Loopback0
+# Assign range larger then:
+# [ total overlay_controllers ]
+overlay_controller_loopback_network_summary: < IPv4_network/Mask >
+# additional lines for overlay-controller BGP config
+overlay_controller_bgp_defaults:
+  #  - update wait-for-convergence
+  #  - update wait-install
+  - no bgp default ipv4-unicast
+  - distance bgp 20 200 200
+  - graceful-restart restart-time 300
+  - graceful-restart
+```
+
+Assigned to Overlay Controller Group:
+
+```yaml
+type: overlay-controller # identifies every host in the group as overlay-controller
+```
+
+
+## Role Enhancements for Flexible EVPN Overlay peering design
+
+This enhancement will allow a more flexible EVPN Overlay peering design.
+Overlay peerings can be configured to any of the following options as well as combinations thereof:
+* l3leaf <-> spine
+* l3leaf <-> super-spine
+* l3leaf <-> overlay-controller
+* spine <-> spine (in other PODs)
+* spine <-> super-spine
+* spine <-> overlay-controller
+* super-spine <-> super-spine (in other DCs)
+* super-spine <-> overlay-controller
+* overlay-controller <-> overlay-controller (in other DCs)
+The overlay peerings will be derived from the variable `evpn_overlay_controller_groups` on the "client".
+Ex. setting `evpn_overlay_controller_groups : [ DC1_SUPER_SPINES ]` in the `DC1-POD1-L3LEAFS.yml` group_var file will setup evpn peerings between 
+all the l3leafs in this group and all devices in the group `DC1_SUPER_SPINES`. The devices in group `DC1_SUPER_SPINES` will detect that others are
+pointing at them, and configure the peering as well.
+
+Currently all spines, super-spines and overlay-controllers will have the EVPN adress-family and EVPN BGP peer-group configured even if they have no
+EVPN overlay peerings.
+
+To be backward compatible the templates will use the old behavior of configuring EVPN Overlay between all spines and l3leafs if `evpn_overlay_controller_groups`
+is not defined on the l3leafs group.
+
+### Inventory Structure
+
+There are no specific requirements for this feature, so this is just an example for reference.
+
+```yaml
+all:
+  children:
+    < DC-group-name >:
+      children:
+        < Overlay Controllers group name >:
+          <-- omitted -->
+        < Super Spines group name >:
+          <-- omitted -->
+        < DC POD 1 group name >:
+          children:
+            < spines group >:
+              <-- omitted -->
+            < leaf group >:
+              <-- omitted -->
+```
+
+### Additional Variables For Flexible EVPN Overlay peerings
+
+Assigned to any device group:
+
+```yaml
+evpn_overlay_controller_groups: [ < inventory_group > ]  # One or more groups containing EVPN RR/RS.
+```
 
 ## License
 

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
@@ -1625,8 +1625,6 @@ overlay_controller_p2p_network_summary: < IPv4_network/Mask >
 overlay_controller_loopback_network_summary: < IPv4_network/Mask >
 # additional lines for overlay-controller BGP config
 overlay_controller_bgp_defaults:
-  #  - update wait-for-convergence
-  #  - update wait-install
   - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - graceful-restart restart-time 300

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/defaults/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/defaults/main.yml
@@ -52,8 +52,6 @@ leaf_bgp_defaults:
   - graceful-restart
 
 overlay_controller_bgp_defaults:
-  - update wait-for-convergence
-  - update wait-install
   - no bgp default ipv4-unicast
   - distance bgp 20 200 200
   - graceful-restart restart-time 300

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/defaults/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/defaults/main.yml
@@ -19,6 +19,7 @@ internal_vlan_order:
 
 max_l3leaf_to_spine_links: 1
 max_spine_to_super_spine_links: 1
+max_overlay_controller_to_switch_links: 1
 
 terminattr_ingestgrpcurl_port: 9910
 terminattr_smashexcludes: "ale,flexCounter,hardware,kni,pulse,strata"
@@ -44,6 +45,14 @@ spine_bgp_defaults:
   - graceful-restart
 
 leaf_bgp_defaults:
+  - update wait-install
+  - no bgp default ipv4-unicast
+  - distance bgp 20 200 200
+  - graceful-restart restart-time 300
+  - graceful-restart
+
+overlay_controller_bgp_defaults:
+  - update wait-for-convergence
   - update wait-install
   - no bgp default ipv4-unicast
   - distance bgp 20 200 200

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l3leaf-yml.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l3leaf-yml.j2
@@ -203,6 +203,35 @@
 {%         endif%}
 {%     endfor %}
 {% endfor %}
+{# Gather overlay peering information #}
+{% set switch.evpn_overlay_peers = [] %}
+{# #}
+{# Look for evpn_overlay_controllers / servers where we are client #}
+{% if evpn_overlay_controller_groups is defined and evpn_overlay_controller_groups is not none %}
+{%     for evpn_overlay_controller_group in evpn_overlay_controller_groups %}
+{%         for evpn_overlay_controller in groups[evpn_overlay_controller_group] %}
+{# Found a match. Gathering information for this peer #}
+{%             set evpn_overlay_controller_vars = hostvars[evpn_overlay_controller] %}
+{%             set peer = namespace() %}
+{%             set peer.description = evpn_overlay_controller %}
+{%             if evpn_overlay_controller_vars.type == 'spine' %}
+{%                 set peer.bgp_as = evpn_overlay_controller_vars.spine.bgp_as %}
+{%                 set peer.ip = evpn_overlay_controller_vars.overlay_loopback_network_summary | ipaddr('network') | ipmath(evpn_overlay_controller_vars.spine.nodes[evpn_overlay_controller].id) %}
+{%             elif evpn_overlay_controller_vars.type == 'super-spine' %}
+{%                 set peer.bgp_as = evpn_overlay_controller_vars.super_spine.bgp_as %}
+{%                 set peer.ip = evpn_overlay_controller_vars.super_spine_loopback_network_summary  | ipaddr('network') | ipmath(evpn_overlay_controller_vars.super_spine.nodes[evpn_overlay_controller].id) %}
+{%             elif evpn_overlay_controller_vars.type == 'overlay-controller' %}
+{%                 if evpn_overlay_controller_vars.overlay_controller.nodes[evpn_overlay_controller].bgp_as is defined %}
+{%                     set peer.bgp_as = evpn_overlay_controller_vars.overlay_controller.nodes[evpn_overlay_controller].bgp_as %}
+{%                 else %}
+{%                     set peer.bgp_as = evpn_overlay_controller_vars.overlay_controller.defaults.bgp_as %}
+{%                 endif %}
+{%                 set peer.ip = evpn_overlay_controller_vars.overlay_controller_loopback_network_summary | ipaddr('network') | ipmath(evpn_overlay_controller_vars.overlay_controller.nodes[evpn_overlay_controller].id) %}
+{%             endif %}
+{%             do switch.evpn_overlay_peers.append(peer) %}
+{%         endfor %}
+{%     endfor %}
+{% endif %}
 ### Leaf Info ###
 l3leaf_node_group: {{ leaf.group }}
 switch_platform: {{ switch.platform }}
@@ -347,6 +376,8 @@ ethernet_interfaces:
 {% include 'l3leaf_l2leafs_uplinks/l3leaf-ethernet-uplinks.j2' %}
 {# Server - Interfaces Configuration #}
 {% include 'edge_ports/leaf-server-interfaces.j2' %}
+{# Point-to-Point Interfaces to overlay-controller #}
+{% include 'fabric/interfaces/switch-p2p-interfaces-overlay-controller.j2' %}
 
 
 {# loopback interfaces #}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-overlay-controller-yml.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-overlay-controller-yml.j2
@@ -1,14 +1,44 @@
-{# Spine Switch Configuration #}
+{# Overlay Controller Configuration #}
 ## Ansible Generated ##
 
 ### {{ inventory_hostname }} ###
-
-{# Set Spine Variables #}
+{# Set Overlay Controller Variables #}
 {% set switch = namespace() %}
-{% set switch.platform = spine.platform %}
-{% set switch.mgmt_ip = spine.nodes[inventory_hostname].mgmt_ip %}
+{% set switch.platform = overlay_controller.platform %}
+{% set switch.mgmt_ip = overlay_controller.nodes[inventory_hostname].mgmt_ip %}
 {% set switch.spanning_tree_mode = "none" %}
-{% set switch.bgp_route_reflector = spine.nodes[inventory_hostname].bgp_route_reflector | default(false) %}
+{% for node in overlay_controller.nodes | arista.avd.natural_sort %}
+{%     if node == inventory_hostname %}
+{%         set switch.id = overlay_controller.nodes[node].id %}
+{%         if overlay_controller.nodes[node].bgp_as is defined %}
+{%             set switch.bgp_as = overlay_controller.nodes[node].bgp_as %}
+{%         else %}
+{%             set switch.bgp_as = overlay_controller.defaults.bgp_as %}
+{%         endif %}
+{# Get local RR/RS interface to configure #}
+{%         if overlay_controller.nodes[node].uplink_to_remote_switches is defined %}
+{%             set switch.uplink_to_remote_switches = overlay_controller.nodes[node].uplink_to_remote_switches %}
+{%         else %}
+{%             set switch.uplink_to_remote_switches = overlay_controller.defaults.uplink_to_remote_switches %}
+{%         endif %}
+{# Get remote switch interface to configure #}
+{%         if overlay_controller.nodes[node].remote_switches_interfaces is defined %}
+{%             set switch.remote_switches_interfaces = overlay_controller.nodes[node].remote_switches_interfaces %}
+{%         endif %}
+{# Get remote hostname #}
+{%         if overlay_controller.nodes[node].remote_switches is defined %}
+{%             set switch.remote_switches = overlay_controller.nodes[node].remote_switches %}
+{%         else %}
+{%             set switch.remote_switches = overlay_controller.defaults.remote_switches %}
+{%         endif %}
+{# Get group of remote devices where RS/RR are connected #}
+{%         if overlay_controller.nodes[node].remote_switches_group is defined %}
+{%             set switch.remote_switches_group = overlay_controller.nodes[node].remote_switches_group %}
+{%         else %}
+{%             set switch.remote_switches_group = overlay_controller.defaults.remote_switches_group %}
+{%         endif %}
+{%     endif %}
+{% endfor %}
 {# Build variables for fabric protocols #}
 {# Logic for underlay routing protocol configured on device #}
 {% if underlay_routing_protocol is defined %}
@@ -42,13 +72,6 @@
 {% else %}
 {%     set switch.overlay_routing_protocol = 'ebgp' %}
 {% endif %}
-{# Logic for route_reflector role #}
-{% set switch.is_route_reflector = false %}
-{% for spine_node in spine.nodes | arista.avd.natural_sort %}
-{%     if spine.nodes[spine_node].bgp_route_reflector is defined and spine.nodes[spine_node].bgp_route_reflector == true %}
-{%         set switch.is_route_reflector = true %}
-{%     endif%}
-{% endfor %}
 {# Gather overlay peering information #}
 {% set switch.evpn_overlay_peers = [] %}
 {# #}
@@ -120,7 +143,8 @@
 {%         endfor %}
 {%     endfor %}
 {% endif %}
-### Spine Info ###
+
+### Overlay Controller Info ###
 switch_platform: {{ switch.platform }}
 switch_mgmt_ip: {{ switch.mgmt_ip }}
 
@@ -134,7 +158,7 @@ hardware_counters:
 {% include 'base/hardware-counters.j2' %}
 
 {# Daemon TerminAttr #}
-### Daemon TerminAttr ###
+### Daemon TerminAttr
 daemon_terminattr:
 {% include 'base/daemon-terminattr.j2' %}
 
@@ -161,6 +185,11 @@ load_interval:
 ### Queue Monitor Lenght ###
 queue_monitor_length:
 {% include 'base/queue-monitor-length.j2' %}
+
+{# logging #}
+### Logging ###
+logging:
+{% include 'base/logging.j2' %}
 
 {# name servers #}
 ### Name Servers ###
@@ -214,16 +243,14 @@ bfd_multihop:
 {# Ethernet Interfaces #}
 ### Ethernet Interfaces ###
 ethernet_interfaces:
-{# Point-to-Point Interfaces to l3leaf #}
-{% include 'fabric/interfaces/spine-p2p-interfaces.j2' %}
-{# Point-to-Point Interfaces to overlay-controller #}
-{% include 'fabric/interfaces/switch-p2p-interfaces-overlay-controller.j2' %}
+{% include 'fabric/interfaces/overlay-controller-p2p-interfaces.j2' %}
 
-{# Loopback Interfaces #}
+{# loopback interfaces #}
 ### Loopback Interfaces ###
 loopback_interfaces:
-{% include 'fabric/interfaces/spine-overlay-loopback.j2' %}
-
+{# overlay peering interface #}
+{% include 'fabric/interfaces/overlay-controller-loopback.j2'%}
+{# intentional blank line #}
 
 {# Management Interfaces #}
 ### Management Interfaces ###
@@ -248,43 +275,36 @@ static_routes:
 {# prefix_lists #}
 ### prefix-lists ###
 prefix_lists:
-{% include 'fabric/bgp_base/spine-prefix-lists.j2' %}
-
+{% include 'fabric/bgp_base/overlay-controller-prefix-lists.j2' %}
 
 {# route maps #}
 ### route-maps ###
 route_maps:
 {% include 'fabric/bgp_base/route-maps.j2' %}
 
-
-{# peer-filter #}
-### peer-filters ###
-peer_filters:
-
-
 {# ##### BGP Configurartion ##### #}
 ### Routing - BGP ###
 router_bgp:
 {# underlay and overlay #}
-{% include 'fabric/bgp_base/spine-router-bgp-base.j2' %}
+{% include 'fabric/bgp_base/overlay-controller-router-bgp-base.j2' %}
   peer_groups:
-{% include 'fabric/bgp_base/spine-router-bgp-peer-groups.j2' %}
+{% include 'fabric/bgp_base/overlay-controller-router-bgp-peer-groups.j2' %}
   neighbors:
-{% include 'fabric/bgp_base/spine-router-bgp-neighbors.j2' %}
+{% include 'fabric/bgp_base/overlay-controller-router-bgp-neighbors.j2' %}
   redistribute_routes:
-{% include 'fabric/ebgp_underlay/spine-router-bgp-redistribute-routes.j2' %}
+{% include 'fabric/ebgp_underlay/overlay-controller-router-bgp-redistribute-routes.j2' %}
   address_family_evpn:
-{% include 'fabric/bgp_overlay/spine-router-bgp-address-family-evpn.j2' %}
+{% include 'fabric/bgp_overlay/overlay-controller-router-bgp-address-family-evpn.j2' %}
   address_family_ipv4:
-{% include 'fabric/ebgp_underlay/spine-router-bgp-address-family-ipv4.j2' %}
+{% include 'fabric/ebgp_underlay/overlay-controller-router-bgp-address-family-ipv4.j2' %}
 
-{# OSPF Configuration #}
+{# OSPF Configurartion #}
 ### Routing - OSPF ###
 router_ospf:
 {# underlay #}
 {% include 'fabric/ospf_underlay/router-ospf.j2' %}
 
-{# ISIS Configuration #}
+{# OSPF Configurartion #}
 ### Routing - ISIS ###
 router_isis:
 {# underlay #}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-super-spine-yml.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-super-spine-yml.j2
@@ -8,6 +8,110 @@
 {% set switch.platform = super_spine.platform %}
 {% set switch.mgmt_ip = super_spine.nodes[inventory_hostname].mgmt_ip %}
 {% set switch.spanning_tree_mode = "none" %}
+{# Build variables for fabric protocols #}
+{# Logic for underlay routing protocol configured on device #}
+{% if underlay_routing_protocol is defined %}
+{%     if underlay_routing_protocol|lower == 'ebgp' %}
+{%         set switch.underlay_routing_protocol = 'ebgp' %}
+{%     elif underlay_routing_protocol|lower == 'bgp' %}
+{%         set switch.underlay_routing_protocol = 'ebgp' %}
+{%     elif underlay_routing_protocol|lower == 'ibgp' %}
+{%         set switch.underlay_routing_protocol = 'ibgp'%}
+{%     elif underlay_routing_protocol|lower == 'isis' %}
+{%         set switch.underlay_routing_protocol = 'isis' %}
+{%     elif underlay_routing_protocol|lower == 'ospf' %}
+{%         set switch.underlay_routing_protocol = 'ospf' %}
+{%     else %}
+{%         set switch.underlay_routing_protocol = 'ebgp' %}
+{%     endif %}
+{% else %}
+{%     set switch.underlay_routing_protocol = 'ebgp' %}
+{% endif %}
+{# Logic for overlay protocol definition #}
+{% if overlay_routing_protocol is defined %}
+{%     if overlay_routing_protocol|lower == 'ebgp' %}
+{%         set switch.overlay_routing_protocol = 'ebgp' %}
+{%     elif overlay_routing_protocol|lower == 'bgp' %}
+{%         set switch.overlay_routing_protocol = 'ebgp' %}
+{%     elif overlay_routing_protocol|lower == 'ibgp' %}
+{%         set switch.overlay_routing_protocol = 'ibgp'%}
+{%     else %}
+{%         set switch.overlay_routing_protocol = 'ebgp' %}
+{%     endif %}
+{% else %}
+{%     set switch.overlay_routing_protocol = 'ebgp' %}
+{% endif %}
+{# Gather overlay peering information #}
+{% set switch.evpn_overlay_peers = [] %}
+{# #}
+{# Look for switches pointing to us as evpn_overlay_controller / server #}
+{% for some_switch in groups['all'] %}
+{%     set some_switch_vars = hostvars[some_switch] %}
+{%     if some_switch_vars.evpn_overlay_controller_groups is defined and some_switch_vars.evpn_overlay_controller_groups is not none %}
+{%         for evpn_overlay_controller_group in some_switch_vars.evpn_overlay_controller_groups %}
+{%             if inventory_hostname in groups[evpn_overlay_controller_group] %}
+{# Found a match. Gathering information for this peer #}
+{%                 set peer = namespace() %}
+{%                 set peer.description = some_switch %}
+{%                 if some_switch_vars.type == 'l3leaf' %}
+{%                     for l3leaf_node_group in some_switch_vars.l3leaf.node_groups | arista.avd.natural_sort %}
+{%                         for node in some_switch_vars.l3leaf.node_groups[l3leaf_node_group].nodes | arista.avd.natural_sort %}
+{%                             if node == some_switch %}
+{%                                 set peer.id = some_switch_vars.l3leaf.node_groups[l3leaf_node_group].nodes[node].id %}
+{%                                 if some_switch_vars.l3leaf.node_groups[l3leaf_node_group].bgp_as is defined %}
+{%                                     set peer.bgp_as = some_switch_vars.l3leaf.node_groups[l3leaf_node_group].bgp_as %}
+{%                                 else %}
+{%                                     set peer.bgp_as = some_switch_vars.l3leaf.defaults.bgp_as %}
+{%                                 endif %}
+{%                             endif %}
+{%                         endfor %}
+{%                     endfor %}
+{%                     set peer.ip = some_switch_vars.overlay_loopback_network_summary | ipaddr('network') | ipmath(peer.id + some_switch_vars.spine.nodes | length) %}
+{%                 elif some_switch_vars.type == 'spine' %}
+{%                     set peer.bgp_as = some_switch_vars.spine.bgp_as %}
+{%                     set peer.ip = some_switch_vars.overlay_loopback_network_summary | ipaddr('network') | ipmath(some_switch_vars.spine.nodes[some_switch].id) %}
+{%                 elif some_switch_vars.type == 'super-spine' %}
+{%                     set peer.bgp_as = some_switch_vars.super_spine.bgp_as %}
+{%                     set peer.ip = some_switch_vars.super_spine_loopback_network_summary  | ipaddr('network') | ipmath(some_switch_vars.super_spine.nodes[some_switch].id) %}
+{%                 elif some_switch_vars.type == 'overlay-controller' %}
+{%                     if some_switch_vars.overlay_controller.nodes[some_switch].bgp_as is defined %}
+{%                         set peer.bgp_as = some_switch_vars.overlay_controller.nodes[some_switch].bgp_as %}
+{%                     else %}
+{%                         set peer.bgp_as = some_switch_vars.overlay_controller.defaults.bgp_as %}
+{%                     endif %}
+{%                     set peer.ip = some_switch_vars.overlay_controller_loopback_network_summary | ipaddr('network') | ipmath(some_switch_vars.overlay_controller.nodes[some_switch].id) %}
+{%                 endif %}
+{%                 do switch.evpn_overlay_peers.append(peer) %}
+{%             endif %}
+{%         endfor %}
+{%     endif %}
+{% endfor %}
+{# Look for evpn_overlay_controllers / servers where we are client #}
+{% if evpn_overlay_controller_groups is defined and evpn_overlay_controller_groups is not none %}
+{%     for evpn_overlay_controller_group in evpn_overlay_controller_groups %}
+{%         for evpn_overlay_controller in groups[evpn_overlay_controller_group] %}
+{# Found a match. Gathering information for this peer #}
+{%             set evpn_overlay_controller_vars = hostvars[evpn_overlay_controller] %}
+{%             set peer = namespace() %}
+{%             set peer.description = evpn_overlay_controller %}
+{%             if evpn_overlay_controller_vars.type == 'spine' %}
+{%                 set peer.bgp_as = evpn_overlay_controller_vars.spine.bgp_as %}
+{%                 set peer.ip = evpn_overlay_controller_vars.overlay_loopback_network_summary | ipaddr('network') | ipmath(evpn_overlay_controller_vars.spine.nodes[evpn_overlay_controller].id) %}
+{%             elif evpn_overlay_controller_vars.type == 'super-spine' %}
+{%                 set peer.bgp_as = evpn_overlay_controller_vars.super_spine.bgp_as %}
+{%                 set peer.ip = evpn_overlay_controller_vars.super_spine_loopback_network_summary  | ipaddr('network') | ipmath(evpn_overlay_controller_vars.super_spine.nodes[evpn_overlay_controller].id) %}
+{%             elif evpn_overlay_controller_vars.type == 'overlay-controller' %}
+{%                 if evpn_overlay_controller_vars.overlay_controller.nodes[evpn_overlay_controller].bgp_as is defined %}
+{%                     set peer.bgp_as = evpn_overlay_controller_vars.overlay_controller.nodes[evpn_overlay_controller].bgp_as %}
+{%                 else %}
+{%                     set peer.bgp_as = evpn_overlay_controller_vars.overlay_controller.defaults.bgp_as %}
+{%                 endif %}
+{%                 set peer.ip = evpn_overlay_controller_vars.overlay_controller_loopback_network_summary | ipaddr('network') | ipmath(evpn_overlay_controller_vars.overlay_controller.nodes[evpn_overlay_controller].id) %}
+{%             endif %}
+{%             do switch.evpn_overlay_peers.append(peer) %}
+{%         endfor %}
+{%     endfor %}
+{% endif %}
 ### Super Spine Info ###
 switch_platform: {{ switch.platform }}
 switch_mgmt_ip: {{ switch.mgmt_ip }}
@@ -107,7 +211,10 @@ bfd_multihop:
 {# Ethernet Interfaces #}
 ### Ethernet Interfaces ###
 ethernet_interfaces:
+{# Point-to-Point Interfaces to spines #}
 {% include 'fabric/interfaces/super-spine-p2p-interfaces.j2' %}
+{# Point-to-Point Interfaces to overlay-controller #}
+{% include 'fabric/interfaces/switch-p2p-interfaces-overlay-controller.j2' %}
 
 {# Loopback Interfaces #}
 ### Loopback Interfaces ###
@@ -144,20 +251,20 @@ prefix_lists:
 {# route maps #}
 ### route-maps ###
 route_maps:
-{% include 'fabric/ebgp_overlay/route-maps.j2' %}
+{% include 'fabric/bgp_base/route-maps.j2' %}
 
 
 {# ##### BGP Configurartion ##### #}
 ### Routing - BGP ###
 router_bgp:
 {# underlay and overlay #}
-{% include 'fabric/super-spine-router-bgp-base.j2' %}
+{% include 'underlay-overlay/super-spine-router-bgp-base.j2' %}
   peer_groups:
-{% include 'fabric/ebgp_underlay/super-spine-router-bgp-peer-groups.j2' %}
+{% include 'underlay-overlay/super-spine-router-bgp-peer-groups.j2' %}
   neighbors:
-{% include 'fabric/ebgp_underlay/super-spine-router-bgp-neighbors.j2' %}
+{% include 'underlay-overlay/super-spine-router-bgp-neighbors.j2' %}
   redistribute_routes:
-{% include 'fabric/ebgp_underlay/super-spine-router-bgp-redistribute-routes.j2' %}
+{% include 'underlay-overlay/super-spine-router-bgp-redistribute-routes.j2' %}
   address_family_ipv4:
     peer_groups:
       IPv4-UNDERLAY-PEERS:

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/bgp_base/leaf-router-bgp-neighbors.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/bgp_base/leaf-router-bgp-neighbors.j2
@@ -12,12 +12,15 @@
     {{ mlag_ips.leaf_peer_l3 | ipaddr('network') | ipmath(leaf.mlag_peer_ip) }}:
       peer_group: MLAG-IPv4-UNDERLAY-PEER
 {%         endif %}
-{## Overlay network peering #}
-{%         for spine_node in spine.nodes | arista.avd.natural_sort %}
+{# Overlay network peering #}
+{# Default to overlay network peering to spines if not using evpn_overlay_controller_groups variable #}
+{%         if evpn_overlay_controller_groups is not defined %}
+{%             for spine_node in spine.nodes | arista.avd.natural_sort %}
     {{ overlay_loopback_network_summary | ipaddr('network') | ipmath(spine.nodes[spine_node].id ) }}:
       peer_group: EVPN-OVERLAY-PEERS
-{%         endfor %}
-{# EBGP #}
+{%             endfor %}
+{%         endif %}
+{# IBGP #}
 {%     elif switch.overlay_routing_protocol == "ibgp"  %}
 {## Overlay network peering #}
 {%         for spine_node in spine.nodes | arista.avd.natural_sort %}
@@ -27,4 +30,11 @@
 {%             endif %}
 {%         endfor %}
 {%     endif %}
+{# Overlay network peerings based on evpn_overlay_controller_groups variable #} 
+{%     for evpn_overlay_peer in switch.evpn_overlay_peers %}
+    {{ evpn_overlay_peer.ip }}:
+      peer_group: EVPN-OVERLAY-PEERS
+      description: {{ evpn_overlay_peer.description }}
+      remote_as: {{ evpn_overlay_peer.bgp_as }}
+{%     endfor %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/bgp_base/leaf-router-bgp-peer-groups.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/bgp_base/leaf-router-bgp-peer-groups.j2
@@ -29,7 +29,7 @@
 {% endif %}
       update_source: Loopback0
       bfd: true
-      ebgp_multihop: 3
+      ebgp_multihop: 15
       password: "{{ bgp_peer_groups.EVPN_OVERLAY_PEERS.password }}"
       send_community: true
       maximum_routes: 0

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/bgp_base/overlay-controller-prefix-lists.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/bgp_base/overlay-controller-prefix-lists.j2
@@ -1,0 +1,9 @@
+{# Overlay Controller prefix-lists #}
+  PL-LOOPBACKS-EVPN-OVERLAY:
+    sequence_numbers:
+      10:
+        action: "permit {{ overlay_controller_loopback_network_summary }} eq 32"
+  PL-P2P-UNDERLAY:
+    sequence_numbers:
+      10:
+        action: "permit {{ overlay_controller_p2p_network_summary }} le 31"

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/bgp_base/overlay-controller-router-bgp-base.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/bgp_base/overlay-controller-router-bgp-base.j2
@@ -1,0 +1,10 @@
+{# Overlay Controller router bgp base configuration #}
+{% if type == "overlay-controller" %}
+  as: {{ switch.bgp_as }}
+  router_id: {{ overlay_controller_loopback_network_summary | ipaddr('network') | ipmath(switch.id) }}
+  bgp_defaults:
+{%     for bgp_default in overlay_controller_bgp_defaults %}
+    - {{ bgp_default }}
+{%     endfor %}
+    - maximum-paths {{ switch.remote_switches_interfaces | length }} ecmp {{ switch.remote_switches_interfaces | length }}
+{% endif%}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/bgp_base/overlay-controller-router-bgp-neighbors.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/bgp_base/overlay-controller-router-bgp-neighbors.j2
@@ -1,0 +1,19 @@
+{# Overlay Controller router bgp neighbors configuration #}
+{% if type == "overlay-controller" %}
+{# EBGP #}
+{## Underlay network peering #}
+{%     if switch.underlay_routing_protocol == "ebgp" %}
+
+{%         for uplink_to_remote_switches in switch.uplink_to_remote_switches %}
+    {{ overlay_controller_p2p_network_summary | ipaddr('network') | ipmath(((switch.id -1) * 2 * overlay_controller.nodes | length * max_overlay_controller_to_switch_links ) + loop.index0 * 2) }}:
+      peer_group: IPv4-UNDERLAY-PEERS
+{%         endfor %}
+{%     endif %}
+{# Overlay network peerings based on evpn_overlay_controller variable #} 
+{%     for evpn_overlay_peer in switch.evpn_overlay_peers %}
+    {{ evpn_overlay_peer.ip }}:
+      peer_group: EVPN-OVERLAY-PEERS
+      description: {{ evpn_overlay_peer.description }}
+      remote_as: {{ evpn_overlay_peer.bgp_as }}
+{%     endfor %}
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/bgp_base/overlay-controller-router-bgp-peer-groups.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/bgp_base/overlay-controller-router-bgp-peer-groups.j2
@@ -1,16 +1,16 @@
-{# Spine router bgp peer groups configuration #}
-{% if type == "spine" %}
+{# Overlay Controller router bgp peer groups configuration #}
+{% if type == "overlay-controller" %}
 {# Underlay network peering #}
 {%     if switch.underlay_routing_protocol == "ebgp" %}
     IPv4-UNDERLAY-PEERS:
       type: ipv4
-      peer_filter: LEAF-AS-RANGE
       password: "{{ bgp_peer_groups.IPv4_UNDERLAY_PEERS.password }}"
       maximum_routes: 12000
 {%     endif %}
+{# Overlay network peering #}
+{%     if switch.overlay_routing_protocol == "ebgp" %}
     EVPN-OVERLAY-PEERS:
       type: evpn
-      peer_filter: LEAF-AS-RANGE
       next_hop_unchanged: true
       update_source: Loopback0
       bfd: true
@@ -18,4 +18,5 @@
       password: "{{ bgp_peer_groups.EVPN_OVERLAY_PEERS.password }}"
       send_community: true
       maximum_routes: 0
+{%     endif %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/bgp_base/spine-router-bgp-neighbors.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/bgp_base/spine-router-bgp-neighbors.j2
@@ -20,9 +20,11 @@
 {%                         endif %}
 {%                     endif %}
 {%                 endfor %}
-{%              endif %}
+{%             endif %}
 {# Overlay network peering #}
-{%             if switch.overlay_routing_protocol == 'ebgp' %}
+{# Default to overlay network peering to leafs if not using evpn_overlay_controller_groups variable #}
+{%             if evpn_overlay_controller_groups is not defined %}
+{%                 if switch.overlay_routing_protocol == 'ebgp' %}
     {{ overlay_loopback_network_summary | ipaddr('network') | ipmath(l3leaf.node_groups[l3leaf_node_group].nodes[node].id + spine.nodes | length ) }}:
       peer_group: EVPN-OVERLAY-PEERS
 {%                     if l3leaf.node_groups[l3leaf_node_group].bgp_as is defined %}
@@ -30,6 +32,7 @@
 {%                     else %}
       remote_as: {{ l3leaf.defaults.bgp_as }}
 {%                     endif %}
+{%                 endif %}
 {%             endif %}
 {%             if switch.overlay_routing_protocol == 'ibgp' and switch.is_route_reflector == true %}
     {{ overlay_loopback_network_summary | ipaddr('network') | ipmath(l3leaf.node_groups[l3leaf_node_group].nodes[node].id + spine.nodes | length ) }}:
@@ -59,4 +62,11 @@
     }}:
       peer_group: IPv4-UNDERLAY-PEERS
       remote_as: {{ super_spine.bgp_as }}
+{% endfor %}
+{# Overlay network peerings based on evpn_overlay_controller_groups variable #} 
+{% for evpn_overlay_peer in switch.evpn_overlay_peers %}
+    {{ evpn_overlay_peer.ip }}:
+      peer_group: EVPN-OVERLAY-PEERS
+      description: {{ evpn_overlay_peer.description }}
+      remote_as: {{ evpn_overlay_peer.bgp_as }}
 {% endfor %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/bgp_base/spine-router-bgp-neighbors.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/bgp_base/spine-router-bgp-neighbors.j2
@@ -45,8 +45,10 @@
 {# Underlay network peering to super spines #}
 {% if spine.nodes[inventory_hostname]['uplinks_to_super_spine_interfaces'] is defined %}
 {%     set spine_uplink_list = spine.nodes[inventory_hostname]['uplinks_to_super_spine_interfaces'] %}
-{% else %}
+{% elif spine.uplinks_to_super_spine_interfaces is defined %}
 {%     set spine_uplink_list = spine.uplinks_to_super_spine_interfaces %}
+{% else %}
+{%     set spine_uplink_list = [] %}
 {% endif %}
 {% for spine_uplink in spine_uplink_list %}
 {%     set s_spine_id = loop.index0 // max_spine_to_super_spine_links + 1 %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/bgp_base/spine-router-bgp-peer-groups.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/bgp_base/spine-router-bgp-peer-groups.j2
@@ -16,7 +16,7 @@
       next_hop_unchanged: true
       update_source: Loopback0
       bfd: true
-      ebgp_multihop: 3
+      ebgp_multihop: 15
       password: "{{ bgp_peer_groups.EVPN_OVERLAY_PEERS.password }}"
       send_community: true
       maximum_routes: 0

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/bgp_overlay/overlay-controller-router-bgp-address-family-evpn.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/bgp_overlay/overlay-controller-router-bgp-address-family-evpn.j2
@@ -1,0 +1,15 @@
+{# Overlay Controller - address family evpn activation #}
+{% if type == "overlay-controller" %}
+    peer_groups:
+{%     if switch.underlay_routing_protocol == "ebgp" %}
+      IPv4-UNDERLAY-PEERS:
+        activate: false
+{%     endif %}
+{%     if switch.overlay_routing_protocol == "ebgp"  %}
+      EVPN-OVERLAY-PEERS:
+        activate: true
+{%     elif switch.overlay_routing_protocol == "ibgp" and switch.is_route_reflector == true %}
+      EVPN-OVERLAY-PEERS:
+        activate: true
+{%     endif %}
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/ebgp_underlay/overlay-controller-router-bgp-address-family-ipv4.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/ebgp_underlay/overlay-controller-router-bgp-address-family-ipv4.j2
@@ -1,0 +1,10 @@
+{# Overlay Controller - address family ipv4 activation #}
+{% if type == "overlay-controller" %}
+    peer_groups:
+{%     if switch.underlay_routing_protocol == "ebgp" %}
+      IPv4-UNDERLAY-PEERS:
+        activate: true
+{%     endif %}
+      EVPN-OVERLAY-PEERS:
+        activate: false
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/ebgp_underlay/overlay-controller-router-bgp-redistribute-routes.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/ebgp_underlay/overlay-controller-router-bgp-redistribute-routes.j2
@@ -1,0 +1,7 @@
+{# Overlay Controller router bgp redistribute routes configuration #}
+{% if type == "overlay-controller" %}
+{%     if switch.underlay_routing_protocol == "ebgp" %}
+    connected:
+      route_map: RM-CONN-2-BGP
+{%     endif %}
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/interfaces/overlay-controller-loopback.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/interfaces/overlay-controller-loopback.j2
@@ -1,0 +1,11 @@
+{# Overlay Controller loopback interface #}
+  Loopback0:
+    description: EVPN_Overlay_Peering
+    ip_address: {{ overlay_controller_loopback_network_summary | ipaddr('network') | ipmath(switch.id) }}/32
+{% if underlay_routing_protocol == "OSPF" %}
+    ospf_area: {{ underlay_ospf_area }}
+{% endif %}
+{% if underlay_routing_protocol == "ISIS" %}
+    isis_enable: EVPN_UNDERLAY
+    isis_passive: true
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/interfaces/overlay-controller-p2p-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/interfaces/overlay-controller-p2p-interfaces.j2
@@ -1,0 +1,26 @@
+{# OVERLAY CONTROLLER P2P interfaces for external RS or RR #}
+{% if switch.uplink_to_remote_switches is defined %}
+{%      for uplink_to_remote_switches in switch.uplink_to_remote_switches %}
+  {{ uplink_to_remote_switches }}:
+    peer: {{ switch.remote_switches[loop.index0] }}
+    peer_interface: {{ switch.remote_switches_interfaces[loop.index0 ] }}
+    peer_type: {{ hostvars[switch.remote_switches[loop.index0]].type }}
+    description: P2P_LINK_TO_{{ switch.remote_switches[loop.index0] | upper }}_{{ switch.remote_switches_interfaces[loop.index0 ] }}
+{%          if switch.p2p_link_interface_speed is defined %}
+    speed: {{ switch.p2p_link_interface_speed }}
+{%          endif %}
+    mtu: {{ p2p_uplinks_mtu }}
+    type: routed
+{# TODO: Validate IP calculation if attached to L3LEAF or SUPER-SPINE #}
+    ip_address: {{ overlay_controller_p2p_network_summary | ipaddr('network') | ipmath(((switch.id -1) * 2 * overlay_controller.nodes | length * max_overlay_controller_to_switch_links ) + loop.index0 * 2 + 1) }}/31
+{%          if underlay_routing_protocol == "OSPF" %}
+    ospf_network_point_to_point: true
+    ospf_area: {{ underlay_ospf_area }}
+{%          endif %}
+{%          if underlay_routing_protocol == "ISIS" %}
+    isis_enable: EVPN_UNDERLAY
+    isis_metric: 50
+    isis_network_point_to_point: true
+{%          endif %}
+{%      endfor %}
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/interfaces/spine-p2p-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/interfaces/spine-p2p-interfaces.j2
@@ -47,8 +47,10 @@
   ### p2p Interfaces to Super Spine Switches
 {% if spine.nodes[inventory_hostname]['uplinks_to_super_spine_interfaces'] is defined %}
 {%     set spine_uplink_list = spine.nodes[inventory_hostname]['uplinks_to_super_spine_interfaces'] %}
-{% else %}
+{% elif spine.uplinks_to_super_spine_interfaces is defined %}
 {%     set spine_uplink_list = spine.uplinks_to_super_spine_interfaces %}
+{% else %}
+{%     set spine_uplink_list = [] %}
 {% endif %}
 {% for spine_uplink in spine_uplink_list %}
 {%     set s_spine_id = loop.index0 // max_spine_to_super_spine_links + 1 %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/interfaces/switch-p2p-interfaces-overlay-controller.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/interfaces/switch-p2p-interfaces-overlay-controller.j2
@@ -1,0 +1,46 @@
+{# Point-to-Point Interfaces to OPTIONAL OVERLAY_CONTROLLER Switches #}
+{% if overlay_controller is defined %}
+{%     for overlay_controller_node in overlay_controller.nodes | arista.avd.natural_sort %}
+{%         if overlay_controller.nodes[overlay_controller_node].remote_switches is defined %}
+{%             set overlay_controller_remote_switches = overlay_controller.nodes[overlay_controller_node].remote_switches %}
+{%         else %}
+{%             set overlay_controller_remote_switches = overlay_controller.defaults.remote_switches %}
+{%         endif %}
+{%         for overlay_controller_remote_switch in overlay_controller_remote_switches %}
+{%             if overlay_controller_remote_switch == inventory_hostname %}
+{%                 set remote_switches_interfaces = overlay_controller.nodes[overlay_controller_node].nodes[node].remote_switches_interfaces %}
+{%                 if overlay_controller.nodes[overlay_controller_node].uplink_to_remote_switches is defined %}
+{%                     set uplink_to_remote_switches = overlay_controller.nodes[overlay_controller_node].uplink_to_remote_switches %}
+{%                 else %}
+{%                 set uplink_to_remote_switches = overlay_controller.defaults.uplink_to_remote_switches %}
+{%                 endif %}
+{%                 if overlay_controller.nodes[overlay_controller_node].p2p_link_interface_speed is defined %}
+{%                     set p2p_link_interface_speed = overlay_controller.nodes[overlay_controller_node].p2p_link_interface_speed %}
+{%                 elif overlay_controller.defaults.p2p_link_interface_speed is defined %}
+{%                     set p2p_link_interface_speed = overlay_controller.defaults.p2p_link_interface_speed %}
+{%                 endif %}
+{%                 set switch_interfaces = overlay_controller.nodes[overlay_controller_node].remote_switches_interfaces %}
+  {{ switch_interfaces[loop.index0] }}:
+    peer: {{ overlay_controller_node }}
+    peer_interface: {{ uplink_to_remote_switches[loop.index0] }}
+    peer_type: overlay_controller
+    description: P2P_LINK_TO_{{ overlay_controller_remote_switch | upper }}_{{ uplink_to_remote_switches[loop.index0] }}
+{%                 if p2p_link_interface_speed is defined %}
+    speed: {{ p2p_link_interface_speed }}
+{%                 endif %}
+    mtu: {{ p2p_uplinks_mtu }}
+    type: routed
+    ip_address: {{ overlay_controller_p2p_network_summary | ipaddr('network') | ipmath(((overlay_controller.nodes[overlay_controller_node].id -1) * 2 * overlay_controller_remote_switches | length * max_overlay_controller_to_switch_links ) + loop.index0 * 2) }}/31
+{%                 if underlay_routing_protocol == "OSPF" %}
+    ospf_network_point_to_point: true
+    ospf_area: {{ underlay_ospf_area }}
+{%                 endif %}
+{%                 if underlay_routing_protocol == "ISIS" %}
+    isis_enable: EVPN_UNDERLAY
+    isis_metric: 50
+    isis_network_point_to_point: true
+{%                 endif %}
+{%             endif %}
+{%         endfor %}
+{%     endfor %}
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/underlay-overlay/super-spine-router-bgp-neighbors.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/underlay-overlay/super-spine-router-bgp-neighbors.j2
@@ -17,3 +17,10 @@
 {%          endfor %}
 {%      endif %}
 {% endfor %}
+{# Overlay network peering based on evpn_overlay_controller variable #} 
+{% for evpn_overlay_peer in switch.evpn_overlay_peers %}
+    {{ evpn_overlay_peer.ip }}:
+      peer_group: EVPN-OVERLAY-PEERS
+      description: {{ evpn_overlay_peer.description }}
+      remote_as: {{ evpn_overlay_peer.bgp_as }}
+{% endfor %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/underlay-overlay/super-spine-router-bgp-peer-groups.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/underlay-overlay/super-spine-router-bgp-peer-groups.j2
@@ -1,8 +1,21 @@
 {# Spine router bgp peer groups configuration #}
 {% if type == "super-spine" %}
 {# Underlay network peering #}
+{%     if switch.underlay_routing_protocol == "ebgp" %}
     IPv4-UNDERLAY-PEERS:
       type: ipv4
       password: "{{ bgp_peer_groups.IPv4_UNDERLAY_PEERS.password }}"
       maximum_routes: 12000
+{%     endif %}
+{%     if switch.evpn_overlay_peers | length > 0 %}
+    EVPN-OVERLAY-PEERS:
+      type: evpn
+      next_hop_unchanged: true
+      update_source: Loopback0
+      bfd: true
+      ebgp_multihop: 15
+      password: "{{ bgp_peer_groups.EVPN_OVERLAY_PEERS.password }}"
+      send_community: true
+      maximum_routes: 0
+{%     endif %}
 {% endif %}


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
* Add new device type `overlay_controller`
* Add `evpn_overlay_controller_groups` to specify upstream EVPN overlay peers
* Small bugfixes

TODO: Create / Adjust generated documentation for these new features.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #269
## Component(s) name
eos_l3ls_evpn

## Proposed changes
<!--- Describe your changes in detail -->
## Role Enchancements for dedicated Overlay Controllers

This enhancement will allow support for dedicated Overlay Controllers connected to fabric nodes.
Overlay Controllers can be connected to any other device type.
Overlay Controllers can currently only be used as EVPN Overlay Controllers

### Inventory Structure

The inventory must have a dedicated group for Overlay Controllers. Example:

```yaml
all:
  children:
    < DC-group-name >:
      children:
        < Overlay Controllers group name >:
          hosts:
            < Overlay Controller name >:
              ansible_host: < management IP >
            < Overlay Controller name >:
              ansible_host: < management IP >
            ...
```

### Additional Variables Required For Overlay Controllers Deployment

Defaults:
```yaml
max_overlay_controller_to_switch_links: 1
```

Assigned to the DC group:

```yaml
overlay_controller:
  platform: <platform>   # overlay-controller platform
  defaults: #Default variables, can be overridden when defined under each node
    remote_switches: [ <switch_inventory_hostname> , <switch_inventory_hostname> ] #Remote Switches connected to uplink interfaces
    uplink_to_remote_switches: [ <uplink_interface> , <uplink_interface> ]
    bgp_as: <BGP AS>
  nodes:
    <inventory_hostname>:
      id: <number> # Starting from 1
      mgmt_ip: < IPv4_address/Mask >
      remote_switches_interfaces: [ <remote_switch_interface> , <remote_switch_interface> ] # Interfaces on remote switch
# Point to Point Network Summary range, assigned as /31 for each uplink interfaces
# Assign range larger than [ total overlay_controllers * max_overlay_controller_to_switch_links * 2]
overlay_controller_p2p_network_summary: < IPv4_network/Mask >
# IP address summary for BGP evpn overlay peering loopback for Overlay Controllers | Required
# Assigned as /32 to Loopback0
# Assign range larger then:
# [ total overlay_controllers ]
overlay_controller_loopback_network_summary: < IPv4_network/Mask >
# additional lines for overlay-controller BGP config
overlay_controller_bgp_defaults:
  #  - update wait-for-convergence
  #  - update wait-install
  - no bgp default ipv4-unicast
  - distance bgp 20 200 200
  - graceful-restart restart-time 300
  - graceful-restart
```

Assigned to Overlay Controller Group:

```yaml
type: overlay-controller # identifies every host in the group as overlay-controller
```


## Role Enhancements for Flexible EVPN Overlay peering design

This enhancement will allow a more flexible EVPN Overlay peering design.
Overlay peerings can be configured to any of the following options as well as combinations thereof:
* l3leaf <-> spine
* l3leaf <-> super-spine
* l3leaf <-> overlay-controller
* spine <-> spine (in other PODs)
* spine <-> super-spine
* spine <-> overlay-controller
* super-spine <-> super-spine (in other DCs)
* super-spine <-> overlay-controller
* overlay-controller <-> overlay-controller (in other DCs)
The overlay peerings will be derived from the variable `evpn_overlay_controller_groups` on the "client".
Ex. setting `evpn_overlay_controller_groups : [ DC1_SUPER_SPINES ]` in the `DC1-POD1-L3LEAFS.yml` group_var file will setup evpn peerings between 
all the l3leafs in this group and all devices in the group `DC1_SUPER_SPINES`. The devices in group `DC1_SUPER_SPINES` will detect that others are
pointing at them, and configure the peering as well.

Currently all spines, super-spines and overlay-controllers will have the EVPN adress-family and EVPN BGP peer-group configured even if they have no
EVPN overlay peerings.

To be backward compatible the templates will use the old behavior of configuring EVPN Overlay between all spines and l3leafs if `evpn_overlay_controller_groups`
is not defined on the l3leafs group.

### Inventory Structure

There are no specific requirements for this feature, so this is just an example for reference.

```yaml
all:
  children:
    < DC-group-name >:
      children:
        < Overlay Controllers group name >:
          <-- omitted -->
        < Super Spines group name >:
          <-- omitted -->
        < DC POD 1 group name >:
          children:
            < spines group >:
              <-- omitted -->
            < leaf group >:
              <-- omitted -->
```

### Additional Variables For Flexible EVPN Overlay peerings

Assigned to any device group:

```yaml
evpn_overlay_controller_groups: [ < inventory_group > ]  # One or more groups containing EVPN RR/RS.
```


## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
https://github.com/ClausHolbechArista/claus-l3ls-dev/tree/superspine-alternative

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
