### PR TITLE
Add extra newline after custom_template include

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/custom-templates.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/custom-templates.j2
@@ -1,5 +1,6 @@
 {% if custom_templates is defined and custom_templates is not none %}
 {%     for custom_template in custom_templates %}
 {%         include custom_template %}
+
 {%     endfor %}
 {% endif %}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add extra newline after custom_template include

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #391 

## Component(s) name
eos_cli_config_gen

## Proposed changes
<!--- Describe your changes in detail -->
Adding an extra empty line in `custom_templates.j2` to ensure that the first line of a templates is not rendered on the same line as the last line of the previous template.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
