### PR TITLE
Implement storm_control for ethernet and port-channel interfaces

### DIFF
--- a/ansible_collections/arista/avd/molecule/Makefile
+++ b/ansible_collections/arista/avd/molecule/Makefile
@@ -30,5 +30,9 @@ commit-facts: ## Commit updated facts for CI
 	git add .
 	git commit --no-verify -m 'Update CI acritfacts' ./
 
+.PHONY: test-git-status
+test-git-status: ## Run post molecule script to check git status
+	sh ../../../../.github/git-repo-state-monitor.sh
+
 .PHONY: sync-facts
 sync-facts: refresh-facts commit-facts ## Refresh and commit CI artifacts

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -221,6 +221,7 @@ No VLANs defined
 | Interface | Description | MTU | Type | Mode | Allowed VLANs (Trunk) | Trunk Group | VRF | IP Address | Channel-Group ID | Channel-Group Type |
 | --------- | ----------- | --- | ---- | ---- | --------------------- | ----------- | --- | ---------- | ---------------- | ------------------ |
 | Ethernet1 | P2P_LINK_TO_DC1-SPINE1_Ethernet1 | 1500 | routed | access | - | - | - | 172.31.255.1/31 | - | - |
+| Ethernet2 | SRV-POD02_Eth1 | 1500 | switched | trunk | 110-111,210-211 | - | - | - | - | - |
 | Ethernet6 | SRV-POD02_Eth1 | 1500 | switched | trunk | 110-111,210-211 | - | - | - | - | - |
 
 *Inherited from Port-Channel Interface
@@ -233,6 +234,13 @@ interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet1
    no switchport
    ip address 172.31.255.1/31
+!
+interface Ethernet2
+   description SRV-POD02_Eth1
+   switchport trunk allowed vlan 110-111,210-211
+   switchport mode trunk
+   storm-control all level 10
+   storm-control broadcast level pps 500
 !
 interface Ethernet6
    description SRV-POD02_Eth1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/base.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/base.cfg
@@ -16,6 +16,7 @@ banner login
 !***!!!Unauthorized access prohibited!!!***!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 EOF
+
 !
 banner motd
 .         Switch       : $(hostname)                            .
@@ -23,6 +24,7 @@ banner motd
 .         Type info for information about the device            .
 .         Type help for information about the aliases           .
 EOF
+
 !
 management api http-commands
    protocol http

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
@@ -11,6 +11,13 @@ interface Ethernet1
    no switchport
    ip address 172.31.255.1/31
 !
+interface Ethernet2
+   description SRV-POD02_Eth1
+   switchport trunk allowed vlan 110-111,210-211
+   switchport mode trunk
+   storm-control all level 10
+   storm-control broadcast level pps 500
+!
 interface Ethernet6
    description SRV-POD02_Eth1
    switchport trunk allowed vlan 110-111,210-211

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
@@ -18,3 +18,19 @@ ethernet_interfaces:
     mode: trunk
     vlans: 110-111,210-211
     profile: ALL
+
+  Ethernet2:
+    peer: SRV-POD03
+    peer_interface: Eth1
+    peer_type: server
+    description: SRV-POD02_Eth1
+    mode: trunk
+    vlans: 110-111,210-211
+    profile: ALL
+    storm_control:
+      all:
+        level: 10
+        unit: percent
+      broadcast:
+        level: 500
+        unit: pps

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -724,6 +724,19 @@ ethernet_interfaces:
     spanning_tree_bpduguard: < true | false >
     spanning_tree_portfast: < edge | network >
     vmtracer: < true | false >
+    storm_control:
+      all:
+        level: < Configure maximum storm-control level >
+        unit: < percent | pps >
+      broadcast:
+        level: < Configure maximum storm-control level >
+        unit: < percent | pps >
+      multicast:
+        level: < Configure maximum storm-control level >
+        unit: < percent | pps >
+      'unknown-unicast':
+        level: < Configure maximum storm-control level >
+        unit: < percent | pps >
 ```
 
 ### Loopback Interfaces

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -141,6 +141,15 @@ interface {{ ethernet_interface }}
 {%             if ethernet_interfaces[ethernet_interface].vmtracer is defined and ethernet_interfaces[ethernet_interface].vmtracer == true %}
    vmtracer vmware-esx
 {%             endif %}
+{%             if ethernet_interfaces[ethernet_interface].storm_control is defined and ethernet_interfaces[ethernet_interface].storm_control is not none %}
+{%                   for section in ethernet_interfaces[ethernet_interface].storm_control | arista.avd.natural_sort %}
+{%                      if ethernet_interfaces[ethernet_interface].storm_control[section].unit is defined and ethernet_interfaces[ethernet_interface].storm_control[section].unit == "pps" %}
+   storm-control {{ section }} level pps {{ethernet_interfaces[ethernet_interface].storm_control[section].level}}
+{%                      else %}
+   storm-control {{ section }} level {{ethernet_interfaces[ethernet_interface].storm_control[section].level}}
+{%                      endif %}
+{%                   endfor %}
+{%             endif %}
 {%         endif %}
 {%     endfor %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
@@ -117,5 +117,14 @@ interface {{ port_channel_interface }}
 {%         if port_channel_interfaces[port_channel_interface].vmtracer is defined and port_channel_interfaces[port_channel_interface].vmtracer == true %}
    vmtracer vmware-esx
 {%         endif %}
+{%         if port_channel_interfaces[port_channel_interface].storm_control is defined and port_channel_interfaces[port_channel_interface].storm_control is not none %}
+{%             for section in port_channel_interfaces[port_channel_interface].storm_control | arista.avd.natural_sort %}
+{%                if port_channel_interfaces[port_channel_interface].storm_control[section].unit is defined and port_channel_interfaces[port_channel_interface].storm_control[section].unit == "pps" %}
+   storm-control {{ section }} level pps {{port_channel_interfaces[port_channel_interface].storm_control[section].level}}
+{%                else %}
+   storm-control {{ section }} level {{port_channel_interfaces[port_channel_interface].storm_control[section].level}}
+{%                endif %}
+{%             endfor %}
+{%         endif %}
 {%     endfor %}
 {% endif %}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
## Change Summary

Add storm-control support to ethernet-interfaces.j2 and port-channel-interfaces.j2.
The port-profile data model can look like:

```yaml
storm_control:
  <broadcast | multicast | all>:
    level: <storm-control-level>
    unit: <percent | pps>
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] New feature (non-breaking change which adds functionality)

## Related Issue(s)

Fixes #154 

## Component(s) name

`eos_cli_config_gen`

## Proposed changes

Update template to support following data-model:

```yaml
  <Ethernet_interface_2 >:
    storm_control:
      all:
        level: < Configure maximum storm-control level >
        unit: < percent | pps >
      broadcast:
        level: < Configure maximum storm-control level >
        unit: < percent | pps >
      multicast:
        level: < Configure maximum storm-control level >
        unit: < percent | pps >
      'unknown-unicast':
        level: < Configure maximum storm-control level >
        unit: < percent | pps >
```

## How to test

Update your host-vars to use the data-model described above.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
