### PR TITLE
Update CI image to use stable v1

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -13,7 +13,7 @@ jobs:
   'rebuild-docker-avd':
     name: Instruct Docker Hub to build image
     runs-on: ubuntu-latest
-    container: avdteam/base:3.6
+    container: avdteam/base:3.6-v1.0
     steps:
       - uses: actions/checkout@master
       - name: 'Send Webhook'

--- a/.github/workflows/installation-test.yml
+++ b/.github/workflows/installation-test.yml
@@ -8,7 +8,7 @@ jobs:
   'setup':
     name: 'One liner installation'
     runs-on: ubuntu-latest
-    container: avdteam/base:3.6
+    container: avdteam/base:3.6-v1.0
     steps:
       - uses: actions/checkout@master
       - name: Execute one-liner installation

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -6,7 +6,7 @@ jobs:
   'pre-commit':
     name: Run pre-commit validation hooks
     runs-on: ubuntu-latest
-    container: avdteam/base:3.6
+    container: avdteam/base:3.6-v1.0
     steps:
       - uses: actions/checkout@master
       - name: Install Pre Commit

--- a/development/Makefile
+++ b/development/Makefile
@@ -1,5 +1,5 @@
 CONTAINER_NAME = avdteam/base
-DOCKER_TAG = 3.6
+DOCKER_TAG = 3.6-v1.0
 CONTAINER = $(CONTAINER_NAME):$(DOCKER_TAG)
 COMPOSE_FILE ?= ansible-avd/development/docker-compose.yml
 PIP_REQ ?=

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   ansible:
-    image: avdteam/base:3.6
+    image: avdteam/base:3.6-v1.0
     container_name: ansible_avd
     volumes:
       - ./../../:/projects


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [x] Other (please describe): Continuous Integration

## Related Issue(s)

N/A

## Component(s) name

N/A

## Proposed changes

`avdteam/base` image has stable tags `<{pythonVersion}-v{gitTag}>` compare to current tag where image can change based on commit in docker repository. This behavior can lead to CI issue or slow down CI image development.

Proposed tag is equal to current `<python-version>` image.

## How to test

CI must be all green to validate change


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
