### PR TITLE
Add ability to not enable mlag dual primary detection

### DIFF
--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF2A.md
@@ -292,7 +292,7 @@ No event handler defined
 | --------- | --------------- | ------------ | --------- |
 | DC1_L2LEAF2 | Vlan4094 | 10.255.252.17 | Port-Channel3 |
 
-Dual primary detection is enabled. The detection delay is 5 seconds.
+Dual primary detection is disabled.
 
 ## MLAG Device Configuration
 
@@ -302,9 +302,7 @@ mlag configuration
    domain-id DC1_L2LEAF2
    local-interface Vlan4094
    peer-address 10.255.252.17
-   peer-address heartbeat 192.168.200.114 vrf MGMT
    peer-link Port-Channel3
-   dual-primary detection delay 5 action errdisable all-interfaces
    reload-delay mlag 300
    reload-delay non-mlag 330
 ```

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF2B.md
@@ -292,7 +292,7 @@ No event handler defined
 | --------- | --------------- | ------------ | --------- |
 | DC1_L2LEAF2 | Vlan4094 | 10.255.252.16 | Port-Channel3 |
 
-Dual primary detection is enabled. The detection delay is 5 seconds.
+Dual primary detection is disabled.
 
 ## MLAG Device Configuration
 
@@ -302,9 +302,7 @@ mlag configuration
    domain-id DC1_L2LEAF2
    local-interface Vlan4094
    peer-address 10.255.252.16
-   peer-address heartbeat 192.168.200.113 vrf MGMT
    peer-link Port-Channel3
-   dual-primary detection delay 5 action errdisable all-interfaces
    reload-delay mlag 300
    reload-delay non-mlag 330
 ```

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF2A.cfg
@@ -130,9 +130,7 @@ mlag configuration
    domain-id DC1_L2LEAF2
    local-interface Vlan4094
    peer-address 10.255.252.17
-   peer-address heartbeat 192.168.200.114 vrf MGMT
    peer-link Port-Channel3
-   dual-primary detection delay 5 action errdisable all-interfaces
    reload-delay mlag 300
    reload-delay non-mlag 330
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF2B.cfg
@@ -130,9 +130,7 @@ mlag configuration
    domain-id DC1_L2LEAF2
    local-interface Vlan4094
    peer-address 10.255.252.16
-   peer-address heartbeat 192.168.200.113 vrf MGMT
    peer-link Port-Channel3
-   dual-primary detection delay 5 action errdisable all-interfaces
    reload-delay mlag 300
    reload-delay non-mlag 330
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -239,10 +239,6 @@ mlag_configuration:
   domain_id: DC1_L2LEAF2
   local_interface: Vlan4094
   peer_address: 10.255.252.17
-  peer_address_heartbeat:
-    peer_ip: 192.168.200.114
-    vrf: MGMT
-  dual_primary_detection_delay: 5
   peer_link: Port-Channel3
   reload_delay_mlag: 300
   reload_delay_non_mlag: 330

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -239,10 +239,6 @@ mlag_configuration:
   domain_id: DC1_L2LEAF2
   local_interface: Vlan4094
   peer_address: 10.255.252.16
-  peer_address_heartbeat:
-    peer_ip: 192.168.200.113
-    vrf: MGMT
-  dual_primary_detection_delay: 5
   peer_link: Port-Channel3
   reload_delay_mlag: 300
   reload_delay_non_mlag: 330

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
@@ -151,6 +151,7 @@ l2leaf:
           mac_address: '0c:1d:c0:1d:62:01'
           l3leaf_interfaces: [ Ethernet7, Ethernet7 ]
     DC1_L2LEAF2:
+      mlag_dual_primary_detection: false
       nodes:
         DC1-L2LEAF2A:
           id: 9

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
@@ -559,8 +559,10 @@ l3leaf:
 
       # Enable / Disable auto MLAG, when two nodes are defined in node group.
       mlag: < true | false -> default true >
+
       # Enable / Disable MLAG dual primary detectiom
       mlag_dual_primary_detection: < true | false -> default true >
+
       # MLAG interfaces (list) | Required when MLAG leafs present in topology.
       mlag_interfaces: [ < ethernet_interface_3 >, < ethernet_interface_4 >]
 
@@ -650,6 +652,7 @@ l3leaf:
       filter:
         tenants: [ Tenant_A, Tenant_B, Tenant_C ]
         tags: [ opzone ]
+      mlag_dual_primary_detection: false
       nodes:
         DC1-LEAF1A:
           id: 1
@@ -725,7 +728,7 @@ l2leaf:
 
       # Enable / Disable MLAG dual primary detectiom
       mlag_dual_primary_detection: < true | false -> default true >
-      
+
       # MLAG interfaces (list) | Required when MLAG leafs present in topology.
       mlag_interfaces: [ < ethernet_interface_3 >, < ethernet_interface_4 >]
 

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
@@ -559,7 +559,8 @@ l3leaf:
 
       # Enable / Disable auto MLAG, when two nodes are defined in node group.
       mlag: < true | false -> default true >
-
+      # Enable / Disable MLAG dual primary detectiom
+      mlag_dual_primary_detection: < true | false -> default true >
       # MLAG interfaces (list) | Required when MLAG leafs present in topology.
       mlag_interfaces: [ < ethernet_interface_3 >, < ethernet_interface_4 >]
 
@@ -722,6 +723,9 @@ l2leaf:
       # Enable / Disable auto MLAG, when two nodes are defined in node group.
       mlag: < true | false -> default true >
 
+      # Enable / Disable MLAG dual primary detectiom
+      mlag_dual_primary_detection: < true | false -> default true >
+      
       # MLAG interfaces (list) | Required when MLAG leafs present in topology.
       mlag_interfaces: [ < ethernet_interface_3 >, < ethernet_interface_4 >]
 

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l2leaf-yml.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l2leaf-yml.j2
@@ -57,6 +57,13 @@
 {%             if loop.length == 2 and switch.mlag == true %}
 {%                 set leaf.mlag = true %}
 {%                 set leaf.mlag_group = l2leaf_node_group %}
+{%                 if l2leaf.node_groups[l2leaf_node_group].dual_primary_detection is defined %}
+{%                     set leaf.dual_primary_detection = l2leaf.node_groups[l2leaf_node_group].dual_primary_detection %}
+{%                 elif l2leaf.defaults.dual_primary_detection is defined %}
+{%                     set leaf.dual_primary_detection = l2leaf.defaults.dual_primary_detection %}
+{%                 else %}
+{%                     set leaf.dual_primary_detection = true %}
+{%                 endif %}
 {%                 if l2leaf.node_groups[l2leaf_node_group].mlag_interfaces is defined %}
 {%                     set leaf.mlag_interfaces = l2leaf.node_groups[l2leaf_node_group].mlag_interfaces %}
 {%                 else %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l2leaf-yml.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l2leaf-yml.j2
@@ -57,12 +57,12 @@
 {%             if loop.length == 2 and switch.mlag == true %}
 {%                 set leaf.mlag = true %}
 {%                 set leaf.mlag_group = l2leaf_node_group %}
-{%                 if l2leaf.node_groups[l2leaf_node_group].dual_primary_detection is defined %}
-{%                     set leaf.dual_primary_detection = l2leaf.node_groups[l2leaf_node_group].dual_primary_detection %}
-{%                 elif l2leaf.defaults.dual_primary_detection is defined %}
-{%                     set leaf.dual_primary_detection = l2leaf.defaults.dual_primary_detection %}
+{%                 if l2leaf.node_groups[l2leaf_node_group].mlag_dual_primary_detection is defined %}
+{%                     set leaf.mlag_dual_primary_detection = l2leaf.node_groups[l2leaf_node_group].mlag_dual_primary_detection %}
+{%                 elif l2leaf.defaults.mlag_dual_primary_detection is defined %}
+{%                     set leaf.mlag_dual_primary_detection = l2leaf.defaults.mlag_dual_primary_detection %}
 {%                 else %}
-{%                     set leaf.dual_primary_detection = true %}
+{%                     set leaf.mlag_dual_primary_detection = true %}
 {%                 endif %}
 {%                 if l2leaf.node_groups[l2leaf_node_group].mlag_interfaces is defined %}
 {%                     set leaf.mlag_interfaces = l2leaf.node_groups[l2leaf_node_group].mlag_interfaces %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l3leaf-yml.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l3leaf-yml.j2
@@ -80,6 +80,13 @@
 {%             if loop.length == 2 and switch.mlag == true %}
 {%                 set leaf.mlag = true %}
 {%                 set leaf.mlag_group = l3leaf_node_group %}
+{%                 if l3leaf.node_groups[l3leaf_node_group].dual_primary_detection is defined %}
+{%                     set leaf.dual_primary_detection = l3leaf.node_groups[l3leaf_node_group].dual_primary_detection %}
+{%                 elif l3leaf.defaults.dual_primary_detection is defined %}
+{%                     set leaf.dual_primary_detection = l3leaf.defaults.dual_primary_detection %}
+{%                 else %}
+{%                     set leaf.dual_primary_detection = true %}
+{%                 endif %}
 {%                 if l3leaf.node_groups[l3leaf_node_group].mlag_interfaces is defined %}
 {%                     set leaf.mlag_interfaces = l3leaf.node_groups[l3leaf_node_group].mlag_interfaces %}
 {%                 else %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l3leaf-yml.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l3leaf-yml.j2
@@ -80,12 +80,12 @@
 {%             if loop.length == 2 and switch.mlag == true %}
 {%                 set leaf.mlag = true %}
 {%                 set leaf.mlag_group = l3leaf_node_group %}
-{%                 if l3leaf.node_groups[l3leaf_node_group].dual_primary_detection is defined %}
-{%                     set leaf.dual_primary_detection = l3leaf.node_groups[l3leaf_node_group].dual_primary_detection %}
-{%                 elif l3leaf.defaults.dual_primary_detection is defined %}
-{%                     set leaf.dual_primary_detection = l3leaf.defaults.dual_primary_detection %}
+{%                 if l3leaf.node_groups[l3leaf_node_group].mlag_dual_primary_detection is defined %}
+{%                     set leaf.mlag_dual_primary_detection = l3leaf.node_groups[l3leaf_node_group].mlag_dual_primary_detection %}
+{%                 elif l3leaf.defaults.mlag_dual_primary_detection is defined %}
+{%                     set leaf.mlag_dual_primary_detection = l3leaf.defaults.mlag_dual_primary_detection %}
 {%                 else %}
-{%                     set leaf.dual_primary_detection = true %}
+{%                     set leaf.mlag_dual_primary_detection = true %}
 {%                 endif %}
 {%                 if l3leaf.node_groups[l3leaf_node_group].mlag_interfaces is defined %}
 {%                     set leaf.mlag_interfaces = l3leaf.node_groups[l3leaf_node_group].mlag_interfaces %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/mlag/leaf-mlag-configuration.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/mlag/leaf-mlag-configuration.j2
@@ -6,7 +6,7 @@ mlag_configuration:
   domain_id: {{ leaf.mlag_group }}
   local_interface: Vlan4094
   peer_address: {{ mlag_ips.mlag_peer | ipaddr('network') | ipmath(leaf.mlag_peer_ip) }}
-{%     if leaf.dual_primary_detection == true %}
+{%     if leaf.mlag_dual_primary_detection == true %}
   peer_address_heartbeat:
     peer_ip: {{ leaf.mlag_peer_mgmt_ip }}
     vrf: {{ mgmt_interface_vrf }}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/mlag/leaf-mlag-configuration.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/mlag/leaf-mlag-configuration.j2
@@ -6,10 +6,12 @@ mlag_configuration:
   domain_id: {{ leaf.mlag_group }}
   local_interface: Vlan4094
   peer_address: {{ mlag_ips.mlag_peer | ipaddr('network') | ipmath(leaf.mlag_peer_ip) }}
+{%     if leaf.dual_primary_detection == true %}
   peer_address_heartbeat:
     peer_ip: {{ leaf.mlag_peer_mgmt_ip }}
     vrf: {{ mgmt_interface_vrf }}
   dual_primary_detection_delay: 5
+{%     endif %}
   peer_link: Port-Channel{{ leaf.mlag_interfaces[0] | regex_findall("\d") | join }}
 {%     set ns = namespace() %}
 {%     for platform_setting in platform_settings %}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Add ability to not enable mlag dual primary detection 


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

#532 
## Component(s) name

`l3ls` role

templates: 
- [eos_l3ls_evpn/templates/evpn-fabric-l3leaf-yml.j2](https://github.com/aristanetworks/ansible-avd/blob/devel/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l3leaf-yml.j2)
- [eos_l3ls_evpn/templates/evpn-fabric-l2leaf-yml.j2](https://github.com/aristanetworks/ansible-avd/blob/devel/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l2leaf-yml.j2)
- [eos_l3ls_evpn/templates/fabric/mlag/leaf-mlag-configuration.j2](https://github.com/aristanetworks/ansible-avd/blob/issue/495/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/mlag/leaf-mlag-configuration.j2)

## Proposed changes

Added a var `dual_primary_detection` (default is true) to `l3leaf/defaults` and `l3leaf/node_groups/group` and `l2leaf/defaults` and `l2leaf/node_groups/group`.

This is consumed by `l3ls` role to generate appropriate structured config

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

run the `l3ls` role with this sort of examples (`dual_primary_detection: false/true` at diff levels)

```
l3leaf:
  defaults:
    virtual_router_mac_address: 00:1c:73:00:dc:01
    platform: vEOS-LAB
    spines: [DC1-SPINE1, DC1-SPINE2]
    uplink_to_spine_interfaces: [Ethernet1, Ethernet2]
    mlag_interfaces: [Ethernet7, Ethernet8]
    dual_primary_detection: false
  node_groups:
    DC1_LEAF1:
      mlag: true
      dual_primary_detection: true
      bgp_as: 65101
      filter:
        tenants: [ Tenant_A, Tenant_D ]
        tags: [ web, app, vm, nfs, erp, db, vmotion ]
      nodes:
        DC1-LEAF1A:
          id: 1
          mgmt_ip: 10.73.1.105/24
          spine_interfaces: [Ethernet1, Ethernet1]
        DC1-LEAF1B:
          id: 2
          mgmt_ip: 10.73.1.106/24
          spine_interfaces: [Ethernet2, Ethernet2]
    DC1_LEAF2:
      bgp_as: 65102
      nodes:
        DC1-LEAF2A:
          id: 3
          mgmt_ip: 10.73.1.107/24
          spine_interfaces: [Ethernet4, Ethernet4]
        DC1-LEAF2B:
          id: 4
          mgmt_ip: 10.73.1.108/24
          spine_interfaces: [Ethernet5, Ethernet5]
l2leaf:
  defaults:
    dual_primary_detection: false
    platform: vEOS-LAB
    parent_l3leafs: [ DC1-LEAF1A, DC1-LEAF1B ]
    uplink_interfaces: [ Ethernet1, Ethernet2 ]
    mlag_interfaces: [ Ethernet7, Ethernet8 ]
    spanning_tree_mode: mstp
    spanning_tree_priority: 16384
  node_groups:
    DC1_L2LEAF:
      parent_l3leafs: [ DC1-LEAF1A, DC1-LEAF1B ]
      filter:
        tenants: [ Tenant_A, Tenant_D ]
        tags: [ opzone, web, app, vm ]
      nodes:
        DC1-L2LEAF1A:
          id: 5
          mgmt_ip: 10.73.1.117/24
          l3leaf_interfaces: [ Ethernet3, Ethernet3 ]
        DC1-L2LEAF2A:
          id: 7
          mgmt_ip: 10.73.1.118/24
          l3leaf_interfaces: [ Ethernet4, Ethernet4 ]
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
