### PR TITLE
Add route-map support to peer groups for EVPN

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-v4-v6-evpn.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-v4-v6-evpn.md
@@ -473,6 +473,8 @@ router bgp 65100
       redistribute learned
    !
    address-family evpn
+      neighbor EVPN-OVERLAY route-map RM-HIDE-AS-PATH in
+      neighbor EVPN-OVERLAY route-map RM-HIDE-AS-PATH out
       neighbor EVPN-OVERLAY activate
    !
    address-family ipv4

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-v4-v6-evpn.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-v4-v6-evpn.cfg
@@ -85,6 +85,8 @@ router bgp 65100
       redistribute learned
    !
    address-family evpn
+      neighbor EVPN-OVERLAY route-map RM-HIDE-AS-PATH in
+      neighbor EVPN-OVERLAY route-map RM-HIDE-AS-PATH out
       neighbor EVPN-OVERLAY activate
    !
    address-family ipv4

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-v4-v6-evpn.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-v4-v6-evpn.yml
@@ -74,6 +74,8 @@ router_bgp:
   address_family_evpn:
     peer_groups:
       EVPN-OVERLAY:
+        route_map_in: RM-HIDE-AS-PATH
+        route_map_out: RM-HIDE-AS-PATH
         activate: true
   address_family_ipv4:
     peer_groups:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1325,6 +1325,8 @@ router_bgp:
   address_family_ipv4:
     networks:
       < prefix_ipv4 >:
+        route_map_in: < route_map_name >
+        route_map_out: < route_map_name >
         route_map: < route_map_name >
     peer_groups:
       < peer_group_name >:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1322,11 +1322,11 @@ router_bgp:
     peer_groups:
       < peer_group_name >:
         activate: < true | false >
+        route_map_in: < route_map_name >
+        route_map_out: < route_map_name >
   address_family_ipv4:
     networks:
       < prefix_ipv4 >:
-        route_map_in: < route_map_name >
-        route_map_out: < route_map_name >
         route_map: < route_map_name >
     peer_groups:
       < peer_group_name >:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -167,6 +167,12 @@ router bgp {{ router_bgp.as }}
    address-family evpn
 {%       if router_bgp.address_family_evpn.peer_groups is defined and router_bgp.address_family_evpn.peer_groups is not none %}
 {%          for peer_group in router_bgp.address_family_evpn.peer_groups | arista.avd.natural_sort %}
+{%             if router_bgp.address_family_evpn.peer_groups[peer_group].route_map_in is defined and router_bgp.address_family_evpn.peer_groups[peer_group].route_map_in is not none %}
+      neighbor {{ peer_group }} route-map {{ router_bgp.address_family_evpn.peer_groups[peer_group].route_map_in }} in
+{%             endif %}
+{%             if router_bgp.address_family_evpn.peer_groups[peer_group].route_map_out is defined and router_bgp.address_family_evpn.peer_groups[peer_group].route_map_out is not none %}
+      neighbor {{ peer_group }} route-map {{ router_bgp.address_family_evpn.peer_groups[peer_group].route_map_out }} out
+{%             endif %}
 {%             if router_bgp.address_family_evpn.peer_groups[peer_group].activate == true %}
       neighbor {{ peer_group }} activate
 {%             elif router_bgp.address_family_evpn.peer_groups[peer_group].activate == false %}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Addition to eos_cli_config_gen router_bgp.j2 and molecule test case
Allows user to configure route-map under AFI/SAFI EVPN for peer groups.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes #494 

## Component(s) name

## Proposed changes
<!--- Describe your changes in detail -->

eos_cli_config_gen

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Molecule

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
