### PR TITLE
Adding support for "-noaaa" on TerminAttr

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/terminattr-prem-noaaa.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/terminattr-prem-noaaa.md
@@ -1,4 +1,4 @@
-# terminattr-cloud
+# terminattr-prem-noaaa
 
 # Table of Contents
 
@@ -181,14 +181,14 @@ Aliases not defined
 
 | CV Compression | Ingest gRPC URL | Ingest Authentication Key | Smash Excludes | Ingest Exclude | Ingest VRF |  NTP VRF | No AAA |
 | -------------- | --------------- | ------------------------- | -------------- | -------------- | ---------- | -------- | ------ |
-| gzip | apiserver.corp.arista.io:9910 | magickey | ale,flexCounter,hardware,kni,pulse,strata | /Sysdb/cell/1/agent,/Sysdb/cell/2/agent | mgt | mgt | False |
+| gzip | 10.10.10.8:9910,10.10.10.9:9910,10.10.10.10:9910 | magickey | ale,flexCounter,hardware,kni,pulse,strata | /Sysdb/cell/1/agent,/Sysdb/cell/2/agent | mgt | mgt | True |
 
 ### TerminAttr Daemon Device Configuration
 
 ```eos
 !
 daemon TerminAttr
-   exec /usr/bin/TerminAttr -cvaddr=apiserver.corp.arista.io:443 -cvcompression=gzip -taillogs -cvauth=token-secure,/tmp/cv-onboarding-token -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent  -cvvrf=mgt
+   exec /usr/bin/TerminAttr -ingestgrpcurl=10.10.10.8:9910,10.10.10.9:9910,10.10.10.10:9910 -cvcompression=gzip -ingestauth=key,magickey -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -ingestvrf=mgt -noaaa -taillogs
    no shutdown
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/terminattr-prem.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/terminattr-prem.md
@@ -179,9 +179,9 @@ Aliases not defined
 
 ### TerminAttr Daemon Summary
 
-| CV Compression | Ingest gRPC URL | Ingest Authentication Key | Smash Excludes | Ingest Exclude | Ingest VRF |  NTP VRF |
-| -------------- | --------------- | ------------------------- | -------------- | -------------- | ---------- | -------- |
-| gzip | 10.10.10.8:9910,10.10.10.9:9910,10.10.10.10:9910 | magickey | ale,flexCounter,hardware,kni,pulse,strata | /Sysdb/cell/1/agent,/Sysdb/cell/2/agent | mgt | mgt |
+| CV Compression | Ingest gRPC URL | Ingest Authentication Key | Smash Excludes | Ingest Exclude | Ingest VRF |  NTP VRF | No AAA |
+| -------------- | --------------- | ------------------------- | -------------- | -------------- | ---------- | -------- | ------ |
+| gzip | 10.10.10.8:9910,10.10.10.9:9910,10.10.10.10:9910 | magickey | ale,flexCounter,hardware,kni,pulse,strata | /Sysdb/cell/1/agent,/Sysdb/cell/2/agent | mgt | mgt | False |
 
 ### TerminAttr Daemon Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/terminattr-prem-noaaa.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/terminattr-prem-noaaa.cfg
@@ -1,0 +1,18 @@
+!RANCID-CONTENT-TYPE: arista
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -ingestgrpcurl=10.10.10.8:9910,10.10.10.9:9910,10.10.10.10:9910 -cvcompression=gzip -ingestauth=key,magickey -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -ingestvrf=mgt -noaaa -taillogs
+   no shutdown
+!
+transceiver qsfp default-mode 4x10G
+!
+hostname terminattr-prem-noaaa
+!
+no aaa root
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/terminattr-prem-noaaa.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/terminattr-prem-noaaa.yml
@@ -1,0 +1,13 @@
+### Daemon TerminAttr
+daemon_terminattr:
+  ingestgrpcurl:
+    ips:
+      - 10.10.10.8
+      - 10.10.10.9
+      - 10.10.10.10
+    port: 9910
+  ingestauth_key: magickey
+  ingestvrf: mgt
+  smashexcludes: "ale,flexCounter,hardware,kni,pulse,strata"
+  ingestexclude: "/Sysdb/cell/1/agent,/Sysdb/cell/2/agent"
+  noaaa: true

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts
@@ -27,6 +27,7 @@ sflow
 snmp_v3
 terminattr-cloud
 terminattr-prem
+terminattr-prem-noaaa
 vlan-interfaces
 vlans
 vrfs

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -167,7 +167,7 @@ daemon_terminattr:
   ingestvrf: < vrf_name >
   smashexcludes: "< list as string >"
   ingestexclude: "< list as string >"
-
+  noaaa: < false | true >
 ```
 
 You can either provide a list of IPs to target on-premise Cloudvision cluster or either use DNS name for your Cloudvision as a Service instance. If you have both on-prem and CVaaS defined, only on-prem is going to be configured.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/daemon-terminattr.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/daemon-terminattr.j2
@@ -1,9 +1,9 @@
 {% if daemon_terminattr is defined and daemon_terminattr is not none %}
 ### TerminAttr Daemon Summary
 
-| CV Compression | Ingest gRPC URL | Ingest Authentication Key | Smash Excludes | Ingest Exclude | Ingest VRF |  NTP VRF |
-| -------------- | --------------- | ------------------------- | -------------- | -------------- | ---------- | -------- |
-| gzip | {% for cvp_ip in daemon_terminattr.ingestgrpcurl.ips %}{{ cvp_ip }}:{{ daemon_terminattr.ingestgrpcurl.port }}{% if not loop.last %},{% endif %}{% endfor %} | {{ daemon_terminattr.ingestauth_key }} | {{ daemon_terminattr.smashexcludes }} | {{ daemon_terminattr.ingestexclude }} | {{ daemon_terminattr.ingestvrf }} | {{ daemon_terminattr.ingestvrf }} |
+| CV Compression | Ingest gRPC URL | Ingest Authentication Key | Smash Excludes | Ingest Exclude | Ingest VRF |  NTP VRF | No AAA |
+| -------------- | --------------- | ------------------------- | -------------- | -------------- | ---------- | -------- | ------ |
+| gzip | {% for cvp_ip in daemon_terminattr.ingestgrpcurl.ips %}{{ cvp_ip }}:{{ daemon_terminattr.ingestgrpcurl.port }}{% if not loop.last %},{% endif %}{% endfor %} | {{ daemon_terminattr.ingestauth_key }} | {{ daemon_terminattr.smashexcludes }} | {{ daemon_terminattr.ingestexclude }} | {{ daemon_terminattr.ingestvrf }} | {{ daemon_terminattr.ingestvrf }} | {{ daemon_terminattr.noaaa | default (false) }} |
 
 ### TerminAttr Daemon Device Configuration
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/daemon-terminattr.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/daemon-terminattr.j2
@@ -14,7 +14,7 @@
 {% endfor %}
 daemon TerminAttr
 {% if cvp_on_prem.ips|length > 0 %}
-   exec /usr/bin/TerminAttr -ingestgrpcurl={% for cvp_ip in cvp_on_prem.ips %}{{ cvp_ip }}:{{ daemon_terminattr.ingestgrpcurl.port }}{% if not loop.last %},{% endif %}{% endfor %} -cvcompression=gzip -ingestauth=key,{{ daemon_terminattr.ingestauth_key }} -smashexcludes={{ daemon_terminattr.smashexcludes }} -ingestexclude={{ daemon_terminattr.ingestexclude }}{% if daemon_terminattr.ingestvrf is ne 'default'%} -ingestvrf={{ daemon_terminattr.ingestvrf }}{% endif %} -taillogs
+   exec /usr/bin/TerminAttr -ingestgrpcurl={% for cvp_ip in cvp_on_prem.ips %}{{ cvp_ip }}:{{ daemon_terminattr.ingestgrpcurl.port }}{% if not loop.last %},{% endif %}{% endfor %} -cvcompression=gzip -ingestauth=key,{{ daemon_terminattr.ingestauth_key }} -smashexcludes={{ daemon_terminattr.smashexcludes }} -ingestexclude={{ daemon_terminattr.ingestexclude }}{% if daemon_terminattr.ingestvrf is ne 'default'%} -ingestvrf={{ daemon_terminattr.ingestvrf }}{% endif %}{{ " -noaaa" if daemon_terminattr.noaaa | arista.avd.default(false) == true else "" }} -taillogs
 {% elif cvaas.ips|length > 0 %}
    exec /usr/bin/TerminAttr -cvaddr={% for cvp_ip in cvaas.ips %}{{ cvp_ip }}:443{% if not loop.last %},{% endif %}{% endfor %} -cvcompression=gzip -taillogs -cvauth=token-secure,/tmp/cv-onboarding-token -smashexcludes={{ daemon_terminattr.smashexcludes }} -ingestexclude={{ daemon_terminattr.ingestexclude }}  -cvvrf={{ daemon_terminattr.ingestvrf }}
 {% endif %}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add knob under `daemon_terminattr` to enable `-noaaa` option.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [x] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

## Component(s) name
eos_cli_config_gen

## Proposed changes
<!--- Describe your changes in detail -->
Added key to datamodel:
```yaml
daemon_terminattr:
  ingestgrpcurl:
    ips:
      - < IPv4_address >
      - < IPv4_address >
      - < IPv4_address >
    port: < port_id >
  ingestauth_key: < ingest_key >
  ingestvrf: < vrf_name >
  smashexcludes: "< list as string >"
  ingestexclude: "< list as string >"
  noaaa: < false | true >
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Tested using `ClausHolbechArista/claus-l3ls-dev` branch `superspine-alternative`
RS have `noaaa:true`
SS have `noaaa:false`
All others have no `noaaa` specified.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
