### PR TITLE
Add route-map support to peer groups for EVPN AFI/SAFI

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-rtc.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-rtc.md
@@ -1,0 +1,503 @@
+# router-bgp-rtc
+
+# Table of Contents
+
+- [Management](#management)
+  - [Management Interfaces](#management-interfaces)
+  - [DNS Domain](#dns-domain)
+  - [Name Servers](#name-servers)
+  - [Domain Lookup](#domain-lookup)
+  - [NTP](#ntp)
+  - [Management SSH](#management-ssh)
+  - [Management GNMI](#management-api-gnmi)
+  - [Management API](#Management-api-http)
+- [Authentication](#authentication)
+  - [Local Users](#local-users)
+  - [TACACS Servers](#tacacs-servers)
+  - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
+  - [RADIUS Servers](#radius-servers)
+  - [AAA Server Groups](#aaa-server-groups)
+  - [AAA Authentication](#aaa-authentication)
+  - [AAA Authorization](#aaa-authorization)
+  - [AAA Accounting](#aaa-accounting)
+- [Management Security](#management-security)
+- [Aliases](#aliases)
+- [Monitoring](#monitoring)
+  - [TerminAttr Daemon](#terminattr-daemon)
+  - [Logging](#logging)
+  - [SNMP](#snmp)
+  - [SFlow](#sflow)
+  - [Hardware Counters](#hardware-counters)
+  - [VM Tracer Sessions](#vm-tracer-sessions)
+  - [Event Handler](#event-handler)
+- [MLAG](#mlag)
+- [Spanning Tree](#spanning-tree)
+- [Internal VLAN Allocation Policy](#internal-vlan-allocation-policy)
+- [VLANs](#vlans)
+- [Interfaces](#interfaces)
+  - [Ethernet Interfaces](#ethernet-interfaces)
+  - [Port-Channel Interfaces](#port-channel-interfaces)
+  - [Loopback Interfaces](#loopback-interfaces)
+  - [VLAN Interfaces](#vlan-interfaces)
+  - [VXLAN Interface](#vxlan-interface)
+- [Routing](#routing)
+  - [Virtual Router MAC Address](#virtual-router-mac-address)
+  - [IP Routing](#ip-routing)
+  - [IPv6 Routing](#ipv6-routing)
+  - [Static Routes](#static-routes)
+  - [IPv6 Static Routes](#ipv6-static-routes)
+  - [Router ISIS](#router-isis)
+  - [Router BGP](#router-bgp)
+  - [Router BFD](#router-bfd)
+- [Multicast](#multicast)
+  - [IP IGMP Snooping](#ip-igmp-snooping)
+  - [Router Multicast](#router-multicast)
+  - [Router PIM Sparse Mode](#router-pim-sparse-mode)
+- [Filters](#filters)
+  - [Community-lists](#community-lists)
+  - [Peer Filters](#peer-filters)
+  - [Prefix-lists](#prefix-lists)
+  - [IPv6 Prefix-lists](#ipv6-prefix-lists)
+  - [Route-maps](#route-maps)
+  - [IP Extended Communities](#ip-extended-communities)
+- [ACL](#acl)
+  - [Standard Access-lists](#standard-access-lists)
+  - [Extended Access-lists](#extended-access-lists)
+  - [IPv6 Standard Access-lists](#ipv6-standard-access-lists)
+  - [IPv6 Extended Access-lists](#ipv6-extended-access-lists)
+- [VRF Instances](#vrf-instances)
+- [Virtual Source NAT](#virtual-source-nat)
+- [Platform](#platform)
+- [Router L2 VPN](#router-l2-vpn)
+- [IP DHCP Relay](#ip-dhcp-relay)
+
+# Management
+
+## Management Interfaces
+
+### Management Interfaces Summary
+
+#### IPv4
+
+| Management Interface | description | VRF | IP Address | Gateway |
+| -------------------- | ----------- | --- | ---------- | ------- |
+| Management1 | oob_management | MGMT | 10.73.255.122/24 | 10.73.255.2 |
+
+#### IPv6
+
+| Management Interface | description | VRF | IPv6 Address | IPv6 Gateway |
+| -------------------- | ----------- | --- | ------------ | ------------ |
+| Management1 | oob_management | MGMT | -  | - |
+
+### Management Interfaces Device Configuration
+
+```eos
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+```
+
+## DNS Domain
+
+DNS domain not defined
+
+## Domain-list
+
+Domain-list not defined
+
+## Name Servers
+
+No name servers defined
+
+## Domain Lookup
+
+DNS domain lookup not defined
+
+## NTP
+
+No NTP servers defined
+
+## Management SSH
+
+Management SSH not defined
+
+## Management API GNMI
+
+Management API gnmi is not defined
+
+## Management API HTTP
+
+Management API HTTP not defined
+
+# Authentication
+
+## Local Users
+
+No users defined
+
+## TACACS Servers
+
+TACACS servers not defined
+
+## IP TACACS Source Interfaces
+
+IP TACACS source interfaces not defined
+
+## RADIUS Servers
+
+RADIUS servers not defined
+
+## AAA Server Groups
+
+AAA server groups not defined
+
+## AAA Authentication
+
+AAA authentication not defined
+
+## AAA Authorization
+
+AAA authorization not defined
+
+## AAA Accounting
+
+AAA accounting not defined
+
+# Management Security
+
+Management security not defined
+
+# Aliases
+
+Aliases not defined
+
+# Monitoring
+
+## TerminAttr Daemon
+
+TerminAttr daemon not defined
+
+## Logging
+
+No logging settings defined
+
+## SNMP
+
+No SNMP settings defined
+
+## SFlow
+
+No sFlow defined
+
+## Hardware Counters
+
+No hardware counters defined
+
+## VM Tracer Sessions
+
+No VM tracer sessions defined
+
+## Event Handler
+
+No event handler defined
+
+# MLAG
+
+MLAG not defined
+
+# Spanning Tree
+
+Spanning-tree not defined
+
+# Internal VLAN Allocation Policy
+
+## Internal VLAN Allocation Policy Summary
+
+**Default Allocation Policy**
+
+| Policy Allocation | Range Beginning | Range Ending |
+| ------------------| --------------- | ------------ |
+| ascending | 1006 | 4094 |
+
+# VLANs
+
+No VLANs defined
+
+# Interfaces
+
+## Ethernet Interfaces
+
+No ethernet interface defined
+
+## Port-Channel Interfaces
+
+No port-channels defined
+
+## Loopback Interfaces
+
+No loopback interfaces defined
+
+## VLAN Interfaces
+
+No VLAN interfaces defined
+
+## VXLAN Interface
+
+No VXLAN interfaces defined
+
+# Routing
+
+## Virtual Router MAC Address
+
+IP virtual router MAC address not defined
+
+## IP Routing
+
+### IP Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | false| 
+### IP Routing Device Configuration
+
+```eos
+```
+
+## IPv6 Routing
+
+### IPv6 Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | false |
+
+## Static Routes
+
+Static routes not defined
+
+## IPv6 Static Routes
+
+IPv6 static routes not defined
+
+## Router ISIS
+
+Router ISIS not defined
+
+## Router BGP
+
+### Router BGP Summary
+
+| BGP AS | Router ID |
+| ------ | --------- |
+| 65101|  192.168.255.3 |
+
+| BGP Tuning |
+| ---------- |
+| no bgp default ipv4-unicast |
+| distance bgp 20 200 200 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
+| maximum-paths 2 ecmp 2 |
+
+### Router BGP Peer Groups
+
+#### EVPN-OVERLAY-PEERS
+
+| Settings | Value |
+| -------- | ----- |
+| Address Family | evpn |
+| Remote_as | 65001 |
+| Source | Loopback0 |
+| Bfd | true |
+| Ebgp multihop | 3 |
+| Send community | true |
+| Maximum routes | 0 (no limit) |
+
+### BGP Neighbors
+
+| Neighbor | Remote AS |
+| -------- | ---------
+| 192.168.255.1 | Inherited from peer group EVPN-OVERLAY-PEERS |
+| 192.168.255.2 | Inherited from peer group EVPN-OVERLAY-PEERS |
+
+### Router BGP EVPN Address Family
+
+#### Router BGP EVPN MAC-VRFs
+
+##### VLAN aware bundles
+
+| VLAN Aware Bundle | Route-Distinguisher | Both Route-Target | Import Route Target | Export Route-Target | Redistribute | VLANs |
+| ----------------- | ------------------- | ----------------- | ------------------- | ------------------- | ------------ | ----- |
+| B-ELAN-201 | 192.168.255.3:20201 |  20201:20201  |  |  | learned | 201 |
+| TENANT_A_PROJECT01 | 192.168.255.3:11 |  11:11  |  |  | learned | 110 |
+| TENANT_A_PROJECT02 | 192.168.255.3:12 |  12:12  |  |  | learned | 112 |
+
+#### Router BGP EVPN VRFs
+
+| VRF | Route-Distinguisher | Redistribute |
+| --- | ------------------- | ------------ |
+| TENANT_A_PROJECT01 | 192.168.255.3:11 | connected |
+| TENANT_A_PROJECT02 | 192.168.255.3:12 | connected |
+
+### Router BGP Device Configuration
+
+```eos
+!
+router bgp 65101
+   router-id 192.168.255.3
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
+   graceful-restart restart-time 300
+   graceful-restart
+   maximum-paths 2 ecmp 2
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS remote-as 65001
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.2 peer group EVPN-OVERLAY-PEERS
+   !
+   vlan-aware-bundle B-ELAN-201
+      rd 192.168.255.3:20201
+      route-target both 20201:20201
+      redistribute learned
+      vlan 201
+   !
+   vlan-aware-bundle TENANT_A_PROJECT01
+      rd 192.168.255.3:11
+      route-target both 11:11
+      redistribute learned
+      vlan 110
+   !
+   vlan-aware-bundle TENANT_A_PROJECT02
+      rd 192.168.255.3:12
+      route-target both 12:12
+      redistribute learned
+      vlan 112
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+      no neighbor MLAG-IPv4-UNDERLAY-PEER activate
+   !
+   address-family rt-membership
+      neighbor EVPN-OVERLAY-PEERS activate
+      neighbor EVPN-OVERLAY-PEERS default-route-target only
+      neighbor EVPN-OVERLAY-PEERS default-route-target encoding origin-as omit
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+   !
+   vrf TENANT_A_PROJECT01
+      rd 192.168.255.3:11
+      route-target import evpn 11:11
+      route-target export evpn 11:11
+      router-id 192.168.255.3
+      neighbor 10.255.251.1 peer group MLAG-IPv4-UNDERLAY-PEER
+      redistribute connected
+   !
+   vrf TENANT_A_PROJECT02
+      rd 192.168.255.3:12
+      route-target import evpn 12:12
+      route-target export evpn 12:12
+      router-id 192.168.255.3
+      neighbor 10.255.251.1 peer group MLAG-IPv4-UNDERLAY-PEER
+      redistribute connected
+```
+
+## Router BFD
+
+### Router BFD Multihop Summary
+
+| Interval | Minimum RX | Multiplier |
+| -------- | ---------- | ---------- |
+| 300 | 300 | 3 |
+
+*No device configuration required - default values
+
+# Multicast
+
+## IP IGMP Snooping
+
+No IP IGMP configuration
+
+## Router Multicast
+
+Routing multicast not defined
+
+## Router PIM Sparse Mode
+
+Router PIM sparse mode not defined
+
+# Filters
+
+## Community-lists
+
+Community-lists not defined
+
+## Peer Filters
+
+No peer filters defined
+
+## Prefix-lists
+
+Prefix-lists not defined
+
+## IPv6 Prefix-lists
+
+IPv6 prefix-lists not defined
+
+## Route-maps
+
+No route-maps defined
+
+## IP Extended Communities
+
+No extended community defined
+
+# ACL
+
+## Standard Access-lists
+
+Standard access-lists not defined
+
+## Extended Access-lists
+
+Extended access-lists not defined
+
+## IPv6 Standard Access-lists
+
+IPv6 standard access-lists not defined
+
+## IPv6 Extended Access-lists
+
+IPv6 extended access-lists not defined
+
+# VRF Instances
+
+No VRF instances defined
+
+# Virtual Source NAT
+
+Virtual source NAT not defined
+
+# Platform
+
+No platform parameters defined
+
+# Router L2 VPN
+
+Router L2 VPN not defined
+
+# IP DHCP Relay
+
+IP DHCP relay not defined
+
+# Custom Templates
+
+No custom templates defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-v4-v6-evpn.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-v4-v6-evpn.md
@@ -463,6 +463,8 @@ router bgp 65100
       redistribute learned
    !
    address-family evpn
+      neighbor EVPN-OVERLAY route-map RM-HIDE-AS-PATH in
+      neighbor EVPN-OVERLAY route-map RM-HIDE-AS-PATH out
       neighbor EVPN-OVERLAY activate
    !
    address-family ipv4

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-rtc.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-rtc.cfg
@@ -1,0 +1,78 @@
+!RANCID-CONTENT-TYPE: arista
+!
+transceiver qsfp default-mode 4x10G
+!
+hostname router-bgp-rtc
+!
+no aaa root
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+!
+router bgp 65101
+   router-id 192.168.255.3
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
+   graceful-restart restart-time 300
+   graceful-restart
+   maximum-paths 2 ecmp 2
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS remote-as 65001
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.2 peer group EVPN-OVERLAY-PEERS
+   !
+   vlan-aware-bundle B-ELAN-201
+      rd 192.168.255.3:20201
+      route-target both 20201:20201
+      redistribute learned
+      vlan 201
+   !
+   vlan-aware-bundle TENANT_A_PROJECT01
+      rd 192.168.255.3:11
+      route-target both 11:11
+      redistribute learned
+      vlan 110
+   !
+   vlan-aware-bundle TENANT_A_PROJECT02
+      rd 192.168.255.3:12
+      route-target both 12:12
+      redistribute learned
+      vlan 112
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+      no neighbor MLAG-IPv4-UNDERLAY-PEER activate
+   !
+   address-family rt-membership
+      neighbor EVPN-OVERLAY-PEERS activate
+      neighbor EVPN-OVERLAY-PEERS default-route-target only
+      neighbor EVPN-OVERLAY-PEERS default-route-target encoding origin-as omit
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+   !
+   vrf TENANT_A_PROJECT01
+      rd 192.168.255.3:11
+      route-target import evpn 11:11
+      route-target export evpn 11:11
+      router-id 192.168.255.3
+      neighbor 10.255.251.1 peer group MLAG-IPv4-UNDERLAY-PEER
+      redistribute connected
+   !
+   vrf TENANT_A_PROJECT02
+      rd 192.168.255.3:12
+      route-target import evpn 12:12
+      route-target export evpn 12:12
+      router-id 192.168.255.3
+      neighbor 10.255.251.1 peer group MLAG-IPv4-UNDERLAY-PEER
+      redistribute connected
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-v4-v6-evpn.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-v4-v6-evpn.cfg
@@ -85,6 +85,8 @@ router bgp 65100
       redistribute learned
    !
    address-family evpn
+      neighbor EVPN-OVERLAY route-map RM-HIDE-AS-PATH in
+      neighbor EVPN-OVERLAY route-map RM-HIDE-AS-PATH out
       neighbor EVPN-OVERLAY activate
    !
    address-family ipv4

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-rtc.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-rtc.yml
@@ -1,0 +1,104 @@
+router_bgp:
+  as: 65101
+  router_id: 192.168.255.3
+  bgp_defaults:
+    - no bgp default ipv4-unicast
+    - distance bgp 20 200 200
+    - graceful-restart restart-time 300
+    - graceful-restart
+    - maximum-paths 2 ecmp 2
+  peer_groups:
+    EVPN-OVERLAY-PEERS:
+      type: evpn
+      remote_as: 65001
+      update_source: Loopback0
+      bfd: true
+      ebgp_multihop: 3
+      password: "q+VNViP5i4rVjW1cxFv2wA=="
+      send_community: true
+      maximum_routes: 0
+  neighbors:
+    192.168.255.1:
+      peer_group: EVPN-OVERLAY-PEERS
+    192.168.255.2:
+      peer_group: EVPN-OVERLAY-PEERS
+  redistribute_routes:
+  address_family_evpn:
+    peer_groups:
+      EVPN-OVERLAY-PEERS:
+        activate: true
+      MLAG-IPv4-UNDERLAY-PEER:
+        activate: false
+  address_family_rtc:
+    peer_groups:
+      EVPN-OVERLAY-PEERS:
+        activate: true
+        default_route_target:
+          only: true
+          encoding_origin_as_omit:
+            disabled: true
+  address_family_ipv4:
+    peer_groups:
+      EVPN-OVERLAY-PEERS:
+        activate: false
+  vlan_aware_bundles:
+## Tenant_A ##
+    TENANT_A_PROJECT01:
+      rd: "192.168.255.3:11"
+      route_targets:
+        both:
+          - "11:11"
+      redistribute_routes:
+        - learned
+      vlan: 110
+    TENANT_A_PROJECT02:
+      rd: "192.168.255.3:12"
+      route_targets:
+        both:
+          - "12:12"
+      redistribute_routes:
+        - learned
+      vlan: 112
+## Tenant_B ##
+    B-ELAN-201:
+      tenant: Tenant_B
+      rd: "192.168.255.3:20201"
+      route_targets:
+        both:
+          - "20201:20201"
+      redistribute_routes:
+        - learned
+      vlan: 201
+  vlans:
+  vrfs:
+## Tenant_A ##
+    TENANT_A_PROJECT01:
+      router_id: 192.168.255.3
+      rd: "192.168.255.3:11"
+      route_targets:
+        import:
+          evpn:
+            - "11:11"
+        export:
+          evpn:
+            - "11:11"
+      neighbors:
+        10.255.251.1:
+          peer_group: MLAG-IPv4-UNDERLAY-PEER
+      redistribute_routes:
+        - connected
+    TENANT_A_PROJECT02:
+      router_id: 192.168.255.3
+      rd: "192.168.255.3:12"
+      route_targets:
+        import:
+          evpn:
+            - "12:12"
+        export:
+          evpn:
+            - "12:12"
+      neighbors:
+        10.255.251.1:
+          peer_group: MLAG-IPv4-UNDERLAY-PEER
+      redistribute_routes:
+        - connected

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-v4-v6-evpn.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-v4-v6-evpn.yml
@@ -75,6 +75,8 @@ router_bgp:
     peer_groups:
       EVPN-OVERLAY:
         activate: true
+        route_map_in: RM-HIDE-AS-PATH
+        route_map_out: RM-HIDE-AS-PATH
   address_family_ipv4:
     peer_groups:
       IPV4-UNDERLAY:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts
@@ -18,6 +18,7 @@ prefix-lists
 route-maps
 router-bgp-base
 router-bgp-evpn
+router-bgp-rtc
 router-bgp-v4-evpn
 router-bgp-v4-v6-evpn
 router-isis

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1145,7 +1145,7 @@ router_bgp:
     - "< bgp command as string >"
   peer_groups:
     < peer_group_name_1>:
-      type: < ipv4 | evpn >
+      type: < ipv4 | evpn | rtc >
       description: "< description as string >"
       shutdown: < true | false >
       peer_filter: < peer_filter >
@@ -1251,6 +1251,15 @@ router_bgp:
     peer_groups:
       < peer_group_name >:
         activate: < true | false >
+  address_family_rtc:
+    peer_groups:
+      < peer_group_name >:
+        activate: < true | false >
+        default_route_target:
+          only:
+          disabled:
+          encoding_origin_as_omit:
+            disabled:
   address_family_ipv4:
     networks:
       < prefix_ipv4 >:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1256,10 +1256,10 @@ router_bgp:
       < peer_group_name >:
         activate: < true | false >
         default_route_target:
-          only:
-          disabled:
+          only: < true | false >
+          disabled: < true | false >
           encoding_origin_as_omit:
-            disabled:
+            disabled: < true | false >
   address_family_ipv4:
     networks:
       < prefix_ipv4 >:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1250,6 +1250,8 @@ router_bgp:
   address_family_evpn:
     peer_groups:
       < peer_group_name >:
+        route_map_in: < route_map_name >
+        route_map_out: < route_map_name >
         activate: < true | false >
   address_family_rtc:
     peer_groups:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -167,6 +167,12 @@ router bgp {{ router_bgp.as }}
    address-family evpn
 {%       if router_bgp.address_family_evpn.peer_groups is defined and router_bgp.address_family_evpn.peer_groups is not none %}
 {%          for peer_group in router_bgp.address_family_evpn.peer_groups | arista.avd.natural_sort %}
+{%             if router_bgp.address_family_evpn.peer_groups[peer_group].route_map_in is defined and router_bgp.address_family_evpn.peer_groups[peer_group].route_map_in is not none %}
+      neighbor {{ peer_group }} route-map {{ router_bgp.address_family_evpn.peer_groups[peer_group].route_map_in }} in
+{%             endif %}
+{%             if router_bgp.address_family_evpn.peer_groups[peer_group].route_map_out is defined and router_bgp.address_family_evpn.peer_groups[peer_group].route_map_out is not none %}
+      neighbor {{ peer_group }} route-map {{ router_bgp.address_family_evpn.peer_groups[peer_group].route_map_out }} out
+{%             endif %}
 {%             if router_bgp.address_family_evpn.peer_groups[peer_group].activate == true %}
       neighbor {{ peer_group }} activate
 {%             elif router_bgp.address_family_evpn.peer_groups[peer_group].activate == false %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -175,6 +175,34 @@ router bgp {{ router_bgp.as }}
 {%          endfor %}
 {%       endif %}
 {%     endif %}
+{# address family rt-membership activation #}
+{%     if router_bgp.address_family_rtc is defined and router_bgp.address_family_rtc is not none %}
+   !
+   address-family rt-membership
+{%       if router_bgp.address_family_rtc.peer_groups is defined and router_bgp.address_family_rtc.peer_groups is not none %}
+{%          for peer_group in router_bgp.address_family_rtc.peer_groups | arista.avd.natural_sort %}
+{%             if router_bgp.address_family_rtc.peer_groups[peer_group].activate == true %}
+      neighbor {{ peer_group }} activate
+{%             elif router_bgp.address_family_rtc.peer_groups[peer_group].activate == false %}
+      no neighbor {{ peer_group }} activate
+{%             endif %}
+{%             if router_bgp.address_family_rtc.peer_groups[peer_group].default_route_target is defined %}
+{%                 if router_bgp.address_family_rtc.peer_groups[peer_group].default_route_target.only is defined and router_bgp.address_family_rtc.peer_groups[peer_group].default_route_target.only == true %}
+      neighbor {{ peer_group }} default-route-target only
+{%                 elif router_bgp.address_family_rtc.peer_groups[peer_group].default_route_target.disabled is defined and router_bgp.address_family_rtc.peer_groups[peer_group].default_route_target.disabled is defined == true %}
+      neighbor {{ peer_group }} default-route-target disabled
+{%                 endif %}
+{%             else %}
+      neighbor {{ peer_group }} default-route-target
+{%             endif %}
+{%             if router_bgp.address_family_rtc.peer_groups[peer_group].default_route_target.encoding_origin_as_omit is defined %}
+      neighbor {{ peer_group }} default-route-target encoding origin-as omit
+{%             elif router_bgp.address_family_rtc.peer_groups[peer_group].default_route_target.encoding_origin_as_omit.disabled is defined and router_bgp.address_family_rtc.peer_groups[peer_group].default_route_target.encoding_origin_as_omit.disabled is defined == true %}
+      neighbor {{ peer_group }} default-route-target encoding origin-as omit disabled
+{%             endif %}
+{%          endfor %}
+{%       endif %}
+{%     endif %}
 {# address family ipv4 activation #}
 {%     if router_bgp.address_family_ipv4 is defined and router_bgp.address_family_ipv4 is not none %}
    !


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Addition to eos_cli_config_gen router_bgp.j2 and molecule test case
Allows user to configure route-map under AFI/SAFI EVPN for peer groups.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes #494 

## Component(s) name
eos_cli_config_gen

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
