### PR TITLE
Fix L2 leaves uplinks when MLAG is not desired 

### DIFF
--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF1A.md
@@ -403,7 +403,7 @@ interface Ethernet2
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel1 | DC1-LEAF2A_Po7 | switched | access | 110-111,120-121,130-131,160-161 | - | - | - | - | 1 | - |
+| Port-Channel1 | DC1-LEAF2A_Po7 | switched | access | 110-111,120-121,130-131,160-161 | - | - | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -413,7 +413,6 @@ interface Port-Channel1
    description DC1-LEAF2A_Po7
    switchport trunk allowed vlan 110-111,120-121,130-131,160-161
    switchport mode trunk
-   mlag 1
 ```
 
 ## Loopback Interfaces

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF1A.cfg
@@ -57,7 +57,6 @@ interface Port-Channel1
    description DC1-LEAF2A_Po7
    switchport trunk allowed vlan 110-111,120-121,130-131,160-161
    switchport mode trunk
-   mlag 1
 !
 interface Ethernet1
    description DC1-LEAF2A_Ethernet7

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -111,7 +111,6 @@ port_channel_interfaces:
     description: DC1-LEAF2A_Po7
     vlans: 110-111,120-121,130-131,160-161
     mode: trunk
-    mlag: 1
 ethernet_interfaces:
   Ethernet1:
     peer: DC1-LEAF2A

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
@@ -135,11 +135,13 @@ l2leaf:
     platform: vEOS-LAB
     parent_l3leafs: [ DC1-SVC3A, DC1-SVC3B ]
     uplink_interfaces: [ Ethernet1, Ethernet2 ]
+    mlag: true
     mlag_interfaces: [ Ethernet3, Ethernet4 ]
     spanning_tree_mode: mstp
     spanning_tree_priority: 16384
   node_groups:
     DC1_L2LEAF1:
+      mlag: false
       parent_l3leafs: [ DC1-LEAF2A, DC1-LEAF2B ]
       filter:
         tenants: [ Tenant_A ]

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/l3leaf_l2leafs_uplinks/l2leaf-port-channel-uplinks.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/l3leaf_l2leafs_uplinks/l2leaf-port-channel-uplinks.j2
@@ -23,7 +23,9 @@
     description: {{ parent_l3leafs[loop.index0]}}_{{ 'Po' + l3leaf.channel_group_id }}
     vlans: {{ leaf.vlans | arista.avd.list_compress }}
     mode: trunk
+{%             if leaf.mlag == true %}
     mlag: {{ channel_group_id }}
+{%             endif %}
 {%         endif %}
 {%     endfor %}
 {% endfor %}


### PR DESCRIPTION
## Change Summary

L2 leaf uplinks with LAG without MLAG 

This [template](https://github.com/aristanetworks/ansible-avd/blob/devel/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l2leaf-yml.j2) includes
```
{% include 'l3leaf_l2leafs_uplinks/l2leaf-port-channel-uplinks.j2' %}
```
And the template [/3leaf_l2leafs_uplinks/l2leaf-port-channel-uplinks.j2](https://github.com/aristanetworks/ansible-avd/blob/devel/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/l3leaf_l2leafs_uplinks/l2leaf-port-channel-uplinks.j2) was always using mlag regardless if mlag was configured or not
```
  Port-Channel{{ channel_group_id }}:
    description: {{ parent_l3leafs[loop.index0]}}_{{ 'Po' + l3leaf.channel_group_id }}
    vlans: {{ leaf.vlans | arista.avd.list_compress }}
    mode: trunk
    mlag: {{ channel_group_id }}
```
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
#543 

## Component(s) name

role eos_l3ls_evpn  
template [/3leaf_l2leafs_uplinks/l2leaf-port-channel-uplinks.j2](https://github.com/aristanetworks/ansible-avd/blob/devel/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/l3leaf_l2leafs_uplinks/l2leaf-port-channel-uplinks.j2)  

## Proposed changes
update template [/3leaf_l2leafs_uplinks/l2leaf-port-channel-uplinks.j2](https://github.com/aristanetworks/ansible-avd/blob/devel/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/l3leaf_l2leafs_uplinks/l2leaf-port-channel-uplinks.j2)  
```
{%             if leaf.mlag == true %}
    mlag: {{ channel_group_id }}
{%             endif %}
```
## How to test

run the role  eos_l3ls_evpn  with and without mlag for l2leaf

without mlag 
```
l2leaf:
  defaults:
    platform: vEOS-LAB
    # Parent L3 switches (list)
    parent_l3leafs: [ DC1-LEAF1A, DC1-LEAF1B ]
    # Uplink interfaces (list), interface located on L2 Leaf,
    uplink_interfaces: [ Ethernet1, Ethernet2 ]
    mlag: false
  node_groups:
    DC1_L2LEAF1:
      parent_l3leafs: [ DC1-LEAF1A, DC1-LEAF1B ]
      nodes:
        DC1-L2LEAF1A:
          id: 5
          mgmt_ip: 10.73.1.117/24
          l3leaf_interfaces: [ Ethernet3, Ethernet3 ]
    DC1_L2LEAF2:
      parent_l3leafs: [ DC1-LEAF1A, DC1-LEAF1B ]
      nodes:
        DC1-L2LEAF2A:
          id: 7
          mgmt_ip: 10.73.1.118/24
          l3leaf_interfaces: [ Ethernet4, Ethernet4 ]
```
expect result
```
port_channel_interfaces:
  Port-Channel1:
    description: DC1-LEAF1A_Po3
    vlans: 110-112,120-121,140-141,150,310-311,350,400-402
    mode: trunk
```
```
interface Port-Channel1
   description DC1-LEAF1A_Po3
   switchport trunk allowed vlan 110-112,120-121,140-141,150,310-311,350,400-402
   switchport mode trunk
```
with mlag
```
l2leaf:
  defaults:
    platform: vEOS-LAB
    # Parent L3 switches (list)
    parent_l3leafs: [ DC1-LEAF1A, DC1-LEAF1B ]
    # Uplink interfaces (list), interface located on L2 Leaf,
    uplink_interfaces: [ Ethernet1, Ethernet2 ]
    mlag: true
    # MLAG interfaces (list)
    mlag_interfaces: [ Ethernet7, Ethernet8 ]
  node_groups:
    DC1_L2LEAF1:
      parent_l3leafs: [ DC1-LEAF1A, DC1-LEAF1B ]
      nodes:
        DC1-L2LEAF1A:
          id: 5
          mgmt_ip: 10.73.1.117/24
          l3leaf_interfaces: [ Ethernet3, Ethernet3 ]
    DC1_L2LEAF2:
      parent_l3leafs: [ DC1-LEAF1A, DC1-LEAF1B ]
      nodes:
        DC1-L2LEAF2A:
          id: 7
          mgmt_ip: 10.73.1.118/24
          l3leaf_interfaces: [ Ethernet4, Ethernet4 ]
``` 
expect results: 
```
interface Port-Channel1
   description DC1-LEAF1A_Po3
   switchport trunk allowed vlan 110-112,120-121,140-141,150,310-311,350,400-402
   switchport mode trunk
   mlag 1
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
