### PR TITLE
Update l3ls defaults with super_spine_bgp_defaults

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/defaults/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/defaults/main.yml
@@ -51,6 +51,14 @@ leaf_bgp_defaults:
   - graceful-restart restart-time 300
   - graceful-restart
 
+super_spine_bgp_defaults:
+  - update wait-for-convergence
+  - update wait-install
+  - no bgp default ipv4-unicast
+  - distance bgp 20 200 200
+  - graceful-restart restart-time 300
+  - graceful-restart
+
 overlay_controller_bgp_defaults:
   - no bgp default ipv4-unicast
   - distance bgp 20 200 200


### PR DESCRIPTION
Somehow the super_spine_bgp_defaults were lost from default variables. This change restores them.