### PR TITLE
Eos structured configuration

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
@@ -161,6 +161,13 @@ redundancy:
 # Use to change the EOS default of 300
 mac_address_table:
   aging_time: < time_in_seconds >
+
+# Direct configuration or overriding of Structured Configuration | Optional
+# This allows support of all features in eos_cli_config_gen without having to map them into l3ls role
+# Keys under eos_structured_config will be merged with the final structured config YAML before running documentation and eos_cli_config_gen roles.
+# The merge is a recursive combine of dictionaries so alloweing to add extra keys or override existing keys. Lists will always be replaced if defined.
+eos_structured_config:
+  < eos_structured_config >
 ```
 
 > In `cvp_instance_ips` you can either provide a list of IPs to target on-premise Cloudvision cluster or either use DNS name for your Cloudvision as a Service instance. If you have both on-prem and CVaaS defined, only on-prem is going to be configured.
@@ -232,6 +239,20 @@ redundancy:
 # MAC address-table aging time
 mac_address_table:
   aging_time: 1500
+
+# Direct configuration or overriding of Structured Configuration | Optional
+# This allows support of all features in eos_cli_config_gen without having to map them into l3ls role
+# Keys under eos_structured_config will be merged with the final structured config YAML before running documentation and eos_cli_config_gen roles.
+# The merge is a recursive combine of dictionaries so alloweing to add extra keys or override existing keys. Lists will always be replaced if defined.
+eos_structured_config:
+  ethernet_interfaces:
+    Ethernet12:
+      description: My Extra Interface
+      ip_address: 1.2.3.4/24
+      mtu: 1500
+      peer: My_Peer
+      peer_interface: Ethernet123
+      peer_type: my_precious
 ```
 
 ### Fabric Underlay and Overlay Topology Variables

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/tasks/main.yml
@@ -3,13 +3,20 @@
 - name: Generate device configuration in structured format (yaml).
   template:
     src: "evpn-fabric-{{ type }}-yml.j2"
-    dest: '{{ root_dir }}/intended/structured_configs//{{ inventory_hostname }}.yml'
+    dest: '{{ root_dir }}/intended/structured_configs/{{ inventory_hostname }}.yml'
   delegate_to: localhost
   check_mode: no
   tags: [build, provision]
 
+- name: Merge generated device configuration with eos_structured_configuration (yaml)
+  template:
+    src: merge_eos_structured_config.j2
+    dest: '{{ root_dir }}/intended/structured_configs/{{ inventory_hostname }}.yml'
+  delegate_to: localhost
+  tags: [build, provision]
+
 - name: Include device structured configuration, that was previously generated.
-  include_vars: '{{ root_dir }}/intended/structured_configs//{{ inventory_hostname }}.yml'
+  include_vars: '{{ root_dir }}/intended/structured_configs/{{ inventory_hostname }}.yml'
   delegate_to: localhost
   tags: [build, provision]
 

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/merge_eos_structured_config.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/merge_eos_structured_config.j2
@@ -1,0 +1,6 @@
+{{
+    lookup('template', root_dir ~ '/intended/structured_configs/' ~ inventory_hostname ~ '.yml') |
+    from_yaml |
+    combine((eos_structured_configuration if eos_structured_configuration is defined else {}), recursive=true) |
+    to_nice_yaml(indent=2,sort_keys=False)
+}}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Adding new key to L3LS role `eos_structured_configuration` to accept direct configuration variables used by `eos_cli_config_gen`.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [X] Other (please describe): Molecule Artifacts will need to change for all l3ls scenarios because of new compact format of structured config YAML files.

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

## Component(s) name
eos_l3ls_evpn

## Proposed changes
<!--- Describe your changes in detail -->
Run extra task, after creating structured_config YAML, that merges content of `eos_structured_configuration` and output to same structured_config YAML file.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Tested replacing name_server list and adding to ethernet_interfaces dict. Also tested not having eos_structured_configuration defined.

```yaml
eos_structured_configuration:
  name_server:
    nodes:
      - 1.1.1.1
      - 8.8.8.8
      - 1.2.3.4
  ethernet_interfaces:
    Ethernet4000:
      description: My test
      ip_address: 1.2.3.4/12
      mtu: 1500
      peer: MY-own-peer
      peer_interface: Ethernet123
      peer_type: my_precious
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
