### PR TITLE
issue #275 add device document for management API HTTP

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-api-http.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-api-http.j2
@@ -1,0 +1,17 @@
+{# Management API HTTP #}
+
+{% if management_api_http is defined and management_api_http is not none %}
+### Management API HTTP summary 
+
+| HTTP | HTTPS | 
+| ---------- | ---------- |
+| {% if management_api_http.enable_http is defined and management_api_http.enable_http is not none %} {{ management_api_http.enable_http }} {% else %} default {% endif %} | {% if management_api_http.enable_https is defined and management_api_http.enable_https is not none %} {{ management_api_http.enable_https }} {% else %} default {% endif %} |
+
+### Management API HTTP configuration 
+
+```eos
+{% include 'eos/management-api-http.j2' %}
+```
+{% else %}
+Management API HTTP is not defined
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-api-http.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-api-http.j2
@@ -1,13 +1,23 @@
 {# Management API HTTP #}
 
 {% if management_api_http is defined and management_api_http is not none %}
-### Management API HTTP summary 
+### Management API HTTP Summary
 
-| HTTP | HTTPS | 
+| HTTP | HTTPS |
 | ---------- | ---------- |
 | {% if management_api_http.enable_http is defined and management_api_http.enable_http is not none %} {{ management_api_http.enable_http }} {% else %} default {% endif %} | {% if management_api_http.enable_https is defined and management_api_http.enable_https is not none %} {{ management_api_http.enable_https }} {% else %} default {% endif %} |
+{%     if management_api_http.enable_vrfs is defined and management_api_http.enable_vrfs is not none %}
 
-### Management API HTTP configuration 
+### Management API VRF Access
+
+| VRF Name | IPv4 ACL | IPv6 ACL |
+| -------- | -------- | -------- |
+{%         for vrf in management_api_http.enable_vrfs | arista.avd.natural_sort %}
+| {{ vrf }} | {% if management_api_http.enable_vrfs[vrf].access_group is defined and management_api_http.enable_vrfs[vrf].access_group is not none %} {{ management_api_http.enable_vrfs[vrf].access_group }} {% else %} Not defined {% endif %} | {% if management_api_http.enable_vrfs[vrf].ipv6_access_group is defined and management_api_http.enable_vrfs[vrf].ipv6_access_group is not none %} {{ management_api_http.enable_vrfs[vrf].ipv6_access_group }} {% else %} Not defined {% endif %} |
+{%         endfor %}
+{%     endif %}
+
+### Management API HTTP Configuration
 
 ```eos
 {% include 'eos/management-api-http.j2' %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-device-documentation.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-device-documentation.j2
@@ -9,6 +9,7 @@
   - [Domain Lookup](#domain-lookup)
   - [NTP](#ntp)
   - [Management SSH](#management-ssh)
+  - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
   - [TACACS Servers](#tacacs-servers)
@@ -96,6 +97,10 @@
 ## Management SSH
 
 {% include 'documentation/management-ssh.j2' %}
+
+## Management API HTTP
+
+{% include 'documentation/management-api-http.j2' %}
 
 # Authentication
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-api-http.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-api-http.j2
@@ -10,7 +10,7 @@ management api http-commands
    protocol http
 {%     endif %}
    no shutdown
-{%     if management_api_http.enable_vrfs is defined -%}
+{%     if management_api_http.enable_vrfs is defined and management_api_http.enable_vrfs is not none -%}
 {%         for vrf in management_api_http.enable_vrfs | arista.avd.natural_sort if vrf is ne 'default' %}
    !
    vrf {{ vrf }}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
## Change Summary

updated the role eos_cli_config_gen to generate device configuration for management API HTTP 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [x] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
Fix #275

## Component(s) name
role eos_cli_config_gen

## Proposed changes
updated the role eos_cli_config_gen to generate device configuration for management API HTTP 
- created the template that generate this configuration 
- updated the master template to include the new template and to update the Table of Contents


## How to test

Once you define devices vars to generate device configuration,  run the role eos_cli_config_gen. 
In addition to the device config it will generate the device documentation 

Example 
```
management_api_http:
  enable_http: true 
  enable_https: false 
  enable_vrfs:
    whatever:
      access_group: IPv4_ACL
      ipv6_access_group: IPv6_ACL
    another_vrf:
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
