### PR TITLE
Fix LLDP topology validation when there is no domain name 

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/lldp_topology_fqdn.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/lldp_topology_fqdn.yml
@@ -1,0 +1,33 @@
+---
+
+# LLDP Topology Tests
+
+- name: Gather lldp topology
+  eos_command:
+    commands: "show lldp neighbors detail | json"
+  ignore_errors: "{{ eos_validate_state_validation_mode_loose }}"
+  register: lldp_topology_state
+  tags:
+    - lldp_topology
+
+- name: Validate lldp topology when there is a domain name
+  assert:
+    that:
+      - lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0] is defined
+      - lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0].systemName == ethernet_interface.value.peer + "." + hostvars[ethernet_interface.value.peer]['dns_domain']
+      - lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0].neighborInterfaceInfo.interfaceId == "\"" + ethernet_interface.value.peer_interface + "\""
+    fail_msg: "{{ lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0].systemName | default('Interface Down') }} - {{ lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0].neighborInterfaceInfo.interfaceId | default('N/A') }}"
+    quiet: true
+  loop: "{{ ethernet_interfaces | default({}, true) | dict2items }}"
+  loop_control:
+    loop_var: ethernet_interface
+  when: |
+    (ethernet_interfaces is defined and ethernet_interfaces is not none) and
+    (ethernet_interface.value.peer is defined and ethernet_interface.value.peer is not none) and
+    (ethernet_interface.value.peer_interface is defined and ethernet_interface.value.peer_interface is not none) and
+    (hostvars[ethernet_interface.value.peer] is defined and hostvars[ethernet_interface.value.peer] is not none) and
+    (hostvars[ethernet_interface.value.peer]['dns_domain'] is defined and hostvars[ethernet_interface.value.peer]['dns_domain'] is not none)
+  ignore_errors: "{{ eos_validate_state_validation_mode_loose }}"
+  register: lldp_topology_results
+  tags:
+    - lldp_topology

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/lldp_topology_no_fqdn.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/lldp_topology_no_fqdn.yml
@@ -10,11 +10,11 @@
   tags:
     - lldp_topology
 
-- name: Validate lldp topology
+- name: Validate lldp topology when there is no domain name
   assert:
     that:
       - lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0] is defined
-      - lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0].systemName == ethernet_interface.value.peer + "." + hostvars[ethernet_interface.value.peer]['dns_domain']
+      - lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0].systemName == ethernet_interface.value.peer
       - lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0].neighborInterfaceInfo.interfaceId == "\"" + ethernet_interface.value.peer_interface + "\""
     fail_msg: "{{ lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0].systemName | default('Interface Down') }} - {{ lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0].neighborInterfaceInfo.interfaceId | default('N/A') }}"
     quiet: true
@@ -25,8 +25,7 @@
     (ethernet_interfaces is defined and ethernet_interfaces is not none) and
     (ethernet_interface.value.peer is defined and ethernet_interface.value.peer is not none) and
     (ethernet_interface.value.peer_interface is defined and ethernet_interface.value.peer_interface is not none) and
-    (hostvars[ethernet_interface.value.peer] is defined and hostvars[ethernet_interface.value.peer] is not none) and
-    (hostvars[ethernet_interface.value.peer]['dns_domain'] is defined and hostvars[ethernet_interface.value.peer]['dns_domain'] is not none)
+    (hostvars[ethernet_interface.value.peer] is defined and hostvars[ethernet_interface.value.peer] is not none)
   ignore_errors: "{{ eos_validate_state_validation_mode_loose }}"
   register: lldp_topology_results
   tags:

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/main.yml
@@ -43,10 +43,17 @@
   tags:
     - interfaces_state
 
-- name: Load LLDP Topology tasks
-  include_tasks: "lldp_topology.yml"
+- name: Load LLDP Topology tasks when dns domain is defined
+  include_tasks: "lldp_topology_fqdn.yml"
   tags:
     - lldp_topology
+  when: dns_domain is defined
+
+- name: Load LLDP Topology tasks when dns domain is not defined
+  include_tasks: "lldp_topology_no_fqdn.yml"
+  tags:
+    - lldp_topology
+  when: dns_domain is not defined
 
 - name: Load mlag tasks
   include_tasks: "mlag.yml"


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->

## Change Summary

Current LLDP topology validation was skepted when no domain-name was defined in the structured config.   
This was due to the output of `sh lldp neighbors detail | json`  where the `systemName` is the fqdn of the neighbor.   
Instead of skipping this test, we are now also testing when no domain-name is defined in the structured config.    
So we have now 2 (conditionnals) tasks for LLDP topology validation.  

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

#497 

## Component(s) name

Role `eos_validate_state`

## How to test

Then run the role `eos_validate_state` with `dns_domain` and without `dns_domain` 

If dns_domain is defined in group_vars then you need to execute the roles eos_l3ls_evpn + eos_cli_config_gen (and to deploy the new configuration). 
If dns_domain is defined  in the structured config, then you need to execute the role eos_cli_config_gen (and to deploy the new configuration). 

Then then run the role `eos_validate_state`, watch the playbook to see which LLDP task is run/skip, and open the report file.  

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
