### PR TITLE
allow for user defined variables in eos_l3ls_evpn role

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l3leaf-yml.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l3leaf-yml.j2
@@ -354,6 +354,8 @@ ethernet_interfaces:
 {% include 'l3leaf_l2leafs_uplinks/l3leaf-ethernet-uplinks.j2' %}
 {# Server - Interfaces Configuration #}
 {% include 'edge_ports/leaf-server-interfaces.j2' %}
+{# User defined #}
+{% include 'user_defined/ethernet-interfaces.j2' %}
 
 
 {# loopback interfaces #}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/user_defined/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/user_defined/ethernet-interfaces.j2
@@ -1,0 +1,3 @@
+{% if ethernet_interfaces is defined and ethernet_interfaces is not none %}
+  {{ ethernet_interfaces | to_nice_yaml(indent=2) | indent(2) }}
+{% endif %}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
## Change Summary

Allow user to define any syntax according to eos_cli_config_gen and be rendered in the structured configuration generated by eos_l3ls_evpn.

This would allow to easily extend configuration by simply using native syntax, without requiring any abstraction template.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Component(s) name

- eos_l3ls_evpn

## Proposed changes
Add user_defined templates for each configuration section.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
