### PR TITLE
Fixed the jinja comment in the router isis template

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-isis.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-isis.j2
@@ -1,4 +1,4 @@
-{# eos - router ospf #}
+{# eos - router isis #}
 {% if router_isis is defined and router_isis is not none %}
 router isis {{ router_isis.instance }}
    net {{ router_isis.net }}


### PR DESCRIPTION
## Change Summary

Fixed the jinja comment in the router isis template. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [x] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
#520 

## Component(s) name

eos_cli_config_gen role 
router-isis.j2 eos template  

## Proposed changes

was {# eos - router ospf #}  
updated it to {# eos - router isis #}   

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
