### PR TITLE
Add support centralized routing designs

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -677,6 +677,9 @@ ethernet_interfaces:
     type: < routed | switched >
     vrf: < vrf_name >
     ip_address: < IPv4_address/Mask >
+    ip_address_secondaries:
+      - < IPv4_address/Mask >
+      - < IPv4_address/Mask >
     ipv6_enable: < true | false >
     ipv6_address: < IPv6_address/Mask >
     ipv6_address_link_local: < link_local_IPv6_address/Mask >
@@ -753,6 +756,9 @@ loopback_interfaces:
     shutdown: < true | false >
     vrf: < vrf_name >
     ip_address: < IPv4_address/Mask >
+    ip_address_secondaries:
+      - < IPv4_address/Mask >
+      - < IPv4_address/Mask >
     ipv6_enable: < true | false >
     ipv6_address: < IPv6_address/Mask >
     ospf_area: < ospf_area >
@@ -789,9 +795,10 @@ vlan_interfaces:
     vrf: < vrf_name >
     arp_aging_timeout: < arp_timeout >
     ip_address: < IPv4_address/Mask >
-    ip_address_secondary: < IPv4_address/Mask >
+    ip_address_secondaries:
+      - < IPv4_address/Mask >
+      - < IPv4_address/Mask >
     ip_router_virtual_address: < IPv4_address >
-    ip_router_virtual_address_secondary: < IPv4_address >
     ip_address_virtual: < IPv4_address/Mask >
     ip_helpers:
       < ip_helper_address_1 >:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ethernet-interfaces.j2
@@ -20,7 +20,15 @@
 {%-      if ethernet_interfaces[ethernet_interface].vlans is defined %} {{ ethernet_interfaces[ethernet_interface].vlans }} {% else %} - {% endif -%} |
 {%-      if ethernet_interfaces[ethernet_interface].trunk_groups is defined %} {% for  trunk_group in ethernet_interfaces[ethernet_interface].trunk_groups | arista.avd.natural_sort  %}{{ trunk_group }}{% if not loop.last %}<br>{% endif %} {% endfor %}{% else %} - {% endif -%} |
 {%-      if ethernet_interfaces[ethernet_interface].vrf is defined %} {{ ethernet_interfaces[ethernet_interface].vrf }} {% else %} - {% endif -%} |
-{%-      if ethernet_interfaces[ethernet_interface].ip_address is defined %} {{ ethernet_interfaces[ethernet_interface].ip_address }} {% else %} - {% endif -%} | - | - |
+{%-      if ethernet_interfaces[ethernet_interface].ip_address is defined %}
+ {{ ethernet_interfaces[ethernet_interface].ip_address }}
+{%-        if ethernet_interfaces[ethernet_interface].ip_address_secondaries is defined and ethernet_interfaces[ethernet_interface].ip_address_secondaries is not none %}
+ <br> {{ ethernet_interfaces[ethernet_interface].ip_address_secondaries | join(' secondary <br> ') }} secondary
+{%-        endif %}
+{%-       else %}
+ -
+{%- endif %}
+ | - | - |
 {%     endif %}
 {%   endfor %}
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/loopback-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/loopback-interfaces.j2
@@ -8,7 +8,15 @@ IPv4
 {%     for loopback_interface in loopback_interfaces | arista.avd.natural_sort %}
 | {{ loopback_interface }} | {{ loopback_interfaces[loopback_interface].description }} |
 {%-        if loopback_interfaces[loopback_interface].vrf is defined %} {{ loopback_interfaces[loopback_interface].vrf }} {% else %} Global Routing Table {% endif -%} |
-{%-        if loopback_interfaces[loopback_interface].ip_address is defined %} {{ loopback_interfaces[loopback_interface].ip_address }} {% else %} - {% endif -%} |
+{%-        if loopback_interfaces[loopback_interface].ip_address is defined %}
+ {{ loopback_interfaces[loopback_interface].ip_address }}
+{%-            if loopback_interfaces[loopback_interface].ip_address_secondaries is defined and loopback_interfaces[loopback_interface].ip_address_secondaries is not none %}
+ <br> {{ loopback_interfaces[loopback_interface].ip_address_secondaries | join(' secondary <br> ') }} secondary
+{%-            endif %}
+{%-        else %}
+ -
+{%-        endif %}
+ |
 {%     endfor %}
 
 IPv6

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vlan-interfaces.j2
@@ -15,7 +15,7 @@
 {%-            endif %}
 {%- else %}
  -
-{%- endif -%}
+{%- endif %}
  |
 {%     endfor %}
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vlan-interfaces.j2
@@ -8,7 +8,15 @@
 {%-        if vlan_interfaces[vlan_interface].vrf is defined %} {{ vlan_interfaces[vlan_interface].vrf }} {% else %} Global Routing Table {% endif -%} |
 {%-        if vlan_interfaces[vlan_interface].ip_address is defined %} {{ vlan_interfaces[vlan_interface].ip_address }} {% else %} - {% endif -%} |
 {%-        if vlan_interfaces[vlan_interface].ip_address_virtual is defined %} {{ vlan_interfaces[vlan_interface].ip_address_virtual }} {% else %} - {% endif -%} |
-{%-        if vlan_interfaces[vlan_interface].ip_virtual_router_address is defined %} {{ vlan_interfaces[vlan_interface].ip_virtual_router_address  }} {% else %} - {% endif -%} |
+{%-        if vlan_interfaces[vlan_interface].ip_virtual_router_address is defined %}
+ {{ vlan_interfaces[vlan_interface].ip_virtual_router_address  }}
+{%-            if vlan_interfaces[vlan_interface].ip_address_secondaries is defined and vlan_interfaces[vlan_interface].ip_address_secondaries is not none %}
+ <br> {{ vlan_interfaces[vlan_interface].ip_address_secondaries | join(' secondary <br> ') }} secondary
+{%-            endif %}
+{%- else %}
+ -
+{%- endif -%}
+ |
 {%     endfor %}
 
 ### VLAN Interfaces Device Configuration

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -61,10 +61,15 @@ interface {{ ethernet_interface }}
    vrf {{ ethernet_interfaces[ethernet_interface].vrf }}
 {%             endif %}
 {%             if ethernet_interfaces[ethernet_interface].ip_proxy_arp is defined and ethernet_interfaces[ethernet_interface].ip_proxy_arp == true %}
-   ip proxy-arp 
+   ip proxy-arp
 {%             endif %}
 {%             if ethernet_interfaces[ethernet_interface].ip_address is defined and ethernet_interfaces[ethernet_interface].ip_address is not none %}
    ip address {{ ethernet_interfaces[ethernet_interface].ip_address }}
+{%             if ethernet_interfaces[ethernet_interface].ip_address_secondaries is defined and ethernet_interfaces[ethernet_interface].ip_address_secondaries is not none %}
+{%                 for ip_address_secondary in ethernet_interfaces[ethernet_interface].ip_address_secondaries %}
+   ip address {{ ip_address_secondary }} secondary
+{%                 endfor %}
+{%             endif %}
 {%             endif %}
 {%             if ethernet_interfaces[ethernet_interface].ipv6_enable is defined and ethernet_interfaces[ethernet_interface].ipv6_enable == true %}
    ipv6 enable

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/loopback-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/loopback-interfaces.j2
@@ -13,10 +13,15 @@ interface {{ loopback_interface }}
    vrf {{ loopback_interfaces[loopback_interface].vrf }}
 {%         endif %}
 {%             if loopback_interfaces[loopback_interface].ip_proxy_arp is defined and loopback_interfaces[loopback_interface].ip_proxy_arp == true %}
-   ip proxy-arp 
+   ip proxy-arp
 {%             endif %}
 {%         if loopback_interfaces[loopback_interface].ip_address is defined and loopback_interfaces[loopback_interface].ip_address is not none %}
    ip address {{ loopback_interfaces[loopback_interface].ip_address }}
+{%             if loopback_interfaces[loopback_interface].ip_address_secondaries is defined and loopback_interfaces[loopback_interface].ip_address_secondaries is not none %}
+{%                 for ip_address_secondary in loopback_interfaces[loopback_interface].ip_address_secondaries %}
+   ip address {{ ip_address_secondary }} secondary
+{%                 endfor %}
+{%             endif %}
 {%         endif %}
 {%         if loopback_interfaces[loopback_interface].ipv6_enable is defined and loopback_interfaces[loopback_interface].ipv6_enable == true %}
    ipv6 enable

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
@@ -22,10 +22,15 @@ interface {{ vlan_interface }}
    arp aging timeout {{ vlan_interfaces[vlan_interface].arp_aging_timeout }}
 {%         endif %}
 {%             if vlan_interfaces[vlan_interface].ip_proxy_arp is defined and vlan_interfaces[vlan_interface].ip_proxy_arp == true %}
-   ip proxy-arp 
+   ip proxy-arp
 {%             endif %}
 {%         if vlan_interfaces[vlan_interface].ip_address is defined %}
    ip address {{ vlan_interfaces[vlan_interface].ip_address }}
+{%             if vlan_interfaces[vlan_interface].ip_address_secondaries is defined and vlan_interfaces[vlan_interface].ip_address_secondaries is not none %}
+{%                 for ip_address_secondary in vlan_interfaces[vlan_interface].ip_address_secondaries %}
+   ip address {{ ip_address_secondary }} secondary
+{%                 endfor %}
+{%             endif %}
 {%         endif %}
 {%         if vlan_interfaces[vlan_interface].ip_virtual_router_address is defined %}
    ip virtual-router address {{ vlan_interfaces[vlan_interface].ip_virtual_router_address }}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
@@ -295,6 +295,10 @@ overlay_loopback_network_summary: < IPv4_network/Mask >
 # Assign range larger then total L3 leafs
 vtep_loopback_network_summary: < IPv4_network/Mask >
 
+# IP Address used as Virtual VTEP. Will be configured as secondary IP on loopback1 | Optional
+# This is only needed for centralized routing designs
+vtep_vvtep_ip: < IPv4_address/Mask >
+
 # IP address summary used for MLAG Peer Link (control link) and underlay L3 peering | *Required
 # * When MLAG leafs present in topology.
 # Assign range larger then total: L3 Leafs + 2 ]

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
@@ -550,6 +550,10 @@ l3leaf:
     # Activate or deactivate IGMP snooping for all l3leaf devices | Optional default is true
     igmp_snooping_enabled: < true | false >
 
+    # Possibility to prevent configuration of Tenant VRFs and SVIs | Optional, default is true
+    # This allows support for centralized routing.
+    overlay_svis: < true | false >
+
   # The node groups are group of one or two nodes where specific variables can be defined related to the topology
   # and allowed L3 and L2 network services.
   # All variables defined under `defaults` dictionary can be defined under each node group to override it.
@@ -569,6 +573,10 @@ l3leaf:
 
       # Activate or deactivate IGMP snooping for node groups devices
       igmp_snooping_enabled: < true | false >
+
+      # Possibility to prevent configuration of Tenant VRFs and SVIs | Optional, default is true
+      # This allows support for centralized routing.
+      overlay_svis: < true | false >
 
       # Define one or two nodes - same name as inventory_hostname | Required
       # When two nodes are defined, this will create an MLAG pair.
@@ -862,7 +870,7 @@ tenants:
     # By default an IBGP peering is configured per VRF between MLAG peers on separate VLANs.
     # Setting enable_mlag_ibgp_peering_vrfs: false under tenant will change this default to prevent configuration of these peerings and VLANs for all VRFs in the tenant.
     # This setting can be overridden per VRF.
-    enable_mlag_ibgp_peering_vrfs: < true | false > 
+    enable_mlag_ibgp_peering_vrfs: < true | false >
 
     # Define L3 network services organized by vrf.
     vrfs:
@@ -885,7 +893,7 @@ tenants:
         # MLAG IBGP peering per VRF | Optional
         # By default an IBGP peering is configured per VRF between MLAG peers on separate VLANs.
         # Setting enable_mlag_ibgp_peering_vrfs: false under vrf will change this default and/or override the tenant-wide setting
-        enable_mlag_ibgp_peering_vrfs: < true | false > 
+        enable_mlag_ibgp_peering_vrfs: < true | false >
 
         # Enable VTEP Network diagnostics | Optional.
         # This will create a loopback with virtual source-nat enable to perform diagnostics from the switch.
@@ -1715,7 +1723,7 @@ Overlay peerings can be configured to any of the following options as well as co
 * super-spine <-> overlay-controller
 * overlay-controller <-> overlay-controller (in other DCs)
 The overlay peerings will be derived from the variable `evpn_overlay_controller_groups` on the "client".
-Ex. setting `evpn_overlay_controller_groups : [ DC1_SUPER_SPINES ]` in the `DC1-POD1-L3LEAFS.yml` group_var file will setup evpn peerings between 
+Ex. setting `evpn_overlay_controller_groups : [ DC1_SUPER_SPINES ]` in the `DC1-POD1-L3LEAFS.yml` group_var file will setup evpn peerings between
 all the l3leafs in this group and all devices in the group `DC1_SUPER_SPINES`. The devices in group `DC1_SUPER_SPINES` will detect that others are
 pointing at them, and configure the peering as well.
 

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
@@ -554,9 +554,9 @@ l3leaf:
     # Activate or deactivate IGMP snooping for all l3leaf devices | Optional default is true
     igmp_snooping_enabled: < true | false >
 
-    # Possibility to prevent configuration of Tenant VRFs and SVIs | Optional, default is true
+    # Possibility to prevent configuration of Tenant VRFs and SVIs | Optional, default is false
     # This allows support for centralized routing.
-    overlay_svis: < true | false >
+    evpn_services_l2_only: < false | true >
 
   # The node groups are group of one or two nodes where specific variables can be defined related to the topology
   # and allowed L3 and L2 network services.
@@ -578,9 +578,9 @@ l3leaf:
       # Activate or deactivate IGMP snooping for node groups devices
       igmp_snooping_enabled: < true | false >
 
-      # Possibility to prevent configuration of Tenant VRFs and SVIs | Optional, default is true
+      # Possibility to prevent configuration of Tenant VRFs and SVIs | Optional, default is false
       # This allows support for centralized routing.
-      overlay_svis: < true | false >
+      evpn_services_l2_only: < false | true >
 
       # Define one or two nodes - same name as inventory_hostname | Required
       # When two nodes are defined, this will create an MLAG pair.

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l3leaf-yml.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l3leaf-yml.j2
@@ -98,6 +98,13 @@
 {%             else %}
 {%                 set leaf.mlag = false %}
 {%             endif %}
+{%             if l3leaf.node_groups[l3leaf_node_group].overlay_svis is defined %}
+{%                 set leaf.overlay_svis = l3leaf.node_groups[l3leaf_node_group].overlay_svis %}
+{%             elif l3leaf.defaults.overlay_svis is defined %}
+{%                 set leaf.overlay_svis = l3leaf.defaults.overlay_svis %}
+{%             else %}
+{%                 set leaf.overlay_svis = true %}
+{%             endif %}
 {%         endif %}
 {%     endfor %}
 {% endfor %}
@@ -245,6 +252,7 @@ switch_platform: {{ switch.platform }}
 leaf_bgp_as: {{ leaf.bgp_as }}
 leaf_id: {{ leaf.id }}
 switch_mgmt_ip: {{ switch.mgmt_ip }}
+leaf_overlay_svis: {{ leaf.overlay_svis }}
 leaf_filter_tenants: {{ leaf.filter_tenants }}
 leaf_filter_tags: {{ leaf.filter_tags }}
 leaf_allowed_vrfs: {{ leaf.vrfs }}
@@ -354,8 +362,10 @@ vrfs:
 {# management #}
 {% include 'base/mgmt-vrf.j2' %}
 
+{% if leaf.overlay_svis == true %}
 {# Tenant VRFS #}
 {% include 'tenant_evpn_vxlan/leaf-tenant-vrfs.j2' %}
+{% endif %}
 
 {# bfd multihop #}
 ### bfd multihop ###
@@ -409,8 +419,10 @@ management_interfaces:
 vlan_interfaces:
 {# mlag vlan interfaces #}
 {% include 'fabric/mlag/leaf-mlag-vlan-interfaces.j2' %}
+{% if leaf.overlay_svis == true %}
 {# Tenant vlan interfaces #}
-{% include 'tenant_evpn_vxlan/leaf-tenant-vlan-interfaces.j2' %}
+{%     include 'tenant_evpn_vxlan/leaf-tenant-vlan-interfaces.j2' %}
+{% endif %}
 
 {# vxlan interface #}
 ### VxLAN interface ###
@@ -427,12 +439,14 @@ tcam_profile:
 mac_address_table:
 {% include 'base/mac-address-table.j2' %}
 
+{% if leaf.overlay_svis == true %}
 {# virtual router mac address #}
 ip_virtual_router_mac_address: {{ leaf.virtual_router_mac_address | lower }}
 
 {# Tenant - Virtual Source NAT - to allow VTEPs daignostics from switch #}
 virtual_source_nat_vrfs:
-{% include 'tenant_evpn_vxlan/leaf-tenant-virtual-source-nat-vrfs.j2' %}
+{%     include 'tenant_evpn_vxlan/leaf-tenant-virtual-source-nat-vrfs.j2' %}
+{% endif %}
 
 {# Tenant ip-igmp-snooping #}
 ip_igmp_snooping:
@@ -476,8 +490,10 @@ router_bgp:
 {% include 'tenant_evpn_vxlan/leaf-tenant-router-bgp-evpn-vlan-aware-bundles.j2' %}
   vlans:
 {% include 'tenant_evpn_vxlan/leaf-tenant-router-bgp-evpn-vlans.j2' %}
+{% if leaf.overlay_svis == true %}
   vrfs:
-{% include 'tenant_evpn_vxlan/leaf-tenant-router-bgp-evpn-vrfs.j2' %}
+{%     include 'tenant_evpn_vxlan/leaf-tenant-router-bgp-evpn-vrfs.j2' %}
+{% endif %}
 
 {# Extended Community Lists Configuration #}
 ### Extended Community Lists ###

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l3leaf-yml.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l3leaf-yml.j2
@@ -360,10 +360,8 @@ vrfs:
 {# management #}
 {% include 'base/mgmt-vrf.j2' %}
 
-{% if leaf.evpn_services_l2_only == false %}
 {# Tenant VRFS #}
 {% include 'tenant_evpn_vxlan/leaf-tenant-vrfs.j2' %}
-{% endif %}
 
 {# bfd multihop #}
 ### bfd multihop ###
@@ -417,10 +415,8 @@ management_interfaces:
 vlan_interfaces:
 {# mlag vlan interfaces #}
 {% include 'fabric/mlag/leaf-mlag-vlan-interfaces.j2' %}
-{% if leaf.evpn_services_l2_only == false %}
 {# Tenant vlan interfaces #}
-{%     include 'tenant_evpn_vxlan/leaf-tenant-vlan-interfaces.j2' %}
-{% endif %}
+{% include 'tenant_evpn_vxlan/leaf-tenant-vlan-interfaces.j2' %}
 
 {# vxlan interface #}
 ### VxLAN interface ###
@@ -440,11 +436,11 @@ mac_address_table:
 {% if leaf.evpn_services_l2_only == false %}
 {# virtual router mac address #}
 ip_virtual_router_mac_address: {{ leaf.virtual_router_mac_address | lower }}
+{% endif %}
 
 {# Tenant - Virtual Source NAT - to allow VTEPs daignostics from switch #}
 virtual_source_nat_vrfs:
-{%     include 'tenant_evpn_vxlan/leaf-tenant-virtual-source-nat-vrfs.j2' %}
-{% endif %}
+{% include 'tenant_evpn_vxlan/leaf-tenant-virtual-source-nat-vrfs.j2' %}
 
 {# Tenant ip-igmp-snooping #}
 ip_igmp_snooping:
@@ -488,10 +484,8 @@ router_bgp:
 {% include 'tenant_evpn_vxlan/leaf-tenant-router-bgp-evpn-vlan-aware-bundles.j2' %}
   vlans:
 {% include 'tenant_evpn_vxlan/leaf-tenant-router-bgp-evpn-vlans.j2' %}
-{% if leaf.evpn_services_l2_only == false %}
   vrfs:
-{%     include 'tenant_evpn_vxlan/leaf-tenant-router-bgp-evpn-vrfs.j2' %}
-{% endif %}
+{% include 'tenant_evpn_vxlan/leaf-tenant-router-bgp-evpn-vrfs.j2' %}
 
 {# Extended Community Lists Configuration #}
 ### Extended Community Lists ###

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l3leaf-yml.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l3leaf-yml.j2
@@ -98,12 +98,10 @@
 {%             else %}
 {%                 set leaf.mlag = false %}
 {%             endif %}
-{%             if l3leaf.node_groups[l3leaf_node_group].overlay_svis is defined %}
-{%                 set leaf.overlay_svis = l3leaf.node_groups[l3leaf_node_group].overlay_svis %}
-{%             elif l3leaf.defaults.overlay_svis is defined %}
-{%                 set leaf.overlay_svis = l3leaf.defaults.overlay_svis %}
+{%             if l3leaf.node_groups[l3leaf_node_group].evpn_services_l2_only is defined %}
+{%                 set leaf.evpn_services_l2_only = l3leaf.node_groups[l3leaf_node_group].evpn_services_l2_only %}
 {%             else %}
-{%                 set leaf.overlay_svis = true %}
+{%                 set leaf.evpn_services_l2_only = l3leaf.defaults.evpn_services_l2_only | default(false) %}
 {%             endif %}
 {%         endif %}
 {%     endfor %}
@@ -252,7 +250,7 @@ switch_platform: {{ switch.platform }}
 leaf_bgp_as: {{ leaf.bgp_as }}
 leaf_id: {{ leaf.id }}
 switch_mgmt_ip: {{ switch.mgmt_ip }}
-leaf_overlay_svis: {{ leaf.overlay_svis }}
+leaf_evpn_services_l2_only: {{ leaf.evpn_services_l2_only }}
 leaf_filter_tenants: {{ leaf.filter_tenants }}
 leaf_filter_tags: {{ leaf.filter_tags }}
 leaf_allowed_vrfs: {{ leaf.vrfs }}
@@ -362,7 +360,7 @@ vrfs:
 {# management #}
 {% include 'base/mgmt-vrf.j2' %}
 
-{% if leaf.overlay_svis == true %}
+{% if leaf.evpn_services_l2_only == false %}
 {# Tenant VRFS #}
 {% include 'tenant_evpn_vxlan/leaf-tenant-vrfs.j2' %}
 {% endif %}
@@ -419,7 +417,7 @@ management_interfaces:
 vlan_interfaces:
 {# mlag vlan interfaces #}
 {% include 'fabric/mlag/leaf-mlag-vlan-interfaces.j2' %}
-{% if leaf.overlay_svis == true %}
+{% if leaf.evpn_services_l2_only == false %}
 {# Tenant vlan interfaces #}
 {%     include 'tenant_evpn_vxlan/leaf-tenant-vlan-interfaces.j2' %}
 {% endif %}
@@ -439,7 +437,7 @@ tcam_profile:
 mac_address_table:
 {% include 'base/mac-address-table.j2' %}
 
-{% if leaf.overlay_svis == true %}
+{% if leaf.evpn_services_l2_only == false %}
 {# virtual router mac address #}
 ip_virtual_router_mac_address: {{ leaf.virtual_router_mac_address | lower }}
 
@@ -490,7 +488,7 @@ router_bgp:
 {% include 'tenant_evpn_vxlan/leaf-tenant-router-bgp-evpn-vlan-aware-bundles.j2' %}
   vlans:
 {% include 'tenant_evpn_vxlan/leaf-tenant-router-bgp-evpn-vlans.j2' %}
-{% if leaf.overlay_svis == true %}
+{% if leaf.evpn_services_l2_only == false %}
   vrfs:
 {%     include 'tenant_evpn_vxlan/leaf-tenant-router-bgp-evpn-vrfs.j2' %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/interfaces/leaf-vtep-vxlan-tunnel-loopback.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/interfaces/leaf-vtep-vxlan-tunnel-loopback.j2
@@ -8,6 +8,9 @@
 {% else %}
     ip_address: {{ vtep_loopback_network_summary | ipaddr('network') | ipmath(leaf.id + spine.nodes | length) }}/32
 {% endif %}
+{% if vtep_vvtep_ip is defined and vtep_vvtep_ip is not none and leaf.overlay_svis == true %}
+    ip_address_secondaries : [ {{ vtep_vvtep_ip }} ]
+{% endif %}
 {% if underlay_routing_protocol|lower == "ospf" %}
     ospf_area: {{ underlay_ospf_area }}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/interfaces/leaf-vtep-vxlan-tunnel-loopback.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/interfaces/leaf-vtep-vxlan-tunnel-loopback.j2
@@ -8,7 +8,7 @@
 {% else %}
     ip_address: {{ vtep_loopback_network_summary | ipaddr('network') | ipmath(leaf.id + spine.nodes | length) }}/32
 {% endif %}
-{% if vtep_vvtep_ip is defined and vtep_vvtep_ip is not none and leaf.overlay_svis == true %}
+{% if vtep_vvtep_ip is defined and vtep_vvtep_ip is not none and leaf.evpn_services_l2_only == false %}
     ip_address_secondaries : [ {{ vtep_vvtep_ip }} ]
 {% endif %}
 {% if underlay_routing_protocol|lower == "ospf" %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-router-bgp-evpn-vrfs.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-router-bgp-evpn-vrfs.j2
@@ -1,5 +1,5 @@
 {# Leaf tenant router bgp evpn VRFs #}
-{% for tenant in tenants | arista.avd.natural_sort if tenant in leaf.filter_tenants or "all" in leaf.filter_tenants %}
+{% for tenant in tenants | arista.avd.natural_sort if ( tenant in leaf.filter_tenants or "all" in leaf.filter_tenants ) and leaf.evpn_services_l2_only == false %}
 ## {{ tenant }} ##
 {%     if tenants[tenant].vrfs is defined %}
 {%         for vrf in tenants[tenant].vrfs | arista.avd.natural_sort if leaf.vrfs is not none and vrf in leaf.vrfs %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-virtual-source-nat-vrfs.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-virtual-source-nat-vrfs.j2
@@ -1,5 +1,5 @@
 {# Tenant virtual source NAT vrfs #}
-{% for tenant in tenants | arista.avd.natural_sort if tenant in leaf.filter_tenants or "all" in leaf.filter_tenants %}
+{% for tenant in tenants | arista.avd.natural_sort if ( tenant in leaf.filter_tenants or "all" in leaf.filter_tenants ) and leaf.evpn_services_l2_only == false %}
 {%     if tenants[tenant].vrfs is defined %}
 {%         for vrf in tenants[tenant].vrfs | arista.avd.natural_sort if leaf.vrfs is not none and vrf in leaf.vrfs %}
 {%             if tenants[tenant].vrfs[vrf].vtep_diagnostic is defined %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-vlan-interfaces.j2
@@ -1,5 +1,5 @@
 {# Leaf tenant vlan interfaces #}
-{% for tenant in tenants | arista.avd.natural_sort if tenant in leaf.filter_tenants or "all" in leaf.filter_tenants %}
+{% for tenant in tenants | arista.avd.natural_sort if ( tenant in leaf.filter_tenants or "all" in leaf.filter_tenants ) and leaf.evpn_services_l2_only == false %}
 {%     if tenants[tenant].vrfs is defined %}
 {%         for vrf in tenants[tenant].vrfs | arista.avd.natural_sort %}
 {%             if loop.first %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-vrfs.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-vrfs.j2
@@ -1,5 +1,5 @@
 {# Leaf tenant vrfs #}
-{% for tenant in tenants | arista.avd.natural_sort if tenant in leaf.filter_tenants or "all" in leaf.filter_tenants %}
+{% for tenant in tenants | arista.avd.natural_sort if ( tenant in leaf.filter_tenants or "all" in leaf.filter_tenants ) and leaf.evpn_services_l2_only == false %}
 {%     if tenants[tenant].vrfs is defined %}
 {%         for vrf in tenants[tenant].vrfs | arista.avd.natural_sort if vrf in leaf.vrfs %}
 {%             if loop.first %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-vxlan-vtep-interface.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-vxlan-vtep-interface.j2
@@ -36,13 +36,15 @@
 {%         endfor %}
 {%     endif %}
 {% endfor %}
+{% if leaf.overlay_svis == true %}
       vrfs:
-{% for tenant in tenants | arista.avd.natural_sort if tenant in leaf.filter_tenants or "all" in leaf.filter_tenants %}
+{%     for tenant in tenants | arista.avd.natural_sort if tenant in leaf.filter_tenants or "all" in leaf.filter_tenants %}
 ## {{ tenant }} ##
-{%     if tenants[tenant].vrfs is defined %}
-{%         for vrf in tenants[tenant].vrfs | arista.avd.natural_sort if leaf.vrfs is not none and vrf in leaf.vrfs %}
+{%         if tenants[tenant].vrfs is defined %}
+{%             for vrf in tenants[tenant].vrfs | arista.avd.natural_sort if leaf.vrfs is not none and vrf in leaf.vrfs %}
         {{ vrf }}:
           vni: {{ tenants[tenant].vrfs[vrf].vrf_vni }}
-{%         endfor %}
-{%     endif %}
-{% endfor %}
+{%             endfor %}
+{%         endif %}
+{%     endfor %}
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-vxlan-vtep-interface.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-vxlan-vtep-interface.j2
@@ -36,7 +36,7 @@
 {%         endfor %}
 {%     endif %}
 {% endfor %}
-{% if leaf.overlay_svis == true %}
+{% if leaf.evpn_services_l2_only == false %}
       vrfs:
 {%     for tenant in tenants | arista.avd.natural_sort if tenant in leaf.filter_tenants or "all" in leaf.filter_tenants %}
 ## {{ tenant }} ##


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
For designs with centralized routing, some L3 leafs can be provisioned without VRFs and SVIs, but still have all vlans.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [x] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

## Component(s) name
eos_l3ls_evpn

## Proposed changes
<!--- Describe your changes in detail -->
Adding optional `overlay_svis` knob under l3leaf (default=true). 
This can be configured under defaults and/or per node_group.
```yaml
l3leaf:

  # L3 Leaf default variables, can be overridden when defined under < node_group >.
  defaults:

    # Possibility to prevent configuration of Tenant VRFs and SVIs | Optional, default is false
    # This allows support for centralized routing.
    evpn_services_l2_only: < false | true >

  # All variables defined under `defaults` dictionary can be defined under each node group to override it.
  node_groups:

    < node-group >

      # Possibility to prevent configuration of Tenant VRFs and SVIs | Optional, default is false
      # This allows support for centralized routing.
      evpn_services_l2_only: < false | true >
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Tested by adding `overlay_svis: false` on a node_group and comparing structured config, documentation and configuration before / after.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
