### PR TITLE
Data-model update in eos_cli_config_gen for SNMP local interfaces

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-api-http.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-api-http.md
@@ -2,15 +2,26 @@
 
 # Table of Contents
 
+- [management-api-http](#management-api-http)
+- [Table of Contents](#table-of-contents)
 - [Management](#management)
   - [Management Interfaces](#management-interfaces)
+    - [Management Interfaces Summary](#management-interfaces-summary)
+      - [IPv4](#ipv4)
+      - [IPv6](#ipv6)
+    - [Management Interfaces Device Configuration](#management-interfaces-device-configuration)
   - [DNS Domain](#dns-domain)
+  - [Domain-list](#domain-list)
   - [Name Servers](#name-servers)
   - [Domain Lookup](#domain-lookup)
   - [NTP](#ntp)
+  - [PTP](#ptp)
   - [Management SSH](#management-ssh)
-  - [Management GNMI](#management-api-gnmi)
-  - [Management API](#Management-api-http)
+  - [Management API GNMI](#management-api-gnmi)
+  - [Management API HTTP](#management-api-http-1)
+    - [Management API HTTP Summary](#management-api-http-summary)
+    - [Management API VRF Access](#management-api-vrf-access)
+    - [Management API HTTP Configuration](#management-api-http-configuration)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
   - [Enable Password](#enable-password)
@@ -34,9 +45,10 @@
 - [MLAG](#mlag)
 - [Spanning Tree](#spanning-tree)
 - [Internal VLAN Allocation Policy](#internal-vlan-allocation-policy)
+  - [Internal VLAN Allocation Policy Summary](#internal-vlan-allocation-policy-summary)
 - [VLANs](#vlans)
 - [Interfaces](#interfaces)
-  - [Interface Defaults](#internet-defaults)
+  - [Interface Defaults](#interface-defaults)
   - [Ethernet Interfaces](#ethernet-interfaces)
   - [Port-Channel Interfaces](#port-channel-interfaces)
   - [Loopback Interfaces](#loopback-interfaces)
@@ -45,13 +57,18 @@
 - [Routing](#routing)
   - [Virtual Router MAC Address](#virtual-router-mac-address)
   - [IP Routing](#ip-routing)
+    - [IP Routing Summary](#ip-routing-summary)
+    - [IP Routing Device Configuration](#ip-routing-device-configuration)
   - [IPv6 Routing](#ipv6-routing)
+    - [IPv6 Routing Summary](#ipv6-routing-summary)
   - [Static Routes](#static-routes)
   - [IPv6 Static Routes](#ipv6-static-routes)
+  - [ARP](#arp)
   - [Router OSPF](#router-ospf)
   - [Router ISIS](#router-isis)
   - [Router BGP](#router-bgp)
   - [Router BFD](#router-bfd)
+    - [Router BFD Multihop Summary](#router-bfd-multihop-summary)
 - [Multicast](#multicast)
   - [IP IGMP Snooping](#ip-igmp-snooping)
   - [Router Multicast](#router-multicast)
@@ -65,6 +82,9 @@
   - [IP Extended Communities](#ip-extended-communities)
 - [ACL](#acl)
   - [Standard Access-lists](#standard-access-lists)
+    - [Standard Access-lists Summary](#standard-access-lists-summary)
+      - [ACL-API](#acl-api)
+    - [Standard Access-lists Device Configuration](#standard-access-lists-device-configuration)
   - [Extended Access-lists](#extended-access-lists)
   - [IPv6 Standard Access-lists](#ipv6-standard-access-lists)
   - [IPv6 Extended Access-lists](#ipv6-extended-access-lists)
@@ -74,9 +94,11 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
-- [MAC security](#mac-security)
+- [MACsec](#macsec)
+- [MACsec](#macsec-1)
 - [QOS](#qos)
 - [QOS Profiles](#qos-profiles)
+- [Custom Templates](#custom-templates)
 
 # Management
 
@@ -450,6 +472,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # MACsec
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/snmp_v3.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/snmp_v3.md
@@ -210,7 +210,9 @@ No logging settings defined
 
 | Local Interface | VRF |
 | --------------- | --- |
-| Management0 | mgt |
+| Management1 | MGMT |
+| Loopback0 | default |
+| Loopback12 | Tenant_A_APP_Zone |
 
 ### SNMP VRF Status
 
@@ -229,19 +231,19 @@ No logging settings defined
 
 ### SNMP Views Configuration
 
-| View | MIB Family Name | Status |  
-| ---- | --------------- | ------ | 
+| View | MIB Family Name | Status |
+| ---- | --------------- | ------ |
 | VW-WRITE | iso |  Included | VW-READ | iso |  Included 
 ### SNMP Groups Configuration
 
-| Group | SNMP Version | Authentication | Read | Write | Notify |  
+| Group | SNMP Version | Authentication | Read | Write | Notify |
 | ----- | ------------ | -------------- | ---- | ----- | ------ |
 | GRP-READ-ONLY | v3 | priv | v3read | - | - |
 | GRP-READ-WRITE | v3 | auth | v3read | v3write | - |
 
 ### SNMP Users Configuration
 
-| User | Group | Version | Authentication | Privacy | 
+| User | Group | Version | Authentication | Privacy |
 | ---- | ----- | ------- | -------------- | ------- |
 | USER-READ | GRP-READ-ONLY | v3 | sha | aes |
 | USER-WRITE | GRP-READ-WRITE | v3 | sha | aes |
@@ -255,7 +257,9 @@ snmp-server contact DC1_OPS
 snmp-server location DC1
 snmp-server ipv4 access-list onur
 snmp-server ipv6 access-list onurv6
-snmp-server vrf mgt local-interface Management0
+snmp-server vrf MGMT local-interface Management1
+snmp-server local-interface Loopback0
+snmp-server vrf Tenant_A_APP_Zone local-interface Loopback12
 snmp-server view VW-WRITE iso included
 snmp-server view VW-READ iso included
 snmp-server group GRP-READ-ONLY v3  priv read v3read 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/snmp_v3.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/snmp_v3.cfg
@@ -8,7 +8,9 @@ snmp-server contact DC1_OPS
 snmp-server location DC1
 snmp-server ipv4 access-list onur
 snmp-server ipv6 access-list onurv6
-snmp-server vrf mgt local-interface Management0
+snmp-server vrf MGMT local-interface Management1
+snmp-server local-interface Loopback0
+snmp-server vrf Tenant_A_APP_Zone local-interface Loopback12
 snmp-server view VW-WRITE iso included
 snmp-server view VW-READ iso included
 snmp-server group GRP-READ-ONLY v3  priv read v3read 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/snmp_v3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/snmp_v3.yml
@@ -3,8 +3,11 @@ snmp_server:
   contact: DC1_OPS
   location: DC1
   local_interfaces:
-    - name: Management0
-      vrf: mgt
+    Management1:
+      vrf: MGMT
+    Loopback0:
+    Loopback12:
+      vrf: Tenant_A_APP_Zone
   ipv4_access_list: onur
   ipv6_access_list: onurv6
   views:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -428,9 +428,11 @@ snmp_server:
   ipv4_access_list: < ipv4-access-list >
   ipv6_access_list: < ipv6-access-list >
   local_interfaces:
-    - name: < interface_name_1 >
+    < interface_name_1 >:
       vrf: < vrf_name >
-    - name: < interface_name_2 >
+    < interface_name_2 >:
+    < interface_name_3 >:
+      vrf: < vrf_name >
   views:
     - name: < view_name >
       MIB_family_name: < MIB_family_name >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/snmp-settings.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/snmp-settings.j2
@@ -11,7 +11,7 @@
 | --------------- | --- |
 {% if snmp_server.local_interfaces is defined and snmp_server.local_interfaces is not none %}
 {%      for interface in snmp_server.local_interfaces %}
-| {{interface.name}} | {{interface.vrf | default('default')}} |
+| {{interface}} | {{snmp_server.local_interfaces[interface]['vrf'] | default('default')}} |
 {%      endfor %}
 {% endif %}
 
@@ -41,8 +41,8 @@
 {%  if snmp_server.views is defined and snmp_server.views is not none %}
 ### SNMP Views Configuration
 
-| View | MIB Family Name | Status |  
-| ---- | --------------- | ------ | 
+| View | MIB Family Name | Status |
+| ---- | --------------- | ------ |
 {%      for view in snmp_server.views %}
 | {{ view.name | default('default') }} | {{ view.MIB_family_name | default('-') }} | {% if view.included %} Included {% else %} Excluded {% endif %}
 {%      endfor %}
@@ -51,7 +51,7 @@
 {%  if snmp_server.groups is defined and snmp_server.groups is not none %}
 ### SNMP Groups Configuration
 
-| Group | SNMP Version | Authentication | Read | Write | Notify |  
+| Group | SNMP Version | Authentication | Read | Write | Notify |
 | ----- | ------------ | -------------- | ---- | ----- | ------ |
 {%      for group in snmp_server.groups %}
 | {{ group.name | default('default') }} | {{ group.version | default('-') }} | {{ group.authentication | default('-') }} | {{ group.read | default('-') }} | {{ group.write | default('-') }} | {{ group.notify | default('-') }} |
@@ -61,7 +61,7 @@
 {%  if snmp_server.users is defined and snmp_server.users is not none %}
 ### SNMP Users Configuration
 
-| User | Group | Version | Authentication | Privacy | 
+| User | Group | Version | Authentication | Privacy |
 | ---- | ----- | ------- | -------------- | ------- |
 {%      for user in snmp_server.users %}
 | {{ user.name | default('default') }} | {{ user.group | default('-') }} | {{ user.version | default('-') }} | {{ user.auth | default('-') }} | {{ user.priv | default('-') }} |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/snmp-settings.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/snmp-settings.j2
@@ -15,9 +15,14 @@ snmp-server ipv6 access-list {{ snmp_server.ipv6_access_list }}
 {%     endif %}
 {%     if snmp_server.local_interfaces is defined and snmp_server.local_interfaces is not none %}
 {%          for local_interface in snmp_server.local_interfaces %}
-snmp-server {% if local_interface['vrf'] is defined and local_interface['vrf'] is not none %}vrf {{ local_interface['vrf'] }} {% endif %}local-interface {{ local_interface['name'] }}
+snmp-server {% if snmp_server.local_interfaces[local_interface]['vrf'] is defined and snmp_server.local_interfaces[local_interface]['vrf'] is not none %}vrf {{ snmp_server.local_interfaces[local_interface]['vrf'] }} {% endif %}local-interface {{ local_interface }}
 {%          endfor %}
 {%     endif %}
+{# {%     if snmp_server.local_interfaces is defined and snmp_server.local_interfaces is not none %}
+{%          for local_interface in snmp_server.local_interfaces %}
+snmp-server {% if local_interface['vrf'] is defined and local_interface['vrf'] is not none %}vrf {{ local_interface['vrf'] }} {% endif %}local-interface {{ local_interface['name'] }}
+{%          endfor %}
+{%     endif %} #}
 {%     if snmp_server.views is defined and snmp_server.views is not none %}
 {%          for view in snmp_server.views %}
 snmp-server view {{ view['name'] }} {{ view['MIB_family_name'] }} {% if view['included'] == true %}included{% else %}excluded {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/snmp-settings.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/snmp-settings.j2
@@ -18,11 +18,6 @@ snmp-server ipv6 access-list {{ snmp_server.ipv6_access_list }}
 snmp-server {% if snmp_server.local_interfaces[local_interface]['vrf'] is defined and snmp_server.local_interfaces[local_interface]['vrf'] is not none %}vrf {{ snmp_server.local_interfaces[local_interface]['vrf'] }} {% endif %}local-interface {{ local_interface }}
 {%          endfor %}
 {%     endif %}
-{# {%     if snmp_server.local_interfaces is defined and snmp_server.local_interfaces is not none %}
-{%          for local_interface in snmp_server.local_interfaces %}
-snmp-server {% if local_interface['vrf'] is defined and local_interface['vrf'] is not none %}vrf {{ local_interface['vrf'] }} {% endif %}local-interface {{ local_interface['name'] }}
-{%          endfor %}
-{%     endif %} #}
 {%     if snmp_server.views is defined and snmp_server.views is not none %}
 {%          for view in snmp_server.views %}
 snmp-server view {{ view['name'] }} {{ view['MIB_family_name'] }} {% if view['included'] == true %}included{% else %}excluded {% endif %}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
## Change Summary

Data-model update in eos_cli_config_gen for SNMP local interfaces   
Change in the data-model for local interfaces for SNMP  as one interface can only be associated to one VRF in EOS.  

with this new data model 
```
snmp_server:
  local_interfaces:
    Management1:
      vrf: mgt
    Loopback0:
    Loopback12:
      vrf: test2
```
eos_cli_config_gen will then render the following which is also the configuration in EOS:
```
snmp-server vrf mgt local-interface Management1
snmp-server local-interface Loopback0
snmp-server vrf test2 local-interface Loopback12
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
#507 
## Component(s) name

Eos_cli_config_gen role 

- eos template https://github.com/aristanetworks/ansible-avd/blob/devel/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/snmp-settings.j2   
- doc template https://github.com/aristanetworks/ansible-avd/blob/devel/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/snmp-settings.j2   

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

add this to a device structure config 
```
snmp_server:
  local_interfaces:
    Management1:
      vrf: MGMT
    Loopback0:
    Loopback12:
      vrf: Tenant_A_APP_Zone
```
and run the `Eos_cli_config_gen` role 
and verify the cli config is
```
snmp-server vrf mgt local-interface Management1
snmp-server local-interface Loopback0
snmp-server vrf test2 local-interface Loopback12
``` 
and verify the device markdown documentation 
```
### SNMP Local Interfaces

| Local Interface | VRF |
| --------------- | --- |
| Management1 | MGMT |
| Loopback0 | default |
| Loopback12 | Tenant_A_APP_Zone |
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
