### PR TITLE
eos_cli_config_gen: update logging template

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/logging.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/logging.j2
@@ -31,14 +31,20 @@ logging format sequence-numbers
 {%     if logging.source_interface is defined and logging.source_interface is not none %}
 logging source-interface {{ logging.source_interface }}
 {%     endif %}
-{%     if logging.vrfs is defined and logging.vrfs is not none %}
+{%     if logging.vrfs is defined and logging.vrfs is not none  %}
 {%          for vrf in logging.vrfs | arista.avd.natural_sort %}
-{%              if logging.vrfs[vrf].source_interface is defined and logging.vrfs[vrf].source_interface is not none %}
+{%              if logging.vrfs[vrf].source_interface is defined and logging.vrfs[vrf].source_interface is not none and vrf is ne 'default' %}
 logging vrf {{ vrf }} source-interface {{ logging.vrfs[vrf].source_interface }}
+{%              elif logging.vrfs[vrf].source_interface is defined  and vrf == 'default' %}
+logging source-interface {{ logging.vrfs[vrf].source_interface }}
 {%              endif %}
-{%              if logging.vrfs[vrf].hosts is defined and logging.vrfs[vrf].hosts is not none %}
+{%              if logging.vrfs[vrf].hosts is defined and logging.vrfs[vrf].hosts is not none and vrf is ne 'default' %}
 {%                  for host in logging.vrfs[vrf].hosts | arista.avd.natural_sort %}
 logging vrf {{ vrf }} host {{ host }}
+{%                  endfor %}
+{%              elif vrf == 'default' %}
+{%                  for host in logging.vrfs[vrf].hosts | arista.avd.natural_sort %}
+logging host {{ host }}
 {%                  endfor %}
 {%              endif %}
 {%          endfor %}

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -23,6 +23,6 @@ services:
     volumes:
       - ${PWD}/:/docs
     ports:
-      - 8002:8000
+      - 8000:8000
     entrypoint: ""
     command: ["sh", "-c", "pip install -r ansible-avd/ansible_collections/arista/avd/docs/requirements.txt && mkdocs serve --dev-addr=0.0.0.0:8000 -f ansible-avd/mkdocs.yml"]

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -23,6 +23,6 @@ services:
     volumes:
       - ${PWD}/:/docs
     ports:
-      - 8000:8000
+      - 8002:8000
     entrypoint: ""
     command: ["sh", "-c", "pip install -r ansible-avd/ansible_collections/arista/avd/docs/requirements.txt && mkdocs serve --dev-addr=0.0.0.0:8000 -f ansible-avd/mkdocs.yml"]


### PR DESCRIPTION
## Change Summary
Make logging syntax consistent with EOS when using default VRF

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
Fixes #198 

## Component(s) name

## Proposed changes
Added conditions when vrf is `default` it should not generate the config with `vrf default` in the config line

## How to test
Added this to the group_vars

```
logging:
  console: informational
  #monitor:
  buffered:
    size: 64000
    level: debugging #this is the default
  #trap: < severity_level >
  source_interface: Loopback0
  vrfs:
    default:
      #source_interface: should use logging source_interface

      hosts:
        - 192.168.1.1
        - 192.168.1.4
    red:
      source_interface: Loopback1
      hosts:
        - 192.168.1.2
        - 192.168.1.3
```
That generated:

```
logging console informational
logging buffered 64000 debugging
logging source-interface Loopback0
logging host 192.168.1.1
logging host 192.168.1.4
logging vrf red source-interface Loopback1
logging vrf red host 192.168.1.2
logging vrf red host 192.168.1.3
```

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
