### PR TITLE
bgp: vrf: enhance neighbor options

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1255,6 +1255,8 @@ router_bgp:
   vrfs:
     < vrf_name_1 >:
       rd: "< route distinguisher >"
+      router_id: "< router id >"
+      timers: "< keepalive_hold_timer_values >"
       route_targets:
         import:
           < address_family >:
@@ -1270,6 +1272,9 @@ router_bgp:
         neighbors:
           < neighbor_ip_address >:
             remote_as: < asn >
+            timers: < keepalive_hold_timer_values >
+            description: "< description as string >"
+            next_hop_self: < true | false >
           < neighbor_ip_address >:
             remote_as: < asn >
       redistribute_routes:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -334,14 +334,26 @@ router bgp {{ router_bgp.as }}
 {%             if router_bgp.vrfs[vrf].router_id is defined %}
       router-id {{ router_bgp.vrfs[vrf].router_id }}
 {%             endif %}
+{%             if router_bgp.vrfs[vrf].timers is defined and router_bgp.vrfs[vrf].timers is not none %}
+      timers bgp {{ router_bgp.vrfs[vrf].timers }}
+{%             endif %}
 {%             if router_bgp.vrfs[vrf].neighbors is defined and router_bgp.vrfs[vrf].neighbors is not none %}
-{%                 for neighbor in router_bgp.vrfs[vrf].neighbors %}
-{%                      if router_bgp.vrfs[vrf].neighbors[neighbor].remote_as is defined and router_bgp.vrfs[vrf].neighbors[neighbor].remote_as is not none %}
+{%                for neighbor in router_bgp.vrfs[vrf].neighbors %}
+{%                   if router_bgp.vrfs[vrf].neighbors[neighbor].remote_as is defined and router_bgp.vrfs[vrf].neighbors[neighbor].remote_as is not none %}
       neighbor {{ neighbor }} remote-as {{ router_bgp.vrfs[vrf].neighbors[neighbor].remote_as }}
-{%                      elif router_bgp.vrfs[vrf].neighbors[neighbor].peer_group is defined and router_bgp.vrfs[vrf].neighbors[neighbor].peer_group is not none %}
+{%                   elif router_bgp.vrfs[vrf].neighbors[neighbor].peer_group is defined and router_bgp.vrfs[vrf].neighbors[neighbor].peer_group is not none %}
       neighbor {{ neighbor }} peer group {{ router_bgp.vrfs[vrf].neighbors[neighbor].peer_group }}
-{%                      endif %}
-{%                 endfor %}
+{%                   endif %}
+{%                   if router_bgp.vrfs[vrf].neighbors[neighbor].description is defined and router_bgp.vrfs[vrf].neighbors[neighbor].description is not none %}
+      neighbor {{ neighbor }} description {{ router_bgp.vrfs[vrf].neighbors[neighbor].description }}
+{%                   endif %}
+{%                   if router_bgp.vrfs[vrf].neighbors[neighbor].next_hop_self is defined and router_bgp.vrfs[vrf].neighbors[neighbor].next_hop_self == true %}
+      neighbor {{ neighbor }} next-hop-self
+{%                   endif %}
+{%                   if router_bgp.vrfs[vrf].neighbors[neighbor].timers is defined and router_bgp.vrfs[vrf].neighbors[neighbor].timers is not none %}
+      neighbor {{ neighbor }} timers {{ router_bgp.vrfs[vrf].neighbors[neighbor].timers }}
+{%                   endif %}
+{%                endfor %}
 {%             endif %}
 {%             if router_bgp.vrfs[vrf].redistribute_routes is defined and router_bgp.vrfs[vrf].redistribute_routes is not none %}
 {%                for redistribute_route in router_bgp.vrfs[vrf].redistribute_routes | arista.avd.natural_sort %}


### PR DESCRIPTION
Currently it is not possible to utilize an iBGP peering using BGP VRFs as
next-hop-self can not be specified. In addition timers can not be programmed
and a neighbor can not carry a description.

Extend the Jinja2 template to support
- bgp vrf neighbor description
- bgp vrf neighbor next-hop-self
- bgp vrf timers

<!-- All PR should follow this template to allow a clean and transparent review -->
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [x] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
This implements https://github.com/aristanetworks/ansible-avd/issues/489

## Component(s) name

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
