### PR TITLE
eos_cli_config_gen add support for platform sand lag and mode

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/platform.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/platform.md
@@ -1,0 +1,375 @@
+# platform
+
+# Table of Contents
+
+- [Management](#management)
+  - [Management Interfaces](#management-interfaces)
+  - [DNS Domain](#dns-domain)
+  - [Name Servers](#name-servers)
+  - [Domain Lookup](#domain-lookup)
+  - [NTP](#ntp)
+  - [Management SSH](#management-ssh)
+- [Authentication](#authentication)
+  - [Local Users](#local-users)
+  - [TACACS Servers](#tacacs-servers)
+  - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
+  - [RADIUS Servers](#radius-servers)
+  - [AAA Server Groups](#aaa-server-groups)
+  - [AAA Authentication](#aaa-authentication)
+  - [AAA Authorization](#aaa-authorization)
+  - [AAA Accounting](#aaa-accounting)
+- [Management Security](#management-security)
+- [Aliases](#aliases)
+- [Monitoring](#monitoring)
+  - [TerminAttr Daemon](#terminattr-daemon)
+  - [Logging](#logging)
+  - [SFlow](#sflow)
+  - [Hardware Counters](#hardware-counters)
+  - [VM Tracer Sessions](#vm-tracer-sessions)
+  - [Event Handler](#event-handler)
+- [MLAG](#mlag)
+- [Spanning Tree](#spanning-tree)
+- [Internal VLAN Allocation Policy](#internal-vlan-allocation-policy)
+- [VLANs](#vlans)
+- [Interfaces](#interfaces)
+  - [Ethernet Interfaces](#ethernet-interfaces)
+  - [Port-Channel Interfaces](#port-channel-interfaces)
+  - [Loopback Interfaces](#loopback-interfaces)
+  - [VLAN Interfaces](#vlan-interfaces)
+  - [VXLAN Interface](#vxlan-interface)
+- [Routing](#routing)
+  - [Virtual Router MAC Address](#virtual-router-mac-address)
+  - [IP Routing](#ip-routing)
+  - [IPv6 Routing](#ipv6-routing)
+  - [Static Routes](#static-routes)
+  - [Router ISIS](#router-isis)
+  - [Router BGP](#router-bgp)
+  - [Router BFD](#router-bfd)
+- [Multicast](#multicast)
+  - [IP IGMP Snooping](#ip-igmp-snooping)
+  - [Router Multicast](#router-multicast)
+  - [Router PIM Sparse Mode](#router-pim-sparse-mode)
+- [Filters](#filters)
+  - [Community Lists](#community-lists)
+  - [Peer Filters](#peer-filters)
+  - [Prefix Lists](#prefix-lists)
+  - [IPv6 Prefix Lists](#ipv6-prefix-lists)
+  - [Route Maps](#route-maps)
+  - [IP Extended Communities](#ip-extended-communities)
+- [ACL](#acl)
+  - [Standard Access-lists](#standard-access-lists)
+  - [Extended Access-lists](#extended-access-lists)
+  - [IPv6 Standard Access-lists](#ipv6-standard-access-lists)
+  - [IPv6 Extended Access-lists](#ipv6-extended-access-lists)
+- [VRF Instances](#vrf-instances)
+- [Virtual Source NAT](#virtual-source-nat)
+- [Platform](#platform)
+- [Router L2 VPN](#router-l2-vpn)
+- [IP DHCP Relay](#ip-dhcp-relay)
+
+# Management
+
+## Management Interfaces
+
+### Management Interfaces Summary
+
+IPv4
+
+| Management Interface | description | VRF | IP Address | Gateway |
+| -------------------- | ----------- | --- | ---------- | ------- |
+| Management1 | oob_management | MGMT | 10.73.255.122/24 | 10.73.255.2 |
+
+IPv6
+
+| Management Interface | description | VRF | IPv6 Address | IPv6 Gateway |
+| -------------------- | ----------- | --- | ------------ | ------------ |
+| Management1 | oob_management | MGMT | not configured  | not configured |
+
+### Management Interfaces Device Configuration
+
+```eos
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+```
+
+## DNS Domain
+
+DNS domain not defined
+
+## Domain-List
+
+Domain-list not defined
+
+## Name Servers
+
+No Name Servers defined
+
+## Domain Lookup
+
+DNS domain lookup not defined
+
+## NTP
+
+No NTP servers defined
+
+## Management SSH
+
+
+Management SSH is not defined
+
+# Authentication
+
+## Local Users
+
+No Users Defined
+
+## TACACS Servers
+
+TACACS servers not configured
+
+## IP TACACS Source Interfaces
+
+IP TACACS source interfaces not defined
+
+## RADIUS Servers
+
+RADIUS servers not configured
+
+## AAA Server Groups
+
+AAA server groups not defined
+
+## AAA Authentication
+
+AAA authentication not defined
+
+## AAA Authorization
+
+AAA authorization not defined
+
+## AAA Accounting
+
+AAA accounting not defined
+
+# Management Security
+
+Management Security not defined
+
+# Aliases
+
+Aliases not defined
+
+# Monitoring
+
+## TerminAttr Daemon
+
+TerminAttr Daemon not defined
+
+## Logging
+
+No logging settings defined
+
+## SFlow
+
+No sFlow defined
+
+## Hardware Counters
+
+
+No Hardware Counters defined
+
+## VM Tracer Sessions
+
+No VM tracer session defined
+
+## Event Handler
+
+No Event Handler Defined
+
+# MLAG
+
+MLAG not defined
+
+# Spanning Tree
+
+Spanning-Tree Not Defined
+
+# Internal VLAN Allocation Policy
+
+### Internal VLAN Allocation Policy Summary
+
+**Default Allocation Policy**
+
+| Policy Allocation | Range Beginning | Range Ending |
+| ------------------| --------------- | ------------ |
+| ascending | 1006 | 4094 |
+
+
+# VLANs
+
+No VLANs defined
+
+# Interfaces
+
+## Ethernet Interfaces
+
+
+## Port-Channel Interfaces
+
+No Port-Channels defined
+
+## Loopback Interfaces
+
+No Loopback interfaces defined
+
+## VLAN Interfaces
+
+No VLAN interfaces defined
+
+## VXLAN Interface
+
+No VXLAN interface defined
+
+# Routing
+
+## Virtual Router MAC Address
+
+IP Virtual Router MAC Address is not defined
+
+## IP Routing
+
+### IP Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default |  False | 
+
+### IP Routing Device Configuration
+
+```eos
+```
+## IPv6 Routing
+
+### IPv6 Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default |  False | 
+ 
+
+
+## Static Routes
+
+
+## Router ISIS
+
+Router ISIS not defined
+
+# Router BGP
+
+Router BGP not defined
+
+## Router BFD
+
+### Router BFD Multihop Summary
+
+| Interval | Minimum RX | Multiplier |
+| -------- | ---------- | ---------- |
+| 300 | 300 | 3 |
+
+*No device configuration required - default values
+
+# Multicast
+
+## IP IGMP Snooping
+
+
+## Router Multicast
+
+Routing multicast not defined
+
+## Router PIM Sparse Mode
+
+Router PIM sparse mode not defined
+
+# Filters
+
+## Community Lists
+
+Community Lists not defined
+
+## Peer Filters
+
+No Peer Filters defined
+
+## Prefix Lists
+
+Prefix lists not defined
+
+## IPv6 Prefix Lists
+
+IPv6 Prefix lists not defined
+
+## Route Maps
+
+No route maps defined
+
+## IP Extended Communities
+
+No Extended community defined
+
+# ACL
+
+## Standard Access-lists
+
+Standard Access-lists not defined
+
+## Extended Access-lists
+
+Extended Access-lists not defined
+
+## IPv6 Standard Access-lists
+
+IPv6 Standard Access-lists not defined
+
+## IPv6 Extended Access-lists
+
+IPv6 Extended Access-lists not defined
+
+# VRF Instances
+
+No VRFs defined
+
+# Virtual Source NAT
+
+Virtual Source NAT is not defined
+
+# Platform
+
+### Platform
+
+   The platform trident forwarding-table partition is 2.
+
+### Platform Configuration
+
+```eos
+!
+platform trident forwarding-table partition 2
+platform sand lag hardware-only
+platform sand lag mode 512x32
+```
+
+# Router L2 VPN
+
+Router L2 VPN not defined
+
+# IP DHCP Relay
+
+IP DHCP Relay not defined
+
+## Custom Templates
+
+No Custom Templates Defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/platform.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/platform.cfg
@@ -1,0 +1,18 @@
+!RANCID-CONTENT-TYPE: arista
+!
+transceiver qsfp default-mode 4x10G
+!
+hostname platform
+!
+platform trident forwarding-table partition 2
+platform sand lag hardware-only
+platform sand lag mode 512x32
+!
+no aaa root
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/platform.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/platform.yml
@@ -1,0 +1,7 @@
+platform:
+  trident:
+    forwarding_table_partition: 2
+  sand:
+    lag:
+      hardware_only: true
+      mode: "512x32"

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts
@@ -10,6 +10,7 @@ logging
 loopbacks-interfaces
 mcast-pim
 none_configuration
+platform
 port-channel-interfaces
 prefix-lists
 route-maps

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -465,6 +465,10 @@ spanning_tree:
 platform:
   trident:
     forwarding_table_partition: < partition >
+  sand:
+    lag:
+      hardware_only: < true | false >
+      mode: < mode | default -> 1024x16 >
 ```
 
 ### Tacacs+ Servers

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
@@ -53,8 +53,8 @@ hostname {{ inventory_hostname }}
 {% include 'eos/redundancy.j2' %}
 {# snmp settings #}
 {% include 'eos/snmp-settings.j2' %}
-{# hardware speed-group configuration #}
-{% include 'eos/speed-group.j2' %}
+{# hardware configuration #}
+{% include 'eos/hardware.j2' %}
 {# spanning-tree #}
 {% include 'eos/spanning-tree.j2' %}
 {# platform #}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/hardware.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/hardware.j2
@@ -1,4 +1,6 @@
-{# eos - interface speed-group #}
+{# eos - hardware settings #}
+
+{# interface - speed-group #}
 {% if hardware is defined and hardware.speed_groups is defined and hardware.speed_groups is not none %}
 !
 {%   for speed_group in hardware.speed_groups %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/hardware.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/hardware.j2
@@ -1,6 +1,4 @@
 {# eos - hardware settings #}
-
-{# interface - speed-group #}
 {% if hardware is defined and hardware.speed_groups is defined and hardware.speed_groups is not none %}
 !
 {%   for speed_group in hardware.speed_groups %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/platform.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/platform.j2
@@ -1,9 +1,19 @@
 {# eos - platform #}
 {% if platform is defined and platform is not none %}
-{%   if platform.trident is defined and platform.trident is not none %}
-{%     if platform.trident.forwarding_table_partition is defined and platform.trident.forwarding_table_partition is not none %}
 !
+{%     if platform.trident is defined and platform.trident is not none %}
+{%         if platform.trident.forwarding_table_partition is defined and platform.trident.forwarding_table_partition is not none %}
 platform trident forwarding-table partition {{ platform.trident.forwarding_table_partition }}
+{%         endif %}
 {%     endif %}
-{%   endif %}
+{%     if platform.sand is defined and platform.sand is not none %}
+{%         if platform.sand.lag is defined and platform.sand.lag is not none %}
+{%             if platform.sand.lag.hardware_only is defined and platform.sand.lag.hardware_only == true %}
+platform sand lag hardware-only
+{%             endif %}
+{%             if platform.sand.lag.mode is defined and platform.sand.lag.mode is not none and platform.sand.lag.mode  != "1024x16" %}
+platform sand lag mode {{ platform.sand.lag.mode }}
+{%             endif %}
+{%         endif %}
+{%     endif %}
 {% endif %}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
## Change Summary

Added platform sand lag and mode knobs.
rename eos/speed-group.j2 -> eos/hardware.j2

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

resolves #416

## Component(s) name

- eos_cli_config_gen

## Proposed changes

```yaml
platform:
  sand:
    lag:
      hardware_only: true
      mode: "512x32" 
```

## How to test

see molecule platform test case for eos_cli_config_gen

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
