### PR TITLE
BUGFIX: No VRF loopback when evpn_services_l2_only is true

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-vrf-loopbacks.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-vrf-loopbacks.j2
@@ -1,5 +1,5 @@
 {# Leaf Tenant vrf loopback interfaces for VTEP diagnostic #}
-{% for tenant in tenants | arista.avd.natural_sort if tenant in leaf.filter_tenants or "all" in leaf.filter_tenants %}
+{% for tenant in tenants | arista.avd.natural_sort if ( tenant in leaf.filter_tenants or "all" in leaf.filter_tenants ) and leaf.evpn_services_l2_only == false %}
 {%     if tenants[tenant].vrfs is defined %}
 {%         for vrf in tenants[tenant].vrfs | arista.avd.natural_sort if leaf.vrfs is not none and vrf in leaf.vrfs %}
 {%             if tenants[tenant].vrfs[vrf].vtep_diagnostic is defined %}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Prevent creation of VRF loopbacks (VTEP Diagnostic interface) when `evpn_services_l2_only : true`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

## Component(s) name
eos_l3ls_evpn

## Proposed changes
<!--- Describe your changes in detail -->
Add extra condition in template `leaf-tenant-vrf-loopbacks`.

Using the same condition as in the other tenant templates.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Tested with claus-l3ls-dev branch superspine-alternative.

After fix it removed VRF loopback from DC1-POD1-LEAF2A/2B

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
