### PR TITLE
Adjust guidelines for vrf_vni values

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
@@ -863,8 +863,11 @@ tenants:
       < tenant_a_vrf_1 >:
 
         # VRF VNI | Required.
-        # The VRF VNI range is limited.
-        vrf_vni: <1-1024>
+        # The VRF VNI range is not limited, but it is recommended to keep vrf_vni <= 1024
+        # It is necessary to keep [ vrf_vni + MLAG IBGP base_vlan ] < 4094 to support MLAG IBGP peering in VRF.
+        # If vrf_vni > 1094 make sure to change mlag_ibgp_peering_vrfs: { base_vlan : < > } to a lower value (default 3000).
+        # If vrf_vni > 10000 make sure to adjust mac_vrf_vni_base accordingly to avoid overlap.
+        vrf_vni: < 1-1024 >
 
         # IP Helper for DHCP relay
         ip_helpers:
@@ -950,7 +953,7 @@ tenants:
             ip_address_virtual: < IPv4_address/Mask >
 
       < tenant_a_vrf_2 >:
-        vrf_vni: <1-1024>
+        vrf_vni: < 1-1024 >
         svis:
           < 1-4096 >:
             name: < description >
@@ -987,7 +990,7 @@ tenants:
     mac_vrf_vni_base: < 10000-16770000 >
     vrfs:
       < tenant_b_vrf_1 >:
-        vrf_vni: <1-1024>
+        vrf_vni: < 1-1024 >
         vtep_diagnostic:
           loopback: < 2-2100 >
           loopback_ip_range: < IPv4_address/Mask >


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
We don't enforce the vrf_vni : < 1-1024 > limit documented in the Readme file, so this change is only for adjusting the guidelines in Readme.md to make the user aware of what to look out for, before using vrf_vni > 1024.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [x] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #314 

## Component(s) name
eos_l3ls_evpn

## Proposed changes
<!--- Describe your changes in detail -->
* Readme updated with following guidelines:
```yaml
        # VRF VNI | Required.
        # The VRF VNI range is not limited, but it is recommended to keep vrf_vni <= 1024
        # It is necessary to keep [ vrf_vni + MLAG IBGP base_vlan ] < 4094 to support MLAG IBGP peering in VRF.
        # If vrf_vni > 1094 make sure to change mlag_ibgp_peering_vrfs: { base_vlan : < > } to a lower value (default 3000).
        # If vrf_vni > 10000 make sure to adjust mac_vrf_vni_base accordingly to avoid overlap.
        vrf_vni: < 1-1024 >
```
* Small formatting changes for `vrf_vni`

## Types of changes
## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Before changing anything I tested with vrf_vni > 1024 and it worked fine. The MLAG IBGP VLANs are calculated as `vrf_vni` + `base_vlan` so I ended up with VLAN numbers > 4096. Hence we need guidelines to make the user aware.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
