### PR TITLE
svi and l2vlan keys to check and tested as int

### DIFF
--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -887,6 +892,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -887,6 +892,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF1A.md
@@ -335,6 +335,8 @@ vlan internal order ascending range 1006 1199
 | 121 | Tenant_A_WEBZone_2 | none  |
 | 130 | Tenant_A_APP_Zone_1 | none  |
 | 131 | Tenant_A_APP_Zone_2 | none  |
+| 160 | Tenant_A_VMOTION | none  |
+| 161 | Tenant_A_NFS | none  |
 
 ## VLANs Device Configuration
 
@@ -357,6 +359,12 @@ vlan 130
 !
 vlan 131
    name Tenant_A_APP_Zone_2
+!
+vlan 160
+   name Tenant_A_VMOTION
+!
+vlan 161
+   name Tenant_A_NFS
 ```
 
 # Interfaces
@@ -369,8 +377,8 @@ vlan 131
 
 | Interface | Description | Mode | VLANs | Native VLAN | Trunk Group | Channel-Group |
 | --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
-| Ethernet1 | DC1-LEAF2A_Ethernet7 | *trunk | *110-111,120-121,130-131 | *- | *- | 1 |
-| Ethernet2 | DC1-LEAF2B_Ethernet7 | *trunk | *110-111,120-121,130-131 | *- | *- | 1 |
+| Ethernet1 | DC1-LEAF2A_Ethernet7 | *trunk | *110-111,120-121,130-131,160-161 | *- | *- | 1 |
+| Ethernet2 | DC1-LEAF2B_Ethernet7 | *trunk | *110-111,120-121,130-131,160-161 | *- | *- | 1 |
 
 *Inherited from Port-Channel Interface
 
@@ -395,7 +403,7 @@ interface Ethernet2
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel1 | DC1-LEAF2A_Po7 | switched | access | 110-111,120-121,130-131 | - | - | - | - | 1 | - |
+| Port-Channel1 | DC1-LEAF2A_Po7 | switched | access | 110-111,120-121,130-131,160-161 | - | - | - | - | 1 | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -403,7 +411,7 @@ interface Ethernet2
 !
 interface Port-Channel1
    description DC1-LEAF2A_Po7
-   switchport trunk allowed vlan 110-111,120-121,130-131
+   switchport trunk allowed vlan 110-111,120-121,130-131,160-161
    switchport mode trunk
    mlag 1
 ```

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF1A.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -600,6 +605,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF2A.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -702,6 +707,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF2A.md
@@ -360,6 +360,8 @@ vlan internal order ascending range 1006 1199
 | 140 | Tenant_A_DB_BZone_1 | none  |
 | 141 | Tenant_A_DB_Zone_2 | none  |
 | 150 | Tenant_A_WAN_Zone_1 | none  |
+| 160 | Tenant_A_VMOTION | none  |
+| 161 | Tenant_A_NFS | none  |
 | 210 | Tenant_B_OP_Zone_1 | none  |
 | 211 | Tenant_B_OP_Zone_2 | none  |
 | 250 | Tenant_B_WAN_Zone_1 | none  |
@@ -399,6 +401,12 @@ vlan 141
 vlan 150
    name Tenant_A_WAN_Zone_1
 !
+vlan 160
+   name Tenant_A_VMOTION
+!
+vlan 161
+   name Tenant_A_NFS
+!
 vlan 210
    name Tenant_B_OP_Zone_1
 !
@@ -432,8 +440,8 @@ vlan 4094
 
 | Interface | Description | Mode | VLANs | Native VLAN | Trunk Group | Channel-Group |
 | --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
-| Ethernet1 | DC1-SVC3A_Ethernet7 | *trunk | *110-111,120-121,130-131,140-141,150,210-211,250,310-311,350 | *- | *- | 1 |
-| Ethernet2 | DC1-SVC3B_Ethernet7 | *trunk | *110-111,120-121,130-131,140-141,150,210-211,250,310-311,350 | *- | *- | 1 |
+| Ethernet1 | DC1-SVC3A_Ethernet7 | *trunk | *110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350 | *- | *- | 1 |
+| Ethernet2 | DC1-SVC3B_Ethernet7 | *trunk | *110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350 | *- | *- | 1 |
 | Ethernet3 | MLAG_PEER_DC1-L2LEAF2B_Ethernet3 | *trunk | *2-4094 | *- | *['MLAG'] | 3 |
 | Ethernet4 | MLAG_PEER_DC1-L2LEAF2B_Ethernet4 | *trunk | *2-4094 | *- | *['MLAG'] | 3 |
 
@@ -468,7 +476,7 @@ interface Ethernet4
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel1 | DC1-SVC3A_Po7 | switched | access | 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350 | - | - | - | - | 1 | - |
+| Port-Channel1 | DC1-SVC3A_Po7 | switched | access | 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350 | - | - | - | - | 1 | - |
 | Port-Channel3 | MLAG_PEER_DC1-L2LEAF2B_Po3 | switched | access | 2-4094 | - | ['MLAG'] | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
@@ -477,7 +485,7 @@ interface Ethernet4
 !
 interface Port-Channel1
    description DC1-SVC3A_Po7
-   switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350
+   switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350
    switchport mode trunk
    mlag 1
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF2B.md
@@ -360,6 +360,8 @@ vlan internal order ascending range 1006 1199
 | 140 | Tenant_A_DB_BZone_1 | none  |
 | 141 | Tenant_A_DB_Zone_2 | none  |
 | 150 | Tenant_A_WAN_Zone_1 | none  |
+| 160 | Tenant_A_VMOTION | none  |
+| 161 | Tenant_A_NFS | none  |
 | 210 | Tenant_B_OP_Zone_1 | none  |
 | 211 | Tenant_B_OP_Zone_2 | none  |
 | 250 | Tenant_B_WAN_Zone_1 | none  |
@@ -399,6 +401,12 @@ vlan 141
 vlan 150
    name Tenant_A_WAN_Zone_1
 !
+vlan 160
+   name Tenant_A_VMOTION
+!
+vlan 161
+   name Tenant_A_NFS
+!
 vlan 210
    name Tenant_B_OP_Zone_1
 !
@@ -432,8 +440,8 @@ vlan 4094
 
 | Interface | Description | Mode | VLANs | Native VLAN | Trunk Group | Channel-Group |
 | --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
-| Ethernet1 | DC1-SVC3A_Ethernet8 | *trunk | *110-111,120-121,130-131,140-141,150,210-211,250,310-311,350 | *- | *- | 1 |
-| Ethernet2 | DC1-SVC3B_Ethernet8 | *trunk | *110-111,120-121,130-131,140-141,150,210-211,250,310-311,350 | *- | *- | 1 |
+| Ethernet1 | DC1-SVC3A_Ethernet8 | *trunk | *110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350 | *- | *- | 1 |
+| Ethernet2 | DC1-SVC3B_Ethernet8 | *trunk | *110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350 | *- | *- | 1 |
 | Ethernet3 | MLAG_PEER_DC1-L2LEAF2A_Ethernet3 | *trunk | *2-4094 | *- | *['MLAG'] | 3 |
 | Ethernet4 | MLAG_PEER_DC1-L2LEAF2A_Ethernet4 | *trunk | *2-4094 | *- | *['MLAG'] | 3 |
 
@@ -468,7 +476,7 @@ interface Ethernet4
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel1 | DC1-SVC3B_Po7 | switched | access | 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350 | - | - | - | - | 1 | - |
+| Port-Channel1 | DC1-SVC3B_Po7 | switched | access | 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350 | - | - | - | - | 1 | - |
 | Port-Channel3 | MLAG_PEER_DC1-L2LEAF2A_Po3 | switched | access | 2-4094 | - | ['MLAG'] | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
@@ -477,7 +485,7 @@ interface Ethernet4
 !
 interface Port-Channel1
    description DC1-SVC3B_Po7
-   switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350
+   switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350
    switchport mode trunk
    mlag 1
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF2B.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -702,6 +707,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -903,6 +908,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -1297,6 +1302,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -359,6 +359,8 @@ vlan internal order ascending range 1006 1199
 | 131 | Tenant_A_APP_Zone_2 | none  |
 | 140 | Tenant_A_DB_BZone_1 | none  |
 | 141 | Tenant_A_DB_Zone_2 | none  |
+| 160 | Tenant_A_VMOTION | none  |
+| 161 | Tenant_A_NFS | none  |
 | 210 | Tenant_B_OP_Zone_1 | none  |
 | 211 | Tenant_B_OP_Zone_2 | none  |
 | 310 | Tenant_C_OP_Zone_1 | none  |
@@ -399,6 +401,12 @@ vlan 140
 !
 vlan 141
    name Tenant_A_DB_Zone_2
+!
+vlan 160
+   name Tenant_A_VMOTION
+!
+vlan 161
+   name Tenant_A_NFS
 !
 vlan 210
    name Tenant_B_OP_Zone_1
@@ -457,7 +465,7 @@ vlan 4094
 | --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
 | Ethernet5 | MLAG_PEER_DC1-LEAF2B_Ethernet5 | *trunk | *2-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 5 |
 | Ethernet6 | MLAG_PEER_DC1-LEAF2B_Ethernet6 | *trunk | *2-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 5 |
-| Ethernet7 | DC1-L2LEAF1A_Ethernet1 | *trunk | *110-111,120-121,130-131 | *- | *- | 7 |
+| Ethernet7 | DC1-L2LEAF1A_Ethernet1 | *trunk | *110-111,120-121,130-131,160-161 | *- | *- | 7 |
 | Ethernet10 | server01_MLAG_Eth2 | *trunk | *210-211 | *- | *- | 10 |
 
 *Inherited from Port-Channel Interface
@@ -521,7 +529,7 @@ interface Ethernet10
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
 | Port-Channel5 | MLAG_PEER_DC1-LEAF2B_Po5 | switched | access | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
-| Port-Channel7 | DC1_L2LEAF1_Po1 | switched | access | 110-111,120-121,130-131 | - | - | - | - | 7 | - |
+| Port-Channel7 | DC1_L2LEAF1_Po1 | switched | access | 110-111,120-121,130-131,160-161 | - | - | - | - | 7 | - |
 | Port-Channel10 | server01_MLAG_PortChanne1 | switched | access | 210-211 | - | - | - | - | 10 | - |
 
 ### Port-Channel Interfaces Device Configuration
@@ -537,7 +545,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF1_Po1
-   switchport trunk allowed vlan 110-111,120-121,130-131
+   switchport trunk allowed vlan 110-111,120-121,130-131,160-161
    switchport mode trunk
    mlag 7
 !
@@ -769,6 +777,8 @@ interface Vlan4094
 | 131 | 10131 |
 | 140 | 10140 |
 | 141 | 10141 |
+| 160 | 10160 |
+| 161 | 10161 |
 | 210 | 20210 |
 | 211 | 20211 |
 | 310 | 30310 |
@@ -801,6 +811,8 @@ interface Vxlan1
    vxlan vlan 131 vni 10131
    vxlan vlan 140 vni 10140
    vxlan vlan 141 vni 10141
+   vxlan vlan 160 vni 10160
+   vxlan vlan 161 vni 10161
    vxlan vlan 210 vni 20210
    vxlan vlan 211 vni 20211
    vxlan vlan 310 vni 30310
@@ -970,7 +982,9 @@ Router ISIS not defined
 | ----------------- | ------------------- | ----------------- | ------------------- | ------------------- | ------------ | ----- |
 | Tenant_A_APP_Zone | 192.168.255.6:12 |  12:12  |  |  | learned | 130-131 |
 | Tenant_A_DB_Zone | 192.168.255.6:13 |  13:13  |  |  | learned | 140-141 |
+| Tenant_A_NFS | 192.168.255.6:10161 |  10161:10161  |  |  | learned | 161 |
 | Tenant_A_OP_Zone | 192.168.255.6:10 |  10:10  |  |  | learned | 110-111 |
+| Tenant_A_VMOTION | 192.168.255.6:10160 |  10160:10160  |  |  | learned | 160 |
 | Tenant_A_WEB_Zone | 192.168.255.6:11 |  11:11  |  |  | learned | 120-121 |
 | Tenant_B_OP_Zone | 192.168.255.6:20 |  20:20  |  |  | learned | 210-211 |
 | Tenant_C_OP_Zone | 192.168.255.6:30 |  30:30  |  |  | learned | 310-311 |
@@ -1037,11 +1051,23 @@ router bgp 65102
       redistribute learned
       vlan 140-141
    !
+   vlan-aware-bundle Tenant_A_NFS
+      rd 192.168.255.6:10161
+      route-target both 10161:10161
+      redistribute learned
+      vlan 161
+   !
    vlan-aware-bundle Tenant_A_OP_Zone
       rd 192.168.255.6:10
       route-target both 10:10
       redistribute learned
       vlan 110-111
+   !
+   vlan-aware-bundle Tenant_A_VMOTION
+      rd 192.168.255.6:10160
+      route-target both 10160:10160
+      redistribute learned
+      vlan 160
    !
    vlan-aware-bundle Tenant_A_WEB_Zone
       rd 192.168.255.6:11

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -1297,6 +1302,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -359,6 +359,8 @@ vlan internal order ascending range 1006 1199
 | 131 | Tenant_A_APP_Zone_2 | none  |
 | 140 | Tenant_A_DB_BZone_1 | none  |
 | 141 | Tenant_A_DB_Zone_2 | none  |
+| 160 | Tenant_A_VMOTION | none  |
+| 161 | Tenant_A_NFS | none  |
 | 210 | Tenant_B_OP_Zone_1 | none  |
 | 211 | Tenant_B_OP_Zone_2 | none  |
 | 310 | Tenant_C_OP_Zone_1 | none  |
@@ -399,6 +401,12 @@ vlan 140
 !
 vlan 141
    name Tenant_A_DB_Zone_2
+!
+vlan 160
+   name Tenant_A_VMOTION
+!
+vlan 161
+   name Tenant_A_NFS
 !
 vlan 210
    name Tenant_B_OP_Zone_1
@@ -457,7 +465,7 @@ vlan 4094
 | --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
 | Ethernet5 | MLAG_PEER_DC1-LEAF2A_Ethernet5 | *trunk | *2-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 5 |
 | Ethernet6 | MLAG_PEER_DC1-LEAF2A_Ethernet6 | *trunk | *2-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 5 |
-| Ethernet7 | DC1-L2LEAF1A_Ethernet2 | *trunk | *110-111,120-121,130-131 | *- | *- | 7 |
+| Ethernet7 | DC1-L2LEAF1A_Ethernet2 | *trunk | *110-111,120-121,130-131,160-161 | *- | *- | 7 |
 | Ethernet10 | server01_MLAG_Eth3 | *trunk | *210-211 | *- | *- | 10 |
 
 *Inherited from Port-Channel Interface
@@ -521,7 +529,7 @@ interface Ethernet10
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
 | Port-Channel5 | MLAG_PEER_DC1-LEAF2A_Po5 | switched | access | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
-| Port-Channel7 | DC1_L2LEAF1_Po1 | switched | access | 110-111,120-121,130-131 | - | - | - | - | 7 | - |
+| Port-Channel7 | DC1_L2LEAF1_Po1 | switched | access | 110-111,120-121,130-131,160-161 | - | - | - | - | 7 | - |
 | Port-Channel10 | server01_MLAG_PortChanne1 | switched | access | 210-211 | - | - | - | - | 10 | - |
 
 ### Port-Channel Interfaces Device Configuration
@@ -537,7 +545,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF1_Po1
-   switchport trunk allowed vlan 110-111,120-121,130-131
+   switchport trunk allowed vlan 110-111,120-121,130-131,160-161
    switchport mode trunk
    mlag 7
 !
@@ -769,6 +777,8 @@ interface Vlan4094
 | 131 | 10131 |
 | 140 | 10140 |
 | 141 | 10141 |
+| 160 | 10160 |
+| 161 | 10161 |
 | 210 | 20210 |
 | 211 | 20211 |
 | 310 | 30310 |
@@ -801,6 +811,8 @@ interface Vxlan1
    vxlan vlan 131 vni 10131
    vxlan vlan 140 vni 10140
    vxlan vlan 141 vni 10141
+   vxlan vlan 160 vni 10160
+   vxlan vlan 161 vni 10161
    vxlan vlan 210 vni 20210
    vxlan vlan 211 vni 20211
    vxlan vlan 310 vni 30310
@@ -970,7 +982,9 @@ Router ISIS not defined
 | ----------------- | ------------------- | ----------------- | ------------------- | ------------------- | ------------ | ----- |
 | Tenant_A_APP_Zone | 192.168.255.7:12 |  12:12  |  |  | learned | 130-131 |
 | Tenant_A_DB_Zone | 192.168.255.7:13 |  13:13  |  |  | learned | 140-141 |
+| Tenant_A_NFS | 192.168.255.7:10161 |  10161:10161  |  |  | learned | 161 |
 | Tenant_A_OP_Zone | 192.168.255.7:10 |  10:10  |  |  | learned | 110-111 |
+| Tenant_A_VMOTION | 192.168.255.7:10160 |  10160:10160  |  |  | learned | 160 |
 | Tenant_A_WEB_Zone | 192.168.255.7:11 |  11:11  |  |  | learned | 120-121 |
 | Tenant_B_OP_Zone | 192.168.255.7:20 |  20:20  |  |  | learned | 210-211 |
 | Tenant_C_OP_Zone | 192.168.255.7:30 |  30:30  |  |  | learned | 310-311 |
@@ -1037,11 +1051,23 @@ router bgp 65102
       redistribute learned
       vlan 140-141
    !
+   vlan-aware-bundle Tenant_A_NFS
+      rd 192.168.255.7:10161
+      route-target both 10161:10161
+      redistribute learned
+      vlan 161
+   !
    vlan-aware-bundle Tenant_A_OP_Zone
       rd 192.168.255.7:10
       route-target both 10:10
       redistribute learned
       vlan 110-111
+   !
+   vlan-aware-bundle Tenant_A_VMOTION
+      rd 192.168.255.7:10160
+      route-target both 10160:10160
+      redistribute learned
+      vlan 160
    !
    vlan-aware-bundle Tenant_A_WEB_Zone
       rd 192.168.255.7:11

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE1.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -731,6 +736,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE2.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -731,6 +736,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE3.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -731,6 +736,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE4.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -731,6 +736,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -360,6 +360,8 @@ vlan internal order ascending range 1006 1199
 | 140 | Tenant_A_DB_BZone_1 | none  |
 | 141 | Tenant_A_DB_Zone_2 | none  |
 | 150 | Tenant_A_WAN_Zone_1 | none  |
+| 160 | Tenant_A_VMOTION | none  |
+| 161 | Tenant_A_NFS | none  |
 | 210 | Tenant_B_OP_Zone_1 | none  |
 | 211 | Tenant_B_OP_Zone_2 | none  |
 | 250 | Tenant_B_WAN_Zone_1 | none  |
@@ -408,6 +410,12 @@ vlan 141
 !
 vlan 150
    name Tenant_A_WAN_Zone_1
+!
+vlan 160
+   name Tenant_A_VMOTION
+!
+vlan 161
+   name Tenant_A_NFS
 !
 vlan 210
    name Tenant_B_OP_Zone_1
@@ -484,8 +492,8 @@ vlan 4094
 | --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
 | Ethernet5 | MLAG_PEER_DC1-SVC3B_Ethernet5 | *trunk | *2-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 5 |
 | Ethernet6 | MLAG_PEER_DC1-SVC3B_Ethernet6 | *trunk | *2-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 5 |
-| Ethernet7 | DC1-L2LEAF2A_Ethernet1 | *trunk | *110-111,120-121,130-131,140-141,150,210-211,250,310-311,350 | *- | *- | 7 |
-| Ethernet8 | DC1-L2LEAF2B_Ethernet1 | *trunk | *110-111,120-121,130-131,140-141,150,210-211,250,310-311,350 | *- | *- | 7 |
+| Ethernet7 | DC1-L2LEAF2A_Ethernet1 | *trunk | *110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350 | *- | *- | 7 |
+| Ethernet8 | DC1-L2LEAF2B_Ethernet1 | *trunk | *110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350 | *- | *- | 7 |
 | Ethernet10 | server03_ESI_Eth1 | *trunk | *110-111,210-211 | *- | *- | 10 |
 
 *Inherited from Port-Channel Interface
@@ -553,7 +561,7 @@ interface Ethernet10
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
 | Port-Channel5 | MLAG_PEER_DC1-SVC3B_Po5 | switched | access | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
-| Port-Channel7 | DC1_L2LEAF2_Po1 | switched | access | 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350 | - | - | - | - | 7 | - |
+| Port-Channel7 | DC1_L2LEAF2_Po1 | switched | access | 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350 | - | - | - | - | 7 | - |
 | Port-Channel10 | server03_ESI_PortChanne1 | switched | access | 110-111,210-211 | - | - | - | - | 10 | - |
 
 ### Port-Channel Interfaces Device Configuration
@@ -569,7 +577,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF2_Po1
-   switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350
+   switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350
    switchport mode trunk
    mlag 7
 !
@@ -844,6 +852,8 @@ interface Vlan4094
 | 140 | 10140 |
 | 141 | 10141 |
 | 150 | 10150 |
+| 160 | 10160 |
+| 161 | 10161 |
 | 210 | 20210 |
 | 211 | 20211 |
 | 250 | 20250 |
@@ -882,6 +892,8 @@ interface Vxlan1
    vxlan vlan 140 vni 10140
    vxlan vlan 141 vni 10141
    vxlan vlan 150 vni 10150
+   vxlan vlan 160 vni 10160
+   vxlan vlan 161 vni 10161
    vxlan vlan 210 vni 20210
    vxlan vlan 211 vni 20211
    vxlan vlan 250 vni 20250
@@ -1065,7 +1077,9 @@ Router ISIS not defined
 | ----------------- | ------------------- | ----------------- | ------------------- | ------------------- | ------------ | ----- |
 | Tenant_A_APP_Zone | 192.168.255.8:12 |  12:12  |  |  | learned | 130-131 |
 | Tenant_A_DB_Zone | 192.168.255.8:13 |  13:13  |  |  | learned | 140-141 |
+| Tenant_A_NFS | 192.168.255.8:10161 |  10161:10161  |  |  | learned | 161 |
 | Tenant_A_OP_Zone | 192.168.255.8:10 |  10:10  |  |  | learned | 110-111 |
+| Tenant_A_VMOTION | 192.168.255.8:10160 |  10160:10160  |  |  | learned | 160 |
 | Tenant_A_WAN_Zone | 192.168.255.8:14 |  14:14  |  |  | learned | 150 |
 | Tenant_A_WEB_Zone | 192.168.255.8:11 |  11:11  |  |  | learned | 120-121 |
 | Tenant_B_OP_Zone | 192.168.255.8:20 |  20:20  |  |  | learned | 210-211 |
@@ -1138,11 +1152,23 @@ router bgp 65103
       redistribute learned
       vlan 140-141
    !
+   vlan-aware-bundle Tenant_A_NFS
+      rd 192.168.255.8:10161
+      route-target both 10161:10161
+      redistribute learned
+      vlan 161
+   !
    vlan-aware-bundle Tenant_A_OP_Zone
       rd 192.168.255.8:10
       route-target both 10:10
       redistribute learned
       vlan 110-111
+   !
+   vlan-aware-bundle Tenant_A_VMOTION
+      rd 192.168.255.8:10160
+      route-target both 10160:10160
+      redistribute learned
+      vlan 160
    !
    vlan-aware-bundle Tenant_A_WAN_Zone
       rd 192.168.255.8:14

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -1449,6 +1454,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -1437,6 +1442,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -360,6 +360,8 @@ vlan internal order ascending range 1006 1199
 | 140 | Tenant_A_DB_BZone_1 | none  |
 | 141 | Tenant_A_DB_Zone_2 | none  |
 | 150 | Tenant_A_WAN_Zone_1 | none  |
+| 160 | Tenant_A_VMOTION | none  |
+| 161 | Tenant_A_NFS | none  |
 | 210 | Tenant_B_OP_Zone_1 | none  |
 | 211 | Tenant_B_OP_Zone_2 | none  |
 | 250 | Tenant_B_WAN_Zone_1 | none  |
@@ -408,6 +410,12 @@ vlan 141
 !
 vlan 150
    name Tenant_A_WAN_Zone_1
+!
+vlan 160
+   name Tenant_A_VMOTION
+!
+vlan 161
+   name Tenant_A_NFS
 !
 vlan 210
    name Tenant_B_OP_Zone_1
@@ -484,8 +492,8 @@ vlan 4094
 | --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
 | Ethernet5 | MLAG_PEER_DC1-SVC3A_Ethernet5 | *trunk | *2-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 5 |
 | Ethernet6 | MLAG_PEER_DC1-SVC3A_Ethernet6 | *trunk | *2-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 5 |
-| Ethernet7 | DC1-L2LEAF2A_Ethernet2 | *trunk | *110-111,120-121,130-131,140-141,150,210-211,250,310-311,350 | *- | *- | 7 |
-| Ethernet8 | DC1-L2LEAF2B_Ethernet2 | *trunk | *110-111,120-121,130-131,140-141,150,210-211,250,310-311,350 | *- | *- | 7 |
+| Ethernet7 | DC1-L2LEAF2A_Ethernet2 | *trunk | *110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350 | *- | *- | 7 |
+| Ethernet8 | DC1-L2LEAF2B_Ethernet2 | *trunk | *110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350 | *- | *- | 7 |
 
 *Inherited from Port-Channel Interface
 
@@ -548,7 +556,7 @@ interface Ethernet8
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
 | Port-Channel5 | MLAG_PEER_DC1-SVC3A_Po5 | switched | access | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
-| Port-Channel7 | DC1_L2LEAF2_Po1 | switched | access | 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350 | - | - | - | - | 7 | - |
+| Port-Channel7 | DC1_L2LEAF2_Po1 | switched | access | 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350 | - | - | - | - | 7 | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -563,7 +571,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF2_Po1
-   switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350
+   switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350
    switchport mode trunk
    mlag 7
 ```
@@ -832,6 +840,8 @@ interface Vlan4094
 | 140 | 10140 |
 | 141 | 10141 |
 | 150 | 10150 |
+| 160 | 10160 |
+| 161 | 10161 |
 | 210 | 20210 |
 | 211 | 20211 |
 | 250 | 20250 |
@@ -870,6 +880,8 @@ interface Vxlan1
    vxlan vlan 140 vni 10140
    vxlan vlan 141 vni 10141
    vxlan vlan 150 vni 10150
+   vxlan vlan 160 vni 10160
+   vxlan vlan 161 vni 10161
    vxlan vlan 210 vni 20210
    vxlan vlan 211 vni 20211
    vxlan vlan 250 vni 20250
@@ -1053,7 +1065,9 @@ Router ISIS not defined
 | ----------------- | ------------------- | ----------------- | ------------------- | ------------------- | ------------ | ----- |
 | Tenant_A_APP_Zone | 192.168.255.9:12 |  12:12  |  |  | learned | 130-131 |
 | Tenant_A_DB_Zone | 192.168.255.9:13 |  13:13  |  |  | learned | 140-141 |
+| Tenant_A_NFS | 192.168.255.9:10161 |  10161:10161  |  |  | learned | 161 |
 | Tenant_A_OP_Zone | 192.168.255.9:10 |  10:10  |  |  | learned | 110-111 |
+| Tenant_A_VMOTION | 192.168.255.9:10160 |  10160:10160  |  |  | learned | 160 |
 | Tenant_A_WAN_Zone | 192.168.255.9:14 |  14:14  |  |  | learned | 150 |
 | Tenant_A_WEB_Zone | 192.168.255.9:11 |  11:11  |  |  | learned | 120-121 |
 | Tenant_B_OP_Zone | 192.168.255.9:20 |  20:20  |  |  | learned | 210-211 |
@@ -1126,11 +1140,23 @@ router bgp 65103
       redistribute learned
       vlan 140-141
    !
+   vlan-aware-bundle Tenant_A_NFS
+      rd 192.168.255.9:10161
+      route-target both 10161:10161
+      redistribute learned
+      vlan 161
+   !
    vlan-aware-bundle Tenant_A_OP_Zone
       rd 192.168.255.9:10
       route-target both 10:10
       redistribute learned
       vlan 110-111
+   !
+   vlan-aware-bundle Tenant_A_VMOTION
+      rd 192.168.255.9:10160
+      route-target both 10160:10160
+      redistribute learned
+      vlan 160
    !
    vlan-aware-bundle Tenant_A_WAN_Zone
       rd 192.168.255.9:14

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF1A.cfg
@@ -45,11 +45,17 @@ vlan 130
 vlan 131
    name Tenant_A_APP_Zone_2
 !
+vlan 160
+   name Tenant_A_VMOTION
+!
+vlan 161
+   name Tenant_A_NFS
+!
 vrf instance MGMT
 !
 interface Port-Channel1
    description DC1-LEAF2A_Po7
-   switchport trunk allowed vlan 110-111,120-121,130-131
+   switchport trunk allowed vlan 110-111,120-121,130-131,160-161
    switchport mode trunk
    mlag 1
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF2A.cfg
@@ -55,6 +55,12 @@ vlan 141
 vlan 150
    name Tenant_A_WAN_Zone_1
 !
+vlan 160
+   name Tenant_A_VMOTION
+!
+vlan 161
+   name Tenant_A_NFS
+!
 vlan 210
    name Tenant_B_OP_Zone_1
 !
@@ -81,7 +87,7 @@ vrf instance MGMT
 !
 interface Port-Channel1
    description DC1-SVC3A_Po7
-   switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350
+   switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350
    switchport mode trunk
    mlag 1
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF2B.cfg
@@ -55,6 +55,12 @@ vlan 141
 vlan 150
    name Tenant_A_WAN_Zone_1
 !
+vlan 160
+   name Tenant_A_VMOTION
+!
+vlan 161
+   name Tenant_A_NFS
+!
 vlan 210
    name Tenant_B_OP_Zone_1
 !
@@ -81,7 +87,7 @@ vrf instance MGMT
 !
 interface Port-Channel1
    description DC1-SVC3B_Po7
-   switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350
+   switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350
    switchport mode trunk
    mlag 1
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
@@ -52,6 +52,12 @@ vlan 140
 vlan 141
    name Tenant_A_DB_Zone_2
 !
+vlan 160
+   name Tenant_A_VMOTION
+!
+vlan 161
+   name Tenant_A_NFS
+!
 vlan 210
    name Tenant_B_OP_Zone_1
 !
@@ -119,7 +125,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF1_Po1
-   switchport trunk allowed vlan 110-111,120-121,130-131
+   switchport trunk allowed vlan 110-111,120-121,130-131,160-161
    switchport mode trunk
    mlag 7
 !
@@ -298,6 +304,8 @@ interface Vxlan1
    vxlan vlan 131 vni 10131
    vxlan vlan 140 vni 10140
    vxlan vlan 141 vni 10141
+   vxlan vlan 160 vni 10160
+   vxlan vlan 161 vni 10161
    vxlan vlan 210 vni 20210
    vxlan vlan 211 vni 20211
    vxlan vlan 310 vni 30310
@@ -391,11 +399,23 @@ router bgp 65102
       redistribute learned
       vlan 140-141
    !
+   vlan-aware-bundle Tenant_A_NFS
+      rd 192.168.255.6:10161
+      route-target both 10161:10161
+      redistribute learned
+      vlan 161
+   !
    vlan-aware-bundle Tenant_A_OP_Zone
       rd 192.168.255.6:10
       route-target both 10:10
       redistribute learned
       vlan 110-111
+   !
+   vlan-aware-bundle Tenant_A_VMOTION
+      rd 192.168.255.6:10160
+      route-target both 10160:10160
+      redistribute learned
+      vlan 160
    !
    vlan-aware-bundle Tenant_A_WEB_Zone
       rd 192.168.255.6:11

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
@@ -52,6 +52,12 @@ vlan 140
 vlan 141
    name Tenant_A_DB_Zone_2
 !
+vlan 160
+   name Tenant_A_VMOTION
+!
+vlan 161
+   name Tenant_A_NFS
+!
 vlan 210
    name Tenant_B_OP_Zone_1
 !
@@ -119,7 +125,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF1_Po1
-   switchport trunk allowed vlan 110-111,120-121,130-131
+   switchport trunk allowed vlan 110-111,120-121,130-131,160-161
    switchport mode trunk
    mlag 7
 !
@@ -298,6 +304,8 @@ interface Vxlan1
    vxlan vlan 131 vni 10131
    vxlan vlan 140 vni 10140
    vxlan vlan 141 vni 10141
+   vxlan vlan 160 vni 10160
+   vxlan vlan 161 vni 10161
    vxlan vlan 210 vni 20210
    vxlan vlan 211 vni 20211
    vxlan vlan 310 vni 30310
@@ -391,11 +399,23 @@ router bgp 65102
       redistribute learned
       vlan 140-141
    !
+   vlan-aware-bundle Tenant_A_NFS
+      rd 192.168.255.7:10161
+      route-target both 10161:10161
+      redistribute learned
+      vlan 161
+   !
    vlan-aware-bundle Tenant_A_OP_Zone
       rd 192.168.255.7:10
       route-target both 10:10
       redistribute learned
       vlan 110-111
+   !
+   vlan-aware-bundle Tenant_A_VMOTION
+      rd 192.168.255.7:10160
+      route-target both 10160:10160
+      redistribute learned
+      vlan 160
    !
    vlan-aware-bundle Tenant_A_WEB_Zone
       rd 192.168.255.7:11

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
@@ -55,6 +55,12 @@ vlan 141
 vlan 150
    name Tenant_A_WAN_Zone_1
 !
+vlan 160
+   name Tenant_A_VMOTION
+!
+vlan 161
+   name Tenant_A_NFS
+!
 vlan 210
    name Tenant_B_OP_Zone_1
 !
@@ -146,7 +152,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF2_Po1
-   switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350
+   switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350
    switchport mode trunk
    mlag 7
 !
@@ -360,6 +366,8 @@ interface Vxlan1
    vxlan vlan 140 vni 10140
    vxlan vlan 141 vni 10141
    vxlan vlan 150 vni 10150
+   vxlan vlan 160 vni 10160
+   vxlan vlan 161 vni 10161
    vxlan vlan 210 vni 20210
    vxlan vlan 211 vni 20211
    vxlan vlan 250 vni 20250
@@ -461,11 +469,23 @@ router bgp 65103
       redistribute learned
       vlan 140-141
    !
+   vlan-aware-bundle Tenant_A_NFS
+      rd 192.168.255.8:10161
+      route-target both 10161:10161
+      redistribute learned
+      vlan 161
+   !
    vlan-aware-bundle Tenant_A_OP_Zone
       rd 192.168.255.8:10
       route-target both 10:10
       redistribute learned
       vlan 110-111
+   !
+   vlan-aware-bundle Tenant_A_VMOTION
+      rd 192.168.255.8:10160
+      route-target both 10160:10160
+      redistribute learned
+      vlan 160
    !
    vlan-aware-bundle Tenant_A_WAN_Zone
       rd 192.168.255.8:14

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
@@ -55,6 +55,12 @@ vlan 141
 vlan 150
    name Tenant_A_WAN_Zone_1
 !
+vlan 160
+   name Tenant_A_VMOTION
+!
+vlan 161
+   name Tenant_A_NFS
+!
 vlan 210
    name Tenant_B_OP_Zone_1
 !
@@ -146,7 +152,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF2_Po1
-   switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350
+   switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350
    switchport mode trunk
    mlag 7
 !
@@ -350,6 +356,8 @@ interface Vxlan1
    vxlan vlan 140 vni 10140
    vxlan vlan 141 vni 10141
    vxlan vlan 150 vni 10150
+   vxlan vlan 160 vni 10160
+   vxlan vlan 161 vni 10161
    vxlan vlan 210 vni 20210
    vxlan vlan 211 vni 20211
    vxlan vlan 250 vni 20250
@@ -451,11 +459,23 @@ router bgp 65103
       redistribute learned
       vlan 140-141
    !
+   vlan-aware-bundle Tenant_A_NFS
+      rd 192.168.255.9:10161
+      route-target both 10161:10161
+      redistribute learned
+      vlan 161
+   !
    vlan-aware-bundle Tenant_A_OP_Zone
       rd 192.168.255.9:10
       route-target both 10:10
       redistribute learned
       vlan 110-111
+   !
+   vlan-aware-bundle Tenant_A_VMOTION
+      rd 192.168.255.9:10160
+      route-target both 10160:10160
+      redistribute learned
+      vlan 160
    !
    vlan-aware-bundle Tenant_A_WAN_Zone
       rd 192.168.255.9:14

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -26,6 +26,8 @@ leaf_allowed_vlans:
 - 111
 - 120
 - 121
+- 160
+- 161
 leaf_mlag: false
 service_routing_protocols_model: multi-agent
 ip_routing: true
@@ -95,13 +97,19 @@ vlans:
   121:
     tenant: Tenant_A
     name: Tenant_A_WEBZone_2
+  160:
+    tenant: Tenant_A
+    name: Tenant_A_VMOTION
+  161:
+    tenant: Tenant_A
+    name: Tenant_A_NFS
 vrfs:
   MGMT:
     ip_routing: false
 port_channel_interfaces:
   Port-Channel1:
     description: DC1-LEAF2A_Po7
-    vlans: 110-111,120-121,130-131
+    vlans: 110-111,120-121,130-131,160-161
     mode: trunk
     mlag: 1
 ethernet_interfaces:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -42,6 +42,8 @@ leaf_allowed_vlans:
 - 150
 - 120
 - 121
+- 160
+- 161
 - 210
 - 211
 - 250
@@ -138,6 +140,12 @@ vlans:
   121:
     tenant: Tenant_A
     name: Tenant_A_WEBZone_2
+  160:
+    tenant: Tenant_A
+    name: Tenant_A_VMOTION
+  161:
+    tenant: Tenant_A
+    name: Tenant_A_NFS
   210:
     tenant: Tenant_B
     name: Tenant_B_OP_Zone_1
@@ -162,7 +170,7 @@ vrfs:
 port_channel_interfaces:
   Port-Channel1:
     description: DC1-SVC3A_Po7
-    vlans: 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350
+    vlans: 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350
     mode: trunk
     mlag: 1
   Port-Channel3:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -42,6 +42,8 @@ leaf_allowed_vlans:
 - 150
 - 120
 - 121
+- 160
+- 161
 - 210
 - 211
 - 250
@@ -138,6 +140,12 @@ vlans:
   121:
     tenant: Tenant_A
     name: Tenant_A_WEBZone_2
+  160:
+    tenant: Tenant_A
+    name: Tenant_A_VMOTION
+  161:
+    tenant: Tenant_A
+    name: Tenant_A_NFS
   210:
     tenant: Tenant_B
     name: Tenant_B_OP_Zone_1
@@ -162,7 +170,7 @@ vrfs:
 port_channel_interfaces:
   Port-Channel1:
     description: DC1-SVC3B_Po7
-    vlans: 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350
+    vlans: 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350
     mode: trunk
     mlag: 1
   Port-Channel3:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -44,6 +44,8 @@ leaf_allowed_vlans:
 - 111
 - 120
 - 121
+- 160
+- 161
 - 210
 - 211
 - 310
@@ -160,6 +162,12 @@ vlans:
     name: MLAG_iBGP_Tenant_A_WEB_Zone
     trunk_groups:
     - LEAF_PEER_L3
+  160:
+    tenant: Tenant_A
+    name: Tenant_A_VMOTION
+  161:
+    tenant: Tenant_A
+    name: Tenant_A_NFS
   210:
     tenant: Tenant_B
     name: Tenant_B_OP_Zone_1
@@ -210,7 +218,7 @@ bfd_multihop:
 port_channel_interfaces:
   Port-Channel7:
     description: DC1_L2LEAF1_Po1
-    vlans: 110-111,120-121,130-131
+    vlans: 110-111,120-121,130-131,160-161
     mode: trunk
     mlag: 7
   Port-Channel5:
@@ -489,6 +497,10 @@ vxlan_tunnel_interface:
           vni: 10120
         121:
           vni: 10121
+        160:
+          vni: 10160
+        161:
+          vni: 10161
         210:
           vni: 20210
         211:
@@ -651,6 +663,24 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: 120-121
+    Tenant_A_VMOTION:
+      tenant: Tenant_A
+      rd: 192.168.255.6:10160
+      route_targets:
+        both:
+        - 10160:10160
+      redistribute_routes:
+      - learned
+      vlan: 160
+    Tenant_A_NFS:
+      tenant: Tenant_A
+      rd: 192.168.255.6:10161
+      route_targets:
+        both:
+        - 10161:10161
+      redistribute_routes:
+      - learned
+      vlan: 161
     Tenant_B_OP_Zone:
       rd: 192.168.255.6:20
       route_targets:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -44,6 +44,8 @@ leaf_allowed_vlans:
 - 111
 - 120
 - 121
+- 160
+- 161
 - 210
 - 211
 - 310
@@ -160,6 +162,12 @@ vlans:
     name: MLAG_iBGP_Tenant_A_WEB_Zone
     trunk_groups:
     - LEAF_PEER_L3
+  160:
+    tenant: Tenant_A
+    name: Tenant_A_VMOTION
+  161:
+    tenant: Tenant_A
+    name: Tenant_A_NFS
   210:
     tenant: Tenant_B
     name: Tenant_B_OP_Zone_1
@@ -210,7 +218,7 @@ bfd_multihop:
 port_channel_interfaces:
   Port-Channel7:
     description: DC1_L2LEAF1_Po1
-    vlans: 110-111,120-121,130-131
+    vlans: 110-111,120-121,130-131,160-161
     mode: trunk
     mlag: 7
   Port-Channel5:
@@ -489,6 +497,10 @@ vxlan_tunnel_interface:
           vni: 10120
         121:
           vni: 10121
+        160:
+          vni: 10160
+        161:
+          vni: 10161
         210:
           vni: 20210
         211:
@@ -651,6 +663,24 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: 120-121
+    Tenant_A_VMOTION:
+      tenant: Tenant_A
+      rd: 192.168.255.7:10160
+      route_targets:
+        both:
+        - 10160:10160
+      redistribute_routes:
+      - learned
+      vlan: 160
+    Tenant_A_NFS:
+      tenant: Tenant_A
+      rd: 192.168.255.7:10161
+      route_targets:
+        both:
+        - 10161:10161
+      redistribute_routes:
+      - learned
+      vlan: 161
     Tenant_B_OP_Zone:
       rd: 192.168.255.7:20
       route_targets:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -52,6 +52,8 @@ leaf_allowed_vlans:
 - 150
 - 120
 - 121
+- 160
+- 161
 - 210
 - 211
 - 250
@@ -178,6 +180,12 @@ vlans:
     name: MLAG_iBGP_Tenant_A_WEB_Zone
     trunk_groups:
     - LEAF_PEER_L3
+  160:
+    tenant: Tenant_A
+    name: Tenant_A_VMOTION
+  161:
+    tenant: Tenant_A
+    name: Tenant_A_NFS
   210:
     tenant: Tenant_B
     name: Tenant_B_OP_Zone_1
@@ -253,7 +261,7 @@ bfd_multihop:
 port_channel_interfaces:
   Port-Channel7:
     description: DC1_L2LEAF2_Po1
-    vlans: 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350
+    vlans: 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350
     mode: trunk
     mlag: 7
   Port-Channel5:
@@ -584,6 +592,10 @@ vxlan_tunnel_interface:
           vni: 10120
         121:
           vni: 10121
+        160:
+          vni: 10160
+        161:
+          vni: 10161
         210:
           vni: 20210
         211:
@@ -764,6 +776,24 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: 120-121
+    Tenant_A_VMOTION:
+      tenant: Tenant_A
+      rd: 192.168.255.8:10160
+      route_targets:
+        both:
+        - 10160:10160
+      redistribute_routes:
+      - learned
+      vlan: 160
+    Tenant_A_NFS:
+      tenant: Tenant_A
+      rd: 192.168.255.8:10161
+      route_targets:
+        both:
+        - 10161:10161
+      redistribute_routes:
+      - learned
+      vlan: 161
     Tenant_B_OP_Zone:
       rd: 192.168.255.8:20
       route_targets:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -52,6 +52,8 @@ leaf_allowed_vlans:
 - 150
 - 120
 - 121
+- 160
+- 161
 - 210
 - 211
 - 250
@@ -178,6 +180,12 @@ vlans:
     name: MLAG_iBGP_Tenant_A_WEB_Zone
     trunk_groups:
     - LEAF_PEER_L3
+  160:
+    tenant: Tenant_A
+    name: Tenant_A_VMOTION
+  161:
+    tenant: Tenant_A
+    name: Tenant_A_NFS
   210:
     tenant: Tenant_B
     name: Tenant_B_OP_Zone_1
@@ -253,7 +261,7 @@ bfd_multihop:
 port_channel_interfaces:
   Port-Channel7:
     description: DC1_L2LEAF2_Po1
-    vlans: 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350
+    vlans: 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350
     mode: trunk
     mlag: 7
   Port-Channel5:
@@ -568,6 +576,10 @@ vxlan_tunnel_interface:
           vni: 10120
         121:
           vni: 10121
+        160:
+          vni: 10160
+        161:
+          vni: 10161
         210:
           vni: 20210
         211:
@@ -748,6 +760,24 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: 120-121
+    Tenant_A_VMOTION:
+      tenant: Tenant_A
+      rd: 192.168.255.9:10160
+      route_targets:
+        both:
+        - 10160:10160
+      redistribute_routes:
+      - learned
+      vlan: 160
+    Tenant_A_NFS:
+      tenant: Tenant_A
+      rd: 192.168.255.9:10161
+      route_targets:
+        both:
+        - 10161:10161
+      redistribute_routes:
+      - learned
+      vlan: 161
     Tenant_B_OP_Zone:
       rd: 192.168.255.9:20
       route_targets:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_TENANTS_NETWORKS.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_TENANTS_NETWORKS.yml
@@ -39,11 +39,13 @@ tenants:
           loopback: 100
           loopback_ip_range: 10.255.1.0/24
         svis:
-          110:
+          # SVI as string
+          '110':
             name: Tenant_A_OP_Zone_1
             tags: ['opzone']
             enabled: True
             ip_address_virtual: 10.1.10.1/24
+          # SVI as integer
           111:
             vni_override: 50111
             name: Tenant_A_OP_Zone_2
@@ -100,6 +102,15 @@ tenants:
             tags: ['wan']
             enabled: True
             ip_address_virtual: 10.1.40.1/24
+    l2vlans:
+      # L2 vlan as string
+      '160':
+        name: Tenant_A_VMOTION
+        tags: ['opzone']
+      # L2 vlan as integer
+      161:
+        name: Tenant_A_NFS
+        tags: ['opzone']
   # Tenant_B Specific Information - VRFs / VLANs
   Tenant_B:
     mac_vrf_vni_base: 20000

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-igmp-snooping.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-igmp-snooping.j2
@@ -8,7 +8,7 @@
 {% for tenant in tenants | arista.avd.natural_sort if tenant in leaf.filter_tenants or "all" in leaf.filter_tenants %}
 {%     if tenants[tenant].vrfs is defined %}
 {%         for vrf in tenants[tenant].vrfs | arista.avd.natural_sort if leaf.vrfs is not none and vrf in leaf.vrfs %}
-{%             for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if leaf.svis is not none and svi in leaf.svis %}
+{%             for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if leaf.svis is not none and svi|int in leaf.svis %}
 {%                  if tenants[tenant].vrfs[vrf].svis[svi].igmp_snooping is defined %}
 {%                      set igmp_snooping.configured = true %}
 {%                  endif %}
@@ -35,7 +35,7 @@
 {%          if tenants[tenant].vrfs is defined %}
 {%              for vrf in tenants[tenant].vrfs | arista.avd.natural_sort if leaf.vrfs is not none and vrf in leaf.vrfs %}
 {# Tenant VLANs w/SVIs #}
-{%                  for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if leaf.svis is not none and svi in leaf.svis %}
+{%                  for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if leaf.svis is not none and svi|int in leaf.svis %}
 {# Detect if a svi_profile exists #}
 {# If exists, create a shortpath to access profile data #}
 {%                      set per_svi = namespace() %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-router-bgp-evpn-vlan-aware-bundles.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-router-bgp-evpn-vlan-aware-bundles.j2
@@ -12,14 +12,14 @@
       redistribute_routes:
         - learned
 {%                 set vlan_range = [] %}
-{%                 for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if leaf.svis is not none and svi in leaf.svis %}
+{%                 for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if leaf.svis is not none and svi|int in leaf.svis %}
 {%                     do vlan_range.append( svi| int ) %}
 {%                 endfor %}
       vlan: {{ vlan_range | arista.avd.list_compress }}
 {%             endfor %}
 {%         endif %}
 {%         if tenants[tenant].l2vlans is defined %}
-{%             for l2vlan in tenants[tenant].l2vlans | arista.avd.natural_sort if leaf.vlans is not none and l2vlan in leaf.vlans %}
+{%             for l2vlan in tenants[tenant].l2vlans | arista.avd.natural_sort if leaf.vlans is not none and l2vlan|int in leaf.vlans %}
 {%                 set l2vlan_int = l2vlan | int %}
 {%                 if tenants[tenant].l2vlans[l2vlan].vni_override is defined %}
 {%                     set vni = tenants[tenant].l2vlans[l2vlan].vni_override %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-router-bgp-evpn-vlans.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-router-bgp-evpn-vlans.j2
@@ -4,7 +4,7 @@
 ## {{ tenant }} ##
 {%         if tenants[tenant].vrfs is defined %}
 {%             for vrf in tenants[tenant].vrfs | arista.avd.natural_sort if leaf.vrfs is not none and vrf in leaf.vrfs %}
-{%                 for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if svi in leaf.svis %}
+{%                 for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if svi|int in leaf.svis %}
 {%                      set svi_int = svi | int %}
 {%                     if tenants[tenant].vrfs[vrf].svis[svi].vni_override is defined %}
 {%                         set vni = tenants[tenant].vrfs[vrf].svis[svi].vni_override %}
@@ -23,7 +23,7 @@
 {%             endfor %}
 {%         endif %}
 {%         if tenants[tenant].l2vlans is defined %}
-{%             for l2vlan in tenants[tenant].l2vlans | arista.avd.natural_sort if leaf.vlans is not none and l2vlan in leaf.vlans %}
+{%             for l2vlan in tenants[tenant].l2vlans | arista.avd.natural_sort if leaf.vlans is not none and l2vlan|int in leaf.vlans %}
 {%                 set l2vlan_int = l2vlan | int %}
 {%                 if tenants[tenant].l2vlans[l2vlan].vni_override is defined %}
 {%                     set vni = tenants[tenant].l2vlans[l2vlan].vni_override %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-vlan-interfaces.j2
@@ -5,7 +5,7 @@
 {%             if loop.first %}
 ## {{ tenant }} ##
 {%             endif %}
-{%             for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if svi in leaf.svis %}
+{%             for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if svi|int in leaf.svis %}
 {# Detect if a svi_profile exists #}
 {# If exists, create a shortpath to access profile data #}
 {%                 set per_svi = namespace() %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-vlans.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-vlans.j2
@@ -4,7 +4,7 @@
 {%     if tenants[tenant].vrfs is defined %}
 {%         for vrf in tenants[tenant].vrfs | arista.avd.natural_sort if leaf.vrfs is not none and vrf in leaf.vrfs %}
 {# Tenant VLANs w/SVIs #}
-{%             for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if leaf.svis is not none and svi in leaf.svis %}
+{%             for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if leaf.svis is not none and svi|int in leaf.svis %}
   {{ svi| int }}:
     tenant: {{ tenant }}
     name: {{ tenants[tenant].vrfs[vrf].svis[svi].name }}
@@ -29,7 +29,7 @@
 {%     endif %}
 {# Tenant L2 VLANs #}
 {%     if tenants[tenant].l2vlans is defined %}
-{%         for l2vlan in tenants[tenant].l2vlans | arista.avd.natural_sort if leaf.vlans is not none and l2vlan in leaf.vlans %}
+{%         for l2vlan in tenants[tenant].l2vlans | arista.avd.natural_sort if leaf.vlans is not none and l2vlan|int in leaf.vlans %}
   {{ l2vlan| int }}:
     tenant: {{ tenant }}
     name: {{ tenants[tenant].l2vlans[l2vlan].name }}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-vxlan-vtep-interface.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-vxlan-vtep-interface.j2
@@ -13,7 +13,7 @@
 ## {{ tenant }} ##
 {%     if tenants[tenant].vrfs is defined %}
 {%         for vrf in tenants[tenant].vrfs | arista.avd.natural_sort if leaf.vrfs is not none and vrf in leaf.vrfs %}
-{%             for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if leaf.svis is not none and svi in leaf.svis %}
+{%             for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if leaf.svis is not none and svi|int in leaf.svis %}
 {%            set svi_int = svi | int %}
         {{ svi_int }}:
 {%                 if tenants[tenant].vrfs[vrf].svis[svi].vni_override is defined %}
@@ -25,7 +25,7 @@
 {%         endfor %}
 {%     endif %}
 {%     if tenants[tenant].l2vlans is defined %}
-{%         for l2vlan in tenants[tenant].l2vlans | arista.avd.natural_sort if leaf.vlans is not none and l2vlan in leaf.vlans %}
+{%         for l2vlan in tenants[tenant].l2vlans | arista.avd.natural_sort if leaf.vlans is not none and l2vlan|int in leaf.vlans %}
 {%            set l2vlan_int = l2vlan | int %}
         {{ l2vlan_int }}:
 {%              if tenants[tenant].l2vlans[l2vlan].vni_override is defined %}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
With this change we can use both strings and integer under l2vlan and svi and do the checks correctly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

## Component(s) name
eos_l3ls_evpn

## Proposed changes
<!--- Describe your changes in detail -->
Anything matching svi or l2vlan under any if condition will have | int 

`svi | int in leaf.svi`
`l2vlan | int in leaf.l2vlans`

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Tested in venv and created molecule test case, validated both before and after.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
