### PR TITLE
Fix incorrect rstrip configuration #394

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/banners.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/banners.j2
@@ -1,13 +1,13 @@
 {# banners #}
 {% if banners is defined and banners is not none %}
-{%     if banners.login is defined and banners.login is not none -%}
+{%     if banners.login is defined and banners.login is not none %}
 !
 banner login
 {{ banners.login }}
-{%-   endif %}
-{%     if banners.motd is defined and banners.motd is not none -%}
+{%   endif %}
+{%     if banners.motd is defined and banners.motd is not none %}
 !
 banner motd
 {{ banners.motd }}
-{%-    endif %}
+{%    endif %}
 {% endif %}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
## Change Summary

Remove `-` from condition lines since it breaks multiline output for
banner.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Fixes #394 

## Component(s) name

`eos_cli_config_gen`

## Proposed changes

Use AVD standard condition line without `-`

## How to test

```yaml
banners:
  login: |-
    My first banner line
    Connected to Device $(hostname) EOF
```

Result should be:

```eos
!
banner login
My first banner line
    Connected to Device $(hostname) EOF
!
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
