### PR TITLE
PTP capability

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/aaa.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/aaa.md
@@ -122,7 +122,6 @@ No NTP servers defined
 
 ## PTP
 
-### PTP Summary
 PTP is not defined.
 
 ## Management SSH

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/aaa.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/aaa.md
@@ -120,6 +120,11 @@ DNS domain lookup not defined
 
 No NTP servers defined
 
+## PTP
+
+### PTP Summary
+PTP is not defined.
+
 ## Management SSH
 
 Management SSH not defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/acl.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/acl.md
@@ -122,7 +122,6 @@ No NTP servers defined
 
 ## PTP
 
-### PTP Summary
 PTP is not defined.
 
 ## Management SSH

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/acl.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/acl.md
@@ -120,6 +120,11 @@ DNS domain lookup not defined
 
 No NTP servers defined
 
+## PTP
+
+### PTP Summary
+PTP is not defined.
+
 ## Management SSH
 
 Management SSH not defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/base.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/base.md
@@ -122,7 +122,6 @@ No NTP servers defined
 
 ## PTP
 
-### PTP Summary
 PTP is not defined.
 
 ## Management SSH

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/dns-ntp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/dns-ntp.md
@@ -169,7 +169,6 @@ ntp server vrf mgt 10.10.111.2
 
 ## PTP
 
-### PTP Summary
 PTP is not defined.
 
 ## Management SSH

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/dns-ntp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/dns-ntp.md
@@ -167,6 +167,11 @@ ntp server vrf mgt 10.10.111.1 prefer
 ntp server vrf mgt 10.10.111.2
 ```
 
+## PTP
+
+### PTP Summary
+PTP is not defined.
+
 ## Management SSH
 
 Management SSH not defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -122,7 +122,6 @@ No NTP servers defined
 
 ## PTP
 
-### PTP Summary
 PTP is not defined.
 
 ## Management SSH

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -120,6 +120,11 @@ DNS domain lookup not defined
 
 No NTP servers defined
 
+## PTP
+
+### PTP Summary
+PTP is not defined.
+
 ## Management SSH
 
 Management SSH not defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet_interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet_interfaces.md
@@ -122,7 +122,6 @@ No NTP servers defined
 
 ## PTP
 
-### PTP Summary
 PTP is not defined.
 
 ## Management SSH

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet_interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet_interfaces.md
@@ -120,6 +120,11 @@ DNS domain lookup not defined
 
 No NTP servers defined
 
+## PTP
+
+### PTP Summary
+PTP is not defined.
+
 ## Management SSH
 
 Management SSH not defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/logging-minimal.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/logging-minimal.md
@@ -122,7 +122,6 @@ No NTP servers defined
 
 ## PTP
 
-### PTP Summary
 PTP is not defined.
 
 ## Management SSH

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/logging-minimal.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/logging-minimal.md
@@ -120,6 +120,11 @@ DNS domain lookup not defined
 
 No NTP servers defined
 
+## PTP
+
+### PTP Summary
+PTP is not defined.
+
 ## Management SSH
 
 Management SSH not defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/logging.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/logging.md
@@ -122,7 +122,6 @@ No NTP servers defined
 
 ## PTP
 
-### PTP Summary
 PTP is not defined.
 
 ## Management SSH

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/logging.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/logging.md
@@ -120,6 +120,11 @@ DNS domain lookup not defined
 
 No NTP servers defined
 
+## PTP
+
+### PTP Summary
+PTP is not defined.
+
 ## Management SSH
 
 Management SSH not defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/loopbacks-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/loopbacks-interfaces.md
@@ -122,7 +122,6 @@ No NTP servers defined
 
 ## PTP
 
-### PTP Summary
 PTP is not defined.
 
 ## Management SSH

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/loopbacks-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/loopbacks-interfaces.md
@@ -120,6 +120,11 @@ DNS domain lookup not defined
 
 No NTP servers defined
 
+## PTP
+
+### PTP Summary
+PTP is not defined.
+
 ## Management SSH
 
 Management SSH not defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-gnmi.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-gnmi.md
@@ -122,7 +122,6 @@ No NTP servers defined
 
 ## PTP
 
-### PTP Summary
 PTP is not defined.
 
 ## Management SSH

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-gnmi.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-gnmi.md
@@ -120,6 +120,11 @@ DNS domain lookup not defined
 
 No NTP servers defined
 
+## PTP
+
+### PTP Summary
+PTP is not defined.
+
 ## Management SSH
 
 Management SSH not defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-ssh.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-ssh.md
@@ -122,7 +122,6 @@ No NTP servers defined
 
 ## PTP
 
-### PTP Summary
 PTP is not defined.
 
 ## Management SSH

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-ssh.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-ssh.md
@@ -120,6 +120,11 @@ DNS domain lookup not defined
 
 No NTP servers defined
 
+## PTP
+
+### PTP Summary
+PTP is not defined.
+
 ## Management SSH
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mcast-pim.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mcast-pim.md
@@ -122,7 +122,6 @@ No NTP servers defined
 
 ## PTP
 
-### PTP Summary
 PTP is not defined.
 
 ## Management SSH

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mcast-pim.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mcast-pim.md
@@ -120,6 +120,11 @@ DNS domain lookup not defined
 
 No NTP servers defined
 
+## PTP
+
+### PTP Summary
+PTP is not defined.
+
 ## Management SSH
 
 Management SSH not defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/none_configuration.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/none_configuration.md
@@ -122,7 +122,6 @@ No NTP servers defined
 
 ## PTP
 
-### PTP Summary
 PTP is not defined.
 
 ## Management SSH

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/none_configuration.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/none_configuration.md
@@ -120,6 +120,11 @@ DNS domain lookup not defined
 
 No NTP servers defined
 
+## PTP
+
+### PTP Summary
+PTP is not defined.
+
 ## Management SSH
 
 Management SSH not defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/platform.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/platform.md
@@ -122,7 +122,6 @@ No NTP servers defined
 
 ## PTP
 
-### PTP Summary
 PTP is not defined.
 
 ## Management SSH

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/platform.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/platform.md
@@ -120,6 +120,11 @@ DNS domain lookup not defined
 
 No NTP servers defined
 
+## PTP
+
+### PTP Summary
+PTP is not defined.
+
 ## Management SSH
 
 Management SSH not defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
@@ -122,7 +122,6 @@ No NTP servers defined
 
 ## PTP
 
-### PTP Summary
 PTP is not defined.
 
 ## Management SSH

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
@@ -120,6 +120,11 @@ DNS domain lookup not defined
 
 No NTP servers defined
 
+## PTP
+
+### PTP Summary
+PTP is not defined.
+
 ## Management SSH
 
 Management SSH not defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/prefix-lists.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/prefix-lists.md
@@ -122,7 +122,6 @@ No NTP servers defined
 
 ## PTP
 
-### PTP Summary
 PTP is not defined.
 
 ## Management SSH

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/prefix-lists.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/prefix-lists.md
@@ -120,6 +120,11 @@ DNS domain lookup not defined
 
 No NTP servers defined
 
+## PTP
+
+### PTP Summary
+PTP is not defined.
+
 ## Management SSH
 
 Management SSH not defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ptp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ptp.md
@@ -1,4 +1,4 @@
-# base
+# ptp
 
 # Table of Contents
 
@@ -70,7 +70,6 @@
 - [Platform](#platform)
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
-- [Errdisable](#errdisable)
 
 # Management
 
@@ -123,21 +122,32 @@ No NTP servers defined
 ## PTP
 
 ### PTP Summary
-PTP is not defined.
+| PTP setting | Value |
+| ----------- | ----- |
+| Clock-identity | 123.123.123.123 |
+| Source IP | 1.1.1.1 |
+| Priority1 | 1 |
+| Priority2 | 2 |
+| TTL | 200 |
+| Msg General | DSCP 4 |
+| Msg Event | DSCP 8 |
 
-## Management SSH
+### PTP Device Configuration
 
 ```eos
 !
-management ssh
-   ip access-group ACL-SSH in
-   ip access-group ACL-SSH-VRF vrf mgt in
-   ipv6 access-group ACL-SSH6 in
-   ipv6 access-group ACL-SSH-VRF6 vrf mgt in
-   idle-timeout 15
-   vrf mgt
-      no shutdown
+ptp clock-identity 123.123.123.123
+ptp source ip 1.1.1.1
+ptp priority1 1
+ptp priority2 2
+ptp ttl 200
+ptp message-type general dscp 4
+ptp message-type event dscp 8
 ```
+
+## Management SSH
+
+Management SSH not defined
 
 ## Management API GNMI
 
@@ -145,30 +155,7 @@ Management API gnmi is not defined
 
 ## Management API HTTP
 
-### Management API HTTP Summary
-
-| HTTP | HTTPS |
-| ---------- | ---------- |
-|  true  |  true  |
-
-### Management API VRF Access
-
-| VRF Name | IPv4 ACL | IPv6 ACL |
-| -------- | -------- | -------- |
-| mgt |  ACL-API  |  -  |
-
-### Management API HTTP Configuration
-
-```eos
-!
-management api http-commands
-   protocol http
-   no shutdown
-   !
-   vrf mgt
-      no shutdown
-      ip access-group ACL-API
-```
+Management API HTTP not defined
 
 # Authentication
 
@@ -206,17 +193,7 @@ AAA accounting not defined
 
 # Management Security
 
-## Management Security
-
-   Management Security password encryption is common.
-
-## Management Security Configuration
-
-```eos
-!
-management security
-   password encryption-key common
-```
+Management security not defined
 
 # Aliases
 
@@ -278,7 +255,25 @@ No VLANs defined
 
 ## Ethernet Interfaces
 
-No ethernet interface defined
+### Ethernet Interfaces Summary
+
+| Interface | Description | MTU | Type | Mode | Allowed VLANs (Trunk) | Trunk Group | VRF | IP Address | Channel-Group ID | Channel-Group Type |
+| --------- | ----------- | --- | ---- | ---- | --------------------- | ----------- | --- | ---------- | ---------------- | ------------------ |
+| Ethernet3 | P2P_LINK_TO_DC1-SPINE2_Ethernet5 | 1500 | routed | access | - | - | - | 172.31.255.15/31 | - | - |
+
+*Inherited from Port-Channel Interface
+
+
+### Ethernet Interfaces Device Configuration
+
+```eos
+!
+interface Ethernet3
+   description P2P_LINK_TO_DC1-SPINE2_Ethernet5
+   no switchport
+   ip address 172.31.255.15/31
+   ptp enable
+```
 
 ## Port-Channel Interfaces
 
@@ -329,10 +324,6 @@ Static routes not defined
 ## IPv6 Static Routes
 
 IPv6 static routes not defined
-
-## ARP
-
-Global ARP timeout not defined.
 
 ## Router ISIS
 
@@ -429,10 +420,6 @@ Router L2 VPN not defined
 # IP DHCP Relay
 
 IP DHCP relay not defined
-
-# Errdisable
-
-Errdisable is not defined.
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ptp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ptp.md
@@ -131,7 +131,6 @@ No NTP servers defined
 | TTL | 200 |
 | Msg General | DSCP 4 |
 | Msg Event | DSCP 8 |
-
 ### PTP Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ptp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ptp.md
@@ -122,6 +122,7 @@ No NTP servers defined
 ## PTP
 
 ### PTP Summary
+
 | PTP setting | Value |
 | ----------- | ----- |
 | Clock-identity | 123.123.123.123 |
@@ -131,6 +132,7 @@ No NTP servers defined
 | TTL | 200 |
 | Msg General | DSCP 4 |
 | Msg Event | DSCP 8 |
+
 ### PTP Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/route-maps.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/route-maps.md
@@ -122,7 +122,6 @@ No NTP servers defined
 
 ## PTP
 
-### PTP Summary
 PTP is not defined.
 
 ## Management SSH

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/route-maps.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/route-maps.md
@@ -120,6 +120,11 @@ DNS domain lookup not defined
 
 No NTP servers defined
 
+## PTP
+
+### PTP Summary
+PTP is not defined.
+
 ## Management SSH
 
 Management SSH not defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
@@ -122,7 +122,6 @@ No NTP servers defined
 
 ## PTP
 
-### PTP Summary
 PTP is not defined.
 
 ## Management SSH

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
@@ -120,6 +120,11 @@ DNS domain lookup not defined
 
 No NTP servers defined
 
+## PTP
+
+### PTP Summary
+PTP is not defined.
+
 ## Management SSH
 
 Management SSH not defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-evpn.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-evpn.md
@@ -122,7 +122,6 @@ No NTP servers defined
 
 ## PTP
 
-### PTP Summary
 PTP is not defined.
 
 ## Management SSH

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-evpn.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-evpn.md
@@ -120,6 +120,11 @@ DNS domain lookup not defined
 
 No NTP servers defined
 
+## PTP
+
+### PTP Summary
+PTP is not defined.
+
 ## Management SSH
 
 Management SSH not defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-v4-evpn.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-v4-evpn.md
@@ -122,7 +122,6 @@ No NTP servers defined
 
 ## PTP
 
-### PTP Summary
 PTP is not defined.
 
 ## Management SSH

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-v4-evpn.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-v4-evpn.md
@@ -120,6 +120,11 @@ DNS domain lookup not defined
 
 No NTP servers defined
 
+## PTP
+
+### PTP Summary
+PTP is not defined.
+
 ## Management SSH
 
 Management SSH not defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-v4-v6-evpn.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-v4-v6-evpn.md
@@ -122,7 +122,6 @@ No NTP servers defined
 
 ## PTP
 
-### PTP Summary
 PTP is not defined.
 
 ## Management SSH

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-v4-v6-evpn.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-v4-v6-evpn.md
@@ -120,6 +120,11 @@ DNS domain lookup not defined
 
 No NTP servers defined
 
+## PTP
+
+### PTP Summary
+PTP is not defined.
+
 ## Management SSH
 
 Management SSH not defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis.md
@@ -122,7 +122,6 @@ No NTP servers defined
 
 ## PTP
 
-### PTP Summary
 PTP is not defined.
 
 ## Management SSH

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis.md
@@ -120,6 +120,11 @@ DNS domain lookup not defined
 
 No NTP servers defined
 
+## PTP
+
+### PTP Summary
+PTP is not defined.
+
 ## Management SSH
 
 Management SSH not defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
@@ -122,7 +122,6 @@ No NTP servers defined
 
 ## PTP
 
-### PTP Summary
 PTP is not defined.
 
 ## Management SSH

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
@@ -120,6 +120,11 @@ DNS domain lookup not defined
 
 No NTP servers defined
 
+## PTP
+
+### PTP Summary
+PTP is not defined.
+
 ## Management SSH
 
 Management SSH not defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-static.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-static.md
@@ -122,7 +122,6 @@ No NTP servers defined
 
 ## PTP
 
-### PTP Summary
 PTP is not defined.
 
 ## Management SSH

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-static.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-static.md
@@ -120,6 +120,11 @@ DNS domain lookup not defined
 
 No NTP servers defined
 
+## PTP
+
+### PTP Summary
+PTP is not defined.
+
 ## Management SSH
 
 Management SSH not defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/sflow.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/sflow.md
@@ -122,7 +122,6 @@ No NTP servers defined
 
 ## PTP
 
-### PTP Summary
 PTP is not defined.
 
 ## Management SSH

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/sflow.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/sflow.md
@@ -120,6 +120,11 @@ DNS domain lookup not defined
 
 No NTP servers defined
 
+## PTP
+
+### PTP Summary
+PTP is not defined.
+
 ## Management SSH
 
 Management SSH not defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/snmp_v3.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/snmp_v3.md
@@ -122,7 +122,6 @@ No NTP servers defined
 
 ## PTP
 
-### PTP Summary
 PTP is not defined.
 
 ## Management SSH

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/snmp_v3.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/snmp_v3.md
@@ -120,6 +120,11 @@ DNS domain lookup not defined
 
 No NTP servers defined
 
+## PTP
+
+### PTP Summary
+PTP is not defined.
+
 ## Management SSH
 
 Management SSH not defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/terminattr-cloud.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/terminattr-cloud.md
@@ -122,7 +122,6 @@ No NTP servers defined
 
 ## PTP
 
-### PTP Summary
 PTP is not defined.
 
 ## Management SSH

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/terminattr-cloud.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/terminattr-cloud.md
@@ -120,6 +120,11 @@ DNS domain lookup not defined
 
 No NTP servers defined
 
+## PTP
+
+### PTP Summary
+PTP is not defined.
+
 ## Management SSH
 
 Management SSH not defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/terminattr-prem.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/terminattr-prem.md
@@ -122,7 +122,6 @@ No NTP servers defined
 
 ## PTP
 
-### PTP Summary
 PTP is not defined.
 
 ## Management SSH

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/terminattr-prem.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/terminattr-prem.md
@@ -120,6 +120,11 @@ DNS domain lookup not defined
 
 No NTP servers defined
 
+## PTP
+
+### PTP Summary
+PTP is not defined.
+
 ## Management SSH
 
 Management SSH not defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
@@ -122,7 +122,6 @@ No NTP servers defined
 
 ## PTP
 
-### PTP Summary
 PTP is not defined.
 
 ## Management SSH

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
@@ -120,6 +120,11 @@ DNS domain lookup not defined
 
 No NTP servers defined
 
+## PTP
+
+### PTP Summary
+PTP is not defined.
+
 ## Management SSH
 
 Management SSH not defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlans.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlans.md
@@ -122,7 +122,6 @@ No NTP servers defined
 
 ## PTP
 
-### PTP Summary
 PTP is not defined.
 
 ## Management SSH

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlans.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlans.md
@@ -120,6 +120,11 @@ DNS domain lookup not defined
 
 No NTP servers defined
 
+## PTP
+
+### PTP Summary
+PTP is not defined.
+
 ## Management SSH
 
 Management SSH not defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vrfs.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vrfs.md
@@ -122,7 +122,6 @@ No NTP servers defined
 
 ## PTP
 
-### PTP Summary
 PTP is not defined.
 
 ## Management SSH

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vrfs.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vrfs.md
@@ -120,6 +120,11 @@ DNS domain lookup not defined
 
 No NTP servers defined
 
+## PTP
+
+### PTP Summary
+PTP is not defined.
+
 ## Management SSH
 
 Management SSH not defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ptp.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ptp.cfg
@@ -1,0 +1,28 @@
+!RANCID-CONTENT-TYPE: arista
+!
+transceiver qsfp default-mode 4x10G
+!
+hostname ptp
+!
+ptp clock-identity 123.123.123.123
+ptp source ip 1.1.1.1
+ptp priority1 1
+ptp priority2 2
+ptp ttl 200
+ptp message-type general dscp 4
+ptp message-type event dscp 8
+!
+no aaa root
+!
+interface Ethernet3
+   description P2P_LINK_TO_DC1-SPINE2_Ethernet5
+   no switchport
+   ip address 172.31.255.15/31
+   ptp enable
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ptp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ptp.yml
@@ -1,0 +1,27 @@
+### ptp
+
+ptp:
+  clock_identity: 123.123.123.123
+  source:
+    ip: 1.1.1.1
+  priority1: 1
+  priority2: 2
+  ttl: 200
+  message_type:
+    general:
+      dscp: 4
+    event:
+      dscp: 8
+
+### interface
+ethernet_interfaces:
+  Ethernet3:
+    peer: DC1-SPINE2
+    peer_interface: Ethernet5
+    peer_type: spine
+    description: P2P_LINK_TO_DC1-SPINE2_Ethernet5
+    mtu: 1500
+    type: routed
+    ip_address: 172.31.255.15/31
+    ptp:
+      enable: true

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts
@@ -18,6 +18,7 @@ none_configuration
 platform
 port-channel-interfaces
 prefix-lists
+ptp
 route-maps
 router-bgp-base
 router-bgp-evpn

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -750,6 +750,8 @@ ethernet_interfaces:
     isis_passive: < boolean >
     isis_metric: < integer >
     isis_network_point_to_point: < boolean >
+    ptp:
+      enable: < true | false >
 
 # Switched Interfaces
   <Ethernet_interface_2 >:
@@ -771,6 +773,8 @@ ethernet_interfaces:
     spanning_tree_bpduguard: < true | false >
     spanning_tree_portfast: < edge | network >
     vmtracer: < true | false >
+    ptp:
+      enable: < true | false >
     storm_control:
       all:
         level: < Configure maximum storm-control level >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -86,6 +86,7 @@
     - [Management Console](#management-console)
     - [Management Security](#management-security)
     - [Management SSH](#management-ssh)
+    - [PTP](#ptp)
     - [Custom Templates](#custom-templates)
   - [License](#license)
 
@@ -1563,7 +1564,22 @@ management_ssh:
     < vrf_name_2 >:
       enable: < true | false >
 ```
+### PTP
 
+```yaml
+ptp:
+  clock_identity: < clock-id >
+  source:
+    ip: < source-ip>
+  priority1: < priority1 >
+  priority2: < priority2 >
+  ttl: < ttl >
+  message_type:
+    general:
+      dscp: < dscp-value >
+    event:
+      dscp: < dscp-Value >
+```
 ### Custom Templates
 
 ```yaml

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ptp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ptp.j2
@@ -1,0 +1,42 @@
+### PTP Summary
+{% if ptp is defined and ptp is not none %}
+| PTP setting | Value |
+| ----------- | ----- |
+{%   if ptp.clock_identity is defined and ptp.clock_identity is not none %}
+| Clock-identity | {{ ptp.clock_identity }} |
+{%   endif %}
+{%   if ptp.source is defined and ptp.source is not none %}
+{%       if ptp.source.ip is defined and ptp.source.ip is not none %}
+| Source IP | {{ ptp.source.ip }} |
+{%       endif %}
+{%   endif %}
+{%   if ptp.priority1 is defined and ptp.priority1 is not none %}
+| Priority1 | {{ ptp.priority1 }} |
+{%   endif %}
+{%   if ptp.priority2 is defined and ptp.priority2 is not none %}
+| Priority2 | {{ ptp.priority2 }} |
+{%   endif %}
+{%   if ptp.ttl is defined and ptp.ttl is not none %}
+| TTL | {{ ptp.ttl }} |
+{%   endif %}
+{%   if ptp.message_type is defined and ptp.message_type is not none %}
+{%       if ptp.message_type.general is defined and ptp.message_type.general is not none %}
+{%           if ptp.message_type.general.dscp is defined and ptp.message_type.general.dscp is not none %}
+| Msg General | DSCP {{ ptp.message_type.general.dscp }} |
+{%             endif %}
+{%         endif %}
+{%       if ptp.message_type.event is defined and ptp.message_type.event is not none %}
+{%           if ptp.message_type.event.dscp is defined and ptp.message_type.event.dscp is not none %}
+| Msg Event | DSCP {{ ptp.message_type.event.dscp }} |
+{%             endif %}
+{%         endif %}
+{%     endif %}
+
+### PTP Device Configuration
+
+```eos
+{% include 'eos/ptp.j2' %}
+```
+{% else %}
+PTP is not defined.
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ptp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ptp.j2
@@ -1,5 +1,6 @@
-### PTP Summary
 {% if ptp is defined and ptp is not none %}
+### PTP Summary
+
 | PTP setting | Value |
 | ----------- | ----- |
 {%     if ptp.clock_identity is defined and ptp.clock_identity is not none %}
@@ -31,6 +32,7 @@
 {%             endif %}
 {%         endif %}
 {%     endif %}
+
 ### PTP Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ptp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ptp.j2
@@ -2,36 +2,35 @@
 {% if ptp is defined and ptp is not none %}
 | PTP setting | Value |
 | ----------- | ----- |
-{%   if ptp.clock_identity is defined and ptp.clock_identity is not none %}
+{%     if ptp.clock_identity is defined and ptp.clock_identity is not none %}
 | Clock-identity | {{ ptp.clock_identity }} |
-{%   endif %}
-{%   if ptp.source is defined and ptp.source is not none %}
-{%       if ptp.source.ip is defined and ptp.source.ip is not none %}
+{%     endif %}
+{%     if ptp.source is defined and ptp.source is not none %}
+{%         if ptp.source.ip is defined and ptp.source.ip is not none %}
 | Source IP | {{ ptp.source.ip }} |
-{%       endif %}
-{%   endif %}
-{%   if ptp.priority1 is defined and ptp.priority1 is not none %}
+{%         endif %}
+{%     endif %}
+{%     if ptp.priority1 is defined and ptp.priority1 is not none %}
 | Priority1 | {{ ptp.priority1 }} |
-{%   endif %}
-{%   if ptp.priority2 is defined and ptp.priority2 is not none %}
+{%     endif %}
+{%     if ptp.priority2 is defined and ptp.priority2 is not none %}
 | Priority2 | {{ ptp.priority2 }} |
-{%   endif %}
-{%   if ptp.ttl is defined and ptp.ttl is not none %}
+{%     endif %}
+{%     if ptp.ttl is defined and ptp.ttl is not none %}
 | TTL | {{ ptp.ttl }} |
-{%   endif %}
-{%   if ptp.message_type is defined and ptp.message_type is not none %}
-{%       if ptp.message_type.general is defined and ptp.message_type.general is not none %}
-{%           if ptp.message_type.general.dscp is defined and ptp.message_type.general.dscp is not none %}
+{%     endif %}
+{%     if ptp.message_type is defined and ptp.message_type is not none %}
+{%         if ptp.message_type.general is defined and ptp.message_type.general is not none %}
+{%             if ptp.message_type.general.dscp is defined and ptp.message_type.general.dscp is not none %}
 | Msg General | DSCP {{ ptp.message_type.general.dscp }} |
 {%             endif %}
 {%         endif %}
-{%       if ptp.message_type.event is defined and ptp.message_type.event is not none %}
-{%           if ptp.message_type.event.dscp is defined and ptp.message_type.event.dscp is not none %}
+{%         if ptp.message_type.event is defined and ptp.message_type.event is not none %}
+{%             if ptp.message_type.event.dscp is defined and ptp.message_type.event.dscp is not none %}
 | Msg Event | DSCP {{ ptp.message_type.event.dscp }} |
 {%             endif %}
 {%         endif %}
 {%     endif %}
-
 ### PTP Device Configuration
 
 ```eos
@@ -40,3 +39,4 @@
 {% else %}
 PTP is not defined.
 {% endif %}
+

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-device-documentation.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-device-documentation.j2
@@ -98,6 +98,10 @@
 
 {% include 'documentation/ntp-servers.j2' %}
 
+## PTP
+
+{% include 'documentation/ptp.j2' %}
+
 ## Management SSH
 
 {% include 'documentation/management-ssh.j2' %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
@@ -43,6 +43,8 @@ hostname {{ inventory_hostname }}
 {% include 'eos/domain-list.j2' %}
 {# ntp servers #}
 {% include 'eos/ntp-servers.j2' %}
+{# ptp #}
+{% include 'eos/ptp.j2' %}
 {# radius servers #}
 {% include 'eos/radius-servers.j2' %}
 {# aaa server groups #}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -146,6 +146,11 @@ interface {{ ethernet_interface }}
 {%             if ethernet_interfaces[ethernet_interface].vmtracer is defined and ethernet_interfaces[ethernet_interface].vmtracer == true %}
    vmtracer vmware-esx
 {%             endif %}
+{%             if ethernet_interfaces[ethernet_interface].ptp is defined %}
+{%                 if ethernet_interfaces[ethernet_interface].ptp.enable is defined and ethernet_interfaces[ethernet_interface].ptp.enable == true %}
+   ptp enable
+{%                 endif %}
+{%             endif %}
 {%             if ethernet_interfaces[ethernet_interface].storm_control is defined and ethernet_interfaces[ethernet_interface].storm_control is not none %}
 {%                   for section in ethernet_interfaces[ethernet_interface].storm_control | arista.avd.natural_sort %}
 {%                      if ethernet_interfaces[ethernet_interface].storm_control[section].unit is defined and ethernet_interfaces[ethernet_interface].storm_control[section].unit == "pps" %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ptp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ptp.j2
@@ -1,33 +1,34 @@
 {# eos - PTP #}
 {% if ptp is defined and ptp is not none %}
 !
-{%   if ptp.clock_identity is defined and ptp.clock_identity is not none %}
+{%     if ptp.clock_identity is defined and ptp.clock_identity is not none %}
 ptp clock-identity {{ ptp.clock_identity }}
-{%   endif %}
-{%   if ptp.source is defined and ptp.source is not none %}
-{%       if ptp.source.ip is defined and ptp.source.ip is not none %}
+{%     endif %}
+{%     if ptp.source is defined and ptp.source is not none %}
+{%         if ptp.source.ip is defined and ptp.source.ip is not none %}
 ptp source ip {{ ptp.source.ip }}
-{%       endif %}
-{%   endif %}
-{%   if ptp.priority1 is defined and ptp.priority1 is not none %}
+{%         endif %}
+{%     endif %}
+{%     if ptp.priority1 is defined and ptp.priority1 is not none %}
 ptp priority1 {{ ptp.priority1 }}
-{%   endif %}
-{%   if ptp.priority2 is defined and ptp.priority2 is not none %}
+{%     endif %}
+{%     if ptp.priority2 is defined and ptp.priority2 is not none %}
 ptp priority2 {{ ptp.priority2 }}
-{%   endif %}
-{%   if ptp.ttl is defined and ptp.ttl is not none %}
+{%     endif %}
+{%     if ptp.ttl is defined and ptp.ttl is not none %}
 ptp ttl {{ ptp.ttl }}
-{%   endif %}
-{%   if ptp.message_type is defined and ptp.message_type is not none %}
-{%       if ptp.message_type.general is defined and ptp.message_type.general is not none %}
-{%           if ptp.message_type.general.dscp is defined and ptp.message_type.general.dscp is not none %}
+{%     endif %}
+{%     if ptp.message_type is defined and ptp.message_type is not none %}
+{%         if ptp.message_type.general is defined and ptp.message_type.general is not none %}
+{%             if ptp.message_type.general.dscp is defined and ptp.message_type.general.dscp is not none %}
 ptp message-type general dscp {{ ptp.message_type.general.dscp }}
 {%             endif %}
 {%         endif %}
-{%       if ptp.message_type.event is defined and ptp.message_type.event is not none %}
-{%           if ptp.message_type.event.dscp is defined and ptp.message_type.event.dscp is not none %}
+{%         if ptp.message_type.event is defined and ptp.message_type.event is not none %}
+{%             if ptp.message_type.event.dscp is defined and ptp.message_type.event.dscp is not none %}
 ptp message-type event dscp {{ ptp.message_type.event.dscp }}
 {%             endif %}
 {%         endif %}
 {%     endif %}
 {% endif %}
+

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ptp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ptp.j2
@@ -1,0 +1,33 @@
+{# eos - PTP #}
+{% if ptp is defined and ptp is not none %}
+!
+{%   if ptp.clock_identity is defined and ptp.clock_identity is not none %}
+ptp clock-identity {{ ptp.clock_identity }}
+{%   endif %}
+{%   if ptp.source is defined and ptp.source is not none %}
+{%       if ptp.source.ip is defined and ptp.source.ip is not none %}
+ptp source ip {{ ptp.source.ip }}
+{%       endif %}
+{%   endif %}
+{%   if ptp.priority1 is defined and ptp.priority1 is not none %}
+ptp priority1 {{ ptp.priority1 }}
+{%   endif %}
+{%   if ptp.priority2 is defined and ptp.priority2 is not none %}
+ptp priority2 {{ ptp.priority2 }}
+{%   endif %}
+{%   if ptp.ttl is defined and ptp.ttl is not none %}
+ptp ttl {{ ptp.ttl }}
+{%   endif %}
+{%   if ptp.message_type is defined and ptp.message_type is not none %}
+{%       if ptp.message_type.general is defined and ptp.message_type.general is not none %}
+{%           if ptp.message_type.general.dscp is defined and ptp.message_type.general.dscp is not none %}
+ptp message-type general dscp {{ ptp.message_type.general.dscp }}
+{%             endif %}
+{%         endif %}
+{%       if ptp.message_type.event is defined and ptp.message_type.event is not none %}
+{%           if ptp.message_type.event.dscp is defined and ptp.message_type.event.dscp is not none %}
+ptp message-type event dscp {{ ptp.message_type.event.dscp }}
+{%             endif %}
+{%         endif %}
+{%     endif %}
+{% endif %}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Allows implementation of PTP in the eos_cli_config_gen

Next step add more knobs and maybe create data model for boradcast & media.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [x] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes #440
 
## Component(s) name
eos_cli_config_gen

## Proposed changes
<!--- Describe your changes in detail -->
Interface level and global ptp.j2

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Successful venv/physical DUT, and molecule tests.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
