### PR TITLE
bgp: ipv6: fix rendering of prefix-lists to mirror ipv4 behavior

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ipv6-prefix-lists.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ipv6-prefix-lists.j2
@@ -1,5 +1,5 @@
 {# eos - prefix-lists #}
-{% if ipv6_prefix_lists is defined %}
+{% if ipv6_prefix_lists is defined and ipv6_prefix_lists is not none %}
 {%     for ipv6_prefix_list in ipv6_prefix_lists | arista.avd.natural_sort %}
 !
 ipv6 prefix-list {{ ipv6_prefix_list }}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Adjust the Jinja2 BGP prefix-list template to not only check if the `ipv6_prefix_lists` key is defined but also that it contains valid data.

This fix mirrors the behavior of the IPv4 prefix-lists.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

## Component(s) name
- eos_cli_config_gen
  - ipv6 prefix-list

## Proposed changes
<!--- Describe your changes in detail -->
Adjust the Jinja2 BGP prefix-list template to not only check if the `ipv6_prefix_lists` key is defined but also that it contains valid data.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Use an empty `ipv6_prefix_lists:`
```
ipv6_prefix_lists:
{% include 'routing/prefix-lists-ipv6.j2' %}
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
