### PR TITLE
Aggregate bgp

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
@@ -287,6 +287,14 @@ Router ISIS not defined
 
 
 
+### BGP Route Aggregation
+
+| Prefix | AS Set | Summary Only | Attribute Map | Match Map | Advertise Only |
+| ------ | ------ | ------------ | ------------- | --------- | -------------- |
+| 1.1.1.0/24 | False | False  | Not Defined | Not Defined | True |
+| 1.12.1.0/24 | True | True  | RM-ATTRIBUTE | RM-MATCH | True |
+| 2.2.1.0/24 | False | False  | Not Defined | Not Defined | False |
+
 ### Router BGP EVPN Address Family
 
 #### Router BGP EVPN MAC-VRFs
@@ -307,6 +315,9 @@ router bgp 65101
    graceful-restart restart-time 300
    graceful-restart
    maximum-paths 2 ecmp 2
+   aggregate-address 1.1.1.0/24 advertise-only
+   aggregate-address 1.12.1.0/24 as-set summary-only attribute-map RM-ATTRIBUTE match-map RM-MATCH advertise-only
+   aggregate-address 2.2.1.0/24
 ```
 
 ## Router BFD

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
@@ -286,7 +286,6 @@ Router ISIS not defined
 | maximum-paths 2 ecmp 2 |
 
 
-
 ### BGP Route Aggregation
 
 | Prefix | AS Set | Summary Only | Attribute Map | Match Map | Advertise Only |

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-base.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-base.cfg
@@ -18,5 +18,8 @@ router bgp 65101
    graceful-restart restart-time 300
    graceful-restart
    maximum-paths 2 ecmp 2
+   aggregate-address 1.1.1.0/24 advertise-only
+   aggregate-address 1.12.1.0/24 as-set summary-only attribute-map RM-ATTRIBUTE match-map RM-MATCH advertise-only
+   aggregate-address 2.2.1.0/24
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-base.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-base.yml
@@ -7,3 +7,13 @@ router_bgp:
     - graceful-restart restart-time 300
     - graceful-restart
     - maximum-paths 2 ecmp 2
+  aggregate_addresses:
+    1.1.1.0/24:
+      advertise_only: true
+    2.2.1.0/24:
+    1.12.1.0/24:
+      as_set: true
+      summary_only: true
+      attribute_map: RM-ATTRIBUTE
+      match_map: RM-MATCH
+      advertise_only: true

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1165,6 +1165,16 @@ router_bgp:
       password: "< encrypted_password >"
     < IPv6_address_1 >:
       remote_as: < bgp_as >
+  aggregate_addresses:
+    < aggregate_address_1/mask >:
+      advertise_only: < true | false >
+    < aggregate_address_2/mask >:
+    < aggregate_address_3/mask >:
+      as_set: < true | false >
+      summary_only: < true | false >
+      attribute_map: < route_map_name >
+      match_map: < route_map_name >
+      advertise_only: true
   redistribute_routes:
     < route_type >:
       route_map: < route_map_name >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1174,7 +1174,7 @@ router_bgp:
       summary_only: < true | false >
       attribute_map: < route_map_name >
       match_map: < route_map_name >
-      advertise_only: true
+      advertise_only: < true | false >
   redistribute_routes:
     < route_type >:
       route_map: < route_map_name >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
@@ -77,6 +77,16 @@
 {%   endfor %}
 {% endif %}
 
+{%     if router_bgp.aggregate_addresses is defined and router_bgp.aggregate_addresses is not none %}
+### BGP Route Aggregation
+
+| Prefix | AS Set | Summary Only | Attribute Map | Match Map | Advertise Only |
+| ------ | ------ | ------------ | ------------- | --------- | -------------- |
+{%         for aggregate_address in router_bgp.aggregate_addresses | arista.avd.natural_sort %}
+| {{ aggregate_address }} |{% if router_bgp.aggregate_addresses[aggregate_address].as_set is defined and router_bgp.aggregate_addresses[aggregate_address].as_set == true %} True {% else %} False {% endif %}|{% if router_bgp.aggregate_addresses[aggregate_address].summary_only is defined and router_bgp.aggregate_addresses[aggregate_address].summary_only == true %} True {% else %} False {% endif %} |{% if router_bgp.aggregate_addresses[aggregate_address].attribute_map is defined and router_bgp.aggregate_addresses[aggregate_address].attribute_map is not none %} {{ router_bgp.aggregate_addresses[aggregate_address].attribute_map }} {% else %} Not Defined {% endif %}|{% if router_bgp.aggregate_addresses[aggregate_address].match_map is defined and router_bgp.aggregate_addresses[aggregate_address].match_map is not none %} {{ router_bgp.aggregate_addresses[aggregate_address].match_map }} {% else %} Not Defined {% endif %}|{% if router_bgp.aggregate_addresses[aggregate_address].advertise_only is defined and router_bgp.aggregate_addresses[aggregate_address].advertise_only == true %} True {% else %} False {% endif %}|
+{%         endfor %}
+{%     endif %}
+
 ### Router BGP EVPN Address Family
 
 #### Router BGP EVPN MAC-VRFs

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
@@ -13,85 +13,84 @@
 
 | BGP Tuning |
 | ---------- |
-{%   for bgp_default in router_bgp.bgp_defaults %}
+{% for bgp_default in router_bgp.bgp_defaults %}
 | {{ bgp_default }} |
-{%   endfor %}
+{% endfor %}
 
-{%   if router_bgp.peer_groups is defined and router_bgp.peer_groups is not none %}
+{% if router_bgp.peer_groups is defined and router_bgp.peer_groups is not none %}
 ### Router BGP Peer Groups
-{%      for peer_group in router_bgp.peer_groups | arista.avd.natural_sort %}
+{%     for peer_group in router_bgp.peer_groups | arista.avd.natural_sort %}
 
 **{{ peer_group }}**:
 
 | Settings | Value |
 | -------- | ----- |
-{%          if router_bgp.peer_groups[peer_group].type is defined and router_bgp.peer_groups[peer_group].type is not none %}
+{%         if router_bgp.peer_groups[peer_group].type is defined and router_bgp.peer_groups[peer_group].type is not none %}
 | Address Family | {{ router_bgp.peer_groups[peer_group].type }} |
-{%          endif %}
-{%          if router_bgp.peer_groups[peer_group].remote_as is defined and router_bgp.peer_groups[peer_group].remote_as is not none %}
+{%         endif %}
+{%         if router_bgp.peer_groups[peer_group].remote_as is defined and router_bgp.peer_groups[peer_group].remote_as is not none %}
 | remote_as | {{ router_bgp.peer_groups[peer_group].remote_as }} |
-{%          endif %}
-{%          if router_bgp.peer_groups[peer_group].route_reflector_client is defined and router_bgp.peer_groups[peer_group].route_reflector_client is not none %}
+{%         endif %}
+{%         if router_bgp.peer_groups[peer_group].route_reflector_client is defined and router_bgp.peer_groups[peer_group].route_reflector_client is not none %}
 | Route Reflector Client | Yes |
-{%          endif %}
-{%          if router_bgp.peer_groups[peer_group].bgp_listen_range_prefix is defined and router_bgp.peer_groups[peer_group].bgp_listen_range_prefix is not none %}
+{%         endif %}
+{%         if router_bgp.peer_groups[peer_group].bgp_listen_range_prefix is defined and router_bgp.peer_groups[peer_group].bgp_listen_range_prefix is not none %}
 | listen range prefix | {{ router_bgp.peer_groups[peer_group].bgp_listen_range_prefix }} |
-{%          endif %}
-{%          if router_bgp.peer_groups[peer_group].next_hop_self is defined and router_bgp.peer_groups[peer_group].next_hop_self == true %}
+{%         endif %}
+{%         if router_bgp.peer_groups[peer_group].next_hop_self is defined and router_bgp.peer_groups[peer_group].next_hop_self == true %}
 | next-hop self | true |
-{%          endif %}
-{%          if router_bgp.peer_groups[peer_group].next_hop_unchanged is defined and router_bgp.peer_groups[peer_group].next_hop_unchanged == true %}
+{%         endif %}
+{%         if router_bgp.peer_groups[peer_group].next_hop_unchanged is defined and router_bgp.peer_groups[peer_group].next_hop_unchanged == true %}
 | next-hop unchanged | true |
-{%          endif %}
-{%          if router_bgp.peer_groups[peer_group].update_source is defined  and router_bgp.peer_groups[peer_group].update_source is not none %}
+{%         endif %}
+{%         if router_bgp.peer_groups[peer_group].update_source is defined  and router_bgp.peer_groups[peer_group].update_source is not none %}
 | source | {{ router_bgp.peer_groups[peer_group].update_source }} |
-{%          endif %}
-{%          if router_bgp.peer_groups[peer_group].bfd is defined and router_bgp.peer_groups[peer_group].bfd == true %}
+{%         endif %}
+{%         if router_bgp.peer_groups[peer_group].bfd is defined and router_bgp.peer_groups[peer_group].bfd == true %}
 | bfd | true |
-{%          endif %}
-{%          if router_bgp.peer_groups[peer_group].ebgp_multihop is defined and router_bgp.peer_groups[peer_group].ebgp_multihop is not none %}
+{%         endif %}
+{%         if router_bgp.peer_groups[peer_group].ebgp_multihop is defined and router_bgp.peer_groups[peer_group].ebgp_multihop is not none %}
 | ebgp multihop | {{ router_bgp.peer_groups[peer_group].ebgp_multihop }} |
-{%          endif %}
-{%          if router_bgp.peer_groups[peer_group].send_community is defined and router_bgp.peer_groups[peer_group].send_community == true %}
+{%         endif %}
+{%         if router_bgp.peer_groups[peer_group].send_community is defined and router_bgp.peer_groups[peer_group].send_community == true %}
 | send community | true |
-{%          endif %}
-{%          if router_bgp.peer_groups[peer_group].maximum_routes is defined and router_bgp.peer_groups[peer_group].maximum_routes is not none %}
+{%         endif %}
+{%         if router_bgp.peer_groups[peer_group].maximum_routes is defined and router_bgp.peer_groups[peer_group].maximum_routes is not none %}
 | maximum routes |{% if router_bgp.peer_groups[peer_group].maximum_routes == 0 %} 0 (no limit) |{% else %} {{ router_bgp.peer_groups[peer_group].maximum_routes }} |{% endif %}
 
-{%          endif %}
-{%    endfor %}
-{%   endif %}
+{%         endif %}
+{%     endfor %}
+{% endif %}
 
 {% if router_bgp.neighbors is defined and router_bgp.neighbors is not none %}
 ### BGP Neighbors
 
 | Neighbor | Remote AS |
 | -------- | ---------
-{%   for neighbor in router_bgp.neighbors | arista.avd.natural_sort %}
-{%      if router_bgp.neighbors[neighbor].remote_as is defined and router_bgp.neighbors[neighbor].remote_as is not none %}
+{%     for neighbor in router_bgp.neighbors | arista.avd.natural_sort %}
+{%         if router_bgp.neighbors[neighbor].remote_as is defined and router_bgp.neighbors[neighbor].remote_as is not none %}
 | {{ neighbor }} | {{ router_bgp.neighbors[neighbor].remote_as }} |
-{%      else %}
-{% if router_bgp.neighbors[neighbor].peer_group is defined and router_bgp.neighbors[neighbor].peer_group is not none %}
+{%         else %}
+{%             if router_bgp.neighbors[neighbor].peer_group is defined and router_bgp.neighbors[neighbor].peer_group is not none %}
 | {{ neighbor }} | Inherited from peer group {{ router_bgp.neighbors[neighbor].peer_group }}{% endif %} |
-{%      endif %}
-{%   endfor %}
+{%         endif %}
+{%     endfor %}
 {% endif %}
-
-{%     if router_bgp.aggregate_addresses is defined and router_bgp.aggregate_addresses is not none %}
+{% if router_bgp.aggregate_addresses is defined and router_bgp.aggregate_addresses is not none %}
 ### BGP Route Aggregation
 
 | Prefix | AS Set | Summary Only | Attribute Map | Match Map | Advertise Only |
 | ------ | ------ | ------------ | ------------- | --------- | -------------- |
-{%         for aggregate_address in router_bgp.aggregate_addresses | arista.avd.natural_sort %}
+{%     for aggregate_address in router_bgp.aggregate_addresses | arista.avd.natural_sort %}
 | {{ aggregate_address }} |{% if router_bgp.aggregate_addresses[aggregate_address].as_set is defined and router_bgp.aggregate_addresses[aggregate_address].as_set == true %} True {% else %} False {% endif %}|{% if router_bgp.aggregate_addresses[aggregate_address].summary_only is defined and router_bgp.aggregate_addresses[aggregate_address].summary_only == true %} True {% else %} False {% endif %} |{% if router_bgp.aggregate_addresses[aggregate_address].attribute_map is defined and router_bgp.aggregate_addresses[aggregate_address].attribute_map is not none %} {{ router_bgp.aggregate_addresses[aggregate_address].attribute_map }} {% else %} Not Defined {% endif %}|{% if router_bgp.aggregate_addresses[aggregate_address].match_map is defined and router_bgp.aggregate_addresses[aggregate_address].match_map is not none %} {{ router_bgp.aggregate_addresses[aggregate_address].match_map }} {% else %} Not Defined {% endif %}|{% if router_bgp.aggregate_addresses[aggregate_address].advertise_only is defined and router_bgp.aggregate_addresses[aggregate_address].advertise_only == true %} True {% else %} False {% endif %}|
-{%         endfor %}
-{%     endif %}
+{%     endfor %}
+{% endif %}
 
 ### Router BGP EVPN Address Family
 
 #### Router BGP EVPN MAC-VRFs
 
-{%   if router_bgp.vlan_aware_bundles is defined and router_bgp.vlan_aware_bundles is not none %}
+{% if router_bgp.vlan_aware_bundles is defined and router_bgp.vlan_aware_bundles is not none %}
 **VLAN aware bundles:**
 
 | VLAN Aware Bundle | Route-Distinguisher | Both Route-Target | Import Route Target | Export Route-Target | Redistribute | VLANs |
@@ -99,9 +98,9 @@
 {%     for vlan_aware_bundle in router_bgp.vlan_aware_bundles | arista.avd.natural_sort %}
 | {{ vlan_aware_bundle }} | {{ router_bgp.vlan_aware_bundles[vlan_aware_bundle].rd }} | {% if router_bgp.vlan_aware_bundles[vlan_aware_bundle].route_targets.both is defined and router_bgp.vlan_aware_bundles[vlan_aware_bundle].route_targets.both is not none %}{% for route_target in router_bgp.vlan_aware_bundles[vlan_aware_bundle].route_targets.both %} {{ route_target }}{% if not loop.last %}<br>{% endif %} {% endfor %}{% endif %} | {% if router_bgp.vlan_aware_bundles[vlan_aware_bundle].route_targets.import is defined and router_bgp.vlan_aware_bundles[vlan_aware_bundle].route_targets.import is not none %}{% for route_target in router_bgp.vlan_aware_bundles[vlan_aware_bundle].route_targets.import %} {{ route_target }}{% if not loop.last %}<br>{% endif %} {% endfor %}{% endif %} | {% if router_bgp.vlan_aware_bundles[vlan_aware_bundle].route_targets.export is defined and router_bgp.vlan_aware_bundles[vlan_aware_bundle].route_targets.export is not none %} {% for route_target in router_bgp.vlan_aware_bundles[vlan_aware_bundle].route_targets.export %} {{ route_target }}{% if not loop.last %}<br>{% endif %}{% endfor %}{% endif %} | {%- for redistribute_route in router_bgp.vlan_aware_bundles[vlan_aware_bundle].redistribute_routes | arista.avd.natural_sort %} {{ redistribute_route }}{% if not loop.last %}<br>{% endif %} {% endfor -%} | {{ router_bgp.vlan_aware_bundles[vlan_aware_bundle].vlan }} |
 {%     endfor %}
-{%   endif %}
+{% endif %}
 
-{%   if router_bgp.vlans is defined and router_bgp.vlans is not none %}
+{% if router_bgp.vlans is defined and router_bgp.vlans is not none %}
 **VLAN Based:**
 
 | VLAN | Route-Distinguisher | Both Route-Target | Import Route Target | Export Route-Target | Redistribute |
@@ -109,17 +108,17 @@
 {%     for vlan in router_bgp.vlans | arista.avd.natural_sort %}
 | {{ vlan }} | {{ router_bgp.vlans[vlan].rd }} | {% if router_bgp.vlans[vlan].route_targets.both is defined and router_bgp.vlans[vlan].route_targets.both is not none %}{% for route_target in router_bgp.vlans[vlan].route_targets.both %} {{ route_target }}{% if not loop.last %}<br>{% endif %}{% endfor %}{% else%} - {% endif %} | {% if router_bgp.vlans[vlan].route_targets.import is defined and router_bgp.vlans[vlan].route_targets.import is not none %}{% for route_target in router_bgp.vlans[vlan].route_targets.import %} {{ route_target }}{% if not loop.last %}<br>{% endif %} {% endfor %}{% else %} - {% endif %} |{% if router_bgp.vlans[vlan].route_targets.export is defined and router_bgp.vlans[vlan].route_targets.export is not none %}{% for route_target in router_bgp.vlans[vlan].route_targets.export %} {{ route_target }} {% if not loop.last %}<br>{% endif %}{% endfor %}{% else %} - {% endif %} | {%- for redistribute_route in router_bgp.vlans[vlan].redistribute_routes | arista.avd.natural_sort %} {{ redistribute_route }}{% if not loop.last %}<br>{% endif %} {% endfor -%} |
 {%     endfor %}
-{%   endif %}
+{% endif %}
 
 #### Router BGP EVPN VRFs
 
-{%   if router_bgp.vrfs is defined and router_bgp.vrfs is not none %}
+{% if router_bgp.vrfs is defined and router_bgp.vrfs is not none %}
 | VRF | Route-Distinguisher | Redistribute |
 | --- | ------------------- | ------------ |
 {%     for vrf in router_bgp.vrfs | arista.avd.natural_sort %}
 | {{ vrf }} | {{ router_bgp.vrfs[vrf].rd }} |{%- if router_bgp.vrfs[vrf].redistribute_routes is defined and router_bgp.vrfs[vrf].redistribute_routes is not none %}{%- for redistribute_route in router_bgp.vrfs[vrf].redistribute_routes | arista.avd.natural_sort %} {{ redistribute_route }}{% if not loop.last %}<br>{% endif %} {% endfor -%}{% endif %} |
 {%     endfor %}
-{%   endif %}
+{% endif %}
 
 ### Router BGP Device Configuration
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -95,6 +95,12 @@ router bgp {{ router_bgp.as }}
 {%             endif %}
 {%         endfor %}
 {%     endif %}
+{%     if router_bgp.aggregate_addresses is defined and router_bgp.aggregate_addresses is not none %}
+{%         for aggregate_address in router_bgp.aggregate_addresses | arista.avd.natural_sort %}
+   aggregate-address {{ aggregate_address }}{% if router_bgp.aggregate_addresses[aggregate_address].as_set is defined and router_bgp.aggregate_addresses[aggregate_address].as_set == true %} as-set{% endif %}{% if router_bgp.aggregate_addresses[aggregate_address].summary_only is defined and router_bgp.aggregate_addresses[aggregate_address].summary_only == true %} summary-only{% endif %}{% if router_bgp.aggregate_addresses[aggregate_address].attribute_map is defined and router_bgp.aggregate_addresses[aggregate_address].attribute_map is not none %} attribute-map {{ router_bgp.aggregate_addresses[aggregate_address].attribute_map }}{% endif %}{% if router_bgp.aggregate_addresses[aggregate_address].match_map is defined and router_bgp.aggregate_addresses[aggregate_address].match_map is not none %} match-map {{ router_bgp.aggregate_addresses[aggregate_address].match_map }}{% endif %}{% if router_bgp.aggregate_addresses[aggregate_address].advertise_only is defined and router_bgp.aggregate_addresses[aggregate_address].advertise_only == true %} advertise-only{% endif %}
+
+{%         endfor %}
+{%     endif %}
 {%     if router_bgp.redistribute_routes is defined and router_bgp.redistribute_routes is not none %}
 {%         for redistribute_route in router_bgp.redistribute_routes | arista.avd.natural_sort %}
    redistribute {{ redistribute_route }}{% if router_bgp.redistribute_routes[redistribute_route].route_map is defined and router_bgp.redistribute_routes[redistribute_route].route_map is not none %} route-map {{ router_bgp.redistribute_routes[redistribute_route].route_map }}{% endif %}


### PR DESCRIPTION
## Aggregate Address in router_bgp for eos_cli_config_gen Role


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Proposed changes
Added the following keys in router_bgp:
```yaml
  aggregate_addresses:
    < aggregate_address_1/mask >:
      advertise_only: < true | false >
    < aggregate_address_2/mask >:
    < aggregate_address_3/mask >:
      as_set: < true | false >
      summary_only: < true | false >
      attribute_map: < route_map_name >
      match_map: < route_map_name >
      advertise_only: < true | false >
```

## How to test
Use the following for example in a leaf structured YAML file under router_bgp:

```yaml
  aggregate_addresses:
    1.1.1.0/24:
      advertise_only: true
    2.2.1.0/24:
    1.12.1.0/24:
      as_set: true
      summary_only: true
      attribute_map: RM-ATTRIBUTE
      match_map: RM-MATCH
      advertise_only: true
```

It should render the following:
```eos
router bgp xxx
   aggregate-address 1.1.1.0/24 advertise-only
   aggregate-address 1.12.1.0/24 as-set summary-only attribute-map RM-ATTRIBUTE match-map RM-MATCH advertise-only
   aggregate-address 2.2.1.0/24
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
