### PR TITLE
Implement dot1q encap for L3 sub interface - #546

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -251,6 +251,8 @@ No VLANs defined
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
 | Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet1  |  routed  | - |  172.31.255.1/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet100.101 |  IFL for TENANT01  |  switchport  | - |  10.1.1.3/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet100.102 |  IFL for TENANT02  |  switchport  | - |  10.1.2.3/31  |  C2  |  1500  |  -  |  -  |  -  |
 
 ### Ethernet Interfaces Device Configuration
 
@@ -273,6 +275,20 @@ interface Ethernet6
    description SRV-POD02_Eth1
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
+!
+interface Ethernet100
+   no switchport
+!
+interface Ethernet100.101
+   description IFL for TENANT01
+   encapsulation dot1q vlan 101
+   ip address 10.1.1.3/31
+!
+interface Ethernet100.102
+   description IFL for TENANT02
+   encapsulation dot1q vlan 102
+   vrf C2
+   ip address 10.1.2.3/31
 ```
 
 ## Port-Channel Interfaces

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-api-http.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-api-http.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -119,6 +120,10 @@ DNS domain lookup not defined
 ## NTP
 
 No NTP servers defined
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -428,6 +433,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
@@ -281,6 +281,13 @@ interface Ethernet50
 | Port-Channel5 | DC1_L2LEAF1_Po1 | switched | access | 110,201 | - | - | - | - | 5 | - |
 | Port-Channel50 | SRV-POD03_PortChanne1 | switched | access | 1-4000 | - | - | - | - | - | 0000:0000:0303:0202:0101 |
 
+#### IPv4
+
+| Interface | Description | Type | MLAG ID | IP Address | VRF | MTU | Shutdown | ACL In | ACL Out |
+| --------- | ----------- | ---- | ------- | ---------- | --- | --- | -------- | ------ | ------- |
+| Port-Channel100.101 | IFL for TENANT01 | routed | - | 10.1.1.3/31 | default | 1500 | - | - | - |
+| Port-Channel100.102 | IFL for TENANT02 | routed | - | 10.1.2.3/31 | C2 | 1500 | - | - | - |
+
 ### Port-Channel Interfaces Device Configuration
 
 ```eos
@@ -308,6 +315,22 @@ interface Port-Channel50
        route-target import 03:03:02:02:01:01
    !
    lacp system-id 0303.0202.0101
+!
+interface Port-Channel100
+   no switchport
+!
+interface Port-Channel100.101
+   description IFL for TENANT01
+   mtu 1500
+   encapsulation dot1q vlan 101
+   ip address 10.1.1.3/31
+!
+interface Port-Channel100.102
+   description IFL for TENANT02
+   mtu 1500
+   encapsulation dot1q vlan 102
+   vrf C2
+   ip address 10.1.2.3/31
 ```
 
 ## Loopback Interfaces

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
@@ -24,6 +24,20 @@ interface Ethernet6
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
 !
+interface Ethernet100
+   no switchport
+!
+interface Ethernet100.101
+   description IFL for TENANT01
+   encapsulation dot1q vlan 101
+   ip address 10.1.1.3/31
+!
+interface Ethernet100.102
+   description IFL for TENANT02
+   encapsulation dot1q vlan 102
+   vrf C2
+   ip address 10.1.2.3/31
+!
 interface Management1
    description oob_management
    vrf MGMT

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
@@ -30,6 +30,22 @@ interface Port-Channel50
    !
    lacp system-id 0303.0202.0101
 !
+interface Port-Channel100
+   no switchport
+!
+interface Port-Channel100.101
+   description IFL for TENANT01
+   mtu 1500
+   encapsulation dot1q vlan 101
+   ip address 10.1.1.3/31
+!
+interface Port-Channel100.102
+   description IFL for TENANT02
+   mtu 1500
+   encapsulation dot1q vlan 102
+   vrf C2
+   ip address 10.1.2.3/31
+!
 interface Ethernet3
    description MLAG_PEER_DC1-LEAF1B_Ethernet3
    channel-group 3 mode active

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
@@ -36,3 +36,21 @@ ethernet_interfaces:
       unknown_unicast:
         level: 1
         unit: percent
+
+  Ethernet100:
+    type: routed
+  Ethernet100.101:
+    description: IFL for TENANT01
+    mtu: 1500
+    ip_address: 10.1.1.3/31
+    encapsulation:
+      dot1q:
+        vlan: 101
+  Ethernet100.102:
+    description: IFL for TENANT02
+    mtu: 1500
+    ip_address: 10.1.2.3/31
+    vrf: C2
+    encapsulation:
+      dot1q:
+        vlan: 102

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
@@ -24,6 +24,24 @@ port_channel_interfaces:
     rt: 03:03:02:02:01:01
     lacp_id: 0303.0202.0101
 
+  Port-Channel100:
+    type: routed
+  Port-Channel100.101:
+    description: IFL for TENANT01
+    mtu: 1500
+    ip_address: 10.1.1.3/31
+    encapsulation:
+      dot1q:
+        vlan: 101
+  Port-Channel100.102:
+    description: IFL for TENANT02
+    mtu: 1500
+    ip_address: 10.1.2.3/31
+    vrf: C2
+    encapsulation:
+      dot1q:
+        vlan: 102
+
 # Children interfaces
 ethernet_interfaces:
   Ethernet5:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -684,6 +684,9 @@ port_channel_interfaces:
     description: < description >
     mtu: < mtu >
     type: < switched | routed >
+    encapsulation:
+      dot1q:
+        vlan: < vlan-id >
     ip_address:  < IP_address/mask >
     ipv6_enable: < true | false >
     ipv6_address: < IPv6_address/mask >
@@ -716,6 +719,9 @@ ethernet_interfaces:
     speed: < interface_speed >
     mtu: < mtu >
     type: < routed | switched >
+    encapsulation:
+      dot1q:
+        vlan: < vlan-id >
     vrf: < vrf_name >
     ip_address: < IPv4_address/Mask >
     ip_address_secondaries:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ethernet-interfaces.j2
@@ -10,7 +10,7 @@
 {%         set port_channel_interface = 'Port-Channel' + ethernet_interfaces[ethernet_interface].channel_group.id | string %}
 {%         if port_channel_interfaces[port_channel_interface].type is not defined or port_channel_interfaces[port_channel_interface].type != "routed" %}
 {%             set description = ethernet_interfaces[ethernet_interface].description | default("-") %}
-{%             set mode = port_channel_interfaces[port_channel_interface].mode | default("access") %}
+{%             set mode = port_channel_interfaces[port_channel_interface].mode | default("-") %}
 {%             set vlans = port_channel_interfaces[port_channel_interface].vlans | default ('-') %}
 {%             set native_vlan = port_channel_interfaces[port_channel_interface].native_vlan | default ('-') %}
 {%             set channel_group = ethernet_interfaces[ethernet_interface].channel_group.id %}
@@ -26,9 +26,9 @@
 {%             endif %}
 | {{ ethernet_interface }} | {{ description }} | *{{ mode }} | *{{ vlans }} | *{{ native_vlan }} | *{{ l2.trunk_groups }} | {{ channel_group }} |
 {%         endif %}
-{%     elif (ethernet_interfaces[ethernet_interface].type is not defined or ethernet_interfaces[ethernet_interface].type != "routed") or ethernet_interfaces[ethernet_interface].encapsulation is not defined %}
+{%     elif (ethernet_interfaces[ethernet_interface].type is not defined and ethernet_interfaces[ethernet_interface].encapsulation is not defined) or (ethernet_interfaces[ethernet_interface].type is defined and ethernet_interfaces[ethernet_interface].type != "routed") %}
 {%         set description = ethernet_interfaces[ethernet_interface].description | default("-") %}
-{%         set mode = ethernet_interfaces[ethernet_interface].mode | default("access") %}
+{%         set mode = ethernet_interfaces[ethernet_interface].mode | default("-") %}
 {%         set vlans = ethernet_interfaces[ethernet_interface].vlans | default ('-') %}
 {%         set native_vlan = ethernet_interfaces[ethernet_interface].native_vlan | default ('-') %}
 {%         if ethernet_interfaces[ethernet_interface].trunk_groups is defined %}
@@ -50,7 +50,7 @@
 {%     set ethernet_interface_ipv4 = namespace() %}
 {%     set ethernet_interface_ipv4.configured = false %}
 {%     for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort %}
-{%          if (ethernet_interfaces[ethernet_interface].type is defined and ethernet_interfaces[ethernet_interface].type == 'routed') and ethernet_interfaces[ethernet_interface].encapsulation is defined %}
+{%          if (ethernet_interfaces[ethernet_interface].type is defined and ethernet_interfaces[ethernet_interface].type == 'routed') or ethernet_interfaces[ethernet_interface].encapsulation is defined %}
 {%              set ethernet_interface_ipv4.configured = true %}
 {%          endif %}
 {%     endfor %}
@@ -58,7 +58,7 @@
 {%     set port_channel_interface_ipv4.configured = false %}
 {%     if port_channel_interfaces is defined and port_channel_interfaces is not none %}
 {%         for port_channel_interface in port_channel_interfaces | arista.avd.natural_sort %}
-{%              if port_channel_interfaces[port_channel_interface].type is defined and port_channel_interfaces[port_channel_interface].type == 'routed' and port_channel_interfaces[port_channel_interface].ip_address is defined %}
+{%              if (port_channel_interfaces[port_channel_interface].type is defined and port_channel_interfaces[port_channel_interface].type == 'routed') or port_channel_interfaces[port_channel_interface].encapsulation is defined %}
 {%                  set port_channel_interface_ipv4.configured = true %}
 {%              endif %}
 {%         endfor %}
@@ -73,15 +73,16 @@
 {%             if ethernet_interfaces[ethernet_interface].channel_group.id is defined and ethernet_interfaces[ethernet_interface].channel_group.id is not none %}
 {%                 set port_channel_interface = 'Port-Channel' + ethernet_interfaces[ethernet_interface].channel_group.id | string %}
 {%                 if port_channel_interfaces[port_channel_interface].ip_address is defined and port_channel_interfaces[port_channel_interface].ip_address is not none %}
-| {{ ethernet_interface }} | {% if ethernet_interfaces[ethernet_interface].description is defined and ethernet_interfaces[ethernet_interface].description is not none %} {{ ethernet_interfaces[ethernet_interface].description }} {% else %} - {% endif %} | {% if port_channel_interfaces[port_channel_interface].type is defined and port_channel_interfaces[port_channel_interface].type is not none %} *{{ port_channel_interfaces[port_channel_interface].type }} {% else %} *switchport {% endif %} | {% if ethernet_interfaces[ethernet_interface].channel_group.id is defined and ethernet_interfaces[ethernet_interface].channel_group.id is not none %} {{ ethernet_interfaces[ethernet_interface].channel_group.id }} {% else %} - {% endif %} | {% if port_channel_interfaces[port_channel_interface].ip_address is defined and port_channel_interfaces[port_channel_interface].ip_address is not none %} *{{ port_channel_interfaces[port_channel_interface].ip_address }} {% else %} *- {% endif %} | {% if port_channel_interfaces[port_channel_interface].vrf is defined and port_channel_interfaces[port_channel_interface].vrf is not none %} *{{ port_channel_interfaces[port_channel_interface].vrf }} {% else %} *default {% endif %} | {% if port_channel_interfaces[port_channel_interface].mtu is defined and port_channel_interfaces[port_channel_interface].mtu is not none %} *{{ port_channel_interfaces[port_channel_interface].mtu }} {% else %} *- {% endif %} | {% if port_channel_interfaces[port_channel_interface].shutdown is defined and port_channel_interfaces[port_channel_interface].shutdown is not none %} *{{ port_channel_interfaces[port_channel_interface].shutdown | lower }} {% else %} *- {% endif %} | {% if port_channel_interfaces[port_channel_interface].access_group_in is defined and port_channel_interfaces[port_channel_interface].access_group_in is not none %} *{{ port_channel_interfaces[port_channel_interface].access_group_in }} {% else %} *- {% endif %} | {% if port_channel_interfaces[port_channel_interface].access_group_out is defined and port_channel_interfaces[port_channel_interface].access_group_out is not none %} *{{ port_channel_interfaces[port_channel_interface].access_group_out }} {% else %} *- {% endif %} |
+| {{ ethernet_interface }} | {% if ethernet_interfaces[ethernet_interface].description is defined and ethernet_interfaces[ethernet_interface].description is not none %} {{ ethernet_interfaces[ethernet_interface].description }} {% else %} - {% endif %} | {% if port_channel_interfaces[port_channel_interface].type is defined and port_channel_interfaces[port_channel_interface].type is not none %} *{{ port_channel_interfaces[port_channel_interface].type }} {% elif port_channel_interfaces[port_channel_interface].encapsulation is defined %} *routed {% else %} *switchport {% endif %} | {% if ethernet_interfaces[ethernet_interface].channel_group.id is defined and ethernet_interfaces[ethernet_interface].channel_group.id is not none %} {{ ethernet_interfaces[ethernet_interface].channel_group.id }} {% else %} - {% endif %} | {% if port_channel_interfaces[port_channel_interface].ip_address is defined and port_channel_interfaces[port_channel_interface].ip_address is not none %} *{{ port_channel_interfaces[port_channel_interface].ip_address }} {% else %} *- {% endif %} | {% if port_channel_interfaces[port_channel_interface].vrf is defined and port_channel_interfaces[port_channel_interface].vrf is not none %} *{{ port_channel_interfaces[port_channel_interface].vrf }} {% else %} *default {% endif %} | {% if port_channel_interfaces[port_channel_interface].mtu is defined and port_channel_interfaces[port_channel_interface].mtu is not none %} *{{ port_channel_interfaces[port_channel_interface].mtu }} {% else %} *- {% endif %} | {% if port_channel_interfaces[port_channel_interface].shutdown is defined and port_channel_interfaces[port_channel_interface].shutdown is not none %} *{{ port_channel_interfaces[port_channel_interface].shutdown | lower }} {% else %} *- {% endif %} | {% if port_channel_interfaces[port_channel_interface].access_group_in is defined and port_channel_interfaces[port_channel_interface].access_group_in is not none %} *{{ port_channel_interfaces[port_channel_interface].access_group_in }} {% else %} *- {% endif %} | {% if port_channel_interfaces[port_channel_interface].access_group_out is defined and port_channel_interfaces[port_channel_interface].access_group_out is not none %} *{{ port_channel_interfaces[port_channel_interface].access_group_out }} {% else %} *- {% endif %} |
 {%                 endif %}
 {%             else %}
 {%                 if ethernet_interfaces[ethernet_interface].ip_address is defined and ethernet_interfaces[ethernet_interface].ip_address is not none %}
-| {{ ethernet_interface }} | {% if ethernet_interfaces[ethernet_interface].description is defined and ethernet_interfaces[ethernet_interface].description is not none %} {{ ethernet_interfaces[ethernet_interface].description }} {% else %} - {% endif %} | {% if ethernet_interfaces[ethernet_interface].type is defined and ethernet_interfaces[ethernet_interface].type is not none %} {{ ethernet_interfaces[ethernet_interface].type }} {% else %} switchport {% endif %} | - | {% if ethernet_interfaces[ethernet_interface].ip_address is defined and ethernet_interfaces[ethernet_interface].ip_address is not none %} {{ ethernet_interfaces[ethernet_interface].ip_address }} {% else %} - {% endif %} | {% if ethernet_interfaces[ethernet_interface].vrf is defined and ethernet_interfaces[ethernet_interface].vrf is not none %} {{ ethernet_interfaces[ethernet_interface].vrf }} {% else %} default {% endif %} | {% if ethernet_interfaces[ethernet_interface].mtu is defined and ethernet_interfaces[ethernet_interface].mtu is not none %} {{ ethernet_interfaces[ethernet_interface].mtu }} {% else %} - {% endif %} | {% if ethernet_interfaces[ethernet_interface].shutdown is defined and ethernet_interfaces[ethernet_interface].shutdown is not none %} {{ ethernet_interfaces[ethernet_interface].shutdown | lower }} {% else %} - {% endif %} | {% if ethernet_interfaces[ethernet_interface].access_group_in is defined and ethernet_interfaces[ethernet_interface].access_group_in is not none %} {{ ethernet_interfaces[ethernet_interface].access_group_in }} {% else %} - {% endif %} | {% if ethernet_interfaces[ethernet_interface].access_group_out is defined and ethernet_interfaces[ethernet_interface].access_group_out is not none %} {{ ethernet_interfaces[ethernet_interface].access_group_out }} {% else %} - {% endif %} |
+| {{ ethernet_interface }} | {% if ethernet_interfaces[ethernet_interface].description is defined and ethernet_interfaces[ethernet_interface].description is not none %} {{ ethernet_interfaces[ethernet_interface].description }} {% else %} - {% endif %} | {% if ethernet_interfaces[ethernet_interface].type is defined and ethernet_interfaces[ethernet_interface].type is not none %} {{ ethernet_interfaces[ethernet_interface].type }} {% elif ethernet_interfaces[ethernet_interface].encapsulation is defined %} routed {% else %} switchport {% endif %} | - | {% if ethernet_interfaces[ethernet_interface].ip_address is defined and ethernet_interfaces[ethernet_interface].ip_address is not none %} {{ ethernet_interfaces[ethernet_interface].ip_address }} {% else %} - {% endif %} | {% if ethernet_interfaces[ethernet_interface].vrf is defined and ethernet_interfaces[ethernet_interface].vrf is not none %} {{ ethernet_interfaces[ethernet_interface].vrf }} {% else %} default {% endif %} | {% if ethernet_interfaces[ethernet_interface].mtu is defined and ethernet_interfaces[ethernet_interface].mtu is not none %} {{ ethernet_interfaces[ethernet_interface].mtu }} {% else %} - {% endif %} | {% if ethernet_interfaces[ethernet_interface].shutdown is defined and ethernet_interfaces[ethernet_interface].shutdown is not none %} {{ ethernet_interfaces[ethernet_interface].shutdown | lower }} {% else %} - {% endif %} | {% if ethernet_interfaces[ethernet_interface].access_group_in is defined and ethernet_interfaces[ethernet_interface].access_group_in is not none %} {{ ethernet_interfaces[ethernet_interface].access_group_in }} {% else %} - {% endif %} | {% if ethernet_interfaces[ethernet_interface].access_group_out is defined and ethernet_interfaces[ethernet_interface].access_group_out is not none %} {{ ethernet_interfaces[ethernet_interface].access_group_out }} {% else %} - {% endif %} |
 {%                 endif %}
 {%             endif %}
 {%         endfor %}
 {%     endif %}
+
 {% if port_channel_interface_ipv4.configured == true %} *Inherited from Port-Channel Interface {% endif %}
 {# IPv6 #}
 {%     set ethernet_interface_ipv6 = namespace() %}
@@ -119,6 +120,7 @@
 {%             endif %}
 {%         endfor %}
 {%     endif %}
+
 {% if port_channel_interface_ipv6.configured == true %} *Inherited from Port-Channel Interface {% endif %}
 {# OSPF #}
 {%     set ethernet_interface_ospf = namespace() %}
@@ -140,6 +142,7 @@
 {%     if ethernet_interface_ospf.configured == true or port_channel_interface_ospf.configured == true %}
 
 #### OSPF
+
 | Interface | Channel Group | Area | Cost | Mode |
 | --------- | ------------- | ---- | ---- |----- |
 {%         for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ethernet-interfaces.j2
@@ -26,7 +26,7 @@
 {%             endif %}
 | {{ ethernet_interface }} | {{ description }} | *{{ mode }} | *{{ vlans }} | *{{ native_vlan }} | *{{ l2.trunk_groups }} | {{ channel_group }} |
 {%         endif %}
-{%     elif ethernet_interfaces[ethernet_interface].type is not defined or ethernet_interfaces[ethernet_interface].type != "routed" %}
+{%     elif (ethernet_interfaces[ethernet_interface].type is not defined or ethernet_interfaces[ethernet_interface].type != "routed") or ethernet_interfaces[ethernet_interface].encapsulation is not defined %}
 {%         set description = ethernet_interfaces[ethernet_interface].description | default("-") %}
 {%         set mode = ethernet_interfaces[ethernet_interface].mode | default("access") %}
 {%         set vlans = ethernet_interfaces[ethernet_interface].vlans | default ('-') %}
@@ -50,7 +50,7 @@
 {%     set ethernet_interface_ipv4 = namespace() %}
 {%     set ethernet_interface_ipv4.configured = false %}
 {%     for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort %}
-{%          if ethernet_interfaces[ethernet_interface].type is defined and ethernet_interfaces[ethernet_interface].type == 'routed' and ethernet_interfaces[ethernet_interface].ip_address is defined %}
+{%          if (ethernet_interfaces[ethernet_interface].type is defined and ethernet_interfaces[ethernet_interface].type == 'routed') and ethernet_interfaces[ethernet_interface].encapsulation is defined %}
 {%              set ethernet_interface_ipv4.configured = true %}
 {%          endif %}
 {%     endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/port-channel-interfaces.j2
@@ -6,7 +6,7 @@
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
 {%     for port_channel_interface in port_channel_interfaces | arista.avd.natural_sort %}
-{%         if port_channel_interfaces[port_channel_interface].type is not defined or port_channel_interfaces[port_channel_interface].type != "routed" %}
+{%         if (port_channel_interfaces[port_channel_interface].type is not defined or port_channel_interfaces[port_channel_interface].type != "routed") and port_channel_interfaces[port_channel_interface].encapsulation is not defined %}
 {%             set description = port_channel_interfaces[port_channel_interface].description | default ("-")%}
 {%             set type = port_channel_interfaces[port_channel_interface].type | default ("switched")%}
 {%             set mode = port_channel_interfaces[port_channel_interface].type | default ("access")%}
@@ -34,7 +34,7 @@
 {%   set port_channel_interface_ipv4.configured = false %}
 {%   if port_channel_interfaces is defined and port_channel_interfaces is not none %}
 {%       for port_channel_interface in port_channel_interfaces | arista.avd.natural_sort %}
-{%           if port_channel_interfaces[port_channel_interface].type is defined and port_channel_interfaces[port_channel_interface].type == 'routed' and port_channel_interfaces[port_channel_interface].ip_address is defined %}
+{%           if (port_channel_interfaces[port_channel_interface].type is defined and port_channel_interfaces[port_channel_interface].type == 'routed') or  port_channel_interfaces[port_channel_interface].encapsulation is defined %}
 {%               set port_channel_interface_ipv4.configured = true %}
 {%           endif %}
 {%        endfor %}
@@ -46,7 +46,7 @@
 | Interface | Description | Type | MLAG ID | IP Address | VRF | MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | ---- | ------- | ---------- | --- | --- | -------- | ------ | ------- |
 {%        for port_channel_interface in port_channel_interfaces | arista.avd.natural_sort %}
-{%            if port_channel_interfaces[port_channel_interface].type is defined and port_channel_interfaces[port_channel_interface].type == "routed" and port_channel_interfaces[port_channel_interface].ip_address is defined and port_channel_interfaces[port_channel_interface].ip_address is not none %}
+{%            if (port_channel_interfaces[port_channel_interface].type is defined and port_channel_interfaces[port_channel_interface].type == "routed" or port_channel_interfaces[port_channel_interface].encapsulation is defined) and port_channel_interfaces[port_channel_interface].ip_address is defined and port_channel_interfaces[port_channel_interface].ip_address is not none %}
 {%                set description = port_channel_interfaces[port_channel_interface].description | default ("-")%}
 {%                set type = "routed" %}
 {%                set mlag = port_channel_interfaces[port_channel_interface].mlag | default ("-")%}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -43,6 +43,9 @@ interface {{ ethernet_interface }}
    switchport trunk group {{ trunk_group }}
 {%                 endfor %}
 {%             endif %}
+{%             if ethernet_interfaces[ethernet_interface].encapsulation.dot1q.vlan is defined %}
+   encapsulation dot1q vlan {{ ethernet_interfaces[ethernet_interface].encapsulation.dot1q.vlan }}
+{%             endif %}
 {%             if ethernet_interfaces[ethernet_interface].qos.trust is defined and ethernet_interfaces[ethernet_interface].qos.trust is not none %}
    qos trust {{ ethernet_interfaces[ethernet_interface].qos.trust }}
 {%             endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
@@ -27,6 +27,9 @@ interface {{ port_channel_interface }}
 {%         if port_channel_interfaces[port_channel_interface].mode is defined and port_channel_interfaces[port_channel_interface].mode == "trunk" %}
    switchport mode {{ port_channel_interfaces[port_channel_interface].mode }}
 {%         endif %}
+{%             if port_channel_interfaces[port_channel_interface].encapsulation.dot1q.vlan is defined %}
+   encapsulation dot1q vlan {{ port_channel_interfaces[port_channel_interface].encapsulation.dot1q.vlan }}
+{%             endif %}
 {%         if port_channel_interfaces[port_channel_interface].trunk_groups is defined %}
 {%             for  trunk_group in port_channel_interfaces[port_channel_interface].trunk_groups | arista.avd.natural_sort %}
    switchport trunk group {{ trunk_group }}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Fixes #546 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Extend data model as per issue #546 

```yaml
ethernet_interfaces:
  ethernet1.101:
    encapsulation:
      dot1q:
        vlan: 101
```

Applied also on `port-channel` interfaces

## How to test

Run Molecule scenario for `eos-cli_config_gen`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
