### PR TITLE
New arista.avd.default filter

### DIFF
--- a/ansible_collections/arista/avd/plugins/README.md
+++ b/ansible_collections/arista/avd/plugins/README.md
@@ -38,12 +38,24 @@ To use this filter:
 {% endfor %}
 ```
 
+### **default filter**
+
+The `default` filter can provide the same basic capability as the builtin `default` filter. It will return the input value only if it is valid and if not, provide a default value instead. Our custom filter required a value to be `not undefined` and `not None` to pass through.
+Furthermore the filter allows multiple default values as arguments, which will undergo the same validation one after one until we find a valid default value.
+As a last resort the filter will return None.
+
+To use this filter:
+
+```jinja
+{{ variable | arista.avd.default( default_value_1 , default_value_2 ... ) }}
+```
+
 ## Modules
 
 ### **Inventory to CloudVision Containers**
 
 The `inventory_to_container` module provides following capabilities:
-- Transform inventory groups into CloudVision containers topology. 
+- Transform inventory groups into CloudVision containers topology.
 - Create list of configlets definition.
 
 It saves everything in a `YAML` file using **`destination`** keyword.

--- a/ansible_collections/arista/avd/plugins/filter/default.py
+++ b/ansible_collections/arista/avd/plugins/filter/default.py
@@ -13,7 +13,7 @@ def default(primary_value, *default_values ):
             #Return the result of another loop
             return default(default_values[0],*default_values[1:])
         else:
-            #Return undefined
+            #Return None
             return
     else:
         #Return the valid value

--- a/ansible_collections/arista/avd/plugins/filter/default.py
+++ b/ansible_collections/arista/avd/plugins/filter/default.py
@@ -1,0 +1,26 @@
+#
+# def arista.avd.default
+#
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from jinja2.runtime import Undefined
+
+def default(primary_value, *default_values ):
+    if isinstance(primary_value, Undefined) or primary_value is None:
+        #Invalid value - try defaults
+        if len(default_values) >= 1:
+            #Return the result of another loop
+            return default(default_values[0],*default_values[1:])
+        else:
+            #Return undefined
+            return
+    else:
+        #Return the valid value
+        return primary_value
+
+class FilterModule(object):
+    def filters(self):
+        return {
+            'default': default,
+        }


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add new custom filter `arista.avd.default`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [x] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

## Component(s) name
General for the collection
ansible_avd

## Proposed changes
<!--- Describe your changes in detail -->
The `default` filter can provide the same basic capability as the builtin `default` filter. It will return the input value only if it is valid and if not, provide a default value instead. Our custom filter requires a value to be `not undefined` and `not None` to pass through.
Furthermore the filter allows multiple default values as arguments, which will undergo the same validation one after one until we find a valid default value.
As a last resort the filter will return None.

To use this filter:

```jinja
{{ variable | arista.avd.default( default_value_1 , default_value_2 ... ) }}
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Comparing tests of current style with new filter:
```jinja
{### Setting Variables ###}
{# a is undefined #}
{% set b = none %}
{% set c1 = none %}
{# c2 is undefined #}
{% set d1 = 'd1' %}
{% set d2 = 'd2' %}
{# e1 is undefined #}
{% set e2 = 'e2' %}
{% set f = false %}

{### Current style ###}
a : {% if a is defined and a is not none %}{{a}}{% else %}test{% endif %}
b : {% if b is defined and b is not none %}{{b}}{% else %}test{% endif %}
c : {% if c1 is defined and c1 is not none %}{{c1}}{% elif c2 is defined and c2 is not none %}{{c2}}{% else %}test{% endif %}
d : {% if d1 is defined and d1 is not none %}{{d1}}{% elif d2 is defined and d2 is not none %}{{d2}}{% else %}test{% endif %}
e : {% if e1 is defined and e1 is not none %}{{e1}}{% elif e2 is defined and e2 is not none %}{{e2}}{% else %}test{% endif %}
f : {% if f is defined and f is not none %}{{f}}{% else %}test{% endif %}

{### New Filter ###}
a : {{ a | arista.avd.default("test") }}
b : {{ b | arista.avd.default("test") }}
c : {{ c1 | arista.avd.default(c2,"test") }}
d : {{ d1 | arista.avd.default(d2,"test") }}
e : {{ e1 | arista.avd.default(e2,"test") }}
f : {{ f | arista.avd.default("test") }}
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
