### PR TITLE
Add is_valid filter

### DIFF
--- a/ansible_collections/arista/avd/plugins/README.md
+++ b/ansible_collections/arista/avd/plugins/README.md
@@ -40,7 +40,7 @@ To use this filter:
 
 ### **default filter**
 
-The `default` filter can provide the same basic capability as the builtin `default` filter. It will return the input value only if it is valid and if not, provide a default value instead. Our custom filter required a value to be `not undefined` and `not None` to pass through.
+The `default` filter can provide the same basic capability as the builtin `default` filter. It will return the input value only if it is valid and if not, provide a default value instead. Our custom filter requires a value to be `not undefined` and `not None` to pass through.
 Furthermore the filter allows multiple default values as arguments, which will undergo the same validation one after one until we find a valid default value.
 As a last resort the filter will return None.
 
@@ -48,6 +48,26 @@ To use this filter:
 
 ```jinja
 {{ variable | arista.avd.default( default_value_1 , default_value_2 ... ) }}
+```
+
+### **is_valid filter**
+
+The `is_valid` will return `False` if the passed value is `Undefined` or `None`. Else it will return `True`.
+
+To use this filter:
+
+```jinja
+{% if variable | arista.avd.is_valid %}
+text : {{ variable }}
+{% endif %}
+```
+
+The `is_valid` filter can be useful as an alternative to:
+
+```jinja
+{% if variable is defined and variable is not none %}
+text : {{ variable }}
+{% endif %}
 ```
 
 ## Modules

--- a/ansible_collections/arista/avd/plugins/filter/is_valid.py
+++ b/ansible_collections/arista/avd/plugins/filter/is_valid.py
@@ -1,0 +1,21 @@
+#
+# def arista.avd.is_valid
+#
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from jinja2.runtime import Undefined
+
+def is_valid(value):
+    if isinstance(value, Undefined) or value is None:
+        #Invalid value - return false
+        return False
+    else:
+        #Valid value - return true
+        return True
+
+class FilterModule(object):
+    def filters(self):
+        return {
+            'is_valid': is_valid,
+        }


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add a new Jinja filter `arista.avd.is_valid` filter to simplify variable validation in our templates.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [x] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

## Component(s) name
ansible_avd collection

## Proposed changes
<!--- Describe your changes in detail -->
The `is_valid` will return `False` if the passed value is `Undefined` or `None`. Else it will return `True`.

To use this filter:

```jinja
{% if variable | arista.avd.is_valid %}
text : {{ variable }}
{% endif %}
```

The `is_valid` filter can be useful as an alternative to:

```jinja
{% if variable is defined and variable is not none %}
text : {{ variable }}
{% endif %}
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
I have tested with the following jinja run as a custom_template.
```jinja
{# a is undefined #}
{% set b = none %}
{% set c1 = none %}
{# c2 is undefined #}
{% set d1 = 'd1' %}
{% set d2 = 'd2' %}
{# e1 is undefined #}
{% set e2 = 'e2' %}
{% set f = false %}

{### New arista.avd.is_valid Filter ###}
a : {{ a | arista.avd.is_valid }}
b : {{ b | arista.avd.is_valid }}
c1 : {{ c1 | arista.avd.is_valid }}
c2 : {{ c2 | arista.avd.is_valid }}
d1 : {{ d1 | arista.avd.is_valid }}
d2 : {{ d1 | arista.avd.is_valid }}
e1 : {{ e1 | arista.avd.is_valid }}
f : {{ f | arista.avd.is_valid }}
```
Result:
```
a : False
b : False
c1 : False
c2 : False
d1 : True
d2 : True
e1 : False
f : True
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
