### PR TITLE
Additional STP knobs and MST configuration settings

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/spanning-tree-rapid-pvst.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/spanning-tree-rapid-pvst.md
@@ -35,6 +35,7 @@
 - [Internal VLAN Allocation Policy](#internal-vlan-allocation-policy)
 - [VLANs](#vlans)
 - [Interfaces](#interfaces)
+  - [Interface Defaults](#internet-defaults)
   - [Ethernet Interfaces](#ethernet-interfaces)
   - [Port-Channel Interfaces](#port-channel-interfaces)
   - [Loopback Interfaces](#loopback-interfaces)
@@ -70,6 +71,10 @@
 - [Platform](#platform)
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
+- [Errdisable](#errdisable)
+- [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -118,6 +123,10 @@ DNS domain lookup not defined
 ## NTP
 
 No NTP servers defined
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -211,7 +220,7 @@ MLAG not defined
 
 ## Spanning Tree Summary
 
-STP mode running: **rapid-pvst**
+STP mode: **rapid-pvst**
 
 ### Rapid-PVST Instance and Priority
 
@@ -249,6 +258,10 @@ spanning-tree vlan-id 100-500 priority 16384
 No VLANs defined
 
 # Interfaces
+
+## Interface Defaults
+
+No Interface Defaults defined
 
 ## Ethernet Interfaces
 
@@ -303,6 +316,10 @@ Static routes not defined
 ## IPv6 Static Routes
 
 IPv6 static routes not defined
+
+## ARP
+
+Global ARP timeout not defined.
 
 ## Router ISIS
 
@@ -399,6 +416,22 @@ Router L2 VPN not defined
 # IP DHCP Relay
 
 IP DHCP relay not defined
+
+# Errdisable
+
+Errdisable is not defined.
+
+# MACsec
+
+MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/spanning-tree-rapid-pvst.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/spanning-tree-rapid-pvst.md
@@ -1,4 +1,4 @@
-# spanning-tree
+# spanning-tree-rapid-pvst
 
 # Table of Contents
 
@@ -211,49 +211,27 @@ MLAG not defined
 
 ## Spanning Tree Summary
 
-STP mode running: **mstp**
-MST PSVT Border is enabled.
+STP mode running: **rapid-pvst**
 
-### MSTP Instance and Priority
+### Rapid-PVST Instance and Priority
 
 | Instance(s) | Priority |
 | -------- | -------- |
-| 0 | 4096 |
-| 100-200 | 8192 |
-
-### MST Configuration
-
-| Variable | Value |
-| -------- | -------- |
-| Name | test |
-| Revision | 5 |
-| Instance 2 | VLAN(s) 15,16,17,18 |
-| Instance 3 | VLAN(s) 15 |
-| Instance 4 | VLAN(s) 200-300 |
-
+| 1,2,3,4,5,10-15 |  | 4096 |
+| 3 |  | 8192 |
+| 100-500 |  | 16384 |
 
 ### Global Spanning-Tree Settings
 
-Spanning Tree disabled for VLANs: **105,202,505-506**
-Global BPDU Guard for Edge ports is enabled.
 
 ## Spanning Tree Device Configuration
 
 ```eos
 !
-spanning-tree edge-port bpduguard default
-spanning-tree mode mstp
-no spanning-tree vlan-id 105,202,505-506
-spanning-tree mst 0 priority 4096
-spanning-tree mst 100-200 priority 8192
-spanning-tree mst pvst border
-!
-spanning-tree mst configuration
-   name test
-   revision 5
-   instance 2 vlan 15,16,17,18
-   instance 3 vlan 15
-   instance 4 vlan 200-300
+spanning-tree mode rapid-pvst
+spanning-tree vlan-id 1,2,3,4,5,10-15 priority 4096
+spanning-tree vlan-id 3 priority 8192
+spanning-tree vlan-id 100-500 priority 16384
 ```
 
 # Internal VLAN Allocation Policy

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/spanning-tree-rstp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/spanning-tree-rstp.md
@@ -1,4 +1,4 @@
-# spanning-tree
+# spanning-tree-rstp
 
 # Table of Contents
 
@@ -211,49 +211,19 @@ MLAG not defined
 
 ## Spanning Tree Summary
 
-STP mode running: **mstp**
-MST PSVT Border is enabled.
-
-### MSTP Instance and Priority
-
-| Instance(s) | Priority |
-| -------- | -------- |
-| 0 | 4096 |
-| 100-200 | 8192 |
-
-### MST Configuration
-
-| Variable | Value |
-| -------- | -------- |
-| Name | test |
-| Revision | 5 |
-| Instance 2 | VLAN(s) 15,16,17,18 |
-| Instance 3 | VLAN(s) 15 |
-| Instance 4 | VLAN(s) 200-300 |
+STP mode running: **rstp**
 
 
 ### Global Spanning-Tree Settings
 
-Spanning Tree disabled for VLANs: **105,202,505-506**
-Global BPDU Guard for Edge ports is enabled.
+Global RSTP priority: 8192
 
 ## Spanning Tree Device Configuration
 
 ```eos
 !
-spanning-tree edge-port bpduguard default
-spanning-tree mode mstp
-no spanning-tree vlan-id 105,202,505-506
-spanning-tree mst 0 priority 4096
-spanning-tree mst 100-200 priority 8192
-spanning-tree mst pvst border
-!
-spanning-tree mst configuration
-   name test
-   revision 5
-   instance 2 vlan 15,16,17,18
-   instance 3 vlan 15
-   instance 4 vlan 200-300
+spanning-tree mode rstp
+spanning-tree priority 8192
 ```
 
 # Internal VLAN Allocation Policy

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/spanning-tree-rstp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/spanning-tree-rstp.md
@@ -35,6 +35,7 @@
 - [Internal VLAN Allocation Policy](#internal-vlan-allocation-policy)
 - [VLANs](#vlans)
 - [Interfaces](#interfaces)
+  - [Interface Defaults](#internet-defaults)
   - [Ethernet Interfaces](#ethernet-interfaces)
   - [Port-Channel Interfaces](#port-channel-interfaces)
   - [Loopback Interfaces](#loopback-interfaces)
@@ -70,6 +71,10 @@
 - [Platform](#platform)
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
+- [Errdisable](#errdisable)
+- [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -118,6 +123,10 @@ DNS domain lookup not defined
 ## NTP
 
 No NTP servers defined
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -211,7 +220,7 @@ MLAG not defined
 
 ## Spanning Tree Summary
 
-STP mode running: **rstp**
+STP mode: **rstp**
 
 
 ### Global Spanning-Tree Settings
@@ -241,6 +250,10 @@ spanning-tree priority 8192
 No VLANs defined
 
 # Interfaces
+
+## Interface Defaults
+
+No Interface Defaults defined
 
 ## Ethernet Interfaces
 
@@ -295,6 +308,10 @@ Static routes not defined
 ## IPv6 Static Routes
 
 IPv6 static routes not defined
+
+## ARP
+
+Global ARP timeout not defined.
 
 ## Router ISIS
 
@@ -391,6 +408,22 @@ Router L2 VPN not defined
 # IP DHCP Relay
 
 IP DHCP relay not defined
+
+# Errdisable
+
+Errdisable is not defined.
+
+# MACsec
+
+MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/spanning-tree.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/spanning-tree.md
@@ -1,0 +1,423 @@
+# spanning-tree
+
+# Table of Contents
+
+- [Management](#management)
+  - [Management Interfaces](#management-interfaces)
+  - [DNS Domain](#dns-domain)
+  - [Name Servers](#name-servers)
+  - [Domain Lookup](#domain-lookup)
+  - [NTP](#ntp)
+  - [Management SSH](#management-ssh)
+  - [Management GNMI](#management-api-gnmi)
+  - [Management API](#Management-api-http)
+- [Authentication](#authentication)
+  - [Local Users](#local-users)
+  - [TACACS Servers](#tacacs-servers)
+  - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
+  - [RADIUS Servers](#radius-servers)
+  - [AAA Server Groups](#aaa-server-groups)
+  - [AAA Authentication](#aaa-authentication)
+  - [AAA Authorization](#aaa-authorization)
+  - [AAA Accounting](#aaa-accounting)
+- [Management Security](#management-security)
+- [Aliases](#aliases)
+- [Monitoring](#monitoring)
+  - [TerminAttr Daemon](#terminattr-daemon)
+  - [Logging](#logging)
+  - [SNMP](#snmp)
+  - [SFlow](#sflow)
+  - [Hardware Counters](#hardware-counters)
+  - [VM Tracer Sessions](#vm-tracer-sessions)
+  - [Event Handler](#event-handler)
+- [MLAG](#mlag)
+- [Spanning Tree](#spanning-tree)
+- [Internal VLAN Allocation Policy](#internal-vlan-allocation-policy)
+- [VLANs](#vlans)
+- [Interfaces](#interfaces)
+  - [Ethernet Interfaces](#ethernet-interfaces)
+  - [Port-Channel Interfaces](#port-channel-interfaces)
+  - [Loopback Interfaces](#loopback-interfaces)
+  - [VLAN Interfaces](#vlan-interfaces)
+  - [VXLAN Interface](#vxlan-interface)
+- [Routing](#routing)
+  - [Virtual Router MAC Address](#virtual-router-mac-address)
+  - [IP Routing](#ip-routing)
+  - [IPv6 Routing](#ipv6-routing)
+  - [Static Routes](#static-routes)
+  - [IPv6 Static Routes](#ipv6-static-routes)
+  - [Router ISIS](#router-isis)
+  - [Router BGP](#router-bgp)
+  - [Router BFD](#router-bfd)
+- [Multicast](#multicast)
+  - [IP IGMP Snooping](#ip-igmp-snooping)
+  - [Router Multicast](#router-multicast)
+  - [Router PIM Sparse Mode](#router-pim-sparse-mode)
+- [Filters](#filters)
+  - [Community-lists](#community-lists)
+  - [Peer Filters](#peer-filters)
+  - [Prefix-lists](#prefix-lists)
+  - [IPv6 Prefix-lists](#ipv6-prefix-lists)
+  - [Route-maps](#route-maps)
+  - [IP Extended Communities](#ip-extended-communities)
+- [ACL](#acl)
+  - [Standard Access-lists](#standard-access-lists)
+  - [Extended Access-lists](#extended-access-lists)
+  - [IPv6 Standard Access-lists](#ipv6-standard-access-lists)
+  - [IPv6 Extended Access-lists](#ipv6-extended-access-lists)
+- [VRF Instances](#vrf-instances)
+- [Virtual Source NAT](#virtual-source-nat)
+- [Platform](#platform)
+- [Router L2 VPN](#router-l2-vpn)
+- [IP DHCP Relay](#ip-dhcp-relay)
+
+# Management
+
+## Management Interfaces
+
+### Management Interfaces Summary
+
+#### IPv4
+
+| Management Interface | description | VRF | IP Address | Gateway |
+| -------------------- | ----------- | --- | ---------- | ------- |
+| Management1 | oob_management | MGMT | 10.73.255.122/24 | 10.73.255.2 |
+
+#### IPv6
+
+| Management Interface | description | VRF | IPv6 Address | IPv6 Gateway |
+| -------------------- | ----------- | --- | ------------ | ------------ |
+| Management1 | oob_management | MGMT | -  | - |
+
+### Management Interfaces Device Configuration
+
+```eos
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+```
+
+## DNS Domain
+
+DNS domain not defined
+
+## Domain-list
+
+Domain-list not defined
+
+## Name Servers
+
+No name servers defined
+
+## Domain Lookup
+
+DNS domain lookup not defined
+
+## NTP
+
+No NTP servers defined
+
+## Management SSH
+
+Management SSH not defined
+
+## Management API GNMI
+
+Management API gnmi is not defined
+
+## Management API HTTP
+
+Management API HTTP not defined
+
+# Authentication
+
+## Local Users
+
+No users defined
+
+## TACACS Servers
+
+TACACS servers not defined
+
+## IP TACACS Source Interfaces
+
+IP TACACS source interfaces not defined
+
+## RADIUS Servers
+
+RADIUS servers not defined
+
+## AAA Server Groups
+
+AAA server groups not defined
+
+## AAA Authentication
+
+AAA authentication not defined
+
+## AAA Authorization
+
+AAA authorization not defined
+
+## AAA Accounting
+
+AAA accounting not defined
+
+# Management Security
+
+Management security not defined
+
+# Aliases
+
+Aliases not defined
+
+# Monitoring
+
+## TerminAttr Daemon
+
+TerminAttr daemon not defined
+
+## Logging
+
+No logging settings defined
+
+## SNMP
+
+No SNMP settings defined
+
+## SFlow
+
+No sFlow defined
+
+## Hardware Counters
+
+No hardware counters defined
+
+## VM Tracer Sessions
+
+No VM tracer sessions defined
+
+## Event Handler
+
+No event handler defined
+
+# MLAG
+
+MLAG not defined
+
+# Spanning Tree
+
+## Spanning Tree Summary
+
+STP mode running: **mstp**
+Global BPDU Guard for Edge ports is enabled.
+MST PSVT Border is enabled.
+Spanning Tree disabled for VLANs: **105,202,505-506**
+
+### MSTP Instance and Priority
+
+| Instance(s) | Priority |
+| -------- | -------- |
+| 0 | 4096 |
+| 100-200 | 8192 |
+
+### MST Configuration
+
+| Variable | Value |
+| -------- | -------- |
+| Name | test |
+| Revision | 5 |
+| Instance 2 | VLAN(s) 15,16,17,18 |
+| Instance 3 | VLAN(s) 15 |
+| Instance 4 | VLAN(s) 200-300 |
+
+## Spanning Tree Device Configuration
+
+```eos
+!
+spanning-tree edge-port bpduguard default
+spanning-tree mode mstp
+no spanning-tree vlan-id 105,202,505-506
+spanning-tree mst 0 priority 4096
+spanning-tree mst 100-200 priority 8192
+spanning-tree mst pvst border
+!
+spanning-tree mst configuration
+   name test
+   revision 5
+   instance 2 vlan 15,16,17,18
+   instance 3 vlan 15
+   instance 4 vlan 200-300
+```
+
+# Internal VLAN Allocation Policy
+
+## Internal VLAN Allocation Policy Summary
+
+**Default Allocation Policy**
+
+| Policy Allocation | Range Beginning | Range Ending |
+| ------------------| --------------- | ------------ |
+| ascending | 1006 | 4094 |
+
+# VLANs
+
+No VLANs defined
+
+# Interfaces
+
+## Ethernet Interfaces
+
+No ethernet interface defined
+
+## Port-Channel Interfaces
+
+No port-channels defined
+
+## Loopback Interfaces
+
+No loopback interfaces defined
+
+## VLAN Interfaces
+
+No VLAN interfaces defined
+
+## VXLAN Interface
+
+No VXLAN interfaces defined
+
+# Routing
+
+## Virtual Router MAC Address
+
+IP virtual router MAC address not defined
+
+## IP Routing
+
+### IP Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | false| 
+### IP Routing Device Configuration
+
+```eos
+```
+
+## IPv6 Routing
+
+### IPv6 Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | false |
+
+## Static Routes
+
+Static routes not defined
+
+## IPv6 Static Routes
+
+IPv6 static routes not defined
+
+## Router ISIS
+
+Router ISIS not defined
+
+## Router BGP
+
+Router BGP not defined
+
+## Router BFD
+
+### Router BFD Multihop Summary
+
+| Interval | Minimum RX | Multiplier |
+| -------- | ---------- | ---------- |
+| 300 | 300 | 3 |
+
+*No device configuration required - default values
+
+# Multicast
+
+## IP IGMP Snooping
+
+No IP IGMP configuration
+
+## Router Multicast
+
+Routing multicast not defined
+
+## Router PIM Sparse Mode
+
+Router PIM sparse mode not defined
+
+# Filters
+
+## Community-lists
+
+Community-lists not defined
+
+## Peer Filters
+
+No peer filters defined
+
+## Prefix-lists
+
+Prefix-lists not defined
+
+## IPv6 Prefix-lists
+
+IPv6 prefix-lists not defined
+
+## Route-maps
+
+No route-maps defined
+
+## IP Extended Communities
+
+No extended community defined
+
+# ACL
+
+## Standard Access-lists
+
+Standard access-lists not defined
+
+## Extended Access-lists
+
+Extended access-lists not defined
+
+## IPv6 Standard Access-lists
+
+IPv6 standard access-lists not defined
+
+## IPv6 Extended Access-lists
+
+IPv6 extended access-lists not defined
+
+# VRF Instances
+
+No VRF instances defined
+
+# Virtual Source NAT
+
+Virtual source NAT not defined
+
+# Platform
+
+No platform parameters defined
+
+# Router L2 VPN
+
+Router L2 VPN not defined
+
+# IP DHCP Relay
+
+IP DHCP relay not defined
+
+# Custom Templates
+
+No custom templates defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/spanning-tree.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/spanning-tree.md
@@ -35,6 +35,7 @@
 - [Internal VLAN Allocation Policy](#internal-vlan-allocation-policy)
 - [VLANs](#vlans)
 - [Interfaces](#interfaces)
+  - [Interface Defaults](#internet-defaults)
   - [Ethernet Interfaces](#ethernet-interfaces)
   - [Port-Channel Interfaces](#port-channel-interfaces)
   - [Loopback Interfaces](#loopback-interfaces)
@@ -70,6 +71,10 @@
 - [Platform](#platform)
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
+- [Errdisable](#errdisable)
+- [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -118,6 +123,10 @@ DNS domain lookup not defined
 ## NTP
 
 No NTP servers defined
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -211,7 +220,7 @@ MLAG not defined
 
 ## Spanning Tree Summary
 
-STP mode running: **mstp**
+STP mode: **mstp**
 MST PSVT Border is enabled.
 
 ### MSTP Instance and Priority
@@ -272,6 +281,10 @@ No VLANs defined
 
 # Interfaces
 
+## Interface Defaults
+
+No Interface Defaults defined
+
 ## Ethernet Interfaces
 
 No ethernet interface defined
@@ -325,6 +338,10 @@ Static routes not defined
 ## IPv6 Static Routes
 
 IPv6 static routes not defined
+
+## ARP
+
+Global ARP timeout not defined.
 
 ## Router ISIS
 
@@ -421,6 +438,22 @@ Router L2 VPN not defined
 # IP DHCP Relay
 
 IP DHCP relay not defined
+
+# Errdisable
+
+Errdisable is not defined.
+
+# MACsec
+
+MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/spanning-tree-rapid-pvst.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/spanning-tree-rapid-pvst.cfg
@@ -1,0 +1,19 @@
+!RANCID-CONTENT-TYPE: arista
+!
+transceiver qsfp default-mode 4x10G
+!
+hostname spanning-tree-rapid-pvst
+!
+spanning-tree mode rapid-pvst
+spanning-tree vlan-id 1,2,3,4,5,10-15 priority 4096
+spanning-tree vlan-id 3 priority 8192
+spanning-tree vlan-id 100-500 priority 16384
+!
+no aaa root
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/spanning-tree-rstp.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/spanning-tree-rstp.cfg
@@ -1,0 +1,17 @@
+!RANCID-CONTENT-TYPE: arista
+!
+transceiver qsfp default-mode 4x10G
+!
+hostname spanning-tree-rstp
+!
+spanning-tree mode rstp
+spanning-tree priority 8192
+!
+no aaa root
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/spanning-tree.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/spanning-tree.cfg
@@ -1,0 +1,28 @@
+!RANCID-CONTENT-TYPE: arista
+!
+transceiver qsfp default-mode 4x10G
+!
+hostname spanning-tree
+!
+spanning-tree edge-port bpduguard default
+spanning-tree mode mstp
+no spanning-tree vlan-id 105,202,505-506
+spanning-tree mst 0 priority 4096
+spanning-tree mst 100-200 priority 8192
+spanning-tree mst pvst border
+!
+spanning-tree mst configuration
+   name test
+   revision 5
+   instance 2 vlan 15,16,17,18
+   instance 3 vlan 15
+   instance 4 vlan 200-300
+!
+no aaa root
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/spanning-tree-rapid-pvst.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/spanning-tree-rapid-pvst.yml
@@ -1,0 +1,10 @@
+### Spanning-Tree (Rapid-PVST settings)
+spanning_tree:
+  mode: rapid-pvst
+  rapid_pvst_instances:
+    "1,2,3,4,5,10-15":
+      priority: 4096
+    "3":
+      priority: 8192
+    "100-500":
+      priority: 16384

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/spanning-tree-rstp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/spanning-tree-rstp.yml
@@ -1,0 +1,4 @@
+### Spanning-Tree (Rapid-PVST settings)
+spanning_tree:
+  mode: rstp
+  rstp_priority: 8192

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/spanning-tree.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/spanning-tree.yml
@@ -1,0 +1,23 @@
+### Spanning-Tree (MST settings)
+spanning_tree:
+  mst:
+    configuration:
+      name: test
+      revision: 5
+      instances:
+        2:
+          vlans: 15,16,17,18
+        3:
+          vlans: 15
+        4:
+          vlans: 200-300
+    pvst_border: true
+  edge_port:
+    bpduguard_default: true
+  mode: mstp
+  no_spanning_tree_vlan: 105,202,505-506
+  mst_instances:
+    0:
+      priority: 4096
+    100-200:
+      priority: 8192

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts
@@ -34,6 +34,8 @@ router-static
 sflow
 snmp_v3
 spanning-tree
+spanning-tree-rstp
+spanning-tree-rapid-pvst
 terminattr-cloud
 terminattr-prem
 terminattr-prem-disableaaa

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts
@@ -33,6 +33,7 @@ router-ospf
 router-static
 sflow
 snmp_v3
+spanning-tree
 terminattr-cloud
 terminattr-prem
 terminattr-prem-disableaaa

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1A.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -315,13 +317,21 @@ mlag configuration
 
 ## Spanning Tree Summary
 
-Mode: mstp
+STP mode: **mstp**
 
 ### MSTP Instance and Priority
 
-| Instance | Priority |
+| Instance(s) | Priority |
 | -------- | -------- |
 | 0 | 4096 |
+
+### MST Configuration
+
+
+
+### Global Spanning-Tree Settings
+
+Spanning Tree disabled for VLANs: **4093-4094**
 
 ## Spanning Tree Device Configuration
 
@@ -530,9 +540,9 @@ interface Loopback1
 | Vlan150 |  Tenant_A_WAN_Zone_1  |  Tenant_A_WAN_Zone  |  -  |  false  |
 | Vlan250 |  Tenant_B_WAN_Zone_1  |  Tenant_B_WAN_Zone  |  -  |  false  |
 | Vlan350 |  Tenant_C_WAN_Zone_1  |  Tenant_C_WAN_Zone  |  -  |  false  |
-| Vlan3013 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone  |  Tenant_A_WAN_Zone  |  -  |  false  |
-| Vlan3020 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone  |  Tenant_B_WAN_Zone  |  -  |  false  |
-| Vlan3030 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone  |  Tenant_C_WAN_Zone  |  -  |  false  |
+| Vlan3013 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone  |  Tenant_A_WAN_Zone  |  1500  |  false  |
+| Vlan3020 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone  |  Tenant_B_WAN_Zone  |  1500  |  false  |
+| Vlan3030 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone  |  Tenant_C_WAN_Zone  |  1500  |  false  |
 | Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  false  |
 | Vlan4094 |  MLAG_PEER  |  default  |  1500  |  false  |
 
@@ -1049,9 +1059,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1B.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -315,13 +317,21 @@ mlag configuration
 
 ## Spanning Tree Summary
 
-Mode: mstp
+STP mode: **mstp**
 
 ### MSTP Instance and Priority
 
-| Instance | Priority |
+| Instance(s) | Priority |
 | -------- | -------- |
 | 0 | 4096 |
+
+### MST Configuration
+
+
+
+### Global Spanning-Tree Settings
+
+Spanning Tree disabled for VLANs: **4093-4094**
 
 ## Spanning Tree Device Configuration
 
@@ -530,9 +540,9 @@ interface Loopback1
 | Vlan150 |  Tenant_A_WAN_Zone_1  |  Tenant_A_WAN_Zone  |  -  |  false  |
 | Vlan250 |  Tenant_B_WAN_Zone_1  |  Tenant_B_WAN_Zone  |  -  |  false  |
 | Vlan350 |  Tenant_C_WAN_Zone_1  |  Tenant_C_WAN_Zone  |  -  |  false  |
-| Vlan3013 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone  |  Tenant_A_WAN_Zone  |  -  |  false  |
-| Vlan3020 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone  |  Tenant_B_WAN_Zone  |  -  |  false  |
-| Vlan3030 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone  |  Tenant_C_WAN_Zone  |  -  |  false  |
+| Vlan3013 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone  |  Tenant_A_WAN_Zone  |  1500  |  false  |
+| Vlan3020 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone  |  Tenant_B_WAN_Zone  |  1500  |  false  |
+| Vlan3030 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone  |  Tenant_C_WAN_Zone  |  1500  |  false  |
 | Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  false  |
 | Vlan4094 |  MLAG_PEER  |  default  |  1500  |  false  |
 
@@ -1049,9 +1059,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-L2LEAF1A.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -294,13 +296,20 @@ MLAG not defined
 
 ## Spanning Tree Summary
 
-Mode: mstp
+STP mode: **mstp**
 
 ### MSTP Instance and Priority
 
-| Instance | Priority |
+| Instance(s) | Priority |
 | -------- | -------- |
 | 0 | 16384 |
+
+### MST Configuration
+
+
+
+### Global Spanning-Tree Settings
+
 
 ## Spanning Tree Device Configuration
 
@@ -614,9 +623,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-L2LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-L2LEAF2A.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -315,13 +317,21 @@ mlag configuration
 
 ## Spanning Tree Summary
 
-Mode: mstp
+STP mode: **mstp**
 
 ### MSTP Instance and Priority
 
-| Instance | Priority |
+| Instance(s) | Priority |
 | -------- | -------- |
 | 0 | 16384 |
+
+### MST Configuration
+
+
+
+### Global Spanning-Tree Settings
+
+Spanning Tree disabled for VLANs: **4094**
 
 ## Spanning Tree Device Configuration
 
@@ -722,9 +732,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-L2LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-L2LEAF2B.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -315,13 +317,21 @@ mlag configuration
 
 ## Spanning Tree Summary
 
-Mode: mstp
+STP mode: **mstp**
 
 ### MSTP Instance and Priority
 
-| Instance | Priority |
+| Instance(s) | Priority |
 | -------- | -------- |
 | 0 | 16384 |
+
+### MST Configuration
+
+
+
+### Global Spanning-Tree Settings
+
+Spanning Tree disabled for VLANs: **4094**
 
 ## Spanning Tree Device Configuration
 
@@ -722,9 +732,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF1A.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -294,13 +296,20 @@ MLAG not defined
 
 ## Spanning Tree Summary
 
-Mode: mstp
+STP mode: **mstp**
 
 ### MSTP Instance and Priority
 
-| Instance | Priority |
+| Instance(s) | Priority |
 | -------- | -------- |
 | 0 | 4096 |
+
+### MST Configuration
+
+
+
+### Global Spanning-Tree Settings
+
 
 ## Spanning Tree Device Configuration
 
@@ -921,9 +930,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2A.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -315,13 +317,21 @@ mlag configuration
 
 ## Spanning Tree Summary
 
-Mode: mstp
+STP mode: **mstp**
 
 ### MSTP Instance and Priority
 
-| Instance | Priority |
+| Instance(s) | Priority |
 | -------- | -------- |
 | 0 | 4096 |
+
+### MST Configuration
+
+
+
+### Global Spanning-Tree Settings
+
+Spanning Tree disabled for VLANs: **4093-4094**
 
 ## Spanning Tree Device Configuration
 
@@ -628,12 +638,12 @@ interface Loopback100
 | Vlan211 |  Tenant_B_OP_Zone_2  |  Tenant_B_OP_Zone  |  -  |  false  |
 | Vlan310 |  Tenant_C_OP_Zone_1  |  Tenant_C_OP_Zone  |  -  |  false  |
 | Vlan311 |  Tenant_C_OP_Zone_2  |  Tenant_C_OP_Zone  |  -  |  false  |
-| Vlan3009 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone  |  Tenant_A_OP_Zone  |  -  |  false  |
-| Vlan3010 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone  |  Tenant_A_WEB_Zone  |  -  |  false  |
-| Vlan3011 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone  |  Tenant_A_APP_Zone  |  -  |  false  |
-| Vlan3012 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone  |  Tenant_A_DB_Zone  |  -  |  false  |
-| Vlan3019 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone  |  Tenant_B_OP_Zone  |  -  |  false  |
-| Vlan3029 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone  |  Tenant_C_OP_Zone  |  -  |  false  |
+| Vlan3009 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone  |  Tenant_A_OP_Zone  |  1500  |  false  |
+| Vlan3010 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone  |  Tenant_A_WEB_Zone  |  1500  |  false  |
+| Vlan3011 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone  |  Tenant_A_APP_Zone  |  1500  |  false  |
+| Vlan3012 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone  |  Tenant_A_DB_Zone  |  1500  |  false  |
+| Vlan3019 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone  |  Tenant_B_OP_Zone  |  1500  |  false  |
+| Vlan3029 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone  |  Tenant_C_OP_Zone  |  1500  |  false  |
 | Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  false  |
 | Vlan4094 |  MLAG_PEER  |  default  |  1500  |  false  |
 
@@ -1344,9 +1354,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2B.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -315,13 +317,21 @@ mlag configuration
 
 ## Spanning Tree Summary
 
-Mode: mstp
+STP mode: **mstp**
 
 ### MSTP Instance and Priority
 
-| Instance | Priority |
+| Instance(s) | Priority |
 | -------- | -------- |
 | 0 | 4096 |
+
+### MST Configuration
+
+
+
+### Global Spanning-Tree Settings
+
+Spanning Tree disabled for VLANs: **4093-4094**
 
 ## Spanning Tree Device Configuration
 
@@ -628,12 +638,12 @@ interface Loopback100
 | Vlan211 |  Tenant_B_OP_Zone_2  |  Tenant_B_OP_Zone  |  -  |  false  |
 | Vlan310 |  Tenant_C_OP_Zone_1  |  Tenant_C_OP_Zone  |  -  |  false  |
 | Vlan311 |  Tenant_C_OP_Zone_2  |  Tenant_C_OP_Zone  |  -  |  false  |
-| Vlan3009 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone  |  Tenant_A_OP_Zone  |  -  |  false  |
-| Vlan3010 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone  |  Tenant_A_WEB_Zone  |  -  |  false  |
-| Vlan3011 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone  |  Tenant_A_APP_Zone  |  -  |  false  |
-| Vlan3012 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone  |  Tenant_A_DB_Zone  |  -  |  false  |
-| Vlan3019 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone  |  Tenant_B_OP_Zone  |  -  |  false  |
-| Vlan3029 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone  |  Tenant_C_OP_Zone  |  -  |  false  |
+| Vlan3009 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone  |  Tenant_A_OP_Zone  |  1500  |  false  |
+| Vlan3010 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone  |  Tenant_A_WEB_Zone  |  1500  |  false  |
+| Vlan3011 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone  |  Tenant_A_APP_Zone  |  1500  |  false  |
+| Vlan3012 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone  |  Tenant_A_DB_Zone  |  1500  |  false  |
+| Vlan3019 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone  |  Tenant_B_OP_Zone  |  1500  |  false  |
+| Vlan3029 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone  |  Tenant_C_OP_Zone  |  1500  |  false  |
 | Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  false  |
 | Vlan4094 |  MLAG_PEER  |  default  |  1500  |  false  |
 
@@ -1344,9 +1354,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE1.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -294,7 +296,11 @@ MLAG not defined
 
 ## Spanning Tree Summary
 
-Mode: none
+STP mode: **none**
+
+
+### Global Spanning-Tree Settings
+
 
 ## Spanning Tree Device Configuration
 
@@ -750,9 +756,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE2.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -294,7 +296,11 @@ MLAG not defined
 
 ## Spanning Tree Summary
 
-Mode: none
+STP mode: **none**
+
+
+### Global Spanning-Tree Settings
+
 
 ## Spanning Tree Device Configuration
 
@@ -750,9 +756,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE3.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -294,7 +296,11 @@ MLAG not defined
 
 ## Spanning Tree Summary
 
-Mode: none
+STP mode: **none**
+
+
+### Global Spanning-Tree Settings
+
 
 ## Spanning Tree Device Configuration
 
@@ -750,9 +756,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE4.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -294,7 +296,11 @@ MLAG not defined
 
 ## Spanning Tree Summary
 
-Mode: none
+STP mode: **none**
+
+
+### Global Spanning-Tree Settings
+
 
 ## Spanning Tree Device Configuration
 
@@ -750,9 +756,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3A.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -315,13 +317,21 @@ mlag configuration
 
 ## Spanning Tree Summary
 
-Mode: mstp
+STP mode: **mstp**
 
 ### MSTP Instance and Priority
 
-| Instance | Priority |
+| Instance(s) | Priority |
 | -------- | -------- |
 | 0 | 4096 |
+
+### MST Configuration
+
+
+
+### Global Spanning-Tree Settings
+
+Spanning Tree disabled for VLANs: **4093-4094**
 
 ## Spanning Tree Device Configuration
 
@@ -664,15 +674,15 @@ interface Loopback100
 | Vlan310 |  Tenant_C_OP_Zone_1  |  Tenant_C_OP_Zone  |  -  |  false  |
 | Vlan311 |  Tenant_C_OP_Zone_2  |  Tenant_C_OP_Zone  |  -  |  false  |
 | Vlan350 |  Tenant_C_WAN_Zone_1  |  Tenant_C_WAN_Zone  |  -  |  false  |
-| Vlan3009 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone  |  Tenant_A_OP_Zone  |  -  |  false  |
-| Vlan3010 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone  |  Tenant_A_WEB_Zone  |  -  |  false  |
-| Vlan3011 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone  |  Tenant_A_APP_Zone  |  -  |  false  |
-| Vlan3012 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone  |  Tenant_A_DB_Zone  |  -  |  false  |
-| Vlan3013 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone  |  Tenant_A_WAN_Zone  |  -  |  false  |
-| Vlan3019 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone  |  Tenant_B_OP_Zone  |  -  |  false  |
-| Vlan3020 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone  |  Tenant_B_WAN_Zone  |  -  |  false  |
-| Vlan3029 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone  |  Tenant_C_OP_Zone  |  -  |  false  |
-| Vlan3030 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone  |  Tenant_C_WAN_Zone  |  -  |  false  |
+| Vlan3009 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone  |  Tenant_A_OP_Zone  |  1500  |  false  |
+| Vlan3010 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone  |  Tenant_A_WEB_Zone  |  1500  |  false  |
+| Vlan3011 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone  |  Tenant_A_APP_Zone  |  1500  |  false  |
+| Vlan3012 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone  |  Tenant_A_DB_Zone  |  1500  |  false  |
+| Vlan3013 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone  |  Tenant_A_WAN_Zone  |  1500  |  false  |
+| Vlan3019 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone  |  Tenant_B_OP_Zone  |  1500  |  false  |
+| Vlan3020 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone  |  Tenant_B_WAN_Zone  |  1500  |  false  |
+| Vlan3029 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone  |  Tenant_C_OP_Zone  |  1500  |  false  |
+| Vlan3030 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone  |  Tenant_C_WAN_Zone  |  1500  |  false  |
 | Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  false  |
 | Vlan4094 |  MLAG_PEER  |  default  |  1500  |  false  |
 
@@ -1503,9 +1513,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3B.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -315,13 +317,21 @@ mlag configuration
 
 ## Spanning Tree Summary
 
-Mode: mstp
+STP mode: **mstp**
 
 ### MSTP Instance and Priority
 
-| Instance | Priority |
+| Instance(s) | Priority |
 | -------- | -------- |
 | 0 | 4096 |
+
+### MST Configuration
+
+
+
+### Global Spanning-Tree Settings
+
+Spanning Tree disabled for VLANs: **4093-4094**
 
 ## Spanning Tree Device Configuration
 
@@ -649,15 +659,15 @@ interface Loopback100
 | Vlan310 |  Tenant_C_OP_Zone_1  |  Tenant_C_OP_Zone  |  -  |  false  |
 | Vlan311 |  Tenant_C_OP_Zone_2  |  Tenant_C_OP_Zone  |  -  |  false  |
 | Vlan350 |  Tenant_C_WAN_Zone_1  |  Tenant_C_WAN_Zone  |  -  |  false  |
-| Vlan3009 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone  |  Tenant_A_OP_Zone  |  -  |  false  |
-| Vlan3010 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone  |  Tenant_A_WEB_Zone  |  -  |  false  |
-| Vlan3011 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone  |  Tenant_A_APP_Zone  |  -  |  false  |
-| Vlan3012 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone  |  Tenant_A_DB_Zone  |  -  |  false  |
-| Vlan3013 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone  |  Tenant_A_WAN_Zone  |  -  |  false  |
-| Vlan3019 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone  |  Tenant_B_OP_Zone  |  -  |  false  |
-| Vlan3020 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone  |  Tenant_B_WAN_Zone  |  -  |  false  |
-| Vlan3029 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone  |  Tenant_C_OP_Zone  |  -  |  false  |
-| Vlan3030 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone  |  Tenant_C_WAN_Zone  |  -  |  false  |
+| Vlan3009 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone  |  Tenant_A_OP_Zone  |  1500  |  false  |
+| Vlan3010 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone  |  Tenant_A_WEB_Zone  |  1500  |  false  |
+| Vlan3011 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone  |  Tenant_A_APP_Zone  |  1500  |  false  |
+| Vlan3012 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone  |  Tenant_A_DB_Zone  |  1500  |  false  |
+| Vlan3013 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone  |  Tenant_A_WAN_Zone  |  1500  |  false  |
+| Vlan3019 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone  |  Tenant_B_OP_Zone  |  1500  |  false  |
+| Vlan3020 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone  |  Tenant_B_WAN_Zone  |  1500  |  false  |
+| Vlan3029 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone  |  Tenant_C_OP_Zone  |  1500  |  false  |
+| Vlan3030 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone  |  Tenant_C_WAN_Zone  |  1500  |  false  |
 | Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  false  |
 | Vlan4094 |  MLAG_PEER  |  default  |  1500  |  false  |
 
@@ -1488,9 +1498,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1A.yml
@@ -64,7 +64,9 @@ ntp_server:
 redundancy: null
 spanning_tree:
   mode: mstp
-  priority: 4096
+  mst_instances:
+    0:
+      priority: 4096
   no_spanning_tree_vlan: 4093-4094
 aaa_authorization: null
 local_users:
@@ -238,6 +240,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone'
     vrf: Tenant_A_WAN_Zone
     ip_address: 10.255.251.10/31
+    mtu: 1500
   Vlan250:
     tenant: Tenant_B
     tags:
@@ -253,6 +256,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone'
     vrf: Tenant_B_WAN_Zone
     ip_address: 10.255.251.10/31
+    mtu: 1500
   Vlan350:
     tenant: Tenant_C
     tags:
@@ -268,6 +272,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone'
     vrf: Tenant_C_WAN_Zone
     ip_address: 10.255.251.10/31
+    mtu: 1500
 vxlan_tunnel_interface:
   Vxlan1:
     description: DC1-BL1A_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1B.yml
@@ -64,7 +64,9 @@ ntp_server:
 redundancy: null
 spanning_tree:
   mode: mstp
-  priority: 4096
+  mst_instances:
+    0:
+      priority: 4096
   no_spanning_tree_vlan: 4093-4094
 aaa_authorization: null
 local_users:
@@ -238,6 +240,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone'
     vrf: Tenant_A_WAN_Zone
     ip_address: 10.255.251.11/31
+    mtu: 1500
   Vlan250:
     tenant: Tenant_B
     tags:
@@ -253,6 +256,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone'
     vrf: Tenant_B_WAN_Zone
     ip_address: 10.255.251.11/31
+    mtu: 1500
   Vlan350:
     tenant: Tenant_C
     tags:
@@ -268,6 +272,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone'
     vrf: Tenant_C_WAN_Zone
     ip_address: 10.255.251.11/31
+    mtu: 1500
 vxlan_tunnel_interface:
   Vxlan1:
     description: DC1-BL1B_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -64,7 +64,9 @@ ntp_server:
 redundancy: null
 spanning_tree:
   mode: mstp
-  priority: 16384
+  mst_instances:
+    0:
+      priority: 16384
 aaa_authorization: null
 local_users:
   admin:

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -92,7 +92,9 @@ ntp_server:
 redundancy: null
 spanning_tree:
   mode: mstp
-  priority: 16384
+  mst_instances:
+    0:
+      priority: 16384
   no_spanning_tree_vlan: 4094
 aaa_authorization: null
 local_users:

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -92,7 +92,9 @@ ntp_server:
 redundancy: null
 spanning_tree:
   mode: mstp
-  priority: 16384
+  mst_instances:
+    0:
+      priority: 16384
   no_spanning_tree_vlan: 4094
 aaa_authorization: null
 local_users:

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF1A.yml
@@ -60,7 +60,9 @@ ntp_server:
 redundancy: null
 spanning_tree:
   mode: mstp
-  priority: 4096
+  mst_instances:
+    0:
+      priority: 4096
 aaa_authorization: null
 local_users:
   admin:

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2A.yml
@@ -92,7 +92,9 @@ ntp_server:
 redundancy: null
 spanning_tree:
   mode: mstp
-  priority: 4096
+  mst_instances:
+    0:
+      priority: 4096
   no_spanning_tree_vlan: 4093-4094
 aaa_authorization: null
 local_users:
@@ -368,6 +370,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone'
     vrf: Tenant_A_APP_Zone
     ip_address: 10.255.251.2/31
+    mtu: 1500
   Vlan140:
     tenant: Tenant_A
     tags:
@@ -392,6 +395,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone'
     vrf: Tenant_A_DB_Zone
     ip_address: 10.255.251.2/31
+    mtu: 1500
   Vlan110:
     tenant: Tenant_A
     tags:
@@ -419,6 +423,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone'
     vrf: Tenant_A_OP_Zone
     ip_address: 10.255.251.2/31
+    mtu: 1500
   Vlan120:
     tenant: Tenant_A
     tags:
@@ -448,6 +453,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone'
     vrf: Tenant_A_WEB_Zone
     ip_address: 10.255.251.2/31
+    mtu: 1500
   Vlan210:
     tenant: Tenant_B
     tags:
@@ -471,6 +477,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone'
     vrf: Tenant_B_OP_Zone
     ip_address: 10.255.251.2/31
+    mtu: 1500
   Vlan310:
     tenant: Tenant_C
     tags:
@@ -494,6 +501,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone'
     vrf: Tenant_C_OP_Zone
     ip_address: 10.255.251.2/31
+    mtu: 1500
 vxlan_tunnel_interface:
   Vxlan1:
     description: DC1-LEAF2A_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2B.yml
@@ -92,7 +92,9 @@ ntp_server:
 redundancy: null
 spanning_tree:
   mode: mstp
-  priority: 4096
+  mst_instances:
+    0:
+      priority: 4096
   no_spanning_tree_vlan: 4093-4094
 aaa_authorization: null
 local_users:
@@ -368,6 +370,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone'
     vrf: Tenant_A_APP_Zone
     ip_address: 10.255.251.3/31
+    mtu: 1500
   Vlan140:
     tenant: Tenant_A
     tags:
@@ -392,6 +395,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone'
     vrf: Tenant_A_DB_Zone
     ip_address: 10.255.251.3/31
+    mtu: 1500
   Vlan110:
     tenant: Tenant_A
     tags:
@@ -419,6 +423,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone'
     vrf: Tenant_A_OP_Zone
     ip_address: 10.255.251.3/31
+    mtu: 1500
   Vlan120:
     tenant: Tenant_A
     tags:
@@ -448,6 +453,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone'
     vrf: Tenant_A_WEB_Zone
     ip_address: 10.255.251.3/31
+    mtu: 1500
   Vlan210:
     tenant: Tenant_B
     tags:
@@ -471,6 +477,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone'
     vrf: Tenant_B_OP_Zone
     ip_address: 10.255.251.3/31
+    mtu: 1500
   Vlan310:
     tenant: Tenant_C
     tags:
@@ -494,6 +501,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone'
     vrf: Tenant_C_OP_Zone
     ip_address: 10.255.251.3/31
+    mtu: 1500
 vxlan_tunnel_interface:
   Vxlan1:
     description: DC1-LEAF2B_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3A.yml
@@ -102,7 +102,9 @@ ntp_server:
 redundancy: null
 spanning_tree:
   mode: mstp
-  priority: 4096
+  mst_instances:
+    0:
+      priority: 4096
   no_spanning_tree_vlan: 4093-4094
 aaa_authorization: null
 local_users:
@@ -421,6 +423,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone'
     vrf: Tenant_A_APP_Zone
     ip_address: 10.255.251.6/31
+    mtu: 1500
   Vlan140:
     tenant: Tenant_A
     tags:
@@ -445,6 +448,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone'
     vrf: Tenant_A_DB_Zone
     ip_address: 10.255.251.6/31
+    mtu: 1500
   Vlan110:
     tenant: Tenant_A
     tags:
@@ -472,6 +476,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone'
     vrf: Tenant_A_OP_Zone
     ip_address: 10.255.251.6/31
+    mtu: 1500
   Vlan150:
     tenant: Tenant_A
     tags:
@@ -487,6 +492,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone'
     vrf: Tenant_A_WAN_Zone
     ip_address: 10.255.251.6/31
+    mtu: 1500
   Vlan120:
     tenant: Tenant_A
     tags:
@@ -516,6 +522,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone'
     vrf: Tenant_A_WEB_Zone
     ip_address: 10.255.251.6/31
+    mtu: 1500
   Vlan210:
     tenant: Tenant_B
     tags:
@@ -539,6 +546,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone'
     vrf: Tenant_B_OP_Zone
     ip_address: 10.255.251.6/31
+    mtu: 1500
   Vlan250:
     tenant: Tenant_B
     tags:
@@ -554,6 +562,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone'
     vrf: Tenant_B_WAN_Zone
     ip_address: 10.255.251.6/31
+    mtu: 1500
   Vlan310:
     tenant: Tenant_C
     tags:
@@ -577,6 +586,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone'
     vrf: Tenant_C_OP_Zone
     ip_address: 10.255.251.6/31
+    mtu: 1500
   Vlan350:
     tenant: Tenant_C
     tags:
@@ -592,6 +602,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone'
     vrf: Tenant_C_WAN_Zone
     ip_address: 10.255.251.6/31
+    mtu: 1500
 vxlan_tunnel_interface:
   Vxlan1:
     description: DC1-SVC3A_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3B.yml
@@ -102,7 +102,9 @@ ntp_server:
 redundancy: null
 spanning_tree:
   mode: mstp
-  priority: 4096
+  mst_instances:
+    0:
+      priority: 4096
   no_spanning_tree_vlan: 4093-4094
 aaa_authorization: null
 local_users:
@@ -401,6 +403,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone'
     vrf: Tenant_A_APP_Zone
     ip_address: 10.255.251.7/31
+    mtu: 1500
   Vlan140:
     tenant: Tenant_A
     tags:
@@ -425,6 +428,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone'
     vrf: Tenant_A_DB_Zone
     ip_address: 10.255.251.7/31
+    mtu: 1500
   Vlan110:
     tenant: Tenant_A
     tags:
@@ -452,6 +456,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone'
     vrf: Tenant_A_OP_Zone
     ip_address: 10.255.251.7/31
+    mtu: 1500
   Vlan150:
     tenant: Tenant_A
     tags:
@@ -467,6 +472,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone'
     vrf: Tenant_A_WAN_Zone
     ip_address: 10.255.251.7/31
+    mtu: 1500
   Vlan120:
     tenant: Tenant_A
     tags:
@@ -496,6 +502,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone'
     vrf: Tenant_A_WEB_Zone
     ip_address: 10.255.251.7/31
+    mtu: 1500
   Vlan210:
     tenant: Tenant_B
     tags:
@@ -519,6 +526,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone'
     vrf: Tenant_B_OP_Zone
     ip_address: 10.255.251.7/31
+    mtu: 1500
   Vlan250:
     tenant: Tenant_B
     tags:
@@ -534,6 +542,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone'
     vrf: Tenant_B_WAN_Zone
     ip_address: 10.255.251.7/31
+    mtu: 1500
   Vlan310:
     tenant: Tenant_C
     tags:
@@ -557,6 +566,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone'
     vrf: Tenant_C_OP_Zone
     ip_address: 10.255.251.7/31
+    mtu: 1500
   Vlan350:
     tenant: Tenant_C
     tags:
@@ -572,6 +582,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone'
     vrf: Tenant_C_WAN_Zone
     ip_address: 10.255.251.7/31
+    mtu: 1500
 vxlan_tunnel_interface:
   Vxlan1:
     description: DC1-SVC3B_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/cvp/cv_server.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/cvp/cv_server.yml
@@ -30,24 +30,6 @@ CVP_DEVICES:
     configlets:
       - AVD_DC1-SPINE4
     imageBundle: []
-  DC1-L2LEAF1A:
-    name: DC1-L2LEAF1A
-    parentContainerName: DC1_L2LEAF1
-    configlets:
-      - AVD_DC1-L2LEAF1A
-    imageBundle: []
-  DC1-L2LEAF2A:
-    name: DC1-L2LEAF2A
-    parentContainerName: DC1_L2LEAF2
-    configlets:
-      - AVD_DC1-L2LEAF2A
-    imageBundle: []
-  DC1-L2LEAF2B:
-    name: DC1-L2LEAF2B
-    parentContainerName: DC1_L2LEAF2
-    configlets:
-      - AVD_DC1-L2LEAF2B
-    imageBundle: []
   DC1-LEAF2A:
     name: DC1-LEAF2A
     parentContainerName: DC1_LEAF2
@@ -71,6 +53,24 @@ CVP_DEVICES:
     parentContainerName: DC1_BL1
     configlets:
       - AVD_DC1-BL1B
+    imageBundle: []
+  DC1-L2LEAF1A:
+    name: DC1-L2LEAF1A
+    parentContainerName: DC1_L2LEAF1
+    configlets:
+      - AVD_DC1-L2LEAF1A
+    imageBundle: []
+  DC1-L2LEAF2A:
+    name: DC1-L2LEAF2A
+    parentContainerName: DC1_L2LEAF2
+    configlets:
+      - AVD_DC1-L2LEAF2A
+    imageBundle: []
+  DC1-L2LEAF2B:
+    name: DC1-L2LEAF2B
+    parentContainerName: DC1_L2LEAF2
+    configlets:
+      - AVD_DC1-L2LEAF2B
     imageBundle: []
 CVP_CONTAINERS:
   DC1_FABRIC:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -294,13 +296,20 @@ MLAG not defined
 
 ## Spanning Tree Summary
 
-Mode: mstp
+STP mode: **mstp**
 
 ### MSTP Instance and Priority
 
-| Instance | Priority |
+| Instance(s) | Priority |
 | -------- | -------- |
 | 0 | 4096 |
+
+### MST Configuration
+
+
+
+### Global Spanning-Tree Settings
+
 
 ## Spanning Tree Device Configuration
 
@@ -907,9 +916,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -294,13 +296,20 @@ MLAG not defined
 
 ## Spanning Tree Summary
 
-Mode: mstp
+STP mode: **mstp**
 
 ### MSTP Instance and Priority
 
-| Instance | Priority |
+| Instance(s) | Priority |
 | -------- | -------- |
 | 0 | 4096 |
+
+### MST Configuration
+
+
+
+### Global Spanning-Tree Settings
+
 
 ## Spanning Tree Device Configuration
 
@@ -907,9 +916,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF1A.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -294,13 +296,20 @@ MLAG not defined
 
 ## Spanning Tree Summary
 
-Mode: mstp
+STP mode: **mstp**
 
 ### MSTP Instance and Priority
 
-| Instance | Priority |
+| Instance(s) | Priority |
 | -------- | -------- |
 | 0 | 16384 |
+
+### MST Configuration
+
+
+
+### Global Spanning-Tree Settings
+
 
 ## Spanning Tree Device Configuration
 
@@ -622,9 +631,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF2A.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -313,13 +315,21 @@ mlag configuration
 
 ## Spanning Tree Summary
 
-Mode: mstp
+STP mode: **mstp**
 
 ### MSTP Instance and Priority
 
-| Instance | Priority |
+| Instance(s) | Priority |
 | -------- | -------- |
 | 0 | 16384 |
+
+### MST Configuration
+
+
+
+### Global Spanning-Tree Settings
+
+Spanning Tree disabled for VLANs: **4094**
 
 ## Spanning Tree Device Configuration
 
@@ -728,9 +738,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF2B.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -313,13 +315,21 @@ mlag configuration
 
 ## Spanning Tree Summary
 
-Mode: mstp
+STP mode: **mstp**
 
 ### MSTP Instance and Priority
 
-| Instance | Priority |
+| Instance(s) | Priority |
 | -------- | -------- |
 | 0 | 16384 |
+
+### MST Configuration
+
+
+
+### Global Spanning-Tree Settings
+
+Spanning Tree disabled for VLANs: **4094**
 
 ## Spanning Tree Device Configuration
 
@@ -728,9 +738,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -294,13 +296,20 @@ MLAG not defined
 
 ## Spanning Tree Summary
 
-Mode: mstp
+STP mode: **mstp**
 
 ### MSTP Instance and Priority
 
-| Instance | Priority |
+| Instance(s) | Priority |
 | -------- | -------- |
 | 0 | 4096 |
+
+### MST Configuration
+
+
+
+### Global Spanning-Tree Settings
+
 
 ## Spanning Tree Device Configuration
 
@@ -927,9 +936,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -315,13 +317,21 @@ mlag configuration
 
 ## Spanning Tree Summary
 
-Mode: mstp
+STP mode: **mstp**
 
 ### MSTP Instance and Priority
 
-| Instance | Priority |
+| Instance(s) | Priority |
 | -------- | -------- |
 | 0 | 4096 |
+
+### MST Configuration
+
+
+
+### Global Spanning-Tree Settings
+
+Spanning Tree disabled for VLANs: **4093-4094**
 
 ## Spanning Tree Device Configuration
 
@@ -1370,9 +1380,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -315,13 +317,21 @@ mlag configuration
 
 ## Spanning Tree Summary
 
-Mode: mstp
+STP mode: **mstp**
 
 ### MSTP Instance and Priority
 
-| Instance | Priority |
+| Instance(s) | Priority |
 | -------- | -------- |
 | 0 | 4096 |
+
+### MST Configuration
+
+
+
+### Global Spanning-Tree Settings
+
+Spanning Tree disabled for VLANs: **4093-4094**
 
 ## Spanning Tree Device Configuration
 
@@ -1370,9 +1380,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE1.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -294,7 +296,11 @@ MLAG not defined
 
 ## Spanning Tree Summary
 
-Mode: none
+STP mode: **none**
+
+
+### Global Spanning-Tree Settings
+
 
 ## Spanning Tree Device Configuration
 
@@ -750,9 +756,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE2.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -294,7 +296,11 @@ MLAG not defined
 
 ## Spanning Tree Summary
 
-Mode: none
+STP mode: **none**
+
+
+### Global Spanning-Tree Settings
+
 
 ## Spanning Tree Device Configuration
 
@@ -750,9 +756,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE3.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -294,7 +296,11 @@ MLAG not defined
 
 ## Spanning Tree Summary
 
-Mode: none
+STP mode: **none**
+
+
+### Global Spanning-Tree Settings
+
 
 ## Spanning Tree Device Configuration
 
@@ -750,9 +756,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE4.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -294,7 +296,11 @@ MLAG not defined
 
 ## Spanning Tree Summary
 
-Mode: none
+STP mode: **none**
+
+
+### Global Spanning-Tree Settings
+
 
 ## Spanning Tree Device Configuration
 
@@ -750,9 +756,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -315,13 +317,21 @@ mlag configuration
 
 ## Spanning Tree Summary
 
-Mode: mstp
+STP mode: **mstp**
 
 ### MSTP Instance and Priority
 
-| Instance | Priority |
+| Instance(s) | Priority |
 | -------- | -------- |
 | 0 | 4096 |
+
+### MST Configuration
+
+
+
+### Global Spanning-Tree Settings
+
+Spanning Tree disabled for VLANs: **4093-4094**
 
 ## Spanning Tree Device Configuration
 
@@ -1529,9 +1539,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -315,13 +317,21 @@ mlag configuration
 
 ## Spanning Tree Summary
 
-Mode: mstp
+STP mode: **mstp**
 
 ### MSTP Instance and Priority
 
-| Instance | Priority |
+| Instance(s) | Priority |
 | -------- | -------- |
 | 0 | 4096 |
+
+### MST Configuration
+
+
+
+### Global Spanning-Tree Settings
+
+Spanning Tree disabled for VLANs: **4093-4094**
 
 ## Spanning Tree Device Configuration
 
@@ -1514,9 +1524,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
@@ -58,7 +58,9 @@ ntp_server:
 redundancy: null
 spanning_tree:
   mode: mstp
-  priority: 4096
+  mst_instances:
+    0:
+      priority: 4096
 aaa_authorization: null
 local_users:
   admin:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
@@ -58,7 +58,9 @@ ntp_server:
 redundancy: null
 spanning_tree:
   mode: mstp
-  priority: 4096
+  mst_instances:
+    0:
+      priority: 4096
 aaa_authorization: null
 local_users:
   admin:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -66,7 +66,9 @@ ntp_server:
 redundancy: null
 spanning_tree:
   mode: mstp
-  priority: 16384
+  mst_instances:
+    0:
+      priority: 16384
 aaa_authorization: null
 local_users:
   admin:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -94,7 +94,9 @@ ntp_server:
 redundancy: null
 spanning_tree:
   mode: mstp
-  priority: 16384
+  mst_instances:
+    0:
+      priority: 16384
   no_spanning_tree_vlan: 4094
 aaa_authorization: null
 local_users:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -94,7 +94,9 @@ ntp_server:
 redundancy: null
 spanning_tree:
   mode: mstp
-  priority: 16384
+  mst_instances:
+    0:
+      priority: 16384
   no_spanning_tree_vlan: 4094
 aaa_authorization: null
 local_users:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
@@ -60,7 +60,9 @@ ntp_server:
 redundancy: null
 spanning_tree:
   mode: mstp
-  priority: 4096
+  mst_instances:
+    0:
+      priority: 4096
 aaa_authorization: null
 local_users:
   admin:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -94,7 +94,9 @@ ntp_server:
 redundancy: null
 spanning_tree:
   mode: mstp
-  priority: 4096
+  mst_instances:
+    0:
+      priority: 4096
   no_spanning_tree_vlan: 4093-4094
 aaa_authorization: null
 local_users:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -94,7 +94,9 @@ ntp_server:
 redundancy: null
 spanning_tree:
   mode: mstp
-  priority: 4096
+  mst_instances:
+    0:
+      priority: 4096
   no_spanning_tree_vlan: 4093-4094
 aaa_authorization: null
 local_users:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -104,7 +104,9 @@ ntp_server:
 redundancy: null
 spanning_tree:
   mode: mstp
-  priority: 4096
+  mst_instances:
+    0:
+      priority: 4096
   no_spanning_tree_vlan: 4093-4094
 aaa_authorization: null
 local_users:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -104,7 +104,9 @@ ntp_server:
 redundancy: null
 spanning_tree:
   mode: mstp
-  priority: 4096
+  mst_instances:
+    0:
+      priority: 4096
   no_spanning_tree_vlan: 4093-4094
 aaa_authorization: null
 local_users:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1A.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -315,13 +317,21 @@ mlag configuration
 
 ## Spanning Tree Summary
 
-Mode: mstp
+STP mode: **mstp**
 
 ### MSTP Instance and Priority
 
-| Instance | Priority |
+| Instance(s) | Priority |
 | -------- | -------- |
 | 0 | 4096 |
+
+### MST Configuration
+
+
+
+### Global Spanning-Tree Settings
+
+Spanning Tree disabled for VLANs: **4093-4094**
 
 ## Spanning Tree Device Configuration
 
@@ -916,9 +926,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1B.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -315,13 +317,21 @@ mlag configuration
 
 ## Spanning Tree Summary
 
-Mode: mstp
+STP mode: **mstp**
 
 ### MSTP Instance and Priority
 
-| Instance | Priority |
+| Instance(s) | Priority |
 | -------- | -------- |
 | 0 | 4096 |
+
+### MST Configuration
+
+
+
+### Global Spanning-Tree Settings
+
+Spanning Tree disabled for VLANs: **4093-4094**
 
 ## Spanning Tree Device Configuration
 
@@ -916,9 +926,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-L2LEAF1A.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -294,13 +296,20 @@ MLAG not defined
 
 ## Spanning Tree Summary
 
-Mode: mstp
+STP mode: **mstp**
 
 ### MSTP Instance and Priority
 
-| Instance | Priority |
+| Instance(s) | Priority |
 | -------- | -------- |
 | 0 | 16384 |
+
+### MST Configuration
+
+
+
+### Global Spanning-Tree Settings
+
 
 ## Spanning Tree Device Configuration
 
@@ -576,9 +585,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-L2LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-L2LEAF2A.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -315,13 +317,21 @@ mlag configuration
 
 ## Spanning Tree Summary
 
-Mode: mstp
+STP mode: **mstp**
 
 ### MSTP Instance and Priority
 
-| Instance | Priority |
+| Instance(s) | Priority |
 | -------- | -------- |
 | 0 | 16384 |
+
+### MST Configuration
+
+
+
+### Global Spanning-Tree Settings
+
+Spanning Tree disabled for VLANs: **4094**
 
 ## Spanning Tree Device Configuration
 
@@ -656,9 +666,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-L2LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-L2LEAF2B.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -315,13 +317,21 @@ mlag configuration
 
 ## Spanning Tree Summary
 
-Mode: mstp
+STP mode: **mstp**
 
 ### MSTP Instance and Priority
 
-| Instance | Priority |
+| Instance(s) | Priority |
 | -------- | -------- |
 | 0 | 16384 |
+
+### MST Configuration
+
+
+
+### Global Spanning-Tree Settings
+
+Spanning Tree disabled for VLANs: **4094**
 
 ## Spanning Tree Device Configuration
 
@@ -656,9 +666,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF1A.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -294,13 +296,20 @@ MLAG not defined
 
 ## Spanning Tree Summary
 
-Mode: mstp
+STP mode: **mstp**
 
 ### MSTP Instance and Priority
 
-| Instance | Priority |
+| Instance(s) | Priority |
 | -------- | -------- |
 | 0 | 4096 |
+
+### MST Configuration
+
+
+
+### Global Spanning-Tree Settings
+
 
 ## Spanning Tree Device Configuration
 
@@ -803,9 +812,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2A.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -315,13 +317,21 @@ mlag configuration
 
 ## Spanning Tree Summary
 
-Mode: mstp
+STP mode: **mstp**
 
 ### MSTP Instance and Priority
 
-| Instance | Priority |
+| Instance(s) | Priority |
 | -------- | -------- |
 | 0 | 4096 |
+
+### MST Configuration
+
+
+
+### Global Spanning-Tree Settings
+
+Spanning Tree disabled for VLANs: **4093-4094**
 
 ## Spanning Tree Device Configuration
 
@@ -931,9 +941,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2B.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -315,13 +317,21 @@ mlag configuration
 
 ## Spanning Tree Summary
 
-Mode: mstp
+STP mode: **mstp**
 
 ### MSTP Instance and Priority
 
-| Instance | Priority |
+| Instance(s) | Priority |
 | -------- | -------- |
 | 0 | 4096 |
+
+### MST Configuration
+
+
+
+### Global Spanning-Tree Settings
+
+Spanning Tree disabled for VLANs: **4093-4094**
 
 ## Spanning Tree Device Configuration
 
@@ -931,9 +941,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE1.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -294,7 +296,11 @@ MLAG not defined
 
 ## Spanning Tree Summary
 
-Mode: none
+STP mode: **none**
+
+
+### Global Spanning-Tree Settings
+
 
 ## Spanning Tree Device Configuration
 
@@ -767,9 +773,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE2.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -294,7 +296,11 @@ MLAG not defined
 
 ## Spanning Tree Summary
 
-Mode: none
+STP mode: **none**
+
+
+### Global Spanning-Tree Settings
+
 
 ## Spanning Tree Device Configuration
 
@@ -767,9 +773,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE3.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -294,7 +296,11 @@ MLAG not defined
 
 ## Spanning Tree Summary
 
-Mode: none
+STP mode: **none**
+
+
+### Global Spanning-Tree Settings
+
 
 ## Spanning Tree Device Configuration
 
@@ -767,9 +773,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE4.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -294,7 +296,11 @@ MLAG not defined
 
 ## Spanning Tree Summary
 
-Mode: none
+STP mode: **none**
+
+
+### Global Spanning-Tree Settings
+
 
 ## Spanning Tree Device Configuration
 
@@ -767,9 +773,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3A.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -315,13 +317,21 @@ mlag configuration
 
 ## Spanning Tree Summary
 
-Mode: mstp
+STP mode: **mstp**
 
 ### MSTP Instance and Priority
 
-| Instance | Priority |
+| Instance(s) | Priority |
 | -------- | -------- |
 | 0 | 4096 |
+
+### MST Configuration
+
+
+
+### Global Spanning-Tree Settings
+
+Spanning Tree disabled for VLANs: **4093-4094**
 
 ## Spanning Tree Device Configuration
 
@@ -937,9 +947,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3B.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -315,13 +317,21 @@ mlag configuration
 
 ## Spanning Tree Summary
 
-Mode: mstp
+STP mode: **mstp**
 
 ### MSTP Instance and Priority
 
-| Instance | Priority |
+| Instance(s) | Priority |
 | -------- | -------- |
 | 0 | 4096 |
+
+### MST Configuration
+
+
+
+### Global Spanning-Tree Settings
+
+Spanning Tree disabled for VLANs: **4093-4094**
 
 ## Spanning Tree Device Configuration
 
@@ -937,9 +947,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-BL1A.yml
@@ -55,7 +55,9 @@ ntp_server:
 redundancy: null
 spanning_tree:
   mode: mstp
-  priority: 4096
+  mst_instances:
+    0:
+      priority: 4096
   no_spanning_tree_vlan: 4093-4094
 aaa_authorization: null
 local_users:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-BL1B.yml
@@ -55,7 +55,9 @@ ntp_server:
 redundancy: null
 spanning_tree:
   mode: mstp
-  priority: 4096
+  mst_instances:
+    0:
+      priority: 4096
   no_spanning_tree_vlan: 4093-4094
 aaa_authorization: null
 local_users:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -49,7 +49,9 @@ ntp_server:
 redundancy: null
 spanning_tree:
   mode: mstp
-  priority: 16384
+  mst_instances:
+    0:
+      priority: 16384
 aaa_authorization: null
 local_users:
   admin:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -53,7 +53,9 @@ ntp_server:
 redundancy: null
 spanning_tree:
   mode: mstp
-  priority: 16384
+  mst_instances:
+    0:
+      priority: 16384
   no_spanning_tree_vlan: 4094
 aaa_authorization: null
 local_users:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -53,7 +53,9 @@ ntp_server:
 redundancy: null
 spanning_tree:
   mode: mstp
-  priority: 16384
+  mst_instances:
+    0:
+      priority: 16384
   no_spanning_tree_vlan: 4094
 aaa_authorization: null
 local_users:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF1A.yml
@@ -50,7 +50,9 @@ ntp_server:
 redundancy: null
 spanning_tree:
   mode: mstp
-  priority: 4096
+  mst_instances:
+    0:
+      priority: 4096
 aaa_authorization: null
 local_users:
   admin:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -62,7 +62,9 @@ ntp_server:
 redundancy: null
 spanning_tree:
   mode: mstp
-  priority: 4096
+  mst_instances:
+    0:
+      priority: 4096
   no_spanning_tree_vlan: 4093-4094
 aaa_authorization: null
 local_users:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -62,7 +62,9 @@ ntp_server:
 redundancy: null
 spanning_tree:
   mode: mstp
-  priority: 4096
+  mst_instances:
+    0:
+      priority: 4096
   no_spanning_tree_vlan: 4093-4094
 aaa_authorization: null
 local_users:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SVC3A.yml
@@ -63,7 +63,9 @@ ntp_server:
 redundancy: null
 spanning_tree:
   mode: mstp
-  priority: 4096
+  mst_instances:
+    0:
+      priority: 4096
   no_spanning_tree_vlan: 4093-4094
 aaa_authorization: null
 local_users:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SVC3B.yml
@@ -63,7 +63,9 @@ ntp_server:
 redundancy: null
 spanning_tree:
   mode: mstp
-  priority: 4096
+  mst_instances:
+    0:
+      priority: 4096
   no_spanning_tree_vlan: 4093-4094
 aaa_authorization: null
 local_users:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -315,13 +317,21 @@ mlag configuration
 
 ## Spanning Tree Summary
 
-Mode: mstp
+STP mode: **mstp**
 
 ### MSTP Instance and Priority
 
-| Instance | Priority |
+| Instance(s) | Priority |
 | -------- | -------- |
 | 0 | 4096 |
+
+### MST Configuration
+
+
+
+### Global Spanning-Tree Settings
+
+Spanning Tree disabled for VLANs: **4093-4094**
 
 ## Spanning Tree Device Configuration
 
@@ -834,9 +844,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -315,13 +317,21 @@ mlag configuration
 
 ## Spanning Tree Summary
 
-Mode: mstp
+STP mode: **mstp**
 
 ### MSTP Instance and Priority
 
-| Instance | Priority |
+| Instance(s) | Priority |
 | -------- | -------- |
 | 0 | 4096 |
+
+### MST Configuration
+
+
+
+### Global Spanning-Tree Settings
+
+Spanning Tree disabled for VLANs: **4093-4094**
 
 ## Spanning Tree Device Configuration
 
@@ -834,9 +844,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-L2LEAF1A.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -294,13 +296,20 @@ MLAG not defined
 
 ## Spanning Tree Summary
 
-Mode: mstp
+STP mode: **mstp**
 
 ### MSTP Instance and Priority
 
-| Instance | Priority |
+| Instance(s) | Priority |
 | -------- | -------- |
 | 0 | 16384 |
+
+### MST Configuration
+
+
+
+### Global Spanning-Tree Settings
+
 
 ## Spanning Tree Device Configuration
 
@@ -576,9 +585,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-L2LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-L2LEAF2A.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -315,13 +317,21 @@ mlag configuration
 
 ## Spanning Tree Summary
 
-Mode: mstp
+STP mode: **mstp**
 
 ### MSTP Instance and Priority
 
-| Instance | Priority |
+| Instance(s) | Priority |
 | -------- | -------- |
 | 0 | 16384 |
+
+### MST Configuration
+
+
+
+### Global Spanning-Tree Settings
+
+Spanning Tree disabled for VLANs: **4094**
 
 ## Spanning Tree Device Configuration
 
@@ -656,9 +666,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-L2LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-L2LEAF2B.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -315,13 +317,21 @@ mlag configuration
 
 ## Spanning Tree Summary
 
-Mode: mstp
+STP mode: **mstp**
 
 ### MSTP Instance and Priority
 
-| Instance | Priority |
+| Instance(s) | Priority |
 | -------- | -------- |
 | 0 | 16384 |
+
+### MST Configuration
+
+
+
+### Global Spanning-Tree Settings
+
+Spanning Tree disabled for VLANs: **4094**
 
 ## Spanning Tree Device Configuration
 
@@ -656,9 +666,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -294,13 +296,20 @@ MLAG not defined
 
 ## Spanning Tree Summary
 
-Mode: mstp
+STP mode: **mstp**
 
 ### MSTP Instance and Priority
 
-| Instance | Priority |
+| Instance(s) | Priority |
 | -------- | -------- |
 | 0 | 4096 |
+
+### MST Configuration
+
+
+
+### Global Spanning-Tree Settings
+
 
 ## Spanning Tree Device Configuration
 
@@ -724,9 +733,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -315,13 +317,21 @@ mlag configuration
 
 ## Spanning Tree Summary
 
-Mode: mstp
+STP mode: **mstp**
 
 ### MSTP Instance and Priority
 
-| Instance | Priority |
+| Instance(s) | Priority |
 | -------- | -------- |
 | 0 | 4096 |
+
+### MST Configuration
+
+
+
+### Global Spanning-Tree Settings
+
+Spanning Tree disabled for VLANs: **4093-4094**
 
 ## Spanning Tree Device Configuration
 
@@ -849,9 +859,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -315,13 +317,21 @@ mlag configuration
 
 ## Spanning Tree Summary
 
-Mode: mstp
+STP mode: **mstp**
 
 ### MSTP Instance and Priority
 
-| Instance | Priority |
+| Instance(s) | Priority |
 | -------- | -------- |
 | 0 | 4096 |
+
+### MST Configuration
+
+
+
+### Global Spanning-Tree Settings
+
+Spanning Tree disabled for VLANs: **4093-4094**
 
 ## Spanning Tree Device Configuration
 
@@ -849,9 +859,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE1.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -294,7 +296,11 @@ MLAG not defined
 
 ## Spanning Tree Summary
 
-Mode: none
+STP mode: **none**
+
+
+### Global Spanning-Tree Settings
+
 
 ## Spanning Tree Device Configuration
 
@@ -728,9 +734,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE2.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -294,7 +296,11 @@ MLAG not defined
 
 ## Spanning Tree Summary
 
-Mode: none
+STP mode: **none**
+
+
+### Global Spanning-Tree Settings
+
 
 ## Spanning Tree Device Configuration
 
@@ -728,9 +734,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE3.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -294,7 +296,11 @@ MLAG not defined
 
 ## Spanning Tree Summary
 
-Mode: none
+STP mode: **none**
+
+
+### Global Spanning-Tree Settings
+
 
 ## Spanning Tree Device Configuration
 
@@ -728,9 +734,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE4.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -294,7 +296,11 @@ MLAG not defined
 
 ## Spanning Tree Summary
 
-Mode: none
+STP mode: **none**
+
+
+### Global Spanning-Tree Settings
+
 
 ## Spanning Tree Device Configuration
 
@@ -728,9 +734,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -315,13 +317,21 @@ mlag configuration
 
 ## Spanning Tree Summary
 
-Mode: mstp
+STP mode: **mstp**
 
 ### MSTP Instance and Priority
 
-| Instance | Priority |
+| Instance(s) | Priority |
 | -------- | -------- |
 | 0 | 4096 |
+
+### MST Configuration
+
+
+
+### Global Spanning-Tree Settings
+
+Spanning Tree disabled for VLANs: **4093-4094**
 
 ## Spanning Tree Device Configuration
 
@@ -855,9 +865,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -315,13 +317,21 @@ mlag configuration
 
 ## Spanning Tree Summary
 
-Mode: mstp
+STP mode: **mstp**
 
 ### MSTP Instance and Priority
 
-| Instance | Priority |
+| Instance(s) | Priority |
 | -------- | -------- |
 | 0 | 4096 |
+
+### MST Configuration
+
+
+
+### Global Spanning-Tree Settings
+
+Spanning Tree disabled for VLANs: **4093-4094**
 
 ## Spanning Tree Device Configuration
 
@@ -855,9 +865,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
@@ -55,7 +55,9 @@ ntp_server:
 redundancy: null
 spanning_tree:
   mode: mstp
-  priority: 4096
+  mst_instances:
+    0:
+      priority: 4096
   no_spanning_tree_vlan: 4093-4094
 aaa_authorization: null
 local_users:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
@@ -55,7 +55,9 @@ ntp_server:
 redundancy: null
 spanning_tree:
   mode: mstp
-  priority: 4096
+  mst_instances:
+    0:
+      priority: 4096
   no_spanning_tree_vlan: 4093-4094
 aaa_authorization: null
 local_users:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -49,7 +49,9 @@ ntp_server:
 redundancy: null
 spanning_tree:
   mode: mstp
-  priority: 16384
+  mst_instances:
+    0:
+      priority: 16384
 aaa_authorization: null
 local_users:
   admin:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -53,7 +53,9 @@ ntp_server:
 redundancy: null
 spanning_tree:
   mode: mstp
-  priority: 16384
+  mst_instances:
+    0:
+      priority: 16384
   no_spanning_tree_vlan: 4094
 aaa_authorization: null
 local_users:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -53,7 +53,9 @@ ntp_server:
 redundancy: null
 spanning_tree:
   mode: mstp
-  priority: 16384
+  mst_instances:
+    0:
+      priority: 16384
   no_spanning_tree_vlan: 4094
 aaa_authorization: null
 local_users:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
@@ -50,7 +50,9 @@ ntp_server:
 redundancy: null
 spanning_tree:
   mode: mstp
-  priority: 4096
+  mst_instances:
+    0:
+      priority: 4096
 aaa_authorization: null
 local_users:
   admin:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -62,7 +62,9 @@ ntp_server:
 redundancy: null
 spanning_tree:
   mode: mstp
-  priority: 4096
+  mst_instances:
+    0:
+      priority: 4096
   no_spanning_tree_vlan: 4093-4094
 aaa_authorization: null
 local_users:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -62,7 +62,9 @@ ntp_server:
 redundancy: null
 spanning_tree:
   mode: mstp
-  priority: 4096
+  mst_instances:
+    0:
+      priority: 4096
   no_spanning_tree_vlan: 4093-4094
 aaa_authorization: null
 local_users:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -63,7 +63,9 @@ ntp_server:
 redundancy: null
 spanning_tree:
   mode: mstp
-  priority: 4096
+  mst_instances:
+    0:
+      priority: 4096
   no_spanning_tree_vlan: 4093-4094
 aaa_authorization: null
 local_users:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -63,7 +63,9 @@ ntp_server:
 redundancy: null
 spanning_tree:
   mode: mstp
-  priority: 4096
+  mst_instances:
+    0:
+      priority: 4096
   no_spanning_tree_vlan: 4093-4094
 aaa_authorization: null
 local_users:

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-BL1A.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -315,13 +317,21 @@ mlag configuration
 
 ## Spanning Tree Summary
 
-Mode: mstp
+STP mode: **mstp**
 
 ### MSTP Instance and Priority
 
-| Instance | Priority |
+| Instance(s) | Priority |
 | -------- | -------- |
 | 0 | 4096 |
+
+### MST Configuration
+
+
+
+### Global Spanning-Tree Settings
+
+Spanning Tree disabled for VLANs: **4093-4094**
 
 ## Spanning Tree Device Configuration
 
@@ -530,9 +540,9 @@ interface Loopback1
 | Vlan150 |  Tenant_A_WAN_Zone_1  |  Tenant_A_WAN_Zone  |  -  |  false  |
 | Vlan250 |  Tenant_B_WAN_Zone_1  |  Tenant_B_WAN_Zone  |  -  |  false  |
 | Vlan350 |  Tenant_C_WAN_Zone_1  |  Tenant_C_WAN_Zone  |  -  |  false  |
-| Vlan3013 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone  |  Tenant_A_WAN_Zone  |  -  |  false  |
-| Vlan3020 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone  |  Tenant_B_WAN_Zone  |  -  |  false  |
-| Vlan3030 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone  |  Tenant_C_WAN_Zone  |  -  |  false  |
+| Vlan3013 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone  |  Tenant_A_WAN_Zone  |  1500  |  false  |
+| Vlan3020 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone  |  Tenant_B_WAN_Zone  |  1500  |  false  |
+| Vlan3030 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone  |  Tenant_C_WAN_Zone  |  1500  |  false  |
 | Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  false  |
 | Vlan4094 |  MLAG_PEER  |  default  |  1500  |  false  |
 
@@ -1049,9 +1059,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-BL1B.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -315,13 +317,21 @@ mlag configuration
 
 ## Spanning Tree Summary
 
-Mode: mstp
+STP mode: **mstp**
 
 ### MSTP Instance and Priority
 
-| Instance | Priority |
+| Instance(s) | Priority |
 | -------- | -------- |
 | 0 | 4096 |
+
+### MST Configuration
+
+
+
+### Global Spanning-Tree Settings
+
+Spanning Tree disabled for VLANs: **4093-4094**
 
 ## Spanning Tree Device Configuration
 
@@ -530,9 +540,9 @@ interface Loopback1
 | Vlan150 |  Tenant_A_WAN_Zone_1  |  Tenant_A_WAN_Zone  |  -  |  false  |
 | Vlan250 |  Tenant_B_WAN_Zone_1  |  Tenant_B_WAN_Zone  |  -  |  false  |
 | Vlan350 |  Tenant_C_WAN_Zone_1  |  Tenant_C_WAN_Zone  |  -  |  false  |
-| Vlan3013 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone  |  Tenant_A_WAN_Zone  |  -  |  false  |
-| Vlan3020 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone  |  Tenant_B_WAN_Zone  |  -  |  false  |
-| Vlan3030 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone  |  Tenant_C_WAN_Zone  |  -  |  false  |
+| Vlan3013 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone  |  Tenant_A_WAN_Zone  |  1500  |  false  |
+| Vlan3020 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone  |  Tenant_B_WAN_Zone  |  1500  |  false  |
+| Vlan3030 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone  |  Tenant_C_WAN_Zone  |  1500  |  false  |
 | Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  false  |
 | Vlan4094 |  MLAG_PEER  |  default  |  1500  |  false  |
 
@@ -1049,9 +1059,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-L2LEAF1A.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -294,13 +296,20 @@ MLAG not defined
 
 ## Spanning Tree Summary
 
-Mode: mstp
+STP mode: **mstp**
 
 ### MSTP Instance and Priority
 
-| Instance | Priority |
+| Instance(s) | Priority |
 | -------- | -------- |
 | 0 | 16384 |
+
+### MST Configuration
+
+
+
+### Global Spanning-Tree Settings
+
 
 ## Spanning Tree Device Configuration
 
@@ -608,9 +617,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-L2LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-L2LEAF2A.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -315,13 +317,21 @@ mlag configuration
 
 ## Spanning Tree Summary
 
-Mode: mstp
+STP mode: **mstp**
 
 ### MSTP Instance and Priority
 
-| Instance | Priority |
+| Instance(s) | Priority |
 | -------- | -------- |
 | 0 | 16384 |
+
+### MST Configuration
+
+
+
+### Global Spanning-Tree Settings
+
+Spanning Tree disabled for VLANs: **4094**
 
 ## Spanning Tree Device Configuration
 
@@ -716,9 +726,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-L2LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-L2LEAF2B.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -315,13 +317,21 @@ mlag configuration
 
 ## Spanning Tree Summary
 
-Mode: mstp
+STP mode: **mstp**
 
 ### MSTP Instance and Priority
 
-| Instance | Priority |
+| Instance(s) | Priority |
 | -------- | -------- |
 | 0 | 16384 |
+
+### MST Configuration
+
+
+
+### Global Spanning-Tree Settings
+
+Spanning Tree disabled for VLANs: **4094**
 
 ## Spanning Tree Device Configuration
 
@@ -716,9 +726,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-LEAF1A.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -294,13 +296,20 @@ MLAG not defined
 
 ## Spanning Tree Summary
 
-Mode: mstp
+STP mode: **mstp**
 
 ### MSTP Instance and Priority
 
-| Instance | Priority |
+| Instance(s) | Priority |
 | -------- | -------- |
 | 0 | 4096 |
+
+### MST Configuration
+
+
+
+### Global Spanning-Tree Settings
+
 
 ## Spanning Tree Device Configuration
 
@@ -914,9 +923,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-LEAF2A.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -315,13 +317,21 @@ mlag configuration
 
 ## Spanning Tree Summary
 
-Mode: mstp
+STP mode: **mstp**
 
 ### MSTP Instance and Priority
 
-| Instance | Priority |
+| Instance(s) | Priority |
 | -------- | -------- |
 | 0 | 4096 |
+
+### MST Configuration
+
+
+
+### Global Spanning-Tree Settings
+
+Spanning Tree disabled for VLANs: **4093-4094**
 
 ## Spanning Tree Device Configuration
 
@@ -643,12 +653,12 @@ interface Loopback100
 | Vlan211 |  Tenant_B_OP_Zone_2  |  Tenant_B_OP_Zone  |  -  |  false  |
 | Vlan310 |  Tenant_C_OP_Zone_1  |  Tenant_C_OP_Zone  |  -  |  false  |
 | Vlan311 |  Tenant_C_OP_Zone_2  |  Tenant_C_OP_Zone  |  -  |  false  |
-| Vlan3009 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone  |  Tenant_A_OP_Zone  |  -  |  false  |
-| Vlan3010 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone  |  Tenant_A_WEB_Zone  |  -  |  false  |
-| Vlan3011 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone  |  Tenant_A_APP_Zone  |  -  |  false  |
-| Vlan3012 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone  |  Tenant_A_DB_Zone  |  -  |  false  |
-| Vlan3019 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone  |  Tenant_B_OP_Zone  |  -  |  false  |
-| Vlan3029 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone  |  Tenant_C_OP_Zone  |  -  |  false  |
+| Vlan3009 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone  |  Tenant_A_OP_Zone  |  1500  |  false  |
+| Vlan3010 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone  |  Tenant_A_WEB_Zone  |  1500  |  false  |
+| Vlan3011 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone  |  Tenant_A_APP_Zone  |  1500  |  false  |
+| Vlan3012 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone  |  Tenant_A_DB_Zone  |  1500  |  false  |
+| Vlan3019 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone  |  Tenant_B_OP_Zone  |  1500  |  false  |
+| Vlan3029 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone  |  Tenant_C_OP_Zone  |  1500  |  false  |
 | Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  false  |
 | Vlan4094 |  MLAG_PEER  |  default  |  1500  |  false  |
 
@@ -1350,9 +1360,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-LEAF2B.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -315,13 +317,21 @@ mlag configuration
 
 ## Spanning Tree Summary
 
-Mode: mstp
+STP mode: **mstp**
 
 ### MSTP Instance and Priority
 
-| Instance | Priority |
+| Instance(s) | Priority |
 | -------- | -------- |
 | 0 | 4096 |
+
+### MST Configuration
+
+
+
+### Global Spanning-Tree Settings
+
+Spanning Tree disabled for VLANs: **4093-4094**
 
 ## Spanning Tree Device Configuration
 
@@ -643,12 +653,12 @@ interface Loopback100
 | Vlan211 |  Tenant_B_OP_Zone_2  |  Tenant_B_OP_Zone  |  -  |  false  |
 | Vlan310 |  Tenant_C_OP_Zone_1  |  Tenant_C_OP_Zone  |  -  |  false  |
 | Vlan311 |  Tenant_C_OP_Zone_2  |  Tenant_C_OP_Zone  |  -  |  false  |
-| Vlan3009 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone  |  Tenant_A_OP_Zone  |  -  |  false  |
-| Vlan3010 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone  |  Tenant_A_WEB_Zone  |  -  |  false  |
-| Vlan3011 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone  |  Tenant_A_APP_Zone  |  -  |  false  |
-| Vlan3012 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone  |  Tenant_A_DB_Zone  |  -  |  false  |
-| Vlan3019 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone  |  Tenant_B_OP_Zone  |  -  |  false  |
-| Vlan3029 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone  |  Tenant_C_OP_Zone  |  -  |  false  |
+| Vlan3009 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone  |  Tenant_A_OP_Zone  |  1500  |  false  |
+| Vlan3010 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone  |  Tenant_A_WEB_Zone  |  1500  |  false  |
+| Vlan3011 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone  |  Tenant_A_APP_Zone  |  1500  |  false  |
+| Vlan3012 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone  |  Tenant_A_DB_Zone  |  1500  |  false  |
+| Vlan3019 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone  |  Tenant_B_OP_Zone  |  1500  |  false  |
+| Vlan3029 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone  |  Tenant_C_OP_Zone  |  1500  |  false  |
 | Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  false  |
 | Vlan4094 |  MLAG_PEER  |  default  |  1500  |  false  |
 
@@ -1350,9 +1360,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-SPINE1.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -294,7 +296,11 @@ MLAG not defined
 
 ## Spanning Tree Summary
 
-Mode: none
+STP mode: **none**
+
+
+### Global Spanning-Tree Settings
+
 
 ## Spanning Tree Device Configuration
 
@@ -750,9 +756,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-SPINE2.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -294,7 +296,11 @@ MLAG not defined
 
 ## Spanning Tree Summary
 
-Mode: none
+STP mode: **none**
+
+
+### Global Spanning-Tree Settings
+
 
 ## Spanning Tree Device Configuration
 
@@ -750,9 +756,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-SPINE3.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -294,7 +296,11 @@ MLAG not defined
 
 ## Spanning Tree Summary
 
-Mode: none
+STP mode: **none**
+
+
+### Global Spanning-Tree Settings
+
 
 ## Spanning Tree Device Configuration
 
@@ -750,9 +756,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-SPINE4.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -294,7 +296,11 @@ MLAG not defined
 
 ## Spanning Tree Summary
 
-Mode: none
+STP mode: **none**
+
+
+### Global Spanning-Tree Settings
+
 
 ## Spanning Tree Device Configuration
 
@@ -750,9 +756,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-SVC3A.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -315,13 +317,21 @@ mlag configuration
 
 ## Spanning Tree Summary
 
-Mode: mstp
+STP mode: **mstp**
 
 ### MSTP Instance and Priority
 
-| Instance | Priority |
+| Instance(s) | Priority |
 | -------- | -------- |
 | 0 | 4096 |
+
+### MST Configuration
+
+
+
+### Global Spanning-Tree Settings
+
+Spanning Tree disabled for VLANs: **4093-4094**
 
 ## Spanning Tree Device Configuration
 
@@ -679,15 +689,15 @@ interface Loopback100
 | Vlan310 |  Tenant_C_OP_Zone_1  |  Tenant_C_OP_Zone  |  -  |  false  |
 | Vlan311 |  Tenant_C_OP_Zone_2  |  Tenant_C_OP_Zone  |  -  |  false  |
 | Vlan350 |  Tenant_C_WAN_Zone_1  |  Tenant_C_WAN_Zone  |  -  |  false  |
-| Vlan3009 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone  |  Tenant_A_OP_Zone  |  -  |  false  |
-| Vlan3010 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone  |  Tenant_A_WEB_Zone  |  -  |  false  |
-| Vlan3011 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone  |  Tenant_A_APP_Zone  |  -  |  false  |
-| Vlan3012 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone  |  Tenant_A_DB_Zone  |  -  |  false  |
-| Vlan3013 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone  |  Tenant_A_WAN_Zone  |  -  |  false  |
-| Vlan3019 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone  |  Tenant_B_OP_Zone  |  -  |  false  |
-| Vlan3020 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone  |  Tenant_B_WAN_Zone  |  -  |  false  |
-| Vlan3029 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone  |  Tenant_C_OP_Zone  |  -  |  false  |
-| Vlan3030 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone  |  Tenant_C_WAN_Zone  |  -  |  false  |
+| Vlan3009 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone  |  Tenant_A_OP_Zone  |  1500  |  false  |
+| Vlan3010 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone  |  Tenant_A_WEB_Zone  |  1500  |  false  |
+| Vlan3011 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone  |  Tenant_A_APP_Zone  |  1500  |  false  |
+| Vlan3012 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone  |  Tenant_A_DB_Zone  |  1500  |  false  |
+| Vlan3013 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone  |  Tenant_A_WAN_Zone  |  1500  |  false  |
+| Vlan3019 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone  |  Tenant_B_OP_Zone  |  1500  |  false  |
+| Vlan3020 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone  |  Tenant_B_WAN_Zone  |  1500  |  false  |
+| Vlan3029 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone  |  Tenant_C_OP_Zone  |  1500  |  false  |
+| Vlan3030 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone  |  Tenant_C_WAN_Zone  |  1500  |  false  |
 | Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  false  |
 | Vlan4094 |  MLAG_PEER  |  default  |  1500  |  false  |
 
@@ -1509,9 +1519,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-SVC3B.md
@@ -73,6 +73,8 @@
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
 - [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
 
 # Management
 
@@ -315,13 +317,21 @@ mlag configuration
 
 ## Spanning Tree Summary
 
-Mode: mstp
+STP mode: **mstp**
 
 ### MSTP Instance and Priority
 
-| Instance | Priority |
+| Instance(s) | Priority |
 | -------- | -------- |
 | 0 | 4096 |
+
+### MST Configuration
+
+
+
+### Global Spanning-Tree Settings
+
+Spanning Tree disabled for VLANs: **4093-4094**
 
 ## Spanning Tree Device Configuration
 
@@ -679,15 +689,15 @@ interface Loopback100
 | Vlan310 |  Tenant_C_OP_Zone_1  |  Tenant_C_OP_Zone  |  -  |  false  |
 | Vlan311 |  Tenant_C_OP_Zone_2  |  Tenant_C_OP_Zone  |  -  |  false  |
 | Vlan350 |  Tenant_C_WAN_Zone_1  |  Tenant_C_WAN_Zone  |  -  |  false  |
-| Vlan3009 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone  |  Tenant_A_OP_Zone  |  -  |  false  |
-| Vlan3010 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone  |  Tenant_A_WEB_Zone  |  -  |  false  |
-| Vlan3011 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone  |  Tenant_A_APP_Zone  |  -  |  false  |
-| Vlan3012 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone  |  Tenant_A_DB_Zone  |  -  |  false  |
-| Vlan3013 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone  |  Tenant_A_WAN_Zone  |  -  |  false  |
-| Vlan3019 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone  |  Tenant_B_OP_Zone  |  -  |  false  |
-| Vlan3020 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone  |  Tenant_B_WAN_Zone  |  -  |  false  |
-| Vlan3029 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone  |  Tenant_C_OP_Zone  |  -  |  false  |
-| Vlan3030 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone  |  Tenant_C_WAN_Zone  |  -  |  false  |
+| Vlan3009 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone  |  Tenant_A_OP_Zone  |  1500  |  false  |
+| Vlan3010 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone  |  Tenant_A_WEB_Zone  |  1500  |  false  |
+| Vlan3011 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone  |  Tenant_A_APP_Zone  |  1500  |  false  |
+| Vlan3012 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone  |  Tenant_A_DB_Zone  |  1500  |  false  |
+| Vlan3013 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone  |  Tenant_A_WAN_Zone  |  1500  |  false  |
+| Vlan3019 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone  |  Tenant_B_OP_Zone  |  1500  |  false  |
+| Vlan3020 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone  |  Tenant_B_WAN_Zone  |  1500  |  false  |
+| Vlan3029 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone  |  Tenant_C_OP_Zone  |  1500  |  false  |
+| Vlan3030 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone  |  Tenant_C_WAN_Zone  |  1500  |  false  |
 | Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  false  |
 | Vlan4094 |  MLAG_PEER  |  default  |  1500  |  false  |
 
@@ -1509,9 +1519,18 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+
 # MACsec
 
 MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-BL1A.yml
@@ -64,7 +64,9 @@ ntp_server:
 redundancy: null
 spanning_tree:
   mode: mstp
-  priority: 4096
+  mst_instances:
+    0:
+      priority: 4096
   no_spanning_tree_vlan: 4093-4094
 aaa_authorization: null
 local_users:
@@ -238,6 +240,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone'
     vrf: Tenant_A_WAN_Zone
     ip_address: 10.255.251.10/31
+    mtu: 1500
   Vlan250:
     tenant: Tenant_B
     tags:
@@ -253,6 +256,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone'
     vrf: Tenant_B_WAN_Zone
     ip_address: 10.255.251.10/31
+    mtu: 1500
   Vlan350:
     tenant: Tenant_C
     tags:
@@ -268,6 +272,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone'
     vrf: Tenant_C_WAN_Zone
     ip_address: 10.255.251.10/31
+    mtu: 1500
 vxlan_tunnel_interface:
   Vxlan1:
     description: DC1-BL1A_VTEP

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-BL1B.yml
@@ -64,7 +64,9 @@ ntp_server:
 redundancy: null
 spanning_tree:
   mode: mstp
-  priority: 4096
+  mst_instances:
+    0:
+      priority: 4096
   no_spanning_tree_vlan: 4093-4094
 aaa_authorization: null
 local_users:
@@ -238,6 +240,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone'
     vrf: Tenant_A_WAN_Zone
     ip_address: 10.255.251.11/31
+    mtu: 1500
   Vlan250:
     tenant: Tenant_B
     tags:
@@ -253,6 +256,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone'
     vrf: Tenant_B_WAN_Zone
     ip_address: 10.255.251.11/31
+    mtu: 1500
   Vlan350:
     tenant: Tenant_C
     tags:
@@ -268,6 +272,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone'
     vrf: Tenant_C_WAN_Zone
     ip_address: 10.255.251.11/31
+    mtu: 1500
 vxlan_tunnel_interface:
   Vxlan1:
     description: DC1-BL1B_VTEP

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -64,7 +64,9 @@ ntp_server:
 redundancy: null
 spanning_tree:
   mode: mstp
-  priority: 16384
+  mst_instances:
+    0:
+      priority: 16384
 aaa_authorization: null
 local_users:
   admin:

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -92,7 +92,9 @@ ntp_server:
 redundancy: null
 spanning_tree:
   mode: mstp
-  priority: 16384
+  mst_instances:
+    0:
+      priority: 16384
   no_spanning_tree_vlan: 4094
 aaa_authorization: null
 local_users:

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -92,7 +92,9 @@ ntp_server:
 redundancy: null
 spanning_tree:
   mode: mstp
-  priority: 16384
+  mst_instances:
+    0:
+      priority: 16384
   no_spanning_tree_vlan: 4094
 aaa_authorization: null
 local_users:

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-LEAF1A.yml
@@ -60,7 +60,9 @@ ntp_server:
 redundancy: null
 spanning_tree:
   mode: mstp
-  priority: 4096
+  mst_instances:
+    0:
+      priority: 4096
 aaa_authorization: null
 local_users:
   admin:

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-LEAF2A.yml
@@ -92,7 +92,9 @@ ntp_server:
 redundancy: null
 spanning_tree:
   mode: mstp
-  priority: 4096
+  mst_instances:
+    0:
+      priority: 4096
   no_spanning_tree_vlan: 4093-4094
 aaa_authorization: null
 local_users:
@@ -388,6 +390,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone'
     vrf: Tenant_A_APP_Zone
     ip_address: 10.255.251.2/31
+    mtu: 1500
   Vlan140:
     tenant: Tenant_A
     tags:
@@ -412,6 +415,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone'
     vrf: Tenant_A_DB_Zone
     ip_address: 10.255.251.2/31
+    mtu: 1500
   Vlan110:
     tenant: Tenant_A
     tags:
@@ -435,6 +439,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone'
     vrf: Tenant_A_OP_Zone
     ip_address: 10.255.251.2/31
+    mtu: 1500
   Vlan120:
     tenant: Tenant_A
     tags:
@@ -459,6 +464,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone'
     vrf: Tenant_A_WEB_Zone
     ip_address: 10.255.251.2/31
+    mtu: 1500
   Vlan210:
     tenant: Tenant_B
     tags:
@@ -482,6 +488,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone'
     vrf: Tenant_B_OP_Zone
     ip_address: 10.255.251.2/31
+    mtu: 1500
   Vlan310:
     tenant: Tenant_C
     tags:
@@ -505,6 +512,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone'
     vrf: Tenant_C_OP_Zone
     ip_address: 10.255.251.2/31
+    mtu: 1500
 vxlan_tunnel_interface:
   Vxlan1:
     description: DC1-LEAF2A_VTEP

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-LEAF2B.yml
@@ -92,7 +92,9 @@ ntp_server:
 redundancy: null
 spanning_tree:
   mode: mstp
-  priority: 4096
+  mst_instances:
+    0:
+      priority: 4096
   no_spanning_tree_vlan: 4093-4094
 aaa_authorization: null
 local_users:
@@ -388,6 +390,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone'
     vrf: Tenant_A_APP_Zone
     ip_address: 10.255.251.3/31
+    mtu: 1500
   Vlan140:
     tenant: Tenant_A
     tags:
@@ -412,6 +415,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone'
     vrf: Tenant_A_DB_Zone
     ip_address: 10.255.251.3/31
+    mtu: 1500
   Vlan110:
     tenant: Tenant_A
     tags:
@@ -435,6 +439,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone'
     vrf: Tenant_A_OP_Zone
     ip_address: 10.255.251.3/31
+    mtu: 1500
   Vlan120:
     tenant: Tenant_A
     tags:
@@ -459,6 +464,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone'
     vrf: Tenant_A_WEB_Zone
     ip_address: 10.255.251.3/31
+    mtu: 1500
   Vlan210:
     tenant: Tenant_B
     tags:
@@ -482,6 +488,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone'
     vrf: Tenant_B_OP_Zone
     ip_address: 10.255.251.3/31
+    mtu: 1500
   Vlan310:
     tenant: Tenant_C
     tags:
@@ -505,6 +512,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone'
     vrf: Tenant_C_OP_Zone
     ip_address: 10.255.251.3/31
+    mtu: 1500
 vxlan_tunnel_interface:
   Vxlan1:
     description: DC1-LEAF2B_VTEP

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-SVC3A.yml
@@ -102,7 +102,9 @@ ntp_server:
 redundancy: null
 spanning_tree:
   mode: mstp
-  priority: 4096
+  mst_instances:
+    0:
+      priority: 4096
   no_spanning_tree_vlan: 4093-4094
 aaa_authorization: null
 local_users:
@@ -441,6 +443,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone'
     vrf: Tenant_A_APP_Zone
     ip_address: 10.255.251.6/31
+    mtu: 1500
   Vlan140:
     tenant: Tenant_A
     tags:
@@ -465,6 +468,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone'
     vrf: Tenant_A_DB_Zone
     ip_address: 10.255.251.6/31
+    mtu: 1500
   Vlan110:
     tenant: Tenant_A
     tags:
@@ -488,6 +492,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone'
     vrf: Tenant_A_OP_Zone
     ip_address: 10.255.251.6/31
+    mtu: 1500
   Vlan150:
     tenant: Tenant_A
     tags:
@@ -503,6 +508,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone'
     vrf: Tenant_A_WAN_Zone
     ip_address: 10.255.251.6/31
+    mtu: 1500
   Vlan120:
     tenant: Tenant_A
     tags:
@@ -527,6 +533,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone'
     vrf: Tenant_A_WEB_Zone
     ip_address: 10.255.251.6/31
+    mtu: 1500
   Vlan210:
     tenant: Tenant_B
     tags:
@@ -550,6 +557,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone'
     vrf: Tenant_B_OP_Zone
     ip_address: 10.255.251.6/31
+    mtu: 1500
   Vlan250:
     tenant: Tenant_B
     tags:
@@ -565,6 +573,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone'
     vrf: Tenant_B_WAN_Zone
     ip_address: 10.255.251.6/31
+    mtu: 1500
   Vlan310:
     tenant: Tenant_C
     tags:
@@ -588,6 +597,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone'
     vrf: Tenant_C_OP_Zone
     ip_address: 10.255.251.6/31
+    mtu: 1500
   Vlan350:
     tenant: Tenant_C
     tags:
@@ -603,6 +613,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone'
     vrf: Tenant_C_WAN_Zone
     ip_address: 10.255.251.6/31
+    mtu: 1500
 vxlan_tunnel_interface:
   Vxlan1:
     description: DC1-SVC3A_VTEP

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-SVC3B.yml
@@ -102,7 +102,9 @@ ntp_server:
 redundancy: null
 spanning_tree:
   mode: mstp
-  priority: 4096
+  mst_instances:
+    0:
+      priority: 4096
   no_spanning_tree_vlan: 4093-4094
 aaa_authorization: null
 local_users:
@@ -441,6 +443,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone'
     vrf: Tenant_A_APP_Zone
     ip_address: 10.255.251.7/31
+    mtu: 1500
   Vlan140:
     tenant: Tenant_A
     tags:
@@ -465,6 +468,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone'
     vrf: Tenant_A_DB_Zone
     ip_address: 10.255.251.7/31
+    mtu: 1500
   Vlan110:
     tenant: Tenant_A
     tags:
@@ -488,6 +492,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone'
     vrf: Tenant_A_OP_Zone
     ip_address: 10.255.251.7/31
+    mtu: 1500
   Vlan150:
     tenant: Tenant_A
     tags:
@@ -503,6 +508,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone'
     vrf: Tenant_A_WAN_Zone
     ip_address: 10.255.251.7/31
+    mtu: 1500
   Vlan120:
     tenant: Tenant_A
     tags:
@@ -527,6 +533,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone'
     vrf: Tenant_A_WEB_Zone
     ip_address: 10.255.251.7/31
+    mtu: 1500
   Vlan210:
     tenant: Tenant_B
     tags:
@@ -550,6 +557,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone'
     vrf: Tenant_B_OP_Zone
     ip_address: 10.255.251.7/31
+    mtu: 1500
   Vlan250:
     tenant: Tenant_B
     tags:
@@ -565,6 +573,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone'
     vrf: Tenant_B_WAN_Zone
     ip_address: 10.255.251.7/31
+    mtu: 1500
   Vlan310:
     tenant: Tenant_C
     tags:
@@ -588,6 +597,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone'
     vrf: Tenant_C_OP_Zone
     ip_address: 10.255.251.7/31
+    mtu: 1500
   Vlan350:
     tenant: Tenant_C
     tags:
@@ -603,6 +613,7 @@ vlan_interfaces:
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone'
     vrf: Tenant_C_WAN_Zone
     ip_address: 10.255.251.7/31
+    mtu: 1500
 vxlan_tunnel_interface:
   Vxlan1:
     description: DC1-SVC3B_VTEP

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -499,7 +499,7 @@ hardware:
 spanning_tree:
   edge_port:
     bpduguard_default: < true | false >
-  mode: < mstp | rstp | rapid-pvst >
+  mode: < mstp | rstp | rapid-pvst | none >
   rstp_priority: < priority >
   mst:
     pvst_border: < true | false >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -500,6 +500,7 @@ spanning_tree:
   edge_port:
     bpduguard_default: < true | false >
   mode: < spanning_tree_mode >
+  rstp_priority: < priority >
   mst:
     pvst_border: < true | false >
     configuration:
@@ -513,6 +514,11 @@ spanning_tree:
     < instance_id >:
       priority: < priority >
   no_spanning_tree_vlan: < vlan_id >, < vlan_id >-< vlan_id >
+  rapid_pvst_instances:
+    < vlan_id >:
+      priority: < priority >
+    < vlan_id >, < vlan_id >-< vlan_id >:
+      priority: < priority >
 ```
 
 ### Platform

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -499,7 +499,7 @@ hardware:
 spanning_tree:
   edge_port:
     bpduguard_default: < true | false >
-  mode: < spanning_tree_mode >
+  mode: < mstp | rstp | rapid-pvst >
   rstp_priority: < priority >
   mst:
     pvst_border: < true | false >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -500,7 +500,18 @@ spanning_tree:
   edge_port:
     bpduguard_default: < true | false >
   mode: < spanning_tree_mode >
-  priority: < priority_level >
+  mst:
+    pvst_border: < true | false >
+    configuration:
+      name: < name >
+      revision: < 0-65535 >
+      instances:
+        < instance_id >: < vlan_id >, < vlan_id >-< vlan_id >
+  mst_instances:
+    < instance_id >:
+      priority: < priority >
+    < instance_id >:
+      priority: < priority >
   no_spanning_tree_vlan: < vlan_id >, < vlan_id >-< vlan_id >
 ```
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/spanning-tree.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/spanning-tree.j2
@@ -2,7 +2,7 @@
 {% if spanning_tree is defined and spanning_tree is not none %}
 ## Spanning Tree Summary
 
-STP mode running: **{{ spanning_tree.mode }}**
+STP mode: **{{ spanning_tree.mode }}**
 {%     if spanning_tree.mode == "mstp" %}
 {%         if spanning_tree.mst is defined and spanning_tree.mst is not none %}
 {%             if spanning_tree.mst.pvst_border is defined and spanning_tree.mst.pvst_border == true %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/spanning-tree.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/spanning-tree.j2
@@ -2,14 +2,48 @@
 {% if spanning_tree is defined and spanning_tree is not none %}
 ## Spanning Tree Summary
 
-Mode: {{ spanning_tree.mode }}
+STP mode running: **{{ spanning_tree.mode }}**
 {%     if spanning_tree.mode == "mstp" %}
+{%         if spanning_tree.edge_port.bpduguard_default is defined and spanning_tree.edge_port.bpduguard_default == true %}
+Global BPDU Guard for Edge ports is enabled.
+{%         endif %}
+{%         if spanning_tree.mst is defined and spanning_tree.mst is not none %}
+{%             if spanning_tree.mst.pvst_border is defined and spanning_tree.mst.pvst_border == true %}
+MST PSVT Border is enabled.
+{%             endif %}
+{%         endif %}
+{%     if spanning_tree.no_spanning_tree_vlan is defined %}
+Spanning Tree disabled for VLANs: **{{ spanning_tree.no_spanning_tree_vlan }}**
+{%     endif %}
 
 ### MSTP Instance and Priority
 
-| Instance | Priority |
+| Instance(s) | Priority |
 | -------- | -------- |
-| 0 | {{ spanning_tree.priority }} |
+{%         if spanning_tree.mst_instances is defined and spanning_tree.mst_instances is not none %}
+{%            for mst_instance in spanning_tree.mst_instances | arista.avd.natural_sort %}
+| {{ mst_instance }} | {{ spanning_tree.mst_instances[mst_instance].priority }} |
+{%            endfor %}
+{%         endif %}
+{%     endif %}
+
+### MST Configuration
+
+{%     if spanning_tree.mst.configuration is defined and spanning_tree.configuration is not none %}
+| Variable | Value |
+| -------- | -------- |
+{%         if spanning_tree.mst.configuration.name is defined and spanning_tree.configuration.name is not none %}
+| Name | {{ spanning_tree.mst.configuration.name }} |
+{%         endif %}
+{%         if spanning_tree.mst.configuration.revision is defined and spanning_tree.configuration.revision is not none %}
+| Revision | {{ spanning_tree.mst.configuration.revision }} |
+{%         endif %}
+{%         if spanning_tree.mst.configuration.instances is defined and spanning_tree.configuration.instances is not none %}
+{%             for instance in spanning_tree.mst.configuration.instances | arista.avd.natural_sort %}
+| Instance {{ instance }} | VLAN(s) {% if spanning_tree.mst.configuration.instances[instance].vlans is defined and spanning_tree.mst.configuration.instances[instance].vlans is not none %}{{ spanning_tree.mst.configuration.instances[instance].vlans }} |
+{%                 endif %}
+{%             endfor %}
+{%         endif %}
 {%     endif %}
 
 ## Spanning Tree Device Configuration

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/spanning-tree.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/spanning-tree.j2
@@ -4,17 +4,11 @@
 
 STP mode running: **{{ spanning_tree.mode }}**
 {%     if spanning_tree.mode == "mstp" %}
-{%         if spanning_tree.edge_port.bpduguard_default is defined and spanning_tree.edge_port.bpduguard_default == true %}
-Global BPDU Guard for Edge ports is enabled.
-{%         endif %}
 {%         if spanning_tree.mst is defined and spanning_tree.mst is not none %}
 {%             if spanning_tree.mst.pvst_border is defined and spanning_tree.mst.pvst_border == true %}
 MST PSVT Border is enabled.
 {%             endif %}
 {%         endif %}
-{%     if spanning_tree.no_spanning_tree_vlan is defined %}
-Spanning Tree disabled for VLANs: **{{ spanning_tree.no_spanning_tree_vlan }}**
-{%     endif %}
 
 ### MSTP Instance and Priority
 
@@ -25,25 +19,52 @@ Spanning Tree disabled for VLANs: **{{ spanning_tree.no_spanning_tree_vlan }}**
 | {{ mst_instance }} | {{ spanning_tree.mst_instances[mst_instance].priority }} |
 {%            endfor %}
 {%         endif %}
-{%     endif %}
 
 ### MST Configuration
 
-{%     if spanning_tree.mst.configuration is defined and spanning_tree.configuration is not none %}
+{%         if spanning_tree.mst.configuration is defined and spanning_tree.configuration is not none %}
 | Variable | Value |
 | -------- | -------- |
-{%         if spanning_tree.mst.configuration.name is defined and spanning_tree.configuration.name is not none %}
+{%             if spanning_tree.mst.configuration.name is defined and spanning_tree.configuration.name is not none %}
 | Name | {{ spanning_tree.mst.configuration.name }} |
-{%         endif %}
-{%         if spanning_tree.mst.configuration.revision is defined and spanning_tree.configuration.revision is not none %}
+{%             endif %}
+{%             if spanning_tree.mst.configuration.revision is defined and spanning_tree.configuration.revision is not none %}
 | Revision | {{ spanning_tree.mst.configuration.revision }} |
-{%         endif %}
-{%         if spanning_tree.mst.configuration.instances is defined and spanning_tree.configuration.instances is not none %}
-{%             for instance in spanning_tree.mst.configuration.instances | arista.avd.natural_sort %}
+{%             endif %}
+{%             if spanning_tree.mst.configuration.instances is defined and spanning_tree.configuration.instances is not none %}
+{%                 for instance in spanning_tree.mst.configuration.instances | arista.avd.natural_sort %}
 | Instance {{ instance }} | VLAN(s) {% if spanning_tree.mst.configuration.instances[instance].vlans is defined and spanning_tree.mst.configuration.instances[instance].vlans is not none %}{{ spanning_tree.mst.configuration.instances[instance].vlans }} |
+{%                     endif %}
+{%                 endfor %}
+{%             endif %}
+{%         endif %}
+{%     endif %}
+
+{%     if spanning_tree.mode == "rapid-pvst" %}
+### Rapid-PVST Instance and Priority
+
+| Instance(s) | Priority |
+| -------- | -------- |
+{%         if spanning_tree.rapid_pvst_instances is defined and spanning_tree.rapid_pvst_instances is not none  %}
+{%             for vlan_id in spanning_tree.rapid_pvst_instances | arista.avd.natural_sort %}
+| {{ vlan_id }} | {% if spanning_tree.rapid_pvst_instances[vlan_id].priority is defined and spanning_tree.rapid_pvst_instances[vlan_id].priority is not none %} | {{ spanning_tree.rapid_pvst_instances[vlan_id].priority }} |
 {%                 endif %}
 {%             endfor %}
 {%         endif %}
+{%     endif %}
+
+### Global Spanning-Tree Settings
+
+{%     if spanning_tree.mode == "rstp" %}
+{%         if spanning_tree.rstp_priority is defined and spanning_tree.rstp_priority is not none  %}
+Global RSTP priority: {{ spanning_tree.rstp_priority }}
+{%         endif %}
+{%     endif %}
+{%     if spanning_tree.no_spanning_tree_vlan is defined %}
+Spanning Tree disabled for VLANs: **{{ spanning_tree.no_spanning_tree_vlan }}**
+{%     endif %}
+{%     if spanning_tree.edge_port.bpduguard_default is defined and spanning_tree.edge_port.bpduguard_default == true %}
+Global BPDU Guard for Edge ports is enabled.
 {%     endif %}
 
 ## Spanning Tree Device Configuration

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/spanning-tree.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/spanning-tree.j2
@@ -16,7 +16,7 @@ MST PSVT Border is enabled.
 | -------- | -------- |
 {%         if spanning_tree.mst_instances is defined and spanning_tree.mst_instances is not none %}
 {%            for mst_instance in spanning_tree.mst_instances | arista.avd.natural_sort %}
-| {{ mst_instance }} | {{ spanning_tree.mst_instances[mst_instance].priority }} |
+| {{ mst_instance }} | {{ spanning_tree.mst_instances[mst_instance].priority | arista.avd.default("-") }} |
 {%            endfor %}
 {%         endif %}
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/spanning-tree.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/spanning-tree.j2
@@ -3,12 +3,6 @@
 ## Spanning Tree Summary
 
 STP mode: **{{ spanning_tree.mode }}**
-{%     if spanning_tree.mode == "mstp" %}
-{%         if spanning_tree.mst is defined and spanning_tree.mst is not none %}
-{%             if spanning_tree.mst.pvst_border is defined and spanning_tree.mst.pvst_border == true %}
-MST PSVT Border is enabled.
-{%             endif %}
-{%         endif %}
 
 ### MSTP Instance and Priority
 
@@ -66,6 +60,12 @@ Spanning Tree disabled for VLANs: **{{ spanning_tree.no_spanning_tree_vlan }}**
 {%     if spanning_tree.edge_port.bpduguard_default is defined and spanning_tree.edge_port.bpduguard_default == true %}
 Global BPDU Guard for Edge ports is enabled.
 {%     endif %}
+{%     if spanning_tree.mode == "mstp" %}
+{%         if spanning_tree.mst is defined and spanning_tree.mst is not none %}
+{%             if spanning_tree.mst.pvst_border is defined and spanning_tree.mst.pvst_border == true %}
+MST PSVT Border is enabled.
+{%             endif %}
+{%         endif %}
 
 ## Spanning Tree Device Configuration
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/spanning-tree.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/spanning-tree.j2
@@ -15,6 +15,17 @@ spanning-tree mst {{ mst_instance }} priority {% if spanning_tree.mst_instances[
 {%                 endif %}
 {%             endfor %}
 {%         endif %}
+{%     elif spanning_tree.mode == "rapid-pvst" %}
+{%         if spanning_tree.rapid_pvst_instances is defined and spanning_tree.rapid_pvst_instances is not none  %}
+{%             for vlan_id in spanning_tree.rapid_pvst_instances | arista.avd.natural_sort %}
+spanning-tree vlan-id {{ vlan_id }} priority {% if spanning_tree.rapid_pvst_instances[vlan_id].priority is defined and spanning_tree.rapid_pvst_instances[vlan_id].priority is not none %}{{ spanning_tree.rapid_pvst_instances[vlan_id].priority }}
+{%                 endif %}
+{%             endfor %}
+{%         endif %}
+{%     else %}
+{%         if spanning_tree.rstp_priority is defined and spanning_tree.rstp_priority is not none  %}
+spanning-tree priority {{ spanning_tree.rstp_priority }}
+{%         endif %}
 {%     endif %}
 {%     if spanning_tree.mst is defined and spanning_tree.mst is not none %}
 {%         if spanning_tree.mst.pvst_border is defined and spanning_tree.mst.pvst_border == true %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/spanning-tree.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/spanning-tree.j2
@@ -11,14 +11,16 @@ no spanning-tree vlan-id {{ spanning_tree.no_spanning_tree_vlan }}
 {%     if spanning_tree.mode == "mstp" %}
 {%         if spanning_tree.mst_instances is defined and spanning_tree.mst_instances is not none  %}
 {%             for mst_instance in spanning_tree.mst_instances | arista.avd.natural_sort %}
-spanning-tree mst {{ mst_instance }} priority {% if spanning_tree.mst_instances[mst_instance].priority is defined and spanning_tree.mst_instances[mst_instance].priority is not none %}{{ spanning_tree.mst_instances[mst_instance].priority }}
+{%                 if spanning_tree.mst_instances[mst_instance].priority is defined and spanning_tree.mst_instances[mst_instance].priority is not none %}
+spanning-tree mst {{ mst_instance }} priority {{ spanning_tree.mst_instances[mst_instance].priority }}
 {%                 endif %}
 {%             endfor %}
 {%         endif %}
 {%     elif spanning_tree.mode == "rapid-pvst" %}
 {%         if spanning_tree.rapid_pvst_instances is defined and spanning_tree.rapid_pvst_instances is not none  %}
 {%             for vlan_id in spanning_tree.rapid_pvst_instances | arista.avd.natural_sort %}
-spanning-tree vlan-id {{ vlan_id }} priority {% if spanning_tree.rapid_pvst_instances[vlan_id].priority is defined and spanning_tree.rapid_pvst_instances[vlan_id].priority is not none %}{{ spanning_tree.rapid_pvst_instances[vlan_id].priority }}
+{%                 if spanning_tree.rapid_pvst_instances[vlan_id].priority is defined and spanning_tree.rapid_pvst_instances[vlan_id].priority is not none %}
+spanning-tree vlan-id {{ vlan_id }} priority {{ spanning_tree.rapid_pvst_instances[vlan_id].priority }}
 {%                 endif %}
 {%             endfor %}
 {%         endif %}
@@ -42,7 +44,8 @@ spanning-tree mst configuration
 {%             endif %}
 {%             if spanning_tree.mst.configuration.instances is defined and spanning_tree.configuration.instances is not none %}
 {%                 for instance in spanning_tree.mst.configuration.instances | arista.avd.natural_sort %}
-   instance {{ instance }} vlan {% if spanning_tree.mst.configuration.instances[instance].vlans is defined and spanning_tree.mst.configuration.instances[instance].vlans is not none %}{{ spanning_tree.mst.configuration.instances[instance].vlans }}
+{%                     if spanning_tree.mst.configuration.instances[instance].vlans is defined and spanning_tree.mst.configuration.instances[instance].vlans is not none %}
+   instance {{ instance }} vlan {{ spanning_tree.mst.configuration.instances[instance].vlans }}
 {%                     endif %}
 {%                 endfor %}
 {%             endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/spanning-tree.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/spanning-tree.j2
@@ -9,6 +9,32 @@ spanning-tree mode {{ spanning_tree.mode }}
 no spanning-tree vlan-id {{ spanning_tree.no_spanning_tree_vlan }}
 {%     endif %}
 {%     if spanning_tree.mode == "mstp" %}
-spanning-tree mst 0 priority {{ spanning_tree.priority }}
+{%         if spanning_tree.mst_instances is defined and spanning_tree.mst_instances is not none  %}
+{%             for mst_instance in spanning_tree.mst_instances | arista.avd.natural_sort %}
+spanning-tree mst {{ mst_instance }} priority {% if spanning_tree.mst_instances[mst_instance].priority is defined and spanning_tree.mst_instances[mst_instance].priority is not none %}{{ spanning_tree.mst_instances[mst_instance].priority }}
+{%                 endif %}
+{%             endfor %}
+{%         endif %}
+{%     endif %}
+{%     if spanning_tree.mst is defined and spanning_tree.mst is not none %}
+{%         if spanning_tree.mst.pvst_border is defined and spanning_tree.mst.pvst_border == true %}
+spanning-tree mst pvst border
+{%         endif %}
+{%         if spanning_tree.mst.configuration is defined and spanning_tree.configuration is not none %}
+!
+spanning-tree mst configuration
+{%             if spanning_tree.mst.configuration.name is defined and spanning_tree.configuration.name is not none %}
+   name {{ spanning_tree.mst.configuration.name }}
+{%             endif %}
+{%             if spanning_tree.mst.configuration.revision is defined and spanning_tree.configuration.revision is not none %}
+   revision {{ spanning_tree.mst.configuration.revision }}
+{%             endif %}
+{%             if spanning_tree.mst.configuration.instances is defined and spanning_tree.configuration.instances is not none %}
+{%                 for instance in spanning_tree.mst.configuration.instances | arista.avd.natural_sort %}
+   instance {{ instance }} vlan {% if spanning_tree.mst.configuration.instances[instance].vlans is defined and spanning_tree.mst.configuration.instances[instance].vlans is not none %}{{ spanning_tree.mst.configuration.instances[instance].vlans }}
+{%                     endif %}
+{%                 endfor %}
+{%             endif %}
+{%         endif %}
 {%     endif %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
@@ -584,11 +584,11 @@ l3leaf:
       # MLAG interfaces (list) | Required when MLAG leafs present in topology.
       mlag_interfaces: [ < ethernet_interface_3 >, < ethernet_interface_4 >]
 
-      # Spanning tree mode (note - only mstp has been validated at this time) | Required.
-      spanning_tree_mode: < mstp >
+      # Spanning tree mode | Required.
+      spanning_tree_mode: < mstp | rstp | rapid-pvst | none >
 
-      # Spanning tree priority | Required.
-      spanning_tree_priority: < spanning-tree priority >
+      # Spanning tree priority.
+      spanning_tree_priority: < spanning-tree priority -> default 32768 >
 
       # Virtual router mac address for anycast gateway | Required.
       virtual_router_mac_address: < mac address >

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/base/spanning-tree.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/base/spanning-tree.j2
@@ -1,7 +1,15 @@
 {# spanning-tree #}
-{% if switch.spanning_tree_mode is defined %}
+{% if switch.spanning_tree_mode is arista.avd.defined %}
   mode: {{ switch.spanning_tree_mode }}
-{% endif %}
-{% if switch.spanning_tree_priority is defined %}
-  priority: {{ switch.spanning_tree_priority }}
+{%     if switch.spanning_tree_mode == "mstp" %}
+  mst_instances:
+    0:
+      priority: {{ switch.spanning_tree_priority | arista.avd.default("32768") }}
+{%     elif switch.spanning_tree_mode == "rapid-pvst" %}
+  rapid_pvst_instances:
+    "1-4094":
+      priority: {{ switch.spanning_tree_priority | arista.avd.default("32768") }}
+{%     elif switch.spanning_tree_mode == "rstp" %}
+  rstp_priority: {{ switch.spanning_tree_priority | arista.avd.default("32768") }}
+{%     endif %}
 {% endif %}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
This helps us add new knobs to STP including per instance priority, support for PVST border, MST config section etc.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [x] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes #493 
Fixes #277 

## Component(s) name
eos_cli_config_gen

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Molecule and hardware


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
