### PR TITLE
Fix l3ls role documentation about igmp snooping

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
@@ -355,7 +355,7 @@ vxlan_vlan_aware_bundles: < boolean | default -> false >
 
 # Disable IGMP snooping at fabric level.
 # If set, it overrides per vlan settings
-default_igmp_snooping: < boolean | default -> true >
+default_igmp_snooping_enabled: < boolean | default -> true >
 
 # BFD Multihop tunning | Required.
 bfd_multihop:
@@ -1020,7 +1020,8 @@ tenants:
       < 1-4096 >:
         name: < description >
         tags: [ < tag_1 >, < tag_2 > ]
-
+        # Activate or deactivate IGMP snooping | Optional, default is true
+        igmp_snooping_enabled: < true | false >
 
   < tenant_a >:
     mac_vrf_vni_base: < 10000-16770000 >


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Fix l3ls role documentation about igmp snooping

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [x] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
#540 

## Component(s) name
l3ls role
readme file 

## Proposed changes

Fix l3ls role documentation about igmp snooping 

Current doc
```
fabric_name: < Fabric_Name >
# Disable IGMP snooping at fabric level.
# If set, it overrides per vlan settings
default_igmp_snooping: < boolean | default -> true >
```
But according to the code and my tests it is not `default_igmp_snooping` it is `default_igmp_snooping_enabled`:  
- `default_igmp_snooping_enabled` (at the root level) 
- `igmp_snooping_enabled` (under l3leaf/default or l3leaf/nodes/xxx) (templates/evpn-fabric-l3leaf-yml.j2)
- `igmp_snooping_enabled` (under l2leaf/default or l2leaf/nodes/xxx) (templates/evpn-fabric-l2leaf-yml.j2)
- `igmp_snooping_enabled` (under tenants/vrfs/svis) (templates/tenant_evpn_vxlan/leaf-tenant-igmp-snooping.j2)
- `igmp_snooping_enabled` (under tenants/l2vlans) (templates/tenant_evpn_vxlan/leaf-tenant-igmp-snooping.j2)
-
## How to test

Example:  
```
fabric_name: DC1_FABRIC
default_igmp_snooping_enabled: false
```
```
l3leaf:
  defaults:
     igmp_snooping_enabled: true
  node_groups:
    DC1_LEAF1:
      igmp_snooping_enabled: false
```
```
tenants:
  Tenant_A:
    mac_vrf_vni_base: 10000
    vrfs:
      Tenant_A_OP_Zone:
        svis:
          12:
            name: Tenant_A_OP_Zone_Test
            tags: [app]
            enabled: true
            igmp_snooping_enabled: false
            ip_address_virtual: 172.16.112.1/24
    l2vlans:
      160:
        vni_override: 55160
        name: Tenant_A_VMOTION
        tags: [vmotion]
        igmp_snooping_enabled: false
      161:
        name: Tenant_A_NFS
        tags: [nfs]
        igmp_snooping_enabled: true
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
