### PR TITLE
ip/v6 static routes documentation and metric

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/aaa.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/aaa.md
@@ -348,6 +348,9 @@ IP Virtual Router MAC Address is not defined
 ## Static Routes
 
 
+## IPv6 Static Routes
+
+
 ## Router ISIS
 
 Router ISIS not defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/acl.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/acl.md
@@ -264,6 +264,9 @@ IP Virtual Router MAC Address is not defined
 ## Static Routes
 
 
+## IPv6 Static Routes
+
+
 ## Router ISIS
 
 Router ISIS not defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/base.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/base.md
@@ -284,6 +284,9 @@ IP Virtual Router MAC Address is not defined
 ## Static Routes
 
 
+## IPv6 Static Routes
+
+
 ## Router ISIS
 
 Router ISIS not defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/dns-ntp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/dns-ntp.md
@@ -314,6 +314,9 @@ IP Virtual Router MAC Address is not defined
 ## Static Routes
 
 
+## IPv6 Static Routes
+
+
 ## Router ISIS
 
 Router ISIS not defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -295,6 +295,9 @@ IP Virtual Router MAC Address is not defined
 ## Static Routes
 
 
+## IPv6 Static Routes
+
+
 ## Router ISIS
 
 Router ISIS not defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet_interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet_interfaces.md
@@ -264,6 +264,9 @@ IP Virtual Router MAC Address is not defined
 ## Static Routes
 
 
+## IPv6 Static Routes
+
+
 ## Router ISIS
 
 Router ISIS not defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/logging-minimal.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/logging-minimal.md
@@ -283,6 +283,9 @@ IP Virtual Router MAC Address is not defined
 ## Static Routes
 
 
+## IPv6 Static Routes
+
+
 ## Router ISIS
 
 Router ISIS not defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/logging.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/logging.md
@@ -289,6 +289,9 @@ IP Virtual Router MAC Address is not defined
 ## Static Routes
 
 
+## IPv6 Static Routes
+
+
 ## Router ISIS
 
 Router ISIS not defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/loopbacks-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/loopbacks-interfaces.md
@@ -298,6 +298,9 @@ IP Virtual Router MAC Address is not defined
 ## Static Routes
 
 
+## IPv6 Static Routes
+
+
 ## Router ISIS
 
 Router ISIS not defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mcast-pim.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mcast-pim.md
@@ -264,6 +264,9 @@ IP Virtual Router MAC Address is not defined
 ## Static Routes
 
 
+## IPv6 Static Routes
+
+
 ## Router ISIS
 
 Router ISIS not defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/none_configuration.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/none_configuration.md
@@ -264,6 +264,9 @@ IP Virtual Router MAC Address is not defined
 ## Static Routes
 
 
+## IPv6 Static Routes
+
+
 ## Router ISIS
 
 Router ISIS not defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
@@ -330,6 +330,9 @@ IP Virtual Router MAC Address is not defined
 ## Static Routes
 
 
+## IPv6 Static Routes
+
+
 ## Router ISIS
 
 Router ISIS not defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/prefix-lists.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/prefix-lists.md
@@ -264,6 +264,9 @@ IP Virtual Router MAC Address is not defined
 ## Static Routes
 
 
+## IPv6 Static Routes
+
+
 ## Router ISIS
 
 Router ISIS not defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/route-maps.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/route-maps.md
@@ -264,6 +264,9 @@ IP Virtual Router MAC Address is not defined
 ## Static Routes
 
 
+## IPv6 Static Routes
+
+
 ## Router ISIS
 
 Router ISIS not defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
@@ -264,6 +264,9 @@ IP Virtual Router MAC Address is not defined
 ## Static Routes
 
 
+## IPv6 Static Routes
+
+
 ## Router ISIS
 
 Router ISIS not defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-evpn.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-evpn.md
@@ -264,6 +264,9 @@ IP Virtual Router MAC Address is not defined
 ## Static Routes
 
 
+## IPv6 Static Routes
+
+
 ## Router ISIS
 
 Router ISIS not defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-v4-evpn.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-v4-evpn.md
@@ -264,6 +264,9 @@ IP Virtual Router MAC Address is not defined
 ## Static Routes
 
 
+## IPv6 Static Routes
+
+
 ## Router ISIS
 
 Router ISIS not defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-v4-v6-evpn.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-v4-v6-evpn.md
@@ -264,6 +264,9 @@ IP Virtual Router MAC Address is not defined
 ## Static Routes
 
 
+## IPv6 Static Routes
+
+
 ## Router ISIS
 
 Router ISIS not defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis.md
@@ -264,6 +264,9 @@ IP Virtual Router MAC Address is not defined
 ## Static Routes
 
 
+## IPv6 Static Routes
+
+
 ## Router ISIS
 
 ### Router ISIS Summary

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
@@ -264,6 +264,9 @@ IP Virtual Router MAC Address is not defined
 ## Static Routes
 
 
+## IPv6 Static Routes
+
+
 ## Router ISIS
 
 Router ISIS not defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-static.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-static.md
@@ -1,4 +1,4 @@
-# test2
+# router-static
 
 # Table of Contents
 
@@ -201,37 +201,16 @@ Spanning-Tree Not Defined
 
 ### Internal VLAN Allocation Policy Summary
 
+**Default Allocation Policy**
+
 | Policy Allocation | Range Beginning | Range Ending |
 | ------------------| --------------- | ------------ |
-| ascending | 1006 | 1199 |
+| ascending | 1006 | 4094 |
 
-### Internal VLAN Allocation Policy Configuration
-
-```eos
-!
-vlan internal order ascending range 1006 1199
-```
 
 # VLANs
 
-### VLANs Summary
-
-| VLAN ID | Name | Trunk Groups |
-| ------- | ---- | ------------ |
-| 110 | PR01-DMZ | none  |
-| 3010 | MLAG_iBGP_TENANT_A_PROJECT01 | LEAF_PEER_L3  |
-
-### VLANs Device Configuration
-
-```eos
-!
-vlan 110
-   name PR01-DMZ
-!
-vlan 3010
-   name MLAG_iBGP_TENANT_A_PROJECT01
-   trunk group LEAF_PEER_L3
-```
+No VLANs defined
 
 # Interfaces
 
@@ -266,7 +245,7 @@ IP Virtual Router MAC Address is not defined
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default |  False |
+| default |  False | 
 
 ### IP Routing Device Configuration
 
@@ -278,12 +257,55 @@ IP Virtual Router MAC Address is not defined
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default |  False |
-
+| default |  False | 
+ 
 
 
 ## Static Routes
 
+
+### Static Routes Summary
+
+| VRF | Destination Prefix | Next Hop IP             | Exit interface      | Administrative Distance       | Tag               | Route Name                    | Metric         |
+| --- | ------------------ | ----------------------- | ------------------- | ----------------------------- | ----------------- | ----------------------------- | -------------- |
+| default  | 1.1.1.0/24 |  10.1.1.1  |  vlan101  |  Default  |  -  |  -  |  - |
+| default  | 1.1.2.0/24 |  10.1.1.1  |  vlan101  |  200  |  666  |  RT-TO-FAKE-DMZ  |  - |
+| customer01  | 1.2.1.0/24 |  10.1.2.1  |  vlan202  |  Default  |  -  |  -  |  - |
+| customer01  | 1.2.2.0/24 |  10.1.2.1  |  vlan101  |  201  |  667  |  RT-TO-FAKE-DMZ  |  - |
+
+### Static Routes Device Configuration
+
+```eos
+!
+ip route 1.1.1.0/24 Vlan101 10.1.1.1
+ip route 1.1.2.0/24 Vlan101 10.1.1.1 200 tag 666 name RT-TO-FAKE-DMZ
+ip route vrf customer01 1.2.1.0/24 Vlan202 10.1.2.1
+ip route vrf customer01 1.2.2.0/24 Vlan101 10.1.2.1 201 tag 667 name RT-TO-FAKE-DMZ
+```
+
+## IPv6 Static Routes
+
+
+### IPv6 Static Routes Summary
+
+| VRF | Destination Prefix | Next Hop IP             | Exit interface      | Administrative Distance       | Tag               | Route Name                    | Metric         |
+| --- | ------------------ | ----------------------- | ------------------- | ----------------------------- | ----------------- | ----------------------------- | -------------- |
+| default  | 2a01:cb04:4e6:d300::/64 |  2a01:cb04:4e6:d100::1  |  vlan101  |  Default  |  -  |  -  |  - |
+| default  | 2a01:cb04:4e6:d400::/64 |  2a01:cb04:4e6:d100::1  |  vlan101  |  200  |  666  |  RT-TO-FAKE-DMZ  |  - |
+| default  | 2a01:cb04:4e6:d400::/64 |  2a01:cb04:4e6:d100::1  |  vlan101  |  200  |  666  |  RT-TO-FAKE-DB-ZONE  |  100 |
+| customer01  | 2a01:cb04:4e6:a300::/64 |  2a01:cb04:4e6:100::1  |  vlan101  |  Default  |  -  |  -  |  - |
+| customer01  | 2a01:cb04:4e6:a400::/64 |  2a01:cb04:4e6:100::1  |  vlan101  |  201  |  667  |  RT-TO-FAKE-DMZ  |  - |
+
+### Static Routes Device Configuration
+
+```eos
+!
+ipv6 route 2a01:cb04:4e6:d300::/64 Vlan101 2a01:cb04:4e6:d100::1
+ipv6 route 2a01:cb04:4e6:d400::/64 Vlan101 2a01:cb04:4e6:d100::1 200 tag 666 name RT-TO-FAKE-DMZ
+ipv6 route 2a01:cb04:4e6:d400::/64 Vlan101 2a01:cb04:4e6:d100::1 200 tag 666 name RT-TO-FAKE-DB-ZONE metric 100
+ipv6 route vrf customer01 2a01:cb04:4e6:a300::/64 Vlan101 2a01:cb04:4e6:100::1
+ipv6 route vrf customer01 2a01:cb04:4e6:a400::/64 Vlan101 2a01:cb04:4e6:100::1 201 tag 667 name RT-TO-FAKE-DMZ
+```
 
 ## Router ISIS
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/sflow.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/sflow.md
@@ -299,6 +299,9 @@ IP Virtual Router MAC Address is not defined
 ## Static Routes
 
 
+## IPv6 Static Routes
+
+
 ## Router ISIS
 
 Router ISIS not defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/snmp_v3.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/snmp_v3.md
@@ -264,6 +264,9 @@ IP Virtual Router MAC Address is not defined
 ## Static Routes
 
 
+## IPv6 Static Routes
+
+
 ## Router ISIS
 
 Router ISIS not defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/terminattr-cloud.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/terminattr-cloud.md
@@ -277,6 +277,9 @@ IP Virtual Router MAC Address is not defined
 ## Static Routes
 
 
+## IPv6 Static Routes
+
+
 ## Router ISIS
 
 Router ISIS not defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/terminattr-prem.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/terminattr-prem.md
@@ -277,6 +277,9 @@ IP Virtual Router MAC Address is not defined
 ## Static Routes
 
 
+## IPv6 Static Routes
+
+
 ## Router ISIS
 
 Router ISIS not defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
@@ -390,6 +390,9 @@ IP Virtual Router MAC Address is not defined
 ## Static Routes
 
 
+## IPv6 Static Routes
+
+
 ## Router ISIS
 
 Router ISIS not defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlans.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlans.md
@@ -285,6 +285,9 @@ IP Virtual Router MAC Address is not defined
 ## Static Routes
 
 
+## IPv6 Static Routes
+
+
 ## Router ISIS
 
 Router ISIS not defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vrfs.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vrfs.md
@@ -273,6 +273,9 @@ ip routing vrf TENANT_A_PROJECT02
 ## Static Routes
 
 
+## IPv6 Static Routes
+
+
 ## Router ISIS
 
 Router ISIS not defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-static.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-static.cfg
@@ -1,0 +1,25 @@
+!RANCID-CONTENT-TYPE: arista
+!
+transceiver qsfp default-mode 4x10G
+!
+hostname router-static
+!
+no aaa root
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+!
+ip route 1.1.1.0/24 Vlan101 10.1.1.1
+ip route 1.1.2.0/24 Vlan101 10.1.1.1 200 tag 666 name RT-TO-FAKE-DMZ
+ip route vrf customer01 1.2.1.0/24 Vlan202 10.1.2.1
+ip route vrf customer01 1.2.2.0/24 Vlan101 10.1.2.1 201 tag 667 name RT-TO-FAKE-DMZ
+!
+ipv6 route 2a01:cb04:4e6:d300::/64 Vlan101 2a01:cb04:4e6:d100::1
+ipv6 route 2a01:cb04:4e6:d400::/64 Vlan101 2a01:cb04:4e6:d100::1 200 tag 666 name RT-TO-FAKE-DMZ
+ipv6 route 2a01:cb04:4e6:d400::/64 Vlan101 2a01:cb04:4e6:d100::1 200 tag 666 name RT-TO-FAKE-DB-ZONE metric 100
+ipv6 route vrf customer01 2a01:cb04:4e6:a300::/64 Vlan101 2a01:cb04:4e6:100::1
+ipv6 route vrf customer01 2a01:cb04:4e6:a400::/64 Vlan101 2a01:cb04:4e6:100::1 201 tag 667 name RT-TO-FAKE-DMZ
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-static.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-static.yml
@@ -1,0 +1,64 @@
+---
+static_routes:
+  - vrf: default
+    destination_address_prefix: 1.1.1.0/24
+    interface: vlan101
+    gateway: 10.1.1.1
+
+  - vrf: default
+    destination_address_prefix: 1.1.2.0/24
+    interface: vlan101
+    gateway: 10.1.1.1
+    distance: 200
+    tag: 666
+    name: RT-TO-FAKE-DMZ
+
+  - vrf: customer01
+    destination_address_prefix: 1.2.1.0/24
+    interface: vlan202
+    gateway: 10.1.2.1
+
+  - vrf: customer01
+    destination_address_prefix: 1.2.2.0/24
+    interface: vlan101
+    gateway: 10.1.2.1
+    distance: 201
+    tag: 667
+    name: RT-TO-FAKE-DMZ
+
+
+ipv6_static_routes:
+  - vrf: default
+    destination_address_prefix: 2a01:cb04:4e6:d300::/64
+    interface: vlan101
+    gateway: 2a01:cb04:4e6:d100::1
+
+  - vrf: default
+    destination_address_prefix: 2a01:cb04:4e6:d400::/64
+    interface: vlan101
+    gateway: 2a01:cb04:4e6:d100::1
+    distance: 200
+    tag: 666
+    name: RT-TO-FAKE-DMZ
+
+  - vrf: default
+    destination_address_prefix: 2a01:cb04:4e6:d400::/64
+    interface: vlan101
+    gateway: 2a01:cb04:4e6:d100::1
+    distance: 200
+    tag: 666
+    metric: 100
+    name: RT-TO-FAKE-DB-ZONE
+
+  - vrf: customer01
+    destination_address_prefix: 2a01:cb04:4e6:a300::/64
+    interface: vlan101
+    gateway: 2a01:cb04:4e6:100::1
+
+  - vrf: customer01
+    destination_address_prefix: 2a01:cb04:4e6:a400::/64
+    interface: vlan101
+    gateway: 2a01:cb04:4e6:100::1
+    distance: 201
+    tag: 667
+    name: RT-TO-FAKE-DMZ

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts
@@ -19,6 +19,7 @@ router-bgp-v4-evpn
 router-bgp-v4-v6-evpn
 router-isis
 router-ospf
+router-static
 sflow
 snmp_v3
 terminattr-cloud

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -973,6 +973,7 @@ static_routes:
     distance: < 1-255 >
     tag: < 0-4294967295 >
     name: < description >
+    metric: < 0-4294967295 >
   - destination_address_prefix: < IPv4_network/Mask >
     gateway: < IPv4_address >
 ```
@@ -988,6 +989,7 @@ ipv6_static_routes:
     distance: < 1-255 >
     tag: < 0-4294967295 >
     name: < description >
+    metric: < 0-4294967295 >
   - destination_address_prefix: < IPv6_network/Mask >
     gateway: < IPv6_address >
 ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ipv6-static-routes.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ipv6-static-routes.j2
@@ -1,16 +1,16 @@
-{% if static_routes is defined and static_routes is not none %}
+{% if ipv6_static_routes is defined and ipv6_static_routes is not none %}
 
-### Static Routes Summary
+### IPv6 Static Routes Summary
 
 | VRF | Destination Prefix | Next Hop IP             | Exit interface      | Administrative Distance       | Tag               | Route Name                    | Metric         |
 | --- | ------------------ | ----------------------- | ------------------- | ----------------------------- | ----------------- | ----------------------------- | -------------- |
-{%  for static_route in static_routes %}
+{%  for static_route in ipv6_static_routes %}
 |{% if static_route.vrf is defined and static_route.vrf is not none %} {{ static_route.vrf }} {% else %} default {%  endif %} | {{ static_route.destination_address_prefix }} | {% if static_route.gateway is defined and static_route.gateway is not none%} {{ static_route.gateway }} {% else %} - {% endif %} | {% if static_route.interface is defined and static_route.interface is not none%} {{ static_route.interface }} {% else %} - {% endif %} | {% if static_route.distance is defined and static_route.distance is not none %} {{ static_route.distance }} {% else %} Default {% endif %} | {% if static_route.tag is defined and static_route.tag is not none %} {{ static_route.tag }} {% else %} - {% endif %} | {% if static_route.name is defined and static_route.name is not none %} {{ static_route.name }} {% else %} - {% endif %} | {% if static_route.metric is defined and static_route.metric is not none %} {{ static_route.metric }} {% else %} - {% endif %}|
 {%  endfor %}
 
 ### Static Routes Device Configuration
 
 ```eos
-{% include 'eos/static-routes.j2' %}
+{% include 'eos/ipv6-static-routes.j2' %}
 ```
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-device-documentation.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-device-documentation.j2
@@ -221,6 +221,10 @@
 
 {% include 'documentation/static-routes.j2' %}
 
+## IPv6 Static Routes
+
+{% include 'documentation/ipv6-static-routes.j2' %}
+
 ## Router ISIS
 
 {% include 'documentation/router-isis.j2' %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ipv6-static-routes.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ipv6-static-routes.j2
@@ -3,12 +3,13 @@
 !
 {%     for ipv6_static_route in ipv6_static_routes %}
 ipv6 route
-{%- if ipv6_static_route['vrf'] is defined and ipv6_static_route['vrf'] != 'default' %} vrf {{ ipv6_static_route['vrf'] }}{% endif %} {{ ipv6_static_route['destination_address_prefix'] }}
+{%- if ipv6_static_route['vrf'] is defined and ipv6_static_route['vrf'] != 'default' and ipv6_static_route['vrf'] is not none %} vrf {{ ipv6_static_route['vrf'] }}{% endif %} {{ ipv6_static_route['destination_address_prefix'] }}
 {%- if ipv6_static_route['interface'] is defined and ipv6_static_route['interface'] is not none and ipv6_static_route['interface'] | capitalize != 'Null0' %} {{ ipv6_static_route['interface'] | capitalize }}{% elif ipv6_static_route['interface'] is defined and ipv6_static_route['interface'] is not none and ipv6_static_route['interface'] | capitalize == 'Null0' %} {{ ipv6_static_route['interface'] | capitalize }}{%- endif -%}
 {%- if ipv6_static_route['gateway'] is defined and ipv6_static_route['gateway'] is not none and (static_route['interface'] is not defined or ipv6_static_route['interface'] | capitalize != 'Null0') %} {{ ipv6_static_route['gateway'] }}{% endif -%}
 {%- if ipv6_static_route['distance'] is defined and ipv6_static_route['distance'] is not none %} {{ ipv6_static_route['distance'] }}{% endif -%}
 {%- if ipv6_static_route['tag'] is defined and ipv6_static_route['tag'] is not none %} tag {{ ipv6_static_route['tag'] }}{% endif -%}
 {%- if ipv6_static_route['name'] is defined and ipv6_static_route['name'] is not none %} name {{ ipv6_static_route['name'] }}{% endif %}
+{%- if ipv6_static_route['metric'] is defined and ipv6_static_route['metric'] is not none %} metric {{ ipv6_static_route['metric'] }}{% endif %}
 
 {%          endfor %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/static-routes.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/static-routes.j2
@@ -3,12 +3,13 @@
 !
 {%     for static_route in static_routes %}
 ip route
-{%- if static_route['vrf'] is defined and static_route['vrf'] != 'default' %} vrf {{ static_route['vrf'] }}{% endif %} {{ static_route['destination_address_prefix'] }}
+{%- if static_route['vrf'] is defined and static_route['vrf'] != 'default' and static_route['vrf'] is not none%} vrf {{ static_route['vrf'] }}{% endif %} {{ static_route['destination_address_prefix'] }}
 {%- if static_route['interface'] is defined and static_route['interface'] is not none and static_route['interface'] | capitalize != 'Null0' %} {{ static_route['interface'] | capitalize }}{% elif static_route['interface'] is defined and static_route['interface'] is not none and static_route['interface'] | capitalize == 'Null0' %} {{ static_route['interface'] | capitalize }}{%- endif -%}
 {%- if static_route['gateway'] is defined and static_route['gateway'] is not none and (static_route['interface'] is not defined or static_route['interface'] | capitalize != 'Null0') %} {{ static_route['gateway'] }}{% endif -%}
 {%- if static_route['distance'] is defined and static_route['distance'] is not none %} {{ static_route['distance'] }}{% endif -%}
 {%- if static_route['tag'] is defined and static_route['tag'] is not none %} tag {{ static_route['tag'] }}{% endif -%}
 {%- if static_route['name'] is defined and static_route['name'] is not none %} name {{ static_route['name'] }}{% endif %}
+{%- if static_route['metric'] is defined and static_route['metric'] is not none %} metric {{ static_route['metric'] }}{% endif %}
 
 {%          endfor %}
 {% endif %}


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

1. IPv4 static routes documentation increased with missing variables.
2. IPv6 static routes documentation developed based on IPv4.
3. IPv4 and IPv6 metric EOS command included.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [x] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #278 
## Component(s) name

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
