### PR TITLE
Add explicit no shutdown and switchport config

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -263,6 +263,7 @@ interface Ethernet1
 !
 interface Ethernet2
    description SRV-POD02_Eth1
+   switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
    storm-control all level 10
@@ -271,6 +272,7 @@ interface Ethernet2
 !
 interface Ethernet6
    description SRV-POD02_Eth1
+   switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
 ```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mac-security-eth-po-entropy.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mac-security-eth-po-entropy.md
@@ -274,7 +274,7 @@ interface Ethernet1
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel3 | L2-PORT | switched | access | 1-5 | - | - | - | - | - | - |
+| Port-Channel3 | L2-PORT | switched | trunk | 1-5 | - | - | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mac-security-eth-po-entropy.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mac-security-eth-po-entropy.md
@@ -261,6 +261,7 @@ No VLANs defined
 ```eos
 !
 interface Ethernet1
+   switchport
    ip address 1.1.1.1/24
    mac security profile A1
 ```
@@ -281,6 +282,7 @@ interface Ethernet1
 !
 interface Port-Channel3
    description L2-PORT
+   switchport
    switchport trunk allowed vlan 1-5
    switchport mode trunk
 ```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-api-http.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-api-http.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -119,6 +120,10 @@ DNS domain lookup not defined
 ## NTP
 
 No NTP servers defined
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -428,6 +433,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
@@ -287,6 +287,7 @@ interface Ethernet50
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-LEAF1B_Po3
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -294,12 +295,14 @@ interface Port-Channel3
 !
 interface Port-Channel5
    description DC1_L2LEAF1_Po1
+   switchport
    switchport trunk allowed vlan 110,201
    switchport mode trunk
    mlag 5
 !
 interface Port-Channel50
    description SRV-POD03_PortChanne1
+   switchport
    switchport trunk allowed vlan 1-4000
    switchport mode trunk
    !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
@@ -277,9 +277,9 @@ interface Ethernet50
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel3 | MLAG_PEER_DC1-LEAF1B_Po3 | switched | access | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
-| Port-Channel5 | DC1_L2LEAF1_Po1 | switched | access | 110,201 | - | - | - | - | 5 | - |
-| Port-Channel50 | SRV-POD03_PortChanne1 | switched | access | 1-4000 | - | - | - | - | - | 0000:0000:0303:0202:0101 |
+| Port-Channel3 | MLAG_PEER_DC1-LEAF1B_Po3 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
+| Port-Channel5 | DC1_L2LEAF1_Po1 | switched | trunk | 110,201 | - | - | - | - | 5 | - |
+| Port-Channel50 | SRV-POD03_PortChanne1 | switched | trunk | 1-4000 | - | - | - | - | - | 0000:0000:0303:0202:0101 |
 
 ### Port-Channel Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis.md
@@ -362,6 +362,7 @@ interface Loopback1
 !
 interface Vlan110
    description PR01-DEMO
+   no shutdown
    vrf TENANT_A_PROJECT01
    ip address virtual 10.1.10.254/24
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
@@ -308,6 +308,7 @@ No loopback interfaces defined
 !
 interface Vlan24
    description SVI Description
+   no shutdown
    ip address virtual 10.10.24.1/24
    ipv6 address 1b11:3a00:22b0:6::15/64
    ipv6 nd managed-config-flag
@@ -316,6 +317,7 @@ interface Vlan24
 !
 interface Vlan41
    description SVI Description
+   no shutdown
    ip address virtual 10.10.41.1/24
    ip helper-address 10.10.64.150  source-interface Loopback0
    ip helper-address 10.10.96.150  source-interface Loopback0
@@ -323,10 +325,12 @@ interface Vlan41
 !
 interface Vlan42
    description SVI Description
+   no shutdown
    ip address virtual 10.10.42.1/24
 !
 interface Vlan75
    description SVI Description
+   no shutdown
    ip address virtual 10.10.75.1/24
    ipv6 address 1b11:3a00:22b0:1000::15/64
    ipv6 nd managed-config-flag
@@ -335,6 +339,7 @@ interface Vlan75
 !
 interface Vlan83
    description SVI Description
+   no shutdown
    ip address virtual 10.10.83.1/24
 !
 interface Vlan84
@@ -359,6 +364,7 @@ interface Vlan88
 !
 interface Vlan89
    description SVI Description
+   no shutdown
    ip address virtual 10.10.144.3/20
    ipv6 address 1b11:3a00:22b0:5200::15/64
    ipv6 nd managed-config-flag
@@ -370,12 +376,14 @@ interface Vlan89
 !
 interface Vlan501
    description SVI Description
+   no shutdown
    ip address 10.50.26.29/27
    ipv6 address 1b11:3a00:22b0:0088::207/127
    ipv6 nd ra disabled
 !
 interface Vlan1001
    description SVI Description
+   no shutdown
    vrf Tenant_A
    ip address virtual 10.1.1.1/24
    ipv6 address a1::1/64
@@ -384,6 +392,7 @@ interface Vlan1001
 !
 interface Vlan1002
    description SVI Description
+   no shutdown
    vrf Tenant_A
    ip address virtual 10.1.2.1/24
    ipv6 address a2::1/64

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
@@ -13,6 +13,7 @@ interface Ethernet1
 !
 interface Ethernet2
    description SRV-POD02_Eth1
+   switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
    storm-control all level 10
@@ -21,6 +22,7 @@ interface Ethernet2
 !
 interface Ethernet6
    description SRV-POD02_Eth1
+   switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/mac-security-eth-po-entropy.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/mac-security-eth-po-entropy.cfg
@@ -21,10 +21,12 @@ no aaa root
 !
 interface Port-Channel3
    description L2-PORT
+   switchport
    switchport trunk allowed vlan 1-5
    switchport mode trunk
 !
 interface Ethernet1
+   switchport
    ip address 1.1.1.1/24
    mac security profile A1
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
@@ -8,6 +8,7 @@ no aaa root
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-LEAF1B_Po3
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -15,12 +16,14 @@ interface Port-Channel3
 !
 interface Port-Channel5
    description DC1_L2LEAF1_Po1
+   switchport
    switchport trunk allowed vlan 110,201
    switchport mode trunk
    mlag 5
 !
 interface Port-Channel50
    description SRV-POD03_PortChanne1
+   switchport
    switchport trunk allowed vlan 1-4000
    switchport mode trunk
    !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-isis.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-isis.cfg
@@ -45,6 +45,7 @@ interface Management1
 !
 interface Vlan110
    description PR01-DEMO
+   no shutdown
    vrf TENANT_A_PROJECT01
    ip address virtual 10.1.10.254/24
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
@@ -13,6 +13,7 @@ interface Management1
 !
 interface Vlan24
    description SVI Description
+   no shutdown
    ip address virtual 10.10.24.1/24
    ipv6 address 1b11:3a00:22b0:6::15/64
    ipv6 nd managed-config-flag
@@ -21,6 +22,7 @@ interface Vlan24
 !
 interface Vlan41
    description SVI Description
+   no shutdown
    ip address virtual 10.10.41.1/24
    ip helper-address 10.10.64.150  source-interface Loopback0
    ip helper-address 10.10.96.150  source-interface Loopback0
@@ -28,10 +30,12 @@ interface Vlan41
 !
 interface Vlan42
    description SVI Description
+   no shutdown
    ip address virtual 10.10.42.1/24
 !
 interface Vlan75
    description SVI Description
+   no shutdown
    ip address virtual 10.10.75.1/24
    ipv6 address 1b11:3a00:22b0:1000::15/64
    ipv6 nd managed-config-flag
@@ -40,6 +44,7 @@ interface Vlan75
 !
 interface Vlan83
    description SVI Description
+   no shutdown
    ip address virtual 10.10.83.1/24
 !
 interface Vlan84
@@ -64,6 +69,7 @@ interface Vlan88
 !
 interface Vlan89
    description SVI Description
+   no shutdown
    ip address virtual 10.10.144.3/20
    ipv6 address 1b11:3a00:22b0:5200::15/64
    ipv6 nd managed-config-flag
@@ -75,12 +81,14 @@ interface Vlan89
 !
 interface Vlan501
    description SVI Description
+   no shutdown
    ip address 10.50.26.29/27
    ipv6 address 1b11:3a00:22b0:0088::207/127
    ipv6 nd ra disabled
 !
 interface Vlan1001
    description SVI Description
+   no shutdown
    vrf Tenant_A
    ip address virtual 10.1.1.1/24
    ipv6 address a1::1/64
@@ -89,6 +97,7 @@ interface Vlan1001
 !
 interface Vlan1002
    description SVI Description
+   no shutdown
    vrf Tenant_A
    ip address virtual 10.1.2.1/24
    ipv6 address a2::1/64

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1A.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.110/24
 ```
@@ -413,10 +414,10 @@ vlan 4094
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet6  |  routed  | - |  172.31.255.41/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet6  |  routed  | - |  172.31.255.43/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet6  |  routed  | - |  172.31.255.45/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet6  |  routed  | - |  172.31.255.47/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet6  |  routed  | - |  172.31.255.41/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet6  |  routed  | - |  172.31.255.43/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet6  |  routed  | - |  172.31.255.45/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet6  |  routed  | - |  172.31.255.47/31  |  default  |  1500  |  false  |  -  |  -  |
 
 ### Ethernet Interfaces Device Configuration
 
@@ -424,30 +425,36 @@ vlan 4094
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet6
+   no shutdown
    no switchport
    ip address 172.31.255.41/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet6
+   no shutdown
    no switchport
    ip address 172.31.255.43/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet6
+   no shutdown
    no switchport
    ip address 172.31.255.45/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet6
+   no shutdown
    no switchport
    ip address 172.31.255.47/31
 !
 interface Ethernet5
    description MLAG_PEER_DC1-BL1B_Ethernet5
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-BL1B_Ethernet6
+   no shutdown
    channel-group 5 mode active
 ```
 
@@ -459,7 +466,7 @@ interface Ethernet6
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel5 | MLAG_PEER_DC1-BL1B_Po5 | switched | access | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
+| Port-Channel5 | MLAG_PEER_DC1-BL1B_Po5 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -467,6 +474,7 @@ interface Ethernet6
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-BL1B_Po5
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -499,10 +507,12 @@ interface Port-Channel5
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.10/32
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.10/32
 ```
 
@@ -515,11 +525,11 @@ interface Loopback1
 | Vlan150 |  Tenant_A_WAN_Zone_1  |  Tenant_A_WAN_Zone  |  -  |  false  |
 | Vlan250 |  Tenant_B_WAN_Zone_1  |  Tenant_B_WAN_Zone  |  -  |  false  |
 | Vlan350 |  Tenant_C_WAN_Zone_1  |  Tenant_C_WAN_Zone  |  -  |  false  |
-| Vlan3013 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone  |  Tenant_A_WAN_Zone  |  -  |  -  |
-| Vlan3020 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone  |  Tenant_B_WAN_Zone  |  -  |  -  |
-| Vlan3030 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone  |  Tenant_C_WAN_Zone  |  -  |  -  |
-| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  -  |
-| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  -  |
+| Vlan3013 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone  |  Tenant_A_WAN_Zone  |  -  |  false  |
+| Vlan3020 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone  |  Tenant_B_WAN_Zone  |  -  |  false  |
+| Vlan3030 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone  |  Tenant_C_WAN_Zone  |  -  |  false  |
+| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  false  |
+| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  false  |
 
 #### IPv4
 
@@ -560,25 +570,30 @@ interface Vlan350
 !
 interface Vlan3013
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone
+   no shutdown
    vrf Tenant_A_WAN_Zone
    ip address 10.255.251.10/31
 !
 interface Vlan3020
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone
+   no shutdown
    vrf Tenant_B_WAN_Zone
    ip address 10.255.251.10/31
 !
 interface Vlan3030
    description MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone
+   no shutdown
    vrf Tenant_C_WAN_Zone
    ip address 10.255.251.10/31
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
+   no shutdown
    ip address 10.255.251.10/31
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.10/31
 ```

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1A.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -462,6 +467,7 @@ interface Ethernet6
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-BL1B_Po5
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -536,16 +542,19 @@ interface Loopback1
 !
 interface Vlan150
    description Tenant_A_WAN_Zone_1
+   no shutdown
    vrf Tenant_A_WAN_Zone
    ip address virtual 10.1.40.1/24
 !
 interface Vlan250
    description Tenant_B_WAN_Zone_1
+   no shutdown
    vrf Tenant_B_WAN_Zone
    ip address virtual 10.2.50.1/24
 !
 interface Vlan350
    description Tenant_C_WAN_Zone_1
+   no shutdown
    vrf Tenant_C_WAN_Zone
    ip address virtual 10.3.50.1/24
 !
@@ -1020,6 +1029,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1B.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -462,6 +467,7 @@ interface Ethernet6
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-BL1A_Po5
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -536,16 +542,19 @@ interface Loopback1
 !
 interface Vlan150
    description Tenant_A_WAN_Zone_1
+   no shutdown
    vrf Tenant_A_WAN_Zone
    ip address virtual 10.1.40.1/24
 !
 interface Vlan250
    description Tenant_B_WAN_Zone_1
+   no shutdown
    vrf Tenant_B_WAN_Zone
    ip address virtual 10.2.50.1/24
 !
 interface Vlan350
    description Tenant_C_WAN_Zone_1
+   no shutdown
    vrf Tenant_C_WAN_Zone
    ip address virtual 10.3.50.1/24
 !
@@ -1020,6 +1029,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1B.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.111/24
 ```
@@ -413,10 +414,10 @@ vlan 4094
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet7  |  routed  | - |  172.31.255.49/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet7  |  routed  | - |  172.31.255.51/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet7  |  routed  | - |  172.31.255.53/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet7  |  routed  | - |  172.31.255.55/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet7  |  routed  | - |  172.31.255.49/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet7  |  routed  | - |  172.31.255.51/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet7  |  routed  | - |  172.31.255.53/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet7  |  routed  | - |  172.31.255.55/31  |  default  |  1500  |  false  |  -  |  -  |
 
 ### Ethernet Interfaces Device Configuration
 
@@ -424,30 +425,36 @@ vlan 4094
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet7
+   no shutdown
    no switchport
    ip address 172.31.255.49/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet7
+   no shutdown
    no switchport
    ip address 172.31.255.51/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet7
+   no shutdown
    no switchport
    ip address 172.31.255.53/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet7
+   no shutdown
    no switchport
    ip address 172.31.255.55/31
 !
 interface Ethernet5
    description MLAG_PEER_DC1-BL1A_Ethernet5
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-BL1A_Ethernet6
+   no shutdown
    channel-group 5 mode active
 ```
 
@@ -459,7 +466,7 @@ interface Ethernet6
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel5 | MLAG_PEER_DC1-BL1A_Po5 | switched | access | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
+| Port-Channel5 | MLAG_PEER_DC1-BL1A_Po5 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -467,6 +474,7 @@ interface Ethernet6
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-BL1A_Po5
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -499,10 +507,12 @@ interface Port-Channel5
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.11/32
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.10/32
 ```
 
@@ -515,11 +525,11 @@ interface Loopback1
 | Vlan150 |  Tenant_A_WAN_Zone_1  |  Tenant_A_WAN_Zone  |  -  |  false  |
 | Vlan250 |  Tenant_B_WAN_Zone_1  |  Tenant_B_WAN_Zone  |  -  |  false  |
 | Vlan350 |  Tenant_C_WAN_Zone_1  |  Tenant_C_WAN_Zone  |  -  |  false  |
-| Vlan3013 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone  |  Tenant_A_WAN_Zone  |  -  |  -  |
-| Vlan3020 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone  |  Tenant_B_WAN_Zone  |  -  |  -  |
-| Vlan3030 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone  |  Tenant_C_WAN_Zone  |  -  |  -  |
-| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  -  |
-| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  -  |
+| Vlan3013 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone  |  Tenant_A_WAN_Zone  |  -  |  false  |
+| Vlan3020 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone  |  Tenant_B_WAN_Zone  |  -  |  false  |
+| Vlan3030 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone  |  Tenant_C_WAN_Zone  |  -  |  false  |
+| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  false  |
+| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  false  |
 
 #### IPv4
 
@@ -560,25 +570,30 @@ interface Vlan350
 !
 interface Vlan3013
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone
+   no shutdown
    vrf Tenant_A_WAN_Zone
    ip address 10.255.251.11/31
 !
 interface Vlan3020
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone
+   no shutdown
    vrf Tenant_B_WAN_Zone
    ip address 10.255.251.11/31
 !
 interface Vlan3030
    description MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone
+   no shutdown
    vrf Tenant_C_WAN_Zone
    ip address 10.255.251.11/31
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
+   no shutdown
    ip address 10.255.251.11/31
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.11/31
 ```

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-L2LEAF1A.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.112/24
 ```
@@ -380,10 +381,12 @@ vlan 131
 !
 interface Ethernet1
    description DC1-LEAF2A_Ethernet7
+   no shutdown
    channel-group 1 mode active
 !
 interface Ethernet2
    description DC1-LEAF2B_Ethernet7
+   no shutdown
    channel-group 1 mode active
 ```
 
@@ -395,7 +398,7 @@ interface Ethernet2
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel1 | DC1-LEAF2A_Po7 | switched | access | 110-111,120-121,130-131 | - | - | - | - | - | - |
+| Port-Channel1 | DC1-LEAF2A_Po7 | switched | trunk | 110-111,120-121,130-131 | - | - | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -403,6 +406,7 @@ interface Ethernet2
 !
 interface Port-Channel1
    description DC1-LEAF2A_Po7
+   no shutdown
    switchport
    switchport trunk allowed vlan 110-111,120-121,130-131
    switchport mode trunk

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-L2LEAF1A.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -390,7 +395,7 @@ interface Ethernet2
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel1 | DC1-LEAF2A_Po7 | switched | access | 110-111,120-121,130-131 | - | - | - | - | 1 | - |
+| Port-Channel1 | DC1-LEAF2A_Po7 | switched | access | 110-111,120-121,130-131 | - | - | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -398,9 +403,9 @@ interface Ethernet2
 !
 interface Port-Channel1
    description DC1-LEAF2A_Po7
+   switchport
    switchport trunk allowed vlan 110-111,120-121,130-131
    switchport mode trunk
-   mlag 1
 ```
 
 ## Loopback Interfaces
@@ -600,6 +605,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-L2LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-L2LEAF2A.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.113/24
 ```
@@ -445,18 +446,22 @@ vlan 4094
 !
 interface Ethernet1
    description DC1-SVC3A_Ethernet7
+   no shutdown
    channel-group 1 mode active
 !
 interface Ethernet2
    description DC1-SVC3B_Ethernet7
+   no shutdown
    channel-group 1 mode active
 !
 interface Ethernet3
    description MLAG_PEER_DC1-L2LEAF2B_Ethernet3
+   no shutdown
    channel-group 3 mode active
 !
 interface Ethernet4
    description MLAG_PEER_DC1-L2LEAF2B_Ethernet4
+   no shutdown
    channel-group 3 mode active
 ```
 
@@ -468,8 +473,8 @@ interface Ethernet4
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel1 | DC1-SVC3A_Po7 | switched | access | 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350 | - | - | - | - | 1 | - |
-| Port-Channel3 | MLAG_PEER_DC1-L2LEAF2B_Po3 | switched | access | 2-4094 | - | ['MLAG'] | - | - | - | - |
+| Port-Channel1 | DC1-SVC3A_Po7 | switched | trunk | 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350 | - | - | - | - | 1 | - |
+| Port-Channel3 | MLAG_PEER_DC1-L2LEAF2B_Po3 | switched | trunk | 2-4094 | - | ['MLAG'] | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -477,6 +482,7 @@ interface Ethernet4
 !
 interface Port-Channel1
    description DC1-SVC3A_Po7
+   no shutdown
    switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350
    switchport mode trunk
@@ -484,6 +490,7 @@ interface Port-Channel1
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-L2LEAF2B_Po3
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -500,7 +507,7 @@ No loopback interfaces defined
 
 | Interface | Description | VRF |  MTU | Shutdown |
 | --------- | ----------- | --- | ---- | -------- |
-| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  -  |
+| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  false  |
 
 #### IPv4
 
@@ -516,6 +523,7 @@ No loopback interfaces defined
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.16/31
 ```

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-L2LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-L2LEAF2A.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -472,12 +477,14 @@ interface Ethernet4
 !
 interface Port-Channel1
    description DC1-SVC3A_Po7
+   switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350
    switchport mode trunk
    mlag 1
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-L2LEAF2B_Po3
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group MLAG
@@ -702,6 +709,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-L2LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-L2LEAF2B.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.114/24
 ```
@@ -445,18 +446,22 @@ vlan 4094
 !
 interface Ethernet1
    description DC1-SVC3A_Ethernet8
+   no shutdown
    channel-group 1 mode active
 !
 interface Ethernet2
    description DC1-SVC3B_Ethernet8
+   no shutdown
    channel-group 1 mode active
 !
 interface Ethernet3
    description MLAG_PEER_DC1-L2LEAF2A_Ethernet3
+   no shutdown
    channel-group 3 mode active
 !
 interface Ethernet4
    description MLAG_PEER_DC1-L2LEAF2A_Ethernet4
+   no shutdown
    channel-group 3 mode active
 ```
 
@@ -468,8 +473,8 @@ interface Ethernet4
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel1 | DC1-SVC3B_Po7 | switched | access | 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350 | - | - | - | - | 1 | - |
-| Port-Channel3 | MLAG_PEER_DC1-L2LEAF2A_Po3 | switched | access | 2-4094 | - | ['MLAG'] | - | - | - | - |
+| Port-Channel1 | DC1-SVC3B_Po7 | switched | trunk | 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350 | - | - | - | - | 1 | - |
+| Port-Channel3 | MLAG_PEER_DC1-L2LEAF2A_Po3 | switched | trunk | 2-4094 | - | ['MLAG'] | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -477,6 +482,7 @@ interface Ethernet4
 !
 interface Port-Channel1
    description DC1-SVC3B_Po7
+   no shutdown
    switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350
    switchport mode trunk
@@ -484,6 +490,7 @@ interface Port-Channel1
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-L2LEAF2A_Po3
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -500,7 +507,7 @@ No loopback interfaces defined
 
 | Interface | Description | VRF |  MTU | Shutdown |
 | --------- | ----------- | --- | ---- | -------- |
-| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  -  |
+| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  false  |
 
 #### IPv4
 
@@ -516,6 +523,7 @@ No loopback interfaces defined
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.17/31
 ```

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-L2LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-L2LEAF2B.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -472,12 +477,14 @@ interface Ethernet4
 !
 interface Port-Channel1
    description DC1-SVC3B_Po7
+   switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350
    switchport mode trunk
    mlag 1
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-L2LEAF2A_Po3
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group MLAG
@@ -702,6 +709,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF1A.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -396,11 +401,13 @@ interface Ethernet4
 !
 interface Ethernet6
    description server02_SINGLE_NODE_TRUNK_Eth1
+   switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
 !
 interface Ethernet7
    description server02_SINGLE_NODE_Eth1
+   switchport
    switchport access vlan 110
 ```
 
@@ -468,6 +475,7 @@ interface Loopback1
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST  source-interface lo100
@@ -481,11 +489,13 @@ interface Vlan121
 !
 interface Vlan130
    description Tenant_A_APP_Zone_1
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.30.1/24
 !
 interface Vlan131
    description Tenant_A_APP_Zone_2
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.31.1/24
 ```
@@ -897,6 +907,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF1A.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.105/24
 ```
@@ -370,10 +371,10 @@ vlan 131
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet1  |  routed  | - |  172.31.255.1/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet1  |  routed  | - |  172.31.255.3/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet1  |  routed  | - |  172.31.255.5/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet1  |  routed  | - |  172.31.255.7/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet1  |  routed  | - |  172.31.255.1/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet1  |  routed  | - |  172.31.255.3/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet1  |  routed  | - |  172.31.255.5/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet1  |  routed  | - |  172.31.255.7/31  |  default  |  1500  |  false  |  -  |  -  |
 
 ### Ethernet Interfaces Device Configuration
 
@@ -381,32 +382,38 @@ vlan 131
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.1/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.3/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.5/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.7/31
 !
 interface Ethernet6
    description server02_SINGLE_NODE_TRUNK_Eth1
+   no shutdown
    switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
 !
 interface Ethernet7
    description server02_SINGLE_NODE_Eth1
+   no shutdown
    switchport
    switchport access vlan 110
 ```
@@ -440,10 +447,12 @@ No port-channels defined
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.5/32
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.5/32
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2A.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.106/24
 ```
@@ -466,10 +467,10 @@ vlan 4094
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet2  |  routed  | - |  172.31.255.9/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet2  |  routed  | - |  172.31.255.11/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet2  |  routed  | - |  172.31.255.13/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet2  |  routed  | - |  172.31.255.15/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet2  |  routed  | - |  172.31.255.9/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet2  |  routed  | - |  172.31.255.11/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet2  |  routed  | - |  172.31.255.13/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet2  |  routed  | - |  172.31.255.15/31  |  default  |  1500  |  false  |  -  |  -  |
 
 ### Ethernet Interfaces Device Configuration
 
@@ -477,38 +478,46 @@ vlan 4094
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.9/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.11/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.13/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.15/31
 !
 interface Ethernet5
    description MLAG_PEER_DC1-LEAF2B_Ethernet5
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-LEAF2B_Ethernet6
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet7
    description DC1-L2LEAF1A_Ethernet1
+   no shutdown
    channel-group 7 mode active
 !
 interface Ethernet10
    description server01_MLAG_Eth2
+   no shutdown
    channel-group 10 mode active
 ```
 
@@ -520,9 +529,9 @@ interface Ethernet10
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel5 | MLAG_PEER_DC1-LEAF2B_Po5 | switched | access | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
-| Port-Channel7 | DC1_L2LEAF1_Po1 | switched | access | 110-111,120-121,130-131 | - | - | - | - | 7 | - |
-| Port-Channel10 | server01_MLAG_PortChanne1 | switched | access | 210-211 | - | - | - | - | 10 | - |
+| Port-Channel5 | MLAG_PEER_DC1-LEAF2B_Po5 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
+| Port-Channel7 | DC1_L2LEAF1_Po1 | switched | trunk | 110-111,120-121,130-131 | - | - | - | - | 7 | - |
+| Port-Channel10 | server01_MLAG_PortChanne1 | switched | trunk | 210-211 | - | - | - | - | 10 | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -530,6 +539,7 @@ interface Ethernet10
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-LEAF2B_Po5
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -538,6 +548,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF1_Po1
+   no shutdown
    switchport
    switchport trunk allowed vlan 110-111,120-121,130-131
    switchport mode trunk
@@ -545,6 +556,7 @@ interface Port-Channel7
 !
 interface Port-Channel10
    description server01_MLAG_PortChanne1
+   no shutdown
    switchport
    switchport trunk allowed vlan 210-211
    switchport mode trunk
@@ -578,14 +590,17 @@ interface Port-Channel10
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.6/32
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.6/32
 !
 interface Loopback100
    description Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address 10.255.1.6/32
 ```
@@ -608,14 +623,14 @@ interface Loopback100
 | Vlan211 |  Tenant_B_OP_Zone_2  |  Tenant_B_OP_Zone  |  -  |  false  |
 | Vlan310 |  Tenant_C_OP_Zone_1  |  Tenant_C_OP_Zone  |  -  |  false  |
 | Vlan311 |  Tenant_C_OP_Zone_2  |  Tenant_C_OP_Zone  |  -  |  false  |
-| Vlan3009 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone  |  Tenant_A_OP_Zone  |  -  |  -  |
-| Vlan3010 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone  |  Tenant_A_WEB_Zone  |  -  |  -  |
-| Vlan3011 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone  |  Tenant_A_APP_Zone  |  -  |  -  |
-| Vlan3012 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone  |  Tenant_A_DB_Zone  |  -  |  -  |
-| Vlan3019 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone  |  Tenant_B_OP_Zone  |  -  |  -  |
-| Vlan3029 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone  |  Tenant_C_OP_Zone  |  -  |  -  |
-| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  -  |
-| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  -  |
+| Vlan3009 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone  |  Tenant_A_OP_Zone  |  -  |  false  |
+| Vlan3010 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone  |  Tenant_A_WEB_Zone  |  -  |  false  |
+| Vlan3011 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone  |  Tenant_A_APP_Zone  |  -  |  false  |
+| Vlan3012 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone  |  Tenant_A_DB_Zone  |  -  |  false  |
+| Vlan3019 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone  |  Tenant_B_OP_Zone  |  -  |  false  |
+| Vlan3029 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone  |  Tenant_C_OP_Zone  |  -  |  false  |
+| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  false  |
+| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  false  |
 
 #### IPv4
 
@@ -725,40 +740,48 @@ interface Vlan311
 !
 interface Vlan3009
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address 10.255.251.2/31
 !
 interface Vlan3010
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address 10.255.251.2/31
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address 10.255.251.2/31
 !
 interface Vlan3012
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address 10.255.251.2/31
 !
 interface Vlan3019
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address 10.255.251.2/31
 !
 interface Vlan3029
    description MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address 10.255.251.2/31
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
+   no shutdown
    ip address 10.255.251.2/31
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.2/31
 ```

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2A.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -525,6 +530,7 @@ interface Ethernet10
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-LEAF2B_Po5
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -532,12 +538,14 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF1_Po1
+   switchport
    switchport trunk allowed vlan 110-111,120-121,130-131
    switchport mode trunk
    mlag 7
 !
 interface Port-Channel10
    description server01_MLAG_PortChanne1
+   switchport
    switchport trunk allowed vlan 210-211
    switchport mode trunk
    mlag 10
@@ -642,17 +650,20 @@ interface Loopback100
 !
 interface Vlan110
    description Tenant_A_OP_Zone_1
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address virtual 10.1.10.1/24
 !
 interface Vlan111
    description Tenant_A_OP_Zone_2
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT  source-interface lo100
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST  source-interface lo100
@@ -666,41 +677,49 @@ interface Vlan121
 !
 interface Vlan130
    description Tenant_A_APP_Zone_1
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.30.1/24
 !
 interface Vlan131
    description Tenant_A_APP_Zone_2
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.31.1/24
 !
 interface Vlan140
    description Tenant_A_DB_BZone_1
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address virtual 10.1.40.1/24
 !
 interface Vlan141
    description Tenant_A_DB_Zone_2
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address virtual 10.1.41.1/24
 !
 interface Vlan210
    description Tenant_B_OP_Zone_1
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address virtual 10.2.10.1/24
 !
 interface Vlan211
    description Tenant_B_OP_Zone_2
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address virtual 10.2.11.1/24
 !
 interface Vlan310
    description Tenant_C_OP_Zone_1
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address virtual 10.3.10.1/24
 !
 interface Vlan311
    description Tenant_C_OP_Zone_2
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address virtual 10.3.11.1/24
 !
@@ -1297,6 +1316,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2B.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.107/24
 ```
@@ -466,10 +467,10 @@ vlan 4094
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet3  |  routed  | - |  172.31.255.17/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet3  |  routed  | - |  172.31.255.19/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet3  |  routed  | - |  172.31.255.21/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet3  |  routed  | - |  172.31.255.23/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet3  |  routed  | - |  172.31.255.17/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet3  |  routed  | - |  172.31.255.19/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet3  |  routed  | - |  172.31.255.21/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet3  |  routed  | - |  172.31.255.23/31  |  default  |  1500  |  false  |  -  |  -  |
 
 ### Ethernet Interfaces Device Configuration
 
@@ -477,38 +478,46 @@ vlan 4094
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.17/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.19/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.21/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.23/31
 !
 interface Ethernet5
    description MLAG_PEER_DC1-LEAF2A_Ethernet5
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-LEAF2A_Ethernet6
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet7
    description DC1-L2LEAF1A_Ethernet2
+   no shutdown
    channel-group 7 mode active
 !
 interface Ethernet10
    description server01_MLAG_Eth3
+   no shutdown
    channel-group 10 mode active
 ```
 
@@ -520,9 +529,9 @@ interface Ethernet10
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel5 | MLAG_PEER_DC1-LEAF2A_Po5 | switched | access | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
-| Port-Channel7 | DC1_L2LEAF1_Po1 | switched | access | 110-111,120-121,130-131 | - | - | - | - | 7 | - |
-| Port-Channel10 | server01_MLAG_PortChanne1 | switched | access | 210-211 | - | - | - | - | 10 | - |
+| Port-Channel5 | MLAG_PEER_DC1-LEAF2A_Po5 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
+| Port-Channel7 | DC1_L2LEAF1_Po1 | switched | trunk | 110-111,120-121,130-131 | - | - | - | - | 7 | - |
+| Port-Channel10 | server01_MLAG_PortChanne1 | switched | trunk | 210-211 | - | - | - | - | 10 | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -530,6 +539,7 @@ interface Ethernet10
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-LEAF2A_Po5
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -538,6 +548,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF1_Po1
+   no shutdown
    switchport
    switchport trunk allowed vlan 110-111,120-121,130-131
    switchport mode trunk
@@ -545,6 +556,7 @@ interface Port-Channel7
 !
 interface Port-Channel10
    description server01_MLAG_PortChanne1
+   no shutdown
    switchport
    switchport trunk allowed vlan 210-211
    switchport mode trunk
@@ -578,14 +590,17 @@ interface Port-Channel10
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.7/32
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.6/32
 !
 interface Loopback100
    description Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address 10.255.1.7/32
 ```
@@ -608,14 +623,14 @@ interface Loopback100
 | Vlan211 |  Tenant_B_OP_Zone_2  |  Tenant_B_OP_Zone  |  -  |  false  |
 | Vlan310 |  Tenant_C_OP_Zone_1  |  Tenant_C_OP_Zone  |  -  |  false  |
 | Vlan311 |  Tenant_C_OP_Zone_2  |  Tenant_C_OP_Zone  |  -  |  false  |
-| Vlan3009 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone  |  Tenant_A_OP_Zone  |  -  |  -  |
-| Vlan3010 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone  |  Tenant_A_WEB_Zone  |  -  |  -  |
-| Vlan3011 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone  |  Tenant_A_APP_Zone  |  -  |  -  |
-| Vlan3012 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone  |  Tenant_A_DB_Zone  |  -  |  -  |
-| Vlan3019 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone  |  Tenant_B_OP_Zone  |  -  |  -  |
-| Vlan3029 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone  |  Tenant_C_OP_Zone  |  -  |  -  |
-| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  -  |
-| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  -  |
+| Vlan3009 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone  |  Tenant_A_OP_Zone  |  -  |  false  |
+| Vlan3010 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone  |  Tenant_A_WEB_Zone  |  -  |  false  |
+| Vlan3011 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone  |  Tenant_A_APP_Zone  |  -  |  false  |
+| Vlan3012 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone  |  Tenant_A_DB_Zone  |  -  |  false  |
+| Vlan3019 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone  |  Tenant_B_OP_Zone  |  -  |  false  |
+| Vlan3029 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone  |  Tenant_C_OP_Zone  |  -  |  false  |
+| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  false  |
+| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  false  |
 
 #### IPv4
 
@@ -725,40 +740,48 @@ interface Vlan311
 !
 interface Vlan3009
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address 10.255.251.3/31
 !
 interface Vlan3010
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address 10.255.251.3/31
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address 10.255.251.3/31
 !
 interface Vlan3012
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address 10.255.251.3/31
 !
 interface Vlan3019
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address 10.255.251.3/31
 !
 interface Vlan3029
    description MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address 10.255.251.3/31
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
+   no shutdown
    ip address 10.255.251.3/31
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.3/31
 ```

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2B.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -525,6 +530,7 @@ interface Ethernet10
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-LEAF2A_Po5
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -532,12 +538,14 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF1_Po1
+   switchport
    switchport trunk allowed vlan 110-111,120-121,130-131
    switchport mode trunk
    mlag 7
 !
 interface Port-Channel10
    description server01_MLAG_PortChanne1
+   switchport
    switchport trunk allowed vlan 210-211
    switchport mode trunk
    mlag 10
@@ -642,17 +650,20 @@ interface Loopback100
 !
 interface Vlan110
    description Tenant_A_OP_Zone_1
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address virtual 10.1.10.1/24
 !
 interface Vlan111
    description Tenant_A_OP_Zone_2
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT  source-interface lo100
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST  source-interface lo100
@@ -666,41 +677,49 @@ interface Vlan121
 !
 interface Vlan130
    description Tenant_A_APP_Zone_1
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.30.1/24
 !
 interface Vlan131
    description Tenant_A_APP_Zone_2
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.31.1/24
 !
 interface Vlan140
    description Tenant_A_DB_BZone_1
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address virtual 10.1.40.1/24
 !
 interface Vlan141
    description Tenant_A_DB_Zone_2
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address virtual 10.1.41.1/24
 !
 interface Vlan210
    description Tenant_B_OP_Zone_1
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address virtual 10.2.10.1/24
 !
 interface Vlan211
    description Tenant_B_OP_Zone_2
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address virtual 10.2.11.1/24
 !
 interface Vlan310
    description Tenant_C_OP_Zone_1
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address virtual 10.3.10.1/24
 !
 interface Vlan311
    description Tenant_C_OP_Zone_2
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address virtual 10.3.11.1/24
 !
@@ -1297,6 +1316,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE1.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -731,6 +736,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE1.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.101/24
 ```
@@ -337,13 +338,13 @@ No VLANs defined
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 |  P2P_LINK_TO_DC1-LEAF1A_Ethernet1  |  routed  | - |  172.31.255.0/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet2 |  P2P_LINK_TO_DC1-LEAF2A_Ethernet1  |  routed  | - |  172.31.255.8/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet3 |  P2P_LINK_TO_DC1-LEAF2B_Ethernet1  |  routed  | - |  172.31.255.16/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet4 |  P2P_LINK_TO_DC1-SVC3A_Ethernet1  |  routed  | - |  172.31.255.24/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet5 |  P2P_LINK_TO_DC1-SVC3B_Ethernet1  |  routed  | - |  172.31.255.32/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet6 |  P2P_LINK_TO_DC1-BL1A_Ethernet1  |  routed  | - |  172.31.255.40/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet7 |  P2P_LINK_TO_DC1-BL1B_Ethernet1  |  routed  | - |  172.31.255.48/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet1 |  P2P_LINK_TO_DC1-LEAF1A_Ethernet1  |  routed  | - |  172.31.255.0/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet2 |  P2P_LINK_TO_DC1-LEAF2A_Ethernet1  |  routed  | - |  172.31.255.8/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet3 |  P2P_LINK_TO_DC1-LEAF2B_Ethernet1  |  routed  | - |  172.31.255.16/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4 |  P2P_LINK_TO_DC1-SVC3A_Ethernet1  |  routed  | - |  172.31.255.24/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet5 |  P2P_LINK_TO_DC1-SVC3B_Ethernet1  |  routed  | - |  172.31.255.32/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet6 |  P2P_LINK_TO_DC1-BL1A_Ethernet1  |  routed  | - |  172.31.255.40/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet7 |  P2P_LINK_TO_DC1-BL1B_Ethernet1  |  routed  | - |  172.31.255.48/31  |  default  |  1500  |  false  |  -  |  -  |
 
 ### Ethernet Interfaces Device Configuration
 
@@ -351,36 +352,43 @@ No VLANs defined
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.0/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-LEAF2A_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.8/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-LEAF2B_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.16/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SVC3A_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.24/31
 !
 interface Ethernet5
    description P2P_LINK_TO_DC1-SVC3B_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.32/31
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-BL1A_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.40/31
 !
 interface Ethernet7
    description P2P_LINK_TO_DC1-BL1B_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.48/31
 ```
@@ -412,6 +420,7 @@ No port-channels defined
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.1/32
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE2.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -731,6 +736,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE2.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.102/24
 ```
@@ -337,13 +338,13 @@ No VLANs defined
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 |  P2P_LINK_TO_DC1-LEAF1A_Ethernet2  |  routed  | - |  172.31.255.2/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet2 |  P2P_LINK_TO_DC1-LEAF2A_Ethernet2  |  routed  | - |  172.31.255.10/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet3 |  P2P_LINK_TO_DC1-LEAF2B_Ethernet2  |  routed  | - |  172.31.255.18/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet4 |  P2P_LINK_TO_DC1-SVC3A_Ethernet2  |  routed  | - |  172.31.255.26/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet5 |  P2P_LINK_TO_DC1-SVC3B_Ethernet2  |  routed  | - |  172.31.255.34/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet6 |  P2P_LINK_TO_DC1-BL1A_Ethernet2  |  routed  | - |  172.31.255.42/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet7 |  P2P_LINK_TO_DC1-BL1B_Ethernet2  |  routed  | - |  172.31.255.50/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet1 |  P2P_LINK_TO_DC1-LEAF1A_Ethernet2  |  routed  | - |  172.31.255.2/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet2 |  P2P_LINK_TO_DC1-LEAF2A_Ethernet2  |  routed  | - |  172.31.255.10/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet3 |  P2P_LINK_TO_DC1-LEAF2B_Ethernet2  |  routed  | - |  172.31.255.18/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4 |  P2P_LINK_TO_DC1-SVC3A_Ethernet2  |  routed  | - |  172.31.255.26/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet5 |  P2P_LINK_TO_DC1-SVC3B_Ethernet2  |  routed  | - |  172.31.255.34/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet6 |  P2P_LINK_TO_DC1-BL1A_Ethernet2  |  routed  | - |  172.31.255.42/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet7 |  P2P_LINK_TO_DC1-BL1B_Ethernet2  |  routed  | - |  172.31.255.50/31  |  default  |  1500  |  false  |  -  |  -  |
 
 ### Ethernet Interfaces Device Configuration
 
@@ -351,36 +352,43 @@ No VLANs defined
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.2/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-LEAF2A_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.10/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-LEAF2B_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.18/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SVC3A_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.26/31
 !
 interface Ethernet5
    description P2P_LINK_TO_DC1-SVC3B_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.34/31
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-BL1A_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.42/31
 !
 interface Ethernet7
    description P2P_LINK_TO_DC1-BL1B_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.50/31
 ```
@@ -412,6 +420,7 @@ No port-channels defined
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.2/32
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE3.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -731,6 +736,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE3.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.103/24
 ```
@@ -337,13 +338,13 @@ No VLANs defined
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 |  P2P_LINK_TO_DC1-LEAF1A_Ethernet3  |  routed  | - |  172.31.255.4/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet2 |  P2P_LINK_TO_DC1-LEAF2A_Ethernet3  |  routed  | - |  172.31.255.12/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet3 |  P2P_LINK_TO_DC1-LEAF2B_Ethernet3  |  routed  | - |  172.31.255.20/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet4 |  P2P_LINK_TO_DC1-SVC3A_Ethernet3  |  routed  | - |  172.31.255.28/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet5 |  P2P_LINK_TO_DC1-SVC3B_Ethernet3  |  routed  | - |  172.31.255.36/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet6 |  P2P_LINK_TO_DC1-BL1A_Ethernet3  |  routed  | - |  172.31.255.44/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet7 |  P2P_LINK_TO_DC1-BL1B_Ethernet3  |  routed  | - |  172.31.255.52/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet1 |  P2P_LINK_TO_DC1-LEAF1A_Ethernet3  |  routed  | - |  172.31.255.4/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet2 |  P2P_LINK_TO_DC1-LEAF2A_Ethernet3  |  routed  | - |  172.31.255.12/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet3 |  P2P_LINK_TO_DC1-LEAF2B_Ethernet3  |  routed  | - |  172.31.255.20/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4 |  P2P_LINK_TO_DC1-SVC3A_Ethernet3  |  routed  | - |  172.31.255.28/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet5 |  P2P_LINK_TO_DC1-SVC3B_Ethernet3  |  routed  | - |  172.31.255.36/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet6 |  P2P_LINK_TO_DC1-BL1A_Ethernet3  |  routed  | - |  172.31.255.44/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet7 |  P2P_LINK_TO_DC1-BL1B_Ethernet3  |  routed  | - |  172.31.255.52/31  |  default  |  1500  |  false  |  -  |  -  |
 
 ### Ethernet Interfaces Device Configuration
 
@@ -351,36 +352,43 @@ No VLANs defined
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.4/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-LEAF2A_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.12/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-LEAF2B_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.20/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SVC3A_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.28/31
 !
 interface Ethernet5
    description P2P_LINK_TO_DC1-SVC3B_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.36/31
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-BL1A_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.44/31
 !
 interface Ethernet7
    description P2P_LINK_TO_DC1-BL1B_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.52/31
 ```
@@ -412,6 +420,7 @@ No port-channels defined
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.3/32
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE4.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -731,6 +736,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE4.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.104/24
 ```
@@ -337,13 +338,13 @@ No VLANs defined
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 |  P2P_LINK_TO_DC1-LEAF1A_Ethernet4  |  routed  | - |  172.31.255.6/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet2 |  P2P_LINK_TO_DC1-LEAF2A_Ethernet4  |  routed  | - |  172.31.255.14/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet3 |  P2P_LINK_TO_DC1-LEAF2B_Ethernet4  |  routed  | - |  172.31.255.22/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet4 |  P2P_LINK_TO_DC1-SVC3A_Ethernet4  |  routed  | - |  172.31.255.30/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet5 |  P2P_LINK_TO_DC1-SVC3B_Ethernet4  |  routed  | - |  172.31.255.38/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet6 |  P2P_LINK_TO_DC1-BL1A_Ethernet4  |  routed  | - |  172.31.255.46/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet7 |  P2P_LINK_TO_DC1-BL1B_Ethernet4  |  routed  | - |  172.31.255.54/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet1 |  P2P_LINK_TO_DC1-LEAF1A_Ethernet4  |  routed  | - |  172.31.255.6/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet2 |  P2P_LINK_TO_DC1-LEAF2A_Ethernet4  |  routed  | - |  172.31.255.14/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet3 |  P2P_LINK_TO_DC1-LEAF2B_Ethernet4  |  routed  | - |  172.31.255.22/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4 |  P2P_LINK_TO_DC1-SVC3A_Ethernet4  |  routed  | - |  172.31.255.30/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet5 |  P2P_LINK_TO_DC1-SVC3B_Ethernet4  |  routed  | - |  172.31.255.38/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet6 |  P2P_LINK_TO_DC1-BL1A_Ethernet4  |  routed  | - |  172.31.255.46/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet7 |  P2P_LINK_TO_DC1-BL1B_Ethernet4  |  routed  | - |  172.31.255.54/31  |  default  |  1500  |  false  |  -  |  -  |
 
 ### Ethernet Interfaces Device Configuration
 
@@ -351,36 +352,43 @@ No VLANs defined
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.6/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-LEAF2A_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.14/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-LEAF2B_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.22/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SVC3A_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.30/31
 !
 interface Ethernet5
    description P2P_LINK_TO_DC1-SVC3B_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.38/31
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-BL1A_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.46/31
 !
 interface Ethernet7
    description P2P_LINK_TO_DC1-BL1B_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.54/31
 ```
@@ -412,6 +420,7 @@ No port-channels defined
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.4/32
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3A.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.108/24
 ```
@@ -494,10 +495,10 @@ vlan 4094
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet4  |  routed  | - |  172.31.255.25/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet4  |  routed  | - |  172.31.255.27/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet4  |  routed  | - |  172.31.255.29/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet4  |  routed  | - |  172.31.255.31/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet4  |  routed  | - |  172.31.255.25/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet4  |  routed  | - |  172.31.255.27/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet4  |  routed  | - |  172.31.255.29/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet4  |  routed  | - |  172.31.255.31/31  |  default  |  1500  |  false  |  -  |  -  |
 
 ### Ethernet Interfaces Device Configuration
 
@@ -505,42 +506,51 @@ vlan 4094
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.25/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.27/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.29/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.31/31
 !
 interface Ethernet5
    description MLAG_PEER_DC1-SVC3B_Ethernet5
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-SVC3B_Ethernet6
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet7
    description DC1-L2LEAF2A_Ethernet1
+   no shutdown
    channel-group 7 mode active
 !
 interface Ethernet8
    description DC1-L2LEAF2B_Ethernet1
+   no shutdown
    channel-group 7 mode active
 !
 interface Ethernet10
    description server03_ESI_Eth1
+   no shutdown
    channel-group 10 mode active
 ```
 
@@ -552,9 +562,9 @@ interface Ethernet10
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel5 | MLAG_PEER_DC1-SVC3B_Po5 | switched | access | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
-| Port-Channel7 | DC1_L2LEAF2_Po1 | switched | access | 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350 | - | - | - | - | 7 | - |
-| Port-Channel10 | server03_ESI_PortChanne1 | switched | access | 110-111,210-211 | - | - | - | - | 10 | - |
+| Port-Channel5 | MLAG_PEER_DC1-SVC3B_Po5 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
+| Port-Channel7 | DC1_L2LEAF2_Po1 | switched | trunk | 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350 | - | - | - | - | 7 | - |
+| Port-Channel10 | server03_ESI_PortChanne1 | switched | trunk | 110-111,210-211 | - | - | - | - | 10 | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -562,6 +572,7 @@ interface Ethernet10
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-SVC3B_Po5
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -570,6 +581,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF2_Po1
+   no shutdown
    switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350
    switchport mode trunk
@@ -577,6 +589,7 @@ interface Port-Channel7
 !
 interface Port-Channel10
    description server03_ESI_PortChanne1
+   no shutdown
    switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
@@ -610,14 +623,17 @@ interface Port-Channel10
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.8/32
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.8/32
 !
 interface Loopback100
    description Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address 10.255.1.8/32
 ```
@@ -643,17 +659,17 @@ interface Loopback100
 | Vlan310 |  Tenant_C_OP_Zone_1  |  Tenant_C_OP_Zone  |  -  |  false  |
 | Vlan311 |  Tenant_C_OP_Zone_2  |  Tenant_C_OP_Zone  |  -  |  false  |
 | Vlan350 |  Tenant_C_WAN_Zone_1  |  Tenant_C_WAN_Zone  |  -  |  false  |
-| Vlan3009 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone  |  Tenant_A_OP_Zone  |  -  |  -  |
-| Vlan3010 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone  |  Tenant_A_WEB_Zone  |  -  |  -  |
-| Vlan3011 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone  |  Tenant_A_APP_Zone  |  -  |  -  |
-| Vlan3012 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone  |  Tenant_A_DB_Zone  |  -  |  -  |
-| Vlan3013 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone  |  Tenant_A_WAN_Zone  |  -  |  -  |
-| Vlan3019 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone  |  Tenant_B_OP_Zone  |  -  |  -  |
-| Vlan3020 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone  |  Tenant_B_WAN_Zone  |  -  |  -  |
-| Vlan3029 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone  |  Tenant_C_OP_Zone  |  -  |  -  |
-| Vlan3030 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone  |  Tenant_C_WAN_Zone  |  -  |  -  |
-| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  -  |
-| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  -  |
+| Vlan3009 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone  |  Tenant_A_OP_Zone  |  -  |  false  |
+| Vlan3010 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone  |  Tenant_A_WEB_Zone  |  -  |  false  |
+| Vlan3011 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone  |  Tenant_A_APP_Zone  |  -  |  false  |
+| Vlan3012 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone  |  Tenant_A_DB_Zone  |  -  |  false  |
+| Vlan3013 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone  |  Tenant_A_WAN_Zone  |  -  |  false  |
+| Vlan3019 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone  |  Tenant_B_OP_Zone  |  -  |  false  |
+| Vlan3020 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone  |  Tenant_B_WAN_Zone  |  -  |  false  |
+| Vlan3029 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone  |  Tenant_C_OP_Zone  |  -  |  false  |
+| Vlan3030 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone  |  Tenant_C_WAN_Zone  |  -  |  false  |
+| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  false  |
+| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  false  |
 
 #### IPv4
 
@@ -787,55 +803,66 @@ interface Vlan350
 !
 interface Vlan3009
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address 10.255.251.6/31
 !
 interface Vlan3010
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address 10.255.251.6/31
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address 10.255.251.6/31
 !
 interface Vlan3012
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address 10.255.251.6/31
 !
 interface Vlan3013
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone
+   no shutdown
    vrf Tenant_A_WAN_Zone
    ip address 10.255.251.6/31
 !
 interface Vlan3019
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address 10.255.251.6/31
 !
 interface Vlan3020
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone
+   no shutdown
    vrf Tenant_B_WAN_Zone
    ip address 10.255.251.6/31
 !
 interface Vlan3029
    description MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address 10.255.251.6/31
 !
 interface Vlan3030
    description MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone
+   no shutdown
    vrf Tenant_C_WAN_Zone
    ip address 10.255.251.6/31
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
+   no shutdown
    ip address 10.255.251.6/31
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.6/31
 ```

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3A.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -557,6 +562,7 @@ interface Ethernet10
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-SVC3B_Po5
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -564,12 +570,14 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF2_Po1
+   switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350
    switchport mode trunk
    mlag 7
 !
 interface Port-Channel10
    description server03_ESI_PortChanne1
+   switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
    mlag 10
@@ -686,17 +694,20 @@ interface Loopback100
 !
 interface Vlan110
    description Tenant_A_OP_Zone_1
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address virtual 10.1.10.1/24
 !
 interface Vlan111
    description Tenant_A_OP_Zone_2
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT  source-interface lo100
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST  source-interface lo100
@@ -710,56 +721,67 @@ interface Vlan121
 !
 interface Vlan130
    description Tenant_A_APP_Zone_1
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.30.1/24
 !
 interface Vlan131
    description Tenant_A_APP_Zone_2
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.31.1/24
 !
 interface Vlan140
    description Tenant_A_DB_BZone_1
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address virtual 10.1.40.1/24
 !
 interface Vlan141
    description Tenant_A_DB_Zone_2
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address virtual 10.1.41.1/24
 !
 interface Vlan150
    description Tenant_A_WAN_Zone_1
+   no shutdown
    vrf Tenant_A_WAN_Zone
    ip address virtual 10.1.40.1/24
 !
 interface Vlan210
    description Tenant_B_OP_Zone_1
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address virtual 10.2.10.1/24
 !
 interface Vlan211
    description Tenant_B_OP_Zone_2
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address virtual 10.2.11.1/24
 !
 interface Vlan250
    description Tenant_B_WAN_Zone_1
+   no shutdown
    vrf Tenant_B_WAN_Zone
    ip address virtual 10.2.50.1/24
 !
 interface Vlan310
    description Tenant_C_OP_Zone_1
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address virtual 10.3.10.1/24
 !
 interface Vlan311
    description Tenant_C_OP_Zone_2
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address virtual 10.3.11.1/24
 !
 interface Vlan350
    description Tenant_C_WAN_Zone_1
+   no shutdown
    vrf Tenant_C_WAN_Zone
    ip address virtual 10.3.50.1/24
 !
@@ -1449,6 +1471,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3B.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -551,6 +556,7 @@ interface Ethernet8
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-SVC3A_Po5
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -558,6 +564,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF2_Po1
+   switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350
    switchport mode trunk
    mlag 7
@@ -674,17 +681,20 @@ interface Loopback100
 !
 interface Vlan110
    description Tenant_A_OP_Zone_1
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address virtual 10.1.10.1/24
 !
 interface Vlan111
    description Tenant_A_OP_Zone_2
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT  source-interface lo100
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST  source-interface lo100
@@ -698,56 +708,67 @@ interface Vlan121
 !
 interface Vlan130
    description Tenant_A_APP_Zone_1
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.30.1/24
 !
 interface Vlan131
    description Tenant_A_APP_Zone_2
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.31.1/24
 !
 interface Vlan140
    description Tenant_A_DB_BZone_1
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address virtual 10.1.40.1/24
 !
 interface Vlan141
    description Tenant_A_DB_Zone_2
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address virtual 10.1.41.1/24
 !
 interface Vlan150
    description Tenant_A_WAN_Zone_1
+   no shutdown
    vrf Tenant_A_WAN_Zone
    ip address virtual 10.1.40.1/24
 !
 interface Vlan210
    description Tenant_B_OP_Zone_1
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address virtual 10.2.10.1/24
 !
 interface Vlan211
    description Tenant_B_OP_Zone_2
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address virtual 10.2.11.1/24
 !
 interface Vlan250
    description Tenant_B_WAN_Zone_1
+   no shutdown
    vrf Tenant_B_WAN_Zone
    ip address virtual 10.2.50.1/24
 !
 interface Vlan310
    description Tenant_C_OP_Zone_1
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address virtual 10.3.10.1/24
 !
 interface Vlan311
    description Tenant_C_OP_Zone_2
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address virtual 10.3.11.1/24
 !
 interface Vlan350
    description Tenant_C_WAN_Zone_1
+   no shutdown
    vrf Tenant_C_WAN_Zone
    ip address virtual 10.3.50.1/24
 !
@@ -1437,6 +1458,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3B.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.109/24
 ```
@@ -493,10 +494,10 @@ vlan 4094
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet5  |  routed  | - |  172.31.255.33/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet5  |  routed  | - |  172.31.255.35/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet5  |  routed  | - |  172.31.255.37/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet5  |  routed  | - |  172.31.255.39/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet5  |  routed  | - |  172.31.255.33/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet5  |  routed  | - |  172.31.255.35/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet5  |  routed  | - |  172.31.255.37/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet5  |  routed  | - |  172.31.255.39/31  |  default  |  1500  |  false  |  -  |  -  |
 
 ### Ethernet Interfaces Device Configuration
 
@@ -504,38 +505,46 @@ vlan 4094
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet5
+   no shutdown
    no switchport
    ip address 172.31.255.33/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet5
+   no shutdown
    no switchport
    ip address 172.31.255.35/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet5
+   no shutdown
    no switchport
    ip address 172.31.255.37/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet5
+   no shutdown
    no switchport
    ip address 172.31.255.39/31
 !
 interface Ethernet5
    description MLAG_PEER_DC1-SVC3A_Ethernet5
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-SVC3A_Ethernet6
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet7
    description DC1-L2LEAF2A_Ethernet2
+   no shutdown
    channel-group 7 mode active
 !
 interface Ethernet8
    description DC1-L2LEAF2B_Ethernet2
+   no shutdown
    channel-group 7 mode active
 ```
 
@@ -547,8 +556,8 @@ interface Ethernet8
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel5 | MLAG_PEER_DC1-SVC3A_Po5 | switched | access | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
-| Port-Channel7 | DC1_L2LEAF2_Po1 | switched | access | 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350 | - | - | - | - | 7 | - |
+| Port-Channel5 | MLAG_PEER_DC1-SVC3A_Po5 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
+| Port-Channel7 | DC1_L2LEAF2_Po1 | switched | trunk | 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350 | - | - | - | - | 7 | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -556,6 +565,7 @@ interface Ethernet8
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-SVC3A_Po5
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -564,6 +574,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF2_Po1
+   no shutdown
    switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350
    switchport mode trunk
@@ -597,14 +608,17 @@ interface Port-Channel7
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.9/32
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.8/32
 !
 interface Loopback100
    description Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address 10.255.1.9/32
 ```
@@ -630,17 +644,17 @@ interface Loopback100
 | Vlan310 |  Tenant_C_OP_Zone_1  |  Tenant_C_OP_Zone  |  -  |  false  |
 | Vlan311 |  Tenant_C_OP_Zone_2  |  Tenant_C_OP_Zone  |  -  |  false  |
 | Vlan350 |  Tenant_C_WAN_Zone_1  |  Tenant_C_WAN_Zone  |  -  |  false  |
-| Vlan3009 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone  |  Tenant_A_OP_Zone  |  -  |  -  |
-| Vlan3010 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone  |  Tenant_A_WEB_Zone  |  -  |  -  |
-| Vlan3011 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone  |  Tenant_A_APP_Zone  |  -  |  -  |
-| Vlan3012 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone  |  Tenant_A_DB_Zone  |  -  |  -  |
-| Vlan3013 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone  |  Tenant_A_WAN_Zone  |  -  |  -  |
-| Vlan3019 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone  |  Tenant_B_OP_Zone  |  -  |  -  |
-| Vlan3020 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone  |  Tenant_B_WAN_Zone  |  -  |  -  |
-| Vlan3029 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone  |  Tenant_C_OP_Zone  |  -  |  -  |
-| Vlan3030 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone  |  Tenant_C_WAN_Zone  |  -  |  -  |
-| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  -  |
-| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  -  |
+| Vlan3009 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone  |  Tenant_A_OP_Zone  |  -  |  false  |
+| Vlan3010 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone  |  Tenant_A_WEB_Zone  |  -  |  false  |
+| Vlan3011 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone  |  Tenant_A_APP_Zone  |  -  |  false  |
+| Vlan3012 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone  |  Tenant_A_DB_Zone  |  -  |  false  |
+| Vlan3013 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone  |  Tenant_A_WAN_Zone  |  -  |  false  |
+| Vlan3019 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone  |  Tenant_B_OP_Zone  |  -  |  false  |
+| Vlan3020 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone  |  Tenant_B_WAN_Zone  |  -  |  false  |
+| Vlan3029 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone  |  Tenant_C_OP_Zone  |  -  |  false  |
+| Vlan3030 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone  |  Tenant_C_WAN_Zone  |  -  |  false  |
+| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  false  |
+| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  false  |
 
 #### IPv4
 
@@ -774,55 +788,66 @@ interface Vlan350
 !
 interface Vlan3009
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address 10.255.251.7/31
 !
 interface Vlan3010
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address 10.255.251.7/31
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address 10.255.251.7/31
 !
 interface Vlan3012
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address 10.255.251.7/31
 !
 interface Vlan3013
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone
+   no shutdown
    vrf Tenant_A_WAN_Zone
    ip address 10.255.251.7/31
 !
 interface Vlan3019
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address 10.255.251.7/31
 !
 interface Vlan3020
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone
+   no shutdown
    vrf Tenant_B_WAN_Zone
    ip address 10.255.251.7/31
 !
 interface Vlan3029
    description MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address 10.255.251.7/31
 !
 interface Vlan3030
    description MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone
+   no shutdown
    vrf Tenant_C_WAN_Zone
    ip address 10.255.251.7/31
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
+   no shutdown
    ip address 10.255.251.7/31
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.7/31
 ```

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-BL1A.cfg
@@ -65,6 +65,7 @@ vrf instance Tenant_C_WAN_Zone
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-BL1B_Po5
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -73,42 +74,51 @@ interface Port-Channel5
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet6
+   no shutdown
    no switchport
    ip address 172.31.255.41/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet6
+   no shutdown
    no switchport
    ip address 172.31.255.43/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet6
+   no shutdown
    no switchport
    ip address 172.31.255.45/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet6
+   no shutdown
    no switchport
    ip address 172.31.255.47/31
 !
 interface Ethernet5
    description MLAG_PEER_DC1-BL1B_Ethernet5
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-BL1B_Ethernet6
+   no shutdown
    channel-group 5 mode active
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.10/32
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.10/32
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.110/24
 !
@@ -132,25 +142,30 @@ interface Vlan350
 !
 interface Vlan3013
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone
+   no shutdown
    vrf Tenant_A_WAN_Zone
    ip address 10.255.251.10/31
 !
 interface Vlan3020
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone
+   no shutdown
    vrf Tenant_B_WAN_Zone
    ip address 10.255.251.10/31
 !
 interface Vlan3030
    description MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone
+   no shutdown
    vrf Tenant_C_WAN_Zone
    ip address 10.255.251.10/31
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
+   no shutdown
    ip address 10.255.251.10/31
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.10/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-BL1A.cfg
@@ -65,6 +65,7 @@ vrf instance Tenant_C_WAN_Zone
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-BL1B_Po5
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -113,16 +114,19 @@ interface Management1
 !
 interface Vlan150
    description Tenant_A_WAN_Zone_1
+   no shutdown
    vrf Tenant_A_WAN_Zone
    ip address virtual 10.1.40.1/24
 !
 interface Vlan250
    description Tenant_B_WAN_Zone_1
+   no shutdown
    vrf Tenant_B_WAN_Zone
    ip address virtual 10.2.50.1/24
 !
 interface Vlan350
    description Tenant_C_WAN_Zone_1
+   no shutdown
    vrf Tenant_C_WAN_Zone
    ip address virtual 10.3.50.1/24
 !

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-BL1B.cfg
@@ -65,6 +65,7 @@ vrf instance Tenant_C_WAN_Zone
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-BL1A_Po5
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -113,16 +114,19 @@ interface Management1
 !
 interface Vlan150
    description Tenant_A_WAN_Zone_1
+   no shutdown
    vrf Tenant_A_WAN_Zone
    ip address virtual 10.1.40.1/24
 !
 interface Vlan250
    description Tenant_B_WAN_Zone_1
+   no shutdown
    vrf Tenant_B_WAN_Zone
    ip address virtual 10.2.50.1/24
 !
 interface Vlan350
    description Tenant_C_WAN_Zone_1
+   no shutdown
    vrf Tenant_C_WAN_Zone
    ip address virtual 10.3.50.1/24
 !

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-BL1B.cfg
@@ -65,6 +65,7 @@ vrf instance Tenant_C_WAN_Zone
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-BL1A_Po5
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -73,42 +74,51 @@ interface Port-Channel5
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet7
+   no shutdown
    no switchport
    ip address 172.31.255.49/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet7
+   no shutdown
    no switchport
    ip address 172.31.255.51/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet7
+   no shutdown
    no switchport
    ip address 172.31.255.53/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet7
+   no shutdown
    no switchport
    ip address 172.31.255.55/31
 !
 interface Ethernet5
    description MLAG_PEER_DC1-BL1A_Ethernet5
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-BL1A_Ethernet6
+   no shutdown
    channel-group 5 mode active
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.11/32
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.10/32
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.111/24
 !
@@ -132,25 +142,30 @@ interface Vlan350
 !
 interface Vlan3013
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone
+   no shutdown
    vrf Tenant_A_WAN_Zone
    ip address 10.255.251.11/31
 !
 interface Vlan3020
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone
+   no shutdown
    vrf Tenant_B_WAN_Zone
    ip address 10.255.251.11/31
 !
 interface Vlan3030
    description MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone
+   no shutdown
    vrf Tenant_C_WAN_Zone
    ip address 10.255.251.11/31
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
+   no shutdown
    ip address 10.255.251.11/31
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.11/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-L2LEAF1A.cfg
@@ -49,20 +49,24 @@ vrf instance MGMT
 !
 interface Port-Channel1
    description DC1-LEAF2A_Po7
+   no shutdown
    switchport
    switchport trunk allowed vlan 110-111,120-121,130-131
    switchport mode trunk
 !
 interface Ethernet1
    description DC1-LEAF2A_Ethernet7
+   no shutdown
    channel-group 1 mode active
 !
 interface Ethernet2
    description DC1-LEAF2B_Ethernet7
+   no shutdown
    channel-group 1 mode active
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.112/24
 !

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-L2LEAF1A.cfg
@@ -49,9 +49,9 @@ vrf instance MGMT
 !
 interface Port-Channel1
    description DC1-LEAF2A_Po7
+   switchport
    switchport trunk allowed vlan 110-111,120-121,130-131
    switchport mode trunk
-   mlag 1
 !
 interface Ethernet1
    description DC1-LEAF2A_Ethernet7

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-L2LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-L2LEAF2A.cfg
@@ -81,12 +81,14 @@ vrf instance MGMT
 !
 interface Port-Channel1
    description DC1-SVC3A_Po7
+   switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350
    switchport mode trunk
    mlag 1
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-L2LEAF2B_Po3
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group MLAG

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-L2LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-L2LEAF2A.cfg
@@ -81,6 +81,7 @@ vrf instance MGMT
 !
 interface Port-Channel1
    description DC1-SVC3A_Po7
+   no shutdown
    switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350
    switchport mode trunk
@@ -88,6 +89,7 @@ interface Port-Channel1
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-L2LEAF2B_Po3
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -95,27 +97,33 @@ interface Port-Channel3
 !
 interface Ethernet1
    description DC1-SVC3A_Ethernet7
+   no shutdown
    channel-group 1 mode active
 !
 interface Ethernet2
    description DC1-SVC3B_Ethernet7
+   no shutdown
    channel-group 1 mode active
 !
 interface Ethernet3
    description MLAG_PEER_DC1-L2LEAF2B_Ethernet3
+   no shutdown
    channel-group 3 mode active
 !
 interface Ethernet4
    description MLAG_PEER_DC1-L2LEAF2B_Ethernet4
+   no shutdown
    channel-group 3 mode active
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.113/24
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.16/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-L2LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-L2LEAF2B.cfg
@@ -81,12 +81,14 @@ vrf instance MGMT
 !
 interface Port-Channel1
    description DC1-SVC3B_Po7
+   switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350
    switchport mode trunk
    mlag 1
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-L2LEAF2A_Po3
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group MLAG

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-L2LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-L2LEAF2B.cfg
@@ -81,6 +81,7 @@ vrf instance MGMT
 !
 interface Port-Channel1
    description DC1-SVC3B_Po7
+   no shutdown
    switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350
    switchport mode trunk
@@ -88,6 +89,7 @@ interface Port-Channel1
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-L2LEAF2A_Po3
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -95,27 +97,33 @@ interface Port-Channel3
 !
 interface Ethernet1
    description DC1-SVC3A_Ethernet8
+   no shutdown
    channel-group 1 mode active
 !
 interface Ethernet2
    description DC1-SVC3B_Ethernet8
+   no shutdown
    channel-group 1 mode active
 !
 interface Ethernet3
    description MLAG_PEER_DC1-L2LEAF2A_Ethernet3
+   no shutdown
    channel-group 3 mode active
 !
 interface Ethernet4
    description MLAG_PEER_DC1-L2LEAF2A_Ethernet4
+   no shutdown
    channel-group 3 mode active
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.114/24
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.17/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-LEAF1A.cfg
@@ -67,11 +67,13 @@ interface Ethernet4
 !
 interface Ethernet6
    description server02_SINGLE_NODE_TRUNK_Eth1
+   switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
 !
 interface Ethernet7
    description server02_SINGLE_NODE_Eth1
+   switchport
    switchport access vlan 110
 !
 interface Loopback0
@@ -89,6 +91,7 @@ interface Management1
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST  source-interface lo100
@@ -102,11 +105,13 @@ interface Vlan121
 !
 interface Vlan130
    description Tenant_A_APP_Zone_1
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.30.1/24
 !
 interface Vlan131
    description Tenant_A_APP_Zone_2
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.31.1/24
 !

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-LEAF1A.cfg
@@ -47,45 +47,54 @@ vrf instance Tenant_A_WEB_Zone
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.1/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.3/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.5/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.7/31
 !
 interface Ethernet6
    description server02_SINGLE_NODE_TRUNK_Eth1
+   no shutdown
    switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
 !
 interface Ethernet7
    description server02_SINGLE_NODE_Eth1
+   no shutdown
    switchport
    switchport access vlan 110
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.5/32
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.5/32
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.105/24
 !

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-LEAF2A.cfg
@@ -112,6 +112,7 @@ vrf instance Tenant_C_OP_Zone
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-LEAF2B_Po5
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -120,6 +121,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF1_Po1
+   no shutdown
    switchport
    switchport trunk allowed vlan 110-111,120-121,130-131
    switchport mode trunk
@@ -127,6 +129,7 @@ interface Port-Channel7
 !
 interface Port-Channel10
    description server01_MLAG_PortChanne1
+   no shutdown
    switchport
    switchport trunk allowed vlan 210-211
    switchport mode trunk
@@ -134,55 +137,67 @@ interface Port-Channel10
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.9/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.11/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.13/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.15/31
 !
 interface Ethernet5
    description MLAG_PEER_DC1-LEAF2B_Ethernet5
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-LEAF2B_Ethernet6
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet7
    description DC1-L2LEAF1A_Ethernet1
+   no shutdown
    channel-group 7 mode active
 !
 interface Ethernet10
    description server01_MLAG_Eth2
+   no shutdown
    channel-group 10 mode active
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.6/32
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.6/32
 !
 interface Loopback100
    description Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address 10.255.1.6/32
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.106/24
 !
@@ -263,40 +278,48 @@ interface Vlan311
 !
 interface Vlan3009
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address 10.255.251.2/31
 !
 interface Vlan3010
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address 10.255.251.2/31
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address 10.255.251.2/31
 !
 interface Vlan3012
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address 10.255.251.2/31
 !
 interface Vlan3019
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address 10.255.251.2/31
 !
 interface Vlan3029
    description MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address 10.255.251.2/31
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
+   no shutdown
    ip address 10.255.251.2/31
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.2/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-LEAF2A.cfg
@@ -112,6 +112,7 @@ vrf instance Tenant_C_OP_Zone
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-LEAF2B_Po5
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -119,12 +120,14 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF1_Po1
+   switchport
    switchport trunk allowed vlan 110-111,120-121,130-131
    switchport mode trunk
    mlag 7
 !
 interface Port-Channel10
    description server01_MLAG_PortChanne1
+   switchport
    switchport trunk allowed vlan 210-211
    switchport mode trunk
    mlag 10
@@ -185,17 +188,20 @@ interface Management1
 !
 interface Vlan110
    description Tenant_A_OP_Zone_1
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address virtual 10.1.10.1/24
 !
 interface Vlan111
    description Tenant_A_OP_Zone_2
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT  source-interface lo100
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST  source-interface lo100
@@ -209,41 +215,49 @@ interface Vlan121
 !
 interface Vlan130
    description Tenant_A_APP_Zone_1
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.30.1/24
 !
 interface Vlan131
    description Tenant_A_APP_Zone_2
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.31.1/24
 !
 interface Vlan140
    description Tenant_A_DB_BZone_1
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address virtual 10.1.40.1/24
 !
 interface Vlan141
    description Tenant_A_DB_Zone_2
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address virtual 10.1.41.1/24
 !
 interface Vlan210
    description Tenant_B_OP_Zone_1
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address virtual 10.2.10.1/24
 !
 interface Vlan211
    description Tenant_B_OP_Zone_2
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address virtual 10.2.11.1/24
 !
 interface Vlan310
    description Tenant_C_OP_Zone_1
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address virtual 10.3.10.1/24
 !
 interface Vlan311
    description Tenant_C_OP_Zone_2
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address virtual 10.3.11.1/24
 !

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-LEAF2B.cfg
@@ -112,6 +112,7 @@ vrf instance Tenant_C_OP_Zone
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-LEAF2A_Po5
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -120,6 +121,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF1_Po1
+   no shutdown
    switchport
    switchport trunk allowed vlan 110-111,120-121,130-131
    switchport mode trunk
@@ -127,6 +129,7 @@ interface Port-Channel7
 !
 interface Port-Channel10
    description server01_MLAG_PortChanne1
+   no shutdown
    switchport
    switchport trunk allowed vlan 210-211
    switchport mode trunk
@@ -134,55 +137,67 @@ interface Port-Channel10
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.17/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.19/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.21/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.23/31
 !
 interface Ethernet5
    description MLAG_PEER_DC1-LEAF2A_Ethernet5
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-LEAF2A_Ethernet6
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet7
    description DC1-L2LEAF1A_Ethernet2
+   no shutdown
    channel-group 7 mode active
 !
 interface Ethernet10
    description server01_MLAG_Eth3
+   no shutdown
    channel-group 10 mode active
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.7/32
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.6/32
 !
 interface Loopback100
    description Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address 10.255.1.7/32
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.107/24
 !
@@ -263,40 +278,48 @@ interface Vlan311
 !
 interface Vlan3009
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address 10.255.251.3/31
 !
 interface Vlan3010
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address 10.255.251.3/31
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address 10.255.251.3/31
 !
 interface Vlan3012
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address 10.255.251.3/31
 !
 interface Vlan3019
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address 10.255.251.3/31
 !
 interface Vlan3029
    description MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address 10.255.251.3/31
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
+   no shutdown
    ip address 10.255.251.3/31
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.3/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-LEAF2B.cfg
@@ -112,6 +112,7 @@ vrf instance Tenant_C_OP_Zone
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-LEAF2A_Po5
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -119,12 +120,14 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF1_Po1
+   switchport
    switchport trunk allowed vlan 110-111,120-121,130-131
    switchport mode trunk
    mlag 7
 !
 interface Port-Channel10
    description server01_MLAG_PortChanne1
+   switchport
    switchport trunk allowed vlan 210-211
    switchport mode trunk
    mlag 10
@@ -185,17 +188,20 @@ interface Management1
 !
 interface Vlan110
    description Tenant_A_OP_Zone_1
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address virtual 10.1.10.1/24
 !
 interface Vlan111
    description Tenant_A_OP_Zone_2
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT  source-interface lo100
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST  source-interface lo100
@@ -209,41 +215,49 @@ interface Vlan121
 !
 interface Vlan130
    description Tenant_A_APP_Zone_1
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.30.1/24
 !
 interface Vlan131
    description Tenant_A_APP_Zone_2
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.31.1/24
 !
 interface Vlan140
    description Tenant_A_DB_BZone_1
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address virtual 10.1.40.1/24
 !
 interface Vlan141
    description Tenant_A_DB_Zone_2
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address virtual 10.1.41.1/24
 !
 interface Vlan210
    description Tenant_B_OP_Zone_1
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address virtual 10.2.10.1/24
 !
 interface Vlan211
    description Tenant_B_OP_Zone_2
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address virtual 10.2.11.1/24
 !
 interface Vlan310
    description Tenant_C_OP_Zone_1
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address virtual 10.3.10.1/24
 !
 interface Vlan311
    description Tenant_C_OP_Zone_2
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address virtual 10.3.11.1/24
 !

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SPINE1.cfg
@@ -28,45 +28,54 @@ vrf instance MGMT
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.0/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-LEAF2A_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.8/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-LEAF2B_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.16/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SVC3A_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.24/31
 !
 interface Ethernet5
    description P2P_LINK_TO_DC1-SVC3B_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.32/31
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-BL1A_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.40/31
 !
 interface Ethernet7
    description P2P_LINK_TO_DC1-BL1B_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.48/31
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.1/32
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.101/24
 !

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SPINE2.cfg
@@ -28,45 +28,54 @@ vrf instance MGMT
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.2/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-LEAF2A_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.10/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-LEAF2B_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.18/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SVC3A_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.26/31
 !
 interface Ethernet5
    description P2P_LINK_TO_DC1-SVC3B_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.34/31
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-BL1A_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.42/31
 !
 interface Ethernet7
    description P2P_LINK_TO_DC1-BL1B_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.50/31
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.2/32
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.102/24
 !

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SPINE3.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SPINE3.cfg
@@ -28,45 +28,54 @@ vrf instance MGMT
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.4/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-LEAF2A_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.12/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-LEAF2B_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.20/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SVC3A_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.28/31
 !
 interface Ethernet5
    description P2P_LINK_TO_DC1-SVC3B_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.36/31
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-BL1A_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.44/31
 !
 interface Ethernet7
    description P2P_LINK_TO_DC1-BL1B_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.52/31
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.3/32
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.103/24
 !

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SPINE4.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SPINE4.cfg
@@ -28,45 +28,54 @@ vrf instance MGMT
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.6/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-LEAF2A_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.14/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-LEAF2B_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.22/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SVC3A_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.30/31
 !
 interface Ethernet5
    description P2P_LINK_TO_DC1-SVC3B_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.38/31
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-BL1A_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.46/31
 !
 interface Ethernet7
    description P2P_LINK_TO_DC1-BL1B_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.54/31
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.4/32
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.104/24
 !

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SVC3A.cfg
@@ -139,6 +139,7 @@ vrf instance Tenant_C_WAN_Zone
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-SVC3B_Po5
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -146,12 +147,14 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF2_Po1
+   switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350
    switchport mode trunk
    mlag 7
 !
 interface Port-Channel10
    description server03_ESI_PortChanne1
+   switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
    mlag 10
@@ -216,17 +219,20 @@ interface Management1
 !
 interface Vlan110
    description Tenant_A_OP_Zone_1
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address virtual 10.1.10.1/24
 !
 interface Vlan111
    description Tenant_A_OP_Zone_2
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT  source-interface lo100
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST  source-interface lo100
@@ -240,56 +246,67 @@ interface Vlan121
 !
 interface Vlan130
    description Tenant_A_APP_Zone_1
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.30.1/24
 !
 interface Vlan131
    description Tenant_A_APP_Zone_2
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.31.1/24
 !
 interface Vlan140
    description Tenant_A_DB_BZone_1
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address virtual 10.1.40.1/24
 !
 interface Vlan141
    description Tenant_A_DB_Zone_2
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address virtual 10.1.41.1/24
 !
 interface Vlan150
    description Tenant_A_WAN_Zone_1
+   no shutdown
    vrf Tenant_A_WAN_Zone
    ip address virtual 10.1.40.1/24
 !
 interface Vlan210
    description Tenant_B_OP_Zone_1
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address virtual 10.2.10.1/24
 !
 interface Vlan211
    description Tenant_B_OP_Zone_2
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address virtual 10.2.11.1/24
 !
 interface Vlan250
    description Tenant_B_WAN_Zone_1
+   no shutdown
    vrf Tenant_B_WAN_Zone
    ip address virtual 10.2.50.1/24
 !
 interface Vlan310
    description Tenant_C_OP_Zone_1
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address virtual 10.3.10.1/24
 !
 interface Vlan311
    description Tenant_C_OP_Zone_2
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address virtual 10.3.11.1/24
 !
 interface Vlan350
    description Tenant_C_WAN_Zone_1
+   no shutdown
    vrf Tenant_C_WAN_Zone
    ip address virtual 10.3.50.1/24
 !

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SVC3A.cfg
@@ -139,6 +139,7 @@ vrf instance Tenant_C_WAN_Zone
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-SVC3B_Po5
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -147,6 +148,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF2_Po1
+   no shutdown
    switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350
    switchport mode trunk
@@ -154,6 +156,7 @@ interface Port-Channel7
 !
 interface Port-Channel10
    description server03_ESI_PortChanne1
+   no shutdown
    switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
@@ -161,59 +164,72 @@ interface Port-Channel10
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.25/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.27/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.29/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.31/31
 !
 interface Ethernet5
    description MLAG_PEER_DC1-SVC3B_Ethernet5
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-SVC3B_Ethernet6
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet7
    description DC1-L2LEAF2A_Ethernet1
+   no shutdown
    channel-group 7 mode active
 !
 interface Ethernet8
    description DC1-L2LEAF2B_Ethernet1
+   no shutdown
    channel-group 7 mode active
 !
 interface Ethernet10
    description server03_ESI_Eth1
+   no shutdown
    channel-group 10 mode active
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.8/32
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.8/32
 !
 interface Loopback100
    description Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address 10.255.1.8/32
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.108/24
 !
@@ -312,55 +328,66 @@ interface Vlan350
 !
 interface Vlan3009
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address 10.255.251.6/31
 !
 interface Vlan3010
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address 10.255.251.6/31
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address 10.255.251.6/31
 !
 interface Vlan3012
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address 10.255.251.6/31
 !
 interface Vlan3013
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone
+   no shutdown
    vrf Tenant_A_WAN_Zone
    ip address 10.255.251.6/31
 !
 interface Vlan3019
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address 10.255.251.6/31
 !
 interface Vlan3020
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone
+   no shutdown
    vrf Tenant_B_WAN_Zone
    ip address 10.255.251.6/31
 !
 interface Vlan3029
    description MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address 10.255.251.6/31
 !
 interface Vlan3030
    description MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone
+   no shutdown
    vrf Tenant_C_WAN_Zone
    ip address 10.255.251.6/31
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
+   no shutdown
    ip address 10.255.251.6/31
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.6/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SVC3B.cfg
@@ -139,6 +139,7 @@ vrf instance Tenant_C_WAN_Zone
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-SVC3A_Po5
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -147,6 +148,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF2_Po1
+   no shutdown
    switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350
    switchport mode trunk
@@ -154,55 +156,67 @@ interface Port-Channel7
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet5
+   no shutdown
    no switchport
    ip address 172.31.255.33/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet5
+   no shutdown
    no switchport
    ip address 172.31.255.35/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet5
+   no shutdown
    no switchport
    ip address 172.31.255.37/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet5
+   no shutdown
    no switchport
    ip address 172.31.255.39/31
 !
 interface Ethernet5
    description MLAG_PEER_DC1-SVC3A_Ethernet5
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-SVC3A_Ethernet6
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet7
    description DC1-L2LEAF2A_Ethernet2
+   no shutdown
    channel-group 7 mode active
 !
 interface Ethernet8
    description DC1-L2LEAF2B_Ethernet2
+   no shutdown
    channel-group 7 mode active
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.9/32
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.8/32
 !
 interface Loopback100
    description Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address 10.255.1.9/32
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.109/24
 !
@@ -301,55 +315,66 @@ interface Vlan350
 !
 interface Vlan3009
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address 10.255.251.7/31
 !
 interface Vlan3010
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address 10.255.251.7/31
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address 10.255.251.7/31
 !
 interface Vlan3012
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address 10.255.251.7/31
 !
 interface Vlan3013
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone
+   no shutdown
    vrf Tenant_A_WAN_Zone
    ip address 10.255.251.7/31
 !
 interface Vlan3019
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address 10.255.251.7/31
 !
 interface Vlan3020
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone
+   no shutdown
    vrf Tenant_B_WAN_Zone
    ip address 10.255.251.7/31
 !
 interface Vlan3029
    description MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address 10.255.251.7/31
 !
 interface Vlan3030
    description MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone
+   no shutdown
    vrf Tenant_C_WAN_Zone
    ip address 10.255.251.7/31
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
+   no shutdown
    ip address 10.255.251.7/31
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.7/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SVC3B.cfg
@@ -139,6 +139,7 @@ vrf instance Tenant_C_WAN_Zone
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-SVC3A_Po5
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -146,6 +147,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF2_Po1
+   switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350
    switchport mode trunk
    mlag 7
@@ -206,17 +208,20 @@ interface Management1
 !
 interface Vlan110
    description Tenant_A_OP_Zone_1
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address virtual 10.1.10.1/24
 !
 interface Vlan111
    description Tenant_A_OP_Zone_2
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT  source-interface lo100
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST  source-interface lo100
@@ -230,56 +235,67 @@ interface Vlan121
 !
 interface Vlan130
    description Tenant_A_APP_Zone_1
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.30.1/24
 !
 interface Vlan131
    description Tenant_A_APP_Zone_2
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.31.1/24
 !
 interface Vlan140
    description Tenant_A_DB_BZone_1
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address virtual 10.1.40.1/24
 !
 interface Vlan141
    description Tenant_A_DB_Zone_2
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address virtual 10.1.41.1/24
 !
 interface Vlan150
    description Tenant_A_WAN_Zone_1
+   no shutdown
    vrf Tenant_A_WAN_Zone
    ip address virtual 10.1.40.1/24
 !
 interface Vlan210
    description Tenant_B_OP_Zone_1
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address virtual 10.2.10.1/24
 !
 interface Vlan211
    description Tenant_B_OP_Zone_2
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address virtual 10.2.11.1/24
 !
 interface Vlan250
    description Tenant_B_WAN_Zone_1
+   no shutdown
    vrf Tenant_B_WAN_Zone
    ip address virtual 10.2.50.1/24
 !
 interface Vlan310
    description Tenant_C_OP_Zone_1
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address virtual 10.3.10.1/24
 !
 interface Vlan311
    description Tenant_C_OP_Zone_2
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address virtual 10.3.11.1/24
 !
 interface Vlan350
    description Tenant_C_WAN_Zone_1
+   no shutdown
    vrf Tenant_C_WAN_Zone
    ip address virtual 10.3.50.1/24
 !

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1A.yml
@@ -131,6 +131,8 @@ bfd_multihop:
 port_channel_interfaces:
   Port-Channel5:
     description: MLAG_PEER_DC1-BL1B_Po5
+    type: switched
+    shutdown: false
     vlans: 2-4094
     mode: trunk
     trunk_groups:
@@ -144,6 +146,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE1_Ethernet6
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.41/31
   Ethernet2:
     peer: DC1-SPINE2
@@ -152,6 +155,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE2_Ethernet6
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.43/31
   Ethernet3:
     peer: DC1-SPINE3
@@ -160,6 +164,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE3_Ethernet6
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.45/31
   Ethernet4:
     peer: DC1-SPINE4
@@ -168,12 +173,15 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE4_Ethernet6
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.47/31
   Ethernet5:
     peer: DC1-BL1B
     peer_interface: Ethernet5
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-BL1B_Ethernet5
+    type: switched
+    shutdown: false
     channel_group:
       id: 5
       mode: active
@@ -182,29 +190,36 @@ ethernet_interfaces:
     peer_interface: Ethernet6
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-BL1B_Ethernet6
+    type: switched
+    shutdown: false
     channel_group:
       id: 5
       mode: active
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: 192.168.255.10/32
   Loopback1:
     description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
     ip_address: 192.168.254.10/32
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.110/24
     gateway: 192.168.200.5
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING
+    shutdown: false
     ip_address: 10.255.251.10/31
     mtu: 1500
   Vlan4094:
     description: MLAG_PEER
+    shutdown: false
     ip_address: 10.255.252.10/31
     no_autostate: true
     mtu: 1500
@@ -219,6 +234,7 @@ vlan_interfaces:
   Vlan3013:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone'
     vrf: Tenant_A_WAN_Zone
     ip_address: 10.255.251.10/31
@@ -233,6 +249,7 @@ vlan_interfaces:
   Vlan3020:
     tenant: Tenant_B
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone'
     vrf: Tenant_B_WAN_Zone
     ip_address: 10.255.251.10/31
@@ -247,6 +264,7 @@ vlan_interfaces:
   Vlan3030:
     tenant: Tenant_C
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone'
     vrf: Tenant_C_WAN_Zone
     ip_address: 10.255.251.10/31

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1B.yml
@@ -131,6 +131,8 @@ bfd_multihop:
 port_channel_interfaces:
   Port-Channel5:
     description: MLAG_PEER_DC1-BL1A_Po5
+    type: switched
+    shutdown: false
     vlans: 2-4094
     mode: trunk
     trunk_groups:
@@ -144,6 +146,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE1_Ethernet7
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.49/31
   Ethernet2:
     peer: DC1-SPINE2
@@ -152,6 +155,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE2_Ethernet7
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.51/31
   Ethernet3:
     peer: DC1-SPINE3
@@ -160,6 +164,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE3_Ethernet7
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.53/31
   Ethernet4:
     peer: DC1-SPINE4
@@ -168,12 +173,15 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE4_Ethernet7
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.55/31
   Ethernet5:
     peer: DC1-BL1A
     peer_interface: Ethernet5
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-BL1A_Ethernet5
+    type: switched
+    shutdown: false
     channel_group:
       id: 5
       mode: active
@@ -182,29 +190,36 @@ ethernet_interfaces:
     peer_interface: Ethernet6
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-BL1A_Ethernet6
+    type: switched
+    shutdown: false
     channel_group:
       id: 5
       mode: active
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: 192.168.255.11/32
   Loopback1:
     description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
     ip_address: 192.168.254.10/32
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.111/24
     gateway: 192.168.200.5
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING
+    shutdown: false
     ip_address: 10.255.251.11/31
     mtu: 1500
   Vlan4094:
     description: MLAG_PEER
+    shutdown: false
     ip_address: 10.255.252.11/31
     no_autostate: true
     mtu: 1500
@@ -219,6 +234,7 @@ vlan_interfaces:
   Vlan3013:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone'
     vrf: Tenant_A_WAN_Zone
     ip_address: 10.255.251.11/31
@@ -233,6 +249,7 @@ vlan_interfaces:
   Vlan3020:
     tenant: Tenant_B
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone'
     vrf: Tenant_B_WAN_Zone
     ip_address: 10.255.251.11/31
@@ -247,6 +264,7 @@ vlan_interfaces:
   Vlan3030:
     tenant: Tenant_C
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone'
     vrf: Tenant_C_WAN_Zone
     ip_address: 10.255.251.11/31

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -101,6 +101,8 @@ vrfs:
 port_channel_interfaces:
   Port-Channel1:
     description: DC1-LEAF2A_Po7
+    type: switched
+    shutdown: false
     vlans: 110-111,120-121,130-131
     mode: trunk
 ethernet_interfaces:
@@ -109,6 +111,8 @@ ethernet_interfaces:
     peer_interface: Ethernet7
     peer_type: l3leaf
     description: DC1-LEAF2A_Ethernet7
+    type: switched
+    shutdown: false
     channel_group:
       id: 1
       mode: active
@@ -117,12 +121,15 @@ ethernet_interfaces:
     peer_interface: Ethernet7
     peer_type: l3leaf
     description: DC1-LEAF2B_Ethernet7
+    type: switched
+    shutdown: false
     channel_group:
       id: 1
       mode: active
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.112/24
     gateway: 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -103,7 +103,6 @@ port_channel_interfaces:
     description: DC1-LEAF2A_Po7
     vlans: 110-111,120-121,130-131
     mode: trunk
-    mlag: 1
 ethernet_interfaces:
   Ethernet1:
     peer: DC1-LEAF2A

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -162,11 +162,15 @@ vrfs:
 port_channel_interfaces:
   Port-Channel1:
     description: DC1-SVC3A_Po7
+    type: switched
+    shutdown: false
     vlans: 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350
     mode: trunk
     mlag: 1
   Port-Channel3:
     description: MLAG_PEER_DC1-L2LEAF2B_Po3
+    type: switched
+    shutdown: false
     vlans: 2-4094
     mode: trunk
     trunk_groups:
@@ -177,6 +181,8 @@ ethernet_interfaces:
     peer_interface: Ethernet7
     peer_type: l3leaf
     description: DC1-SVC3A_Ethernet7
+    type: switched
+    shutdown: false
     channel_group:
       id: 1
       mode: active
@@ -185,6 +191,8 @@ ethernet_interfaces:
     peer_interface: Ethernet7
     peer_type: l3leaf
     description: DC1-SVC3B_Ethernet7
+    type: switched
+    shutdown: false
     channel_group:
       id: 1
       mode: active
@@ -193,6 +201,8 @@ ethernet_interfaces:
     peer_interface: Ethernet3
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-L2LEAF2B_Ethernet3
+    type: switched
+    shutdown: false
     channel_group:
       id: 3
       mode: active
@@ -201,18 +211,22 @@ ethernet_interfaces:
     peer_interface: Ethernet4
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-L2LEAF2B_Ethernet4
+    type: switched
+    shutdown: false
     channel_group:
       id: 3
       mode: active
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.113/24
     gateway: 192.168.200.5
 vlan_interfaces:
   Vlan4094:
     description: MLAG_PEER
+    shutdown: false
     ip_address: 10.255.252.16/31
     no_autostate: true
     mtu: 1500

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -162,11 +162,15 @@ vrfs:
 port_channel_interfaces:
   Port-Channel1:
     description: DC1-SVC3B_Po7
+    type: switched
+    shutdown: false
     vlans: 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350
     mode: trunk
     mlag: 1
   Port-Channel3:
     description: MLAG_PEER_DC1-L2LEAF2A_Po3
+    type: switched
+    shutdown: false
     vlans: 2-4094
     mode: trunk
     trunk_groups:
@@ -177,6 +181,8 @@ ethernet_interfaces:
     peer_interface: Ethernet8
     peer_type: l3leaf
     description: DC1-SVC3A_Ethernet8
+    type: switched
+    shutdown: false
     channel_group:
       id: 1
       mode: active
@@ -185,6 +191,8 @@ ethernet_interfaces:
     peer_interface: Ethernet8
     peer_type: l3leaf
     description: DC1-SVC3B_Ethernet8
+    type: switched
+    shutdown: false
     channel_group:
       id: 1
       mode: active
@@ -193,6 +201,8 @@ ethernet_interfaces:
     peer_interface: Ethernet3
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-L2LEAF2A_Ethernet3
+    type: switched
+    shutdown: false
     channel_group:
       id: 3
       mode: active
@@ -201,18 +211,22 @@ ethernet_interfaces:
     peer_interface: Ethernet4
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-L2LEAF2A_Ethernet4
+    type: switched
+    shutdown: false
     channel_group:
       id: 3
       mode: active
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.114/24
     gateway: 192.168.200.5
 vlan_interfaces:
   Vlan4094:
     description: MLAG_PEER
+    shutdown: false
     ip_address: 10.255.252.17/31
     no_autostate: true
     mtu: 1500

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF1A.yml
@@ -107,6 +107,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE1_Ethernet1
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.1/31
   Ethernet2:
     peer: DC1-SPINE2
@@ -115,6 +116,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE2_Ethernet1
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.3/31
   Ethernet3:
     peer: DC1-SPINE3
@@ -123,6 +125,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE3_Ethernet1
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.5/31
   Ethernet4:
     peer: DC1-SPINE4
@@ -131,12 +134,15 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE4_Ethernet1
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.7/31
   Ethernet7:
     peer: server02_SINGLE_NODE
     peer_interface: Eth1
     peer_type: server
     description: server02_SINGLE_NODE_Eth1
+    type: switched
+    shutdown: false
     mode: access
     vlans: 110
     profile: TENANT_A
@@ -145,19 +151,24 @@ ethernet_interfaces:
     peer_interface: Eth1
     peer_type: server
     description: server02_SINGLE_NODE_TRUNK_Eth1
+    type: switched
+    shutdown: false
     mode: trunk
     vlans: 110-111,210-211
     profile: TENANT_A_B
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: 192.168.255.5/32
   Loopback1:
     description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
     ip_address: 192.168.254.5/32
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.105/24
     gateway: 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2A.yml
@@ -210,11 +210,15 @@ bfd_multihop:
 port_channel_interfaces:
   Port-Channel7:
     description: DC1_L2LEAF1_Po1
+    type: switched
+    shutdown: false
     vlans: 110-111,120-121,130-131
     mode: trunk
     mlag: 7
   Port-Channel5:
     description: MLAG_PEER_DC1-LEAF2B_Po5
+    type: switched
+    shutdown: false
     vlans: 2-4094
     mode: trunk
     trunk_groups:
@@ -222,6 +226,8 @@ port_channel_interfaces:
     - MLAG
   Port-Channel10:
     description: server01_MLAG_PortChanne1
+    type: switched
+    shutdown: false
     vlans: 210-211
     mode: trunk
     mlag: 10
@@ -233,6 +239,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE1_Ethernet2
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.9/31
   Ethernet2:
     peer: DC1-SPINE2
@@ -241,6 +248,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE2_Ethernet2
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.11/31
   Ethernet3:
     peer: DC1-SPINE3
@@ -249,6 +257,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE3_Ethernet2
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.13/31
   Ethernet4:
     peer: DC1-SPINE4
@@ -257,12 +266,15 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE4_Ethernet2
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.15/31
   Ethernet5:
     peer: DC1-LEAF2B
     peer_interface: Ethernet5
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-LEAF2B_Ethernet5
+    type: switched
+    shutdown: false
     channel_group:
       id: 5
       mode: active
@@ -271,6 +283,8 @@ ethernet_interfaces:
     peer_interface: Ethernet6
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-LEAF2B_Ethernet6
+    type: switched
+    shutdown: false
     channel_group:
       id: 5
       mode: active
@@ -279,6 +293,8 @@ ethernet_interfaces:
     peer_interface: Ethernet1
     peer_type: l2leaf
     description: DC1-L2LEAF1A_Ethernet1
+    type: switched
+    shutdown: false
     channel_group:
       id: 7
       mode: active
@@ -287,6 +303,8 @@ ethernet_interfaces:
     peer_interface: Eth2
     peer_type: server
     description: server01_MLAG_Eth2
+    type: switched
+    shutdown: false
     mode: trunk
     vlans: 210-211
     channel_group:
@@ -296,27 +314,33 @@ ethernet_interfaces:
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: 192.168.255.6/32
   Loopback1:
     description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
     ip_address: 192.168.254.6/32
   Loopback100:
     description: Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
+    shutdown: false
     vrf: Tenant_A_OP_Zone
     ip_address: 10.255.1.6/32
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.106/24
     gateway: 192.168.200.5
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING
+    shutdown: false
     ip_address: 10.255.251.2/31
     mtu: 1500
   Vlan4094:
     description: MLAG_PEER
+    shutdown: false
     ip_address: 10.255.252.2/31
     no_autostate: true
     mtu: 1500
@@ -340,6 +364,7 @@ vlan_interfaces:
   Vlan3011:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone'
     vrf: Tenant_A_APP_Zone
     ip_address: 10.255.251.2/31
@@ -363,6 +388,7 @@ vlan_interfaces:
   Vlan3012:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone'
     vrf: Tenant_A_DB_Zone
     ip_address: 10.255.251.2/31
@@ -389,6 +415,7 @@ vlan_interfaces:
   Vlan3009:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone'
     vrf: Tenant_A_OP_Zone
     ip_address: 10.255.251.2/31
@@ -417,6 +444,7 @@ vlan_interfaces:
   Vlan3010:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone'
     vrf: Tenant_A_WEB_Zone
     ip_address: 10.255.251.2/31
@@ -439,6 +467,7 @@ vlan_interfaces:
   Vlan3019:
     tenant: Tenant_B
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone'
     vrf: Tenant_B_OP_Zone
     ip_address: 10.255.251.2/31
@@ -461,6 +490,7 @@ vlan_interfaces:
   Vlan3029:
     tenant: Tenant_C
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone'
     vrf: Tenant_C_OP_Zone
     ip_address: 10.255.251.2/31

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2B.yml
@@ -210,11 +210,15 @@ bfd_multihop:
 port_channel_interfaces:
   Port-Channel7:
     description: DC1_L2LEAF1_Po1
+    type: switched
+    shutdown: false
     vlans: 110-111,120-121,130-131
     mode: trunk
     mlag: 7
   Port-Channel5:
     description: MLAG_PEER_DC1-LEAF2A_Po5
+    type: switched
+    shutdown: false
     vlans: 2-4094
     mode: trunk
     trunk_groups:
@@ -222,6 +226,8 @@ port_channel_interfaces:
     - MLAG
   Port-Channel10:
     description: server01_MLAG_PortChanne1
+    type: switched
+    shutdown: false
     vlans: 210-211
     mode: trunk
     mlag: 10
@@ -233,6 +239,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE1_Ethernet3
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.17/31
   Ethernet2:
     peer: DC1-SPINE2
@@ -241,6 +248,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE2_Ethernet3
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.19/31
   Ethernet3:
     peer: DC1-SPINE3
@@ -249,6 +257,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE3_Ethernet3
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.21/31
   Ethernet4:
     peer: DC1-SPINE4
@@ -257,12 +266,15 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE4_Ethernet3
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.23/31
   Ethernet5:
     peer: DC1-LEAF2A
     peer_interface: Ethernet5
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-LEAF2A_Ethernet5
+    type: switched
+    shutdown: false
     channel_group:
       id: 5
       mode: active
@@ -271,6 +283,8 @@ ethernet_interfaces:
     peer_interface: Ethernet6
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-LEAF2A_Ethernet6
+    type: switched
+    shutdown: false
     channel_group:
       id: 5
       mode: active
@@ -279,6 +293,8 @@ ethernet_interfaces:
     peer_interface: Ethernet2
     peer_type: l2leaf
     description: DC1-L2LEAF1A_Ethernet2
+    type: switched
+    shutdown: false
     channel_group:
       id: 7
       mode: active
@@ -287,6 +303,8 @@ ethernet_interfaces:
     peer_interface: Eth3
     peer_type: server
     description: server01_MLAG_Eth3
+    type: switched
+    shutdown: false
     mode: trunk
     vlans: 210-211
     channel_group:
@@ -296,27 +314,33 @@ ethernet_interfaces:
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: 192.168.255.7/32
   Loopback1:
     description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
     ip_address: 192.168.254.6/32
   Loopback100:
     description: Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
+    shutdown: false
     vrf: Tenant_A_OP_Zone
     ip_address: 10.255.1.7/32
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.107/24
     gateway: 192.168.200.5
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING
+    shutdown: false
     ip_address: 10.255.251.3/31
     mtu: 1500
   Vlan4094:
     description: MLAG_PEER
+    shutdown: false
     ip_address: 10.255.252.3/31
     no_autostate: true
     mtu: 1500
@@ -340,6 +364,7 @@ vlan_interfaces:
   Vlan3011:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone'
     vrf: Tenant_A_APP_Zone
     ip_address: 10.255.251.3/31
@@ -363,6 +388,7 @@ vlan_interfaces:
   Vlan3012:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone'
     vrf: Tenant_A_DB_Zone
     ip_address: 10.255.251.3/31
@@ -389,6 +415,7 @@ vlan_interfaces:
   Vlan3009:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone'
     vrf: Tenant_A_OP_Zone
     ip_address: 10.255.251.3/31
@@ -417,6 +444,7 @@ vlan_interfaces:
   Vlan3010:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone'
     vrf: Tenant_A_WEB_Zone
     ip_address: 10.255.251.3/31
@@ -439,6 +467,7 @@ vlan_interfaces:
   Vlan3019:
     tenant: Tenant_B
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone'
     vrf: Tenant_B_OP_Zone
     ip_address: 10.255.251.3/31
@@ -461,6 +490,7 @@ vlan_interfaces:
   Vlan3029:
     tenant: Tenant_C
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone'
     vrf: Tenant_C_OP_Zone
     ip_address: 10.255.251.3/31

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE1.yml
@@ -63,6 +63,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-BL1A_Ethernet1
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.40/31
   Ethernet7:
     peer: DC1-BL1B
@@ -71,6 +72,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-BL1B_Ethernet1
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.48/31
   Ethernet1:
     peer: DC1-LEAF1A
@@ -79,6 +81,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF1A_Ethernet1
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.0/31
   Ethernet2:
     peer: DC1-LEAF2A
@@ -87,6 +90,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF2A_Ethernet1
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.8/31
   Ethernet3:
     peer: DC1-LEAF2B
@@ -95,6 +99,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF2B_Ethernet1
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.16/31
   Ethernet4:
     peer: DC1-SVC3A
@@ -103,6 +108,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SVC3A_Ethernet1
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.24/31
   Ethernet5:
     peer: DC1-SVC3B
@@ -111,14 +117,17 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SVC3B_Ethernet1
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.32/31
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: 192.168.255.1/32
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.101/24
     gateway: 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE2.yml
@@ -63,6 +63,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-BL1A_Ethernet2
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.42/31
   Ethernet7:
     peer: DC1-BL1B
@@ -71,6 +72,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-BL1B_Ethernet2
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.50/31
   Ethernet1:
     peer: DC1-LEAF1A
@@ -79,6 +81,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF1A_Ethernet2
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.2/31
   Ethernet2:
     peer: DC1-LEAF2A
@@ -87,6 +90,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF2A_Ethernet2
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.10/31
   Ethernet3:
     peer: DC1-LEAF2B
@@ -95,6 +99,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF2B_Ethernet2
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.18/31
   Ethernet4:
     peer: DC1-SVC3A
@@ -103,6 +108,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SVC3A_Ethernet2
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.26/31
   Ethernet5:
     peer: DC1-SVC3B
@@ -111,14 +117,17 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SVC3B_Ethernet2
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.34/31
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: 192.168.255.2/32
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.102/24
     gateway: 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE3.yml
@@ -63,6 +63,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-BL1A_Ethernet3
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.44/31
   Ethernet7:
     peer: DC1-BL1B
@@ -71,6 +72,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-BL1B_Ethernet3
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.52/31
   Ethernet1:
     peer: DC1-LEAF1A
@@ -79,6 +81,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF1A_Ethernet3
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.4/31
   Ethernet2:
     peer: DC1-LEAF2A
@@ -87,6 +90,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF2A_Ethernet3
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.12/31
   Ethernet3:
     peer: DC1-LEAF2B
@@ -95,6 +99,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF2B_Ethernet3
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.20/31
   Ethernet4:
     peer: DC1-SVC3A
@@ -103,6 +108,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SVC3A_Ethernet3
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.28/31
   Ethernet5:
     peer: DC1-SVC3B
@@ -111,14 +117,17 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SVC3B_Ethernet3
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.36/31
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: 192.168.255.3/32
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.103/24
     gateway: 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE4.yml
@@ -63,6 +63,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-BL1A_Ethernet4
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.46/31
   Ethernet7:
     peer: DC1-BL1B
@@ -71,6 +72,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-BL1B_Ethernet4
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.54/31
   Ethernet1:
     peer: DC1-LEAF1A
@@ -79,6 +81,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF1A_Ethernet4
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.6/31
   Ethernet2:
     peer: DC1-LEAF2A
@@ -87,6 +90,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF2A_Ethernet4
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.14/31
   Ethernet3:
     peer: DC1-LEAF2B
@@ -95,6 +99,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF2B_Ethernet4
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.22/31
   Ethernet4:
     peer: DC1-SVC3A
@@ -103,6 +108,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SVC3A_Ethernet4
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.30/31
   Ethernet5:
     peer: DC1-SVC3B
@@ -111,14 +117,17 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SVC3B_Ethernet4
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.38/31
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: 192.168.255.4/32
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.104/24
     gateway: 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3A.yml
@@ -253,11 +253,15 @@ bfd_multihop:
 port_channel_interfaces:
   Port-Channel7:
     description: DC1_L2LEAF2_Po1
+    type: switched
+    shutdown: false
     vlans: 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350
     mode: trunk
     mlag: 7
   Port-Channel5:
     description: MLAG_PEER_DC1-SVC3B_Po5
+    type: switched
+    shutdown: false
     vlans: 2-4094
     mode: trunk
     trunk_groups:
@@ -265,6 +269,8 @@ port_channel_interfaces:
     - MLAG
   Port-Channel10:
     description: server03_ESI_PortChanne1
+    type: switched
+    shutdown: false
     vlans: 110-111,210-211
     mode: trunk
     mlag: 10
@@ -276,6 +282,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE1_Ethernet4
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.25/31
   Ethernet2:
     peer: DC1-SPINE2
@@ -284,6 +291,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE2_Ethernet4
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.27/31
   Ethernet3:
     peer: DC1-SPINE3
@@ -292,6 +300,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE3_Ethernet4
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.29/31
   Ethernet4:
     peer: DC1-SPINE4
@@ -300,12 +309,15 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE4_Ethernet4
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.31/31
   Ethernet5:
     peer: DC1-SVC3B
     peer_interface: Ethernet5
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-SVC3B_Ethernet5
+    type: switched
+    shutdown: false
     channel_group:
       id: 5
       mode: active
@@ -314,6 +326,8 @@ ethernet_interfaces:
     peer_interface: Ethernet6
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-SVC3B_Ethernet6
+    type: switched
+    shutdown: false
     channel_group:
       id: 5
       mode: active
@@ -322,6 +336,8 @@ ethernet_interfaces:
     peer_interface: Ethernet1
     peer_type: l2leaf
     description: DC1-L2LEAF2A_Ethernet1
+    type: switched
+    shutdown: false
     channel_group:
       id: 7
       mode: active
@@ -330,6 +346,8 @@ ethernet_interfaces:
     peer_interface: Ethernet1
     peer_type: l2leaf
     description: DC1-L2LEAF2B_Ethernet1
+    type: switched
+    shutdown: false
     channel_group:
       id: 7
       mode: active
@@ -338,6 +356,8 @@ ethernet_interfaces:
     peer_interface: Eth1
     peer_type: server
     description: server03_ESI_Eth1
+    type: switched
+    shutdown: false
     mode: trunk
     vlans: 110-111,210-211
     channel_group:
@@ -347,27 +367,33 @@ ethernet_interfaces:
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: 192.168.255.8/32
   Loopback1:
     description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
     ip_address: 192.168.254.8/32
   Loopback100:
     description: Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
+    shutdown: false
     vrf: Tenant_A_OP_Zone
     ip_address: 10.255.1.8/32
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.108/24
     gateway: 192.168.200.5
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING
+    shutdown: false
     ip_address: 10.255.251.6/31
     mtu: 1500
   Vlan4094:
     description: MLAG_PEER
+    shutdown: false
     ip_address: 10.255.252.6/31
     no_autostate: true
     mtu: 1500
@@ -391,6 +417,7 @@ vlan_interfaces:
   Vlan3011:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone'
     vrf: Tenant_A_APP_Zone
     ip_address: 10.255.251.6/31
@@ -414,6 +441,7 @@ vlan_interfaces:
   Vlan3012:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone'
     vrf: Tenant_A_DB_Zone
     ip_address: 10.255.251.6/31
@@ -440,6 +468,7 @@ vlan_interfaces:
   Vlan3009:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone'
     vrf: Tenant_A_OP_Zone
     ip_address: 10.255.251.6/31
@@ -454,6 +483,7 @@ vlan_interfaces:
   Vlan3013:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone'
     vrf: Tenant_A_WAN_Zone
     ip_address: 10.255.251.6/31
@@ -482,6 +512,7 @@ vlan_interfaces:
   Vlan3010:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone'
     vrf: Tenant_A_WEB_Zone
     ip_address: 10.255.251.6/31
@@ -504,6 +535,7 @@ vlan_interfaces:
   Vlan3019:
     tenant: Tenant_B
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone'
     vrf: Tenant_B_OP_Zone
     ip_address: 10.255.251.6/31
@@ -518,6 +550,7 @@ vlan_interfaces:
   Vlan3020:
     tenant: Tenant_B
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone'
     vrf: Tenant_B_WAN_Zone
     ip_address: 10.255.251.6/31
@@ -540,6 +573,7 @@ vlan_interfaces:
   Vlan3029:
     tenant: Tenant_C
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone'
     vrf: Tenant_C_OP_Zone
     ip_address: 10.255.251.6/31
@@ -554,6 +588,7 @@ vlan_interfaces:
   Vlan3030:
     tenant: Tenant_C
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone'
     vrf: Tenant_C_WAN_Zone
     ip_address: 10.255.251.6/31

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3B.yml
@@ -253,11 +253,15 @@ bfd_multihop:
 port_channel_interfaces:
   Port-Channel7:
     description: DC1_L2LEAF2_Po1
+    type: switched
+    shutdown: false
     vlans: 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350
     mode: trunk
     mlag: 7
   Port-Channel5:
     description: MLAG_PEER_DC1-SVC3A_Po5
+    type: switched
+    shutdown: false
     vlans: 2-4094
     mode: trunk
     trunk_groups:
@@ -271,6 +275,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE1_Ethernet5
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.33/31
   Ethernet2:
     peer: DC1-SPINE2
@@ -279,6 +284,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE2_Ethernet5
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.35/31
   Ethernet3:
     peer: DC1-SPINE3
@@ -287,6 +293,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE3_Ethernet5
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.37/31
   Ethernet4:
     peer: DC1-SPINE4
@@ -295,12 +302,15 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE4_Ethernet5
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.39/31
   Ethernet5:
     peer: DC1-SVC3A
     peer_interface: Ethernet5
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-SVC3A_Ethernet5
+    type: switched
+    shutdown: false
     channel_group:
       id: 5
       mode: active
@@ -309,6 +319,8 @@ ethernet_interfaces:
     peer_interface: Ethernet6
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-SVC3A_Ethernet6
+    type: switched
+    shutdown: false
     channel_group:
       id: 5
       mode: active
@@ -317,6 +329,8 @@ ethernet_interfaces:
     peer_interface: Ethernet2
     peer_type: l2leaf
     description: DC1-L2LEAF2A_Ethernet2
+    type: switched
+    shutdown: false
     channel_group:
       id: 7
       mode: active
@@ -325,33 +339,41 @@ ethernet_interfaces:
     peer_interface: Ethernet2
     peer_type: l2leaf
     description: DC1-L2LEAF2B_Ethernet2
+    type: switched
+    shutdown: false
     channel_group:
       id: 7
       mode: active
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: 192.168.255.9/32
   Loopback1:
     description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
     ip_address: 192.168.254.8/32
   Loopback100:
     description: Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
+    shutdown: false
     vrf: Tenant_A_OP_Zone
     ip_address: 10.255.1.9/32
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.109/24
     gateway: 192.168.200.5
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING
+    shutdown: false
     ip_address: 10.255.251.7/31
     mtu: 1500
   Vlan4094:
     description: MLAG_PEER
+    shutdown: false
     ip_address: 10.255.252.7/31
     no_autostate: true
     mtu: 1500
@@ -375,6 +397,7 @@ vlan_interfaces:
   Vlan3011:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone'
     vrf: Tenant_A_APP_Zone
     ip_address: 10.255.251.7/31
@@ -398,6 +421,7 @@ vlan_interfaces:
   Vlan3012:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone'
     vrf: Tenant_A_DB_Zone
     ip_address: 10.255.251.7/31
@@ -424,6 +448,7 @@ vlan_interfaces:
   Vlan3009:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone'
     vrf: Tenant_A_OP_Zone
     ip_address: 10.255.251.7/31
@@ -438,6 +463,7 @@ vlan_interfaces:
   Vlan3013:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone'
     vrf: Tenant_A_WAN_Zone
     ip_address: 10.255.251.7/31
@@ -466,6 +492,7 @@ vlan_interfaces:
   Vlan3010:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone'
     vrf: Tenant_A_WEB_Zone
     ip_address: 10.255.251.7/31
@@ -488,6 +515,7 @@ vlan_interfaces:
   Vlan3019:
     tenant: Tenant_B
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone'
     vrf: Tenant_B_OP_Zone
     ip_address: 10.255.251.7/31
@@ -502,6 +530,7 @@ vlan_interfaces:
   Vlan3020:
     tenant: Tenant_B
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone'
     vrf: Tenant_B_WAN_Zone
     ip_address: 10.255.251.7/31
@@ -524,6 +553,7 @@ vlan_interfaces:
   Vlan3029:
     tenant: Tenant_C
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone'
     vrf: Tenant_C_OP_Zone
     ip_address: 10.255.251.7/31
@@ -538,6 +568,7 @@ vlan_interfaces:
   Vlan3030:
     tenant: Tenant_C
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone'
     vrf: Tenant_C_WAN_Zone
     ip_address: 10.255.251.7/31

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/cvp/cv_server_configlets.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/cvp/cv_server_configlets.yml
@@ -18,9 +18,9 @@ CVP_CONFIGLETS:
     \ LEAF_PEER_L3\n!\nvlan 4094\n   name MLAG_PEER\n   trunk group MLAG\n!\nvrf instance\
     \ MGMT\n!\nvrf instance Tenant_A_WAN_Zone\n!\nvrf instance Tenant_B_WAN_Zone\n\
     !\nvrf instance Tenant_C_WAN_Zone\n!\ninterface Port-Channel5\n   description\
-    \ MLAG_PEER_DC1-BL1B_Po5\n   switchport trunk allowed vlan 2-4094\n   switchport\
-    \ mode trunk\n   switchport trunk group LEAF_PEER_L3\n   switchport trunk group\
-    \ MLAG\n!\ninterface Ethernet1\n   description P2P_LINK_TO_DC1-SPINE1_Ethernet6\n\
+    \ MLAG_PEER_DC1-BL1B_Po5\n   switchport\n   switchport trunk allowed vlan 2-4094\n\
+    \   switchport mode trunk\n   switchport trunk group LEAF_PEER_L3\n   switchport\
+    \ trunk group MLAG\n!\ninterface Ethernet1\n   description P2P_LINK_TO_DC1-SPINE1_Ethernet6\n\
     \   no switchport\n   ip address 172.31.255.41/31\n!\ninterface Ethernet2\n  \
     \ description P2P_LINK_TO_DC1-SPINE2_Ethernet6\n   no switchport\n   ip address\
     \ 172.31.255.43/31\n!\ninterface Ethernet3\n   description P2P_LINK_TO_DC1-SPINE3_Ethernet6\n\
@@ -32,10 +32,11 @@ CVP_CONFIGLETS:
     \   ip address 192.168.255.10/32\n!\ninterface Loopback1\n   description VTEP_VXLAN_Tunnel_Source\n\
     \   ip address 192.168.254.10/32\n!\ninterface Management1\n   description oob_management\n\
     \   vrf MGMT\n   ip address 192.168.200.110/24\n!\ninterface Vlan150\n   description\
-    \ Tenant_A_WAN_Zone_1\n   vrf Tenant_A_WAN_Zone\n   ip address virtual 10.1.40.1/24\n\
-    !\ninterface Vlan250\n   description Tenant_B_WAN_Zone_1\n   vrf Tenant_B_WAN_Zone\n\
-    \   ip address virtual 10.2.50.1/24\n!\ninterface Vlan350\n   description Tenant_C_WAN_Zone_1\n\
-    \   vrf Tenant_C_WAN_Zone\n   ip address virtual 10.3.50.1/24\n!\ninterface Vlan3013\n\
+    \ Tenant_A_WAN_Zone_1\n   no shutdown\n   vrf Tenant_A_WAN_Zone\n   ip address\
+    \ virtual 10.1.40.1/24\n!\ninterface Vlan250\n   description Tenant_B_WAN_Zone_1\n\
+    \   no shutdown\n   vrf Tenant_B_WAN_Zone\n   ip address virtual 10.2.50.1/24\n\
+    !\ninterface Vlan350\n   description Tenant_C_WAN_Zone_1\n   no shutdown\n   vrf\
+    \ Tenant_C_WAN_Zone\n   ip address virtual 10.3.50.1/24\n!\ninterface Vlan3013\n\
     \   description MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone\n   vrf Tenant_A_WAN_Zone\n\
     \   ip address 10.255.251.10/31\n!\ninterface Vlan3020\n   description MLAG_PEER_L3_iBGP:\
     \ vrf Tenant_B_WAN_Zone\n   vrf Tenant_B_WAN_Zone\n   ip address 10.255.251.10/31\n\
@@ -118,9 +119,9 @@ CVP_CONFIGLETS:
     \ LEAF_PEER_L3\n!\nvlan 4094\n   name MLAG_PEER\n   trunk group MLAG\n!\nvrf instance\
     \ MGMT\n!\nvrf instance Tenant_A_WAN_Zone\n!\nvrf instance Tenant_B_WAN_Zone\n\
     !\nvrf instance Tenant_C_WAN_Zone\n!\ninterface Port-Channel5\n   description\
-    \ MLAG_PEER_DC1-BL1A_Po5\n   switchport trunk allowed vlan 2-4094\n   switchport\
-    \ mode trunk\n   switchport trunk group LEAF_PEER_L3\n   switchport trunk group\
-    \ MLAG\n!\ninterface Ethernet1\n   description P2P_LINK_TO_DC1-SPINE1_Ethernet7\n\
+    \ MLAG_PEER_DC1-BL1A_Po5\n   switchport\n   switchport trunk allowed vlan 2-4094\n\
+    \   switchport mode trunk\n   switchport trunk group LEAF_PEER_L3\n   switchport\
+    \ trunk group MLAG\n!\ninterface Ethernet1\n   description P2P_LINK_TO_DC1-SPINE1_Ethernet7\n\
     \   no switchport\n   ip address 172.31.255.49/31\n!\ninterface Ethernet2\n  \
     \ description P2P_LINK_TO_DC1-SPINE2_Ethernet7\n   no switchport\n   ip address\
     \ 172.31.255.51/31\n!\ninterface Ethernet3\n   description P2P_LINK_TO_DC1-SPINE3_Ethernet7\n\
@@ -132,10 +133,11 @@ CVP_CONFIGLETS:
     \   ip address 192.168.255.11/32\n!\ninterface Loopback1\n   description VTEP_VXLAN_Tunnel_Source\n\
     \   ip address 192.168.254.10/32\n!\ninterface Management1\n   description oob_management\n\
     \   vrf MGMT\n   ip address 192.168.200.111/24\n!\ninterface Vlan150\n   description\
-    \ Tenant_A_WAN_Zone_1\n   vrf Tenant_A_WAN_Zone\n   ip address virtual 10.1.40.1/24\n\
-    !\ninterface Vlan250\n   description Tenant_B_WAN_Zone_1\n   vrf Tenant_B_WAN_Zone\n\
-    \   ip address virtual 10.2.50.1/24\n!\ninterface Vlan350\n   description Tenant_C_WAN_Zone_1\n\
-    \   vrf Tenant_C_WAN_Zone\n   ip address virtual 10.3.50.1/24\n!\ninterface Vlan3013\n\
+    \ Tenant_A_WAN_Zone_1\n   no shutdown\n   vrf Tenant_A_WAN_Zone\n   ip address\
+    \ virtual 10.1.40.1/24\n!\ninterface Vlan250\n   description Tenant_B_WAN_Zone_1\n\
+    \   no shutdown\n   vrf Tenant_B_WAN_Zone\n   ip address virtual 10.2.50.1/24\n\
+    !\ninterface Vlan350\n   description Tenant_C_WAN_Zone_1\n   no shutdown\n   vrf\
+    \ Tenant_C_WAN_Zone\n   ip address virtual 10.3.50.1/24\n!\ninterface Vlan3013\n\
     \   description MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone\n   vrf Tenant_A_WAN_Zone\n\
     \   ip address 10.255.251.11/31\n!\ninterface Vlan3020\n   description MLAG_PEER_L3_iBGP:\
     \ vrf Tenant_B_WAN_Zone\n   vrf Tenant_B_WAN_Zone\n   ip address 10.255.251.11/31\n\
@@ -214,9 +216,9 @@ CVP_CONFIGLETS:
     !\nvlan 120\n   name Tenant_A_WEB_Zone_1\n!\nvlan 121\n   name Tenant_A_WEBZone_2\n\
     !\nvlan 130\n   name Tenant_A_APP_Zone_1\n!\nvlan 131\n   name Tenant_A_APP_Zone_2\n\
     !\nvrf instance MGMT\n!\ninterface Port-Channel1\n   description DC1-LEAF2A_Po7\n\
-    \   switchport trunk allowed vlan 110-111,120-121,130-131\n   switchport mode\
-    \ trunk\n   mlag 1\n!\ninterface Ethernet1\n   description DC1-LEAF2A_Ethernet7\n\
-    \   channel-group 1 mode active\n!\ninterface Ethernet2\n   description DC1-LEAF2B_Ethernet7\n\
+    \   switchport\n   switchport trunk allowed vlan 110-111,120-121,130-131\n   switchport\
+    \ mode trunk\n!\ninterface Ethernet1\n   description DC1-LEAF2A_Ethernet7\n  \
+    \ channel-group 1 mode active\n!\ninterface Ethernet2\n   description DC1-LEAF2B_Ethernet7\n\
     \   channel-group 1 mode active\n!\ninterface Management1\n   description oob_management\n\
     \   vrf MGMT\n   ip address 192.168.200.112/24\n!\nip routing\nno ip routing vrf\
     \ MGMT\n!\nip route vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nrouter bfd\n   multihop\
@@ -243,14 +245,14 @@ CVP_CONFIGLETS:
     !\nvlan 310\n   name Tenant_C_OP_Zone_1\n!\nvlan 311\n   name Tenant_C_OP_Zone_2\n\
     !\nvlan 350\n   name Tenant_C_WAN_Zone_1\n!\nvlan 4094\n   name MLAG_PEER\n  \
     \ trunk group MLAG\n!\nvrf instance MGMT\n!\ninterface Port-Channel1\n   description\
-    \ DC1-SVC3A_Po7\n   switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350\n\
+    \ DC1-SVC3A_Po7\n   switchport\n   switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350\n\
     \   switchport mode trunk\n   mlag 1\n!\ninterface Port-Channel3\n   description\
-    \ MLAG_PEER_DC1-L2LEAF2B_Po3\n   switchport trunk allowed vlan 2-4094\n   switchport\
-    \ mode trunk\n   switchport trunk group MLAG\n!\ninterface Ethernet1\n   description\
-    \ DC1-SVC3A_Ethernet7\n   channel-group 1 mode active\n!\ninterface Ethernet2\n\
-    \   description DC1-SVC3B_Ethernet7\n   channel-group 1 mode active\n!\ninterface\
-    \ Ethernet3\n   description MLAG_PEER_DC1-L2LEAF2B_Ethernet3\n   channel-group\
-    \ 3 mode active\n!\ninterface Ethernet4\n   description MLAG_PEER_DC1-L2LEAF2B_Ethernet4\n\
+    \ MLAG_PEER_DC1-L2LEAF2B_Po3\n   switchport\n   switchport trunk allowed vlan\
+    \ 2-4094\n   switchport mode trunk\n   switchport trunk group MLAG\n!\ninterface\
+    \ Ethernet1\n   description DC1-SVC3A_Ethernet7\n   channel-group 1 mode active\n\
+    !\ninterface Ethernet2\n   description DC1-SVC3B_Ethernet7\n   channel-group 1\
+    \ mode active\n!\ninterface Ethernet3\n   description MLAG_PEER_DC1-L2LEAF2B_Ethernet3\n\
+    \   channel-group 3 mode active\n!\ninterface Ethernet4\n   description MLAG_PEER_DC1-L2LEAF2B_Ethernet4\n\
     \   channel-group 3 mode active\n!\ninterface Management1\n   description oob_management\n\
     \   vrf MGMT\n   ip address 192.168.200.113/24\n!\ninterface Vlan4094\n   description\
     \ MLAG_PEER\n   no autostate\n   ip address 10.255.252.16/31\n!\nip routing\n\
@@ -282,14 +284,14 @@ CVP_CONFIGLETS:
     !\nvlan 310\n   name Tenant_C_OP_Zone_1\n!\nvlan 311\n   name Tenant_C_OP_Zone_2\n\
     !\nvlan 350\n   name Tenant_C_WAN_Zone_1\n!\nvlan 4094\n   name MLAG_PEER\n  \
     \ trunk group MLAG\n!\nvrf instance MGMT\n!\ninterface Port-Channel1\n   description\
-    \ DC1-SVC3B_Po7\n   switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350\n\
+    \ DC1-SVC3B_Po7\n   switchport\n   switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350\n\
     \   switchport mode trunk\n   mlag 1\n!\ninterface Port-Channel3\n   description\
-    \ MLAG_PEER_DC1-L2LEAF2A_Po3\n   switchport trunk allowed vlan 2-4094\n   switchport\
-    \ mode trunk\n   switchport trunk group MLAG\n!\ninterface Ethernet1\n   description\
-    \ DC1-SVC3A_Ethernet8\n   channel-group 1 mode active\n!\ninterface Ethernet2\n\
-    \   description DC1-SVC3B_Ethernet8\n   channel-group 1 mode active\n!\ninterface\
-    \ Ethernet3\n   description MLAG_PEER_DC1-L2LEAF2A_Ethernet3\n   channel-group\
-    \ 3 mode active\n!\ninterface Ethernet4\n   description MLAG_PEER_DC1-L2LEAF2A_Ethernet4\n\
+    \ MLAG_PEER_DC1-L2LEAF2A_Po3\n   switchport\n   switchport trunk allowed vlan\
+    \ 2-4094\n   switchport mode trunk\n   switchport trunk group MLAG\n!\ninterface\
+    \ Ethernet1\n   description DC1-SVC3A_Ethernet8\n   channel-group 1 mode active\n\
+    !\ninterface Ethernet2\n   description DC1-SVC3B_Ethernet8\n   channel-group 1\
+    \ mode active\n!\ninterface Ethernet3\n   description MLAG_PEER_DC1-L2LEAF2A_Ethernet3\n\
+    \   channel-group 3 mode active\n!\ninterface Ethernet4\n   description MLAG_PEER_DC1-L2LEAF2A_Ethernet4\n\
     \   channel-group 3 mode active\n!\ninterface Management1\n   description oob_management\n\
     \   vrf MGMT\n   ip address 192.168.200.114/24\n!\ninterface Vlan4094\n   description\
     \ MLAG_PEER\n   no autostate\n   ip address 10.255.252.17/31\n!\nip routing\n\
@@ -320,51 +322,52 @@ CVP_CONFIGLETS:
     !\ninterface Ethernet3\n   description P2P_LINK_TO_DC1-SPINE3_Ethernet1\n   no\
     \ switchport\n   ip address 172.31.255.5/31\n!\ninterface Ethernet4\n   description\
     \ P2P_LINK_TO_DC1-SPINE4_Ethernet1\n   no switchport\n   ip address 172.31.255.7/31\n\
-    !\ninterface Ethernet6\n   description server02_SINGLE_NODE_TRUNK_Eth1\n   switchport\
-    \ trunk allowed vlan 110-111,210-211\n   switchport mode trunk\n!\ninterface Ethernet7\n\
-    \   description server02_SINGLE_NODE_Eth1\n   switchport access vlan 110\n!\n\
-    interface Loopback0\n   description EVPN_Overlay_Peering\n   ip address 192.168.255.5/32\n\
-    !\ninterface Loopback1\n   description VTEP_VXLAN_Tunnel_Source\n   ip address\
-    \ 192.168.254.5/32\n!\ninterface Management1\n   description oob_management\n\
+    !\ninterface Ethernet6\n   description server02_SINGLE_NODE_TRUNK_Eth1\n   switchport\n\
+    \   switchport trunk allowed vlan 110-111,210-211\n   switchport mode trunk\n\
+    !\ninterface Ethernet7\n   description server02_SINGLE_NODE_Eth1\n   switchport\n\
+    \   switchport access vlan 110\n!\ninterface Loopback0\n   description EVPN_Overlay_Peering\n\
+    \   ip address 192.168.255.5/32\n!\ninterface Loopback1\n   description VTEP_VXLAN_Tunnel_Source\n\
+    \   ip address 192.168.254.5/32\n!\ninterface Management1\n   description oob_management\n\
     \   vrf MGMT\n   ip address 192.168.200.105/24\n!\ninterface Vlan120\n   description\
-    \ Tenant_A_WEB_Zone_1\n   vrf Tenant_A_WEB_Zone\n   ip address virtual 10.1.20.1/24\n\
-    \   ip helper-address 1.1.1.1 vrf TEST  source-interface lo100\n!\ninterface Vlan121\n\
-    \   description Tenant_A_WEBZone_2\n   shutdown\n   mtu 1560\n   vrf Tenant_A_WEB_Zone\n\
-    \   ip address virtual 10.1.10.254/24\n!\ninterface Vlan130\n   description Tenant_A_APP_Zone_1\n\
-    \   vrf Tenant_A_APP_Zone\n   ip address virtual 10.1.30.1/24\n!\ninterface Vlan131\n\
-    \   description Tenant_A_APP_Zone_2\n   vrf Tenant_A_APP_Zone\n   ip address virtual\
-    \ 10.1.31.1/24\n!\ninterface Vxlan1\n   vxlan source-interface Loopback1\n   vxlan\
-    \ udp-port 4789\n   vxlan vlan 120 vni 10120\n   vxlan vlan 121 vni 10121\n  \
-    \ vxlan vlan 130 vni 10130\n   vxlan vlan 131 vni 10131\n   vxlan vrf Tenant_A_APP_Zone\
-    \ vni 12\n   vxlan vrf Tenant_A_WEB_Zone vni 11\n!\nip virtual-router mac-address\
-    \ 00:dc:00:00:00:0a\n!\nip routing\nno ip routing vrf MGMT\nip routing vrf Tenant_A_APP_Zone\n\
-    ip routing vrf Tenant_A_WEB_Zone\n!\nip prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n\
-    \   seq 10 permit 192.168.255.0/24 eq 32\n   seq 20 permit 192.168.254.0/24 eq\
-    \ 32\n!\nip route vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nroute-map RM-CONN-2-BGP\
-    \ permit 10\n   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n!\nrouter\
-    \ bfd\n   multihop interval 1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65101\n\
-    \   router-id 192.168.255.5\n   no bgp default ipv4-unicast\n   distance bgp 20\
-    \ 200 200\n   maximum-paths 4 ecmp 4\n   neighbor EVPN-OVERLAY-PEERS peer group\n\
-    \   neighbor EVPN-OVERLAY-PEERS remote-as 65001\n   neighbor EVPN-OVERLAY-PEERS\
-    \ update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS\
-    \ ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n\
-    \   neighbor EVPN-OVERLAY-PEERS send-community\n   neighbor EVPN-OVERLAY-PEERS\
-    \ maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS peer group\n   neighbor IPv4-UNDERLAY-PEERS\
-    \ remote-as 65001\n   neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==\n\
-    \   neighbor IPv4-UNDERLAY-PEERS send-community\n   neighbor IPv4-UNDERLAY-PEERS\
-    \ maximum-routes 12000\n   neighbor 172.31.255.0 peer group IPv4-UNDERLAY-PEERS\n\
-    \   neighbor 172.31.255.2 peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.4\
-    \ peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.6 peer group IPv4-UNDERLAY-PEERS\n\
-    \   neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.2\
-    \ peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.3 peer group EVPN-OVERLAY-PEERS\n\
-    \   neighbor 192.168.255.4 peer group EVPN-OVERLAY-PEERS\n   redistribute connected\
-    \ route-map RM-CONN-2-BGP\n   !\n   vlan-aware-bundle Tenant_A_APP_Zone\n    \
-    \  rd 192.168.255.5:12\n      route-target both 12:12\n      redistribute learned\n\
-    \      vlan 130-131\n   !\n   vlan-aware-bundle Tenant_A_WEB_Zone\n      rd 192.168.255.5:11\n\
-    \      route-target both 11:11\n      redistribute learned\n      vlan 120-121\n\
-    \   !\n   address-family evpn\n      neighbor EVPN-OVERLAY-PEERS activate\n  \
-    \    no neighbor IPv4-UNDERLAY-PEERS activate\n   !\n   address-family ipv4\n\
-    \      no neighbor EVPN-OVERLAY-PEERS activate\n      neighbor IPv4-UNDERLAY-PEERS\
+    \ Tenant_A_WEB_Zone_1\n   no shutdown\n   vrf Tenant_A_WEB_Zone\n   ip address\
+    \ virtual 10.1.20.1/24\n   ip helper-address 1.1.1.1 vrf TEST  source-interface\
+    \ lo100\n!\ninterface Vlan121\n   description Tenant_A_WEBZone_2\n   shutdown\n\
+    \   mtu 1560\n   vrf Tenant_A_WEB_Zone\n   ip address virtual 10.1.10.254/24\n\
+    !\ninterface Vlan130\n   description Tenant_A_APP_Zone_1\n   no shutdown\n   vrf\
+    \ Tenant_A_APP_Zone\n   ip address virtual 10.1.30.1/24\n!\ninterface Vlan131\n\
+    \   description Tenant_A_APP_Zone_2\n   no shutdown\n   vrf Tenant_A_APP_Zone\n\
+    \   ip address virtual 10.1.31.1/24\n!\ninterface Vxlan1\n   vxlan source-interface\
+    \ Loopback1\n   vxlan udp-port 4789\n   vxlan vlan 120 vni 10120\n   vxlan vlan\
+    \ 121 vni 10121\n   vxlan vlan 130 vni 10130\n   vxlan vlan 131 vni 10131\n  \
+    \ vxlan vrf Tenant_A_APP_Zone vni 12\n   vxlan vrf Tenant_A_WEB_Zone vni 11\n\
+    !\nip virtual-router mac-address 00:dc:00:00:00:0a\n!\nip routing\nno ip routing\
+    \ vrf MGMT\nip routing vrf Tenant_A_APP_Zone\nip routing vrf Tenant_A_WEB_Zone\n\
+    !\nip prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n   seq 10 permit 192.168.255.0/24\
+    \ eq 32\n   seq 20 permit 192.168.254.0/24 eq 32\n!\nip route vrf MGMT 0.0.0.0/0\
+    \ 192.168.200.5\n!\nroute-map RM-CONN-2-BGP permit 10\n   match ip address prefix-list\
+    \ PL-LOOPBACKS-EVPN-OVERLAY\n!\nrouter bfd\n   multihop interval 1200 min-rx 1200\
+    \ multiplier 3\n!\nrouter bgp 65101\n   router-id 192.168.255.5\n   no bgp default\
+    \ ipv4-unicast\n   distance bgp 20 200 200\n   maximum-paths 4 ecmp 4\n   neighbor\
+    \ EVPN-OVERLAY-PEERS peer group\n   neighbor EVPN-OVERLAY-PEERS remote-as 65001\n\
+    \   neighbor EVPN-OVERLAY-PEERS update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS\
+    \ bfd\n   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS\
+    \ password 7 q+VNViP5i4rVjW1cxFv2wA==\n   neighbor EVPN-OVERLAY-PEERS send-community\n\
+    \   neighbor EVPN-OVERLAY-PEERS maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS\
+    \ peer group\n   neighbor IPv4-UNDERLAY-PEERS remote-as 65001\n   neighbor IPv4-UNDERLAY-PEERS\
+    \ password 7 AQQvKeimxJu+uGQ/yYvv9w==\n   neighbor IPv4-UNDERLAY-PEERS send-community\n\
+    \   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000\n   neighbor 172.31.255.0\
+    \ peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.2 peer group IPv4-UNDERLAY-PEERS\n\
+    \   neighbor 172.31.255.4 peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.6\
+    \ peer group IPv4-UNDERLAY-PEERS\n   neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS\n\
+    \   neighbor 192.168.255.2 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.3\
+    \ peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.4 peer group EVPN-OVERLAY-PEERS\n\
+    \   redistribute connected route-map RM-CONN-2-BGP\n   !\n   vlan-aware-bundle\
+    \ Tenant_A_APP_Zone\n      rd 192.168.255.5:12\n      route-target both 12:12\n\
+    \      redistribute learned\n      vlan 130-131\n   !\n   vlan-aware-bundle Tenant_A_WEB_Zone\n\
+    \      rd 192.168.255.5:11\n      route-target both 11:11\n      redistribute\
+    \ learned\n      vlan 120-121\n   !\n   address-family evpn\n      neighbor EVPN-OVERLAY-PEERS\
+    \ activate\n      no neighbor IPv4-UNDERLAY-PEERS activate\n   !\n   address-family\
+    \ ipv4\n      no neighbor EVPN-OVERLAY-PEERS activate\n      neighbor IPv4-UNDERLAY-PEERS\
     \ activate\n   !\n   vrf Tenant_A_APP_Zone\n      rd 192.168.255.5:12\n      route-target\
     \ import evpn 12:12\n      route-target export evpn 12:12\n      router-id 192.168.255.5\n\
     \      redistribute connected\n   !\n   vrf Tenant_A_WEB_Zone\n      rd 192.168.255.5:11\n\
@@ -400,12 +403,13 @@ CVP_CONFIGLETS:
     \ Tenant_A_APP_Zone\n!\nvrf instance Tenant_A_DB_Zone\n!\nvrf instance Tenant_A_OP_Zone\n\
     !\nvrf instance Tenant_A_WEB_Zone\n!\nvrf instance Tenant_B_OP_Zone\n!\nvrf instance\
     \ Tenant_C_OP_Zone\n!\ninterface Port-Channel5\n   description MLAG_PEER_DC1-LEAF2B_Po5\n\
-    \   switchport trunk allowed vlan 2-4094\n   switchport mode trunk\n   switchport\
-    \ trunk group LEAF_PEER_L3\n   switchport trunk group MLAG\n!\ninterface Port-Channel7\n\
-    \   description DC1_L2LEAF1_Po1\n   switchport trunk allowed vlan 110-111,120-121,130-131\n\
-    \   switchport mode trunk\n   mlag 7\n!\ninterface Port-Channel10\n   description\
-    \ server01_MLAG_PortChanne1\n   switchport trunk allowed vlan 210-211\n   switchport\
-    \ mode trunk\n   mlag 10\n!\ninterface Ethernet1\n   description P2P_LINK_TO_DC1-SPINE1_Ethernet2\n\
+    \   switchport\n   switchport trunk allowed vlan 2-4094\n   switchport mode trunk\n\
+    \   switchport trunk group LEAF_PEER_L3\n   switchport trunk group MLAG\n!\ninterface\
+    \ Port-Channel7\n   description DC1_L2LEAF1_Po1\n   switchport\n   switchport\
+    \ trunk allowed vlan 110-111,120-121,130-131\n   switchport mode trunk\n   mlag\
+    \ 7\n!\ninterface Port-Channel10\n   description server01_MLAG_PortChanne1\n \
+    \  switchport\n   switchport trunk allowed vlan 210-211\n   switchport mode trunk\n\
+    \   mlag 10\n!\ninterface Ethernet1\n   description P2P_LINK_TO_DC1-SPINE1_Ethernet2\n\
     \   no switchport\n   ip address 172.31.255.9/31\n!\ninterface Ethernet2\n   description\
     \ P2P_LINK_TO_DC1-SPINE2_Ethernet2\n   no switchport\n   ip address 172.31.255.11/31\n\
     !\ninterface Ethernet3\n   description P2P_LINK_TO_DC1-SPINE3_Ethernet2\n   no\
@@ -420,47 +424,50 @@ CVP_CONFIGLETS:
     \   ip address 192.168.254.6/32\n!\ninterface Loopback100\n   description Tenant_A_OP_Zone_VTEP_DIAGNOSTICS\n\
     \   vrf Tenant_A_OP_Zone\n   ip address 10.255.1.6/32\n!\ninterface Management1\n\
     \   description oob_management\n   vrf MGMT\n   ip address 192.168.200.106/24\n\
-    !\ninterface Vlan110\n   description Tenant_A_OP_Zone_1\n   vrf Tenant_A_OP_Zone\n\
-    \   ip address virtual 10.1.10.1/24\n!\ninterface Vlan111\n   description Tenant_A_OP_Zone_2\n\
-    \   vrf Tenant_A_OP_Zone\n   ip address virtual 10.1.11.1/24\n   ip helper-address\
-    \ 1.1.1.1 vrf MGMT  source-interface lo100\n!\ninterface Vlan120\n   description\
-    \ Tenant_A_WEB_Zone_1\n   vrf Tenant_A_WEB_Zone\n   ip address virtual 10.1.20.1/24\n\
-    \   ip helper-address 1.1.1.1 vrf TEST  source-interface lo100\n!\ninterface Vlan121\n\
-    \   description Tenant_A_WEBZone_2\n   shutdown\n   mtu 1560\n   vrf Tenant_A_WEB_Zone\n\
-    \   ip address virtual 10.1.10.254/24\n!\ninterface Vlan130\n   description Tenant_A_APP_Zone_1\n\
-    \   vrf Tenant_A_APP_Zone\n   ip address virtual 10.1.30.1/24\n!\ninterface Vlan131\n\
-    \   description Tenant_A_APP_Zone_2\n   vrf Tenant_A_APP_Zone\n   ip address virtual\
-    \ 10.1.31.1/24\n!\ninterface Vlan140\n   description Tenant_A_DB_BZone_1\n   vrf\
-    \ Tenant_A_DB_Zone\n   ip address virtual 10.1.40.1/24\n!\ninterface Vlan141\n\
-    \   description Tenant_A_DB_Zone_2\n   vrf Tenant_A_DB_Zone\n   ip address virtual\
-    \ 10.1.41.1/24\n!\ninterface Vlan210\n   description Tenant_B_OP_Zone_1\n   vrf\
+    !\ninterface Vlan110\n   description Tenant_A_OP_Zone_1\n   no shutdown\n   vrf\
+    \ Tenant_A_OP_Zone\n   ip address virtual 10.1.10.1/24\n!\ninterface Vlan111\n\
+    \   description Tenant_A_OP_Zone_2\n   no shutdown\n   vrf Tenant_A_OP_Zone\n\
+    \   ip address virtual 10.1.11.1/24\n   ip helper-address 1.1.1.1 vrf MGMT  source-interface\
+    \ lo100\n!\ninterface Vlan120\n   description Tenant_A_WEB_Zone_1\n   no shutdown\n\
+    \   vrf Tenant_A_WEB_Zone\n   ip address virtual 10.1.20.1/24\n   ip helper-address\
+    \ 1.1.1.1 vrf TEST  source-interface lo100\n!\ninterface Vlan121\n   description\
+    \ Tenant_A_WEBZone_2\n   shutdown\n   mtu 1560\n   vrf Tenant_A_WEB_Zone\n   ip\
+    \ address virtual 10.1.10.254/24\n!\ninterface Vlan130\n   description Tenant_A_APP_Zone_1\n\
+    \   no shutdown\n   vrf Tenant_A_APP_Zone\n   ip address virtual 10.1.30.1/24\n\
+    !\ninterface Vlan131\n   description Tenant_A_APP_Zone_2\n   no shutdown\n   vrf\
+    \ Tenant_A_APP_Zone\n   ip address virtual 10.1.31.1/24\n!\ninterface Vlan140\n\
+    \   description Tenant_A_DB_BZone_1\n   no shutdown\n   vrf Tenant_A_DB_Zone\n\
+    \   ip address virtual 10.1.40.1/24\n!\ninterface Vlan141\n   description Tenant_A_DB_Zone_2\n\
+    \   no shutdown\n   vrf Tenant_A_DB_Zone\n   ip address virtual 10.1.41.1/24\n\
+    !\ninterface Vlan210\n   description Tenant_B_OP_Zone_1\n   no shutdown\n   vrf\
     \ Tenant_B_OP_Zone\n   ip address virtual 10.2.10.1/24\n!\ninterface Vlan211\n\
-    \   description Tenant_B_OP_Zone_2\n   vrf Tenant_B_OP_Zone\n   ip address virtual\
-    \ 10.2.11.1/24\n!\ninterface Vlan310\n   description Tenant_C_OP_Zone_1\n   vrf\
-    \ Tenant_C_OP_Zone\n   ip address virtual 10.3.10.1/24\n!\ninterface Vlan311\n\
-    \   description Tenant_C_OP_Zone_2\n   vrf Tenant_C_OP_Zone\n   ip address virtual\
-    \ 10.3.11.1/24\n!\ninterface Vlan3009\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone\n\
-    \   vrf Tenant_A_OP_Zone\n   ip address 10.255.251.2/31\n!\ninterface Vlan3010\n\
-    \   description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone\n   vrf Tenant_A_WEB_Zone\n\
-    \   ip address 10.255.251.2/31\n!\ninterface Vlan3011\n   description MLAG_PEER_L3_iBGP:\
-    \ vrf Tenant_A_APP_Zone\n   vrf Tenant_A_APP_Zone\n   ip address 10.255.251.2/31\n\
-    !\ninterface Vlan3012\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone\n\
-    \   vrf Tenant_A_DB_Zone\n   ip address 10.255.251.2/31\n!\ninterface Vlan3019\n\
-    \   description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone\n   vrf Tenant_B_OP_Zone\n\
-    \   ip address 10.255.251.2/31\n!\ninterface Vlan3029\n   description MLAG_PEER_L3_iBGP:\
-    \ vrf Tenant_C_OP_Zone\n   vrf Tenant_C_OP_Zone\n   ip address 10.255.251.2/31\n\
-    !\ninterface Vlan4093\n   description MLAG_PEER_L3_PEERING\n   ip address 10.255.251.2/31\n\
-    !\ninterface Vlan4094\n   description MLAG_PEER\n   no autostate\n   ip address\
-    \ 10.255.252.2/31\n!\ninterface Vxlan1\n   vxlan source-interface Loopback1\n\
-    \   vxlan virtual-router encapsulation mac-address mlag-system-id\n   vxlan udp-port\
-    \ 4789\n   vxlan vlan 110 vni 10110\n   vxlan vlan 111 vni 50111\n   vxlan vlan\
-    \ 120 vni 10120\n   vxlan vlan 121 vni 10121\n   vxlan vlan 130 vni 10130\n  \
-    \ vxlan vlan 131 vni 10131\n   vxlan vlan 140 vni 10140\n   vxlan vlan 141 vni\
-    \ 10141\n   vxlan vlan 210 vni 20210\n   vxlan vlan 211 vni 20211\n   vxlan vlan\
-    \ 310 vni 30310\n   vxlan vlan 311 vni 30311\n   vxlan vrf Tenant_A_APP_Zone vni\
-    \ 12\n   vxlan vrf Tenant_A_DB_Zone vni 13\n   vxlan vrf Tenant_A_OP_Zone vni\
-    \ 10\n   vxlan vrf Tenant_A_WEB_Zone vni 11\n   vxlan vrf Tenant_B_OP_Zone vni\
-    \ 20\n   vxlan vrf Tenant_C_OP_Zone vni 30\n!\nip virtual-router mac-address 00:dc:00:00:00:0a\n\
+    \   description Tenant_B_OP_Zone_2\n   no shutdown\n   vrf Tenant_B_OP_Zone\n\
+    \   ip address virtual 10.2.11.1/24\n!\ninterface Vlan310\n   description Tenant_C_OP_Zone_1\n\
+    \   no shutdown\n   vrf Tenant_C_OP_Zone\n   ip address virtual 10.3.10.1/24\n\
+    !\ninterface Vlan311\n   description Tenant_C_OP_Zone_2\n   no shutdown\n   vrf\
+    \ Tenant_C_OP_Zone\n   ip address virtual 10.3.11.1/24\n!\ninterface Vlan3009\n\
+    \   description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone\n   vrf Tenant_A_OP_Zone\n\
+    \   ip address 10.255.251.2/31\n!\ninterface Vlan3010\n   description MLAG_PEER_L3_iBGP:\
+    \ vrf Tenant_A_WEB_Zone\n   vrf Tenant_A_WEB_Zone\n   ip address 10.255.251.2/31\n\
+    !\ninterface Vlan3011\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone\n\
+    \   vrf Tenant_A_APP_Zone\n   ip address 10.255.251.2/31\n!\ninterface Vlan3012\n\
+    \   description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone\n   vrf Tenant_A_DB_Zone\n\
+    \   ip address 10.255.251.2/31\n!\ninterface Vlan3019\n   description MLAG_PEER_L3_iBGP:\
+    \ vrf Tenant_B_OP_Zone\n   vrf Tenant_B_OP_Zone\n   ip address 10.255.251.2/31\n\
+    !\ninterface Vlan3029\n   description MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone\n\
+    \   vrf Tenant_C_OP_Zone\n   ip address 10.255.251.2/31\n!\ninterface Vlan4093\n\
+    \   description MLAG_PEER_L3_PEERING\n   ip address 10.255.251.2/31\n!\ninterface\
+    \ Vlan4094\n   description MLAG_PEER\n   no autostate\n   ip address 10.255.252.2/31\n\
+    !\ninterface Vxlan1\n   vxlan source-interface Loopback1\n   vxlan virtual-router\
+    \ encapsulation mac-address mlag-system-id\n   vxlan udp-port 4789\n   vxlan vlan\
+    \ 110 vni 10110\n   vxlan vlan 111 vni 50111\n   vxlan vlan 120 vni 10120\n  \
+    \ vxlan vlan 121 vni 10121\n   vxlan vlan 130 vni 10130\n   vxlan vlan 131 vni\
+    \ 10131\n   vxlan vlan 140 vni 10140\n   vxlan vlan 141 vni 10141\n   vxlan vlan\
+    \ 210 vni 20210\n   vxlan vlan 211 vni 20211\n   vxlan vlan 310 vni 30310\n  \
+    \ vxlan vlan 311 vni 30311\n   vxlan vrf Tenant_A_APP_Zone vni 12\n   vxlan vrf\
+    \ Tenant_A_DB_Zone vni 13\n   vxlan vrf Tenant_A_OP_Zone vni 10\n   vxlan vrf\
+    \ Tenant_A_WEB_Zone vni 11\n   vxlan vrf Tenant_B_OP_Zone vni 20\n   vxlan vrf\
+    \ Tenant_C_OP_Zone vni 30\n!\nip virtual-router mac-address 00:dc:00:00:00:0a\n\
     !\nip address virtual source-nat vrf Tenant_A_OP_Zone address 10.255.1.6\n!\n\
     ip routing\nno ip routing vrf MGMT\nip routing vrf Tenant_A_APP_Zone\nip routing\
     \ vrf Tenant_A_DB_Zone\nip routing vrf Tenant_A_OP_Zone\nip routing vrf Tenant_A_WEB_Zone\n\
@@ -558,12 +565,13 @@ CVP_CONFIGLETS:
     \ Tenant_A_APP_Zone\n!\nvrf instance Tenant_A_DB_Zone\n!\nvrf instance Tenant_A_OP_Zone\n\
     !\nvrf instance Tenant_A_WEB_Zone\n!\nvrf instance Tenant_B_OP_Zone\n!\nvrf instance\
     \ Tenant_C_OP_Zone\n!\ninterface Port-Channel5\n   description MLAG_PEER_DC1-LEAF2A_Po5\n\
-    \   switchport trunk allowed vlan 2-4094\n   switchport mode trunk\n   switchport\
-    \ trunk group LEAF_PEER_L3\n   switchport trunk group MLAG\n!\ninterface Port-Channel7\n\
-    \   description DC1_L2LEAF1_Po1\n   switchport trunk allowed vlan 110-111,120-121,130-131\n\
-    \   switchport mode trunk\n   mlag 7\n!\ninterface Port-Channel10\n   description\
-    \ server01_MLAG_PortChanne1\n   switchport trunk allowed vlan 210-211\n   switchport\
-    \ mode trunk\n   mlag 10\n!\ninterface Ethernet1\n   description P2P_LINK_TO_DC1-SPINE1_Ethernet3\n\
+    \   switchport\n   switchport trunk allowed vlan 2-4094\n   switchport mode trunk\n\
+    \   switchport trunk group LEAF_PEER_L3\n   switchport trunk group MLAG\n!\ninterface\
+    \ Port-Channel7\n   description DC1_L2LEAF1_Po1\n   switchport\n   switchport\
+    \ trunk allowed vlan 110-111,120-121,130-131\n   switchport mode trunk\n   mlag\
+    \ 7\n!\ninterface Port-Channel10\n   description server01_MLAG_PortChanne1\n \
+    \  switchport\n   switchport trunk allowed vlan 210-211\n   switchport mode trunk\n\
+    \   mlag 10\n!\ninterface Ethernet1\n   description P2P_LINK_TO_DC1-SPINE1_Ethernet3\n\
     \   no switchport\n   ip address 172.31.255.17/31\n!\ninterface Ethernet2\n  \
     \ description P2P_LINK_TO_DC1-SPINE2_Ethernet3\n   no switchport\n   ip address\
     \ 172.31.255.19/31\n!\ninterface Ethernet3\n   description P2P_LINK_TO_DC1-SPINE3_Ethernet3\n\
@@ -578,47 +586,50 @@ CVP_CONFIGLETS:
     \   ip address 192.168.254.6/32\n!\ninterface Loopback100\n   description Tenant_A_OP_Zone_VTEP_DIAGNOSTICS\n\
     \   vrf Tenant_A_OP_Zone\n   ip address 10.255.1.7/32\n!\ninterface Management1\n\
     \   description oob_management\n   vrf MGMT\n   ip address 192.168.200.107/24\n\
-    !\ninterface Vlan110\n   description Tenant_A_OP_Zone_1\n   vrf Tenant_A_OP_Zone\n\
-    \   ip address virtual 10.1.10.1/24\n!\ninterface Vlan111\n   description Tenant_A_OP_Zone_2\n\
-    \   vrf Tenant_A_OP_Zone\n   ip address virtual 10.1.11.1/24\n   ip helper-address\
-    \ 1.1.1.1 vrf MGMT  source-interface lo100\n!\ninterface Vlan120\n   description\
-    \ Tenant_A_WEB_Zone_1\n   vrf Tenant_A_WEB_Zone\n   ip address virtual 10.1.20.1/24\n\
-    \   ip helper-address 1.1.1.1 vrf TEST  source-interface lo100\n!\ninterface Vlan121\n\
-    \   description Tenant_A_WEBZone_2\n   shutdown\n   mtu 1560\n   vrf Tenant_A_WEB_Zone\n\
-    \   ip address virtual 10.1.10.254/24\n!\ninterface Vlan130\n   description Tenant_A_APP_Zone_1\n\
-    \   vrf Tenant_A_APP_Zone\n   ip address virtual 10.1.30.1/24\n!\ninterface Vlan131\n\
-    \   description Tenant_A_APP_Zone_2\n   vrf Tenant_A_APP_Zone\n   ip address virtual\
-    \ 10.1.31.1/24\n!\ninterface Vlan140\n   description Tenant_A_DB_BZone_1\n   vrf\
-    \ Tenant_A_DB_Zone\n   ip address virtual 10.1.40.1/24\n!\ninterface Vlan141\n\
-    \   description Tenant_A_DB_Zone_2\n   vrf Tenant_A_DB_Zone\n   ip address virtual\
-    \ 10.1.41.1/24\n!\ninterface Vlan210\n   description Tenant_B_OP_Zone_1\n   vrf\
+    !\ninterface Vlan110\n   description Tenant_A_OP_Zone_1\n   no shutdown\n   vrf\
+    \ Tenant_A_OP_Zone\n   ip address virtual 10.1.10.1/24\n!\ninterface Vlan111\n\
+    \   description Tenant_A_OP_Zone_2\n   no shutdown\n   vrf Tenant_A_OP_Zone\n\
+    \   ip address virtual 10.1.11.1/24\n   ip helper-address 1.1.1.1 vrf MGMT  source-interface\
+    \ lo100\n!\ninterface Vlan120\n   description Tenant_A_WEB_Zone_1\n   no shutdown\n\
+    \   vrf Tenant_A_WEB_Zone\n   ip address virtual 10.1.20.1/24\n   ip helper-address\
+    \ 1.1.1.1 vrf TEST  source-interface lo100\n!\ninterface Vlan121\n   description\
+    \ Tenant_A_WEBZone_2\n   shutdown\n   mtu 1560\n   vrf Tenant_A_WEB_Zone\n   ip\
+    \ address virtual 10.1.10.254/24\n!\ninterface Vlan130\n   description Tenant_A_APP_Zone_1\n\
+    \   no shutdown\n   vrf Tenant_A_APP_Zone\n   ip address virtual 10.1.30.1/24\n\
+    !\ninterface Vlan131\n   description Tenant_A_APP_Zone_2\n   no shutdown\n   vrf\
+    \ Tenant_A_APP_Zone\n   ip address virtual 10.1.31.1/24\n!\ninterface Vlan140\n\
+    \   description Tenant_A_DB_BZone_1\n   no shutdown\n   vrf Tenant_A_DB_Zone\n\
+    \   ip address virtual 10.1.40.1/24\n!\ninterface Vlan141\n   description Tenant_A_DB_Zone_2\n\
+    \   no shutdown\n   vrf Tenant_A_DB_Zone\n   ip address virtual 10.1.41.1/24\n\
+    !\ninterface Vlan210\n   description Tenant_B_OP_Zone_1\n   no shutdown\n   vrf\
     \ Tenant_B_OP_Zone\n   ip address virtual 10.2.10.1/24\n!\ninterface Vlan211\n\
-    \   description Tenant_B_OP_Zone_2\n   vrf Tenant_B_OP_Zone\n   ip address virtual\
-    \ 10.2.11.1/24\n!\ninterface Vlan310\n   description Tenant_C_OP_Zone_1\n   vrf\
-    \ Tenant_C_OP_Zone\n   ip address virtual 10.3.10.1/24\n!\ninterface Vlan311\n\
-    \   description Tenant_C_OP_Zone_2\n   vrf Tenant_C_OP_Zone\n   ip address virtual\
-    \ 10.3.11.1/24\n!\ninterface Vlan3009\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone\n\
-    \   vrf Tenant_A_OP_Zone\n   ip address 10.255.251.3/31\n!\ninterface Vlan3010\n\
-    \   description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone\n   vrf Tenant_A_WEB_Zone\n\
-    \   ip address 10.255.251.3/31\n!\ninterface Vlan3011\n   description MLAG_PEER_L3_iBGP:\
-    \ vrf Tenant_A_APP_Zone\n   vrf Tenant_A_APP_Zone\n   ip address 10.255.251.3/31\n\
-    !\ninterface Vlan3012\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone\n\
-    \   vrf Tenant_A_DB_Zone\n   ip address 10.255.251.3/31\n!\ninterface Vlan3019\n\
-    \   description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone\n   vrf Tenant_B_OP_Zone\n\
-    \   ip address 10.255.251.3/31\n!\ninterface Vlan3029\n   description MLAG_PEER_L3_iBGP:\
-    \ vrf Tenant_C_OP_Zone\n   vrf Tenant_C_OP_Zone\n   ip address 10.255.251.3/31\n\
-    !\ninterface Vlan4093\n   description MLAG_PEER_L3_PEERING\n   ip address 10.255.251.3/31\n\
-    !\ninterface Vlan4094\n   description MLAG_PEER\n   no autostate\n   ip address\
-    \ 10.255.252.3/31\n!\ninterface Vxlan1\n   vxlan source-interface Loopback1\n\
-    \   vxlan virtual-router encapsulation mac-address mlag-system-id\n   vxlan udp-port\
-    \ 4789\n   vxlan vlan 110 vni 10110\n   vxlan vlan 111 vni 50111\n   vxlan vlan\
-    \ 120 vni 10120\n   vxlan vlan 121 vni 10121\n   vxlan vlan 130 vni 10130\n  \
-    \ vxlan vlan 131 vni 10131\n   vxlan vlan 140 vni 10140\n   vxlan vlan 141 vni\
-    \ 10141\n   vxlan vlan 210 vni 20210\n   vxlan vlan 211 vni 20211\n   vxlan vlan\
-    \ 310 vni 30310\n   vxlan vlan 311 vni 30311\n   vxlan vrf Tenant_A_APP_Zone vni\
-    \ 12\n   vxlan vrf Tenant_A_DB_Zone vni 13\n   vxlan vrf Tenant_A_OP_Zone vni\
-    \ 10\n   vxlan vrf Tenant_A_WEB_Zone vni 11\n   vxlan vrf Tenant_B_OP_Zone vni\
-    \ 20\n   vxlan vrf Tenant_C_OP_Zone vni 30\n!\nip virtual-router mac-address 00:dc:00:00:00:0a\n\
+    \   description Tenant_B_OP_Zone_2\n   no shutdown\n   vrf Tenant_B_OP_Zone\n\
+    \   ip address virtual 10.2.11.1/24\n!\ninterface Vlan310\n   description Tenant_C_OP_Zone_1\n\
+    \   no shutdown\n   vrf Tenant_C_OP_Zone\n   ip address virtual 10.3.10.1/24\n\
+    !\ninterface Vlan311\n   description Tenant_C_OP_Zone_2\n   no shutdown\n   vrf\
+    \ Tenant_C_OP_Zone\n   ip address virtual 10.3.11.1/24\n!\ninterface Vlan3009\n\
+    \   description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone\n   vrf Tenant_A_OP_Zone\n\
+    \   ip address 10.255.251.3/31\n!\ninterface Vlan3010\n   description MLAG_PEER_L3_iBGP:\
+    \ vrf Tenant_A_WEB_Zone\n   vrf Tenant_A_WEB_Zone\n   ip address 10.255.251.3/31\n\
+    !\ninterface Vlan3011\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone\n\
+    \   vrf Tenant_A_APP_Zone\n   ip address 10.255.251.3/31\n!\ninterface Vlan3012\n\
+    \   description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone\n   vrf Tenant_A_DB_Zone\n\
+    \   ip address 10.255.251.3/31\n!\ninterface Vlan3019\n   description MLAG_PEER_L3_iBGP:\
+    \ vrf Tenant_B_OP_Zone\n   vrf Tenant_B_OP_Zone\n   ip address 10.255.251.3/31\n\
+    !\ninterface Vlan3029\n   description MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone\n\
+    \   vrf Tenant_C_OP_Zone\n   ip address 10.255.251.3/31\n!\ninterface Vlan4093\n\
+    \   description MLAG_PEER_L3_PEERING\n   ip address 10.255.251.3/31\n!\ninterface\
+    \ Vlan4094\n   description MLAG_PEER\n   no autostate\n   ip address 10.255.252.3/31\n\
+    !\ninterface Vxlan1\n   vxlan source-interface Loopback1\n   vxlan virtual-router\
+    \ encapsulation mac-address mlag-system-id\n   vxlan udp-port 4789\n   vxlan vlan\
+    \ 110 vni 10110\n   vxlan vlan 111 vni 50111\n   vxlan vlan 120 vni 10120\n  \
+    \ vxlan vlan 121 vni 10121\n   vxlan vlan 130 vni 10130\n   vxlan vlan 131 vni\
+    \ 10131\n   vxlan vlan 140 vni 10140\n   vxlan vlan 141 vni 10141\n   vxlan vlan\
+    \ 210 vni 20210\n   vxlan vlan 211 vni 20211\n   vxlan vlan 310 vni 30310\n  \
+    \ vxlan vlan 311 vni 30311\n   vxlan vrf Tenant_A_APP_Zone vni 12\n   vxlan vrf\
+    \ Tenant_A_DB_Zone vni 13\n   vxlan vrf Tenant_A_OP_Zone vni 10\n   vxlan vrf\
+    \ Tenant_A_WEB_Zone vni 11\n   vxlan vrf Tenant_B_OP_Zone vni 20\n   vxlan vrf\
+    \ Tenant_C_OP_Zone vni 30\n!\nip virtual-router mac-address 00:dc:00:00:00:0a\n\
     !\nip address virtual source-nat vrf Tenant_A_OP_Zone address 10.255.1.7\n!\n\
     ip routing\nno ip routing vrf MGMT\nip routing vrf Tenant_A_APP_Zone\nip routing\
     \ vrf Tenant_A_DB_Zone\nip routing vrf Tenant_A_OP_Zone\nip routing vrf Tenant_A_WEB_Zone\n\
@@ -953,22 +964,22 @@ CVP_CONFIGLETS:
     !\nvrf instance Tenant_A_OP_Zone\n!\nvrf instance Tenant_A_WAN_Zone\n!\nvrf instance\
     \ Tenant_A_WEB_Zone\n!\nvrf instance Tenant_B_OP_Zone\n!\nvrf instance Tenant_B_WAN_Zone\n\
     !\nvrf instance Tenant_C_OP_Zone\n!\nvrf instance Tenant_C_WAN_Zone\n!\ninterface\
-    \ Port-Channel5\n   description MLAG_PEER_DC1-SVC3B_Po5\n   switchport trunk allowed\
-    \ vlan 2-4094\n   switchport mode trunk\n   switchport trunk group LEAF_PEER_L3\n\
-    \   switchport trunk group MLAG\n!\ninterface Port-Channel7\n   description DC1_L2LEAF2_Po1\n\
-    \   switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350\n\
-    \   switchport mode trunk\n   mlag 7\n!\ninterface Port-Channel10\n   description\
-    \ server03_ESI_PortChanne1\n   switchport trunk allowed vlan 110-111,210-211\n\
-    \   switchport mode trunk\n   mlag 10\n!\ninterface Ethernet1\n   description\
-    \ P2P_LINK_TO_DC1-SPINE1_Ethernet4\n   no switchport\n   ip address 172.31.255.25/31\n\
-    !\ninterface Ethernet2\n   description P2P_LINK_TO_DC1-SPINE2_Ethernet4\n   no\
-    \ switchport\n   ip address 172.31.255.27/31\n!\ninterface Ethernet3\n   description\
-    \ P2P_LINK_TO_DC1-SPINE3_Ethernet4\n   no switchport\n   ip address 172.31.255.29/31\n\
-    !\ninterface Ethernet4\n   description P2P_LINK_TO_DC1-SPINE4_Ethernet4\n   no\
-    \ switchport\n   ip address 172.31.255.31/31\n!\ninterface Ethernet5\n   description\
-    \ MLAG_PEER_DC1-SVC3B_Ethernet5\n   channel-group 5 mode active\n!\ninterface\
-    \ Ethernet6\n   description MLAG_PEER_DC1-SVC3B_Ethernet6\n   channel-group 5\
-    \ mode active\n!\ninterface Ethernet7\n   description DC1-L2LEAF2A_Ethernet1\n\
+    \ Port-Channel5\n   description MLAG_PEER_DC1-SVC3B_Po5\n   switchport\n   switchport\
+    \ trunk allowed vlan 2-4094\n   switchport mode trunk\n   switchport trunk group\
+    \ LEAF_PEER_L3\n   switchport trunk group MLAG\n!\ninterface Port-Channel7\n \
+    \  description DC1_L2LEAF2_Po1\n   switchport\n   switchport trunk allowed vlan\
+    \ 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350\n   switchport mode\
+    \ trunk\n   mlag 7\n!\ninterface Port-Channel10\n   description server03_ESI_PortChanne1\n\
+    \   switchport\n   switchport trunk allowed vlan 110-111,210-211\n   switchport\
+    \ mode trunk\n   mlag 10\n!\ninterface Ethernet1\n   description P2P_LINK_TO_DC1-SPINE1_Ethernet4\n\
+    \   no switchport\n   ip address 172.31.255.25/31\n!\ninterface Ethernet2\n  \
+    \ description P2P_LINK_TO_DC1-SPINE2_Ethernet4\n   no switchport\n   ip address\
+    \ 172.31.255.27/31\n!\ninterface Ethernet3\n   description P2P_LINK_TO_DC1-SPINE3_Ethernet4\n\
+    \   no switchport\n   ip address 172.31.255.29/31\n!\ninterface Ethernet4\n  \
+    \ description P2P_LINK_TO_DC1-SPINE4_Ethernet4\n   no switchport\n   ip address\
+    \ 172.31.255.31/31\n!\ninterface Ethernet5\n   description MLAG_PEER_DC1-SVC3B_Ethernet5\n\
+    \   channel-group 5 mode active\n!\ninterface Ethernet6\n   description MLAG_PEER_DC1-SVC3B_Ethernet6\n\
+    \   channel-group 5 mode active\n!\ninterface Ethernet7\n   description DC1-L2LEAF2A_Ethernet1\n\
     \   channel-group 7 mode active\n!\ninterface Ethernet8\n   description DC1-L2LEAF2B_Ethernet1\n\
     \   channel-group 7 mode active\n!\ninterface Ethernet10\n   description server03_ESI_Eth1\n\
     \   channel-group 10 mode active\n!\ninterface Loopback0\n   description EVPN_Overlay_Peering\n\
@@ -976,29 +987,32 @@ CVP_CONFIGLETS:
     \   ip address 192.168.254.8/32\n!\ninterface Loopback100\n   description Tenant_A_OP_Zone_VTEP_DIAGNOSTICS\n\
     \   vrf Tenant_A_OP_Zone\n   ip address 10.255.1.8/32\n!\ninterface Management1\n\
     \   description oob_management\n   vrf MGMT\n   ip address 192.168.200.108/24\n\
-    !\ninterface Vlan110\n   description Tenant_A_OP_Zone_1\n   vrf Tenant_A_OP_Zone\n\
-    \   ip address virtual 10.1.10.1/24\n!\ninterface Vlan111\n   description Tenant_A_OP_Zone_2\n\
-    \   vrf Tenant_A_OP_Zone\n   ip address virtual 10.1.11.1/24\n   ip helper-address\
-    \ 1.1.1.1 vrf MGMT  source-interface lo100\n!\ninterface Vlan120\n   description\
-    \ Tenant_A_WEB_Zone_1\n   vrf Tenant_A_WEB_Zone\n   ip address virtual 10.1.20.1/24\n\
-    \   ip helper-address 1.1.1.1 vrf TEST  source-interface lo100\n!\ninterface Vlan121\n\
-    \   description Tenant_A_WEBZone_2\n   shutdown\n   mtu 1560\n   vrf Tenant_A_WEB_Zone\n\
-    \   ip address virtual 10.1.10.254/24\n!\ninterface Vlan130\n   description Tenant_A_APP_Zone_1\n\
-    \   vrf Tenant_A_APP_Zone\n   ip address virtual 10.1.30.1/24\n!\ninterface Vlan131\n\
-    \   description Tenant_A_APP_Zone_2\n   vrf Tenant_A_APP_Zone\n   ip address virtual\
-    \ 10.1.31.1/24\n!\ninterface Vlan140\n   description Tenant_A_DB_BZone_1\n   vrf\
-    \ Tenant_A_DB_Zone\n   ip address virtual 10.1.40.1/24\n!\ninterface Vlan141\n\
-    \   description Tenant_A_DB_Zone_2\n   vrf Tenant_A_DB_Zone\n   ip address virtual\
-    \ 10.1.41.1/24\n!\ninterface Vlan150\n   description Tenant_A_WAN_Zone_1\n   vrf\
+    !\ninterface Vlan110\n   description Tenant_A_OP_Zone_1\n   no shutdown\n   vrf\
+    \ Tenant_A_OP_Zone\n   ip address virtual 10.1.10.1/24\n!\ninterface Vlan111\n\
+    \   description Tenant_A_OP_Zone_2\n   no shutdown\n   vrf Tenant_A_OP_Zone\n\
+    \   ip address virtual 10.1.11.1/24\n   ip helper-address 1.1.1.1 vrf MGMT  source-interface\
+    \ lo100\n!\ninterface Vlan120\n   description Tenant_A_WEB_Zone_1\n   no shutdown\n\
+    \   vrf Tenant_A_WEB_Zone\n   ip address virtual 10.1.20.1/24\n   ip helper-address\
+    \ 1.1.1.1 vrf TEST  source-interface lo100\n!\ninterface Vlan121\n   description\
+    \ Tenant_A_WEBZone_2\n   shutdown\n   mtu 1560\n   vrf Tenant_A_WEB_Zone\n   ip\
+    \ address virtual 10.1.10.254/24\n!\ninterface Vlan130\n   description Tenant_A_APP_Zone_1\n\
+    \   no shutdown\n   vrf Tenant_A_APP_Zone\n   ip address virtual 10.1.30.1/24\n\
+    !\ninterface Vlan131\n   description Tenant_A_APP_Zone_2\n   no shutdown\n   vrf\
+    \ Tenant_A_APP_Zone\n   ip address virtual 10.1.31.1/24\n!\ninterface Vlan140\n\
+    \   description Tenant_A_DB_BZone_1\n   no shutdown\n   vrf Tenant_A_DB_Zone\n\
+    \   ip address virtual 10.1.40.1/24\n!\ninterface Vlan141\n   description Tenant_A_DB_Zone_2\n\
+    \   no shutdown\n   vrf Tenant_A_DB_Zone\n   ip address virtual 10.1.41.1/24\n\
+    !\ninterface Vlan150\n   description Tenant_A_WAN_Zone_1\n   no shutdown\n   vrf\
     \ Tenant_A_WAN_Zone\n   ip address virtual 10.1.40.1/24\n!\ninterface Vlan210\n\
-    \   description Tenant_B_OP_Zone_1\n   vrf Tenant_B_OP_Zone\n   ip address virtual\
-    \ 10.2.10.1/24\n!\ninterface Vlan211\n   description Tenant_B_OP_Zone_2\n   vrf\
-    \ Tenant_B_OP_Zone\n   ip address virtual 10.2.11.1/24\n!\ninterface Vlan250\n\
-    \   description Tenant_B_WAN_Zone_1\n   vrf Tenant_B_WAN_Zone\n   ip address virtual\
-    \ 10.2.50.1/24\n!\ninterface Vlan310\n   description Tenant_C_OP_Zone_1\n   vrf\
-    \ Tenant_C_OP_Zone\n   ip address virtual 10.3.10.1/24\n!\ninterface Vlan311\n\
-    \   description Tenant_C_OP_Zone_2\n   vrf Tenant_C_OP_Zone\n   ip address virtual\
-    \ 10.3.11.1/24\n!\ninterface Vlan350\n   description Tenant_C_WAN_Zone_1\n   vrf\
+    \   description Tenant_B_OP_Zone_1\n   no shutdown\n   vrf Tenant_B_OP_Zone\n\
+    \   ip address virtual 10.2.10.1/24\n!\ninterface Vlan211\n   description Tenant_B_OP_Zone_2\n\
+    \   no shutdown\n   vrf Tenant_B_OP_Zone\n   ip address virtual 10.2.11.1/24\n\
+    !\ninterface Vlan250\n   description Tenant_B_WAN_Zone_1\n   no shutdown\n   vrf\
+    \ Tenant_B_WAN_Zone\n   ip address virtual 10.2.50.1/24\n!\ninterface Vlan310\n\
+    \   description Tenant_C_OP_Zone_1\n   no shutdown\n   vrf Tenant_C_OP_Zone\n\
+    \   ip address virtual 10.3.10.1/24\n!\ninterface Vlan311\n   description Tenant_C_OP_Zone_2\n\
+    \   no shutdown\n   vrf Tenant_C_OP_Zone\n   ip address virtual 10.3.11.1/24\n\
+    !\ninterface Vlan350\n   description Tenant_C_WAN_Zone_1\n   no shutdown\n   vrf\
     \ Tenant_C_WAN_Zone\n   ip address virtual 10.3.50.1/24\n!\ninterface Vlan3009\n\
     \   description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone\n   vrf Tenant_A_OP_Zone\n\
     \   ip address 10.255.251.6/31\n!\ninterface Vlan3010\n   description MLAG_PEER_L3_iBGP:\
@@ -1147,11 +1161,12 @@ CVP_CONFIGLETS:
     !\nvrf instance Tenant_A_OP_Zone\n!\nvrf instance Tenant_A_WAN_Zone\n!\nvrf instance\
     \ Tenant_A_WEB_Zone\n!\nvrf instance Tenant_B_OP_Zone\n!\nvrf instance Tenant_B_WAN_Zone\n\
     !\nvrf instance Tenant_C_OP_Zone\n!\nvrf instance Tenant_C_WAN_Zone\n!\ninterface\
-    \ Port-Channel5\n   description MLAG_PEER_DC1-SVC3A_Po5\n   switchport trunk allowed\
-    \ vlan 2-4094\n   switchport mode trunk\n   switchport trunk group LEAF_PEER_L3\n\
-    \   switchport trunk group MLAG\n!\ninterface Port-Channel7\n   description DC1_L2LEAF2_Po1\n\
-    \   switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350\n\
-    \   switchport mode trunk\n   mlag 7\n!\ninterface Ethernet1\n   description P2P_LINK_TO_DC1-SPINE1_Ethernet5\n\
+    \ Port-Channel5\n   description MLAG_PEER_DC1-SVC3A_Po5\n   switchport\n   switchport\
+    \ trunk allowed vlan 2-4094\n   switchport mode trunk\n   switchport trunk group\
+    \ LEAF_PEER_L3\n   switchport trunk group MLAG\n!\ninterface Port-Channel7\n \
+    \  description DC1_L2LEAF2_Po1\n   switchport\n   switchport trunk allowed vlan\
+    \ 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350\n   switchport mode\
+    \ trunk\n   mlag 7\n!\ninterface Ethernet1\n   description P2P_LINK_TO_DC1-SPINE1_Ethernet5\n\
     \   no switchport\n   ip address 172.31.255.33/31\n!\ninterface Ethernet2\n  \
     \ description P2P_LINK_TO_DC1-SPINE2_Ethernet5\n   no switchport\n   ip address\
     \ 172.31.255.35/31\n!\ninterface Ethernet3\n   description P2P_LINK_TO_DC1-SPINE3_Ethernet5\n\
@@ -1166,29 +1181,32 @@ CVP_CONFIGLETS:
     \   ip address 192.168.254.8/32\n!\ninterface Loopback100\n   description Tenant_A_OP_Zone_VTEP_DIAGNOSTICS\n\
     \   vrf Tenant_A_OP_Zone\n   ip address 10.255.1.9/32\n!\ninterface Management1\n\
     \   description oob_management\n   vrf MGMT\n   ip address 192.168.200.109/24\n\
-    !\ninterface Vlan110\n   description Tenant_A_OP_Zone_1\n   vrf Tenant_A_OP_Zone\n\
-    \   ip address virtual 10.1.10.1/24\n!\ninterface Vlan111\n   description Tenant_A_OP_Zone_2\n\
-    \   vrf Tenant_A_OP_Zone\n   ip address virtual 10.1.11.1/24\n   ip helper-address\
-    \ 1.1.1.1 vrf MGMT  source-interface lo100\n!\ninterface Vlan120\n   description\
-    \ Tenant_A_WEB_Zone_1\n   vrf Tenant_A_WEB_Zone\n   ip address virtual 10.1.20.1/24\n\
-    \   ip helper-address 1.1.1.1 vrf TEST  source-interface lo100\n!\ninterface Vlan121\n\
-    \   description Tenant_A_WEBZone_2\n   shutdown\n   mtu 1560\n   vrf Tenant_A_WEB_Zone\n\
-    \   ip address virtual 10.1.10.254/24\n!\ninterface Vlan130\n   description Tenant_A_APP_Zone_1\n\
-    \   vrf Tenant_A_APP_Zone\n   ip address virtual 10.1.30.1/24\n!\ninterface Vlan131\n\
-    \   description Tenant_A_APP_Zone_2\n   vrf Tenant_A_APP_Zone\n   ip address virtual\
-    \ 10.1.31.1/24\n!\ninterface Vlan140\n   description Tenant_A_DB_BZone_1\n   vrf\
-    \ Tenant_A_DB_Zone\n   ip address virtual 10.1.40.1/24\n!\ninterface Vlan141\n\
-    \   description Tenant_A_DB_Zone_2\n   vrf Tenant_A_DB_Zone\n   ip address virtual\
-    \ 10.1.41.1/24\n!\ninterface Vlan150\n   description Tenant_A_WAN_Zone_1\n   vrf\
+    !\ninterface Vlan110\n   description Tenant_A_OP_Zone_1\n   no shutdown\n   vrf\
+    \ Tenant_A_OP_Zone\n   ip address virtual 10.1.10.1/24\n!\ninterface Vlan111\n\
+    \   description Tenant_A_OP_Zone_2\n   no shutdown\n   vrf Tenant_A_OP_Zone\n\
+    \   ip address virtual 10.1.11.1/24\n   ip helper-address 1.1.1.1 vrf MGMT  source-interface\
+    \ lo100\n!\ninterface Vlan120\n   description Tenant_A_WEB_Zone_1\n   no shutdown\n\
+    \   vrf Tenant_A_WEB_Zone\n   ip address virtual 10.1.20.1/24\n   ip helper-address\
+    \ 1.1.1.1 vrf TEST  source-interface lo100\n!\ninterface Vlan121\n   description\
+    \ Tenant_A_WEBZone_2\n   shutdown\n   mtu 1560\n   vrf Tenant_A_WEB_Zone\n   ip\
+    \ address virtual 10.1.10.254/24\n!\ninterface Vlan130\n   description Tenant_A_APP_Zone_1\n\
+    \   no shutdown\n   vrf Tenant_A_APP_Zone\n   ip address virtual 10.1.30.1/24\n\
+    !\ninterface Vlan131\n   description Tenant_A_APP_Zone_2\n   no shutdown\n   vrf\
+    \ Tenant_A_APP_Zone\n   ip address virtual 10.1.31.1/24\n!\ninterface Vlan140\n\
+    \   description Tenant_A_DB_BZone_1\n   no shutdown\n   vrf Tenant_A_DB_Zone\n\
+    \   ip address virtual 10.1.40.1/24\n!\ninterface Vlan141\n   description Tenant_A_DB_Zone_2\n\
+    \   no shutdown\n   vrf Tenant_A_DB_Zone\n   ip address virtual 10.1.41.1/24\n\
+    !\ninterface Vlan150\n   description Tenant_A_WAN_Zone_1\n   no shutdown\n   vrf\
     \ Tenant_A_WAN_Zone\n   ip address virtual 10.1.40.1/24\n!\ninterface Vlan210\n\
-    \   description Tenant_B_OP_Zone_1\n   vrf Tenant_B_OP_Zone\n   ip address virtual\
-    \ 10.2.10.1/24\n!\ninterface Vlan211\n   description Tenant_B_OP_Zone_2\n   vrf\
-    \ Tenant_B_OP_Zone\n   ip address virtual 10.2.11.1/24\n!\ninterface Vlan250\n\
-    \   description Tenant_B_WAN_Zone_1\n   vrf Tenant_B_WAN_Zone\n   ip address virtual\
-    \ 10.2.50.1/24\n!\ninterface Vlan310\n   description Tenant_C_OP_Zone_1\n   vrf\
-    \ Tenant_C_OP_Zone\n   ip address virtual 10.3.10.1/24\n!\ninterface Vlan311\n\
-    \   description Tenant_C_OP_Zone_2\n   vrf Tenant_C_OP_Zone\n   ip address virtual\
-    \ 10.3.11.1/24\n!\ninterface Vlan350\n   description Tenant_C_WAN_Zone_1\n   vrf\
+    \   description Tenant_B_OP_Zone_1\n   no shutdown\n   vrf Tenant_B_OP_Zone\n\
+    \   ip address virtual 10.2.10.1/24\n!\ninterface Vlan211\n   description Tenant_B_OP_Zone_2\n\
+    \   no shutdown\n   vrf Tenant_B_OP_Zone\n   ip address virtual 10.2.11.1/24\n\
+    !\ninterface Vlan250\n   description Tenant_B_WAN_Zone_1\n   no shutdown\n   vrf\
+    \ Tenant_B_WAN_Zone\n   ip address virtual 10.2.50.1/24\n!\ninterface Vlan310\n\
+    \   description Tenant_C_OP_Zone_1\n   no shutdown\n   vrf Tenant_C_OP_Zone\n\
+    \   ip address virtual 10.3.10.1/24\n!\ninterface Vlan311\n   description Tenant_C_OP_Zone_2\n\
+    \   no shutdown\n   vrf Tenant_C_OP_Zone\n   ip address virtual 10.3.11.1/24\n\
+    !\ninterface Vlan350\n   description Tenant_C_WAN_Zone_1\n   no shutdown\n   vrf\
     \ Tenant_C_WAN_Zone\n   ip address virtual 10.3.50.1/24\n!\ninterface Vlan3009\n\
     \   description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone\n   vrf Tenant_A_OP_Zone\n\
     \   ip address 10.255.251.7/31\n!\ninterface Vlan3010\n   description MLAG_PEER_L3_iBGP:\

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/cvp/cv_server_configlets.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/cvp/cv_server_configlets.yml
@@ -18,51 +18,54 @@ CVP_CONFIGLETS:
     \ LEAF_PEER_L3\n!\nvlan 4094\n   name MLAG_PEER\n   trunk group MLAG\n!\nvrf instance\
     \ MGMT\n!\nvrf instance Tenant_A_WAN_Zone\n!\nvrf instance Tenant_B_WAN_Zone\n\
     !\nvrf instance Tenant_C_WAN_Zone\n!\ninterface Port-Channel5\n   description\
-    \ MLAG_PEER_DC1-BL1B_Po5\n   switchport\n   switchport trunk allowed vlan 2-4094\n\
-    \   switchport mode trunk\n   switchport trunk group LEAF_PEER_L3\n   switchport\
-    \ trunk group MLAG\n!\ninterface Ethernet1\n   description P2P_LINK_TO_DC1-SPINE1_Ethernet6\n\
-    \   no switchport\n   ip address 172.31.255.41/31\n!\ninterface Ethernet2\n  \
-    \ description P2P_LINK_TO_DC1-SPINE2_Ethernet6\n   no switchport\n   ip address\
-    \ 172.31.255.43/31\n!\ninterface Ethernet3\n   description P2P_LINK_TO_DC1-SPINE3_Ethernet6\n\
-    \   no switchport\n   ip address 172.31.255.45/31\n!\ninterface Ethernet4\n  \
-    \ description P2P_LINK_TO_DC1-SPINE4_Ethernet6\n   no switchport\n   ip address\
-    \ 172.31.255.47/31\n!\ninterface Ethernet5\n   description MLAG_PEER_DC1-BL1B_Ethernet5\n\
-    \   channel-group 5 mode active\n!\ninterface Ethernet6\n   description MLAG_PEER_DC1-BL1B_Ethernet6\n\
-    \   channel-group 5 mode active\n!\ninterface Loopback0\n   description EVPN_Overlay_Peering\n\
-    \   ip address 192.168.255.10/32\n!\ninterface Loopback1\n   description VTEP_VXLAN_Tunnel_Source\n\
-    \   ip address 192.168.254.10/32\n!\ninterface Management1\n   description oob_management\n\
-    \   vrf MGMT\n   ip address 192.168.200.110/24\n!\ninterface Vlan150\n   description\
-    \ Tenant_A_WAN_Zone_1\n   no shutdown\n   vrf Tenant_A_WAN_Zone\n   ip address\
-    \ virtual 10.1.40.1/24\n!\ninterface Vlan250\n   description Tenant_B_WAN_Zone_1\n\
+    \ MLAG_PEER_DC1-BL1B_Po5\n   no shutdown\n   switchport\n   switchport trunk allowed\
+    \ vlan 2-4094\n   switchport mode trunk\n   switchport trunk group LEAF_PEER_L3\n\
+    \   switchport trunk group MLAG\n!\ninterface Ethernet1\n   description P2P_LINK_TO_DC1-SPINE1_Ethernet6\n\
+    \   no shutdown\n   no switchport\n   ip address 172.31.255.41/31\n!\ninterface\
+    \ Ethernet2\n   description P2P_LINK_TO_DC1-SPINE2_Ethernet6\n   no shutdown\n\
+    \   no switchport\n   ip address 172.31.255.43/31\n!\ninterface Ethernet3\n  \
+    \ description P2P_LINK_TO_DC1-SPINE3_Ethernet6\n   no shutdown\n   no switchport\n\
+    \   ip address 172.31.255.45/31\n!\ninterface Ethernet4\n   description P2P_LINK_TO_DC1-SPINE4_Ethernet6\n\
+    \   no shutdown\n   no switchport\n   ip address 172.31.255.47/31\n!\ninterface\
+    \ Ethernet5\n   description MLAG_PEER_DC1-BL1B_Ethernet5\n   no shutdown\n   channel-group\
+    \ 5 mode active\n!\ninterface Ethernet6\n   description MLAG_PEER_DC1-BL1B_Ethernet6\n\
+    \   no shutdown\n   channel-group 5 mode active\n!\ninterface Loopback0\n   description\
+    \ EVPN_Overlay_Peering\n   no shutdown\n   ip address 192.168.255.10/32\n!\ninterface\
+    \ Loopback1\n   description VTEP_VXLAN_Tunnel_Source\n   no shutdown\n   ip address\
+    \ 192.168.254.10/32\n!\ninterface Management1\n   description oob_management\n\
+    \   no shutdown\n   vrf MGMT\n   ip address 192.168.200.110/24\n!\ninterface Vlan150\n\
+    \   description Tenant_A_WAN_Zone_1\n   no shutdown\n   vrf Tenant_A_WAN_Zone\n\
+    \   ip address virtual 10.1.40.1/24\n!\ninterface Vlan250\n   description Tenant_B_WAN_Zone_1\n\
     \   no shutdown\n   vrf Tenant_B_WAN_Zone\n   ip address virtual 10.2.50.1/24\n\
     !\ninterface Vlan350\n   description Tenant_C_WAN_Zone_1\n   no shutdown\n   vrf\
     \ Tenant_C_WAN_Zone\n   ip address virtual 10.3.50.1/24\n!\ninterface Vlan3013\n\
-    \   description MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone\n   vrf Tenant_A_WAN_Zone\n\
-    \   ip address 10.255.251.10/31\n!\ninterface Vlan3020\n   description MLAG_PEER_L3_iBGP:\
-    \ vrf Tenant_B_WAN_Zone\n   vrf Tenant_B_WAN_Zone\n   ip address 10.255.251.10/31\n\
-    !\ninterface Vlan3030\n   description MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone\n\
-    \   vrf Tenant_C_WAN_Zone\n   ip address 10.255.251.10/31\n!\ninterface Vlan4093\n\
-    \   description MLAG_PEER_L3_PEERING\n   ip address 10.255.251.10/31\n!\ninterface\
-    \ Vlan4094\n   description MLAG_PEER\n   no autostate\n   ip address 10.255.252.10/31\n\
-    !\ninterface Vxlan1\n   vxlan source-interface Loopback1\n   vxlan virtual-router\
-    \ encapsulation mac-address mlag-system-id\n   vxlan udp-port 4789\n   vxlan vlan\
-    \ 150 vni 10150\n   vxlan vlan 250 vni 20250\n   vxlan vlan 350 vni 30350\n  \
-    \ vxlan vrf Tenant_A_WAN_Zone vni 14\n   vxlan vrf Tenant_B_WAN_Zone vni 21\n\
-    \   vxlan vrf Tenant_C_WAN_Zone vni 31\n!\nip virtual-router mac-address 00:dc:00:00:00:0a\n\
-    !\nip routing\nno ip routing vrf MGMT\nip routing vrf Tenant_A_WAN_Zone\nip routing\
-    \ vrf Tenant_B_WAN_Zone\nip routing vrf Tenant_C_WAN_Zone\n!\nip prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n\
-    \   seq 10 permit 192.168.255.0/24 eq 32\n   seq 20 permit 192.168.254.0/24 eq\
-    \ 32\n!\nmlag configuration\n   domain-id DC1_BL1\n   local-interface Vlan4094\n\
-    \   peer-address 10.255.252.11\n   peer-address heartbeat 192.168.200.111 vrf\
-    \ MGMT\n   peer-link Port-Channel5\n   dual-primary detection delay 5 action errdisable\
-    \ all-interfaces\n   reload-delay mlag 300\n   reload-delay non-mlag 330\n!\n\
-    ip route vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nroute-map RM-CONN-2-BGP permit 10\n\
-    \   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n!\nrouter bfd\n  \
-    \ multihop interval 1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65104\n   router-id\
-    \ 192.168.255.10\n   no bgp default ipv4-unicast\n   distance bgp 20 200 200\n\
-    \   maximum-paths 4 ecmp 4\n   neighbor EVPN-OVERLAY-PEERS peer group\n   neighbor\
-    \ EVPN-OVERLAY-PEERS remote-as 65001\n   neighbor EVPN-OVERLAY-PEERS update-source\
-    \ Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS\
+    \   description MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone\n   no shutdown\n   vrf\
+    \ Tenant_A_WAN_Zone\n   ip address 10.255.251.10/31\n!\ninterface Vlan3020\n \
+    \  description MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone\n   no shutdown\n   vrf\
+    \ Tenant_B_WAN_Zone\n   ip address 10.255.251.10/31\n!\ninterface Vlan3030\n \
+    \  description MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone\n   no shutdown\n   vrf\
+    \ Tenant_C_WAN_Zone\n   ip address 10.255.251.10/31\n!\ninterface Vlan4093\n \
+    \  description MLAG_PEER_L3_PEERING\n   no shutdown\n   ip address 10.255.251.10/31\n\
+    !\ninterface Vlan4094\n   description MLAG_PEER\n   no shutdown\n   no autostate\n\
+    \   ip address 10.255.252.10/31\n!\ninterface Vxlan1\n   vxlan source-interface\
+    \ Loopback1\n   vxlan virtual-router encapsulation mac-address mlag-system-id\n\
+    \   vxlan udp-port 4789\n   vxlan vlan 150 vni 10150\n   vxlan vlan 250 vni 20250\n\
+    \   vxlan vlan 350 vni 30350\n   vxlan vrf Tenant_A_WAN_Zone vni 14\n   vxlan\
+    \ vrf Tenant_B_WAN_Zone vni 21\n   vxlan vrf Tenant_C_WAN_Zone vni 31\n!\nip virtual-router\
+    \ mac-address 00:dc:00:00:00:0a\n!\nip routing\nno ip routing vrf MGMT\nip routing\
+    \ vrf Tenant_A_WAN_Zone\nip routing vrf Tenant_B_WAN_Zone\nip routing vrf Tenant_C_WAN_Zone\n\
+    !\nip prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n   seq 10 permit 192.168.255.0/24\
+    \ eq 32\n   seq 20 permit 192.168.254.0/24 eq 32\n!\nmlag configuration\n   domain-id\
+    \ DC1_BL1\n   local-interface Vlan4094\n   peer-address 10.255.252.11\n   peer-address\
+    \ heartbeat 192.168.200.111 vrf MGMT\n   peer-link Port-Channel5\n   dual-primary\
+    \ detection delay 5 action errdisable all-interfaces\n   reload-delay mlag 300\n\
+    \   reload-delay non-mlag 330\n!\nip route vrf MGMT 0.0.0.0/0 192.168.200.5\n\
+    !\nroute-map RM-CONN-2-BGP permit 10\n   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n\
+    !\nrouter bfd\n   multihop interval 1200 min-rx 1200 multiplier 3\n!\nrouter bgp\
+    \ 65104\n   router-id 192.168.255.10\n   no bgp default ipv4-unicast\n   distance\
+    \ bgp 20 200 200\n   maximum-paths 4 ecmp 4\n   neighbor EVPN-OVERLAY-PEERS peer\
+    \ group\n   neighbor EVPN-OVERLAY-PEERS remote-as 65001\n   neighbor EVPN-OVERLAY-PEERS\
+    \ update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS\
     \ ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n\
     \   neighbor EVPN-OVERLAY-PEERS send-community\n   neighbor EVPN-OVERLAY-PEERS\
     \ maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS peer group\n   neighbor IPv4-UNDERLAY-PEERS\
@@ -119,51 +122,54 @@ CVP_CONFIGLETS:
     \ LEAF_PEER_L3\n!\nvlan 4094\n   name MLAG_PEER\n   trunk group MLAG\n!\nvrf instance\
     \ MGMT\n!\nvrf instance Tenant_A_WAN_Zone\n!\nvrf instance Tenant_B_WAN_Zone\n\
     !\nvrf instance Tenant_C_WAN_Zone\n!\ninterface Port-Channel5\n   description\
-    \ MLAG_PEER_DC1-BL1A_Po5\n   switchport\n   switchport trunk allowed vlan 2-4094\n\
-    \   switchport mode trunk\n   switchport trunk group LEAF_PEER_L3\n   switchport\
-    \ trunk group MLAG\n!\ninterface Ethernet1\n   description P2P_LINK_TO_DC1-SPINE1_Ethernet7\n\
-    \   no switchport\n   ip address 172.31.255.49/31\n!\ninterface Ethernet2\n  \
-    \ description P2P_LINK_TO_DC1-SPINE2_Ethernet7\n   no switchport\n   ip address\
-    \ 172.31.255.51/31\n!\ninterface Ethernet3\n   description P2P_LINK_TO_DC1-SPINE3_Ethernet7\n\
-    \   no switchport\n   ip address 172.31.255.53/31\n!\ninterface Ethernet4\n  \
-    \ description P2P_LINK_TO_DC1-SPINE4_Ethernet7\n   no switchport\n   ip address\
-    \ 172.31.255.55/31\n!\ninterface Ethernet5\n   description MLAG_PEER_DC1-BL1A_Ethernet5\n\
-    \   channel-group 5 mode active\n!\ninterface Ethernet6\n   description MLAG_PEER_DC1-BL1A_Ethernet6\n\
-    \   channel-group 5 mode active\n!\ninterface Loopback0\n   description EVPN_Overlay_Peering\n\
-    \   ip address 192.168.255.11/32\n!\ninterface Loopback1\n   description VTEP_VXLAN_Tunnel_Source\n\
-    \   ip address 192.168.254.10/32\n!\ninterface Management1\n   description oob_management\n\
-    \   vrf MGMT\n   ip address 192.168.200.111/24\n!\ninterface Vlan150\n   description\
-    \ Tenant_A_WAN_Zone_1\n   no shutdown\n   vrf Tenant_A_WAN_Zone\n   ip address\
-    \ virtual 10.1.40.1/24\n!\ninterface Vlan250\n   description Tenant_B_WAN_Zone_1\n\
+    \ MLAG_PEER_DC1-BL1A_Po5\n   no shutdown\n   switchport\n   switchport trunk allowed\
+    \ vlan 2-4094\n   switchport mode trunk\n   switchport trunk group LEAF_PEER_L3\n\
+    \   switchport trunk group MLAG\n!\ninterface Ethernet1\n   description P2P_LINK_TO_DC1-SPINE1_Ethernet7\n\
+    \   no shutdown\n   no switchport\n   ip address 172.31.255.49/31\n!\ninterface\
+    \ Ethernet2\n   description P2P_LINK_TO_DC1-SPINE2_Ethernet7\n   no shutdown\n\
+    \   no switchport\n   ip address 172.31.255.51/31\n!\ninterface Ethernet3\n  \
+    \ description P2P_LINK_TO_DC1-SPINE3_Ethernet7\n   no shutdown\n   no switchport\n\
+    \   ip address 172.31.255.53/31\n!\ninterface Ethernet4\n   description P2P_LINK_TO_DC1-SPINE4_Ethernet7\n\
+    \   no shutdown\n   no switchport\n   ip address 172.31.255.55/31\n!\ninterface\
+    \ Ethernet5\n   description MLAG_PEER_DC1-BL1A_Ethernet5\n   no shutdown\n   channel-group\
+    \ 5 mode active\n!\ninterface Ethernet6\n   description MLAG_PEER_DC1-BL1A_Ethernet6\n\
+    \   no shutdown\n   channel-group 5 mode active\n!\ninterface Loopback0\n   description\
+    \ EVPN_Overlay_Peering\n   no shutdown\n   ip address 192.168.255.11/32\n!\ninterface\
+    \ Loopback1\n   description VTEP_VXLAN_Tunnel_Source\n   no shutdown\n   ip address\
+    \ 192.168.254.10/32\n!\ninterface Management1\n   description oob_management\n\
+    \   no shutdown\n   vrf MGMT\n   ip address 192.168.200.111/24\n!\ninterface Vlan150\n\
+    \   description Tenant_A_WAN_Zone_1\n   no shutdown\n   vrf Tenant_A_WAN_Zone\n\
+    \   ip address virtual 10.1.40.1/24\n!\ninterface Vlan250\n   description Tenant_B_WAN_Zone_1\n\
     \   no shutdown\n   vrf Tenant_B_WAN_Zone\n   ip address virtual 10.2.50.1/24\n\
     !\ninterface Vlan350\n   description Tenant_C_WAN_Zone_1\n   no shutdown\n   vrf\
     \ Tenant_C_WAN_Zone\n   ip address virtual 10.3.50.1/24\n!\ninterface Vlan3013\n\
-    \   description MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone\n   vrf Tenant_A_WAN_Zone\n\
-    \   ip address 10.255.251.11/31\n!\ninterface Vlan3020\n   description MLAG_PEER_L3_iBGP:\
-    \ vrf Tenant_B_WAN_Zone\n   vrf Tenant_B_WAN_Zone\n   ip address 10.255.251.11/31\n\
-    !\ninterface Vlan3030\n   description MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone\n\
-    \   vrf Tenant_C_WAN_Zone\n   ip address 10.255.251.11/31\n!\ninterface Vlan4093\n\
-    \   description MLAG_PEER_L3_PEERING\n   ip address 10.255.251.11/31\n!\ninterface\
-    \ Vlan4094\n   description MLAG_PEER\n   no autostate\n   ip address 10.255.252.11/31\n\
-    !\ninterface Vxlan1\n   vxlan source-interface Loopback1\n   vxlan virtual-router\
-    \ encapsulation mac-address mlag-system-id\n   vxlan udp-port 4789\n   vxlan vlan\
-    \ 150 vni 10150\n   vxlan vlan 250 vni 20250\n   vxlan vlan 350 vni 30350\n  \
-    \ vxlan vrf Tenant_A_WAN_Zone vni 14\n   vxlan vrf Tenant_B_WAN_Zone vni 21\n\
-    \   vxlan vrf Tenant_C_WAN_Zone vni 31\n!\nip virtual-router mac-address 00:dc:00:00:00:0a\n\
-    !\nip routing\nno ip routing vrf MGMT\nip routing vrf Tenant_A_WAN_Zone\nip routing\
-    \ vrf Tenant_B_WAN_Zone\nip routing vrf Tenant_C_WAN_Zone\n!\nip prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n\
-    \   seq 10 permit 192.168.255.0/24 eq 32\n   seq 20 permit 192.168.254.0/24 eq\
-    \ 32\n!\nmlag configuration\n   domain-id DC1_BL1\n   local-interface Vlan4094\n\
-    \   peer-address 10.255.252.10\n   peer-address heartbeat 192.168.200.110 vrf\
-    \ MGMT\n   peer-link Port-Channel5\n   dual-primary detection delay 5 action errdisable\
-    \ all-interfaces\n   reload-delay mlag 300\n   reload-delay non-mlag 330\n!\n\
-    ip route vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nroute-map RM-CONN-2-BGP permit 10\n\
-    \   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n!\nrouter bfd\n  \
-    \ multihop interval 1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65104\n   router-id\
-    \ 192.168.255.11\n   no bgp default ipv4-unicast\n   distance bgp 20 200 200\n\
-    \   maximum-paths 4 ecmp 4\n   neighbor EVPN-OVERLAY-PEERS peer group\n   neighbor\
-    \ EVPN-OVERLAY-PEERS remote-as 65001\n   neighbor EVPN-OVERLAY-PEERS update-source\
-    \ Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS\
+    \   description MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone\n   no shutdown\n   vrf\
+    \ Tenant_A_WAN_Zone\n   ip address 10.255.251.11/31\n!\ninterface Vlan3020\n \
+    \  description MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone\n   no shutdown\n   vrf\
+    \ Tenant_B_WAN_Zone\n   ip address 10.255.251.11/31\n!\ninterface Vlan3030\n \
+    \  description MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone\n   no shutdown\n   vrf\
+    \ Tenant_C_WAN_Zone\n   ip address 10.255.251.11/31\n!\ninterface Vlan4093\n \
+    \  description MLAG_PEER_L3_PEERING\n   no shutdown\n   ip address 10.255.251.11/31\n\
+    !\ninterface Vlan4094\n   description MLAG_PEER\n   no shutdown\n   no autostate\n\
+    \   ip address 10.255.252.11/31\n!\ninterface Vxlan1\n   vxlan source-interface\
+    \ Loopback1\n   vxlan virtual-router encapsulation mac-address mlag-system-id\n\
+    \   vxlan udp-port 4789\n   vxlan vlan 150 vni 10150\n   vxlan vlan 250 vni 20250\n\
+    \   vxlan vlan 350 vni 30350\n   vxlan vrf Tenant_A_WAN_Zone vni 14\n   vxlan\
+    \ vrf Tenant_B_WAN_Zone vni 21\n   vxlan vrf Tenant_C_WAN_Zone vni 31\n!\nip virtual-router\
+    \ mac-address 00:dc:00:00:00:0a\n!\nip routing\nno ip routing vrf MGMT\nip routing\
+    \ vrf Tenant_A_WAN_Zone\nip routing vrf Tenant_B_WAN_Zone\nip routing vrf Tenant_C_WAN_Zone\n\
+    !\nip prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n   seq 10 permit 192.168.255.0/24\
+    \ eq 32\n   seq 20 permit 192.168.254.0/24 eq 32\n!\nmlag configuration\n   domain-id\
+    \ DC1_BL1\n   local-interface Vlan4094\n   peer-address 10.255.252.10\n   peer-address\
+    \ heartbeat 192.168.200.110 vrf MGMT\n   peer-link Port-Channel5\n   dual-primary\
+    \ detection delay 5 action errdisable all-interfaces\n   reload-delay mlag 300\n\
+    \   reload-delay non-mlag 330\n!\nip route vrf MGMT 0.0.0.0/0 192.168.200.5\n\
+    !\nroute-map RM-CONN-2-BGP permit 10\n   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n\
+    !\nrouter bfd\n   multihop interval 1200 min-rx 1200 multiplier 3\n!\nrouter bgp\
+    \ 65104\n   router-id 192.168.255.11\n   no bgp default ipv4-unicast\n   distance\
+    \ bgp 20 200 200\n   maximum-paths 4 ecmp 4\n   neighbor EVPN-OVERLAY-PEERS peer\
+    \ group\n   neighbor EVPN-OVERLAY-PEERS remote-as 65001\n   neighbor EVPN-OVERLAY-PEERS\
+    \ update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS\
     \ ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n\
     \   neighbor EVPN-OVERLAY-PEERS send-community\n   neighbor EVPN-OVERLAY-PEERS\
     \ maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS peer group\n   neighbor IPv4-UNDERLAY-PEERS\
@@ -216,14 +222,15 @@ CVP_CONFIGLETS:
     !\nvlan 120\n   name Tenant_A_WEB_Zone_1\n!\nvlan 121\n   name Tenant_A_WEBZone_2\n\
     !\nvlan 130\n   name Tenant_A_APP_Zone_1\n!\nvlan 131\n   name Tenant_A_APP_Zone_2\n\
     !\nvrf instance MGMT\n!\ninterface Port-Channel1\n   description DC1-LEAF2A_Po7\n\
-    \   switchport\n   switchport trunk allowed vlan 110-111,120-121,130-131\n   switchport\
-    \ mode trunk\n!\ninterface Ethernet1\n   description DC1-LEAF2A_Ethernet7\n  \
-    \ channel-group 1 mode active\n!\ninterface Ethernet2\n   description DC1-LEAF2B_Ethernet7\n\
-    \   channel-group 1 mode active\n!\ninterface Management1\n   description oob_management\n\
-    \   vrf MGMT\n   ip address 192.168.200.112/24\n!\nip routing\nno ip routing vrf\
-    \ MGMT\n!\nip route vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nrouter bfd\n   multihop\
-    \ interval 1200 min-rx 1200 multiplier 3\n!\nmanagement api http-commands\n  \
-    \ no shutdown\n   !\n   vrf MGMT\n      no shutdown\n!\nend"
+    \   no shutdown\n   switchport\n   switchport trunk allowed vlan 110-111,120-121,130-131\n\
+    \   switchport mode trunk\n!\ninterface Ethernet1\n   description DC1-LEAF2A_Ethernet7\n\
+    \   no shutdown\n   channel-group 1 mode active\n!\ninterface Ethernet2\n   description\
+    \ DC1-LEAF2B_Ethernet7\n   no shutdown\n   channel-group 1 mode active\n!\ninterface\
+    \ Management1\n   description oob_management\n   no shutdown\n   vrf MGMT\n  \
+    \ ip address 192.168.200.112/24\n!\nip routing\nno ip routing vrf MGMT\n!\nip\
+    \ route vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nrouter bfd\n   multihop interval\
+    \ 1200 min-rx 1200 multiplier 3\n!\nmanagement api http-commands\n   no shutdown\n\
+    \   !\n   vrf MGMT\n      no shutdown\n!\nend"
   AVD_DC1-L2LEAF2A: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr\
     \ -ingestgrpcurl=192.168.200.11:9910 -cvcompression=gzip -ingestauth=key,telarista\
     \ -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent\
@@ -245,24 +252,26 @@ CVP_CONFIGLETS:
     !\nvlan 310\n   name Tenant_C_OP_Zone_1\n!\nvlan 311\n   name Tenant_C_OP_Zone_2\n\
     !\nvlan 350\n   name Tenant_C_WAN_Zone_1\n!\nvlan 4094\n   name MLAG_PEER\n  \
     \ trunk group MLAG\n!\nvrf instance MGMT\n!\ninterface Port-Channel1\n   description\
-    \ DC1-SVC3A_Po7\n   switchport\n   switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350\n\
-    \   switchport mode trunk\n   mlag 1\n!\ninterface Port-Channel3\n   description\
-    \ MLAG_PEER_DC1-L2LEAF2B_Po3\n   switchport\n   switchport trunk allowed vlan\
-    \ 2-4094\n   switchport mode trunk\n   switchport trunk group MLAG\n!\ninterface\
-    \ Ethernet1\n   description DC1-SVC3A_Ethernet7\n   channel-group 1 mode active\n\
-    !\ninterface Ethernet2\n   description DC1-SVC3B_Ethernet7\n   channel-group 1\
-    \ mode active\n!\ninterface Ethernet3\n   description MLAG_PEER_DC1-L2LEAF2B_Ethernet3\n\
-    \   channel-group 3 mode active\n!\ninterface Ethernet4\n   description MLAG_PEER_DC1-L2LEAF2B_Ethernet4\n\
-    \   channel-group 3 mode active\n!\ninterface Management1\n   description oob_management\n\
-    \   vrf MGMT\n   ip address 192.168.200.113/24\n!\ninterface Vlan4094\n   description\
-    \ MLAG_PEER\n   no autostate\n   ip address 10.255.252.16/31\n!\nip routing\n\
-    no ip routing vrf MGMT\n!\nmlag configuration\n   domain-id DC1_L2LEAF2\n   local-interface\
-    \ Vlan4094\n   peer-address 10.255.252.17\n   peer-address heartbeat 192.168.200.114\
-    \ vrf MGMT\n   peer-link Port-Channel3\n   dual-primary detection delay 5 action\
-    \ errdisable all-interfaces\n   reload-delay mlag 300\n   reload-delay non-mlag\
-    \ 330\n!\nip route vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nrouter bfd\n   multihop\
-    \ interval 1200 min-rx 1200 multiplier 3\n!\nmanagement api http-commands\n  \
-    \ no shutdown\n   !\n   vrf MGMT\n      no shutdown\n!\nend"
+    \ DC1-SVC3A_Po7\n   no shutdown\n   switchport\n   switchport trunk allowed vlan\
+    \ 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350\n   switchport mode\
+    \ trunk\n   mlag 1\n!\ninterface Port-Channel3\n   description MLAG_PEER_DC1-L2LEAF2B_Po3\n\
+    \   no shutdown\n   switchport\n   switchport trunk allowed vlan 2-4094\n   switchport\
+    \ mode trunk\n   switchport trunk group MLAG\n!\ninterface Ethernet1\n   description\
+    \ DC1-SVC3A_Ethernet7\n   no shutdown\n   channel-group 1 mode active\n!\ninterface\
+    \ Ethernet2\n   description DC1-SVC3B_Ethernet7\n   no shutdown\n   channel-group\
+    \ 1 mode active\n!\ninterface Ethernet3\n   description MLAG_PEER_DC1-L2LEAF2B_Ethernet3\n\
+    \   no shutdown\n   channel-group 3 mode active\n!\ninterface Ethernet4\n   description\
+    \ MLAG_PEER_DC1-L2LEAF2B_Ethernet4\n   no shutdown\n   channel-group 3 mode active\n\
+    !\ninterface Management1\n   description oob_management\n   no shutdown\n   vrf\
+    \ MGMT\n   ip address 192.168.200.113/24\n!\ninterface Vlan4094\n   description\
+    \ MLAG_PEER\n   no shutdown\n   no autostate\n   ip address 10.255.252.16/31\n\
+    !\nip routing\nno ip routing vrf MGMT\n!\nmlag configuration\n   domain-id DC1_L2LEAF2\n\
+    \   local-interface Vlan4094\n   peer-address 10.255.252.17\n   peer-address heartbeat\
+    \ 192.168.200.114 vrf MGMT\n   peer-link Port-Channel3\n   dual-primary detection\
+    \ delay 5 action errdisable all-interfaces\n   reload-delay mlag 300\n   reload-delay\
+    \ non-mlag 330\n!\nip route vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nrouter bfd\n\
+    \   multihop interval 1200 min-rx 1200 multiplier 3\n!\nmanagement api http-commands\n\
+    \   no shutdown\n   !\n   vrf MGMT\n      no shutdown\n!\nend"
   AVD_DC1-L2LEAF2B: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr\
     \ -ingestgrpcurl=192.168.200.11:9910 -cvcompression=gzip -ingestauth=key,telarista\
     \ -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent\
@@ -284,24 +293,26 @@ CVP_CONFIGLETS:
     !\nvlan 310\n   name Tenant_C_OP_Zone_1\n!\nvlan 311\n   name Tenant_C_OP_Zone_2\n\
     !\nvlan 350\n   name Tenant_C_WAN_Zone_1\n!\nvlan 4094\n   name MLAG_PEER\n  \
     \ trunk group MLAG\n!\nvrf instance MGMT\n!\ninterface Port-Channel1\n   description\
-    \ DC1-SVC3B_Po7\n   switchport\n   switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350\n\
-    \   switchport mode trunk\n   mlag 1\n!\ninterface Port-Channel3\n   description\
-    \ MLAG_PEER_DC1-L2LEAF2A_Po3\n   switchport\n   switchport trunk allowed vlan\
-    \ 2-4094\n   switchport mode trunk\n   switchport trunk group MLAG\n!\ninterface\
-    \ Ethernet1\n   description DC1-SVC3A_Ethernet8\n   channel-group 1 mode active\n\
-    !\ninterface Ethernet2\n   description DC1-SVC3B_Ethernet8\n   channel-group 1\
-    \ mode active\n!\ninterface Ethernet3\n   description MLAG_PEER_DC1-L2LEAF2A_Ethernet3\n\
-    \   channel-group 3 mode active\n!\ninterface Ethernet4\n   description MLAG_PEER_DC1-L2LEAF2A_Ethernet4\n\
-    \   channel-group 3 mode active\n!\ninterface Management1\n   description oob_management\n\
-    \   vrf MGMT\n   ip address 192.168.200.114/24\n!\ninterface Vlan4094\n   description\
-    \ MLAG_PEER\n   no autostate\n   ip address 10.255.252.17/31\n!\nip routing\n\
-    no ip routing vrf MGMT\n!\nmlag configuration\n   domain-id DC1_L2LEAF2\n   local-interface\
-    \ Vlan4094\n   peer-address 10.255.252.16\n   peer-address heartbeat 192.168.200.113\
-    \ vrf MGMT\n   peer-link Port-Channel3\n   dual-primary detection delay 5 action\
-    \ errdisable all-interfaces\n   reload-delay mlag 300\n   reload-delay non-mlag\
-    \ 330\n!\nip route vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nrouter bfd\n   multihop\
-    \ interval 1200 min-rx 1200 multiplier 3\n!\nmanagement api http-commands\n  \
-    \ no shutdown\n   !\n   vrf MGMT\n      no shutdown\n!\nend"
+    \ DC1-SVC3B_Po7\n   no shutdown\n   switchport\n   switchport trunk allowed vlan\
+    \ 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350\n   switchport mode\
+    \ trunk\n   mlag 1\n!\ninterface Port-Channel3\n   description MLAG_PEER_DC1-L2LEAF2A_Po3\n\
+    \   no shutdown\n   switchport\n   switchport trunk allowed vlan 2-4094\n   switchport\
+    \ mode trunk\n   switchport trunk group MLAG\n!\ninterface Ethernet1\n   description\
+    \ DC1-SVC3A_Ethernet8\n   no shutdown\n   channel-group 1 mode active\n!\ninterface\
+    \ Ethernet2\n   description DC1-SVC3B_Ethernet8\n   no shutdown\n   channel-group\
+    \ 1 mode active\n!\ninterface Ethernet3\n   description MLAG_PEER_DC1-L2LEAF2A_Ethernet3\n\
+    \   no shutdown\n   channel-group 3 mode active\n!\ninterface Ethernet4\n   description\
+    \ MLAG_PEER_DC1-L2LEAF2A_Ethernet4\n   no shutdown\n   channel-group 3 mode active\n\
+    !\ninterface Management1\n   description oob_management\n   no shutdown\n   vrf\
+    \ MGMT\n   ip address 192.168.200.114/24\n!\ninterface Vlan4094\n   description\
+    \ MLAG_PEER\n   no shutdown\n   no autostate\n   ip address 10.255.252.17/31\n\
+    !\nip routing\nno ip routing vrf MGMT\n!\nmlag configuration\n   domain-id DC1_L2LEAF2\n\
+    \   local-interface Vlan4094\n   peer-address 10.255.252.16\n   peer-address heartbeat\
+    \ 192.168.200.113 vrf MGMT\n   peer-link Port-Channel3\n   dual-primary detection\
+    \ delay 5 action errdisable all-interfaces\n   reload-delay mlag 300\n   reload-delay\
+    \ non-mlag 330\n!\nip route vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nrouter bfd\n\
+    \   multihop interval 1200 min-rx 1200 multiplier 3\n!\nmanagement api http-commands\n\
+    \   no shutdown\n   !\n   vrf MGMT\n      no shutdown\n!\nend"
   AVD_DC1-LEAF1A: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr\
     \ -ingestgrpcurl=192.168.200.11:9910 -cvcompression=gzip -ingestauth=key,telarista\
     \ -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent\
@@ -317,31 +328,32 @@ CVP_CONFIGLETS:
     !\nvlan 130\n   name Tenant_A_APP_Zone_1\n!\nvlan 131\n   name Tenant_A_APP_Zone_2\n\
     !\nvrf instance MGMT\n!\nvrf instance Tenant_A_APP_Zone\n!\nvrf instance Tenant_A_WEB_Zone\n\
     !\ninterface Ethernet1\n   description P2P_LINK_TO_DC1-SPINE1_Ethernet1\n   no\
-    \ switchport\n   ip address 172.31.255.1/31\n!\ninterface Ethernet2\n   description\
-    \ P2P_LINK_TO_DC1-SPINE2_Ethernet1\n   no switchport\n   ip address 172.31.255.3/31\n\
-    !\ninterface Ethernet3\n   description P2P_LINK_TO_DC1-SPINE3_Ethernet1\n   no\
-    \ switchport\n   ip address 172.31.255.5/31\n!\ninterface Ethernet4\n   description\
-    \ P2P_LINK_TO_DC1-SPINE4_Ethernet1\n   no switchport\n   ip address 172.31.255.7/31\n\
-    !\ninterface Ethernet6\n   description server02_SINGLE_NODE_TRUNK_Eth1\n   switchport\n\
-    \   switchport trunk allowed vlan 110-111,210-211\n   switchport mode trunk\n\
-    !\ninterface Ethernet7\n   description server02_SINGLE_NODE_Eth1\n   switchport\n\
-    \   switchport access vlan 110\n!\ninterface Loopback0\n   description EVPN_Overlay_Peering\n\
-    \   ip address 192.168.255.5/32\n!\ninterface Loopback1\n   description VTEP_VXLAN_Tunnel_Source\n\
-    \   ip address 192.168.254.5/32\n!\ninterface Management1\n   description oob_management\n\
-    \   vrf MGMT\n   ip address 192.168.200.105/24\n!\ninterface Vlan120\n   description\
-    \ Tenant_A_WEB_Zone_1\n   no shutdown\n   vrf Tenant_A_WEB_Zone\n   ip address\
-    \ virtual 10.1.20.1/24\n   ip helper-address 1.1.1.1 vrf TEST  source-interface\
-    \ lo100\n!\ninterface Vlan121\n   description Tenant_A_WEBZone_2\n   shutdown\n\
-    \   mtu 1560\n   vrf Tenant_A_WEB_Zone\n   ip address virtual 10.1.10.254/24\n\
-    !\ninterface Vlan130\n   description Tenant_A_APP_Zone_1\n   no shutdown\n   vrf\
-    \ Tenant_A_APP_Zone\n   ip address virtual 10.1.30.1/24\n!\ninterface Vlan131\n\
-    \   description Tenant_A_APP_Zone_2\n   no shutdown\n   vrf Tenant_A_APP_Zone\n\
-    \   ip address virtual 10.1.31.1/24\n!\ninterface Vxlan1\n   vxlan source-interface\
-    \ Loopback1\n   vxlan udp-port 4789\n   vxlan vlan 120 vni 10120\n   vxlan vlan\
-    \ 121 vni 10121\n   vxlan vlan 130 vni 10130\n   vxlan vlan 131 vni 10131\n  \
-    \ vxlan vrf Tenant_A_APP_Zone vni 12\n   vxlan vrf Tenant_A_WEB_Zone vni 11\n\
-    !\nip virtual-router mac-address 00:dc:00:00:00:0a\n!\nip routing\nno ip routing\
-    \ vrf MGMT\nip routing vrf Tenant_A_APP_Zone\nip routing vrf Tenant_A_WEB_Zone\n\
+    \ shutdown\n   no switchport\n   ip address 172.31.255.1/31\n!\ninterface Ethernet2\n\
+    \   description P2P_LINK_TO_DC1-SPINE2_Ethernet1\n   no shutdown\n   no switchport\n\
+    \   ip address 172.31.255.3/31\n!\ninterface Ethernet3\n   description P2P_LINK_TO_DC1-SPINE3_Ethernet1\n\
+    \   no shutdown\n   no switchport\n   ip address 172.31.255.5/31\n!\ninterface\
+    \ Ethernet4\n   description P2P_LINK_TO_DC1-SPINE4_Ethernet1\n   no shutdown\n\
+    \   no switchport\n   ip address 172.31.255.7/31\n!\ninterface Ethernet6\n   description\
+    \ server02_SINGLE_NODE_TRUNK_Eth1\n   no shutdown\n   switchport\n   switchport\
+    \ trunk allowed vlan 110-111,210-211\n   switchport mode trunk\n!\ninterface Ethernet7\n\
+    \   description server02_SINGLE_NODE_Eth1\n   no shutdown\n   switchport\n   switchport\
+    \ access vlan 110\n!\ninterface Loopback0\n   description EVPN_Overlay_Peering\n\
+    \   no shutdown\n   ip address 192.168.255.5/32\n!\ninterface Loopback1\n   description\
+    \ VTEP_VXLAN_Tunnel_Source\n   no shutdown\n   ip address 192.168.254.5/32\n!\n\
+    interface Management1\n   description oob_management\n   no shutdown\n   vrf MGMT\n\
+    \   ip address 192.168.200.105/24\n!\ninterface Vlan120\n   description Tenant_A_WEB_Zone_1\n\
+    \   no shutdown\n   vrf Tenant_A_WEB_Zone\n   ip address virtual 10.1.20.1/24\n\
+    \   ip helper-address 1.1.1.1 vrf TEST  source-interface lo100\n!\ninterface Vlan121\n\
+    \   description Tenant_A_WEBZone_2\n   shutdown\n   mtu 1560\n   vrf Tenant_A_WEB_Zone\n\
+    \   ip address virtual 10.1.10.254/24\n!\ninterface Vlan130\n   description Tenant_A_APP_Zone_1\n\
+    \   no shutdown\n   vrf Tenant_A_APP_Zone\n   ip address virtual 10.1.30.1/24\n\
+    !\ninterface Vlan131\n   description Tenant_A_APP_Zone_2\n   no shutdown\n   vrf\
+    \ Tenant_A_APP_Zone\n   ip address virtual 10.1.31.1/24\n!\ninterface Vxlan1\n\
+    \   vxlan source-interface Loopback1\n   vxlan udp-port 4789\n   vxlan vlan 120\
+    \ vni 10120\n   vxlan vlan 121 vni 10121\n   vxlan vlan 130 vni 10130\n   vxlan\
+    \ vlan 131 vni 10131\n   vxlan vrf Tenant_A_APP_Zone vni 12\n   vxlan vrf Tenant_A_WEB_Zone\
+    \ vni 11\n!\nip virtual-router mac-address 00:dc:00:00:00:0a\n!\nip routing\n\
+    no ip routing vrf MGMT\nip routing vrf Tenant_A_APP_Zone\nip routing vrf Tenant_A_WEB_Zone\n\
     !\nip prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n   seq 10 permit 192.168.255.0/24\
     \ eq 32\n   seq 20 permit 192.168.254.0/24 eq 32\n!\nip route vrf MGMT 0.0.0.0/0\
     \ 192.168.200.5\n!\nroute-map RM-CONN-2-BGP permit 10\n   match ip address prefix-list\
@@ -403,36 +415,39 @@ CVP_CONFIGLETS:
     \ Tenant_A_APP_Zone\n!\nvrf instance Tenant_A_DB_Zone\n!\nvrf instance Tenant_A_OP_Zone\n\
     !\nvrf instance Tenant_A_WEB_Zone\n!\nvrf instance Tenant_B_OP_Zone\n!\nvrf instance\
     \ Tenant_C_OP_Zone\n!\ninterface Port-Channel5\n   description MLAG_PEER_DC1-LEAF2B_Po5\n\
-    \   switchport\n   switchport trunk allowed vlan 2-4094\n   switchport mode trunk\n\
-    \   switchport trunk group LEAF_PEER_L3\n   switchport trunk group MLAG\n!\ninterface\
-    \ Port-Channel7\n   description DC1_L2LEAF1_Po1\n   switchport\n   switchport\
-    \ trunk allowed vlan 110-111,120-121,130-131\n   switchport mode trunk\n   mlag\
-    \ 7\n!\ninterface Port-Channel10\n   description server01_MLAG_PortChanne1\n \
-    \  switchport\n   switchport trunk allowed vlan 210-211\n   switchport mode trunk\n\
-    \   mlag 10\n!\ninterface Ethernet1\n   description P2P_LINK_TO_DC1-SPINE1_Ethernet2\n\
-    \   no switchport\n   ip address 172.31.255.9/31\n!\ninterface Ethernet2\n   description\
-    \ P2P_LINK_TO_DC1-SPINE2_Ethernet2\n   no switchport\n   ip address 172.31.255.11/31\n\
-    !\ninterface Ethernet3\n   description P2P_LINK_TO_DC1-SPINE3_Ethernet2\n   no\
-    \ switchport\n   ip address 172.31.255.13/31\n!\ninterface Ethernet4\n   description\
-    \ P2P_LINK_TO_DC1-SPINE4_Ethernet2\n   no switchport\n   ip address 172.31.255.15/31\n\
-    !\ninterface Ethernet5\n   description MLAG_PEER_DC1-LEAF2B_Ethernet5\n   channel-group\
-    \ 5 mode active\n!\ninterface Ethernet6\n   description MLAG_PEER_DC1-LEAF2B_Ethernet6\n\
-    \   channel-group 5 mode active\n!\ninterface Ethernet7\n   description DC1-L2LEAF1A_Ethernet1\n\
-    \   channel-group 7 mode active\n!\ninterface Ethernet10\n   description server01_MLAG_Eth2\n\
-    \   channel-group 10 mode active\n!\ninterface Loopback0\n   description EVPN_Overlay_Peering\n\
-    \   ip address 192.168.255.6/32\n!\ninterface Loopback1\n   description VTEP_VXLAN_Tunnel_Source\n\
-    \   ip address 192.168.254.6/32\n!\ninterface Loopback100\n   description Tenant_A_OP_Zone_VTEP_DIAGNOSTICS\n\
-    \   vrf Tenant_A_OP_Zone\n   ip address 10.255.1.6/32\n!\ninterface Management1\n\
-    \   description oob_management\n   vrf MGMT\n   ip address 192.168.200.106/24\n\
-    !\ninterface Vlan110\n   description Tenant_A_OP_Zone_1\n   no shutdown\n   vrf\
-    \ Tenant_A_OP_Zone\n   ip address virtual 10.1.10.1/24\n!\ninterface Vlan111\n\
-    \   description Tenant_A_OP_Zone_2\n   no shutdown\n   vrf Tenant_A_OP_Zone\n\
-    \   ip address virtual 10.1.11.1/24\n   ip helper-address 1.1.1.1 vrf MGMT  source-interface\
-    \ lo100\n!\ninterface Vlan120\n   description Tenant_A_WEB_Zone_1\n   no shutdown\n\
-    \   vrf Tenant_A_WEB_Zone\n   ip address virtual 10.1.20.1/24\n   ip helper-address\
-    \ 1.1.1.1 vrf TEST  source-interface lo100\n!\ninterface Vlan121\n   description\
-    \ Tenant_A_WEBZone_2\n   shutdown\n   mtu 1560\n   vrf Tenant_A_WEB_Zone\n   ip\
-    \ address virtual 10.1.10.254/24\n!\ninterface Vlan130\n   description Tenant_A_APP_Zone_1\n\
+    \   no shutdown\n   switchport\n   switchport trunk allowed vlan 2-4094\n   switchport\
+    \ mode trunk\n   switchport trunk group LEAF_PEER_L3\n   switchport trunk group\
+    \ MLAG\n!\ninterface Port-Channel7\n   description DC1_L2LEAF1_Po1\n   no shutdown\n\
+    \   switchport\n   switchport trunk allowed vlan 110-111,120-121,130-131\n   switchport\
+    \ mode trunk\n   mlag 7\n!\ninterface Port-Channel10\n   description server01_MLAG_PortChanne1\n\
+    \   no shutdown\n   switchport\n   switchport trunk allowed vlan 210-211\n   switchport\
+    \ mode trunk\n   mlag 10\n!\ninterface Ethernet1\n   description P2P_LINK_TO_DC1-SPINE1_Ethernet2\n\
+    \   no shutdown\n   no switchport\n   ip address 172.31.255.9/31\n!\ninterface\
+    \ Ethernet2\n   description P2P_LINK_TO_DC1-SPINE2_Ethernet2\n   no shutdown\n\
+    \   no switchport\n   ip address 172.31.255.11/31\n!\ninterface Ethernet3\n  \
+    \ description P2P_LINK_TO_DC1-SPINE3_Ethernet2\n   no shutdown\n   no switchport\n\
+    \   ip address 172.31.255.13/31\n!\ninterface Ethernet4\n   description P2P_LINK_TO_DC1-SPINE4_Ethernet2\n\
+    \   no shutdown\n   no switchport\n   ip address 172.31.255.15/31\n!\ninterface\
+    \ Ethernet5\n   description MLAG_PEER_DC1-LEAF2B_Ethernet5\n   no shutdown\n \
+    \  channel-group 5 mode active\n!\ninterface Ethernet6\n   description MLAG_PEER_DC1-LEAF2B_Ethernet6\n\
+    \   no shutdown\n   channel-group 5 mode active\n!\ninterface Ethernet7\n   description\
+    \ DC1-L2LEAF1A_Ethernet1\n   no shutdown\n   channel-group 7 mode active\n!\n\
+    interface Ethernet10\n   description server01_MLAG_Eth2\n   no shutdown\n   channel-group\
+    \ 10 mode active\n!\ninterface Loopback0\n   description EVPN_Overlay_Peering\n\
+    \   no shutdown\n   ip address 192.168.255.6/32\n!\ninterface Loopback1\n   description\
+    \ VTEP_VXLAN_Tunnel_Source\n   no shutdown\n   ip address 192.168.254.6/32\n!\n\
+    interface Loopback100\n   description Tenant_A_OP_Zone_VTEP_DIAGNOSTICS\n   no\
+    \ shutdown\n   vrf Tenant_A_OP_Zone\n   ip address 10.255.1.6/32\n!\ninterface\
+    \ Management1\n   description oob_management\n   no shutdown\n   vrf MGMT\n  \
+    \ ip address 192.168.200.106/24\n!\ninterface Vlan110\n   description Tenant_A_OP_Zone_1\n\
+    \   no shutdown\n   vrf Tenant_A_OP_Zone\n   ip address virtual 10.1.10.1/24\n\
+    !\ninterface Vlan111\n   description Tenant_A_OP_Zone_2\n   no shutdown\n   vrf\
+    \ Tenant_A_OP_Zone\n   ip address virtual 10.1.11.1/24\n   ip helper-address 1.1.1.1\
+    \ vrf MGMT  source-interface lo100\n!\ninterface Vlan120\n   description Tenant_A_WEB_Zone_1\n\
+    \   no shutdown\n   vrf Tenant_A_WEB_Zone\n   ip address virtual 10.1.20.1/24\n\
+    \   ip helper-address 1.1.1.1 vrf TEST  source-interface lo100\n!\ninterface Vlan121\n\
+    \   description Tenant_A_WEBZone_2\n   shutdown\n   mtu 1560\n   vrf Tenant_A_WEB_Zone\n\
+    \   ip address virtual 10.1.10.254/24\n!\ninterface Vlan130\n   description Tenant_A_APP_Zone_1\n\
     \   no shutdown\n   vrf Tenant_A_APP_Zone\n   ip address virtual 10.1.30.1/24\n\
     !\ninterface Vlan131\n   description Tenant_A_APP_Zone_2\n   no shutdown\n   vrf\
     \ Tenant_A_APP_Zone\n   ip address virtual 10.1.31.1/24\n!\ninterface Vlan140\n\
@@ -446,43 +461,44 @@ CVP_CONFIGLETS:
     \   no shutdown\n   vrf Tenant_C_OP_Zone\n   ip address virtual 10.3.10.1/24\n\
     !\ninterface Vlan311\n   description Tenant_C_OP_Zone_2\n   no shutdown\n   vrf\
     \ Tenant_C_OP_Zone\n   ip address virtual 10.3.11.1/24\n!\ninterface Vlan3009\n\
-    \   description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone\n   vrf Tenant_A_OP_Zone\n\
-    \   ip address 10.255.251.2/31\n!\ninterface Vlan3010\n   description MLAG_PEER_L3_iBGP:\
-    \ vrf Tenant_A_WEB_Zone\n   vrf Tenant_A_WEB_Zone\n   ip address 10.255.251.2/31\n\
-    !\ninterface Vlan3011\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone\n\
-    \   vrf Tenant_A_APP_Zone\n   ip address 10.255.251.2/31\n!\ninterface Vlan3012\n\
-    \   description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone\n   vrf Tenant_A_DB_Zone\n\
-    \   ip address 10.255.251.2/31\n!\ninterface Vlan3019\n   description MLAG_PEER_L3_iBGP:\
-    \ vrf Tenant_B_OP_Zone\n   vrf Tenant_B_OP_Zone\n   ip address 10.255.251.2/31\n\
-    !\ninterface Vlan3029\n   description MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone\n\
+    \   description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone\n   no shutdown\n   vrf\
+    \ Tenant_A_OP_Zone\n   ip address 10.255.251.2/31\n!\ninterface Vlan3010\n   description\
+    \ MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone\n   no shutdown\n   vrf Tenant_A_WEB_Zone\n\
+    \   ip address 10.255.251.2/31\n!\ninterface Vlan3011\n   description MLAG_PEER_L3_iBGP:\
+    \ vrf Tenant_A_APP_Zone\n   no shutdown\n   vrf Tenant_A_APP_Zone\n   ip address\
+    \ 10.255.251.2/31\n!\ninterface Vlan3012\n   description MLAG_PEER_L3_iBGP: vrf\
+    \ Tenant_A_DB_Zone\n   no shutdown\n   vrf Tenant_A_DB_Zone\n   ip address 10.255.251.2/31\n\
+    !\ninterface Vlan3019\n   description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone\n\
+    \   no shutdown\n   vrf Tenant_B_OP_Zone\n   ip address 10.255.251.2/31\n!\ninterface\
+    \ Vlan3029\n   description MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone\n   no shutdown\n\
     \   vrf Tenant_C_OP_Zone\n   ip address 10.255.251.2/31\n!\ninterface Vlan4093\n\
-    \   description MLAG_PEER_L3_PEERING\n   ip address 10.255.251.2/31\n!\ninterface\
-    \ Vlan4094\n   description MLAG_PEER\n   no autostate\n   ip address 10.255.252.2/31\n\
-    !\ninterface Vxlan1\n   vxlan source-interface Loopback1\n   vxlan virtual-router\
-    \ encapsulation mac-address mlag-system-id\n   vxlan udp-port 4789\n   vxlan vlan\
-    \ 110 vni 10110\n   vxlan vlan 111 vni 50111\n   vxlan vlan 120 vni 10120\n  \
-    \ vxlan vlan 121 vni 10121\n   vxlan vlan 130 vni 10130\n   vxlan vlan 131 vni\
-    \ 10131\n   vxlan vlan 140 vni 10140\n   vxlan vlan 141 vni 10141\n   vxlan vlan\
-    \ 210 vni 20210\n   vxlan vlan 211 vni 20211\n   vxlan vlan 310 vni 30310\n  \
-    \ vxlan vlan 311 vni 30311\n   vxlan vrf Tenant_A_APP_Zone vni 12\n   vxlan vrf\
-    \ Tenant_A_DB_Zone vni 13\n   vxlan vrf Tenant_A_OP_Zone vni 10\n   vxlan vrf\
-    \ Tenant_A_WEB_Zone vni 11\n   vxlan vrf Tenant_B_OP_Zone vni 20\n   vxlan vrf\
-    \ Tenant_C_OP_Zone vni 30\n!\nip virtual-router mac-address 00:dc:00:00:00:0a\n\
-    !\nip address virtual source-nat vrf Tenant_A_OP_Zone address 10.255.1.6\n!\n\
-    ip routing\nno ip routing vrf MGMT\nip routing vrf Tenant_A_APP_Zone\nip routing\
-    \ vrf Tenant_A_DB_Zone\nip routing vrf Tenant_A_OP_Zone\nip routing vrf Tenant_A_WEB_Zone\n\
-    ip routing vrf Tenant_B_OP_Zone\nip routing vrf Tenant_C_OP_Zone\n!\nip prefix-list\
-    \ PL-LOOPBACKS-EVPN-OVERLAY\n   seq 10 permit 192.168.255.0/24 eq 32\n   seq 20\
-    \ permit 192.168.254.0/24 eq 32\n!\nmlag configuration\n   domain-id DC1_LEAF2\n\
-    \   local-interface Vlan4094\n   peer-address 10.255.252.3\n   peer-address heartbeat\
-    \ 192.168.200.107 vrf MGMT\n   peer-link Port-Channel5\n   dual-primary detection\
-    \ delay 5 action errdisable all-interfaces\n   reload-delay mlag 300\n   reload-delay\
-    \ non-mlag 330\n!\nip route vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nroute-map RM-CONN-2-BGP\
-    \ permit 10\n   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n!\nrouter\
-    \ bfd\n   multihop interval 1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65102\n\
-    \   router-id 192.168.255.6\n   no bgp default ipv4-unicast\n   distance bgp 20\
-    \ 200 200\n   maximum-paths 4 ecmp 4\n   neighbor EVPN-OVERLAY-PEERS peer group\n\
-    \   neighbor EVPN-OVERLAY-PEERS remote-as 65001\n   neighbor EVPN-OVERLAY-PEERS\
+    \   description MLAG_PEER_L3_PEERING\n   no shutdown\n   ip address 10.255.251.2/31\n\
+    !\ninterface Vlan4094\n   description MLAG_PEER\n   no shutdown\n   no autostate\n\
+    \   ip address 10.255.252.2/31\n!\ninterface Vxlan1\n   vxlan source-interface\
+    \ Loopback1\n   vxlan virtual-router encapsulation mac-address mlag-system-id\n\
+    \   vxlan udp-port 4789\n   vxlan vlan 110 vni 10110\n   vxlan vlan 111 vni 50111\n\
+    \   vxlan vlan 120 vni 10120\n   vxlan vlan 121 vni 10121\n   vxlan vlan 130 vni\
+    \ 10130\n   vxlan vlan 131 vni 10131\n   vxlan vlan 140 vni 10140\n   vxlan vlan\
+    \ 141 vni 10141\n   vxlan vlan 210 vni 20210\n   vxlan vlan 211 vni 20211\n  \
+    \ vxlan vlan 310 vni 30310\n   vxlan vlan 311 vni 30311\n   vxlan vrf Tenant_A_APP_Zone\
+    \ vni 12\n   vxlan vrf Tenant_A_DB_Zone vni 13\n   vxlan vrf Tenant_A_OP_Zone\
+    \ vni 10\n   vxlan vrf Tenant_A_WEB_Zone vni 11\n   vxlan vrf Tenant_B_OP_Zone\
+    \ vni 20\n   vxlan vrf Tenant_C_OP_Zone vni 30\n!\nip virtual-router mac-address\
+    \ 00:dc:00:00:00:0a\n!\nip address virtual source-nat vrf Tenant_A_OP_Zone address\
+    \ 10.255.1.6\n!\nip routing\nno ip routing vrf MGMT\nip routing vrf Tenant_A_APP_Zone\n\
+    ip routing vrf Tenant_A_DB_Zone\nip routing vrf Tenant_A_OP_Zone\nip routing vrf\
+    \ Tenant_A_WEB_Zone\nip routing vrf Tenant_B_OP_Zone\nip routing vrf Tenant_C_OP_Zone\n\
+    !\nip prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n   seq 10 permit 192.168.255.0/24\
+    \ eq 32\n   seq 20 permit 192.168.254.0/24 eq 32\n!\nmlag configuration\n   domain-id\
+    \ DC1_LEAF2\n   local-interface Vlan4094\n   peer-address 10.255.252.3\n   peer-address\
+    \ heartbeat 192.168.200.107 vrf MGMT\n   peer-link Port-Channel5\n   dual-primary\
+    \ detection delay 5 action errdisable all-interfaces\n   reload-delay mlag 300\n\
+    \   reload-delay non-mlag 330\n!\nip route vrf MGMT 0.0.0.0/0 192.168.200.5\n\
+    !\nroute-map RM-CONN-2-BGP permit 10\n   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n\
+    !\nrouter bfd\n   multihop interval 1200 min-rx 1200 multiplier 3\n!\nrouter bgp\
+    \ 65102\n   router-id 192.168.255.6\n   no bgp default ipv4-unicast\n   distance\
+    \ bgp 20 200 200\n   maximum-paths 4 ecmp 4\n   neighbor EVPN-OVERLAY-PEERS peer\
+    \ group\n   neighbor EVPN-OVERLAY-PEERS remote-as 65001\n   neighbor EVPN-OVERLAY-PEERS\
     \ update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS\
     \ ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n\
     \   neighbor EVPN-OVERLAY-PEERS send-community\n   neighbor EVPN-OVERLAY-PEERS\
@@ -565,36 +581,39 @@ CVP_CONFIGLETS:
     \ Tenant_A_APP_Zone\n!\nvrf instance Tenant_A_DB_Zone\n!\nvrf instance Tenant_A_OP_Zone\n\
     !\nvrf instance Tenant_A_WEB_Zone\n!\nvrf instance Tenant_B_OP_Zone\n!\nvrf instance\
     \ Tenant_C_OP_Zone\n!\ninterface Port-Channel5\n   description MLAG_PEER_DC1-LEAF2A_Po5\n\
-    \   switchport\n   switchport trunk allowed vlan 2-4094\n   switchport mode trunk\n\
-    \   switchport trunk group LEAF_PEER_L3\n   switchport trunk group MLAG\n!\ninterface\
-    \ Port-Channel7\n   description DC1_L2LEAF1_Po1\n   switchport\n   switchport\
-    \ trunk allowed vlan 110-111,120-121,130-131\n   switchport mode trunk\n   mlag\
-    \ 7\n!\ninterface Port-Channel10\n   description server01_MLAG_PortChanne1\n \
-    \  switchport\n   switchport trunk allowed vlan 210-211\n   switchport mode trunk\n\
-    \   mlag 10\n!\ninterface Ethernet1\n   description P2P_LINK_TO_DC1-SPINE1_Ethernet3\n\
-    \   no switchport\n   ip address 172.31.255.17/31\n!\ninterface Ethernet2\n  \
-    \ description P2P_LINK_TO_DC1-SPINE2_Ethernet3\n   no switchport\n   ip address\
-    \ 172.31.255.19/31\n!\ninterface Ethernet3\n   description P2P_LINK_TO_DC1-SPINE3_Ethernet3\n\
-    \   no switchport\n   ip address 172.31.255.21/31\n!\ninterface Ethernet4\n  \
-    \ description P2P_LINK_TO_DC1-SPINE4_Ethernet3\n   no switchport\n   ip address\
-    \ 172.31.255.23/31\n!\ninterface Ethernet5\n   description MLAG_PEER_DC1-LEAF2A_Ethernet5\n\
-    \   channel-group 5 mode active\n!\ninterface Ethernet6\n   description MLAG_PEER_DC1-LEAF2A_Ethernet6\n\
-    \   channel-group 5 mode active\n!\ninterface Ethernet7\n   description DC1-L2LEAF1A_Ethernet2\n\
-    \   channel-group 7 mode active\n!\ninterface Ethernet10\n   description server01_MLAG_Eth3\n\
-    \   channel-group 10 mode active\n!\ninterface Loopback0\n   description EVPN_Overlay_Peering\n\
-    \   ip address 192.168.255.7/32\n!\ninterface Loopback1\n   description VTEP_VXLAN_Tunnel_Source\n\
-    \   ip address 192.168.254.6/32\n!\ninterface Loopback100\n   description Tenant_A_OP_Zone_VTEP_DIAGNOSTICS\n\
-    \   vrf Tenant_A_OP_Zone\n   ip address 10.255.1.7/32\n!\ninterface Management1\n\
-    \   description oob_management\n   vrf MGMT\n   ip address 192.168.200.107/24\n\
-    !\ninterface Vlan110\n   description Tenant_A_OP_Zone_1\n   no shutdown\n   vrf\
-    \ Tenant_A_OP_Zone\n   ip address virtual 10.1.10.1/24\n!\ninterface Vlan111\n\
-    \   description Tenant_A_OP_Zone_2\n   no shutdown\n   vrf Tenant_A_OP_Zone\n\
-    \   ip address virtual 10.1.11.1/24\n   ip helper-address 1.1.1.1 vrf MGMT  source-interface\
-    \ lo100\n!\ninterface Vlan120\n   description Tenant_A_WEB_Zone_1\n   no shutdown\n\
-    \   vrf Tenant_A_WEB_Zone\n   ip address virtual 10.1.20.1/24\n   ip helper-address\
-    \ 1.1.1.1 vrf TEST  source-interface lo100\n!\ninterface Vlan121\n   description\
-    \ Tenant_A_WEBZone_2\n   shutdown\n   mtu 1560\n   vrf Tenant_A_WEB_Zone\n   ip\
-    \ address virtual 10.1.10.254/24\n!\ninterface Vlan130\n   description Tenant_A_APP_Zone_1\n\
+    \   no shutdown\n   switchport\n   switchport trunk allowed vlan 2-4094\n   switchport\
+    \ mode trunk\n   switchport trunk group LEAF_PEER_L3\n   switchport trunk group\
+    \ MLAG\n!\ninterface Port-Channel7\n   description DC1_L2LEAF1_Po1\n   no shutdown\n\
+    \   switchport\n   switchport trunk allowed vlan 110-111,120-121,130-131\n   switchport\
+    \ mode trunk\n   mlag 7\n!\ninterface Port-Channel10\n   description server01_MLAG_PortChanne1\n\
+    \   no shutdown\n   switchport\n   switchport trunk allowed vlan 210-211\n   switchport\
+    \ mode trunk\n   mlag 10\n!\ninterface Ethernet1\n   description P2P_LINK_TO_DC1-SPINE1_Ethernet3\n\
+    \   no shutdown\n   no switchport\n   ip address 172.31.255.17/31\n!\ninterface\
+    \ Ethernet2\n   description P2P_LINK_TO_DC1-SPINE2_Ethernet3\n   no shutdown\n\
+    \   no switchport\n   ip address 172.31.255.19/31\n!\ninterface Ethernet3\n  \
+    \ description P2P_LINK_TO_DC1-SPINE3_Ethernet3\n   no shutdown\n   no switchport\n\
+    \   ip address 172.31.255.21/31\n!\ninterface Ethernet4\n   description P2P_LINK_TO_DC1-SPINE4_Ethernet3\n\
+    \   no shutdown\n   no switchport\n   ip address 172.31.255.23/31\n!\ninterface\
+    \ Ethernet5\n   description MLAG_PEER_DC1-LEAF2A_Ethernet5\n   no shutdown\n \
+    \  channel-group 5 mode active\n!\ninterface Ethernet6\n   description MLAG_PEER_DC1-LEAF2A_Ethernet6\n\
+    \   no shutdown\n   channel-group 5 mode active\n!\ninterface Ethernet7\n   description\
+    \ DC1-L2LEAF1A_Ethernet2\n   no shutdown\n   channel-group 7 mode active\n!\n\
+    interface Ethernet10\n   description server01_MLAG_Eth3\n   no shutdown\n   channel-group\
+    \ 10 mode active\n!\ninterface Loopback0\n   description EVPN_Overlay_Peering\n\
+    \   no shutdown\n   ip address 192.168.255.7/32\n!\ninterface Loopback1\n   description\
+    \ VTEP_VXLAN_Tunnel_Source\n   no shutdown\n   ip address 192.168.254.6/32\n!\n\
+    interface Loopback100\n   description Tenant_A_OP_Zone_VTEP_DIAGNOSTICS\n   no\
+    \ shutdown\n   vrf Tenant_A_OP_Zone\n   ip address 10.255.1.7/32\n!\ninterface\
+    \ Management1\n   description oob_management\n   no shutdown\n   vrf MGMT\n  \
+    \ ip address 192.168.200.107/24\n!\ninterface Vlan110\n   description Tenant_A_OP_Zone_1\n\
+    \   no shutdown\n   vrf Tenant_A_OP_Zone\n   ip address virtual 10.1.10.1/24\n\
+    !\ninterface Vlan111\n   description Tenant_A_OP_Zone_2\n   no shutdown\n   vrf\
+    \ Tenant_A_OP_Zone\n   ip address virtual 10.1.11.1/24\n   ip helper-address 1.1.1.1\
+    \ vrf MGMT  source-interface lo100\n!\ninterface Vlan120\n   description Tenant_A_WEB_Zone_1\n\
+    \   no shutdown\n   vrf Tenant_A_WEB_Zone\n   ip address virtual 10.1.20.1/24\n\
+    \   ip helper-address 1.1.1.1 vrf TEST  source-interface lo100\n!\ninterface Vlan121\n\
+    \   description Tenant_A_WEBZone_2\n   shutdown\n   mtu 1560\n   vrf Tenant_A_WEB_Zone\n\
+    \   ip address virtual 10.1.10.254/24\n!\ninterface Vlan130\n   description Tenant_A_APP_Zone_1\n\
     \   no shutdown\n   vrf Tenant_A_APP_Zone\n   ip address virtual 10.1.30.1/24\n\
     !\ninterface Vlan131\n   description Tenant_A_APP_Zone_2\n   no shutdown\n   vrf\
     \ Tenant_A_APP_Zone\n   ip address virtual 10.1.31.1/24\n!\ninterface Vlan140\n\
@@ -608,43 +627,44 @@ CVP_CONFIGLETS:
     \   no shutdown\n   vrf Tenant_C_OP_Zone\n   ip address virtual 10.3.10.1/24\n\
     !\ninterface Vlan311\n   description Tenant_C_OP_Zone_2\n   no shutdown\n   vrf\
     \ Tenant_C_OP_Zone\n   ip address virtual 10.3.11.1/24\n!\ninterface Vlan3009\n\
-    \   description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone\n   vrf Tenant_A_OP_Zone\n\
-    \   ip address 10.255.251.3/31\n!\ninterface Vlan3010\n   description MLAG_PEER_L3_iBGP:\
-    \ vrf Tenant_A_WEB_Zone\n   vrf Tenant_A_WEB_Zone\n   ip address 10.255.251.3/31\n\
-    !\ninterface Vlan3011\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone\n\
-    \   vrf Tenant_A_APP_Zone\n   ip address 10.255.251.3/31\n!\ninterface Vlan3012\n\
-    \   description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone\n   vrf Tenant_A_DB_Zone\n\
-    \   ip address 10.255.251.3/31\n!\ninterface Vlan3019\n   description MLAG_PEER_L3_iBGP:\
-    \ vrf Tenant_B_OP_Zone\n   vrf Tenant_B_OP_Zone\n   ip address 10.255.251.3/31\n\
-    !\ninterface Vlan3029\n   description MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone\n\
+    \   description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone\n   no shutdown\n   vrf\
+    \ Tenant_A_OP_Zone\n   ip address 10.255.251.3/31\n!\ninterface Vlan3010\n   description\
+    \ MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone\n   no shutdown\n   vrf Tenant_A_WEB_Zone\n\
+    \   ip address 10.255.251.3/31\n!\ninterface Vlan3011\n   description MLAG_PEER_L3_iBGP:\
+    \ vrf Tenant_A_APP_Zone\n   no shutdown\n   vrf Tenant_A_APP_Zone\n   ip address\
+    \ 10.255.251.3/31\n!\ninterface Vlan3012\n   description MLAG_PEER_L3_iBGP: vrf\
+    \ Tenant_A_DB_Zone\n   no shutdown\n   vrf Tenant_A_DB_Zone\n   ip address 10.255.251.3/31\n\
+    !\ninterface Vlan3019\n   description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone\n\
+    \   no shutdown\n   vrf Tenant_B_OP_Zone\n   ip address 10.255.251.3/31\n!\ninterface\
+    \ Vlan3029\n   description MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone\n   no shutdown\n\
     \   vrf Tenant_C_OP_Zone\n   ip address 10.255.251.3/31\n!\ninterface Vlan4093\n\
-    \   description MLAG_PEER_L3_PEERING\n   ip address 10.255.251.3/31\n!\ninterface\
-    \ Vlan4094\n   description MLAG_PEER\n   no autostate\n   ip address 10.255.252.3/31\n\
-    !\ninterface Vxlan1\n   vxlan source-interface Loopback1\n   vxlan virtual-router\
-    \ encapsulation mac-address mlag-system-id\n   vxlan udp-port 4789\n   vxlan vlan\
-    \ 110 vni 10110\n   vxlan vlan 111 vni 50111\n   vxlan vlan 120 vni 10120\n  \
-    \ vxlan vlan 121 vni 10121\n   vxlan vlan 130 vni 10130\n   vxlan vlan 131 vni\
-    \ 10131\n   vxlan vlan 140 vni 10140\n   vxlan vlan 141 vni 10141\n   vxlan vlan\
-    \ 210 vni 20210\n   vxlan vlan 211 vni 20211\n   vxlan vlan 310 vni 30310\n  \
-    \ vxlan vlan 311 vni 30311\n   vxlan vrf Tenant_A_APP_Zone vni 12\n   vxlan vrf\
-    \ Tenant_A_DB_Zone vni 13\n   vxlan vrf Tenant_A_OP_Zone vni 10\n   vxlan vrf\
-    \ Tenant_A_WEB_Zone vni 11\n   vxlan vrf Tenant_B_OP_Zone vni 20\n   vxlan vrf\
-    \ Tenant_C_OP_Zone vni 30\n!\nip virtual-router mac-address 00:dc:00:00:00:0a\n\
-    !\nip address virtual source-nat vrf Tenant_A_OP_Zone address 10.255.1.7\n!\n\
-    ip routing\nno ip routing vrf MGMT\nip routing vrf Tenant_A_APP_Zone\nip routing\
-    \ vrf Tenant_A_DB_Zone\nip routing vrf Tenant_A_OP_Zone\nip routing vrf Tenant_A_WEB_Zone\n\
-    ip routing vrf Tenant_B_OP_Zone\nip routing vrf Tenant_C_OP_Zone\n!\nip prefix-list\
-    \ PL-LOOPBACKS-EVPN-OVERLAY\n   seq 10 permit 192.168.255.0/24 eq 32\n   seq 20\
-    \ permit 192.168.254.0/24 eq 32\n!\nmlag configuration\n   domain-id DC1_LEAF2\n\
-    \   local-interface Vlan4094\n   peer-address 10.255.252.2\n   peer-address heartbeat\
-    \ 192.168.200.106 vrf MGMT\n   peer-link Port-Channel5\n   dual-primary detection\
-    \ delay 5 action errdisable all-interfaces\n   reload-delay mlag 300\n   reload-delay\
-    \ non-mlag 330\n!\nip route vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nroute-map RM-CONN-2-BGP\
-    \ permit 10\n   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n!\nrouter\
-    \ bfd\n   multihop interval 1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65102\n\
-    \   router-id 192.168.255.7\n   no bgp default ipv4-unicast\n   distance bgp 20\
-    \ 200 200\n   maximum-paths 4 ecmp 4\n   neighbor EVPN-OVERLAY-PEERS peer group\n\
-    \   neighbor EVPN-OVERLAY-PEERS remote-as 65001\n   neighbor EVPN-OVERLAY-PEERS\
+    \   description MLAG_PEER_L3_PEERING\n   no shutdown\n   ip address 10.255.251.3/31\n\
+    !\ninterface Vlan4094\n   description MLAG_PEER\n   no shutdown\n   no autostate\n\
+    \   ip address 10.255.252.3/31\n!\ninterface Vxlan1\n   vxlan source-interface\
+    \ Loopback1\n   vxlan virtual-router encapsulation mac-address mlag-system-id\n\
+    \   vxlan udp-port 4789\n   vxlan vlan 110 vni 10110\n   vxlan vlan 111 vni 50111\n\
+    \   vxlan vlan 120 vni 10120\n   vxlan vlan 121 vni 10121\n   vxlan vlan 130 vni\
+    \ 10130\n   vxlan vlan 131 vni 10131\n   vxlan vlan 140 vni 10140\n   vxlan vlan\
+    \ 141 vni 10141\n   vxlan vlan 210 vni 20210\n   vxlan vlan 211 vni 20211\n  \
+    \ vxlan vlan 310 vni 30310\n   vxlan vlan 311 vni 30311\n   vxlan vrf Tenant_A_APP_Zone\
+    \ vni 12\n   vxlan vrf Tenant_A_DB_Zone vni 13\n   vxlan vrf Tenant_A_OP_Zone\
+    \ vni 10\n   vxlan vrf Tenant_A_WEB_Zone vni 11\n   vxlan vrf Tenant_B_OP_Zone\
+    \ vni 20\n   vxlan vrf Tenant_C_OP_Zone vni 30\n!\nip virtual-router mac-address\
+    \ 00:dc:00:00:00:0a\n!\nip address virtual source-nat vrf Tenant_A_OP_Zone address\
+    \ 10.255.1.7\n!\nip routing\nno ip routing vrf MGMT\nip routing vrf Tenant_A_APP_Zone\n\
+    ip routing vrf Tenant_A_DB_Zone\nip routing vrf Tenant_A_OP_Zone\nip routing vrf\
+    \ Tenant_A_WEB_Zone\nip routing vrf Tenant_B_OP_Zone\nip routing vrf Tenant_C_OP_Zone\n\
+    !\nip prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n   seq 10 permit 192.168.255.0/24\
+    \ eq 32\n   seq 20 permit 192.168.254.0/24 eq 32\n!\nmlag configuration\n   domain-id\
+    \ DC1_LEAF2\n   local-interface Vlan4094\n   peer-address 10.255.252.2\n   peer-address\
+    \ heartbeat 192.168.200.106 vrf MGMT\n   peer-link Port-Channel5\n   dual-primary\
+    \ detection delay 5 action errdisable all-interfaces\n   reload-delay mlag 300\n\
+    \   reload-delay non-mlag 330\n!\nip route vrf MGMT 0.0.0.0/0 192.168.200.5\n\
+    !\nroute-map RM-CONN-2-BGP permit 10\n   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n\
+    !\nrouter bfd\n   multihop interval 1200 min-rx 1200 multiplier 3\n!\nrouter bgp\
+    \ 65102\n   router-id 192.168.255.7\n   no bgp default ipv4-unicast\n   distance\
+    \ bgp 20 200 200\n   maximum-paths 4 ecmp 4\n   neighbor EVPN-OVERLAY-PEERS peer\
+    \ group\n   neighbor EVPN-OVERLAY-PEERS remote-as 65001\n   neighbor EVPN-OVERLAY-PEERS\
     \ update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS\
     \ ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n\
     \   neighbor EVPN-OVERLAY-PEERS send-community\n   neighbor EVPN-OVERLAY-PEERS\
@@ -709,25 +729,27 @@ CVP_CONFIGLETS:
     \ none\n!\nno aaa root\n!\nusername admin privilege 15 role network-admin nopassword\n\
     username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n\
     !\nvrf instance MGMT\n!\ninterface Ethernet1\n   description P2P_LINK_TO_DC1-LEAF1A_Ethernet1\n\
-    \   no switchport\n   ip address 172.31.255.0/31\n!\ninterface Ethernet2\n   description\
-    \ P2P_LINK_TO_DC1-LEAF2A_Ethernet1\n   no switchport\n   ip address 172.31.255.8/31\n\
-    !\ninterface Ethernet3\n   description P2P_LINK_TO_DC1-LEAF2B_Ethernet1\n   no\
-    \ switchport\n   ip address 172.31.255.16/31\n!\ninterface Ethernet4\n   description\
-    \ P2P_LINK_TO_DC1-SVC3A_Ethernet1\n   no switchport\n   ip address 172.31.255.24/31\n\
-    !\ninterface Ethernet5\n   description P2P_LINK_TO_DC1-SVC3B_Ethernet1\n   no\
-    \ switchport\n   ip address 172.31.255.32/31\n!\ninterface Ethernet6\n   description\
-    \ P2P_LINK_TO_DC1-BL1A_Ethernet1\n   no switchport\n   ip address 172.31.255.40/31\n\
-    !\ninterface Ethernet7\n   description P2P_LINK_TO_DC1-BL1B_Ethernet1\n   no switchport\n\
-    \   ip address 172.31.255.48/31\n!\ninterface Loopback0\n   description EVPN_Overlay_Peering\n\
-    \   ip address 192.168.255.1/32\n!\ninterface Management1\n   description oob_management\n\
-    \   vrf MGMT\n   ip address 192.168.200.101/24\n!\nip routing\nno ip routing vrf\
-    \ MGMT\n!\nip prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n   seq 10 permit 192.168.255.0/24\
-    \ le 32\n!\nip route vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nroute-map RM-CONN-2-BGP\
-    \ permit 10\n   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n!\nrouter\
-    \ bfd\n   multihop interval 1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65001\n\
-    \   router-id 192.168.255.1\n   no bgp default ipv4-unicast\n   distance bgp 20\
-    \ 200 200\n   maximum-paths 4 ecmp 4\n   neighbor EVPN-OVERLAY-PEERS peer group\n\
-    \   neighbor EVPN-OVERLAY-PEERS next-hop-unchanged\n   neighbor EVPN-OVERLAY-PEERS\
+    \   no shutdown\n   no switchport\n   ip address 172.31.255.0/31\n!\ninterface\
+    \ Ethernet2\n   description P2P_LINK_TO_DC1-LEAF2A_Ethernet1\n   no shutdown\n\
+    \   no switchport\n   ip address 172.31.255.8/31\n!\ninterface Ethernet3\n   description\
+    \ P2P_LINK_TO_DC1-LEAF2B_Ethernet1\n   no shutdown\n   no switchport\n   ip address\
+    \ 172.31.255.16/31\n!\ninterface Ethernet4\n   description P2P_LINK_TO_DC1-SVC3A_Ethernet1\n\
+    \   no shutdown\n   no switchport\n   ip address 172.31.255.24/31\n!\ninterface\
+    \ Ethernet5\n   description P2P_LINK_TO_DC1-SVC3B_Ethernet1\n   no shutdown\n\
+    \   no switchport\n   ip address 172.31.255.32/31\n!\ninterface Ethernet6\n  \
+    \ description P2P_LINK_TO_DC1-BL1A_Ethernet1\n   no shutdown\n   no switchport\n\
+    \   ip address 172.31.255.40/31\n!\ninterface Ethernet7\n   description P2P_LINK_TO_DC1-BL1B_Ethernet1\n\
+    \   no shutdown\n   no switchport\n   ip address 172.31.255.48/31\n!\ninterface\
+    \ Loopback0\n   description EVPN_Overlay_Peering\n   no shutdown\n   ip address\
+    \ 192.168.255.1/32\n!\ninterface Management1\n   description oob_management\n\
+    \   no shutdown\n   vrf MGMT\n   ip address 192.168.200.101/24\n!\nip routing\n\
+    no ip routing vrf MGMT\n!\nip prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n   seq 10\
+    \ permit 192.168.255.0/24 le 32\n!\nip route vrf MGMT 0.0.0.0/0 192.168.200.5\n\
+    !\nroute-map RM-CONN-2-BGP permit 10\n   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n\
+    !\nrouter bfd\n   multihop interval 1200 min-rx 1200 multiplier 3\n!\nrouter bgp\
+    \ 65001\n   router-id 192.168.255.1\n   no bgp default ipv4-unicast\n   distance\
+    \ bgp 20 200 200\n   maximum-paths 4 ecmp 4\n   neighbor EVPN-OVERLAY-PEERS peer\
+    \ group\n   neighbor EVPN-OVERLAY-PEERS next-hop-unchanged\n   neighbor EVPN-OVERLAY-PEERS\
     \ update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS\
     \ ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n\
     \   neighbor EVPN-OVERLAY-PEERS send-community\n   neighbor EVPN-OVERLAY-PEERS\
@@ -767,25 +789,27 @@ CVP_CONFIGLETS:
     \ none\n!\nno aaa root\n!\nusername admin privilege 15 role network-admin nopassword\n\
     username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n\
     !\nvrf instance MGMT\n!\ninterface Ethernet1\n   description P2P_LINK_TO_DC1-LEAF1A_Ethernet2\n\
-    \   no switchport\n   ip address 172.31.255.2/31\n!\ninterface Ethernet2\n   description\
-    \ P2P_LINK_TO_DC1-LEAF2A_Ethernet2\n   no switchport\n   ip address 172.31.255.10/31\n\
-    !\ninterface Ethernet3\n   description P2P_LINK_TO_DC1-LEAF2B_Ethernet2\n   no\
-    \ switchport\n   ip address 172.31.255.18/31\n!\ninterface Ethernet4\n   description\
-    \ P2P_LINK_TO_DC1-SVC3A_Ethernet2\n   no switchport\n   ip address 172.31.255.26/31\n\
-    !\ninterface Ethernet5\n   description P2P_LINK_TO_DC1-SVC3B_Ethernet2\n   no\
-    \ switchport\n   ip address 172.31.255.34/31\n!\ninterface Ethernet6\n   description\
-    \ P2P_LINK_TO_DC1-BL1A_Ethernet2\n   no switchport\n   ip address 172.31.255.42/31\n\
-    !\ninterface Ethernet7\n   description P2P_LINK_TO_DC1-BL1B_Ethernet2\n   no switchport\n\
-    \   ip address 172.31.255.50/31\n!\ninterface Loopback0\n   description EVPN_Overlay_Peering\n\
-    \   ip address 192.168.255.2/32\n!\ninterface Management1\n   description oob_management\n\
-    \   vrf MGMT\n   ip address 192.168.200.102/24\n!\nip routing\nno ip routing vrf\
-    \ MGMT\n!\nip prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n   seq 10 permit 192.168.255.0/24\
-    \ le 32\n!\nip route vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nroute-map RM-CONN-2-BGP\
-    \ permit 10\n   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n!\nrouter\
-    \ bfd\n   multihop interval 1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65001\n\
-    \   router-id 192.168.255.2\n   no bgp default ipv4-unicast\n   distance bgp 20\
-    \ 200 200\n   maximum-paths 4 ecmp 4\n   neighbor EVPN-OVERLAY-PEERS peer group\n\
-    \   neighbor EVPN-OVERLAY-PEERS next-hop-unchanged\n   neighbor EVPN-OVERLAY-PEERS\
+    \   no shutdown\n   no switchport\n   ip address 172.31.255.2/31\n!\ninterface\
+    \ Ethernet2\n   description P2P_LINK_TO_DC1-LEAF2A_Ethernet2\n   no shutdown\n\
+    \   no switchport\n   ip address 172.31.255.10/31\n!\ninterface Ethernet3\n  \
+    \ description P2P_LINK_TO_DC1-LEAF2B_Ethernet2\n   no shutdown\n   no switchport\n\
+    \   ip address 172.31.255.18/31\n!\ninterface Ethernet4\n   description P2P_LINK_TO_DC1-SVC3A_Ethernet2\n\
+    \   no shutdown\n   no switchport\n   ip address 172.31.255.26/31\n!\ninterface\
+    \ Ethernet5\n   description P2P_LINK_TO_DC1-SVC3B_Ethernet2\n   no shutdown\n\
+    \   no switchport\n   ip address 172.31.255.34/31\n!\ninterface Ethernet6\n  \
+    \ description P2P_LINK_TO_DC1-BL1A_Ethernet2\n   no shutdown\n   no switchport\n\
+    \   ip address 172.31.255.42/31\n!\ninterface Ethernet7\n   description P2P_LINK_TO_DC1-BL1B_Ethernet2\n\
+    \   no shutdown\n   no switchport\n   ip address 172.31.255.50/31\n!\ninterface\
+    \ Loopback0\n   description EVPN_Overlay_Peering\n   no shutdown\n   ip address\
+    \ 192.168.255.2/32\n!\ninterface Management1\n   description oob_management\n\
+    \   no shutdown\n   vrf MGMT\n   ip address 192.168.200.102/24\n!\nip routing\n\
+    no ip routing vrf MGMT\n!\nip prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n   seq 10\
+    \ permit 192.168.255.0/24 le 32\n!\nip route vrf MGMT 0.0.0.0/0 192.168.200.5\n\
+    !\nroute-map RM-CONN-2-BGP permit 10\n   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n\
+    !\nrouter bfd\n   multihop interval 1200 min-rx 1200 multiplier 3\n!\nrouter bgp\
+    \ 65001\n   router-id 192.168.255.2\n   no bgp default ipv4-unicast\n   distance\
+    \ bgp 20 200 200\n   maximum-paths 4 ecmp 4\n   neighbor EVPN-OVERLAY-PEERS peer\
+    \ group\n   neighbor EVPN-OVERLAY-PEERS next-hop-unchanged\n   neighbor EVPN-OVERLAY-PEERS\
     \ update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS\
     \ ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n\
     \   neighbor EVPN-OVERLAY-PEERS send-community\n   neighbor EVPN-OVERLAY-PEERS\
@@ -825,25 +849,27 @@ CVP_CONFIGLETS:
     \ none\n!\nno aaa root\n!\nusername admin privilege 15 role network-admin nopassword\n\
     username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n\
     !\nvrf instance MGMT\n!\ninterface Ethernet1\n   description P2P_LINK_TO_DC1-LEAF1A_Ethernet3\n\
-    \   no switchport\n   ip address 172.31.255.4/31\n!\ninterface Ethernet2\n   description\
-    \ P2P_LINK_TO_DC1-LEAF2A_Ethernet3\n   no switchport\n   ip address 172.31.255.12/31\n\
-    !\ninterface Ethernet3\n   description P2P_LINK_TO_DC1-LEAF2B_Ethernet3\n   no\
-    \ switchport\n   ip address 172.31.255.20/31\n!\ninterface Ethernet4\n   description\
-    \ P2P_LINK_TO_DC1-SVC3A_Ethernet3\n   no switchport\n   ip address 172.31.255.28/31\n\
-    !\ninterface Ethernet5\n   description P2P_LINK_TO_DC1-SVC3B_Ethernet3\n   no\
-    \ switchport\n   ip address 172.31.255.36/31\n!\ninterface Ethernet6\n   description\
-    \ P2P_LINK_TO_DC1-BL1A_Ethernet3\n   no switchport\n   ip address 172.31.255.44/31\n\
-    !\ninterface Ethernet7\n   description P2P_LINK_TO_DC1-BL1B_Ethernet3\n   no switchport\n\
-    \   ip address 172.31.255.52/31\n!\ninterface Loopback0\n   description EVPN_Overlay_Peering\n\
-    \   ip address 192.168.255.3/32\n!\ninterface Management1\n   description oob_management\n\
-    \   vrf MGMT\n   ip address 192.168.200.103/24\n!\nip routing\nno ip routing vrf\
-    \ MGMT\n!\nip prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n   seq 10 permit 192.168.255.0/24\
-    \ le 32\n!\nip route vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nroute-map RM-CONN-2-BGP\
-    \ permit 10\n   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n!\nrouter\
-    \ bfd\n   multihop interval 1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65001\n\
-    \   router-id 192.168.255.3\n   no bgp default ipv4-unicast\n   distance bgp 20\
-    \ 200 200\n   maximum-paths 4 ecmp 4\n   neighbor EVPN-OVERLAY-PEERS peer group\n\
-    \   neighbor EVPN-OVERLAY-PEERS next-hop-unchanged\n   neighbor EVPN-OVERLAY-PEERS\
+    \   no shutdown\n   no switchport\n   ip address 172.31.255.4/31\n!\ninterface\
+    \ Ethernet2\n   description P2P_LINK_TO_DC1-LEAF2A_Ethernet3\n   no shutdown\n\
+    \   no switchport\n   ip address 172.31.255.12/31\n!\ninterface Ethernet3\n  \
+    \ description P2P_LINK_TO_DC1-LEAF2B_Ethernet3\n   no shutdown\n   no switchport\n\
+    \   ip address 172.31.255.20/31\n!\ninterface Ethernet4\n   description P2P_LINK_TO_DC1-SVC3A_Ethernet3\n\
+    \   no shutdown\n   no switchport\n   ip address 172.31.255.28/31\n!\ninterface\
+    \ Ethernet5\n   description P2P_LINK_TO_DC1-SVC3B_Ethernet3\n   no shutdown\n\
+    \   no switchport\n   ip address 172.31.255.36/31\n!\ninterface Ethernet6\n  \
+    \ description P2P_LINK_TO_DC1-BL1A_Ethernet3\n   no shutdown\n   no switchport\n\
+    \   ip address 172.31.255.44/31\n!\ninterface Ethernet7\n   description P2P_LINK_TO_DC1-BL1B_Ethernet3\n\
+    \   no shutdown\n   no switchport\n   ip address 172.31.255.52/31\n!\ninterface\
+    \ Loopback0\n   description EVPN_Overlay_Peering\n   no shutdown\n   ip address\
+    \ 192.168.255.3/32\n!\ninterface Management1\n   description oob_management\n\
+    \   no shutdown\n   vrf MGMT\n   ip address 192.168.200.103/24\n!\nip routing\n\
+    no ip routing vrf MGMT\n!\nip prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n   seq 10\
+    \ permit 192.168.255.0/24 le 32\n!\nip route vrf MGMT 0.0.0.0/0 192.168.200.5\n\
+    !\nroute-map RM-CONN-2-BGP permit 10\n   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n\
+    !\nrouter bfd\n   multihop interval 1200 min-rx 1200 multiplier 3\n!\nrouter bgp\
+    \ 65001\n   router-id 192.168.255.3\n   no bgp default ipv4-unicast\n   distance\
+    \ bgp 20 200 200\n   maximum-paths 4 ecmp 4\n   neighbor EVPN-OVERLAY-PEERS peer\
+    \ group\n   neighbor EVPN-OVERLAY-PEERS next-hop-unchanged\n   neighbor EVPN-OVERLAY-PEERS\
     \ update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS\
     \ ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n\
     \   neighbor EVPN-OVERLAY-PEERS send-community\n   neighbor EVPN-OVERLAY-PEERS\
@@ -883,25 +909,27 @@ CVP_CONFIGLETS:
     \ none\n!\nno aaa root\n!\nusername admin privilege 15 role network-admin nopassword\n\
     username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n\
     !\nvrf instance MGMT\n!\ninterface Ethernet1\n   description P2P_LINK_TO_DC1-LEAF1A_Ethernet4\n\
-    \   no switchport\n   ip address 172.31.255.6/31\n!\ninterface Ethernet2\n   description\
-    \ P2P_LINK_TO_DC1-LEAF2A_Ethernet4\n   no switchport\n   ip address 172.31.255.14/31\n\
-    !\ninterface Ethernet3\n   description P2P_LINK_TO_DC1-LEAF2B_Ethernet4\n   no\
-    \ switchport\n   ip address 172.31.255.22/31\n!\ninterface Ethernet4\n   description\
-    \ P2P_LINK_TO_DC1-SVC3A_Ethernet4\n   no switchport\n   ip address 172.31.255.30/31\n\
-    !\ninterface Ethernet5\n   description P2P_LINK_TO_DC1-SVC3B_Ethernet4\n   no\
-    \ switchport\n   ip address 172.31.255.38/31\n!\ninterface Ethernet6\n   description\
-    \ P2P_LINK_TO_DC1-BL1A_Ethernet4\n   no switchport\n   ip address 172.31.255.46/31\n\
-    !\ninterface Ethernet7\n   description P2P_LINK_TO_DC1-BL1B_Ethernet4\n   no switchport\n\
-    \   ip address 172.31.255.54/31\n!\ninterface Loopback0\n   description EVPN_Overlay_Peering\n\
-    \   ip address 192.168.255.4/32\n!\ninterface Management1\n   description oob_management\n\
-    \   vrf MGMT\n   ip address 192.168.200.104/24\n!\nip routing\nno ip routing vrf\
-    \ MGMT\n!\nip prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n   seq 10 permit 192.168.255.0/24\
-    \ le 32\n!\nip route vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nroute-map RM-CONN-2-BGP\
-    \ permit 10\n   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n!\nrouter\
-    \ bfd\n   multihop interval 1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65001\n\
-    \   router-id 192.168.255.4\n   no bgp default ipv4-unicast\n   distance bgp 20\
-    \ 200 200\n   maximum-paths 4 ecmp 4\n   neighbor EVPN-OVERLAY-PEERS peer group\n\
-    \   neighbor EVPN-OVERLAY-PEERS next-hop-unchanged\n   neighbor EVPN-OVERLAY-PEERS\
+    \   no shutdown\n   no switchport\n   ip address 172.31.255.6/31\n!\ninterface\
+    \ Ethernet2\n   description P2P_LINK_TO_DC1-LEAF2A_Ethernet4\n   no shutdown\n\
+    \   no switchport\n   ip address 172.31.255.14/31\n!\ninterface Ethernet3\n  \
+    \ description P2P_LINK_TO_DC1-LEAF2B_Ethernet4\n   no shutdown\n   no switchport\n\
+    \   ip address 172.31.255.22/31\n!\ninterface Ethernet4\n   description P2P_LINK_TO_DC1-SVC3A_Ethernet4\n\
+    \   no shutdown\n   no switchport\n   ip address 172.31.255.30/31\n!\ninterface\
+    \ Ethernet5\n   description P2P_LINK_TO_DC1-SVC3B_Ethernet4\n   no shutdown\n\
+    \   no switchport\n   ip address 172.31.255.38/31\n!\ninterface Ethernet6\n  \
+    \ description P2P_LINK_TO_DC1-BL1A_Ethernet4\n   no shutdown\n   no switchport\n\
+    \   ip address 172.31.255.46/31\n!\ninterface Ethernet7\n   description P2P_LINK_TO_DC1-BL1B_Ethernet4\n\
+    \   no shutdown\n   no switchport\n   ip address 172.31.255.54/31\n!\ninterface\
+    \ Loopback0\n   description EVPN_Overlay_Peering\n   no shutdown\n   ip address\
+    \ 192.168.255.4/32\n!\ninterface Management1\n   description oob_management\n\
+    \   no shutdown\n   vrf MGMT\n   ip address 192.168.200.104/24\n!\nip routing\n\
+    no ip routing vrf MGMT\n!\nip prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n   seq 10\
+    \ permit 192.168.255.0/24 le 32\n!\nip route vrf MGMT 0.0.0.0/0 192.168.200.5\n\
+    !\nroute-map RM-CONN-2-BGP permit 10\n   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n\
+    !\nrouter bfd\n   multihop interval 1200 min-rx 1200 multiplier 3\n!\nrouter bgp\
+    \ 65001\n   router-id 192.168.255.4\n   no bgp default ipv4-unicast\n   distance\
+    \ bgp 20 200 200\n   maximum-paths 4 ecmp 4\n   neighbor EVPN-OVERLAY-PEERS peer\
+    \ group\n   neighbor EVPN-OVERLAY-PEERS next-hop-unchanged\n   neighbor EVPN-OVERLAY-PEERS\
     \ update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS\
     \ ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n\
     \   neighbor EVPN-OVERLAY-PEERS send-community\n   neighbor EVPN-OVERLAY-PEERS\
@@ -964,38 +992,42 @@ CVP_CONFIGLETS:
     !\nvrf instance Tenant_A_OP_Zone\n!\nvrf instance Tenant_A_WAN_Zone\n!\nvrf instance\
     \ Tenant_A_WEB_Zone\n!\nvrf instance Tenant_B_OP_Zone\n!\nvrf instance Tenant_B_WAN_Zone\n\
     !\nvrf instance Tenant_C_OP_Zone\n!\nvrf instance Tenant_C_WAN_Zone\n!\ninterface\
-    \ Port-Channel5\n   description MLAG_PEER_DC1-SVC3B_Po5\n   switchport\n   switchport\
-    \ trunk allowed vlan 2-4094\n   switchport mode trunk\n   switchport trunk group\
-    \ LEAF_PEER_L3\n   switchport trunk group MLAG\n!\ninterface Port-Channel7\n \
-    \  description DC1_L2LEAF2_Po1\n   switchport\n   switchport trunk allowed vlan\
-    \ 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350\n   switchport mode\
-    \ trunk\n   mlag 7\n!\ninterface Port-Channel10\n   description server03_ESI_PortChanne1\n\
-    \   switchport\n   switchport trunk allowed vlan 110-111,210-211\n   switchport\
-    \ mode trunk\n   mlag 10\n!\ninterface Ethernet1\n   description P2P_LINK_TO_DC1-SPINE1_Ethernet4\n\
+    \ Port-Channel5\n   description MLAG_PEER_DC1-SVC3B_Po5\n   no shutdown\n   switchport\n\
+    \   switchport trunk allowed vlan 2-4094\n   switchport mode trunk\n   switchport\
+    \ trunk group LEAF_PEER_L3\n   switchport trunk group MLAG\n!\ninterface Port-Channel7\n\
+    \   description DC1_L2LEAF2_Po1\n   no shutdown\n   switchport\n   switchport\
+    \ trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350\n\
+    \   switchport mode trunk\n   mlag 7\n!\ninterface Port-Channel10\n   description\
+    \ server03_ESI_PortChanne1\n   no shutdown\n   switchport\n   switchport trunk\
+    \ allowed vlan 110-111,210-211\n   switchport mode trunk\n   mlag 10\n!\ninterface\
+    \ Ethernet1\n   description P2P_LINK_TO_DC1-SPINE1_Ethernet4\n   no shutdown\n\
     \   no switchport\n   ip address 172.31.255.25/31\n!\ninterface Ethernet2\n  \
-    \ description P2P_LINK_TO_DC1-SPINE2_Ethernet4\n   no switchport\n   ip address\
-    \ 172.31.255.27/31\n!\ninterface Ethernet3\n   description P2P_LINK_TO_DC1-SPINE3_Ethernet4\n\
-    \   no switchport\n   ip address 172.31.255.29/31\n!\ninterface Ethernet4\n  \
-    \ description P2P_LINK_TO_DC1-SPINE4_Ethernet4\n   no switchport\n   ip address\
-    \ 172.31.255.31/31\n!\ninterface Ethernet5\n   description MLAG_PEER_DC1-SVC3B_Ethernet5\n\
-    \   channel-group 5 mode active\n!\ninterface Ethernet6\n   description MLAG_PEER_DC1-SVC3B_Ethernet6\n\
-    \   channel-group 5 mode active\n!\ninterface Ethernet7\n   description DC1-L2LEAF2A_Ethernet1\n\
-    \   channel-group 7 mode active\n!\ninterface Ethernet8\n   description DC1-L2LEAF2B_Ethernet1\n\
-    \   channel-group 7 mode active\n!\ninterface Ethernet10\n   description server03_ESI_Eth1\n\
-    \   channel-group 10 mode active\n!\ninterface Loopback0\n   description EVPN_Overlay_Peering\n\
-    \   ip address 192.168.255.8/32\n!\ninterface Loopback1\n   description VTEP_VXLAN_Tunnel_Source\n\
-    \   ip address 192.168.254.8/32\n!\ninterface Loopback100\n   description Tenant_A_OP_Zone_VTEP_DIAGNOSTICS\n\
-    \   vrf Tenant_A_OP_Zone\n   ip address 10.255.1.8/32\n!\ninterface Management1\n\
-    \   description oob_management\n   vrf MGMT\n   ip address 192.168.200.108/24\n\
-    !\ninterface Vlan110\n   description Tenant_A_OP_Zone_1\n   no shutdown\n   vrf\
-    \ Tenant_A_OP_Zone\n   ip address virtual 10.1.10.1/24\n!\ninterface Vlan111\n\
-    \   description Tenant_A_OP_Zone_2\n   no shutdown\n   vrf Tenant_A_OP_Zone\n\
-    \   ip address virtual 10.1.11.1/24\n   ip helper-address 1.1.1.1 vrf MGMT  source-interface\
-    \ lo100\n!\ninterface Vlan120\n   description Tenant_A_WEB_Zone_1\n   no shutdown\n\
-    \   vrf Tenant_A_WEB_Zone\n   ip address virtual 10.1.20.1/24\n   ip helper-address\
-    \ 1.1.1.1 vrf TEST  source-interface lo100\n!\ninterface Vlan121\n   description\
-    \ Tenant_A_WEBZone_2\n   shutdown\n   mtu 1560\n   vrf Tenant_A_WEB_Zone\n   ip\
-    \ address virtual 10.1.10.254/24\n!\ninterface Vlan130\n   description Tenant_A_APP_Zone_1\n\
+    \ description P2P_LINK_TO_DC1-SPINE2_Ethernet4\n   no shutdown\n   no switchport\n\
+    \   ip address 172.31.255.27/31\n!\ninterface Ethernet3\n   description P2P_LINK_TO_DC1-SPINE3_Ethernet4\n\
+    \   no shutdown\n   no switchport\n   ip address 172.31.255.29/31\n!\ninterface\
+    \ Ethernet4\n   description P2P_LINK_TO_DC1-SPINE4_Ethernet4\n   no shutdown\n\
+    \   no switchport\n   ip address 172.31.255.31/31\n!\ninterface Ethernet5\n  \
+    \ description MLAG_PEER_DC1-SVC3B_Ethernet5\n   no shutdown\n   channel-group\
+    \ 5 mode active\n!\ninterface Ethernet6\n   description MLAG_PEER_DC1-SVC3B_Ethernet6\n\
+    \   no shutdown\n   channel-group 5 mode active\n!\ninterface Ethernet7\n   description\
+    \ DC1-L2LEAF2A_Ethernet1\n   no shutdown\n   channel-group 7 mode active\n!\n\
+    interface Ethernet8\n   description DC1-L2LEAF2B_Ethernet1\n   no shutdown\n \
+    \  channel-group 7 mode active\n!\ninterface Ethernet10\n   description server03_ESI_Eth1\n\
+    \   no shutdown\n   channel-group 10 mode active\n!\ninterface Loopback0\n   description\
+    \ EVPN_Overlay_Peering\n   no shutdown\n   ip address 192.168.255.8/32\n!\ninterface\
+    \ Loopback1\n   description VTEP_VXLAN_Tunnel_Source\n   no shutdown\n   ip address\
+    \ 192.168.254.8/32\n!\ninterface Loopback100\n   description Tenant_A_OP_Zone_VTEP_DIAGNOSTICS\n\
+    \   no shutdown\n   vrf Tenant_A_OP_Zone\n   ip address 10.255.1.8/32\n!\ninterface\
+    \ Management1\n   description oob_management\n   no shutdown\n   vrf MGMT\n  \
+    \ ip address 192.168.200.108/24\n!\ninterface Vlan110\n   description Tenant_A_OP_Zone_1\n\
+    \   no shutdown\n   vrf Tenant_A_OP_Zone\n   ip address virtual 10.1.10.1/24\n\
+    !\ninterface Vlan111\n   description Tenant_A_OP_Zone_2\n   no shutdown\n   vrf\
+    \ Tenant_A_OP_Zone\n   ip address virtual 10.1.11.1/24\n   ip helper-address 1.1.1.1\
+    \ vrf MGMT  source-interface lo100\n!\ninterface Vlan120\n   description Tenant_A_WEB_Zone_1\n\
+    \   no shutdown\n   vrf Tenant_A_WEB_Zone\n   ip address virtual 10.1.20.1/24\n\
+    \   ip helper-address 1.1.1.1 vrf TEST  source-interface lo100\n!\ninterface Vlan121\n\
+    \   description Tenant_A_WEBZone_2\n   shutdown\n   mtu 1560\n   vrf Tenant_A_WEB_Zone\n\
+    \   ip address virtual 10.1.10.254/24\n!\ninterface Vlan130\n   description Tenant_A_APP_Zone_1\n\
     \   no shutdown\n   vrf Tenant_A_APP_Zone\n   ip address virtual 10.1.30.1/24\n\
     !\ninterface Vlan131\n   description Tenant_A_APP_Zone_2\n   no shutdown\n   vrf\
     \ Tenant_A_APP_Zone\n   ip address virtual 10.1.31.1/24\n!\ninterface Vlan140\n\
@@ -1014,23 +1046,25 @@ CVP_CONFIGLETS:
     \   no shutdown\n   vrf Tenant_C_OP_Zone\n   ip address virtual 10.3.11.1/24\n\
     !\ninterface Vlan350\n   description Tenant_C_WAN_Zone_1\n   no shutdown\n   vrf\
     \ Tenant_C_WAN_Zone\n   ip address virtual 10.3.50.1/24\n!\ninterface Vlan3009\n\
-    \   description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone\n   vrf Tenant_A_OP_Zone\n\
-    \   ip address 10.255.251.6/31\n!\ninterface Vlan3010\n   description MLAG_PEER_L3_iBGP:\
-    \ vrf Tenant_A_WEB_Zone\n   vrf Tenant_A_WEB_Zone\n   ip address 10.255.251.6/31\n\
-    !\ninterface Vlan3011\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone\n\
-    \   vrf Tenant_A_APP_Zone\n   ip address 10.255.251.6/31\n!\ninterface Vlan3012\n\
-    \   description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone\n   vrf Tenant_A_DB_Zone\n\
-    \   ip address 10.255.251.6/31\n!\ninterface Vlan3013\n   description MLAG_PEER_L3_iBGP:\
-    \ vrf Tenant_A_WAN_Zone\n   vrf Tenant_A_WAN_Zone\n   ip address 10.255.251.6/31\n\
-    !\ninterface Vlan3019\n   description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone\n\
-    \   vrf Tenant_B_OP_Zone\n   ip address 10.255.251.6/31\n!\ninterface Vlan3020\n\
-    \   description MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone\n   vrf Tenant_B_WAN_Zone\n\
-    \   ip address 10.255.251.6/31\n!\ninterface Vlan3029\n   description MLAG_PEER_L3_iBGP:\
-    \ vrf Tenant_C_OP_Zone\n   vrf Tenant_C_OP_Zone\n   ip address 10.255.251.6/31\n\
-    !\ninterface Vlan3030\n   description MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone\n\
-    \   vrf Tenant_C_WAN_Zone\n   ip address 10.255.251.6/31\n!\ninterface Vlan4093\n\
-    \   description MLAG_PEER_L3_PEERING\n   ip address 10.255.251.6/31\n!\ninterface\
-    \ Vlan4094\n   description MLAG_PEER\n   no autostate\n   ip address 10.255.252.6/31\n\
+    \   description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone\n   no shutdown\n   vrf\
+    \ Tenant_A_OP_Zone\n   ip address 10.255.251.6/31\n!\ninterface Vlan3010\n   description\
+    \ MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone\n   no shutdown\n   vrf Tenant_A_WEB_Zone\n\
+    \   ip address 10.255.251.6/31\n!\ninterface Vlan3011\n   description MLAG_PEER_L3_iBGP:\
+    \ vrf Tenant_A_APP_Zone\n   no shutdown\n   vrf Tenant_A_APP_Zone\n   ip address\
+    \ 10.255.251.6/31\n!\ninterface Vlan3012\n   description MLAG_PEER_L3_iBGP: vrf\
+    \ Tenant_A_DB_Zone\n   no shutdown\n   vrf Tenant_A_DB_Zone\n   ip address 10.255.251.6/31\n\
+    !\ninterface Vlan3013\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone\n\
+    \   no shutdown\n   vrf Tenant_A_WAN_Zone\n   ip address 10.255.251.6/31\n!\n\
+    interface Vlan3019\n   description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone\n \
+    \  no shutdown\n   vrf Tenant_B_OP_Zone\n   ip address 10.255.251.6/31\n!\ninterface\
+    \ Vlan3020\n   description MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone\n   no shutdown\n\
+    \   vrf Tenant_B_WAN_Zone\n   ip address 10.255.251.6/31\n!\ninterface Vlan3029\n\
+    \   description MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone\n   no shutdown\n   vrf\
+    \ Tenant_C_OP_Zone\n   ip address 10.255.251.6/31\n!\ninterface Vlan3030\n   description\
+    \ MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone\n   no shutdown\n   vrf Tenant_C_WAN_Zone\n\
+    \   ip address 10.255.251.6/31\n!\ninterface Vlan4093\n   description MLAG_PEER_L3_PEERING\n\
+    \   no shutdown\n   ip address 10.255.251.6/31\n!\ninterface Vlan4094\n   description\
+    \ MLAG_PEER\n   no shutdown\n   no autostate\n   ip address 10.255.252.6/31\n\
     !\ninterface Vxlan1\n   vxlan source-interface Loopback1\n   vxlan virtual-router\
     \ encapsulation mac-address mlag-system-id\n   vxlan udp-port 4789\n   vxlan vlan\
     \ 110 vni 10110\n   vxlan vlan 111 vni 50111\n   vxlan vlan 120 vni 10120\n  \
@@ -1161,35 +1195,38 @@ CVP_CONFIGLETS:
     !\nvrf instance Tenant_A_OP_Zone\n!\nvrf instance Tenant_A_WAN_Zone\n!\nvrf instance\
     \ Tenant_A_WEB_Zone\n!\nvrf instance Tenant_B_OP_Zone\n!\nvrf instance Tenant_B_WAN_Zone\n\
     !\nvrf instance Tenant_C_OP_Zone\n!\nvrf instance Tenant_C_WAN_Zone\n!\ninterface\
-    \ Port-Channel5\n   description MLAG_PEER_DC1-SVC3A_Po5\n   switchport\n   switchport\
-    \ trunk allowed vlan 2-4094\n   switchport mode trunk\n   switchport trunk group\
-    \ LEAF_PEER_L3\n   switchport trunk group MLAG\n!\ninterface Port-Channel7\n \
-    \  description DC1_L2LEAF2_Po1\n   switchport\n   switchport trunk allowed vlan\
-    \ 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350\n   switchport mode\
-    \ trunk\n   mlag 7\n!\ninterface Ethernet1\n   description P2P_LINK_TO_DC1-SPINE1_Ethernet5\n\
-    \   no switchport\n   ip address 172.31.255.33/31\n!\ninterface Ethernet2\n  \
-    \ description P2P_LINK_TO_DC1-SPINE2_Ethernet5\n   no switchport\n   ip address\
-    \ 172.31.255.35/31\n!\ninterface Ethernet3\n   description P2P_LINK_TO_DC1-SPINE3_Ethernet5\n\
-    \   no switchport\n   ip address 172.31.255.37/31\n!\ninterface Ethernet4\n  \
-    \ description P2P_LINK_TO_DC1-SPINE4_Ethernet5\n   no switchport\n   ip address\
-    \ 172.31.255.39/31\n!\ninterface Ethernet5\n   description MLAG_PEER_DC1-SVC3A_Ethernet5\n\
-    \   channel-group 5 mode active\n!\ninterface Ethernet6\n   description MLAG_PEER_DC1-SVC3A_Ethernet6\n\
-    \   channel-group 5 mode active\n!\ninterface Ethernet7\n   description DC1-L2LEAF2A_Ethernet2\n\
-    \   channel-group 7 mode active\n!\ninterface Ethernet8\n   description DC1-L2LEAF2B_Ethernet2\n\
-    \   channel-group 7 mode active\n!\ninterface Loopback0\n   description EVPN_Overlay_Peering\n\
-    \   ip address 192.168.255.9/32\n!\ninterface Loopback1\n   description VTEP_VXLAN_Tunnel_Source\n\
-    \   ip address 192.168.254.8/32\n!\ninterface Loopback100\n   description Tenant_A_OP_Zone_VTEP_DIAGNOSTICS\n\
-    \   vrf Tenant_A_OP_Zone\n   ip address 10.255.1.9/32\n!\ninterface Management1\n\
-    \   description oob_management\n   vrf MGMT\n   ip address 192.168.200.109/24\n\
-    !\ninterface Vlan110\n   description Tenant_A_OP_Zone_1\n   no shutdown\n   vrf\
-    \ Tenant_A_OP_Zone\n   ip address virtual 10.1.10.1/24\n!\ninterface Vlan111\n\
-    \   description Tenant_A_OP_Zone_2\n   no shutdown\n   vrf Tenant_A_OP_Zone\n\
-    \   ip address virtual 10.1.11.1/24\n   ip helper-address 1.1.1.1 vrf MGMT  source-interface\
-    \ lo100\n!\ninterface Vlan120\n   description Tenant_A_WEB_Zone_1\n   no shutdown\n\
-    \   vrf Tenant_A_WEB_Zone\n   ip address virtual 10.1.20.1/24\n   ip helper-address\
-    \ 1.1.1.1 vrf TEST  source-interface lo100\n!\ninterface Vlan121\n   description\
-    \ Tenant_A_WEBZone_2\n   shutdown\n   mtu 1560\n   vrf Tenant_A_WEB_Zone\n   ip\
-    \ address virtual 10.1.10.254/24\n!\ninterface Vlan130\n   description Tenant_A_APP_Zone_1\n\
+    \ Port-Channel5\n   description MLAG_PEER_DC1-SVC3A_Po5\n   no shutdown\n   switchport\n\
+    \   switchport trunk allowed vlan 2-4094\n   switchport mode trunk\n   switchport\
+    \ trunk group LEAF_PEER_L3\n   switchport trunk group MLAG\n!\ninterface Port-Channel7\n\
+    \   description DC1_L2LEAF2_Po1\n   no shutdown\n   switchport\n   switchport\
+    \ trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350\n\
+    \   switchport mode trunk\n   mlag 7\n!\ninterface Ethernet1\n   description P2P_LINK_TO_DC1-SPINE1_Ethernet5\n\
+    \   no shutdown\n   no switchport\n   ip address 172.31.255.33/31\n!\ninterface\
+    \ Ethernet2\n   description P2P_LINK_TO_DC1-SPINE2_Ethernet5\n   no shutdown\n\
+    \   no switchport\n   ip address 172.31.255.35/31\n!\ninterface Ethernet3\n  \
+    \ description P2P_LINK_TO_DC1-SPINE3_Ethernet5\n   no shutdown\n   no switchport\n\
+    \   ip address 172.31.255.37/31\n!\ninterface Ethernet4\n   description P2P_LINK_TO_DC1-SPINE4_Ethernet5\n\
+    \   no shutdown\n   no switchport\n   ip address 172.31.255.39/31\n!\ninterface\
+    \ Ethernet5\n   description MLAG_PEER_DC1-SVC3A_Ethernet5\n   no shutdown\n  \
+    \ channel-group 5 mode active\n!\ninterface Ethernet6\n   description MLAG_PEER_DC1-SVC3A_Ethernet6\n\
+    \   no shutdown\n   channel-group 5 mode active\n!\ninterface Ethernet7\n   description\
+    \ DC1-L2LEAF2A_Ethernet2\n   no shutdown\n   channel-group 7 mode active\n!\n\
+    interface Ethernet8\n   description DC1-L2LEAF2B_Ethernet2\n   no shutdown\n \
+    \  channel-group 7 mode active\n!\ninterface Loopback0\n   description EVPN_Overlay_Peering\n\
+    \   no shutdown\n   ip address 192.168.255.9/32\n!\ninterface Loopback1\n   description\
+    \ VTEP_VXLAN_Tunnel_Source\n   no shutdown\n   ip address 192.168.254.8/32\n!\n\
+    interface Loopback100\n   description Tenant_A_OP_Zone_VTEP_DIAGNOSTICS\n   no\
+    \ shutdown\n   vrf Tenant_A_OP_Zone\n   ip address 10.255.1.9/32\n!\ninterface\
+    \ Management1\n   description oob_management\n   no shutdown\n   vrf MGMT\n  \
+    \ ip address 192.168.200.109/24\n!\ninterface Vlan110\n   description Tenant_A_OP_Zone_1\n\
+    \   no shutdown\n   vrf Tenant_A_OP_Zone\n   ip address virtual 10.1.10.1/24\n\
+    !\ninterface Vlan111\n   description Tenant_A_OP_Zone_2\n   no shutdown\n   vrf\
+    \ Tenant_A_OP_Zone\n   ip address virtual 10.1.11.1/24\n   ip helper-address 1.1.1.1\
+    \ vrf MGMT  source-interface lo100\n!\ninterface Vlan120\n   description Tenant_A_WEB_Zone_1\n\
+    \   no shutdown\n   vrf Tenant_A_WEB_Zone\n   ip address virtual 10.1.20.1/24\n\
+    \   ip helper-address 1.1.1.1 vrf TEST  source-interface lo100\n!\ninterface Vlan121\n\
+    \   description Tenant_A_WEBZone_2\n   shutdown\n   mtu 1560\n   vrf Tenant_A_WEB_Zone\n\
+    \   ip address virtual 10.1.10.254/24\n!\ninterface Vlan130\n   description Tenant_A_APP_Zone_1\n\
     \   no shutdown\n   vrf Tenant_A_APP_Zone\n   ip address virtual 10.1.30.1/24\n\
     !\ninterface Vlan131\n   description Tenant_A_APP_Zone_2\n   no shutdown\n   vrf\
     \ Tenant_A_APP_Zone\n   ip address virtual 10.1.31.1/24\n!\ninterface Vlan140\n\
@@ -1208,23 +1245,25 @@ CVP_CONFIGLETS:
     \   no shutdown\n   vrf Tenant_C_OP_Zone\n   ip address virtual 10.3.11.1/24\n\
     !\ninterface Vlan350\n   description Tenant_C_WAN_Zone_1\n   no shutdown\n   vrf\
     \ Tenant_C_WAN_Zone\n   ip address virtual 10.3.50.1/24\n!\ninterface Vlan3009\n\
-    \   description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone\n   vrf Tenant_A_OP_Zone\n\
-    \   ip address 10.255.251.7/31\n!\ninterface Vlan3010\n   description MLAG_PEER_L3_iBGP:\
-    \ vrf Tenant_A_WEB_Zone\n   vrf Tenant_A_WEB_Zone\n   ip address 10.255.251.7/31\n\
-    !\ninterface Vlan3011\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone\n\
-    \   vrf Tenant_A_APP_Zone\n   ip address 10.255.251.7/31\n!\ninterface Vlan3012\n\
-    \   description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone\n   vrf Tenant_A_DB_Zone\n\
-    \   ip address 10.255.251.7/31\n!\ninterface Vlan3013\n   description MLAG_PEER_L3_iBGP:\
-    \ vrf Tenant_A_WAN_Zone\n   vrf Tenant_A_WAN_Zone\n   ip address 10.255.251.7/31\n\
-    !\ninterface Vlan3019\n   description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone\n\
-    \   vrf Tenant_B_OP_Zone\n   ip address 10.255.251.7/31\n!\ninterface Vlan3020\n\
-    \   description MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone\n   vrf Tenant_B_WAN_Zone\n\
-    \   ip address 10.255.251.7/31\n!\ninterface Vlan3029\n   description MLAG_PEER_L3_iBGP:\
-    \ vrf Tenant_C_OP_Zone\n   vrf Tenant_C_OP_Zone\n   ip address 10.255.251.7/31\n\
-    !\ninterface Vlan3030\n   description MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone\n\
-    \   vrf Tenant_C_WAN_Zone\n   ip address 10.255.251.7/31\n!\ninterface Vlan4093\n\
-    \   description MLAG_PEER_L3_PEERING\n   ip address 10.255.251.7/31\n!\ninterface\
-    \ Vlan4094\n   description MLAG_PEER\n   no autostate\n   ip address 10.255.252.7/31\n\
+    \   description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone\n   no shutdown\n   vrf\
+    \ Tenant_A_OP_Zone\n   ip address 10.255.251.7/31\n!\ninterface Vlan3010\n   description\
+    \ MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone\n   no shutdown\n   vrf Tenant_A_WEB_Zone\n\
+    \   ip address 10.255.251.7/31\n!\ninterface Vlan3011\n   description MLAG_PEER_L3_iBGP:\
+    \ vrf Tenant_A_APP_Zone\n   no shutdown\n   vrf Tenant_A_APP_Zone\n   ip address\
+    \ 10.255.251.7/31\n!\ninterface Vlan3012\n   description MLAG_PEER_L3_iBGP: vrf\
+    \ Tenant_A_DB_Zone\n   no shutdown\n   vrf Tenant_A_DB_Zone\n   ip address 10.255.251.7/31\n\
+    !\ninterface Vlan3013\n   description MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone\n\
+    \   no shutdown\n   vrf Tenant_A_WAN_Zone\n   ip address 10.255.251.7/31\n!\n\
+    interface Vlan3019\n   description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone\n \
+    \  no shutdown\n   vrf Tenant_B_OP_Zone\n   ip address 10.255.251.7/31\n!\ninterface\
+    \ Vlan3020\n   description MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone\n   no shutdown\n\
+    \   vrf Tenant_B_WAN_Zone\n   ip address 10.255.251.7/31\n!\ninterface Vlan3029\n\
+    \   description MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone\n   no shutdown\n   vrf\
+    \ Tenant_C_OP_Zone\n   ip address 10.255.251.7/31\n!\ninterface Vlan3030\n   description\
+    \ MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone\n   no shutdown\n   vrf Tenant_C_WAN_Zone\n\
+    \   ip address 10.255.251.7/31\n!\ninterface Vlan4093\n   description MLAG_PEER_L3_PEERING\n\
+    \   no shutdown\n   ip address 10.255.251.7/31\n!\ninterface Vlan4094\n   description\
+    \ MLAG_PEER\n   no shutdown\n   no autostate\n   ip address 10.255.252.7/31\n\
     !\ninterface Vxlan1\n   vxlan source-interface Loopback1\n   vxlan virtual-router\
     \ encapsulation mac-address mlag-system-id\n   vxlan udp-port 4789\n   vxlan vlan\
     \ 110 vni 10110\n   vxlan vlan 111 vni 50111\n   vxlan vlan 120 vni 10120\n  \

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.110/24
 ```
@@ -364,10 +365,10 @@ vlan 350
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet6  |  routed  | - |  172.31.255.41/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet6  |  routed  | - |  172.31.255.43/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet6  |  routed  | - |  172.31.255.45/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet6  |  routed  | - |  172.31.255.47/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet6  |  routed  | - |  172.31.255.41/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet6  |  routed  | - |  172.31.255.43/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet6  |  routed  | - |  172.31.255.45/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet6  |  routed  | - |  172.31.255.47/31  |  default  |  1500  |  false  |  -  |  -  |
 
 ### Ethernet Interfaces Device Configuration
 
@@ -375,21 +376,25 @@ vlan 350
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet6
+   no shutdown
    no switchport
    ip address 172.31.255.41/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet6
+   no shutdown
    no switchport
    ip address 172.31.255.43/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet6
+   no shutdown
    no switchport
    ip address 172.31.255.45/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet6
+   no shutdown
    no switchport
    ip address 172.31.255.47/31
 ```
@@ -423,10 +428,12 @@ No port-channels defined
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.10/32
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.10/32
 ```
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -456,16 +456,19 @@ interface Loopback1
 !
 interface Vlan150
    description Tenant_A_WAN_Zone_1
+   no shutdown
    vrf Tenant_A_WAN_Zone
    ip address virtual 10.1.40.1/24
 !
 interface Vlan250
    description Tenant_B_WAN_Zone_1
+   no shutdown
    vrf Tenant_B_WAN_Zone
    ip address virtual 10.2.50.1/24
 !
 interface Vlan350
    description Tenant_C_WAN_Zone_1
+   no shutdown
    vrf Tenant_C_WAN_Zone
    ip address virtual 10.3.50.1/24
 ```

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.111/24
 ```
@@ -364,10 +365,10 @@ vlan 350
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet7  |  routed  | - |  172.31.255.49/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet7  |  routed  | - |  172.31.255.51/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet7  |  routed  | - |  172.31.255.53/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet7  |  routed  | - |  172.31.255.55/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet7  |  routed  | - |  172.31.255.49/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet7  |  routed  | - |  172.31.255.51/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet7  |  routed  | - |  172.31.255.53/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet7  |  routed  | - |  172.31.255.55/31  |  default  |  1500  |  false  |  -  |  -  |
 
 ### Ethernet Interfaces Device Configuration
 
@@ -375,21 +376,25 @@ vlan 350
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet7
+   no shutdown
    no switchport
    ip address 172.31.255.49/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet7
+   no shutdown
    no switchport
    ip address 172.31.255.51/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet7
+   no shutdown
    no switchport
    ip address 172.31.255.53/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet7
+   no shutdown
    no switchport
    ip address 172.31.255.55/31
 ```
@@ -423,10 +428,12 @@ No port-channels defined
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.11/32
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.11/32
 ```
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -456,16 +456,19 @@ interface Loopback1
 !
 interface Vlan150
    description Tenant_A_WAN_Zone_1
+   no shutdown
    vrf Tenant_A_WAN_Zone
    ip address virtual 10.1.40.1/24
 !
 interface Vlan250
    description Tenant_B_WAN_Zone_1
+   no shutdown
    vrf Tenant_B_WAN_Zone
    ip address virtual 10.2.50.1/24
 !
 interface Vlan350
    description Tenant_C_WAN_Zone_1
+   no shutdown
    vrf Tenant_C_WAN_Zone
    ip address virtual 10.3.50.1/24
 ```

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF1A.md
@@ -411,6 +411,7 @@ interface Ethernet2
 !
 interface Port-Channel1
    description DC1-LEAF2A_Po7
+   switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,160-161
    switchport mode trunk
 ```

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF1A.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.112/24
 ```
@@ -388,10 +389,12 @@ vlan 161
 !
 interface Ethernet1
    description DC1-LEAF2A_Ethernet7
+   no shutdown
    channel-group 1 mode active
 !
 interface Ethernet2
    description DC1-LEAF2B_Ethernet7
+   no shutdown
    channel-group 1 mode active
 ```
 
@@ -403,7 +406,7 @@ interface Ethernet2
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel1 | DC1-LEAF2A_Po7 | switched | access | 110-111,120-121,130-131,160-161 | - | - | - | - | - | - |
+| Port-Channel1 | DC1-LEAF2A_Po7 | switched | trunk | 110-111,120-121,130-131,160-161 | - | - | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -411,6 +414,7 @@ interface Ethernet2
 !
 interface Port-Channel1
    description DC1-LEAF2A_Po7
+   no shutdown
    switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,160-161
    switchport mode trunk

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF2A.md
@@ -483,12 +483,14 @@ interface Ethernet4
 !
 interface Port-Channel1
    description DC1-SVC3A_Po7
+   switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350
    switchport mode trunk
    mlag 1
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-L2LEAF2B_Po3
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group MLAG

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF2A.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.113/24
 ```
@@ -451,18 +452,22 @@ vlan 4094
 !
 interface Ethernet1
    description DC1-SVC3A_Ethernet7
+   no shutdown
    channel-group 1 mode active
 !
 interface Ethernet2
    description DC1-SVC3B_Ethernet7
+   no shutdown
    channel-group 1 mode active
 !
 interface Ethernet3
    description MLAG_PEER_DC1-L2LEAF2B_Ethernet3
+   no shutdown
    channel-group 3 mode active
 !
 interface Ethernet4
    description MLAG_PEER_DC1-L2LEAF2B_Ethernet4
+   no shutdown
    channel-group 3 mode active
 ```
 
@@ -474,8 +479,8 @@ interface Ethernet4
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel1 | DC1-SVC3A_Po7 | switched | access | 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350 | - | - | - | - | 1 | - |
-| Port-Channel3 | MLAG_PEER_DC1-L2LEAF2B_Po3 | switched | access | 2-4094 | - | ['MLAG'] | - | - | - | - |
+| Port-Channel1 | DC1-SVC3A_Po7 | switched | trunk | 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350 | - | - | - | - | 1 | - |
+| Port-Channel3 | MLAG_PEER_DC1-L2LEAF2B_Po3 | switched | trunk | 2-4094 | - | ['MLAG'] | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -483,6 +488,7 @@ interface Ethernet4
 !
 interface Port-Channel1
    description DC1-SVC3A_Po7
+   no shutdown
    switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350
    switchport mode trunk
@@ -490,6 +496,7 @@ interface Port-Channel1
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-L2LEAF2B_Po3
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -506,7 +513,7 @@ No loopback interfaces defined
 
 | Interface | Description | VRF |  MTU | Shutdown |
 | --------- | ----------- | --- | ---- | -------- |
-| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  -  |
+| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  false  |
 
 #### IPv4
 
@@ -522,6 +529,7 @@ No loopback interfaces defined
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.16/31
 ```

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF2B.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.114/24
 ```
@@ -451,18 +452,22 @@ vlan 4094
 !
 interface Ethernet1
    description DC1-SVC3A_Ethernet8
+   no shutdown
    channel-group 1 mode active
 !
 interface Ethernet2
    description DC1-SVC3B_Ethernet8
+   no shutdown
    channel-group 1 mode active
 !
 interface Ethernet3
    description MLAG_PEER_DC1-L2LEAF2A_Ethernet3
+   no shutdown
    channel-group 3 mode active
 !
 interface Ethernet4
    description MLAG_PEER_DC1-L2LEAF2A_Ethernet4
+   no shutdown
    channel-group 3 mode active
 ```
 
@@ -474,8 +479,8 @@ interface Ethernet4
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel1 | DC1-SVC3B_Po7 | switched | access | 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350 | - | - | - | - | 1 | - |
-| Port-Channel3 | MLAG_PEER_DC1-L2LEAF2A_Po3 | switched | access | 2-4094 | - | ['MLAG'] | - | - | - | - |
+| Port-Channel1 | DC1-SVC3B_Po7 | switched | trunk | 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350 | - | - | - | - | 1 | - |
+| Port-Channel3 | MLAG_PEER_DC1-L2LEAF2A_Po3 | switched | trunk | 2-4094 | - | ['MLAG'] | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -483,6 +488,7 @@ interface Ethernet4
 !
 interface Port-Channel1
    description DC1-SVC3B_Po7
+   no shutdown
    switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350
    switchport mode trunk
@@ -490,6 +496,7 @@ interface Port-Channel1
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-L2LEAF2A_Po3
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -506,7 +513,7 @@ No loopback interfaces defined
 
 | Interface | Description | VRF |  MTU | Shutdown |
 | --------- | ----------- | --- | ---- | -------- |
-| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  -  |
+| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  false  |
 
 #### IPv4
 
@@ -522,6 +529,7 @@ No loopback interfaces defined
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.17/31
 ```

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF2B.md
@@ -483,12 +483,14 @@ interface Ethernet4
 !
 interface Port-Channel1
    description DC1-SVC3B_Po7
+   switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350
    switchport mode trunk
    mlag 1
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-L2LEAF2A_Po3
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group MLAG

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.105/24
 ```
@@ -370,10 +371,10 @@ vlan 131
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet1  |  routed  | - |  172.31.255.1/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet1  |  routed  | - |  172.31.255.3/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet1  |  routed  | - |  172.31.255.5/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet1  |  routed  | - |  172.31.255.7/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet1  |  routed  | - |  172.31.255.1/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet1  |  routed  | - |  172.31.255.3/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet1  |  routed  | - |  172.31.255.5/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet1  |  routed  | - |  172.31.255.7/31  |  default  |  1500  |  false  |  -  |  -  |
 
 ### Ethernet Interfaces Device Configuration
 
@@ -381,26 +382,31 @@ vlan 131
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.1/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.3/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.5/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.7/31
 !
 interface Ethernet6
    description server02_SINGLE_NODE_TRUNK_Eth1
+   no shutdown
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
@@ -413,6 +419,7 @@ interface Ethernet6
 !
 interface Ethernet7
    description server02_SINGLE_NODE_Eth1
+   no shutdown
    switchport
    switchport access vlan 110
 ```
@@ -446,10 +453,12 @@ No port-channels defined
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.5/32
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.5/32
 ```
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -401,6 +401,7 @@ interface Ethernet4
 !
 interface Ethernet6
    description server02_SINGLE_NODE_TRUNK_Eth1
+   switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
    spanning-tree portfast
@@ -412,6 +413,7 @@ interface Ethernet6
 !
 interface Ethernet7
    description server02_SINGLE_NODE_Eth1
+   switchport
    switchport access vlan 110
 ```
 
@@ -479,6 +481,7 @@ interface Loopback1
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST  source-interface lo100
@@ -492,11 +495,13 @@ interface Vlan121
 !
 interface Vlan130
    description Tenant_A_APP_Zone_1
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.30.1/24
 !
 interface Vlan131
    description Tenant_A_APP_Zone_2
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.31.1/24
 ```

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.106/24
 ```
@@ -474,10 +475,10 @@ vlan 4094
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet2  |  routed  | - |  172.31.255.9/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet2  |  routed  | - |  172.31.255.11/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet2  |  routed  | - |  172.31.255.13/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet2  |  routed  | - |  172.31.255.15/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet2  |  routed  | - |  172.31.255.9/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet2  |  routed  | - |  172.31.255.11/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet2  |  routed  | - |  172.31.255.13/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet2  |  routed  | - |  172.31.255.15/31  |  default  |  1500  |  false  |  -  |  -  |
 
 ### Ethernet Interfaces Device Configuration
 
@@ -485,38 +486,46 @@ vlan 4094
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.9/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.11/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.13/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.15/31
 !
 interface Ethernet5
    description MLAG_PEER_DC1-LEAF2B_Ethernet5
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-LEAF2B_Ethernet6
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet7
    description DC1-L2LEAF1A_Ethernet1
+   no shutdown
    channel-group 7 mode active
 !
 interface Ethernet10
    description server01_MLAG_Eth2
+   no shutdown
    channel-group 10 mode active
 ```
 
@@ -528,9 +537,9 @@ interface Ethernet10
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel5 | MLAG_PEER_DC1-LEAF2B_Po5 | switched | access | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
-| Port-Channel7 | DC1_L2LEAF1_Po1 | switched | access | 110-111,120-121,130-131,160-161 | - | - | - | - | 7 | - |
-| Port-Channel10 | server01_MLAG_PortChanne1 | switched | access | 210-211 | - | - | - | - | 10 | - |
+| Port-Channel5 | MLAG_PEER_DC1-LEAF2B_Po5 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
+| Port-Channel7 | DC1_L2LEAF1_Po1 | switched | trunk | 110-111,120-121,130-131,160-161 | - | - | - | - | 7 | - |
+| Port-Channel10 | server01_MLAG_PortChanne1 | switched | trunk | 210-211 | - | - | - | - | 10 | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -538,6 +547,7 @@ interface Ethernet10
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-LEAF2B_Po5
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -546,6 +556,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF1_Po1
+   no shutdown
    switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,160-161
    switchport mode trunk
@@ -553,6 +564,7 @@ interface Port-Channel7
 !
 interface Port-Channel10
    description server01_MLAG_PortChanne1
+   no shutdown
    switchport
    switchport trunk allowed vlan 210-211
    switchport mode trunk
@@ -586,14 +598,17 @@ interface Port-Channel10
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.6/32
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.6/32
 !
 interface Loopback100
    description Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address 10.255.1.6/32
 ```
@@ -616,14 +631,14 @@ interface Loopback100
 | Vlan211 |  Tenant_B_OP_Zone_2  |  Tenant_B_OP_Zone  |  -  |  false  |
 | Vlan310 |  Tenant_C_OP_Zone_1  |  Tenant_C_OP_Zone  |  -  |  false  |
 | Vlan311 |  Tenant_C_OP_Zone_2  |  Tenant_C_OP_Zone  |  -  |  false  |
-| Vlan3009 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone  |  Tenant_A_OP_Zone  |  -  |  -  |
-| Vlan3010 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone  |  Tenant_A_WEB_Zone  |  -  |  -  |
-| Vlan3011 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone  |  Tenant_A_APP_Zone  |  -  |  -  |
-| Vlan3012 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone  |  Tenant_A_DB_Zone  |  -  |  -  |
-| Vlan3019 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone  |  Tenant_B_OP_Zone  |  -  |  -  |
-| Vlan3029 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone  |  Tenant_C_OP_Zone  |  -  |  -  |
-| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  -  |
-| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  -  |
+| Vlan3009 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone  |  Tenant_A_OP_Zone  |  -  |  false  |
+| Vlan3010 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone  |  Tenant_A_WEB_Zone  |  -  |  false  |
+| Vlan3011 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone  |  Tenant_A_APP_Zone  |  -  |  false  |
+| Vlan3012 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone  |  Tenant_A_DB_Zone  |  -  |  false  |
+| Vlan3019 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone  |  Tenant_B_OP_Zone  |  -  |  false  |
+| Vlan3029 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone  |  Tenant_C_OP_Zone  |  -  |  false  |
+| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  false  |
+| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  false  |
 
 #### IPv4
 
@@ -733,40 +748,48 @@ interface Vlan311
 !
 interface Vlan3009
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address 10.255.251.2/31
 !
 interface Vlan3010
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address 10.255.251.2/31
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address 10.255.251.2/31
 !
 interface Vlan3012
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address 10.255.251.2/31
 !
 interface Vlan3019
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address 10.255.251.2/31
 !
 interface Vlan3029
    description MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address 10.255.251.2/31
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
+   no shutdown
    ip address 10.255.251.2/31
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.2/31
 ```

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -538,6 +538,7 @@ interface Ethernet10
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-LEAF2B_Po5
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -545,12 +546,14 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF1_Po1
+   switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,160-161
    switchport mode trunk
    mlag 7
 !
 interface Port-Channel10
    description server01_MLAG_PortChanne1
+   switchport
    switchport trunk allowed vlan 210-211
    switchport mode trunk
    mlag 10
@@ -655,17 +658,20 @@ interface Loopback100
 !
 interface Vlan110
    description Tenant_A_OP_Zone_1
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address virtual 10.1.10.1/24
 !
 interface Vlan111
    description Tenant_A_OP_Zone_2
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT  source-interface lo100
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST  source-interface lo100
@@ -679,41 +685,49 @@ interface Vlan121
 !
 interface Vlan130
    description Tenant_A_APP_Zone_1
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.30.1/24
 !
 interface Vlan131
    description Tenant_A_APP_Zone_2
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.31.1/24
 !
 interface Vlan140
    description Tenant_A_DB_BZone_1
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address virtual 10.1.40.1/24
 !
 interface Vlan141
    description Tenant_A_DB_Zone_2
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address virtual 10.1.41.1/24
 !
 interface Vlan210
    description Tenant_B_OP_Zone_1
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address virtual 10.2.10.1/24
 !
 interface Vlan211
    description Tenant_B_OP_Zone_2
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address virtual 10.2.11.1/24
 !
 interface Vlan310
    description Tenant_C_OP_Zone_1
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address virtual 10.3.10.1/24
 !
 interface Vlan311
    description Tenant_C_OP_Zone_2
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address virtual 10.3.11.1/24
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -538,6 +538,7 @@ interface Ethernet10
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-LEAF2A_Po5
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -545,12 +546,14 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF1_Po1
+   switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,160-161
    switchport mode trunk
    mlag 7
 !
 interface Port-Channel10
    description server01_MLAG_PortChanne1
+   switchport
    switchport trunk allowed vlan 210-211
    switchport mode trunk
    mlag 10
@@ -655,17 +658,20 @@ interface Loopback100
 !
 interface Vlan110
    description Tenant_A_OP_Zone_1
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address virtual 10.1.10.1/24
 !
 interface Vlan111
    description Tenant_A_OP_Zone_2
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT  source-interface lo100
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST  source-interface lo100
@@ -679,41 +685,49 @@ interface Vlan121
 !
 interface Vlan130
    description Tenant_A_APP_Zone_1
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.30.1/24
 !
 interface Vlan131
    description Tenant_A_APP_Zone_2
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.31.1/24
 !
 interface Vlan140
    description Tenant_A_DB_BZone_1
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address virtual 10.1.40.1/24
 !
 interface Vlan141
    description Tenant_A_DB_Zone_2
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address virtual 10.1.41.1/24
 !
 interface Vlan210
    description Tenant_B_OP_Zone_1
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address virtual 10.2.10.1/24
 !
 interface Vlan211
    description Tenant_B_OP_Zone_2
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address virtual 10.2.11.1/24
 !
 interface Vlan310
    description Tenant_C_OP_Zone_1
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address virtual 10.3.10.1/24
 !
 interface Vlan311
    description Tenant_C_OP_Zone_2
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address virtual 10.3.11.1/24
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.107/24
 ```
@@ -474,10 +475,10 @@ vlan 4094
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet3  |  routed  | - |  172.31.255.17/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet3  |  routed  | - |  172.31.255.19/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet3  |  routed  | - |  172.31.255.21/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet3  |  routed  | - |  172.31.255.23/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet3  |  routed  | - |  172.31.255.17/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet3  |  routed  | - |  172.31.255.19/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet3  |  routed  | - |  172.31.255.21/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet3  |  routed  | - |  172.31.255.23/31  |  default  |  1500  |  false  |  -  |  -  |
 
 ### Ethernet Interfaces Device Configuration
 
@@ -485,38 +486,46 @@ vlan 4094
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.17/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.19/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.21/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.23/31
 !
 interface Ethernet5
    description MLAG_PEER_DC1-LEAF2A_Ethernet5
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-LEAF2A_Ethernet6
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet7
    description DC1-L2LEAF1A_Ethernet2
+   no shutdown
    channel-group 7 mode active
 !
 interface Ethernet10
    description server01_MLAG_Eth3
+   no shutdown
    channel-group 10 mode active
 ```
 
@@ -528,9 +537,9 @@ interface Ethernet10
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel5 | MLAG_PEER_DC1-LEAF2A_Po5 | switched | access | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
-| Port-Channel7 | DC1_L2LEAF1_Po1 | switched | access | 110-111,120-121,130-131,160-161 | - | - | - | - | 7 | - |
-| Port-Channel10 | server01_MLAG_PortChanne1 | switched | access | 210-211 | - | - | - | - | 10 | - |
+| Port-Channel5 | MLAG_PEER_DC1-LEAF2A_Po5 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
+| Port-Channel7 | DC1_L2LEAF1_Po1 | switched | trunk | 110-111,120-121,130-131,160-161 | - | - | - | - | 7 | - |
+| Port-Channel10 | server01_MLAG_PortChanne1 | switched | trunk | 210-211 | - | - | - | - | 10 | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -538,6 +547,7 @@ interface Ethernet10
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-LEAF2A_Po5
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -546,6 +556,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF1_Po1
+   no shutdown
    switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,160-161
    switchport mode trunk
@@ -553,6 +564,7 @@ interface Port-Channel7
 !
 interface Port-Channel10
    description server01_MLAG_PortChanne1
+   no shutdown
    switchport
    switchport trunk allowed vlan 210-211
    switchport mode trunk
@@ -586,14 +598,17 @@ interface Port-Channel10
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.7/32
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.6/32
 !
 interface Loopback100
    description Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address 10.255.1.7/32
 ```
@@ -616,14 +631,14 @@ interface Loopback100
 | Vlan211 |  Tenant_B_OP_Zone_2  |  Tenant_B_OP_Zone  |  -  |  false  |
 | Vlan310 |  Tenant_C_OP_Zone_1  |  Tenant_C_OP_Zone  |  -  |  false  |
 | Vlan311 |  Tenant_C_OP_Zone_2  |  Tenant_C_OP_Zone  |  -  |  false  |
-| Vlan3009 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone  |  Tenant_A_OP_Zone  |  -  |  -  |
-| Vlan3010 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone  |  Tenant_A_WEB_Zone  |  -  |  -  |
-| Vlan3011 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone  |  Tenant_A_APP_Zone  |  -  |  -  |
-| Vlan3012 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone  |  Tenant_A_DB_Zone  |  -  |  -  |
-| Vlan3019 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone  |  Tenant_B_OP_Zone  |  -  |  -  |
-| Vlan3029 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone  |  Tenant_C_OP_Zone  |  -  |  -  |
-| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  -  |
-| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  -  |
+| Vlan3009 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone  |  Tenant_A_OP_Zone  |  -  |  false  |
+| Vlan3010 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone  |  Tenant_A_WEB_Zone  |  -  |  false  |
+| Vlan3011 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone  |  Tenant_A_APP_Zone  |  -  |  false  |
+| Vlan3012 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone  |  Tenant_A_DB_Zone  |  -  |  false  |
+| Vlan3019 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone  |  Tenant_B_OP_Zone  |  -  |  false  |
+| Vlan3029 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone  |  Tenant_C_OP_Zone  |  -  |  false  |
+| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  false  |
+| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  false  |
 
 #### IPv4
 
@@ -733,40 +748,48 @@ interface Vlan311
 !
 interface Vlan3009
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address 10.255.251.3/31
 !
 interface Vlan3010
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address 10.255.251.3/31
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address 10.255.251.3/31
 !
 interface Vlan3012
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address 10.255.251.3/31
 !
 interface Vlan3019
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address 10.255.251.3/31
 !
 interface Vlan3029
    description MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address 10.255.251.3/31
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
+   no shutdown
    ip address 10.255.251.3/31
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.3/31
 ```

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE1.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.101/24
 ```
@@ -337,13 +338,13 @@ No VLANs defined
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 |  P2P_LINK_TO_DC1-LEAF1A_Ethernet1  |  routed  | - |  172.31.255.0/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet2 |  P2P_LINK_TO_DC1-LEAF2A_Ethernet1  |  routed  | - |  172.31.255.8/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet3 |  P2P_LINK_TO_DC1-LEAF2B_Ethernet1  |  routed  | - |  172.31.255.16/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet4 |  P2P_LINK_TO_DC1-SVC3A_Ethernet1  |  routed  | - |  172.31.255.24/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet5 |  P2P_LINK_TO_DC1-SVC3B_Ethernet1  |  routed  | - |  172.31.255.32/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet6 |  P2P_LINK_TO_DC1-BL1A_Ethernet1  |  routed  | - |  172.31.255.40/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet7 |  P2P_LINK_TO_DC1-BL1B_Ethernet1  |  routed  | - |  172.31.255.48/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet1 |  P2P_LINK_TO_DC1-LEAF1A_Ethernet1  |  routed  | - |  172.31.255.0/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet2 |  P2P_LINK_TO_DC1-LEAF2A_Ethernet1  |  routed  | - |  172.31.255.8/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet3 |  P2P_LINK_TO_DC1-LEAF2B_Ethernet1  |  routed  | - |  172.31.255.16/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4 |  P2P_LINK_TO_DC1-SVC3A_Ethernet1  |  routed  | - |  172.31.255.24/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet5 |  P2P_LINK_TO_DC1-SVC3B_Ethernet1  |  routed  | - |  172.31.255.32/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet6 |  P2P_LINK_TO_DC1-BL1A_Ethernet1  |  routed  | - |  172.31.255.40/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet7 |  P2P_LINK_TO_DC1-BL1B_Ethernet1  |  routed  | - |  172.31.255.48/31  |  default  |  1500  |  false  |  -  |  -  |
 
 ### Ethernet Interfaces Device Configuration
 
@@ -351,36 +352,43 @@ No VLANs defined
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.0/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-LEAF2A_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.8/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-LEAF2B_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.16/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SVC3A_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.24/31
 !
 interface Ethernet5
    description P2P_LINK_TO_DC1-SVC3B_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.32/31
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-BL1A_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.40/31
 !
 interface Ethernet7
    description P2P_LINK_TO_DC1-BL1B_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.48/31
 ```
@@ -412,6 +420,7 @@ No port-channels defined
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.1/32
 ```
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE2.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.102/24
 ```
@@ -337,13 +338,13 @@ No VLANs defined
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 |  P2P_LINK_TO_DC1-LEAF1A_Ethernet2  |  routed  | - |  172.31.255.2/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet2 |  P2P_LINK_TO_DC1-LEAF2A_Ethernet2  |  routed  | - |  172.31.255.10/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet3 |  P2P_LINK_TO_DC1-LEAF2B_Ethernet2  |  routed  | - |  172.31.255.18/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet4 |  P2P_LINK_TO_DC1-SVC3A_Ethernet2  |  routed  | - |  172.31.255.26/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet5 |  P2P_LINK_TO_DC1-SVC3B_Ethernet2  |  routed  | - |  172.31.255.34/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet6 |  P2P_LINK_TO_DC1-BL1A_Ethernet2  |  routed  | - |  172.31.255.42/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet7 |  P2P_LINK_TO_DC1-BL1B_Ethernet2  |  routed  | - |  172.31.255.50/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet1 |  P2P_LINK_TO_DC1-LEAF1A_Ethernet2  |  routed  | - |  172.31.255.2/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet2 |  P2P_LINK_TO_DC1-LEAF2A_Ethernet2  |  routed  | - |  172.31.255.10/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet3 |  P2P_LINK_TO_DC1-LEAF2B_Ethernet2  |  routed  | - |  172.31.255.18/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4 |  P2P_LINK_TO_DC1-SVC3A_Ethernet2  |  routed  | - |  172.31.255.26/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet5 |  P2P_LINK_TO_DC1-SVC3B_Ethernet2  |  routed  | - |  172.31.255.34/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet6 |  P2P_LINK_TO_DC1-BL1A_Ethernet2  |  routed  | - |  172.31.255.42/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet7 |  P2P_LINK_TO_DC1-BL1B_Ethernet2  |  routed  | - |  172.31.255.50/31  |  default  |  1500  |  false  |  -  |  -  |
 
 ### Ethernet Interfaces Device Configuration
 
@@ -351,36 +352,43 @@ No VLANs defined
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.2/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-LEAF2A_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.10/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-LEAF2B_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.18/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SVC3A_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.26/31
 !
 interface Ethernet5
    description P2P_LINK_TO_DC1-SVC3B_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.34/31
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-BL1A_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.42/31
 !
 interface Ethernet7
    description P2P_LINK_TO_DC1-BL1B_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.50/31
 ```
@@ -412,6 +420,7 @@ No port-channels defined
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.2/32
 ```
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE3.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.103/24
 ```
@@ -337,13 +338,13 @@ No VLANs defined
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 |  P2P_LINK_TO_DC1-LEAF1A_Ethernet3  |  routed  | - |  172.31.255.4/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet2 |  P2P_LINK_TO_DC1-LEAF2A_Ethernet3  |  routed  | - |  172.31.255.12/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet3 |  P2P_LINK_TO_DC1-LEAF2B_Ethernet3  |  routed  | - |  172.31.255.20/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet4 |  P2P_LINK_TO_DC1-SVC3A_Ethernet3  |  routed  | - |  172.31.255.28/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet5 |  P2P_LINK_TO_DC1-SVC3B_Ethernet3  |  routed  | - |  172.31.255.36/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet6 |  P2P_LINK_TO_DC1-BL1A_Ethernet3  |  routed  | - |  172.31.255.44/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet7 |  P2P_LINK_TO_DC1-BL1B_Ethernet3  |  routed  | - |  172.31.255.52/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet1 |  P2P_LINK_TO_DC1-LEAF1A_Ethernet3  |  routed  | - |  172.31.255.4/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet2 |  P2P_LINK_TO_DC1-LEAF2A_Ethernet3  |  routed  | - |  172.31.255.12/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet3 |  P2P_LINK_TO_DC1-LEAF2B_Ethernet3  |  routed  | - |  172.31.255.20/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4 |  P2P_LINK_TO_DC1-SVC3A_Ethernet3  |  routed  | - |  172.31.255.28/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet5 |  P2P_LINK_TO_DC1-SVC3B_Ethernet3  |  routed  | - |  172.31.255.36/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet6 |  P2P_LINK_TO_DC1-BL1A_Ethernet3  |  routed  | - |  172.31.255.44/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet7 |  P2P_LINK_TO_DC1-BL1B_Ethernet3  |  routed  | - |  172.31.255.52/31  |  default  |  1500  |  false  |  -  |  -  |
 
 ### Ethernet Interfaces Device Configuration
 
@@ -351,36 +352,43 @@ No VLANs defined
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.4/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-LEAF2A_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.12/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-LEAF2B_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.20/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SVC3A_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.28/31
 !
 interface Ethernet5
    description P2P_LINK_TO_DC1-SVC3B_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.36/31
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-BL1A_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.44/31
 !
 interface Ethernet7
    description P2P_LINK_TO_DC1-BL1B_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.52/31
 ```
@@ -412,6 +420,7 @@ No port-channels defined
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.3/32
 ```
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE4.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.104/24
 ```
@@ -337,13 +338,13 @@ No VLANs defined
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 |  P2P_LINK_TO_DC1-LEAF1A_Ethernet4  |  routed  | - |  172.31.255.6/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet2 |  P2P_LINK_TO_DC1-LEAF2A_Ethernet4  |  routed  | - |  172.31.255.14/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet3 |  P2P_LINK_TO_DC1-LEAF2B_Ethernet4  |  routed  | - |  172.31.255.22/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet4 |  P2P_LINK_TO_DC1-SVC3A_Ethernet4  |  routed  | - |  172.31.255.30/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet5 |  P2P_LINK_TO_DC1-SVC3B_Ethernet4  |  routed  | - |  172.31.255.38/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet6 |  P2P_LINK_TO_DC1-BL1A_Ethernet4  |  routed  | - |  172.31.255.46/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet7 |  P2P_LINK_TO_DC1-BL1B_Ethernet4  |  routed  | - |  172.31.255.54/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet1 |  P2P_LINK_TO_DC1-LEAF1A_Ethernet4  |  routed  | - |  172.31.255.6/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet2 |  P2P_LINK_TO_DC1-LEAF2A_Ethernet4  |  routed  | - |  172.31.255.14/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet3 |  P2P_LINK_TO_DC1-LEAF2B_Ethernet4  |  routed  | - |  172.31.255.22/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4 |  P2P_LINK_TO_DC1-SVC3A_Ethernet4  |  routed  | - |  172.31.255.30/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet5 |  P2P_LINK_TO_DC1-SVC3B_Ethernet4  |  routed  | - |  172.31.255.38/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet6 |  P2P_LINK_TO_DC1-BL1A_Ethernet4  |  routed  | - |  172.31.255.46/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet7 |  P2P_LINK_TO_DC1-BL1B_Ethernet4  |  routed  | - |  172.31.255.54/31  |  default  |  1500  |  false  |  -  |  -  |
 
 ### Ethernet Interfaces Device Configuration
 
@@ -351,36 +352,43 @@ No VLANs defined
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.6/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-LEAF2A_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.14/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-LEAF2B_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.22/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SVC3A_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.30/31
 !
 interface Ethernet5
    description P2P_LINK_TO_DC1-SVC3B_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.38/31
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-BL1A_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.46/31
 !
 interface Ethernet7
    description P2P_LINK_TO_DC1-BL1B_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.54/31
 ```
@@ -412,6 +420,7 @@ No port-channels defined
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.4/32
 ```
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -570,6 +570,7 @@ interface Ethernet10
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-SVC3B_Po5
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -577,12 +578,14 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF2_Po1
+   switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350
    switchport mode trunk
    mlag 7
 !
 interface Port-Channel10
    description server03_ESI_PortChanne1
+   switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
    mlag 10
@@ -699,17 +702,20 @@ interface Loopback100
 !
 interface Vlan110
    description Tenant_A_OP_Zone_1
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address virtual 10.1.10.1/24
 !
 interface Vlan111
    description Tenant_A_OP_Zone_2
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT  source-interface lo100
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST  source-interface lo100
@@ -723,56 +729,67 @@ interface Vlan121
 !
 interface Vlan130
    description Tenant_A_APP_Zone_1
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.30.1/24
 !
 interface Vlan131
    description Tenant_A_APP_Zone_2
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.31.1/24
 !
 interface Vlan140
    description Tenant_A_DB_BZone_1
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address virtual 10.1.40.1/24
 !
 interface Vlan141
    description Tenant_A_DB_Zone_2
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address virtual 10.1.41.1/24
 !
 interface Vlan150
    description Tenant_A_WAN_Zone_1
+   no shutdown
    vrf Tenant_A_WAN_Zone
    ip address virtual 10.1.40.1/24
 !
 interface Vlan210
    description Tenant_B_OP_Zone_1
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address virtual 10.2.10.1/24
 !
 interface Vlan211
    description Tenant_B_OP_Zone_2
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address virtual 10.2.11.1/24
 !
 interface Vlan250
    description Tenant_B_WAN_Zone_1
+   no shutdown
    vrf Tenant_B_WAN_Zone
    ip address virtual 10.2.50.1/24
 !
 interface Vlan310
    description Tenant_C_OP_Zone_1
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address virtual 10.3.10.1/24
 !
 interface Vlan311
    description Tenant_C_OP_Zone_2
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address virtual 10.3.11.1/24
 !
 interface Vlan350
    description Tenant_C_WAN_Zone_1
+   no shutdown
    vrf Tenant_C_WAN_Zone
    ip address virtual 10.3.50.1/24
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.108/24
 ```
@@ -502,10 +503,10 @@ vlan 4094
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet4  |  routed  | - |  172.31.255.25/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet4  |  routed  | - |  172.31.255.27/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet4  |  routed  | - |  172.31.255.29/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet4  |  routed  | - |  172.31.255.31/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet4  |  routed  | - |  172.31.255.25/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet4  |  routed  | - |  172.31.255.27/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet4  |  routed  | - |  172.31.255.29/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet4  |  routed  | - |  172.31.255.31/31  |  default  |  1500  |  false  |  -  |  -  |
 
 ### Ethernet Interfaces Device Configuration
 
@@ -513,42 +514,51 @@ vlan 4094
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.25/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.27/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.29/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.31/31
 !
 interface Ethernet5
    description MLAG_PEER_DC1-SVC3B_Ethernet5
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-SVC3B_Ethernet6
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet7
    description DC1-L2LEAF2A_Ethernet1
+   no shutdown
    channel-group 7 mode active
 !
 interface Ethernet8
    description DC1-L2LEAF2B_Ethernet1
+   no shutdown
    channel-group 7 mode active
 !
 interface Ethernet10
    description server03_ESI_Eth1
+   no shutdown
    channel-group 10 mode active
 ```
 
@@ -560,9 +570,9 @@ interface Ethernet10
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel5 | MLAG_PEER_DC1-SVC3B_Po5 | switched | access | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
-| Port-Channel7 | DC1_L2LEAF2_Po1 | switched | access | 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350 | - | - | - | - | 7 | - |
-| Port-Channel10 | server03_ESI_PortChanne1 | switched | access | 110-111,210-211 | - | - | - | - | 10 | - |
+| Port-Channel5 | MLAG_PEER_DC1-SVC3B_Po5 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
+| Port-Channel7 | DC1_L2LEAF2_Po1 | switched | trunk | 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350 | - | - | - | - | 7 | - |
+| Port-Channel10 | server03_ESI_PortChanne1 | switched | trunk | 110-111,210-211 | - | - | - | - | 10 | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -570,6 +580,7 @@ interface Ethernet10
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-SVC3B_Po5
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -578,6 +589,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF2_Po1
+   no shutdown
    switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350
    switchport mode trunk
@@ -585,6 +597,7 @@ interface Port-Channel7
 !
 interface Port-Channel10
    description server03_ESI_PortChanne1
+   no shutdown
    switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
@@ -618,14 +631,17 @@ interface Port-Channel10
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.8/32
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.8/32
 !
 interface Loopback100
    description Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address 10.255.1.8/32
 ```
@@ -651,17 +667,17 @@ interface Loopback100
 | Vlan310 |  Tenant_C_OP_Zone_1  |  Tenant_C_OP_Zone  |  -  |  false  |
 | Vlan311 |  Tenant_C_OP_Zone_2  |  Tenant_C_OP_Zone  |  -  |  false  |
 | Vlan350 |  Tenant_C_WAN_Zone_1  |  Tenant_C_WAN_Zone  |  -  |  false  |
-| Vlan3009 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone  |  Tenant_A_OP_Zone  |  -  |  -  |
-| Vlan3010 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone  |  Tenant_A_WEB_Zone  |  -  |  -  |
-| Vlan3011 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone  |  Tenant_A_APP_Zone  |  -  |  -  |
-| Vlan3012 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone  |  Tenant_A_DB_Zone  |  -  |  -  |
-| Vlan3013 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone  |  Tenant_A_WAN_Zone  |  -  |  -  |
-| Vlan3019 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone  |  Tenant_B_OP_Zone  |  -  |  -  |
-| Vlan3020 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone  |  Tenant_B_WAN_Zone  |  -  |  -  |
-| Vlan3029 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone  |  Tenant_C_OP_Zone  |  -  |  -  |
-| Vlan3030 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone  |  Tenant_C_WAN_Zone  |  -  |  -  |
-| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  -  |
-| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  -  |
+| Vlan3009 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone  |  Tenant_A_OP_Zone  |  -  |  false  |
+| Vlan3010 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone  |  Tenant_A_WEB_Zone  |  -  |  false  |
+| Vlan3011 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone  |  Tenant_A_APP_Zone  |  -  |  false  |
+| Vlan3012 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone  |  Tenant_A_DB_Zone  |  -  |  false  |
+| Vlan3013 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone  |  Tenant_A_WAN_Zone  |  -  |  false  |
+| Vlan3019 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone  |  Tenant_B_OP_Zone  |  -  |  false  |
+| Vlan3020 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone  |  Tenant_B_WAN_Zone  |  -  |  false  |
+| Vlan3029 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone  |  Tenant_C_OP_Zone  |  -  |  false  |
+| Vlan3030 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone  |  Tenant_C_WAN_Zone  |  -  |  false  |
+| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  false  |
+| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  false  |
 
 #### IPv4
 
@@ -795,55 +811,66 @@ interface Vlan350
 !
 interface Vlan3009
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address 10.255.251.6/31
 !
 interface Vlan3010
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address 10.255.251.6/31
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address 10.255.251.6/31
 !
 interface Vlan3012
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address 10.255.251.6/31
 !
 interface Vlan3013
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone
+   no shutdown
    vrf Tenant_A_WAN_Zone
    ip address 10.255.251.6/31
 !
 interface Vlan3019
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address 10.255.251.6/31
 !
 interface Vlan3020
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone
+   no shutdown
    vrf Tenant_B_WAN_Zone
    ip address 10.255.251.6/31
 !
 interface Vlan3029
    description MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address 10.255.251.6/31
 !
 interface Vlan3030
    description MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone
+   no shutdown
    vrf Tenant_C_WAN_Zone
    ip address 10.255.251.6/31
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
+   no shutdown
    ip address 10.255.251.6/31
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.6/31
 ```

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.109/24
 ```
@@ -501,10 +502,10 @@ vlan 4094
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet5  |  routed  | - |  172.31.255.33/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet5  |  routed  | - |  172.31.255.35/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet5  |  routed  | - |  172.31.255.37/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet5  |  routed  | - |  172.31.255.39/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet5  |  routed  | - |  172.31.255.33/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet5  |  routed  | - |  172.31.255.35/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet5  |  routed  | - |  172.31.255.37/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet5  |  routed  | - |  172.31.255.39/31  |  default  |  1500  |  false  |  -  |  -  |
 
 ### Ethernet Interfaces Device Configuration
 
@@ -512,38 +513,46 @@ vlan 4094
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet5
+   no shutdown
    no switchport
    ip address 172.31.255.33/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet5
+   no shutdown
    no switchport
    ip address 172.31.255.35/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet5
+   no shutdown
    no switchport
    ip address 172.31.255.37/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet5
+   no shutdown
    no switchport
    ip address 172.31.255.39/31
 !
 interface Ethernet5
    description MLAG_PEER_DC1-SVC3A_Ethernet5
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-SVC3A_Ethernet6
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet7
    description DC1-L2LEAF2A_Ethernet2
+   no shutdown
    channel-group 7 mode active
 !
 interface Ethernet8
    description DC1-L2LEAF2B_Ethernet2
+   no shutdown
    channel-group 7 mode active
 ```
 
@@ -555,8 +564,8 @@ interface Ethernet8
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel5 | MLAG_PEER_DC1-SVC3A_Po5 | switched | access | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
-| Port-Channel7 | DC1_L2LEAF2_Po1 | switched | access | 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350 | - | - | - | - | 7 | - |
+| Port-Channel5 | MLAG_PEER_DC1-SVC3A_Po5 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
+| Port-Channel7 | DC1_L2LEAF2_Po1 | switched | trunk | 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350 | - | - | - | - | 7 | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -564,6 +573,7 @@ interface Ethernet8
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-SVC3A_Po5
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -572,6 +582,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF2_Po1
+   no shutdown
    switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350
    switchport mode trunk
@@ -605,14 +616,17 @@ interface Port-Channel7
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.9/32
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.8/32
 !
 interface Loopback100
    description Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address 10.255.1.9/32
 ```
@@ -638,17 +652,17 @@ interface Loopback100
 | Vlan310 |  Tenant_C_OP_Zone_1  |  Tenant_C_OP_Zone  |  -  |  false  |
 | Vlan311 |  Tenant_C_OP_Zone_2  |  Tenant_C_OP_Zone  |  -  |  false  |
 | Vlan350 |  Tenant_C_WAN_Zone_1  |  Tenant_C_WAN_Zone  |  -  |  false  |
-| Vlan3009 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone  |  Tenant_A_OP_Zone  |  -  |  -  |
-| Vlan3010 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone  |  Tenant_A_WEB_Zone  |  -  |  -  |
-| Vlan3011 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone  |  Tenant_A_APP_Zone  |  -  |  -  |
-| Vlan3012 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone  |  Tenant_A_DB_Zone  |  -  |  -  |
-| Vlan3013 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone  |  Tenant_A_WAN_Zone  |  -  |  -  |
-| Vlan3019 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone  |  Tenant_B_OP_Zone  |  -  |  -  |
-| Vlan3020 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone  |  Tenant_B_WAN_Zone  |  -  |  -  |
-| Vlan3029 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone  |  Tenant_C_OP_Zone  |  -  |  -  |
-| Vlan3030 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone  |  Tenant_C_WAN_Zone  |  -  |  -  |
-| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  -  |
-| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  -  |
+| Vlan3009 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone  |  Tenant_A_OP_Zone  |  -  |  false  |
+| Vlan3010 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone  |  Tenant_A_WEB_Zone  |  -  |  false  |
+| Vlan3011 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone  |  Tenant_A_APP_Zone  |  -  |  false  |
+| Vlan3012 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone  |  Tenant_A_DB_Zone  |  -  |  false  |
+| Vlan3013 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone  |  Tenant_A_WAN_Zone  |  -  |  false  |
+| Vlan3019 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone  |  Tenant_B_OP_Zone  |  -  |  false  |
+| Vlan3020 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone  |  Tenant_B_WAN_Zone  |  -  |  false  |
+| Vlan3029 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone  |  Tenant_C_OP_Zone  |  -  |  false  |
+| Vlan3030 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone  |  Tenant_C_WAN_Zone  |  -  |  false  |
+| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  false  |
+| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  false  |
 
 #### IPv4
 
@@ -782,55 +796,66 @@ interface Vlan350
 !
 interface Vlan3009
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address 10.255.251.7/31
 !
 interface Vlan3010
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address 10.255.251.7/31
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address 10.255.251.7/31
 !
 interface Vlan3012
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address 10.255.251.7/31
 !
 interface Vlan3013
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone
+   no shutdown
    vrf Tenant_A_WAN_Zone
    ip address 10.255.251.7/31
 !
 interface Vlan3019
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address 10.255.251.7/31
 !
 interface Vlan3020
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone
+   no shutdown
    vrf Tenant_B_WAN_Zone
    ip address 10.255.251.7/31
 !
 interface Vlan3029
    description MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address 10.255.251.7/31
 !
 interface Vlan3030
    description MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone
+   no shutdown
    vrf Tenant_C_WAN_Zone
    ip address 10.255.251.7/31
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
+   no shutdown
    ip address 10.255.251.7/31
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.7/31
 ```

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -564,6 +564,7 @@ interface Ethernet8
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-SVC3A_Po5
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -571,6 +572,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF2_Po1
+   switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350
    switchport mode trunk
    mlag 7
@@ -687,17 +689,20 @@ interface Loopback100
 !
 interface Vlan110
    description Tenant_A_OP_Zone_1
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address virtual 10.1.10.1/24
 !
 interface Vlan111
    description Tenant_A_OP_Zone_2
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT  source-interface lo100
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST  source-interface lo100
@@ -711,56 +716,67 @@ interface Vlan121
 !
 interface Vlan130
    description Tenant_A_APP_Zone_1
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.30.1/24
 !
 interface Vlan131
    description Tenant_A_APP_Zone_2
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.31.1/24
 !
 interface Vlan140
    description Tenant_A_DB_BZone_1
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address virtual 10.1.40.1/24
 !
 interface Vlan141
    description Tenant_A_DB_Zone_2
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address virtual 10.1.41.1/24
 !
 interface Vlan150
    description Tenant_A_WAN_Zone_1
+   no shutdown
    vrf Tenant_A_WAN_Zone
    ip address virtual 10.1.40.1/24
 !
 interface Vlan210
    description Tenant_B_OP_Zone_1
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address virtual 10.2.10.1/24
 !
 interface Vlan211
    description Tenant_B_OP_Zone_2
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address virtual 10.2.11.1/24
 !
 interface Vlan250
    description Tenant_B_WAN_Zone_1
+   no shutdown
    vrf Tenant_B_WAN_Zone
    ip address virtual 10.2.50.1/24
 !
 interface Vlan310
    description Tenant_C_OP_Zone_1
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address virtual 10.3.10.1/24
 !
 interface Vlan311
    description Tenant_C_OP_Zone_2
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address virtual 10.3.11.1/24
 !
 interface Vlan350
    description Tenant_C_WAN_Zone_1
+   no shutdown
    vrf Tenant_C_WAN_Zone
    ip address virtual 10.3.50.1/24
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1A.cfg
@@ -44,34 +44,41 @@ vrf instance Tenant_C_WAN_Zone
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet6
+   no shutdown
    no switchport
    ip address 172.31.255.41/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet6
+   no shutdown
    no switchport
    ip address 172.31.255.43/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet6
+   no shutdown
    no switchport
    ip address 172.31.255.45/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet6
+   no shutdown
    no switchport
    ip address 172.31.255.47/31
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.10/32
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.10/32
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.110/24
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1A.cfg
@@ -77,16 +77,19 @@ interface Management1
 !
 interface Vlan150
    description Tenant_A_WAN_Zone_1
+   no shutdown
    vrf Tenant_A_WAN_Zone
    ip address virtual 10.1.40.1/24
 !
 interface Vlan250
    description Tenant_B_WAN_Zone_1
+   no shutdown
    vrf Tenant_B_WAN_Zone
    ip address virtual 10.2.50.1/24
 !
 interface Vlan350
    description Tenant_C_WAN_Zone_1
+   no shutdown
    vrf Tenant_C_WAN_Zone
    ip address virtual 10.3.50.1/24
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1B.cfg
@@ -77,16 +77,19 @@ interface Management1
 !
 interface Vlan150
    description Tenant_A_WAN_Zone_1
+   no shutdown
    vrf Tenant_A_WAN_Zone
    ip address virtual 10.1.40.1/24
 !
 interface Vlan250
    description Tenant_B_WAN_Zone_1
+   no shutdown
    vrf Tenant_B_WAN_Zone
    ip address virtual 10.2.50.1/24
 !
 interface Vlan350
    description Tenant_C_WAN_Zone_1
+   no shutdown
    vrf Tenant_C_WAN_Zone
    ip address virtual 10.3.50.1/24
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1B.cfg
@@ -44,34 +44,41 @@ vrf instance Tenant_C_WAN_Zone
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet7
+   no shutdown
    no switchport
    ip address 172.31.255.49/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet7
+   no shutdown
    no switchport
    ip address 172.31.255.51/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet7
+   no shutdown
    no switchport
    ip address 172.31.255.53/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet7
+   no shutdown
    no switchport
    ip address 172.31.255.55/31
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.11/32
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.11/32
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.111/24
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF1A.cfg
@@ -55,20 +55,24 @@ vrf instance MGMT
 !
 interface Port-Channel1
    description DC1-LEAF2A_Po7
+   no shutdown
    switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,160-161
    switchport mode trunk
 !
 interface Ethernet1
    description DC1-LEAF2A_Ethernet7
+   no shutdown
    channel-group 1 mode active
 !
 interface Ethernet2
    description DC1-LEAF2B_Ethernet7
+   no shutdown
    channel-group 1 mode active
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.112/24
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF1A.cfg
@@ -55,6 +55,7 @@ vrf instance MGMT
 !
 interface Port-Channel1
    description DC1-LEAF2A_Po7
+   switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,160-161
    switchport mode trunk
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF2A.cfg
@@ -87,6 +87,7 @@ vrf instance MGMT
 !
 interface Port-Channel1
    description DC1-SVC3A_Po7
+   no shutdown
    switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350
    switchport mode trunk
@@ -94,6 +95,7 @@ interface Port-Channel1
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-L2LEAF2B_Po3
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -101,27 +103,33 @@ interface Port-Channel3
 !
 interface Ethernet1
    description DC1-SVC3A_Ethernet7
+   no shutdown
    channel-group 1 mode active
 !
 interface Ethernet2
    description DC1-SVC3B_Ethernet7
+   no shutdown
    channel-group 1 mode active
 !
 interface Ethernet3
    description MLAG_PEER_DC1-L2LEAF2B_Ethernet3
+   no shutdown
    channel-group 3 mode active
 !
 interface Ethernet4
    description MLAG_PEER_DC1-L2LEAF2B_Ethernet4
+   no shutdown
    channel-group 3 mode active
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.113/24
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.16/31
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF2A.cfg
@@ -87,12 +87,14 @@ vrf instance MGMT
 !
 interface Port-Channel1
    description DC1-SVC3A_Po7
+   switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350
    switchport mode trunk
    mlag 1
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-L2LEAF2B_Po3
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group MLAG

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF2B.cfg
@@ -87,6 +87,7 @@ vrf instance MGMT
 !
 interface Port-Channel1
    description DC1-SVC3B_Po7
+   no shutdown
    switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350
    switchport mode trunk
@@ -94,6 +95,7 @@ interface Port-Channel1
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-L2LEAF2A_Po3
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -101,27 +103,33 @@ interface Port-Channel3
 !
 interface Ethernet1
    description DC1-SVC3A_Ethernet8
+   no shutdown
    channel-group 1 mode active
 !
 interface Ethernet2
    description DC1-SVC3B_Ethernet8
+   no shutdown
    channel-group 1 mode active
 !
 interface Ethernet3
    description MLAG_PEER_DC1-L2LEAF2A_Ethernet3
+   no shutdown
    channel-group 3 mode active
 !
 interface Ethernet4
    description MLAG_PEER_DC1-L2LEAF2A_Ethernet4
+   no shutdown
    channel-group 3 mode active
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.114/24
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.17/31
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF2B.cfg
@@ -87,12 +87,14 @@ vrf instance MGMT
 !
 interface Port-Channel1
    description DC1-SVC3B_Po7
+   switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350
    switchport mode trunk
    mlag 1
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-L2LEAF2A_Po3
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group MLAG

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
@@ -67,6 +67,7 @@ interface Ethernet4
 !
 interface Ethernet6
    description server02_SINGLE_NODE_TRUNK_Eth1
+   switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
    spanning-tree portfast
@@ -78,6 +79,7 @@ interface Ethernet6
 !
 interface Ethernet7
    description server02_SINGLE_NODE_Eth1
+   switchport
    switchport access vlan 110
 !
 interface Loopback0
@@ -95,6 +97,7 @@ interface Management1
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST  source-interface lo100
@@ -108,11 +111,13 @@ interface Vlan121
 !
 interface Vlan130
    description Tenant_A_APP_Zone_1
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.30.1/24
 !
 interface Vlan131
    description Tenant_A_APP_Zone_2
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.31.1/24
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
@@ -47,26 +47,31 @@ vrf instance Tenant_A_WEB_Zone
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.1/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.3/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.5/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.7/31
 !
 interface Ethernet6
    description server02_SINGLE_NODE_TRUNK_Eth1
+   no shutdown
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
@@ -79,19 +84,23 @@ interface Ethernet6
 !
 interface Ethernet7
    description server02_SINGLE_NODE_Eth1
+   no shutdown
    switchport
    switchport access vlan 110
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.5/32
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.5/32
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.105/24
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
@@ -118,6 +118,7 @@ vrf instance Tenant_C_OP_Zone
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-LEAF2B_Po5
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -125,12 +126,14 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF1_Po1
+   switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,160-161
    switchport mode trunk
    mlag 7
 !
 interface Port-Channel10
    description server01_MLAG_PortChanne1
+   switchport
    switchport trunk allowed vlan 210-211
    switchport mode trunk
    mlag 10
@@ -191,17 +194,20 @@ interface Management1
 !
 interface Vlan110
    description Tenant_A_OP_Zone_1
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address virtual 10.1.10.1/24
 !
 interface Vlan111
    description Tenant_A_OP_Zone_2
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT  source-interface lo100
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST  source-interface lo100
@@ -215,41 +221,49 @@ interface Vlan121
 !
 interface Vlan130
    description Tenant_A_APP_Zone_1
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.30.1/24
 !
 interface Vlan131
    description Tenant_A_APP_Zone_2
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.31.1/24
 !
 interface Vlan140
    description Tenant_A_DB_BZone_1
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address virtual 10.1.40.1/24
 !
 interface Vlan141
    description Tenant_A_DB_Zone_2
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address virtual 10.1.41.1/24
 !
 interface Vlan210
    description Tenant_B_OP_Zone_1
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address virtual 10.2.10.1/24
 !
 interface Vlan211
    description Tenant_B_OP_Zone_2
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address virtual 10.2.11.1/24
 !
 interface Vlan310
    description Tenant_C_OP_Zone_1
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address virtual 10.3.10.1/24
 !
 interface Vlan311
    description Tenant_C_OP_Zone_2
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address virtual 10.3.11.1/24
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
@@ -118,6 +118,7 @@ vrf instance Tenant_C_OP_Zone
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-LEAF2B_Po5
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -126,6 +127,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF1_Po1
+   no shutdown
    switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,160-161
    switchport mode trunk
@@ -133,6 +135,7 @@ interface Port-Channel7
 !
 interface Port-Channel10
    description server01_MLAG_PortChanne1
+   no shutdown
    switchport
    switchport trunk allowed vlan 210-211
    switchport mode trunk
@@ -140,55 +143,67 @@ interface Port-Channel10
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.9/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.11/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.13/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.15/31
 !
 interface Ethernet5
    description MLAG_PEER_DC1-LEAF2B_Ethernet5
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-LEAF2B_Ethernet6
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet7
    description DC1-L2LEAF1A_Ethernet1
+   no shutdown
    channel-group 7 mode active
 !
 interface Ethernet10
    description server01_MLAG_Eth2
+   no shutdown
    channel-group 10 mode active
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.6/32
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.6/32
 !
 interface Loopback100
    description Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address 10.255.1.6/32
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.106/24
 !
@@ -269,40 +284,48 @@ interface Vlan311
 !
 interface Vlan3009
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address 10.255.251.2/31
 !
 interface Vlan3010
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address 10.255.251.2/31
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address 10.255.251.2/31
 !
 interface Vlan3012
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address 10.255.251.2/31
 !
 interface Vlan3019
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address 10.255.251.2/31
 !
 interface Vlan3029
    description MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address 10.255.251.2/31
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
+   no shutdown
    ip address 10.255.251.2/31
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.2/31
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
@@ -118,6 +118,7 @@ vrf instance Tenant_C_OP_Zone
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-LEAF2A_Po5
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -126,6 +127,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF1_Po1
+   no shutdown
    switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,160-161
    switchport mode trunk
@@ -133,6 +135,7 @@ interface Port-Channel7
 !
 interface Port-Channel10
    description server01_MLAG_PortChanne1
+   no shutdown
    switchport
    switchport trunk allowed vlan 210-211
    switchport mode trunk
@@ -140,55 +143,67 @@ interface Port-Channel10
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.17/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.19/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.21/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.23/31
 !
 interface Ethernet5
    description MLAG_PEER_DC1-LEAF2A_Ethernet5
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-LEAF2A_Ethernet6
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet7
    description DC1-L2LEAF1A_Ethernet2
+   no shutdown
    channel-group 7 mode active
 !
 interface Ethernet10
    description server01_MLAG_Eth3
+   no shutdown
    channel-group 10 mode active
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.7/32
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.6/32
 !
 interface Loopback100
    description Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address 10.255.1.7/32
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.107/24
 !
@@ -269,40 +284,48 @@ interface Vlan311
 !
 interface Vlan3009
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address 10.255.251.3/31
 !
 interface Vlan3010
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address 10.255.251.3/31
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address 10.255.251.3/31
 !
 interface Vlan3012
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address 10.255.251.3/31
 !
 interface Vlan3019
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address 10.255.251.3/31
 !
 interface Vlan3029
    description MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address 10.255.251.3/31
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
+   no shutdown
    ip address 10.255.251.3/31
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.3/31
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
@@ -118,6 +118,7 @@ vrf instance Tenant_C_OP_Zone
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-LEAF2A_Po5
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -125,12 +126,14 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF1_Po1
+   switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,160-161
    switchport mode trunk
    mlag 7
 !
 interface Port-Channel10
    description server01_MLAG_PortChanne1
+   switchport
    switchport trunk allowed vlan 210-211
    switchport mode trunk
    mlag 10
@@ -191,17 +194,20 @@ interface Management1
 !
 interface Vlan110
    description Tenant_A_OP_Zone_1
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address virtual 10.1.10.1/24
 !
 interface Vlan111
    description Tenant_A_OP_Zone_2
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT  source-interface lo100
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST  source-interface lo100
@@ -215,41 +221,49 @@ interface Vlan121
 !
 interface Vlan130
    description Tenant_A_APP_Zone_1
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.30.1/24
 !
 interface Vlan131
    description Tenant_A_APP_Zone_2
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.31.1/24
 !
 interface Vlan140
    description Tenant_A_DB_BZone_1
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address virtual 10.1.40.1/24
 !
 interface Vlan141
    description Tenant_A_DB_Zone_2
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address virtual 10.1.41.1/24
 !
 interface Vlan210
    description Tenant_B_OP_Zone_1
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address virtual 10.2.10.1/24
 !
 interface Vlan211
    description Tenant_B_OP_Zone_2
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address virtual 10.2.11.1/24
 !
 interface Vlan310
    description Tenant_C_OP_Zone_1
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address virtual 10.3.10.1/24
 !
 interface Vlan311
    description Tenant_C_OP_Zone_2
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address virtual 10.3.11.1/24
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE1.cfg
@@ -28,45 +28,54 @@ vrf instance MGMT
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.0/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-LEAF2A_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.8/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-LEAF2B_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.16/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SVC3A_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.24/31
 !
 interface Ethernet5
    description P2P_LINK_TO_DC1-SVC3B_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.32/31
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-BL1A_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.40/31
 !
 interface Ethernet7
    description P2P_LINK_TO_DC1-BL1B_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.48/31
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.1/32
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.101/24
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE2.cfg
@@ -28,45 +28,54 @@ vrf instance MGMT
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.2/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-LEAF2A_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.10/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-LEAF2B_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.18/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SVC3A_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.26/31
 !
 interface Ethernet5
    description P2P_LINK_TO_DC1-SVC3B_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.34/31
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-BL1A_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.42/31
 !
 interface Ethernet7
    description P2P_LINK_TO_DC1-BL1B_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.50/31
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.2/32
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.102/24
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE3.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE3.cfg
@@ -28,45 +28,54 @@ vrf instance MGMT
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.4/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-LEAF2A_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.12/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-LEAF2B_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.20/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SVC3A_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.28/31
 !
 interface Ethernet5
    description P2P_LINK_TO_DC1-SVC3B_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.36/31
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-BL1A_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.44/31
 !
 interface Ethernet7
    description P2P_LINK_TO_DC1-BL1B_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.52/31
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.3/32
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.103/24
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE4.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE4.cfg
@@ -28,45 +28,54 @@ vrf instance MGMT
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.6/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-LEAF2A_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.14/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-LEAF2B_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.22/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SVC3A_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.30/31
 !
 interface Ethernet5
    description P2P_LINK_TO_DC1-SVC3B_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.38/31
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-BL1A_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.46/31
 !
 interface Ethernet7
    description P2P_LINK_TO_DC1-BL1B_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.54/31
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.4/32
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.104/24
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
@@ -145,6 +145,7 @@ vrf instance Tenant_C_WAN_Zone
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-SVC3B_Po5
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -153,6 +154,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF2_Po1
+   no shutdown
    switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350
    switchport mode trunk
@@ -160,6 +162,7 @@ interface Port-Channel7
 !
 interface Port-Channel10
    description server03_ESI_PortChanne1
+   no shutdown
    switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
@@ -167,59 +170,72 @@ interface Port-Channel10
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.25/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.27/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.29/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.31/31
 !
 interface Ethernet5
    description MLAG_PEER_DC1-SVC3B_Ethernet5
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-SVC3B_Ethernet6
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet7
    description DC1-L2LEAF2A_Ethernet1
+   no shutdown
    channel-group 7 mode active
 !
 interface Ethernet8
    description DC1-L2LEAF2B_Ethernet1
+   no shutdown
    channel-group 7 mode active
 !
 interface Ethernet10
    description server03_ESI_Eth1
+   no shutdown
    channel-group 10 mode active
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.8/32
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.8/32
 !
 interface Loopback100
    description Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address 10.255.1.8/32
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.108/24
 !
@@ -318,55 +334,66 @@ interface Vlan350
 !
 interface Vlan3009
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address 10.255.251.6/31
 !
 interface Vlan3010
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address 10.255.251.6/31
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address 10.255.251.6/31
 !
 interface Vlan3012
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address 10.255.251.6/31
 !
 interface Vlan3013
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone
+   no shutdown
    vrf Tenant_A_WAN_Zone
    ip address 10.255.251.6/31
 !
 interface Vlan3019
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address 10.255.251.6/31
 !
 interface Vlan3020
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone
+   no shutdown
    vrf Tenant_B_WAN_Zone
    ip address 10.255.251.6/31
 !
 interface Vlan3029
    description MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address 10.255.251.6/31
 !
 interface Vlan3030
    description MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone
+   no shutdown
    vrf Tenant_C_WAN_Zone
    ip address 10.255.251.6/31
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
+   no shutdown
    ip address 10.255.251.6/31
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.6/31
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
@@ -145,6 +145,7 @@ vrf instance Tenant_C_WAN_Zone
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-SVC3B_Po5
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -152,12 +153,14 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF2_Po1
+   switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350
    switchport mode trunk
    mlag 7
 !
 interface Port-Channel10
    description server03_ESI_PortChanne1
+   switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
    mlag 10
@@ -222,17 +225,20 @@ interface Management1
 !
 interface Vlan110
    description Tenant_A_OP_Zone_1
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address virtual 10.1.10.1/24
 !
 interface Vlan111
    description Tenant_A_OP_Zone_2
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT  source-interface lo100
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST  source-interface lo100
@@ -246,56 +252,67 @@ interface Vlan121
 !
 interface Vlan130
    description Tenant_A_APP_Zone_1
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.30.1/24
 !
 interface Vlan131
    description Tenant_A_APP_Zone_2
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.31.1/24
 !
 interface Vlan140
    description Tenant_A_DB_BZone_1
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address virtual 10.1.40.1/24
 !
 interface Vlan141
    description Tenant_A_DB_Zone_2
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address virtual 10.1.41.1/24
 !
 interface Vlan150
    description Tenant_A_WAN_Zone_1
+   no shutdown
    vrf Tenant_A_WAN_Zone
    ip address virtual 10.1.40.1/24
 !
 interface Vlan210
    description Tenant_B_OP_Zone_1
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address virtual 10.2.10.1/24
 !
 interface Vlan211
    description Tenant_B_OP_Zone_2
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address virtual 10.2.11.1/24
 !
 interface Vlan250
    description Tenant_B_WAN_Zone_1
+   no shutdown
    vrf Tenant_B_WAN_Zone
    ip address virtual 10.2.50.1/24
 !
 interface Vlan310
    description Tenant_C_OP_Zone_1
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address virtual 10.3.10.1/24
 !
 interface Vlan311
    description Tenant_C_OP_Zone_2
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address virtual 10.3.11.1/24
 !
 interface Vlan350
    description Tenant_C_WAN_Zone_1
+   no shutdown
    vrf Tenant_C_WAN_Zone
    ip address virtual 10.3.50.1/24
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
@@ -145,6 +145,7 @@ vrf instance Tenant_C_WAN_Zone
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-SVC3A_Po5
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -152,6 +153,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF2_Po1
+   switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350
    switchport mode trunk
    mlag 7
@@ -212,17 +214,20 @@ interface Management1
 !
 interface Vlan110
    description Tenant_A_OP_Zone_1
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address virtual 10.1.10.1/24
 !
 interface Vlan111
    description Tenant_A_OP_Zone_2
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT  source-interface lo100
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST  source-interface lo100
@@ -236,56 +241,67 @@ interface Vlan121
 !
 interface Vlan130
    description Tenant_A_APP_Zone_1
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.30.1/24
 !
 interface Vlan131
    description Tenant_A_APP_Zone_2
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.31.1/24
 !
 interface Vlan140
    description Tenant_A_DB_BZone_1
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address virtual 10.1.40.1/24
 !
 interface Vlan141
    description Tenant_A_DB_Zone_2
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address virtual 10.1.41.1/24
 !
 interface Vlan150
    description Tenant_A_WAN_Zone_1
+   no shutdown
    vrf Tenant_A_WAN_Zone
    ip address virtual 10.1.40.1/24
 !
 interface Vlan210
    description Tenant_B_OP_Zone_1
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address virtual 10.2.10.1/24
 !
 interface Vlan211
    description Tenant_B_OP_Zone_2
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address virtual 10.2.11.1/24
 !
 interface Vlan250
    description Tenant_B_WAN_Zone_1
+   no shutdown
    vrf Tenant_B_WAN_Zone
    ip address virtual 10.2.50.1/24
 !
 interface Vlan310
    description Tenant_C_OP_Zone_1
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address virtual 10.3.10.1/24
 !
 interface Vlan311
    description Tenant_C_OP_Zone_2
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address virtual 10.3.11.1/24
 !
 interface Vlan350
    description Tenant_C_WAN_Zone_1
+   no shutdown
    vrf Tenant_C_WAN_Zone
    ip address virtual 10.3.50.1/24
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
@@ -145,6 +145,7 @@ vrf instance Tenant_C_WAN_Zone
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-SVC3A_Po5
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -153,6 +154,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF2_Po1
+   no shutdown
    switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350
    switchport mode trunk
@@ -160,55 +162,67 @@ interface Port-Channel7
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet5
+   no shutdown
    no switchport
    ip address 172.31.255.33/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet5
+   no shutdown
    no switchport
    ip address 172.31.255.35/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet5
+   no shutdown
    no switchport
    ip address 172.31.255.37/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet5
+   no shutdown
    no switchport
    ip address 172.31.255.39/31
 !
 interface Ethernet5
    description MLAG_PEER_DC1-SVC3A_Ethernet5
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-SVC3A_Ethernet6
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet7
    description DC1-L2LEAF2A_Ethernet2
+   no shutdown
    channel-group 7 mode active
 !
 interface Ethernet8
    description DC1-L2LEAF2B_Ethernet2
+   no shutdown
    channel-group 7 mode active
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.9/32
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.8/32
 !
 interface Loopback100
    description Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address 10.255.1.9/32
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.109/24
 !
@@ -307,55 +321,66 @@ interface Vlan350
 !
 interface Vlan3009
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address 10.255.251.7/31
 !
 interface Vlan3010
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address 10.255.251.7/31
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address 10.255.251.7/31
 !
 interface Vlan3012
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address 10.255.251.7/31
 !
 interface Vlan3013
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone
+   no shutdown
    vrf Tenant_A_WAN_Zone
    ip address 10.255.251.7/31
 !
 interface Vlan3019
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address 10.255.251.7/31
 !
 interface Vlan3020
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone
+   no shutdown
    vrf Tenant_B_WAN_Zone
    ip address 10.255.251.7/31
 !
 interface Vlan3029
    description MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address 10.255.251.7/31
 !
 interface Vlan3030
    description MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone
+   no shutdown
    vrf Tenant_C_WAN_Zone
    ip address 10.255.251.7/31
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
+   no shutdown
    ip address 10.255.251.7/31
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.7/31
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
@@ -105,6 +105,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE1_Ethernet6
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.41/31
   Ethernet2:
     peer: DC1-SPINE2
@@ -113,6 +114,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE2_Ethernet6
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.43/31
   Ethernet3:
     peer: DC1-SPINE3
@@ -121,6 +123,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE3_Ethernet6
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.45/31
   Ethernet4:
     peer: DC1-SPINE4
@@ -129,17 +132,21 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE4_Ethernet6
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.47/31
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: 192.168.255.10/32
   Loopback1:
     description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
     ip_address: 192.168.254.10/32
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.110/24
     gateway: 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
@@ -105,6 +105,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE1_Ethernet7
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.49/31
   Ethernet2:
     peer: DC1-SPINE2
@@ -113,6 +114,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE2_Ethernet7
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.51/31
   Ethernet3:
     peer: DC1-SPINE3
@@ -121,6 +123,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE3_Ethernet7
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.53/31
   Ethernet4:
     peer: DC1-SPINE4
@@ -129,17 +132,21 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE4_Ethernet7
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.55/31
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: 192.168.255.11/32
   Loopback1:
     description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
     ip_address: 192.168.254.11/32
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.111/24
     gateway: 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -109,6 +109,8 @@ vrfs:
 port_channel_interfaces:
   Port-Channel1:
     description: DC1-LEAF2A_Po7
+    type: switched
+    shutdown: false
     vlans: 110-111,120-121,130-131,160-161
     mode: trunk
 ethernet_interfaces:
@@ -117,6 +119,8 @@ ethernet_interfaces:
     peer_interface: Ethernet7
     peer_type: l3leaf
     description: DC1-LEAF2A_Ethernet7
+    type: switched
+    shutdown: false
     channel_group:
       id: 1
       mode: active
@@ -125,12 +129,15 @@ ethernet_interfaces:
     peer_interface: Ethernet7
     peer_type: l3leaf
     description: DC1-LEAF2B_Ethernet7
+    type: switched
+    shutdown: false
     channel_group:
       id: 1
       mode: active
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.112/24
     gateway: 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -170,11 +170,15 @@ vrfs:
 port_channel_interfaces:
   Port-Channel1:
     description: DC1-SVC3A_Po7
+    type: switched
+    shutdown: false
     vlans: 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350
     mode: trunk
     mlag: 1
   Port-Channel3:
     description: MLAG_PEER_DC1-L2LEAF2B_Po3
+    type: switched
+    shutdown: false
     vlans: 2-4094
     mode: trunk
     trunk_groups:
@@ -185,6 +189,8 @@ ethernet_interfaces:
     peer_interface: Ethernet7
     peer_type: l3leaf
     description: DC1-SVC3A_Ethernet7
+    type: switched
+    shutdown: false
     channel_group:
       id: 1
       mode: active
@@ -193,6 +199,8 @@ ethernet_interfaces:
     peer_interface: Ethernet7
     peer_type: l3leaf
     description: DC1-SVC3B_Ethernet7
+    type: switched
+    shutdown: false
     channel_group:
       id: 1
       mode: active
@@ -201,6 +209,8 @@ ethernet_interfaces:
     peer_interface: Ethernet3
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-L2LEAF2B_Ethernet3
+    type: switched
+    shutdown: false
     channel_group:
       id: 3
       mode: active
@@ -209,18 +219,22 @@ ethernet_interfaces:
     peer_interface: Ethernet4
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-L2LEAF2B_Ethernet4
+    type: switched
+    shutdown: false
     channel_group:
       id: 3
       mode: active
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.113/24
     gateway: 192.168.200.5
 vlan_interfaces:
   Vlan4094:
     description: MLAG_PEER
+    shutdown: false
     ip_address: 10.255.252.16/31
     no_autostate: true
     mtu: 1500

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -170,11 +170,15 @@ vrfs:
 port_channel_interfaces:
   Port-Channel1:
     description: DC1-SVC3B_Po7
+    type: switched
+    shutdown: false
     vlans: 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350
     mode: trunk
     mlag: 1
   Port-Channel3:
     description: MLAG_PEER_DC1-L2LEAF2A_Po3
+    type: switched
+    shutdown: false
     vlans: 2-4094
     mode: trunk
     trunk_groups:
@@ -185,6 +189,8 @@ ethernet_interfaces:
     peer_interface: Ethernet8
     peer_type: l3leaf
     description: DC1-SVC3A_Ethernet8
+    type: switched
+    shutdown: false
     channel_group:
       id: 1
       mode: active
@@ -193,6 +199,8 @@ ethernet_interfaces:
     peer_interface: Ethernet8
     peer_type: l3leaf
     description: DC1-SVC3B_Ethernet8
+    type: switched
+    shutdown: false
     channel_group:
       id: 1
       mode: active
@@ -201,6 +209,8 @@ ethernet_interfaces:
     peer_interface: Ethernet3
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-L2LEAF2A_Ethernet3
+    type: switched
+    shutdown: false
     channel_group:
       id: 3
       mode: active
@@ -209,18 +219,22 @@ ethernet_interfaces:
     peer_interface: Ethernet4
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-L2LEAF2A_Ethernet4
+    type: switched
+    shutdown: false
     channel_group:
       id: 3
       mode: active
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.114/24
     gateway: 192.168.200.5
 vlan_interfaces:
   Vlan4094:
     description: MLAG_PEER
+    shutdown: false
     ip_address: 10.255.252.17/31
     no_autostate: true
     mtu: 1500

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
@@ -107,6 +107,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE1_Ethernet1
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.1/31
   Ethernet2:
     peer: DC1-SPINE2
@@ -115,6 +116,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE2_Ethernet1
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.3/31
   Ethernet3:
     peer: DC1-SPINE3
@@ -123,6 +125,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE3_Ethernet1
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.5/31
   Ethernet4:
     peer: DC1-SPINE4
@@ -131,12 +134,15 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE4_Ethernet1
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.7/31
   Ethernet7:
     peer: server02_SINGLE_NODE
     peer_interface: Eth1
     peer_type: server
     description: server02_SINGLE_NODE_Eth1
+    type: switched
+    shutdown: false
     mode: access
     vlans: 110
     profile: TENANT_A
@@ -145,6 +151,8 @@ ethernet_interfaces:
     peer_interface: Eth1
     peer_type: server
     description: server02_SINGLE_NODE_TRUNK_Eth1
+    type: switched
+    shutdown: false
     mode: trunk
     vlans: 1-4094
     spanning_tree_portfast: edge
@@ -166,13 +174,16 @@ ethernet_interfaces:
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: 192.168.255.5/32
   Loopback1:
     description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
     ip_address: 192.168.254.5/32
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.105/24
     gateway: 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -218,11 +218,15 @@ bfd_multihop:
 port_channel_interfaces:
   Port-Channel7:
     description: DC1_L2LEAF1_Po1
+    type: switched
+    shutdown: false
     vlans: 110-111,120-121,130-131,160-161
     mode: trunk
     mlag: 7
   Port-Channel5:
     description: MLAG_PEER_DC1-LEAF2B_Po5
+    type: switched
+    shutdown: false
     vlans: 2-4094
     mode: trunk
     trunk_groups:
@@ -230,6 +234,8 @@ port_channel_interfaces:
     - MLAG
   Port-Channel10:
     description: server01_MLAG_PortChanne1
+    type: switched
+    shutdown: false
     vlans: 210-211
     mode: trunk
     mlag: 10
@@ -241,6 +247,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE1_Ethernet2
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.9/31
   Ethernet2:
     peer: DC1-SPINE2
@@ -249,6 +256,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE2_Ethernet2
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.11/31
   Ethernet3:
     peer: DC1-SPINE3
@@ -257,6 +265,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE3_Ethernet2
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.13/31
   Ethernet4:
     peer: DC1-SPINE4
@@ -265,12 +274,15 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE4_Ethernet2
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.15/31
   Ethernet5:
     peer: DC1-LEAF2B
     peer_interface: Ethernet5
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-LEAF2B_Ethernet5
+    type: switched
+    shutdown: false
     channel_group:
       id: 5
       mode: active
@@ -279,6 +291,8 @@ ethernet_interfaces:
     peer_interface: Ethernet6
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-LEAF2B_Ethernet6
+    type: switched
+    shutdown: false
     channel_group:
       id: 5
       mode: active
@@ -287,6 +301,8 @@ ethernet_interfaces:
     peer_interface: Ethernet1
     peer_type: l2leaf
     description: DC1-L2LEAF1A_Ethernet1
+    type: switched
+    shutdown: false
     channel_group:
       id: 7
       mode: active
@@ -295,6 +311,8 @@ ethernet_interfaces:
     peer_interface: Eth2
     peer_type: server
     description: server01_MLAG_Eth2
+    type: switched
+    shutdown: false
     mode: trunk
     vlans: 210-211
     channel_group:
@@ -304,27 +322,33 @@ ethernet_interfaces:
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: 192.168.255.6/32
   Loopback1:
     description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
     ip_address: 192.168.254.6/32
   Loopback100:
     description: Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
+    shutdown: false
     vrf: Tenant_A_OP_Zone
     ip_address: 10.255.1.6/32
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.106/24
     gateway: 192.168.200.5
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING
+    shutdown: false
     ip_address: 10.255.251.2/31
     mtu: 1500
   Vlan4094:
     description: MLAG_PEER
+    shutdown: false
     ip_address: 10.255.252.2/31
     no_autostate: true
     mtu: 1500
@@ -348,6 +372,7 @@ vlan_interfaces:
   Vlan3011:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone'
     vrf: Tenant_A_APP_Zone
     ip_address: 10.255.251.2/31
@@ -371,6 +396,7 @@ vlan_interfaces:
   Vlan3012:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone'
     vrf: Tenant_A_DB_Zone
     ip_address: 10.255.251.2/31
@@ -397,6 +423,7 @@ vlan_interfaces:
   Vlan3009:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone'
     vrf: Tenant_A_OP_Zone
     ip_address: 10.255.251.2/31
@@ -425,6 +452,7 @@ vlan_interfaces:
   Vlan3010:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone'
     vrf: Tenant_A_WEB_Zone
     ip_address: 10.255.251.2/31
@@ -447,6 +475,7 @@ vlan_interfaces:
   Vlan3019:
     tenant: Tenant_B
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone'
     vrf: Tenant_B_OP_Zone
     ip_address: 10.255.251.2/31
@@ -469,6 +498,7 @@ vlan_interfaces:
   Vlan3029:
     tenant: Tenant_C
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone'
     vrf: Tenant_C_OP_Zone
     ip_address: 10.255.251.2/31

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -218,11 +218,15 @@ bfd_multihop:
 port_channel_interfaces:
   Port-Channel7:
     description: DC1_L2LEAF1_Po1
+    type: switched
+    shutdown: false
     vlans: 110-111,120-121,130-131,160-161
     mode: trunk
     mlag: 7
   Port-Channel5:
     description: MLAG_PEER_DC1-LEAF2A_Po5
+    type: switched
+    shutdown: false
     vlans: 2-4094
     mode: trunk
     trunk_groups:
@@ -230,6 +234,8 @@ port_channel_interfaces:
     - MLAG
   Port-Channel10:
     description: server01_MLAG_PortChanne1
+    type: switched
+    shutdown: false
     vlans: 210-211
     mode: trunk
     mlag: 10
@@ -241,6 +247,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE1_Ethernet3
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.17/31
   Ethernet2:
     peer: DC1-SPINE2
@@ -249,6 +256,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE2_Ethernet3
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.19/31
   Ethernet3:
     peer: DC1-SPINE3
@@ -257,6 +265,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE3_Ethernet3
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.21/31
   Ethernet4:
     peer: DC1-SPINE4
@@ -265,12 +274,15 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE4_Ethernet3
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.23/31
   Ethernet5:
     peer: DC1-LEAF2A
     peer_interface: Ethernet5
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-LEAF2A_Ethernet5
+    type: switched
+    shutdown: false
     channel_group:
       id: 5
       mode: active
@@ -279,6 +291,8 @@ ethernet_interfaces:
     peer_interface: Ethernet6
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-LEAF2A_Ethernet6
+    type: switched
+    shutdown: false
     channel_group:
       id: 5
       mode: active
@@ -287,6 +301,8 @@ ethernet_interfaces:
     peer_interface: Ethernet2
     peer_type: l2leaf
     description: DC1-L2LEAF1A_Ethernet2
+    type: switched
+    shutdown: false
     channel_group:
       id: 7
       mode: active
@@ -295,6 +311,8 @@ ethernet_interfaces:
     peer_interface: Eth3
     peer_type: server
     description: server01_MLAG_Eth3
+    type: switched
+    shutdown: false
     mode: trunk
     vlans: 210-211
     channel_group:
@@ -304,27 +322,33 @@ ethernet_interfaces:
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: 192.168.255.7/32
   Loopback1:
     description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
     ip_address: 192.168.254.6/32
   Loopback100:
     description: Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
+    shutdown: false
     vrf: Tenant_A_OP_Zone
     ip_address: 10.255.1.7/32
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.107/24
     gateway: 192.168.200.5
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING
+    shutdown: false
     ip_address: 10.255.251.3/31
     mtu: 1500
   Vlan4094:
     description: MLAG_PEER
+    shutdown: false
     ip_address: 10.255.252.3/31
     no_autostate: true
     mtu: 1500
@@ -348,6 +372,7 @@ vlan_interfaces:
   Vlan3011:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone'
     vrf: Tenant_A_APP_Zone
     ip_address: 10.255.251.3/31
@@ -371,6 +396,7 @@ vlan_interfaces:
   Vlan3012:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone'
     vrf: Tenant_A_DB_Zone
     ip_address: 10.255.251.3/31
@@ -397,6 +423,7 @@ vlan_interfaces:
   Vlan3009:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone'
     vrf: Tenant_A_OP_Zone
     ip_address: 10.255.251.3/31
@@ -425,6 +452,7 @@ vlan_interfaces:
   Vlan3010:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone'
     vrf: Tenant_A_WEB_Zone
     ip_address: 10.255.251.3/31
@@ -447,6 +475,7 @@ vlan_interfaces:
   Vlan3019:
     tenant: Tenant_B
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone'
     vrf: Tenant_B_OP_Zone
     ip_address: 10.255.251.3/31
@@ -469,6 +498,7 @@ vlan_interfaces:
   Vlan3029:
     tenant: Tenant_C
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone'
     vrf: Tenant_C_OP_Zone
     ip_address: 10.255.251.3/31

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
@@ -63,6 +63,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-BL1A_Ethernet1
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.40/31
   Ethernet7:
     peer: DC1-BL1B
@@ -71,6 +72,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-BL1B_Ethernet1
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.48/31
   Ethernet1:
     peer: DC1-LEAF1A
@@ -79,6 +81,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF1A_Ethernet1
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.0/31
   Ethernet2:
     peer: DC1-LEAF2A
@@ -87,6 +90,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF2A_Ethernet1
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.8/31
   Ethernet3:
     peer: DC1-LEAF2B
@@ -95,6 +99,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF2B_Ethernet1
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.16/31
   Ethernet4:
     peer: DC1-SVC3A
@@ -103,6 +108,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SVC3A_Ethernet1
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.24/31
   Ethernet5:
     peer: DC1-SVC3B
@@ -111,14 +117,17 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SVC3B_Ethernet1
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.32/31
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: 192.168.255.1/32
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.101/24
     gateway: 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
@@ -63,6 +63,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-BL1A_Ethernet2
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.42/31
   Ethernet7:
     peer: DC1-BL1B
@@ -71,6 +72,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-BL1B_Ethernet2
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.50/31
   Ethernet1:
     peer: DC1-LEAF1A
@@ -79,6 +81,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF1A_Ethernet2
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.2/31
   Ethernet2:
     peer: DC1-LEAF2A
@@ -87,6 +90,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF2A_Ethernet2
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.10/31
   Ethernet3:
     peer: DC1-LEAF2B
@@ -95,6 +99,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF2B_Ethernet2
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.18/31
   Ethernet4:
     peer: DC1-SVC3A
@@ -103,6 +108,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SVC3A_Ethernet2
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.26/31
   Ethernet5:
     peer: DC1-SVC3B
@@ -111,14 +117,17 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SVC3B_Ethernet2
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.34/31
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: 192.168.255.2/32
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.102/24
     gateway: 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
@@ -63,6 +63,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-BL1A_Ethernet3
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.44/31
   Ethernet7:
     peer: DC1-BL1B
@@ -71,6 +72,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-BL1B_Ethernet3
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.52/31
   Ethernet1:
     peer: DC1-LEAF1A
@@ -79,6 +81,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF1A_Ethernet3
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.4/31
   Ethernet2:
     peer: DC1-LEAF2A
@@ -87,6 +90,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF2A_Ethernet3
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.12/31
   Ethernet3:
     peer: DC1-LEAF2B
@@ -95,6 +99,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF2B_Ethernet3
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.20/31
   Ethernet4:
     peer: DC1-SVC3A
@@ -103,6 +108,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SVC3A_Ethernet3
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.28/31
   Ethernet5:
     peer: DC1-SVC3B
@@ -111,14 +117,17 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SVC3B_Ethernet3
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.36/31
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: 192.168.255.3/32
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.103/24
     gateway: 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
@@ -63,6 +63,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-BL1A_Ethernet4
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.46/31
   Ethernet7:
     peer: DC1-BL1B
@@ -71,6 +72,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-BL1B_Ethernet4
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.54/31
   Ethernet1:
     peer: DC1-LEAF1A
@@ -79,6 +81,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF1A_Ethernet4
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.6/31
   Ethernet2:
     peer: DC1-LEAF2A
@@ -87,6 +90,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF2A_Ethernet4
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.14/31
   Ethernet3:
     peer: DC1-LEAF2B
@@ -95,6 +99,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF2B_Ethernet4
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.22/31
   Ethernet4:
     peer: DC1-SVC3A
@@ -103,6 +108,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SVC3A_Ethernet4
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.30/31
   Ethernet5:
     peer: DC1-SVC3B
@@ -111,14 +117,17 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SVC3B_Ethernet4
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.38/31
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: 192.168.255.4/32
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.104/24
     gateway: 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -261,11 +261,15 @@ bfd_multihop:
 port_channel_interfaces:
   Port-Channel7:
     description: DC1_L2LEAF2_Po1
+    type: switched
+    shutdown: false
     vlans: 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350
     mode: trunk
     mlag: 7
   Port-Channel5:
     description: MLAG_PEER_DC1-SVC3B_Po5
+    type: switched
+    shutdown: false
     vlans: 2-4094
     mode: trunk
     trunk_groups:
@@ -273,6 +277,8 @@ port_channel_interfaces:
     - MLAG
   Port-Channel10:
     description: server03_ESI_PortChanne1
+    type: switched
+    shutdown: false
     vlans: 110-111,210-211
     mode: trunk
     mlag: 10
@@ -284,6 +290,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE1_Ethernet4
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.25/31
   Ethernet2:
     peer: DC1-SPINE2
@@ -292,6 +299,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE2_Ethernet4
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.27/31
   Ethernet3:
     peer: DC1-SPINE3
@@ -300,6 +308,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE3_Ethernet4
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.29/31
   Ethernet4:
     peer: DC1-SPINE4
@@ -308,12 +317,15 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE4_Ethernet4
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.31/31
   Ethernet5:
     peer: DC1-SVC3B
     peer_interface: Ethernet5
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-SVC3B_Ethernet5
+    type: switched
+    shutdown: false
     channel_group:
       id: 5
       mode: active
@@ -322,6 +334,8 @@ ethernet_interfaces:
     peer_interface: Ethernet6
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-SVC3B_Ethernet6
+    type: switched
+    shutdown: false
     channel_group:
       id: 5
       mode: active
@@ -330,6 +344,8 @@ ethernet_interfaces:
     peer_interface: Ethernet1
     peer_type: l2leaf
     description: DC1-L2LEAF2A_Ethernet1
+    type: switched
+    shutdown: false
     channel_group:
       id: 7
       mode: active
@@ -338,6 +354,8 @@ ethernet_interfaces:
     peer_interface: Ethernet1
     peer_type: l2leaf
     description: DC1-L2LEAF2B_Ethernet1
+    type: switched
+    shutdown: false
     channel_group:
       id: 7
       mode: active
@@ -346,6 +364,8 @@ ethernet_interfaces:
     peer_interface: Eth1
     peer_type: server
     description: server03_ESI_Eth1
+    type: switched
+    shutdown: false
     mode: trunk
     vlans: 110-111,210-211
     channel_group:
@@ -355,27 +375,33 @@ ethernet_interfaces:
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: 192.168.255.8/32
   Loopback1:
     description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
     ip_address: 192.168.254.8/32
   Loopback100:
     description: Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
+    shutdown: false
     vrf: Tenant_A_OP_Zone
     ip_address: 10.255.1.8/32
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.108/24
     gateway: 192.168.200.5
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING
+    shutdown: false
     ip_address: 10.255.251.6/31
     mtu: 1500
   Vlan4094:
     description: MLAG_PEER
+    shutdown: false
     ip_address: 10.255.252.6/31
     no_autostate: true
     mtu: 1500
@@ -399,6 +425,7 @@ vlan_interfaces:
   Vlan3011:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone'
     vrf: Tenant_A_APP_Zone
     ip_address: 10.255.251.6/31
@@ -422,6 +449,7 @@ vlan_interfaces:
   Vlan3012:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone'
     vrf: Tenant_A_DB_Zone
     ip_address: 10.255.251.6/31
@@ -448,6 +476,7 @@ vlan_interfaces:
   Vlan3009:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone'
     vrf: Tenant_A_OP_Zone
     ip_address: 10.255.251.6/31
@@ -462,6 +491,7 @@ vlan_interfaces:
   Vlan3013:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone'
     vrf: Tenant_A_WAN_Zone
     ip_address: 10.255.251.6/31
@@ -490,6 +520,7 @@ vlan_interfaces:
   Vlan3010:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone'
     vrf: Tenant_A_WEB_Zone
     ip_address: 10.255.251.6/31
@@ -512,6 +543,7 @@ vlan_interfaces:
   Vlan3019:
     tenant: Tenant_B
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone'
     vrf: Tenant_B_OP_Zone
     ip_address: 10.255.251.6/31
@@ -526,6 +558,7 @@ vlan_interfaces:
   Vlan3020:
     tenant: Tenant_B
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone'
     vrf: Tenant_B_WAN_Zone
     ip_address: 10.255.251.6/31
@@ -548,6 +581,7 @@ vlan_interfaces:
   Vlan3029:
     tenant: Tenant_C
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone'
     vrf: Tenant_C_OP_Zone
     ip_address: 10.255.251.6/31
@@ -562,6 +596,7 @@ vlan_interfaces:
   Vlan3030:
     tenant: Tenant_C
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone'
     vrf: Tenant_C_WAN_Zone
     ip_address: 10.255.251.6/31

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -261,11 +261,15 @@ bfd_multihop:
 port_channel_interfaces:
   Port-Channel7:
     description: DC1_L2LEAF2_Po1
+    type: switched
+    shutdown: false
     vlans: 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350
     mode: trunk
     mlag: 7
   Port-Channel5:
     description: MLAG_PEER_DC1-SVC3A_Po5
+    type: switched
+    shutdown: false
     vlans: 2-4094
     mode: trunk
     trunk_groups:
@@ -279,6 +283,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE1_Ethernet5
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.33/31
   Ethernet2:
     peer: DC1-SPINE2
@@ -287,6 +292,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE2_Ethernet5
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.35/31
   Ethernet3:
     peer: DC1-SPINE3
@@ -295,6 +301,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE3_Ethernet5
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.37/31
   Ethernet4:
     peer: DC1-SPINE4
@@ -303,12 +310,15 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE4_Ethernet5
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.39/31
   Ethernet5:
     peer: DC1-SVC3A
     peer_interface: Ethernet5
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-SVC3A_Ethernet5
+    type: switched
+    shutdown: false
     channel_group:
       id: 5
       mode: active
@@ -317,6 +327,8 @@ ethernet_interfaces:
     peer_interface: Ethernet6
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-SVC3A_Ethernet6
+    type: switched
+    shutdown: false
     channel_group:
       id: 5
       mode: active
@@ -325,6 +337,8 @@ ethernet_interfaces:
     peer_interface: Ethernet2
     peer_type: l2leaf
     description: DC1-L2LEAF2A_Ethernet2
+    type: switched
+    shutdown: false
     channel_group:
       id: 7
       mode: active
@@ -333,33 +347,41 @@ ethernet_interfaces:
     peer_interface: Ethernet2
     peer_type: l2leaf
     description: DC1-L2LEAF2B_Ethernet2
+    type: switched
+    shutdown: false
     channel_group:
       id: 7
       mode: active
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: 192.168.255.9/32
   Loopback1:
     description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
     ip_address: 192.168.254.8/32
   Loopback100:
     description: Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
+    shutdown: false
     vrf: Tenant_A_OP_Zone
     ip_address: 10.255.1.9/32
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.109/24
     gateway: 192.168.200.5
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING
+    shutdown: false
     ip_address: 10.255.251.7/31
     mtu: 1500
   Vlan4094:
     description: MLAG_PEER
+    shutdown: false
     ip_address: 10.255.252.7/31
     no_autostate: true
     mtu: 1500
@@ -383,6 +405,7 @@ vlan_interfaces:
   Vlan3011:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone'
     vrf: Tenant_A_APP_Zone
     ip_address: 10.255.251.7/31
@@ -406,6 +429,7 @@ vlan_interfaces:
   Vlan3012:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone'
     vrf: Tenant_A_DB_Zone
     ip_address: 10.255.251.7/31
@@ -432,6 +456,7 @@ vlan_interfaces:
   Vlan3009:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone'
     vrf: Tenant_A_OP_Zone
     ip_address: 10.255.251.7/31
@@ -446,6 +471,7 @@ vlan_interfaces:
   Vlan3013:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone'
     vrf: Tenant_A_WAN_Zone
     ip_address: 10.255.251.7/31
@@ -474,6 +500,7 @@ vlan_interfaces:
   Vlan3010:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone'
     vrf: Tenant_A_WEB_Zone
     ip_address: 10.255.251.7/31
@@ -496,6 +523,7 @@ vlan_interfaces:
   Vlan3019:
     tenant: Tenant_B
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone'
     vrf: Tenant_B_OP_Zone
     ip_address: 10.255.251.7/31
@@ -510,6 +538,7 @@ vlan_interfaces:
   Vlan3020:
     tenant: Tenant_B
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone'
     vrf: Tenant_B_WAN_Zone
     ip_address: 10.255.251.7/31
@@ -532,6 +561,7 @@ vlan_interfaces:
   Vlan3029:
     tenant: Tenant_C
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone'
     vrf: Tenant_C_OP_Zone
     ip_address: 10.255.251.7/31
@@ -546,6 +576,7 @@ vlan_interfaces:
   Vlan3030:
     tenant: Tenant_C
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone'
     vrf: Tenant_C_WAN_Zone
     ip_address: 10.255.251.7/31

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1A.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.110/24
 ```
@@ -386,10 +387,10 @@ vlan 4094
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet6  |  routed  | - |  172.31.255.41/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet6  |  routed  | - |  172.31.255.43/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet6  |  routed  | - |  172.31.255.45/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet6  |  routed  | - |  172.31.255.47/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet6  |  routed  | - |  172.31.255.41/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet6  |  routed  | - |  172.31.255.43/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet6  |  routed  | - |  172.31.255.45/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet6  |  routed  | - |  172.31.255.47/31  |  default  |  1500  |  false  |  -  |  -  |
 
 #### ISIS
 
@@ -406,6 +407,7 @@ vlan 4094
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet6
+   no shutdown
    no switchport
    ip address 172.31.255.41/31
    isis enable EVPN_UNDERLAY
@@ -414,6 +416,7 @@ interface Ethernet1
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet6
+   no shutdown
    no switchport
    ip address 172.31.255.43/31
    isis enable EVPN_UNDERLAY
@@ -422,6 +425,7 @@ interface Ethernet2
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet6
+   no shutdown
    no switchport
    ip address 172.31.255.45/31
    isis enable EVPN_UNDERLAY
@@ -430,6 +434,7 @@ interface Ethernet3
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet6
+   no shutdown
    no switchport
    ip address 172.31.255.47/31
    isis enable EVPN_UNDERLAY
@@ -438,10 +443,12 @@ interface Ethernet4
 !
 interface Ethernet5
    description MLAG_PEER_DC1-BL1B_Ethernet5
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-BL1B_Ethernet6
+   no shutdown
    channel-group 5 mode active
 ```
 
@@ -453,7 +460,7 @@ interface Ethernet6
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel5 | MLAG_PEER_DC1-BL1B_Po5 | switched | access | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
+| Port-Channel5 | MLAG_PEER_DC1-BL1B_Po5 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -461,6 +468,7 @@ interface Ethernet6
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-BL1B_Po5
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -499,12 +507,14 @@ interface Port-Channel5
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.10/32
    isis enable EVPN_UNDERLAY
    isis passive
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.10/32
    isis enable EVPN_UNDERLAY
    isis passive
@@ -516,8 +526,8 @@ interface Loopback1
 
 | Interface | Description | VRF |  MTU | Shutdown |
 | --------- | ----------- | --- | ---- | -------- |
-| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  -  |
-| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  -  |
+| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  false  |
+| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  false  |
 
 #### IPv4
 
@@ -540,6 +550,7 @@ interface Loopback1
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
+   no shutdown
    ip address 10.255.251.10/31
    isis enable EVPN_UNDERLAY
    isis metric 50
@@ -547,6 +558,7 @@ interface Vlan4093
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.10/31
 ```

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1A.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -456,6 +461,7 @@ interface Ethernet6
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-BL1B_Po5
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -732,6 +738,8 @@ router bgp 65000
    neighbor 192.168.255.4 peer group EVPN-OVERLAY-PEERS
    !
    address-family evpn
+      neighbor EVPN-OVERLAY-PEERS route-map RM-EVPN-SOO-IN in
+      neighbor EVPN-OVERLAY-PEERS route-map RM-EVPN-SOO-OUT out
       neighbor EVPN-OVERLAY-PEERS activate
    !
    address-family ipv4
@@ -891,6 +899,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1B.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.111/24
 ```
@@ -386,10 +387,10 @@ vlan 4094
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet7  |  routed  | - |  172.31.255.49/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet7  |  routed  | - |  172.31.255.51/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet7  |  routed  | - |  172.31.255.53/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet7  |  routed  | - |  172.31.255.55/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet7  |  routed  | - |  172.31.255.49/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet7  |  routed  | - |  172.31.255.51/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet7  |  routed  | - |  172.31.255.53/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet7  |  routed  | - |  172.31.255.55/31  |  default  |  1500  |  false  |  -  |  -  |
 
 #### ISIS
 
@@ -406,6 +407,7 @@ vlan 4094
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet7
+   no shutdown
    no switchport
    ip address 172.31.255.49/31
    isis enable EVPN_UNDERLAY
@@ -414,6 +416,7 @@ interface Ethernet1
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet7
+   no shutdown
    no switchport
    ip address 172.31.255.51/31
    isis enable EVPN_UNDERLAY
@@ -422,6 +425,7 @@ interface Ethernet2
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet7
+   no shutdown
    no switchport
    ip address 172.31.255.53/31
    isis enable EVPN_UNDERLAY
@@ -430,6 +434,7 @@ interface Ethernet3
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet7
+   no shutdown
    no switchport
    ip address 172.31.255.55/31
    isis enable EVPN_UNDERLAY
@@ -438,10 +443,12 @@ interface Ethernet4
 !
 interface Ethernet5
    description MLAG_PEER_DC1-BL1A_Ethernet5
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-BL1A_Ethernet6
+   no shutdown
    channel-group 5 mode active
 ```
 
@@ -453,7 +460,7 @@ interface Ethernet6
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel5 | MLAG_PEER_DC1-BL1A_Po5 | switched | access | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
+| Port-Channel5 | MLAG_PEER_DC1-BL1A_Po5 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -461,6 +468,7 @@ interface Ethernet6
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-BL1A_Po5
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -499,12 +507,14 @@ interface Port-Channel5
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.11/32
    isis enable EVPN_UNDERLAY
    isis passive
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.10/32
    isis enable EVPN_UNDERLAY
    isis passive
@@ -516,8 +526,8 @@ interface Loopback1
 
 | Interface | Description | VRF |  MTU | Shutdown |
 | --------- | ----------- | --- | ---- | -------- |
-| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  -  |
-| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  -  |
+| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  false  |
+| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  false  |
 
 #### IPv4
 
@@ -540,6 +550,7 @@ interface Loopback1
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
+   no shutdown
    ip address 10.255.251.11/31
    isis enable EVPN_UNDERLAY
    isis metric 50
@@ -547,6 +558,7 @@ interface Vlan4093
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.11/31
 ```

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1B.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -456,6 +461,7 @@ interface Ethernet6
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-BL1A_Po5
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -732,6 +738,8 @@ router bgp 65000
    neighbor 192.168.255.4 peer group EVPN-OVERLAY-PEERS
    !
    address-family evpn
+      neighbor EVPN-OVERLAY-PEERS route-map RM-EVPN-SOO-IN in
+      neighbor EVPN-OVERLAY-PEERS route-map RM-EVPN-SOO-OUT out
       neighbor EVPN-OVERLAY-PEERS activate
    !
    address-family ipv4
@@ -891,6 +899,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-L2LEAF1A.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -358,7 +363,7 @@ interface Ethernet2
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel1 | DC1-LEAF2A_Po7 | switched | access | - | - | - | - | - | 1 | - |
+| Port-Channel1 | DC1-LEAF2A_Po7 | switched | access | - | - | - | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -366,9 +371,9 @@ interface Ethernet2
 !
 interface Port-Channel1
    description DC1-LEAF2A_Po7
+   switchport
    switchport trunk allowed vlan 
    switchport mode trunk
-   mlag 1
 ```
 
 ## Loopback Interfaces
@@ -562,6 +567,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-L2LEAF1A.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.112/24
 ```
@@ -348,10 +349,12 @@ No VLANs defined
 !
 interface Ethernet1
    description DC1-LEAF2A_Ethernet7
+   no shutdown
    channel-group 1 mode active
 !
 interface Ethernet2
    description DC1-LEAF2B_Ethernet7
+   no shutdown
    channel-group 1 mode active
 ```
 
@@ -363,7 +366,7 @@ interface Ethernet2
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel1 | DC1-LEAF2A_Po7 | switched | access | - | - | - | - | - | - | - |
+| Port-Channel1 | DC1-LEAF2A_Po7 | switched | trunk | - | - | - | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -371,6 +374,7 @@ interface Ethernet2
 !
 interface Port-Channel1
    description DC1-LEAF2A_Po7
+   no shutdown
    switchport
    switchport trunk allowed vlan 
    switchport mode trunk

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-L2LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-L2LEAF2A.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.113/24
 ```
@@ -385,18 +386,22 @@ vlan 4094
 !
 interface Ethernet1
    description DC1-SVC3A_Ethernet7
+   no shutdown
    channel-group 1 mode active
 !
 interface Ethernet2
    description DC1-SVC3B_Ethernet7
+   no shutdown
    channel-group 1 mode active
 !
 interface Ethernet3
    description MLAG_PEER_DC1-L2LEAF2B_Ethernet3
+   no shutdown
    channel-group 3 mode active
 !
 interface Ethernet4
    description MLAG_PEER_DC1-L2LEAF2B_Ethernet4
+   no shutdown
    channel-group 3 mode active
 ```
 
@@ -408,8 +413,8 @@ interface Ethernet4
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel1 | DC1-SVC3A_Po7 | switched | access | - | - | - | - | - | 1 | - |
-| Port-Channel3 | MLAG_PEER_DC1-L2LEAF2B_Po3 | switched | access | 2-4094 | - | ['MLAG'] | - | - | - | - |
+| Port-Channel1 | DC1-SVC3A_Po7 | switched | trunk | - | - | - | - | - | 1 | - |
+| Port-Channel3 | MLAG_PEER_DC1-L2LEAF2B_Po3 | switched | trunk | 2-4094 | - | ['MLAG'] | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -417,6 +422,7 @@ interface Ethernet4
 !
 interface Port-Channel1
    description DC1-SVC3A_Po7
+   no shutdown
    switchport
    switchport trunk allowed vlan 
    switchport mode trunk
@@ -424,6 +430,7 @@ interface Port-Channel1
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-L2LEAF2B_Po3
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -440,7 +447,7 @@ No loopback interfaces defined
 
 | Interface | Description | VRF |  MTU | Shutdown |
 | --------- | ----------- | --- | ---- | -------- |
-| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  -  |
+| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  false  |
 
 #### IPv4
 
@@ -456,6 +463,7 @@ No loopback interfaces defined
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.16/31
 ```

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-L2LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-L2LEAF2A.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -412,12 +417,14 @@ interface Ethernet4
 !
 interface Port-Channel1
    description DC1-SVC3A_Po7
+   switchport
    switchport trunk allowed vlan 
    switchport mode trunk
    mlag 1
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-L2LEAF2B_Po3
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group MLAG
@@ -636,6 +643,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-L2LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-L2LEAF2B.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -412,12 +417,14 @@ interface Ethernet4
 !
 interface Port-Channel1
    description DC1-SVC3B_Po7
+   switchport
    switchport trunk allowed vlan 
    switchport mode trunk
    mlag 1
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-L2LEAF2A_Po3
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group MLAG
@@ -636,6 +643,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-L2LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-L2LEAF2B.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.114/24
 ```
@@ -385,18 +386,22 @@ vlan 4094
 !
 interface Ethernet1
    description DC1-SVC3A_Ethernet8
+   no shutdown
    channel-group 1 mode active
 !
 interface Ethernet2
    description DC1-SVC3B_Ethernet8
+   no shutdown
    channel-group 1 mode active
 !
 interface Ethernet3
    description MLAG_PEER_DC1-L2LEAF2A_Ethernet3
+   no shutdown
    channel-group 3 mode active
 !
 interface Ethernet4
    description MLAG_PEER_DC1-L2LEAF2A_Ethernet4
+   no shutdown
    channel-group 3 mode active
 ```
 
@@ -408,8 +413,8 @@ interface Ethernet4
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel1 | DC1-SVC3B_Po7 | switched | access | - | - | - | - | - | 1 | - |
-| Port-Channel3 | MLAG_PEER_DC1-L2LEAF2A_Po3 | switched | access | 2-4094 | - | ['MLAG'] | - | - | - | - |
+| Port-Channel1 | DC1-SVC3B_Po7 | switched | trunk | - | - | - | - | - | 1 | - |
+| Port-Channel3 | MLAG_PEER_DC1-L2LEAF2A_Po3 | switched | trunk | 2-4094 | - | ['MLAG'] | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -417,6 +422,7 @@ interface Ethernet4
 !
 interface Port-Channel1
    description DC1-SVC3B_Po7
+   no shutdown
    switchport
    switchport trunk allowed vlan 
    switchport mode trunk
@@ -424,6 +430,7 @@ interface Port-Channel1
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-L2LEAF2A_Po3
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -440,7 +447,7 @@ No loopback interfaces defined
 
 | Interface | Description | VRF |  MTU | Shutdown |
 | --------- | ----------- | --- | ---- | -------- |
-| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  -  |
+| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  false  |
 
 #### IPv4
 
@@ -456,6 +463,7 @@ No loopback interfaces defined
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.17/31
 ```

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF1A.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.105/24
 ```
@@ -344,10 +345,10 @@ No VLANs defined
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet1  |  routed  | - |  172.31.255.1/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet1  |  routed  | - |  172.31.255.3/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet1  |  routed  | - |  172.31.255.5/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet1  |  routed  | - |  172.31.255.7/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet1  |  routed  | - |  172.31.255.1/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet1  |  routed  | - |  172.31.255.3/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet1  |  routed  | - |  172.31.255.5/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet1  |  routed  | - |  172.31.255.7/31  |  default  |  1500  |  false  |  -  |  -  |
 
 #### ISIS
 
@@ -364,6 +365,7 @@ No VLANs defined
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.1/31
    isis enable EVPN_UNDERLAY
@@ -372,6 +374,7 @@ interface Ethernet1
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.3/31
    isis enable EVPN_UNDERLAY
@@ -380,6 +383,7 @@ interface Ethernet2
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.5/31
    isis enable EVPN_UNDERLAY
@@ -388,6 +392,7 @@ interface Ethernet3
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.7/31
    isis enable EVPN_UNDERLAY
@@ -430,12 +435,14 @@ No port-channels defined
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.5/32
    isis enable EVPN_UNDERLAY
    isis passive
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.5/32
    isis enable EVPN_UNDERLAY
    isis passive

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF1A.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -625,6 +630,8 @@ router bgp 65000
    neighbor 192.168.255.4 peer group EVPN-OVERLAY-PEERS
    !
    address-family evpn
+      neighbor EVPN-OVERLAY-PEERS route-map RM-EVPN-SOO-IN in
+      neighbor EVPN-OVERLAY-PEERS route-map RM-EVPN-SOO-OUT out
       neighbor EVPN-OVERLAY-PEERS activate
    !
    address-family ipv4
@@ -784,6 +791,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2A.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.106/24
 ```
@@ -387,10 +388,10 @@ vlan 4094
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet2  |  routed  | - |  172.31.255.9/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet2  |  routed  | - |  172.31.255.11/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet2  |  routed  | - |  172.31.255.13/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet2  |  routed  | - |  172.31.255.15/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet2  |  routed  | - |  172.31.255.9/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet2  |  routed  | - |  172.31.255.11/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet2  |  routed  | - |  172.31.255.13/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet2  |  routed  | - |  172.31.255.15/31  |  default  |  1500  |  false  |  -  |  -  |
 
 #### ISIS
 
@@ -407,6 +408,7 @@ vlan 4094
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.9/31
    isis enable EVPN_UNDERLAY
@@ -415,6 +417,7 @@ interface Ethernet1
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.11/31
    isis enable EVPN_UNDERLAY
@@ -423,6 +426,7 @@ interface Ethernet2
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.13/31
    isis enable EVPN_UNDERLAY
@@ -431,6 +435,7 @@ interface Ethernet3
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.15/31
    isis enable EVPN_UNDERLAY
@@ -439,14 +444,17 @@ interface Ethernet4
 !
 interface Ethernet5
    description MLAG_PEER_DC1-LEAF2B_Ethernet5
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-LEAF2B_Ethernet6
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet7
    description DC1-L2LEAF1A_Ethernet1
+   no shutdown
    channel-group 7 mode active
 ```
 
@@ -458,8 +466,8 @@ interface Ethernet7
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel5 | MLAG_PEER_DC1-LEAF2B_Po5 | switched | access | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
-| Port-Channel7 | DC1_L2LEAF1_Po1 | switched | access | - | - | - | - | - | 7 | - |
+| Port-Channel5 | MLAG_PEER_DC1-LEAF2B_Po5 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
+| Port-Channel7 | DC1_L2LEAF1_Po1 | switched | trunk | - | - | - | - | - | 7 | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -467,6 +475,7 @@ interface Ethernet7
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-LEAF2B_Po5
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -475,6 +484,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF1_Po1
+   no shutdown
    switchport
    switchport trunk allowed vlan 
    switchport mode trunk
@@ -512,12 +522,14 @@ interface Port-Channel7
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.6/32
    isis enable EVPN_UNDERLAY
    isis passive
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.6/32
    isis enable EVPN_UNDERLAY
    isis passive
@@ -529,8 +541,8 @@ interface Loopback1
 
 | Interface | Description | VRF |  MTU | Shutdown |
 | --------- | ----------- | --- | ---- | -------- |
-| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  -  |
-| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  -  |
+| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  false  |
+| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  false  |
 
 #### IPv4
 
@@ -553,6 +565,7 @@ interface Loopback1
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
+   no shutdown
    ip address 10.255.251.2/31
    isis enable EVPN_UNDERLAY
    isis metric 50
@@ -560,6 +573,7 @@ interface Vlan4093
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.2/31
 ```

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2A.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -462,6 +467,7 @@ interface Ethernet7
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-LEAF2B_Po5
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -469,6 +475,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF1_Po1
+   switchport
    switchport trunk allowed vlan 
    switchport mode trunk
    mlag 7
@@ -744,6 +751,8 @@ router bgp 65000
    neighbor 192.168.255.4 peer group EVPN-OVERLAY-PEERS
    !
    address-family evpn
+      neighbor EVPN-OVERLAY-PEERS route-map RM-EVPN-SOO-IN in
+      neighbor EVPN-OVERLAY-PEERS route-map RM-EVPN-SOO-OUT out
       neighbor EVPN-OVERLAY-PEERS activate
    !
    address-family ipv4
@@ -903,6 +912,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2B.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -462,6 +467,7 @@ interface Ethernet7
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-LEAF2A_Po5
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -469,6 +475,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF1_Po1
+   switchport
    switchport trunk allowed vlan 
    switchport mode trunk
    mlag 7
@@ -744,6 +751,8 @@ router bgp 65000
    neighbor 192.168.255.4 peer group EVPN-OVERLAY-PEERS
    !
    address-family evpn
+      neighbor EVPN-OVERLAY-PEERS route-map RM-EVPN-SOO-IN in
+      neighbor EVPN-OVERLAY-PEERS route-map RM-EVPN-SOO-OUT out
       neighbor EVPN-OVERLAY-PEERS activate
    !
    address-family ipv4
@@ -903,6 +912,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2B.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.107/24
 ```
@@ -387,10 +388,10 @@ vlan 4094
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet3  |  routed  | - |  172.31.255.17/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet3  |  routed  | - |  172.31.255.19/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet3  |  routed  | - |  172.31.255.21/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet3  |  routed  | - |  172.31.255.23/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet3  |  routed  | - |  172.31.255.17/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet3  |  routed  | - |  172.31.255.19/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet3  |  routed  | - |  172.31.255.21/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet3  |  routed  | - |  172.31.255.23/31  |  default  |  1500  |  false  |  -  |  -  |
 
 #### ISIS
 
@@ -407,6 +408,7 @@ vlan 4094
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.17/31
    isis enable EVPN_UNDERLAY
@@ -415,6 +417,7 @@ interface Ethernet1
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.19/31
    isis enable EVPN_UNDERLAY
@@ -423,6 +426,7 @@ interface Ethernet2
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.21/31
    isis enable EVPN_UNDERLAY
@@ -431,6 +435,7 @@ interface Ethernet3
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.23/31
    isis enable EVPN_UNDERLAY
@@ -439,14 +444,17 @@ interface Ethernet4
 !
 interface Ethernet5
    description MLAG_PEER_DC1-LEAF2A_Ethernet5
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-LEAF2A_Ethernet6
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet7
    description DC1-L2LEAF1A_Ethernet2
+   no shutdown
    channel-group 7 mode active
 ```
 
@@ -458,8 +466,8 @@ interface Ethernet7
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel5 | MLAG_PEER_DC1-LEAF2A_Po5 | switched | access | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
-| Port-Channel7 | DC1_L2LEAF1_Po1 | switched | access | - | - | - | - | - | 7 | - |
+| Port-Channel5 | MLAG_PEER_DC1-LEAF2A_Po5 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
+| Port-Channel7 | DC1_L2LEAF1_Po1 | switched | trunk | - | - | - | - | - | 7 | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -467,6 +475,7 @@ interface Ethernet7
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-LEAF2A_Po5
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -475,6 +484,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF1_Po1
+   no shutdown
    switchport
    switchport trunk allowed vlan 
    switchport mode trunk
@@ -512,12 +522,14 @@ interface Port-Channel7
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.7/32
    isis enable EVPN_UNDERLAY
    isis passive
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.6/32
    isis enable EVPN_UNDERLAY
    isis passive
@@ -529,8 +541,8 @@ interface Loopback1
 
 | Interface | Description | VRF |  MTU | Shutdown |
 | --------- | ----------- | --- | ---- | -------- |
-| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  -  |
-| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  -  |
+| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  false  |
+| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  false  |
 
 #### IPv4
 
@@ -553,6 +565,7 @@ interface Loopback1
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
+   no shutdown
    ip address 10.255.251.3/31
    isis enable EVPN_UNDERLAY
    isis metric 50
@@ -560,6 +573,7 @@ interface Vlan4093
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.3/31
 ```

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE1.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.101/24
 ```
@@ -337,13 +338,13 @@ No VLANs defined
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 |  P2P_LINK_TO_DC1-LEAF1A_Ethernet1  |  routed  | - |  172.31.255.0/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet2 |  P2P_LINK_TO_DC1-LEAF2A_Ethernet1  |  routed  | - |  172.31.255.8/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet3 |  P2P_LINK_TO_DC1-LEAF2B_Ethernet1  |  routed  | - |  172.31.255.16/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet4 |  P2P_LINK_TO_DC1-SVC3A_Ethernet1  |  routed  | - |  172.31.255.24/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet5 |  P2P_LINK_TO_DC1-SVC3B_Ethernet1  |  routed  | - |  172.31.255.32/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet6 |  P2P_LINK_TO_DC1-BL1A_Ethernet1  |  routed  | - |  172.31.255.40/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet7 |  P2P_LINK_TO_DC1-BL1B_Ethernet1  |  routed  | - |  172.31.255.48/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet1 |  P2P_LINK_TO_DC1-LEAF1A_Ethernet1  |  routed  | - |  172.31.255.0/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet2 |  P2P_LINK_TO_DC1-LEAF2A_Ethernet1  |  routed  | - |  172.31.255.8/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet3 |  P2P_LINK_TO_DC1-LEAF2B_Ethernet1  |  routed  | - |  172.31.255.16/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4 |  P2P_LINK_TO_DC1-SVC3A_Ethernet1  |  routed  | - |  172.31.255.24/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet5 |  P2P_LINK_TO_DC1-SVC3B_Ethernet1  |  routed  | - |  172.31.255.32/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet6 |  P2P_LINK_TO_DC1-BL1A_Ethernet1  |  routed  | - |  172.31.255.40/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet7 |  P2P_LINK_TO_DC1-BL1B_Ethernet1  |  routed  | - |  172.31.255.48/31  |  default  |  1500  |  false  |  -  |  -  |
 
 #### ISIS
 
@@ -363,6 +364,7 @@ No VLANs defined
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.0/31
    isis enable EVPN_UNDERLAY
@@ -371,6 +373,7 @@ interface Ethernet1
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-LEAF2A_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.8/31
    isis enable EVPN_UNDERLAY
@@ -379,6 +382,7 @@ interface Ethernet2
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-LEAF2B_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.16/31
    isis enable EVPN_UNDERLAY
@@ -387,6 +391,7 @@ interface Ethernet3
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SVC3A_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.24/31
    isis enable EVPN_UNDERLAY
@@ -395,6 +400,7 @@ interface Ethernet4
 !
 interface Ethernet5
    description P2P_LINK_TO_DC1-SVC3B_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.32/31
    isis enable EVPN_UNDERLAY
@@ -403,6 +409,7 @@ interface Ethernet5
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-BL1A_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.40/31
    isis enable EVPN_UNDERLAY
@@ -411,6 +418,7 @@ interface Ethernet6
 !
 interface Ethernet7
    description P2P_LINK_TO_DC1-BL1B_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.48/31
    isis enable EVPN_UNDERLAY
@@ -450,6 +458,7 @@ No port-channels defined
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.1/32
    isis enable EVPN_UNDERLAY
    isis passive

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE1.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -748,6 +753,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE2.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.102/24
 ```
@@ -337,13 +338,13 @@ No VLANs defined
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 |  P2P_LINK_TO_DC1-LEAF1A_Ethernet2  |  routed  | - |  172.31.255.2/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet2 |  P2P_LINK_TO_DC1-LEAF2A_Ethernet2  |  routed  | - |  172.31.255.10/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet3 |  P2P_LINK_TO_DC1-LEAF2B_Ethernet2  |  routed  | - |  172.31.255.18/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet4 |  P2P_LINK_TO_DC1-SVC3A_Ethernet2  |  routed  | - |  172.31.255.26/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet5 |  P2P_LINK_TO_DC1-SVC3B_Ethernet2  |  routed  | - |  172.31.255.34/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet6 |  P2P_LINK_TO_DC1-BL1A_Ethernet2  |  routed  | - |  172.31.255.42/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet7 |  P2P_LINK_TO_DC1-BL1B_Ethernet2  |  routed  | - |  172.31.255.50/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet1 |  P2P_LINK_TO_DC1-LEAF1A_Ethernet2  |  routed  | - |  172.31.255.2/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet2 |  P2P_LINK_TO_DC1-LEAF2A_Ethernet2  |  routed  | - |  172.31.255.10/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet3 |  P2P_LINK_TO_DC1-LEAF2B_Ethernet2  |  routed  | - |  172.31.255.18/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4 |  P2P_LINK_TO_DC1-SVC3A_Ethernet2  |  routed  | - |  172.31.255.26/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet5 |  P2P_LINK_TO_DC1-SVC3B_Ethernet2  |  routed  | - |  172.31.255.34/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet6 |  P2P_LINK_TO_DC1-BL1A_Ethernet2  |  routed  | - |  172.31.255.42/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet7 |  P2P_LINK_TO_DC1-BL1B_Ethernet2  |  routed  | - |  172.31.255.50/31  |  default  |  1500  |  false  |  -  |  -  |
 
 #### ISIS
 
@@ -363,6 +364,7 @@ No VLANs defined
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.2/31
    isis enable EVPN_UNDERLAY
@@ -371,6 +373,7 @@ interface Ethernet1
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-LEAF2A_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.10/31
    isis enable EVPN_UNDERLAY
@@ -379,6 +382,7 @@ interface Ethernet2
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-LEAF2B_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.18/31
    isis enable EVPN_UNDERLAY
@@ -387,6 +391,7 @@ interface Ethernet3
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SVC3A_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.26/31
    isis enable EVPN_UNDERLAY
@@ -395,6 +400,7 @@ interface Ethernet4
 !
 interface Ethernet5
    description P2P_LINK_TO_DC1-SVC3B_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.34/31
    isis enable EVPN_UNDERLAY
@@ -403,6 +409,7 @@ interface Ethernet5
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-BL1A_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.42/31
    isis enable EVPN_UNDERLAY
@@ -411,6 +418,7 @@ interface Ethernet6
 !
 interface Ethernet7
    description P2P_LINK_TO_DC1-BL1B_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.50/31
    isis enable EVPN_UNDERLAY
@@ -450,6 +458,7 @@ No port-channels defined
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.2/32
    isis enable EVPN_UNDERLAY
    isis passive

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE2.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -748,6 +753,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE3.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.103/24
 ```
@@ -337,13 +338,13 @@ No VLANs defined
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 |  P2P_LINK_TO_DC1-LEAF1A_Ethernet3  |  routed  | - |  172.31.255.4/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet2 |  P2P_LINK_TO_DC1-LEAF2A_Ethernet3  |  routed  | - |  172.31.255.12/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet3 |  P2P_LINK_TO_DC1-LEAF2B_Ethernet3  |  routed  | - |  172.31.255.20/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet4 |  P2P_LINK_TO_DC1-SVC3A_Ethernet3  |  routed  | - |  172.31.255.28/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet5 |  P2P_LINK_TO_DC1-SVC3B_Ethernet3  |  routed  | - |  172.31.255.36/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet6 |  P2P_LINK_TO_DC1-BL1A_Ethernet3  |  routed  | - |  172.31.255.44/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet7 |  P2P_LINK_TO_DC1-BL1B_Ethernet3  |  routed  | - |  172.31.255.52/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet1 |  P2P_LINK_TO_DC1-LEAF1A_Ethernet3  |  routed  | - |  172.31.255.4/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet2 |  P2P_LINK_TO_DC1-LEAF2A_Ethernet3  |  routed  | - |  172.31.255.12/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet3 |  P2P_LINK_TO_DC1-LEAF2B_Ethernet3  |  routed  | - |  172.31.255.20/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4 |  P2P_LINK_TO_DC1-SVC3A_Ethernet3  |  routed  | - |  172.31.255.28/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet5 |  P2P_LINK_TO_DC1-SVC3B_Ethernet3  |  routed  | - |  172.31.255.36/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet6 |  P2P_LINK_TO_DC1-BL1A_Ethernet3  |  routed  | - |  172.31.255.44/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet7 |  P2P_LINK_TO_DC1-BL1B_Ethernet3  |  routed  | - |  172.31.255.52/31  |  default  |  1500  |  false  |  -  |  -  |
 
 #### ISIS
 
@@ -363,6 +364,7 @@ No VLANs defined
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.4/31
    isis enable EVPN_UNDERLAY
@@ -371,6 +373,7 @@ interface Ethernet1
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-LEAF2A_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.12/31
    isis enable EVPN_UNDERLAY
@@ -379,6 +382,7 @@ interface Ethernet2
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-LEAF2B_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.20/31
    isis enable EVPN_UNDERLAY
@@ -387,6 +391,7 @@ interface Ethernet3
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SVC3A_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.28/31
    isis enable EVPN_UNDERLAY
@@ -395,6 +400,7 @@ interface Ethernet4
 !
 interface Ethernet5
    description P2P_LINK_TO_DC1-SVC3B_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.36/31
    isis enable EVPN_UNDERLAY
@@ -403,6 +409,7 @@ interface Ethernet5
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-BL1A_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.44/31
    isis enable EVPN_UNDERLAY
@@ -411,6 +418,7 @@ interface Ethernet6
 !
 interface Ethernet7
    description P2P_LINK_TO_DC1-BL1B_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.52/31
    isis enable EVPN_UNDERLAY
@@ -450,6 +458,7 @@ No port-channels defined
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.3/32
    isis enable EVPN_UNDERLAY
    isis passive

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE3.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -748,6 +753,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE4.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.104/24
 ```
@@ -337,13 +338,13 @@ No VLANs defined
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 |  P2P_LINK_TO_DC1-LEAF1A_Ethernet4  |  routed  | - |  172.31.255.6/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet2 |  P2P_LINK_TO_DC1-LEAF2A_Ethernet4  |  routed  | - |  172.31.255.14/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet3 |  P2P_LINK_TO_DC1-LEAF2B_Ethernet4  |  routed  | - |  172.31.255.22/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet4 |  P2P_LINK_TO_DC1-SVC3A_Ethernet4  |  routed  | - |  172.31.255.30/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet5 |  P2P_LINK_TO_DC1-SVC3B_Ethernet4  |  routed  | - |  172.31.255.38/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet6 |  P2P_LINK_TO_DC1-BL1A_Ethernet4  |  routed  | - |  172.31.255.46/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet7 |  P2P_LINK_TO_DC1-BL1B_Ethernet4  |  routed  | - |  172.31.255.54/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet1 |  P2P_LINK_TO_DC1-LEAF1A_Ethernet4  |  routed  | - |  172.31.255.6/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet2 |  P2P_LINK_TO_DC1-LEAF2A_Ethernet4  |  routed  | - |  172.31.255.14/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet3 |  P2P_LINK_TO_DC1-LEAF2B_Ethernet4  |  routed  | - |  172.31.255.22/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4 |  P2P_LINK_TO_DC1-SVC3A_Ethernet4  |  routed  | - |  172.31.255.30/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet5 |  P2P_LINK_TO_DC1-SVC3B_Ethernet4  |  routed  | - |  172.31.255.38/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet6 |  P2P_LINK_TO_DC1-BL1A_Ethernet4  |  routed  | - |  172.31.255.46/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet7 |  P2P_LINK_TO_DC1-BL1B_Ethernet4  |  routed  | - |  172.31.255.54/31  |  default  |  1500  |  false  |  -  |  -  |
 
 #### ISIS
 
@@ -363,6 +364,7 @@ No VLANs defined
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.6/31
    isis enable EVPN_UNDERLAY
@@ -371,6 +373,7 @@ interface Ethernet1
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-LEAF2A_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.14/31
    isis enable EVPN_UNDERLAY
@@ -379,6 +382,7 @@ interface Ethernet2
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-LEAF2B_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.22/31
    isis enable EVPN_UNDERLAY
@@ -387,6 +391,7 @@ interface Ethernet3
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SVC3A_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.30/31
    isis enable EVPN_UNDERLAY
@@ -395,6 +400,7 @@ interface Ethernet4
 !
 interface Ethernet5
    description P2P_LINK_TO_DC1-SVC3B_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.38/31
    isis enable EVPN_UNDERLAY
@@ -403,6 +409,7 @@ interface Ethernet5
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-BL1A_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.46/31
    isis enable EVPN_UNDERLAY
@@ -411,6 +418,7 @@ interface Ethernet6
 !
 interface Ethernet7
    description P2P_LINK_TO_DC1-BL1B_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.54/31
    isis enable EVPN_UNDERLAY
@@ -450,6 +458,7 @@ No port-channels defined
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.4/32
    isis enable EVPN_UNDERLAY
    isis passive

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE4.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -748,6 +753,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3A.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -467,6 +472,7 @@ interface Ethernet8
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-SVC3B_Po5
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -474,6 +480,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF2_Po1
+   switchport
    switchport trunk allowed vlan 
    switchport mode trunk
    mlag 7
@@ -749,6 +756,8 @@ router bgp 65000
    neighbor 192.168.255.4 peer group EVPN-OVERLAY-PEERS
    !
    address-family evpn
+      neighbor EVPN-OVERLAY-PEERS route-map RM-EVPN-SOO-IN in
+      neighbor EVPN-OVERLAY-PEERS route-map RM-EVPN-SOO-OUT out
       neighbor EVPN-OVERLAY-PEERS activate
    !
    address-family ipv4
@@ -908,6 +917,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3A.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.108/24
 ```
@@ -388,10 +389,10 @@ vlan 4094
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet4  |  routed  | - |  172.31.255.25/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet4  |  routed  | - |  172.31.255.27/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet4  |  routed  | - |  172.31.255.29/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet4  |  routed  | - |  172.31.255.31/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet4  |  routed  | - |  172.31.255.25/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet4  |  routed  | - |  172.31.255.27/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet4  |  routed  | - |  172.31.255.29/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet4  |  routed  | - |  172.31.255.31/31  |  default  |  1500  |  false  |  -  |  -  |
 
 #### ISIS
 
@@ -408,6 +409,7 @@ vlan 4094
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.25/31
    isis enable EVPN_UNDERLAY
@@ -416,6 +418,7 @@ interface Ethernet1
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.27/31
    isis enable EVPN_UNDERLAY
@@ -424,6 +427,7 @@ interface Ethernet2
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.29/31
    isis enable EVPN_UNDERLAY
@@ -432,6 +436,7 @@ interface Ethernet3
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.31/31
    isis enable EVPN_UNDERLAY
@@ -440,18 +445,22 @@ interface Ethernet4
 !
 interface Ethernet5
    description MLAG_PEER_DC1-SVC3B_Ethernet5
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-SVC3B_Ethernet6
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet7
    description DC1-L2LEAF2A_Ethernet1
+   no shutdown
    channel-group 7 mode active
 !
 interface Ethernet8
    description DC1-L2LEAF2B_Ethernet1
+   no shutdown
    channel-group 7 mode active
 ```
 
@@ -463,8 +472,8 @@ interface Ethernet8
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel5 | MLAG_PEER_DC1-SVC3B_Po5 | switched | access | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
-| Port-Channel7 | DC1_L2LEAF2_Po1 | switched | access | - | - | - | - | - | 7 | - |
+| Port-Channel5 | MLAG_PEER_DC1-SVC3B_Po5 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
+| Port-Channel7 | DC1_L2LEAF2_Po1 | switched | trunk | - | - | - | - | - | 7 | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -472,6 +481,7 @@ interface Ethernet8
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-SVC3B_Po5
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -480,6 +490,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF2_Po1
+   no shutdown
    switchport
    switchport trunk allowed vlan 
    switchport mode trunk
@@ -517,12 +528,14 @@ interface Port-Channel7
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.8/32
    isis enable EVPN_UNDERLAY
    isis passive
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.8/32
    isis enable EVPN_UNDERLAY
    isis passive
@@ -534,8 +547,8 @@ interface Loopback1
 
 | Interface | Description | VRF |  MTU | Shutdown |
 | --------- | ----------- | --- | ---- | -------- |
-| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  -  |
-| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  -  |
+| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  false  |
+| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  false  |
 
 #### IPv4
 
@@ -558,6 +571,7 @@ interface Loopback1
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
+   no shutdown
    ip address 10.255.251.6/31
    isis enable EVPN_UNDERLAY
    isis metric 50
@@ -565,6 +579,7 @@ interface Vlan4093
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.6/31
 ```

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3B.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.109/24
 ```
@@ -388,10 +389,10 @@ vlan 4094
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet5  |  routed  | - |  172.31.255.33/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet5  |  routed  | - |  172.31.255.35/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet5  |  routed  | - |  172.31.255.37/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet5  |  routed  | - |  172.31.255.39/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet5  |  routed  | - |  172.31.255.33/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet5  |  routed  | - |  172.31.255.35/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet5  |  routed  | - |  172.31.255.37/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet5  |  routed  | - |  172.31.255.39/31  |  default  |  1500  |  false  |  -  |  -  |
 
 #### ISIS
 
@@ -408,6 +409,7 @@ vlan 4094
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet5
+   no shutdown
    no switchport
    ip address 172.31.255.33/31
    isis enable EVPN_UNDERLAY
@@ -416,6 +418,7 @@ interface Ethernet1
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet5
+   no shutdown
    no switchport
    ip address 172.31.255.35/31
    isis enable EVPN_UNDERLAY
@@ -424,6 +427,7 @@ interface Ethernet2
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet5
+   no shutdown
    no switchport
    ip address 172.31.255.37/31
    isis enable EVPN_UNDERLAY
@@ -432,6 +436,7 @@ interface Ethernet3
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet5
+   no shutdown
    no switchport
    ip address 172.31.255.39/31
    isis enable EVPN_UNDERLAY
@@ -440,18 +445,22 @@ interface Ethernet4
 !
 interface Ethernet5
    description MLAG_PEER_DC1-SVC3A_Ethernet5
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-SVC3A_Ethernet6
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet7
    description DC1-L2LEAF2A_Ethernet2
+   no shutdown
    channel-group 7 mode active
 !
 interface Ethernet8
    description DC1-L2LEAF2B_Ethernet2
+   no shutdown
    channel-group 7 mode active
 ```
 
@@ -463,8 +472,8 @@ interface Ethernet8
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel5 | MLAG_PEER_DC1-SVC3A_Po5 | switched | access | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
-| Port-Channel7 | DC1_L2LEAF2_Po1 | switched | access | - | - | - | - | - | 7 | - |
+| Port-Channel5 | MLAG_PEER_DC1-SVC3A_Po5 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
+| Port-Channel7 | DC1_L2LEAF2_Po1 | switched | trunk | - | - | - | - | - | 7 | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -472,6 +481,7 @@ interface Ethernet8
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-SVC3A_Po5
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -480,6 +490,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF2_Po1
+   no shutdown
    switchport
    switchport trunk allowed vlan 
    switchport mode trunk
@@ -517,12 +528,14 @@ interface Port-Channel7
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.9/32
    isis enable EVPN_UNDERLAY
    isis passive
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.8/32
    isis enable EVPN_UNDERLAY
    isis passive
@@ -534,8 +547,8 @@ interface Loopback1
 
 | Interface | Description | VRF |  MTU | Shutdown |
 | --------- | ----------- | --- | ---- | -------- |
-| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  -  |
-| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  -  |
+| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  false  |
+| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  false  |
 
 #### IPv4
 
@@ -558,6 +571,7 @@ interface Loopback1
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
+   no shutdown
    ip address 10.255.251.7/31
    isis enable EVPN_UNDERLAY
    isis metric 50
@@ -565,6 +579,7 @@ interface Vlan4093
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.7/31
 ```

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3B.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -467,6 +472,7 @@ interface Ethernet8
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-SVC3A_Po5
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -474,6 +480,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF2_Po1
+   switchport
    switchport trunk allowed vlan 
    switchport mode trunk
    mlag 7
@@ -749,6 +756,8 @@ router bgp 65000
    neighbor 192.168.255.4 peer group EVPN-OVERLAY-PEERS
    !
    address-family evpn
+      neighbor EVPN-OVERLAY-PEERS route-map RM-EVPN-SOO-IN in
+      neighbor EVPN-OVERLAY-PEERS route-map RM-EVPN-SOO-OUT out
       neighbor EVPN-OVERLAY-PEERS activate
    !
    address-family ipv4
@@ -908,6 +917,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-BL1A.cfg
@@ -38,6 +38,7 @@ vrf instance MGMT
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-BL1B_Po5
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -46,6 +47,7 @@ interface Port-Channel5
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet6
+   no shutdown
    no switchport
    ip address 172.31.255.41/31
    isis enable EVPN_UNDERLAY
@@ -54,6 +56,7 @@ interface Ethernet1
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet6
+   no shutdown
    no switchport
    ip address 172.31.255.43/31
    isis enable EVPN_UNDERLAY
@@ -62,6 +65,7 @@ interface Ethernet2
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet6
+   no shutdown
    no switchport
    ip address 172.31.255.45/31
    isis enable EVPN_UNDERLAY
@@ -70,6 +74,7 @@ interface Ethernet3
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet6
+   no shutdown
    no switchport
    ip address 172.31.255.47/31
    isis enable EVPN_UNDERLAY
@@ -78,31 +83,37 @@ interface Ethernet4
 !
 interface Ethernet5
    description MLAG_PEER_DC1-BL1B_Ethernet5
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-BL1B_Ethernet6
+   no shutdown
    channel-group 5 mode active
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.10/32
    isis enable EVPN_UNDERLAY
    isis passive
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.10/32
    isis enable EVPN_UNDERLAY
    isis passive
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.110/24
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
+   no shutdown
    ip address 10.255.251.10/31
    isis enable EVPN_UNDERLAY
    isis metric 50
@@ -110,6 +121,7 @@ interface Vlan4093
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.10/31
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-BL1A.cfg
@@ -38,6 +38,7 @@ vrf instance MGMT
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-BL1B_Po5
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -163,6 +164,8 @@ router bgp 65000
    neighbor 192.168.255.4 peer group EVPN-OVERLAY-PEERS
    !
    address-family evpn
+      neighbor EVPN-OVERLAY-PEERS route-map RM-EVPN-SOO-IN in
+      neighbor EVPN-OVERLAY-PEERS route-map RM-EVPN-SOO-OUT out
       neighbor EVPN-OVERLAY-PEERS activate
    !
    address-family ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-BL1B.cfg
@@ -38,6 +38,7 @@ vrf instance MGMT
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-BL1A_Po5
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -46,6 +47,7 @@ interface Port-Channel5
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet7
+   no shutdown
    no switchport
    ip address 172.31.255.49/31
    isis enable EVPN_UNDERLAY
@@ -54,6 +56,7 @@ interface Ethernet1
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet7
+   no shutdown
    no switchport
    ip address 172.31.255.51/31
    isis enable EVPN_UNDERLAY
@@ -62,6 +65,7 @@ interface Ethernet2
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet7
+   no shutdown
    no switchport
    ip address 172.31.255.53/31
    isis enable EVPN_UNDERLAY
@@ -70,6 +74,7 @@ interface Ethernet3
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet7
+   no shutdown
    no switchport
    ip address 172.31.255.55/31
    isis enable EVPN_UNDERLAY
@@ -78,31 +83,37 @@ interface Ethernet4
 !
 interface Ethernet5
    description MLAG_PEER_DC1-BL1A_Ethernet5
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-BL1A_Ethernet6
+   no shutdown
    channel-group 5 mode active
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.11/32
    isis enable EVPN_UNDERLAY
    isis passive
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.10/32
    isis enable EVPN_UNDERLAY
    isis passive
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.111/24
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
+   no shutdown
    ip address 10.255.251.11/31
    isis enable EVPN_UNDERLAY
    isis metric 50
@@ -110,6 +121,7 @@ interface Vlan4093
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.11/31
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-BL1B.cfg
@@ -38,6 +38,7 @@ vrf instance MGMT
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-BL1A_Po5
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -163,6 +164,8 @@ router bgp 65000
    neighbor 192.168.255.4 peer group EVPN-OVERLAY-PEERS
    !
    address-family evpn
+      neighbor EVPN-OVERLAY-PEERS route-map RM-EVPN-SOO-IN in
+      neighbor EVPN-OVERLAY-PEERS route-map RM-EVPN-SOO-OUT out
       neighbor EVPN-OVERLAY-PEERS activate
    !
    address-family ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-L2LEAF1A.cfg
@@ -29,20 +29,24 @@ vrf instance MGMT
 !
 interface Port-Channel1
    description DC1-LEAF2A_Po7
+   no shutdown
    switchport
    switchport trunk allowed vlan 
    switchport mode trunk
 !
 interface Ethernet1
    description DC1-LEAF2A_Ethernet7
+   no shutdown
    channel-group 1 mode active
 !
 interface Ethernet2
    description DC1-LEAF2B_Ethernet7
+   no shutdown
    channel-group 1 mode active
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.112/24
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-L2LEAF1A.cfg
@@ -29,9 +29,9 @@ vrf instance MGMT
 !
 interface Port-Channel1
    description DC1-LEAF2A_Po7
+   switchport
    switchport trunk allowed vlan 
    switchport mode trunk
-   mlag 1
 !
 interface Ethernet1
    description DC1-LEAF2A_Ethernet7

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-L2LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-L2LEAF2A.cfg
@@ -34,12 +34,14 @@ vrf instance MGMT
 !
 interface Port-Channel1
    description DC1-SVC3A_Po7
+   switchport
    switchport trunk allowed vlan 
    switchport mode trunk
    mlag 1
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-L2LEAF2B_Po3
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group MLAG

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-L2LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-L2LEAF2A.cfg
@@ -34,6 +34,7 @@ vrf instance MGMT
 !
 interface Port-Channel1
    description DC1-SVC3A_Po7
+   no shutdown
    switchport
    switchport trunk allowed vlan 
    switchport mode trunk
@@ -41,6 +42,7 @@ interface Port-Channel1
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-L2LEAF2B_Po3
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -48,27 +50,33 @@ interface Port-Channel3
 !
 interface Ethernet1
    description DC1-SVC3A_Ethernet7
+   no shutdown
    channel-group 1 mode active
 !
 interface Ethernet2
    description DC1-SVC3B_Ethernet7
+   no shutdown
    channel-group 1 mode active
 !
 interface Ethernet3
    description MLAG_PEER_DC1-L2LEAF2B_Ethernet3
+   no shutdown
    channel-group 3 mode active
 !
 interface Ethernet4
    description MLAG_PEER_DC1-L2LEAF2B_Ethernet4
+   no shutdown
    channel-group 3 mode active
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.113/24
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.16/31
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-L2LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-L2LEAF2B.cfg
@@ -34,12 +34,14 @@ vrf instance MGMT
 !
 interface Port-Channel1
    description DC1-SVC3B_Po7
+   switchport
    switchport trunk allowed vlan 
    switchport mode trunk
    mlag 1
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-L2LEAF2A_Po3
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group MLAG

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-L2LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-L2LEAF2B.cfg
@@ -34,6 +34,7 @@ vrf instance MGMT
 !
 interface Port-Channel1
    description DC1-SVC3B_Po7
+   no shutdown
    switchport
    switchport trunk allowed vlan 
    switchport mode trunk
@@ -41,6 +42,7 @@ interface Port-Channel1
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-L2LEAF2A_Po3
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -48,27 +50,33 @@ interface Port-Channel3
 !
 interface Ethernet1
    description DC1-SVC3A_Ethernet8
+   no shutdown
    channel-group 1 mode active
 !
 interface Ethernet2
    description DC1-SVC3B_Ethernet8
+   no shutdown
    channel-group 1 mode active
 !
 interface Ethernet3
    description MLAG_PEER_DC1-L2LEAF2A_Ethernet3
+   no shutdown
    channel-group 3 mode active
 !
 interface Ethernet4
    description MLAG_PEER_DC1-L2LEAF2A_Ethernet4
+   no shutdown
    channel-group 3 mode active
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.114/24
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.17/31
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-LEAF1A.cfg
@@ -116,6 +116,8 @@ router bgp 65000
    neighbor 192.168.255.4 peer group EVPN-OVERLAY-PEERS
    !
    address-family evpn
+      neighbor EVPN-OVERLAY-PEERS route-map RM-EVPN-SOO-IN in
+      neighbor EVPN-OVERLAY-PEERS route-map RM-EVPN-SOO-OUT out
       neighbor EVPN-OVERLAY-PEERS activate
    !
    address-family ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-LEAF1A.cfg
@@ -29,6 +29,7 @@ vrf instance MGMT
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.1/31
    isis enable EVPN_UNDERLAY
@@ -37,6 +38,7 @@ interface Ethernet1
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.3/31
    isis enable EVPN_UNDERLAY
@@ -45,6 +47,7 @@ interface Ethernet2
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.5/31
    isis enable EVPN_UNDERLAY
@@ -53,6 +56,7 @@ interface Ethernet3
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.7/31
    isis enable EVPN_UNDERLAY
@@ -61,18 +65,21 @@ interface Ethernet4
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.5/32
    isis enable EVPN_UNDERLAY
    isis passive
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.5/32
    isis enable EVPN_UNDERLAY
    isis passive
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.105/24
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-LEAF2A.cfg
@@ -38,6 +38,7 @@ vrf instance MGMT
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-LEAF2B_Po5
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -45,6 +46,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF1_Po1
+   switchport
    switchport trunk allowed vlan 
    switchport mode trunk
    mlag 7
@@ -173,6 +175,8 @@ router bgp 65000
    neighbor 192.168.255.4 peer group EVPN-OVERLAY-PEERS
    !
    address-family evpn
+      neighbor EVPN-OVERLAY-PEERS route-map RM-EVPN-SOO-IN in
+      neighbor EVPN-OVERLAY-PEERS route-map RM-EVPN-SOO-OUT out
       neighbor EVPN-OVERLAY-PEERS activate
    !
    address-family ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-LEAF2A.cfg
@@ -38,6 +38,7 @@ vrf instance MGMT
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-LEAF2B_Po5
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -46,6 +47,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF1_Po1
+   no shutdown
    switchport
    switchport trunk allowed vlan 
    switchport mode trunk
@@ -53,6 +55,7 @@ interface Port-Channel7
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.9/31
    isis enable EVPN_UNDERLAY
@@ -61,6 +64,7 @@ interface Ethernet1
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.11/31
    isis enable EVPN_UNDERLAY
@@ -69,6 +73,7 @@ interface Ethernet2
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.13/31
    isis enable EVPN_UNDERLAY
@@ -77,6 +82,7 @@ interface Ethernet3
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.15/31
    isis enable EVPN_UNDERLAY
@@ -85,35 +91,42 @@ interface Ethernet4
 !
 interface Ethernet5
    description MLAG_PEER_DC1-LEAF2B_Ethernet5
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-LEAF2B_Ethernet6
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet7
    description DC1-L2LEAF1A_Ethernet1
+   no shutdown
    channel-group 7 mode active
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.6/32
    isis enable EVPN_UNDERLAY
    isis passive
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.6/32
    isis enable EVPN_UNDERLAY
    isis passive
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.106/24
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
+   no shutdown
    ip address 10.255.251.2/31
    isis enable EVPN_UNDERLAY
    isis metric 50
@@ -121,6 +134,7 @@ interface Vlan4093
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.2/31
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-LEAF2B.cfg
@@ -38,6 +38,7 @@ vrf instance MGMT
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-LEAF2A_Po5
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -45,6 +46,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF1_Po1
+   switchport
    switchport trunk allowed vlan 
    switchport mode trunk
    mlag 7
@@ -173,6 +175,8 @@ router bgp 65000
    neighbor 192.168.255.4 peer group EVPN-OVERLAY-PEERS
    !
    address-family evpn
+      neighbor EVPN-OVERLAY-PEERS route-map RM-EVPN-SOO-IN in
+      neighbor EVPN-OVERLAY-PEERS route-map RM-EVPN-SOO-OUT out
       neighbor EVPN-OVERLAY-PEERS activate
    !
    address-family ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-LEAF2B.cfg
@@ -38,6 +38,7 @@ vrf instance MGMT
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-LEAF2A_Po5
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -46,6 +47,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF1_Po1
+   no shutdown
    switchport
    switchport trunk allowed vlan 
    switchport mode trunk
@@ -53,6 +55,7 @@ interface Port-Channel7
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.17/31
    isis enable EVPN_UNDERLAY
@@ -61,6 +64,7 @@ interface Ethernet1
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.19/31
    isis enable EVPN_UNDERLAY
@@ -69,6 +73,7 @@ interface Ethernet2
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.21/31
    isis enable EVPN_UNDERLAY
@@ -77,6 +82,7 @@ interface Ethernet3
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.23/31
    isis enable EVPN_UNDERLAY
@@ -85,35 +91,42 @@ interface Ethernet4
 !
 interface Ethernet5
    description MLAG_PEER_DC1-LEAF2A_Ethernet5
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-LEAF2A_Ethernet6
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet7
    description DC1-L2LEAF1A_Ethernet2
+   no shutdown
    channel-group 7 mode active
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.7/32
    isis enable EVPN_UNDERLAY
    isis passive
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.6/32
    isis enable EVPN_UNDERLAY
    isis passive
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.107/24
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
+   no shutdown
    ip address 10.255.251.3/31
    isis enable EVPN_UNDERLAY
    isis metric 50
@@ -121,6 +134,7 @@ interface Vlan4093
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.3/31
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SPINE1.cfg
@@ -28,6 +28,7 @@ vrf instance MGMT
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.0/31
    isis enable EVPN_UNDERLAY
@@ -36,6 +37,7 @@ interface Ethernet1
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-LEAF2A_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.8/31
    isis enable EVPN_UNDERLAY
@@ -44,6 +46,7 @@ interface Ethernet2
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-LEAF2B_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.16/31
    isis enable EVPN_UNDERLAY
@@ -52,6 +55,7 @@ interface Ethernet3
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SVC3A_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.24/31
    isis enable EVPN_UNDERLAY
@@ -60,6 +64,7 @@ interface Ethernet4
 !
 interface Ethernet5
    description P2P_LINK_TO_DC1-SVC3B_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.32/31
    isis enable EVPN_UNDERLAY
@@ -68,6 +73,7 @@ interface Ethernet5
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-BL1A_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.40/31
    isis enable EVPN_UNDERLAY
@@ -76,6 +82,7 @@ interface Ethernet6
 !
 interface Ethernet7
    description P2P_LINK_TO_DC1-BL1B_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.48/31
    isis enable EVPN_UNDERLAY
@@ -84,12 +91,14 @@ interface Ethernet7
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.1/32
    isis enable EVPN_UNDERLAY
    isis passive
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.101/24
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SPINE2.cfg
@@ -28,6 +28,7 @@ vrf instance MGMT
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.2/31
    isis enable EVPN_UNDERLAY
@@ -36,6 +37,7 @@ interface Ethernet1
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-LEAF2A_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.10/31
    isis enable EVPN_UNDERLAY
@@ -44,6 +46,7 @@ interface Ethernet2
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-LEAF2B_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.18/31
    isis enable EVPN_UNDERLAY
@@ -52,6 +55,7 @@ interface Ethernet3
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SVC3A_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.26/31
    isis enable EVPN_UNDERLAY
@@ -60,6 +64,7 @@ interface Ethernet4
 !
 interface Ethernet5
    description P2P_LINK_TO_DC1-SVC3B_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.34/31
    isis enable EVPN_UNDERLAY
@@ -68,6 +73,7 @@ interface Ethernet5
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-BL1A_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.42/31
    isis enable EVPN_UNDERLAY
@@ -76,6 +82,7 @@ interface Ethernet6
 !
 interface Ethernet7
    description P2P_LINK_TO_DC1-BL1B_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.50/31
    isis enable EVPN_UNDERLAY
@@ -84,12 +91,14 @@ interface Ethernet7
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.2/32
    isis enable EVPN_UNDERLAY
    isis passive
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.102/24
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SPINE3.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SPINE3.cfg
@@ -28,6 +28,7 @@ vrf instance MGMT
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.4/31
    isis enable EVPN_UNDERLAY
@@ -36,6 +37,7 @@ interface Ethernet1
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-LEAF2A_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.12/31
    isis enable EVPN_UNDERLAY
@@ -44,6 +46,7 @@ interface Ethernet2
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-LEAF2B_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.20/31
    isis enable EVPN_UNDERLAY
@@ -52,6 +55,7 @@ interface Ethernet3
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SVC3A_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.28/31
    isis enable EVPN_UNDERLAY
@@ -60,6 +64,7 @@ interface Ethernet4
 !
 interface Ethernet5
    description P2P_LINK_TO_DC1-SVC3B_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.36/31
    isis enable EVPN_UNDERLAY
@@ -68,6 +73,7 @@ interface Ethernet5
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-BL1A_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.44/31
    isis enable EVPN_UNDERLAY
@@ -76,6 +82,7 @@ interface Ethernet6
 !
 interface Ethernet7
    description P2P_LINK_TO_DC1-BL1B_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.52/31
    isis enable EVPN_UNDERLAY
@@ -84,12 +91,14 @@ interface Ethernet7
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.3/32
    isis enable EVPN_UNDERLAY
    isis passive
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.103/24
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SPINE4.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SPINE4.cfg
@@ -28,6 +28,7 @@ vrf instance MGMT
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.6/31
    isis enable EVPN_UNDERLAY
@@ -36,6 +37,7 @@ interface Ethernet1
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-LEAF2A_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.14/31
    isis enable EVPN_UNDERLAY
@@ -44,6 +46,7 @@ interface Ethernet2
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-LEAF2B_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.22/31
    isis enable EVPN_UNDERLAY
@@ -52,6 +55,7 @@ interface Ethernet3
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SVC3A_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.30/31
    isis enable EVPN_UNDERLAY
@@ -60,6 +64,7 @@ interface Ethernet4
 !
 interface Ethernet5
    description P2P_LINK_TO_DC1-SVC3B_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.38/31
    isis enable EVPN_UNDERLAY
@@ -68,6 +73,7 @@ interface Ethernet5
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-BL1A_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.46/31
    isis enable EVPN_UNDERLAY
@@ -76,6 +82,7 @@ interface Ethernet6
 !
 interface Ethernet7
    description P2P_LINK_TO_DC1-BL1B_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.54/31
    isis enable EVPN_UNDERLAY
@@ -84,12 +91,14 @@ interface Ethernet7
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.4/32
    isis enable EVPN_UNDERLAY
    isis passive
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.104/24
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SVC3A.cfg
@@ -38,6 +38,7 @@ vrf instance MGMT
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-SVC3B_Po5
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -46,6 +47,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF2_Po1
+   no shutdown
    switchport
    switchport trunk allowed vlan 
    switchport mode trunk
@@ -53,6 +55,7 @@ interface Port-Channel7
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.25/31
    isis enable EVPN_UNDERLAY
@@ -61,6 +64,7 @@ interface Ethernet1
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.27/31
    isis enable EVPN_UNDERLAY
@@ -69,6 +73,7 @@ interface Ethernet2
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.29/31
    isis enable EVPN_UNDERLAY
@@ -77,6 +82,7 @@ interface Ethernet3
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.31/31
    isis enable EVPN_UNDERLAY
@@ -85,39 +91,47 @@ interface Ethernet4
 !
 interface Ethernet5
    description MLAG_PEER_DC1-SVC3B_Ethernet5
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-SVC3B_Ethernet6
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet7
    description DC1-L2LEAF2A_Ethernet1
+   no shutdown
    channel-group 7 mode active
 !
 interface Ethernet8
    description DC1-L2LEAF2B_Ethernet1
+   no shutdown
    channel-group 7 mode active
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.8/32
    isis enable EVPN_UNDERLAY
    isis passive
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.8/32
    isis enable EVPN_UNDERLAY
    isis passive
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.108/24
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
+   no shutdown
    ip address 10.255.251.6/31
    isis enable EVPN_UNDERLAY
    isis metric 50
@@ -125,6 +139,7 @@ interface Vlan4093
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.6/31
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SVC3A.cfg
@@ -38,6 +38,7 @@ vrf instance MGMT
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-SVC3B_Po5
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -45,6 +46,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF2_Po1
+   switchport
    switchport trunk allowed vlan 
    switchport mode trunk
    mlag 7
@@ -177,6 +179,8 @@ router bgp 65000
    neighbor 192.168.255.4 peer group EVPN-OVERLAY-PEERS
    !
    address-family evpn
+      neighbor EVPN-OVERLAY-PEERS route-map RM-EVPN-SOO-IN in
+      neighbor EVPN-OVERLAY-PEERS route-map RM-EVPN-SOO-OUT out
       neighbor EVPN-OVERLAY-PEERS activate
    !
    address-family ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SVC3B.cfg
@@ -38,6 +38,7 @@ vrf instance MGMT
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-SVC3A_Po5
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -46,6 +47,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF2_Po1
+   no shutdown
    switchport
    switchport trunk allowed vlan 
    switchport mode trunk
@@ -53,6 +55,7 @@ interface Port-Channel7
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet5
+   no shutdown
    no switchport
    ip address 172.31.255.33/31
    isis enable EVPN_UNDERLAY
@@ -61,6 +64,7 @@ interface Ethernet1
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet5
+   no shutdown
    no switchport
    ip address 172.31.255.35/31
    isis enable EVPN_UNDERLAY
@@ -69,6 +73,7 @@ interface Ethernet2
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet5
+   no shutdown
    no switchport
    ip address 172.31.255.37/31
    isis enable EVPN_UNDERLAY
@@ -77,6 +82,7 @@ interface Ethernet3
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet5
+   no shutdown
    no switchport
    ip address 172.31.255.39/31
    isis enable EVPN_UNDERLAY
@@ -85,39 +91,47 @@ interface Ethernet4
 !
 interface Ethernet5
    description MLAG_PEER_DC1-SVC3A_Ethernet5
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-SVC3A_Ethernet6
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet7
    description DC1-L2LEAF2A_Ethernet2
+   no shutdown
    channel-group 7 mode active
 !
 interface Ethernet8
    description DC1-L2LEAF2B_Ethernet2
+   no shutdown
    channel-group 7 mode active
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.9/32
    isis enable EVPN_UNDERLAY
    isis passive
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.8/32
    isis enable EVPN_UNDERLAY
    isis passive
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.109/24
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
+   no shutdown
    ip address 10.255.251.7/31
    isis enable EVPN_UNDERLAY
    isis metric 50
@@ -125,6 +139,7 @@ interface Vlan4093
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.7/31
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SVC3B.cfg
@@ -38,6 +38,7 @@ vrf instance MGMT
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-SVC3A_Po5
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -45,6 +46,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF2_Po1
+   switchport
    switchport trunk allowed vlan 
    switchport mode trunk
    mlag 7
@@ -177,6 +179,8 @@ router bgp 65000
    neighbor 192.168.255.4 peer group EVPN-OVERLAY-PEERS
    !
    address-family evpn
+      neighbor EVPN-OVERLAY-PEERS route-map RM-EVPN-SOO-IN in
+      neighbor EVPN-OVERLAY-PEERS route-map RM-EVPN-SOO-OUT out
       neighbor EVPN-OVERLAY-PEERS activate
    !
    address-family ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-BL1A.yml
@@ -89,6 +89,8 @@ bfd_multihop:
 port_channel_interfaces:
   Port-Channel5:
     description: MLAG_PEER_DC1-BL1B_Po5
+    type: switched
+    shutdown: false
     vlans: 2-4094
     mode: trunk
     trunk_groups:
@@ -102,6 +104,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE1_Ethernet6
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.41/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
@@ -113,6 +116,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE2_Ethernet6
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.43/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
@@ -124,6 +128,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE3_Ethernet6
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.45/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
@@ -135,6 +140,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE4_Ethernet6
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.47/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
@@ -144,6 +150,8 @@ ethernet_interfaces:
     peer_interface: Ethernet5
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-BL1B_Ethernet5
+    type: switched
+    shutdown: false
     channel_group:
       id: 5
       mode: active
@@ -152,29 +160,35 @@ ethernet_interfaces:
     peer_interface: Ethernet6
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-BL1B_Ethernet6
+    type: switched
+    shutdown: false
     channel_group:
       id: 5
       mode: active
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: 192.168.255.10/32
     isis_enable: EVPN_UNDERLAY
     isis_passive: true
   Loopback1:
     description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
     ip_address: 192.168.254.10/32
     isis_enable: EVPN_UNDERLAY
     isis_passive: true
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.110/24
     gateway: 192.168.200.5
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING
+    shutdown: false
     ip_address: 10.255.251.10/31
     mtu: 1500
     isis_enable: EVPN_UNDERLAY
@@ -182,6 +196,7 @@ vlan_interfaces:
     isis_network_point_to_point: true
   Vlan4094:
     description: MLAG_PEER
+    shutdown: false
     ip_address: 10.255.252.10/31
     no_autostate: true
     mtu: 1500

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-BL1B.yml
@@ -89,6 +89,8 @@ bfd_multihop:
 port_channel_interfaces:
   Port-Channel5:
     description: MLAG_PEER_DC1-BL1A_Po5
+    type: switched
+    shutdown: false
     vlans: 2-4094
     mode: trunk
     trunk_groups:
@@ -102,6 +104,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE1_Ethernet7
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.49/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
@@ -113,6 +116,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE2_Ethernet7
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.51/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
@@ -124,6 +128,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE3_Ethernet7
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.53/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
@@ -135,6 +140,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE4_Ethernet7
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.55/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
@@ -144,6 +150,8 @@ ethernet_interfaces:
     peer_interface: Ethernet5
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-BL1A_Ethernet5
+    type: switched
+    shutdown: false
     channel_group:
       id: 5
       mode: active
@@ -152,29 +160,35 @@ ethernet_interfaces:
     peer_interface: Ethernet6
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-BL1A_Ethernet6
+    type: switched
+    shutdown: false
     channel_group:
       id: 5
       mode: active
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: 192.168.255.11/32
     isis_enable: EVPN_UNDERLAY
     isis_passive: true
   Loopback1:
     description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
     ip_address: 192.168.254.10/32
     isis_enable: EVPN_UNDERLAY
     isis_passive: true
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.111/24
     gateway: 192.168.200.5
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING
+    shutdown: false
     ip_address: 10.255.251.11/31
     mtu: 1500
     isis_enable: EVPN_UNDERLAY
@@ -182,6 +196,7 @@ vlan_interfaces:
     isis_network_point_to_point: true
   Vlan4094:
     description: MLAG_PEER
+    shutdown: false
     ip_address: 10.255.252.11/31
     no_autostate: true
     mtu: 1500

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -68,6 +68,8 @@ vrfs:
 port_channel_interfaces:
   Port-Channel1:
     description: DC1-LEAF2A_Po7
+    type: switched
+    shutdown: false
     vlans: null
     mode: trunk
 ethernet_interfaces:
@@ -76,6 +78,8 @@ ethernet_interfaces:
     peer_interface: Ethernet7
     peer_type: l3leaf
     description: DC1-LEAF2A_Ethernet7
+    type: switched
+    shutdown: false
     channel_group:
       id: 1
       mode: active
@@ -84,12 +88,15 @@ ethernet_interfaces:
     peer_interface: Ethernet7
     peer_type: l3leaf
     description: DC1-LEAF2B_Ethernet7
+    type: switched
+    shutdown: false
     channel_group:
       id: 1
       mode: active
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.112/24
     gateway: 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -70,7 +70,6 @@ port_channel_interfaces:
     description: DC1-LEAF2A_Po7
     vlans: null
     mode: trunk
-    mlag: 1
 ethernet_interfaces:
   Ethernet1:
     peer: DC1-LEAF2A

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -78,11 +78,15 @@ vrfs:
 port_channel_interfaces:
   Port-Channel1:
     description: DC1-SVC3A_Po7
+    type: switched
+    shutdown: false
     vlans: null
     mode: trunk
     mlag: 1
   Port-Channel3:
     description: MLAG_PEER_DC1-L2LEAF2B_Po3
+    type: switched
+    shutdown: false
     vlans: 2-4094
     mode: trunk
     trunk_groups:
@@ -93,6 +97,8 @@ ethernet_interfaces:
     peer_interface: Ethernet7
     peer_type: l3leaf
     description: DC1-SVC3A_Ethernet7
+    type: switched
+    shutdown: false
     channel_group:
       id: 1
       mode: active
@@ -101,6 +107,8 @@ ethernet_interfaces:
     peer_interface: Ethernet7
     peer_type: l3leaf
     description: DC1-SVC3B_Ethernet7
+    type: switched
+    shutdown: false
     channel_group:
       id: 1
       mode: active
@@ -109,6 +117,8 @@ ethernet_interfaces:
     peer_interface: Ethernet3
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-L2LEAF2B_Ethernet3
+    type: switched
+    shutdown: false
     channel_group:
       id: 3
       mode: active
@@ -117,18 +127,22 @@ ethernet_interfaces:
     peer_interface: Ethernet4
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-L2LEAF2B_Ethernet4
+    type: switched
+    shutdown: false
     channel_group:
       id: 3
       mode: active
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.113/24
     gateway: 192.168.200.5
 vlan_interfaces:
   Vlan4094:
     description: MLAG_PEER
+    shutdown: false
     ip_address: 10.255.252.16/31
     no_autostate: true
     mtu: 1500

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -78,11 +78,15 @@ vrfs:
 port_channel_interfaces:
   Port-Channel1:
     description: DC1-SVC3B_Po7
+    type: switched
+    shutdown: false
     vlans: null
     mode: trunk
     mlag: 1
   Port-Channel3:
     description: MLAG_PEER_DC1-L2LEAF2A_Po3
+    type: switched
+    shutdown: false
     vlans: 2-4094
     mode: trunk
     trunk_groups:
@@ -93,6 +97,8 @@ ethernet_interfaces:
     peer_interface: Ethernet8
     peer_type: l3leaf
     description: DC1-SVC3A_Ethernet8
+    type: switched
+    shutdown: false
     channel_group:
       id: 1
       mode: active
@@ -101,6 +107,8 @@ ethernet_interfaces:
     peer_interface: Ethernet8
     peer_type: l3leaf
     description: DC1-SVC3B_Ethernet8
+    type: switched
+    shutdown: false
     channel_group:
       id: 1
       mode: active
@@ -109,6 +117,8 @@ ethernet_interfaces:
     peer_interface: Ethernet3
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-L2LEAF2A_Ethernet3
+    type: switched
+    shutdown: false
     channel_group:
       id: 3
       mode: active
@@ -117,18 +127,22 @@ ethernet_interfaces:
     peer_interface: Ethernet4
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-L2LEAF2A_Ethernet4
+    type: switched
+    shutdown: false
     channel_group:
       id: 3
       mode: active
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.114/24
     gateway: 192.168.200.5
 vlan_interfaces:
   Vlan4094:
     description: MLAG_PEER
+    shutdown: false
     ip_address: 10.255.252.17/31
     no_autostate: true
     mtu: 1500

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF1A.yml
@@ -79,6 +79,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE1_Ethernet1
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.1/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
@@ -90,6 +91,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE2_Ethernet1
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.3/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
@@ -101,6 +103,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE3_Ethernet1
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.5/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
@@ -112,6 +115,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE4_Ethernet1
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.7/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
@@ -119,17 +123,20 @@ ethernet_interfaces:
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: 192.168.255.5/32
     isis_enable: EVPN_UNDERLAY
     isis_passive: true
   Loopback1:
     description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
     ip_address: 192.168.254.5/32
     isis_enable: EVPN_UNDERLAY
     isis_passive: true
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.105/24
     gateway: 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -96,11 +96,15 @@ bfd_multihop:
 port_channel_interfaces:
   Port-Channel7:
     description: DC1_L2LEAF1_Po1
+    type: switched
+    shutdown: false
     vlans: null
     mode: trunk
     mlag: 7
   Port-Channel5:
     description: MLAG_PEER_DC1-LEAF2B_Po5
+    type: switched
+    shutdown: false
     vlans: 2-4094
     mode: trunk
     trunk_groups:
@@ -114,6 +118,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE1_Ethernet2
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.9/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
@@ -125,6 +130,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE2_Ethernet2
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.11/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
@@ -136,6 +142,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE3_Ethernet2
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.13/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
@@ -147,6 +154,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE4_Ethernet2
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.15/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
@@ -156,6 +164,8 @@ ethernet_interfaces:
     peer_interface: Ethernet5
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-LEAF2B_Ethernet5
+    type: switched
+    shutdown: false
     channel_group:
       id: 5
       mode: active
@@ -164,6 +174,8 @@ ethernet_interfaces:
     peer_interface: Ethernet6
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-LEAF2B_Ethernet6
+    type: switched
+    shutdown: false
     channel_group:
       id: 5
       mode: active
@@ -172,29 +184,35 @@ ethernet_interfaces:
     peer_interface: Ethernet1
     peer_type: l2leaf
     description: DC1-L2LEAF1A_Ethernet1
+    type: switched
+    shutdown: false
     channel_group:
       id: 7
       mode: active
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: 192.168.255.6/32
     isis_enable: EVPN_UNDERLAY
     isis_passive: true
   Loopback1:
     description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
     ip_address: 192.168.254.6/32
     isis_enable: EVPN_UNDERLAY
     isis_passive: true
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.106/24
     gateway: 192.168.200.5
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING
+    shutdown: false
     ip_address: 10.255.251.2/31
     mtu: 1500
     isis_enable: EVPN_UNDERLAY
@@ -202,6 +220,7 @@ vlan_interfaces:
     isis_network_point_to_point: true
   Vlan4094:
     description: MLAG_PEER
+    shutdown: false
     ip_address: 10.255.252.2/31
     no_autostate: true
     mtu: 1500

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -96,11 +96,15 @@ bfd_multihop:
 port_channel_interfaces:
   Port-Channel7:
     description: DC1_L2LEAF1_Po1
+    type: switched
+    shutdown: false
     vlans: null
     mode: trunk
     mlag: 7
   Port-Channel5:
     description: MLAG_PEER_DC1-LEAF2A_Po5
+    type: switched
+    shutdown: false
     vlans: 2-4094
     mode: trunk
     trunk_groups:
@@ -114,6 +118,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE1_Ethernet3
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.17/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
@@ -125,6 +130,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE2_Ethernet3
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.19/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
@@ -136,6 +142,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE3_Ethernet3
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.21/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
@@ -147,6 +154,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE4_Ethernet3
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.23/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
@@ -156,6 +164,8 @@ ethernet_interfaces:
     peer_interface: Ethernet5
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-LEAF2A_Ethernet5
+    type: switched
+    shutdown: false
     channel_group:
       id: 5
       mode: active
@@ -164,6 +174,8 @@ ethernet_interfaces:
     peer_interface: Ethernet6
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-LEAF2A_Ethernet6
+    type: switched
+    shutdown: false
     channel_group:
       id: 5
       mode: active
@@ -172,29 +184,35 @@ ethernet_interfaces:
     peer_interface: Ethernet2
     peer_type: l2leaf
     description: DC1-L2LEAF1A_Ethernet2
+    type: switched
+    shutdown: false
     channel_group:
       id: 7
       mode: active
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: 192.168.255.7/32
     isis_enable: EVPN_UNDERLAY
     isis_passive: true
   Loopback1:
     description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
     ip_address: 192.168.254.6/32
     isis_enable: EVPN_UNDERLAY
     isis_passive: true
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.107/24
     gateway: 192.168.200.5
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING
+    shutdown: false
     ip_address: 10.255.251.3/31
     mtu: 1500
     isis_enable: EVPN_UNDERLAY
@@ -202,6 +220,7 @@ vlan_interfaces:
     isis_network_point_to_point: true
   Vlan4094:
     description: MLAG_PEER
+    shutdown: false
     ip_address: 10.255.252.3/31
     no_autostate: true
     mtu: 1500

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SPINE1.yml
@@ -63,6 +63,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-BL1A_Ethernet1
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.40/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
@@ -74,6 +75,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-BL1B_Ethernet1
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.48/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
@@ -85,6 +87,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF1A_Ethernet1
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.0/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
@@ -96,6 +99,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF2A_Ethernet1
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.8/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
@@ -107,6 +111,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF2B_Ethernet1
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.16/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
@@ -118,6 +123,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SVC3A_Ethernet1
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.24/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
@@ -129,6 +135,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SVC3B_Ethernet1
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.32/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
@@ -136,12 +143,14 @@ ethernet_interfaces:
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: 192.168.255.1/32
     isis_enable: EVPN_UNDERLAY
     isis_passive: true
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.101/24
     gateway: 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SPINE2.yml
@@ -63,6 +63,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-BL1A_Ethernet2
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.42/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
@@ -74,6 +75,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-BL1B_Ethernet2
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.50/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
@@ -85,6 +87,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF1A_Ethernet2
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.2/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
@@ -96,6 +99,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF2A_Ethernet2
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.10/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
@@ -107,6 +111,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF2B_Ethernet2
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.18/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
@@ -118,6 +123,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SVC3A_Ethernet2
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.26/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
@@ -129,6 +135,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SVC3B_Ethernet2
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.34/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
@@ -136,12 +143,14 @@ ethernet_interfaces:
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: 192.168.255.2/32
     isis_enable: EVPN_UNDERLAY
     isis_passive: true
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.102/24
     gateway: 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SPINE3.yml
@@ -63,6 +63,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-BL1A_Ethernet3
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.44/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
@@ -74,6 +75,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-BL1B_Ethernet3
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.52/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
@@ -85,6 +87,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF1A_Ethernet3
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.4/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
@@ -96,6 +99,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF2A_Ethernet3
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.12/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
@@ -107,6 +111,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF2B_Ethernet3
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.20/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
@@ -118,6 +123,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SVC3A_Ethernet3
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.28/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
@@ -129,6 +135,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SVC3B_Ethernet3
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.36/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
@@ -136,12 +143,14 @@ ethernet_interfaces:
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: 192.168.255.3/32
     isis_enable: EVPN_UNDERLAY
     isis_passive: true
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.103/24
     gateway: 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SPINE4.yml
@@ -63,6 +63,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-BL1A_Ethernet4
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.46/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
@@ -74,6 +75,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-BL1B_Ethernet4
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.54/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
@@ -85,6 +87,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF1A_Ethernet4
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.6/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
@@ -96,6 +99,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF2A_Ethernet4
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.14/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
@@ -107,6 +111,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF2B_Ethernet4
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.22/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
@@ -118,6 +123,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SVC3A_Ethernet4
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.30/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
@@ -129,6 +135,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SVC3B_Ethernet4
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.38/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
@@ -136,12 +143,14 @@ ethernet_interfaces:
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: 192.168.255.4/32
     isis_enable: EVPN_UNDERLAY
     isis_passive: true
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.104/24
     gateway: 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SVC3A.yml
@@ -97,11 +97,15 @@ bfd_multihop:
 port_channel_interfaces:
   Port-Channel7:
     description: DC1_L2LEAF2_Po1
+    type: switched
+    shutdown: false
     vlans: null
     mode: trunk
     mlag: 7
   Port-Channel5:
     description: MLAG_PEER_DC1-SVC3B_Po5
+    type: switched
+    shutdown: false
     vlans: 2-4094
     mode: trunk
     trunk_groups:
@@ -115,6 +119,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE1_Ethernet4
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.25/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
@@ -126,6 +131,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE2_Ethernet4
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.27/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
@@ -137,6 +143,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE3_Ethernet4
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.29/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
@@ -148,6 +155,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE4_Ethernet4
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.31/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
@@ -157,6 +165,8 @@ ethernet_interfaces:
     peer_interface: Ethernet5
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-SVC3B_Ethernet5
+    type: switched
+    shutdown: false
     channel_group:
       id: 5
       mode: active
@@ -165,6 +175,8 @@ ethernet_interfaces:
     peer_interface: Ethernet6
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-SVC3B_Ethernet6
+    type: switched
+    shutdown: false
     channel_group:
       id: 5
       mode: active
@@ -173,6 +185,8 @@ ethernet_interfaces:
     peer_interface: Ethernet1
     peer_type: l2leaf
     description: DC1-L2LEAF2A_Ethernet1
+    type: switched
+    shutdown: false
     channel_group:
       id: 7
       mode: active
@@ -181,29 +195,35 @@ ethernet_interfaces:
     peer_interface: Ethernet1
     peer_type: l2leaf
     description: DC1-L2LEAF2B_Ethernet1
+    type: switched
+    shutdown: false
     channel_group:
       id: 7
       mode: active
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: 192.168.255.8/32
     isis_enable: EVPN_UNDERLAY
     isis_passive: true
   Loopback1:
     description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
     ip_address: 192.168.254.8/32
     isis_enable: EVPN_UNDERLAY
     isis_passive: true
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.108/24
     gateway: 192.168.200.5
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING
+    shutdown: false
     ip_address: 10.255.251.6/31
     mtu: 1500
     isis_enable: EVPN_UNDERLAY
@@ -211,6 +231,7 @@ vlan_interfaces:
     isis_network_point_to_point: true
   Vlan4094:
     description: MLAG_PEER
+    shutdown: false
     ip_address: 10.255.252.6/31
     no_autostate: true
     mtu: 1500

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SVC3B.yml
@@ -97,11 +97,15 @@ bfd_multihop:
 port_channel_interfaces:
   Port-Channel7:
     description: DC1_L2LEAF2_Po1
+    type: switched
+    shutdown: false
     vlans: null
     mode: trunk
     mlag: 7
   Port-Channel5:
     description: MLAG_PEER_DC1-SVC3A_Po5
+    type: switched
+    shutdown: false
     vlans: 2-4094
     mode: trunk
     trunk_groups:
@@ -115,6 +119,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE1_Ethernet5
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.33/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
@@ -126,6 +131,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE2_Ethernet5
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.35/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
@@ -137,6 +143,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE3_Ethernet5
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.37/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
@@ -148,6 +155,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE4_Ethernet5
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.39/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
@@ -157,6 +165,8 @@ ethernet_interfaces:
     peer_interface: Ethernet5
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-SVC3A_Ethernet5
+    type: switched
+    shutdown: false
     channel_group:
       id: 5
       mode: active
@@ -165,6 +175,8 @@ ethernet_interfaces:
     peer_interface: Ethernet6
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-SVC3A_Ethernet6
+    type: switched
+    shutdown: false
     channel_group:
       id: 5
       mode: active
@@ -173,6 +185,8 @@ ethernet_interfaces:
     peer_interface: Ethernet2
     peer_type: l2leaf
     description: DC1-L2LEAF2A_Ethernet2
+    type: switched
+    shutdown: false
     channel_group:
       id: 7
       mode: active
@@ -181,29 +195,35 @@ ethernet_interfaces:
     peer_interface: Ethernet2
     peer_type: l2leaf
     description: DC1-L2LEAF2B_Ethernet2
+    type: switched
+    shutdown: false
     channel_group:
       id: 7
       mode: active
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: 192.168.255.9/32
     isis_enable: EVPN_UNDERLAY
     isis_passive: true
   Loopback1:
     description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
     ip_address: 192.168.254.8/32
     isis_enable: EVPN_UNDERLAY
     isis_passive: true
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.109/24
     gateway: 192.168.200.5
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING
+    shutdown: false
     ip_address: 10.255.251.7/31
     mtu: 1500
     isis_enable: EVPN_UNDERLAY
@@ -211,6 +231,7 @@ vlan_interfaces:
     isis_network_point_to_point: true
   Vlan4094:
     description: MLAG_PEER
+    shutdown: false
     ip_address: 10.255.252.7/31
     no_autostate: true
     mtu: 1500

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.110/24
 ```
@@ -386,10 +387,10 @@ vlan 4094
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet6  |  routed  | - |  172.31.255.41/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet6  |  routed  | - |  172.31.255.43/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet6  |  routed  | - |  172.31.255.45/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet6  |  routed  | - |  172.31.255.47/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet6  |  routed  | - |  172.31.255.41/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet6  |  routed  | - |  172.31.255.43/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet6  |  routed  | - |  172.31.255.45/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet6  |  routed  | - |  172.31.255.47/31  |  default  |  1500  |  false  |  -  |  -  |
 
 #### OSPF
 | Interface | Channel Group | Area | Cost | Mode |
@@ -405,6 +406,7 @@ vlan 4094
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet6
+   no shutdown
    no switchport
    ip address 172.31.255.41/31
    ip ospf network point-to-point
@@ -412,6 +414,7 @@ interface Ethernet1
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet6
+   no shutdown
    no switchport
    ip address 172.31.255.43/31
    ip ospf network point-to-point
@@ -419,6 +422,7 @@ interface Ethernet2
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet6
+   no shutdown
    no switchport
    ip address 172.31.255.45/31
    ip ospf network point-to-point
@@ -426,6 +430,7 @@ interface Ethernet3
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet6
+   no shutdown
    no switchport
    ip address 172.31.255.47/31
    ip ospf network point-to-point
@@ -433,10 +438,12 @@ interface Ethernet4
 !
 interface Ethernet5
    description MLAG_PEER_DC1-BL1B_Ethernet5
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-BL1B_Ethernet6
+   no shutdown
    channel-group 5 mode active
 ```
 
@@ -448,7 +455,7 @@ interface Ethernet6
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel5 | MLAG_PEER_DC1-BL1B_Po5 | switched | access | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
+| Port-Channel5 | MLAG_PEER_DC1-BL1B_Po5 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -456,6 +463,7 @@ interface Ethernet6
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-BL1B_Po5
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -488,11 +496,13 @@ interface Port-Channel5
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.10/32
    ip ospf area 0.0.0.0
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.10/32
    ip ospf area 0.0.0.0
 ```
@@ -503,8 +513,8 @@ interface Loopback1
 
 | Interface | Description | VRF |  MTU | Shutdown |
 | --------- | ----------- | --- | ---- | -------- |
-| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  -  |
-| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  -  |
+| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  false  |
+| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  false  |
 
 #### IPv4
 
@@ -526,12 +536,14 @@ interface Loopback1
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
+   no shutdown
    ip address 10.255.251.10/31
    ip ospf network point-to-point
    ip ospf area 0.0.0.0
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.10/31
 ```

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -451,6 +456,7 @@ interface Ethernet6
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-BL1B_Po5
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -811,6 +817,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -451,6 +456,7 @@ interface Ethernet6
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-BL1A_Po5
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -811,6 +817,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.111/24
 ```
@@ -386,10 +387,10 @@ vlan 4094
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet7  |  routed  | - |  172.31.255.49/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet7  |  routed  | - |  172.31.255.51/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet7  |  routed  | - |  172.31.255.53/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet7  |  routed  | - |  172.31.255.55/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet7  |  routed  | - |  172.31.255.49/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet7  |  routed  | - |  172.31.255.51/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet7  |  routed  | - |  172.31.255.53/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet7  |  routed  | - |  172.31.255.55/31  |  default  |  1500  |  false  |  -  |  -  |
 
 #### OSPF
 | Interface | Channel Group | Area | Cost | Mode |
@@ -405,6 +406,7 @@ vlan 4094
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet7
+   no shutdown
    no switchport
    ip address 172.31.255.49/31
    ip ospf network point-to-point
@@ -412,6 +414,7 @@ interface Ethernet1
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet7
+   no shutdown
    no switchport
    ip address 172.31.255.51/31
    ip ospf network point-to-point
@@ -419,6 +422,7 @@ interface Ethernet2
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet7
+   no shutdown
    no switchport
    ip address 172.31.255.53/31
    ip ospf network point-to-point
@@ -426,6 +430,7 @@ interface Ethernet3
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet7
+   no shutdown
    no switchport
    ip address 172.31.255.55/31
    ip ospf network point-to-point
@@ -433,10 +438,12 @@ interface Ethernet4
 !
 interface Ethernet5
    description MLAG_PEER_DC1-BL1A_Ethernet5
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-BL1A_Ethernet6
+   no shutdown
    channel-group 5 mode active
 ```
 
@@ -448,7 +455,7 @@ interface Ethernet6
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel5 | MLAG_PEER_DC1-BL1A_Po5 | switched | access | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
+| Port-Channel5 | MLAG_PEER_DC1-BL1A_Po5 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -456,6 +463,7 @@ interface Ethernet6
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-BL1A_Po5
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -488,11 +496,13 @@ interface Port-Channel5
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.11/32
    ip ospf area 0.0.0.0
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.10/32
    ip ospf area 0.0.0.0
 ```
@@ -503,8 +513,8 @@ interface Loopback1
 
 | Interface | Description | VRF |  MTU | Shutdown |
 | --------- | ----------- | --- | ---- | -------- |
-| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  -  |
-| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  -  |
+| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  false  |
+| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  false  |
 
 #### IPv4
 
@@ -526,12 +536,14 @@ interface Loopback1
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
+   no shutdown
    ip address 10.255.251.11/31
    ip ospf network point-to-point
    ip ospf area 0.0.0.0
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.11/31
 ```

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-L2LEAF1A.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -358,7 +363,7 @@ interface Ethernet2
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel1 | DC1-LEAF2A_Po7 | switched | access | - | - | - | - | - | 1 | - |
+| Port-Channel1 | DC1-LEAF2A_Po7 | switched | access | - | - | - | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -366,9 +371,9 @@ interface Ethernet2
 !
 interface Port-Channel1
    description DC1-LEAF2A_Po7
+   switchport
    switchport trunk allowed vlan 
    switchport mode trunk
-   mlag 1
 ```
 
 ## Loopback Interfaces
@@ -562,6 +567,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-L2LEAF1A.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.112/24
 ```
@@ -348,10 +349,12 @@ No VLANs defined
 !
 interface Ethernet1
    description DC1-LEAF2A_Ethernet7
+   no shutdown
    channel-group 1 mode active
 !
 interface Ethernet2
    description DC1-LEAF2B_Ethernet7
+   no shutdown
    channel-group 1 mode active
 ```
 
@@ -363,7 +366,7 @@ interface Ethernet2
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel1 | DC1-LEAF2A_Po7 | switched | access | - | - | - | - | - | - | - |
+| Port-Channel1 | DC1-LEAF2A_Po7 | switched | trunk | - | - | - | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -371,6 +374,7 @@ interface Ethernet2
 !
 interface Port-Channel1
    description DC1-LEAF2A_Po7
+   no shutdown
    switchport
    switchport trunk allowed vlan 
    switchport mode trunk

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-L2LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-L2LEAF2A.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.113/24
 ```
@@ -385,18 +386,22 @@ vlan 4094
 !
 interface Ethernet1
    description DC1-SVC3A_Ethernet7
+   no shutdown
    channel-group 1 mode active
 !
 interface Ethernet2
    description DC1-SVC3B_Ethernet7
+   no shutdown
    channel-group 1 mode active
 !
 interface Ethernet3
    description MLAG_PEER_DC1-L2LEAF2B_Ethernet3
+   no shutdown
    channel-group 3 mode active
 !
 interface Ethernet4
    description MLAG_PEER_DC1-L2LEAF2B_Ethernet4
+   no shutdown
    channel-group 3 mode active
 ```
 
@@ -408,8 +413,8 @@ interface Ethernet4
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel1 | DC1-SVC3A_Po7 | switched | access | - | - | - | - | - | 1 | - |
-| Port-Channel3 | MLAG_PEER_DC1-L2LEAF2B_Po3 | switched | access | 2-4094 | - | ['MLAG'] | - | - | - | - |
+| Port-Channel1 | DC1-SVC3A_Po7 | switched | trunk | - | - | - | - | - | 1 | - |
+| Port-Channel3 | MLAG_PEER_DC1-L2LEAF2B_Po3 | switched | trunk | 2-4094 | - | ['MLAG'] | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -417,6 +422,7 @@ interface Ethernet4
 !
 interface Port-Channel1
    description DC1-SVC3A_Po7
+   no shutdown
    switchport
    switchport trunk allowed vlan 
    switchport mode trunk
@@ -424,6 +430,7 @@ interface Port-Channel1
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-L2LEAF2B_Po3
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -440,7 +447,7 @@ No loopback interfaces defined
 
 | Interface | Description | VRF |  MTU | Shutdown |
 | --------- | ----------- | --- | ---- | -------- |
-| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  -  |
+| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  false  |
 
 #### IPv4
 
@@ -456,6 +463,7 @@ No loopback interfaces defined
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.16/31
 ```

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-L2LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-L2LEAF2A.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -412,12 +417,14 @@ interface Ethernet4
 !
 interface Port-Channel1
    description DC1-SVC3A_Po7
+   switchport
    switchport trunk allowed vlan 
    switchport mode trunk
    mlag 1
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-L2LEAF2B_Po3
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group MLAG
@@ -636,6 +643,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-L2LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-L2LEAF2B.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -412,12 +417,14 @@ interface Ethernet4
 !
 interface Port-Channel1
    description DC1-SVC3B_Po7
+   switchport
    switchport trunk allowed vlan 
    switchport mode trunk
    mlag 1
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-L2LEAF2A_Po3
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group MLAG
@@ -636,6 +643,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-L2LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-L2LEAF2B.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.114/24
 ```
@@ -385,18 +386,22 @@ vlan 4094
 !
 interface Ethernet1
    description DC1-SVC3A_Ethernet8
+   no shutdown
    channel-group 1 mode active
 !
 interface Ethernet2
    description DC1-SVC3B_Ethernet8
+   no shutdown
    channel-group 1 mode active
 !
 interface Ethernet3
    description MLAG_PEER_DC1-L2LEAF2A_Ethernet3
+   no shutdown
    channel-group 3 mode active
 !
 interface Ethernet4
    description MLAG_PEER_DC1-L2LEAF2A_Ethernet4
+   no shutdown
    channel-group 3 mode active
 ```
 
@@ -408,8 +413,8 @@ interface Ethernet4
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel1 | DC1-SVC3B_Po7 | switched | access | - | - | - | - | - | 1 | - |
-| Port-Channel3 | MLAG_PEER_DC1-L2LEAF2A_Po3 | switched | access | 2-4094 | - | ['MLAG'] | - | - | - | - |
+| Port-Channel1 | DC1-SVC3B_Po7 | switched | trunk | - | - | - | - | - | 1 | - |
+| Port-Channel3 | MLAG_PEER_DC1-L2LEAF2A_Po3 | switched | trunk | 2-4094 | - | ['MLAG'] | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -417,6 +422,7 @@ interface Ethernet4
 !
 interface Port-Channel1
    description DC1-SVC3B_Po7
+   no shutdown
    switchport
    switchport trunk allowed vlan 
    switchport mode trunk
@@ -424,6 +430,7 @@ interface Port-Channel1
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-L2LEAF2A_Po3
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -440,7 +447,7 @@ No loopback interfaces defined
 
 | Interface | Description | VRF |  MTU | Shutdown |
 | --------- | ----------- | --- | ---- | -------- |
-| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  -  |
+| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  false  |
 
 #### IPv4
 
@@ -456,6 +463,7 @@ No loopback interfaces defined
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.17/31
 ```

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -707,6 +712,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.105/24
 ```
@@ -344,10 +345,10 @@ No VLANs defined
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet1  |  routed  | - |  172.31.255.1/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet1  |  routed  | - |  172.31.255.3/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet1  |  routed  | - |  172.31.255.5/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet1  |  routed  | - |  172.31.255.7/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet1  |  routed  | - |  172.31.255.1/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet1  |  routed  | - |  172.31.255.3/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet1  |  routed  | - |  172.31.255.5/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet1  |  routed  | - |  172.31.255.7/31  |  default  |  1500  |  false  |  -  |  -  |
 
 #### OSPF
 | Interface | Channel Group | Area | Cost | Mode |
@@ -363,6 +364,7 @@ No VLANs defined
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.1/31
    ip ospf network point-to-point
@@ -370,6 +372,7 @@ interface Ethernet1
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.3/31
    ip ospf network point-to-point
@@ -377,6 +380,7 @@ interface Ethernet2
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.5/31
    ip ospf network point-to-point
@@ -384,6 +388,7 @@ interface Ethernet3
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.7/31
    ip ospf network point-to-point
@@ -419,11 +424,13 @@ No port-channels defined
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.5/32
    ip ospf area 0.0.0.0
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.5/32
    ip ospf area 0.0.0.0
 ```

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -457,6 +462,7 @@ interface Ethernet7
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-LEAF2B_Po5
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -464,6 +470,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF1_Po1
+   switchport
    switchport trunk allowed vlan 
    switchport mode trunk
    mlag 7
@@ -823,6 +830,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.106/24
 ```
@@ -387,10 +388,10 @@ vlan 4094
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet2  |  routed  | - |  172.31.255.9/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet2  |  routed  | - |  172.31.255.11/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet2  |  routed  | - |  172.31.255.13/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet2  |  routed  | - |  172.31.255.15/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet2  |  routed  | - |  172.31.255.9/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet2  |  routed  | - |  172.31.255.11/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet2  |  routed  | - |  172.31.255.13/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet2  |  routed  | - |  172.31.255.15/31  |  default  |  1500  |  false  |  -  |  -  |
 
 #### OSPF
 | Interface | Channel Group | Area | Cost | Mode |
@@ -406,6 +407,7 @@ vlan 4094
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.9/31
    ip ospf network point-to-point
@@ -413,6 +415,7 @@ interface Ethernet1
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.11/31
    ip ospf network point-to-point
@@ -420,6 +423,7 @@ interface Ethernet2
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.13/31
    ip ospf network point-to-point
@@ -427,6 +431,7 @@ interface Ethernet3
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.15/31
    ip ospf network point-to-point
@@ -434,14 +439,17 @@ interface Ethernet4
 !
 interface Ethernet5
    description MLAG_PEER_DC1-LEAF2B_Ethernet5
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-LEAF2B_Ethernet6
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet7
    description DC1-L2LEAF1A_Ethernet1
+   no shutdown
    channel-group 7 mode active
 ```
 
@@ -453,8 +461,8 @@ interface Ethernet7
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel5 | MLAG_PEER_DC1-LEAF2B_Po5 | switched | access | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
-| Port-Channel7 | DC1_L2LEAF1_Po1 | switched | access | - | - | - | - | - | 7 | - |
+| Port-Channel5 | MLAG_PEER_DC1-LEAF2B_Po5 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
+| Port-Channel7 | DC1_L2LEAF1_Po1 | switched | trunk | - | - | - | - | - | 7 | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -462,6 +470,7 @@ interface Ethernet7
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-LEAF2B_Po5
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -470,6 +479,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF1_Po1
+   no shutdown
    switchport
    switchport trunk allowed vlan 
    switchport mode trunk
@@ -501,11 +511,13 @@ interface Port-Channel7
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.6/32
    ip ospf area 0.0.0.0
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.6/32
    ip ospf area 0.0.0.0
 ```
@@ -516,8 +528,8 @@ interface Loopback1
 
 | Interface | Description | VRF |  MTU | Shutdown |
 | --------- | ----------- | --- | ---- | -------- |
-| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  -  |
-| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  -  |
+| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  false  |
+| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  false  |
 
 #### IPv4
 
@@ -539,12 +551,14 @@ interface Loopback1
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
+   no shutdown
    ip address 10.255.251.2/31
    ip ospf network point-to-point
    ip ospf area 0.0.0.0
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.2/31
 ```

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -457,6 +462,7 @@ interface Ethernet7
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-LEAF2A_Po5
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -464,6 +470,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF1_Po1
+   switchport
    switchport trunk allowed vlan 
    switchport mode trunk
    mlag 7
@@ -823,6 +830,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.107/24
 ```
@@ -387,10 +388,10 @@ vlan 4094
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet3  |  routed  | - |  172.31.255.17/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet3  |  routed  | - |  172.31.255.19/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet3  |  routed  | - |  172.31.255.21/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet3  |  routed  | - |  172.31.255.23/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet3  |  routed  | - |  172.31.255.17/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet3  |  routed  | - |  172.31.255.19/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet3  |  routed  | - |  172.31.255.21/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet3  |  routed  | - |  172.31.255.23/31  |  default  |  1500  |  false  |  -  |  -  |
 
 #### OSPF
 | Interface | Channel Group | Area | Cost | Mode |
@@ -406,6 +407,7 @@ vlan 4094
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.17/31
    ip ospf network point-to-point
@@ -413,6 +415,7 @@ interface Ethernet1
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.19/31
    ip ospf network point-to-point
@@ -420,6 +423,7 @@ interface Ethernet2
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.21/31
    ip ospf network point-to-point
@@ -427,6 +431,7 @@ interface Ethernet3
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.23/31
    ip ospf network point-to-point
@@ -434,14 +439,17 @@ interface Ethernet4
 !
 interface Ethernet5
    description MLAG_PEER_DC1-LEAF2A_Ethernet5
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-LEAF2A_Ethernet6
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet7
    description DC1-L2LEAF1A_Ethernet2
+   no shutdown
    channel-group 7 mode active
 ```
 
@@ -453,8 +461,8 @@ interface Ethernet7
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel5 | MLAG_PEER_DC1-LEAF2A_Po5 | switched | access | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
-| Port-Channel7 | DC1_L2LEAF1_Po1 | switched | access | - | - | - | - | - | 7 | - |
+| Port-Channel5 | MLAG_PEER_DC1-LEAF2A_Po5 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
+| Port-Channel7 | DC1_L2LEAF1_Po1 | switched | trunk | - | - | - | - | - | 7 | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -462,6 +470,7 @@ interface Ethernet7
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-LEAF2A_Po5
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -470,6 +479,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF1_Po1
+   no shutdown
    switchport
    switchport trunk allowed vlan 
    switchport mode trunk
@@ -501,11 +511,13 @@ interface Port-Channel7
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.7/32
    ip ospf area 0.0.0.0
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.6/32
    ip ospf area 0.0.0.0
 ```
@@ -516,8 +528,8 @@ interface Loopback1
 
 | Interface | Description | VRF |  MTU | Shutdown |
 | --------- | ----------- | --- | ---- | -------- |
-| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  -  |
-| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  -  |
+| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  false  |
+| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  false  |
 
 #### IPv4
 
@@ -539,12 +551,14 @@ interface Loopback1
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
+   no shutdown
    ip address 10.255.251.3/31
    ip ospf network point-to-point
    ip ospf area 0.0.0.0
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.3/31
 ```

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE1.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -709,6 +714,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE1.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.101/24
 ```
@@ -337,13 +338,13 @@ No VLANs defined
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 |  P2P_LINK_TO_DC1-LEAF1A_Ethernet1  |  routed  | - |  172.31.255.0/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet2 |  P2P_LINK_TO_DC1-LEAF2A_Ethernet1  |  routed  | - |  172.31.255.8/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet3 |  P2P_LINK_TO_DC1-LEAF2B_Ethernet1  |  routed  | - |  172.31.255.16/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet4 |  P2P_LINK_TO_DC1-SVC3A_Ethernet1  |  routed  | - |  172.31.255.24/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet5 |  P2P_LINK_TO_DC1-SVC3B_Ethernet1  |  routed  | - |  172.31.255.32/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet6 |  P2P_LINK_TO_DC1-BL1A_Ethernet1  |  routed  | - |  172.31.255.40/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet7 |  P2P_LINK_TO_DC1-BL1B_Ethernet1  |  routed  | - |  172.31.255.48/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet1 |  P2P_LINK_TO_DC1-LEAF1A_Ethernet1  |  routed  | - |  172.31.255.0/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet2 |  P2P_LINK_TO_DC1-LEAF2A_Ethernet1  |  routed  | - |  172.31.255.8/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet3 |  P2P_LINK_TO_DC1-LEAF2B_Ethernet1  |  routed  | - |  172.31.255.16/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4 |  P2P_LINK_TO_DC1-SVC3A_Ethernet1  |  routed  | - |  172.31.255.24/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet5 |  P2P_LINK_TO_DC1-SVC3B_Ethernet1  |  routed  | - |  172.31.255.32/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet6 |  P2P_LINK_TO_DC1-BL1A_Ethernet1  |  routed  | - |  172.31.255.40/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet7 |  P2P_LINK_TO_DC1-BL1B_Ethernet1  |  routed  | - |  172.31.255.48/31  |  default  |  1500  |  false  |  -  |  -  |
 
 #### OSPF
 | Interface | Channel Group | Area | Cost | Mode |
@@ -362,6 +363,7 @@ No VLANs defined
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.0/31
    ip ospf network point-to-point
@@ -369,6 +371,7 @@ interface Ethernet1
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-LEAF2A_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.8/31
    ip ospf network point-to-point
@@ -376,6 +379,7 @@ interface Ethernet2
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-LEAF2B_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.16/31
    ip ospf network point-to-point
@@ -383,6 +387,7 @@ interface Ethernet3
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SVC3A_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.24/31
    ip ospf network point-to-point
@@ -390,6 +395,7 @@ interface Ethernet4
 !
 interface Ethernet5
    description P2P_LINK_TO_DC1-SVC3B_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.32/31
    ip ospf network point-to-point
@@ -397,6 +403,7 @@ interface Ethernet5
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-BL1A_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.40/31
    ip ospf network point-to-point
@@ -404,6 +411,7 @@ interface Ethernet6
 !
 interface Ethernet7
    description P2P_LINK_TO_DC1-BL1B_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.48/31
    ip ospf network point-to-point
@@ -437,6 +445,7 @@ No port-channels defined
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.1/32
    ip ospf area 0.0.0.0
 ```

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE2.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -709,6 +714,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE2.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.102/24
 ```
@@ -337,13 +338,13 @@ No VLANs defined
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 |  P2P_LINK_TO_DC1-LEAF1A_Ethernet2  |  routed  | - |  172.31.255.2/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet2 |  P2P_LINK_TO_DC1-LEAF2A_Ethernet2  |  routed  | - |  172.31.255.10/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet3 |  P2P_LINK_TO_DC1-LEAF2B_Ethernet2  |  routed  | - |  172.31.255.18/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet4 |  P2P_LINK_TO_DC1-SVC3A_Ethernet2  |  routed  | - |  172.31.255.26/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet5 |  P2P_LINK_TO_DC1-SVC3B_Ethernet2  |  routed  | - |  172.31.255.34/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet6 |  P2P_LINK_TO_DC1-BL1A_Ethernet2  |  routed  | - |  172.31.255.42/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet7 |  P2P_LINK_TO_DC1-BL1B_Ethernet2  |  routed  | - |  172.31.255.50/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet1 |  P2P_LINK_TO_DC1-LEAF1A_Ethernet2  |  routed  | - |  172.31.255.2/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet2 |  P2P_LINK_TO_DC1-LEAF2A_Ethernet2  |  routed  | - |  172.31.255.10/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet3 |  P2P_LINK_TO_DC1-LEAF2B_Ethernet2  |  routed  | - |  172.31.255.18/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4 |  P2P_LINK_TO_DC1-SVC3A_Ethernet2  |  routed  | - |  172.31.255.26/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet5 |  P2P_LINK_TO_DC1-SVC3B_Ethernet2  |  routed  | - |  172.31.255.34/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet6 |  P2P_LINK_TO_DC1-BL1A_Ethernet2  |  routed  | - |  172.31.255.42/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet7 |  P2P_LINK_TO_DC1-BL1B_Ethernet2  |  routed  | - |  172.31.255.50/31  |  default  |  1500  |  false  |  -  |  -  |
 
 #### OSPF
 | Interface | Channel Group | Area | Cost | Mode |
@@ -362,6 +363,7 @@ No VLANs defined
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.2/31
    ip ospf network point-to-point
@@ -369,6 +371,7 @@ interface Ethernet1
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-LEAF2A_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.10/31
    ip ospf network point-to-point
@@ -376,6 +379,7 @@ interface Ethernet2
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-LEAF2B_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.18/31
    ip ospf network point-to-point
@@ -383,6 +387,7 @@ interface Ethernet3
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SVC3A_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.26/31
    ip ospf network point-to-point
@@ -390,6 +395,7 @@ interface Ethernet4
 !
 interface Ethernet5
    description P2P_LINK_TO_DC1-SVC3B_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.34/31
    ip ospf network point-to-point
@@ -397,6 +403,7 @@ interface Ethernet5
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-BL1A_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.42/31
    ip ospf network point-to-point
@@ -404,6 +411,7 @@ interface Ethernet6
 !
 interface Ethernet7
    description P2P_LINK_TO_DC1-BL1B_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.50/31
    ip ospf network point-to-point
@@ -437,6 +445,7 @@ No port-channels defined
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.2/32
    ip ospf area 0.0.0.0
 ```

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE3.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -709,6 +714,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE3.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.103/24
 ```
@@ -337,13 +338,13 @@ No VLANs defined
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 |  P2P_LINK_TO_DC1-LEAF1A_Ethernet3  |  routed  | - |  172.31.255.4/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet2 |  P2P_LINK_TO_DC1-LEAF2A_Ethernet3  |  routed  | - |  172.31.255.12/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet3 |  P2P_LINK_TO_DC1-LEAF2B_Ethernet3  |  routed  | - |  172.31.255.20/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet4 |  P2P_LINK_TO_DC1-SVC3A_Ethernet3  |  routed  | - |  172.31.255.28/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet5 |  P2P_LINK_TO_DC1-SVC3B_Ethernet3  |  routed  | - |  172.31.255.36/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet6 |  P2P_LINK_TO_DC1-BL1A_Ethernet3  |  routed  | - |  172.31.255.44/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet7 |  P2P_LINK_TO_DC1-BL1B_Ethernet3  |  routed  | - |  172.31.255.52/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet1 |  P2P_LINK_TO_DC1-LEAF1A_Ethernet3  |  routed  | - |  172.31.255.4/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet2 |  P2P_LINK_TO_DC1-LEAF2A_Ethernet3  |  routed  | - |  172.31.255.12/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet3 |  P2P_LINK_TO_DC1-LEAF2B_Ethernet3  |  routed  | - |  172.31.255.20/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4 |  P2P_LINK_TO_DC1-SVC3A_Ethernet3  |  routed  | - |  172.31.255.28/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet5 |  P2P_LINK_TO_DC1-SVC3B_Ethernet3  |  routed  | - |  172.31.255.36/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet6 |  P2P_LINK_TO_DC1-BL1A_Ethernet3  |  routed  | - |  172.31.255.44/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet7 |  P2P_LINK_TO_DC1-BL1B_Ethernet3  |  routed  | - |  172.31.255.52/31  |  default  |  1500  |  false  |  -  |  -  |
 
 #### OSPF
 | Interface | Channel Group | Area | Cost | Mode |
@@ -362,6 +363,7 @@ No VLANs defined
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.4/31
    ip ospf network point-to-point
@@ -369,6 +371,7 @@ interface Ethernet1
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-LEAF2A_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.12/31
    ip ospf network point-to-point
@@ -376,6 +379,7 @@ interface Ethernet2
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-LEAF2B_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.20/31
    ip ospf network point-to-point
@@ -383,6 +387,7 @@ interface Ethernet3
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SVC3A_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.28/31
    ip ospf network point-to-point
@@ -390,6 +395,7 @@ interface Ethernet4
 !
 interface Ethernet5
    description P2P_LINK_TO_DC1-SVC3B_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.36/31
    ip ospf network point-to-point
@@ -397,6 +403,7 @@ interface Ethernet5
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-BL1A_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.44/31
    ip ospf network point-to-point
@@ -404,6 +411,7 @@ interface Ethernet6
 !
 interface Ethernet7
    description P2P_LINK_TO_DC1-BL1B_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.52/31
    ip ospf network point-to-point
@@ -437,6 +445,7 @@ No port-channels defined
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.3/32
    ip ospf area 0.0.0.0
 ```

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE4.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -709,6 +714,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE4.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.104/24
 ```
@@ -337,13 +338,13 @@ No VLANs defined
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 |  P2P_LINK_TO_DC1-LEAF1A_Ethernet4  |  routed  | - |  172.31.255.6/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet2 |  P2P_LINK_TO_DC1-LEAF2A_Ethernet4  |  routed  | - |  172.31.255.14/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet3 |  P2P_LINK_TO_DC1-LEAF2B_Ethernet4  |  routed  | - |  172.31.255.22/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet4 |  P2P_LINK_TO_DC1-SVC3A_Ethernet4  |  routed  | - |  172.31.255.30/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet5 |  P2P_LINK_TO_DC1-SVC3B_Ethernet4  |  routed  | - |  172.31.255.38/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet6 |  P2P_LINK_TO_DC1-BL1A_Ethernet4  |  routed  | - |  172.31.255.46/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet7 |  P2P_LINK_TO_DC1-BL1B_Ethernet4  |  routed  | - |  172.31.255.54/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet1 |  P2P_LINK_TO_DC1-LEAF1A_Ethernet4  |  routed  | - |  172.31.255.6/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet2 |  P2P_LINK_TO_DC1-LEAF2A_Ethernet4  |  routed  | - |  172.31.255.14/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet3 |  P2P_LINK_TO_DC1-LEAF2B_Ethernet4  |  routed  | - |  172.31.255.22/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4 |  P2P_LINK_TO_DC1-SVC3A_Ethernet4  |  routed  | - |  172.31.255.30/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet5 |  P2P_LINK_TO_DC1-SVC3B_Ethernet4  |  routed  | - |  172.31.255.38/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet6 |  P2P_LINK_TO_DC1-BL1A_Ethernet4  |  routed  | - |  172.31.255.46/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet7 |  P2P_LINK_TO_DC1-BL1B_Ethernet4  |  routed  | - |  172.31.255.54/31  |  default  |  1500  |  false  |  -  |  -  |
 
 #### OSPF
 | Interface | Channel Group | Area | Cost | Mode |
@@ -362,6 +363,7 @@ No VLANs defined
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.6/31
    ip ospf network point-to-point
@@ -369,6 +371,7 @@ interface Ethernet1
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-LEAF2A_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.14/31
    ip ospf network point-to-point
@@ -376,6 +379,7 @@ interface Ethernet2
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-LEAF2B_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.22/31
    ip ospf network point-to-point
@@ -383,6 +387,7 @@ interface Ethernet3
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SVC3A_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.30/31
    ip ospf network point-to-point
@@ -390,6 +395,7 @@ interface Ethernet4
 !
 interface Ethernet5
    description P2P_LINK_TO_DC1-SVC3B_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.38/31
    ip ospf network point-to-point
@@ -397,6 +403,7 @@ interface Ethernet5
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-BL1A_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.46/31
    ip ospf network point-to-point
@@ -404,6 +411,7 @@ interface Ethernet6
 !
 interface Ethernet7
    description P2P_LINK_TO_DC1-BL1B_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.54/31
    ip ospf network point-to-point
@@ -437,6 +445,7 @@ No port-channels defined
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.4/32
    ip ospf area 0.0.0.0
 ```

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -462,6 +467,7 @@ interface Ethernet8
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-SVC3B_Po5
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -469,6 +475,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF2_Po1
+   switchport
    switchport trunk allowed vlan 
    switchport mode trunk
    mlag 7
@@ -828,6 +835,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.108/24
 ```
@@ -388,10 +389,10 @@ vlan 4094
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet4  |  routed  | - |  172.31.255.25/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet4  |  routed  | - |  172.31.255.27/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet4  |  routed  | - |  172.31.255.29/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet4  |  routed  | - |  172.31.255.31/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet4  |  routed  | - |  172.31.255.25/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet4  |  routed  | - |  172.31.255.27/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet4  |  routed  | - |  172.31.255.29/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet4  |  routed  | - |  172.31.255.31/31  |  default  |  1500  |  false  |  -  |  -  |
 
 #### OSPF
 | Interface | Channel Group | Area | Cost | Mode |
@@ -407,6 +408,7 @@ vlan 4094
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.25/31
    ip ospf network point-to-point
@@ -414,6 +416,7 @@ interface Ethernet1
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.27/31
    ip ospf network point-to-point
@@ -421,6 +424,7 @@ interface Ethernet2
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.29/31
    ip ospf network point-to-point
@@ -428,6 +432,7 @@ interface Ethernet3
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.31/31
    ip ospf network point-to-point
@@ -435,18 +440,22 @@ interface Ethernet4
 !
 interface Ethernet5
    description MLAG_PEER_DC1-SVC3B_Ethernet5
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-SVC3B_Ethernet6
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet7
    description DC1-L2LEAF2A_Ethernet1
+   no shutdown
    channel-group 7 mode active
 !
 interface Ethernet8
    description DC1-L2LEAF2B_Ethernet1
+   no shutdown
    channel-group 7 mode active
 ```
 
@@ -458,8 +467,8 @@ interface Ethernet8
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel5 | MLAG_PEER_DC1-SVC3B_Po5 | switched | access | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
-| Port-Channel7 | DC1_L2LEAF2_Po1 | switched | access | - | - | - | - | - | 7 | - |
+| Port-Channel5 | MLAG_PEER_DC1-SVC3B_Po5 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
+| Port-Channel7 | DC1_L2LEAF2_Po1 | switched | trunk | - | - | - | - | - | 7 | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -467,6 +476,7 @@ interface Ethernet8
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-SVC3B_Po5
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -475,6 +485,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF2_Po1
+   no shutdown
    switchport
    switchport trunk allowed vlan 
    switchport mode trunk
@@ -506,11 +517,13 @@ interface Port-Channel7
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.8/32
    ip ospf area 0.0.0.0
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.8/32
    ip ospf area 0.0.0.0
 ```
@@ -521,8 +534,8 @@ interface Loopback1
 
 | Interface | Description | VRF |  MTU | Shutdown |
 | --------- | ----------- | --- | ---- | -------- |
-| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  -  |
-| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  -  |
+| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  false  |
+| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  false  |
 
 #### IPv4
 
@@ -544,12 +557,14 @@ interface Loopback1
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
+   no shutdown
    ip address 10.255.251.6/31
    ip ospf network point-to-point
    ip ospf area 0.0.0.0
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.6/31
 ```

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -462,6 +467,7 @@ interface Ethernet8
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-SVC3A_Po5
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -469,6 +475,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF2_Po1
+   switchport
    switchport trunk allowed vlan 
    switchport mode trunk
    mlag 7
@@ -828,6 +835,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.109/24
 ```
@@ -388,10 +389,10 @@ vlan 4094
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet5  |  routed  | - |  172.31.255.33/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet5  |  routed  | - |  172.31.255.35/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet5  |  routed  | - |  172.31.255.37/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet5  |  routed  | - |  172.31.255.39/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet5  |  routed  | - |  172.31.255.33/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet5  |  routed  | - |  172.31.255.35/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet5  |  routed  | - |  172.31.255.37/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet5  |  routed  | - |  172.31.255.39/31  |  default  |  1500  |  false  |  -  |  -  |
 
 #### OSPF
 | Interface | Channel Group | Area | Cost | Mode |
@@ -407,6 +408,7 @@ vlan 4094
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet5
+   no shutdown
    no switchport
    ip address 172.31.255.33/31
    ip ospf network point-to-point
@@ -414,6 +416,7 @@ interface Ethernet1
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet5
+   no shutdown
    no switchport
    ip address 172.31.255.35/31
    ip ospf network point-to-point
@@ -421,6 +424,7 @@ interface Ethernet2
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet5
+   no shutdown
    no switchport
    ip address 172.31.255.37/31
    ip ospf network point-to-point
@@ -428,6 +432,7 @@ interface Ethernet3
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet5
+   no shutdown
    no switchport
    ip address 172.31.255.39/31
    ip ospf network point-to-point
@@ -435,18 +440,22 @@ interface Ethernet4
 !
 interface Ethernet5
    description MLAG_PEER_DC1-SVC3A_Ethernet5
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-SVC3A_Ethernet6
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet7
    description DC1-L2LEAF2A_Ethernet2
+   no shutdown
    channel-group 7 mode active
 !
 interface Ethernet8
    description DC1-L2LEAF2B_Ethernet2
+   no shutdown
    channel-group 7 mode active
 ```
 
@@ -458,8 +467,8 @@ interface Ethernet8
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel5 | MLAG_PEER_DC1-SVC3A_Po5 | switched | access | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
-| Port-Channel7 | DC1_L2LEAF2_Po1 | switched | access | - | - | - | - | - | 7 | - |
+| Port-Channel5 | MLAG_PEER_DC1-SVC3A_Po5 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
+| Port-Channel7 | DC1_L2LEAF2_Po1 | switched | trunk | - | - | - | - | - | 7 | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -467,6 +476,7 @@ interface Ethernet8
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-SVC3A_Po5
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -475,6 +485,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF2_Po1
+   no shutdown
    switchport
    switchport trunk allowed vlan 
    switchport mode trunk
@@ -506,11 +517,13 @@ interface Port-Channel7
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.9/32
    ip ospf area 0.0.0.0
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.8/32
    ip ospf area 0.0.0.0
 ```
@@ -521,8 +534,8 @@ interface Loopback1
 
 | Interface | Description | VRF |  MTU | Shutdown |
 | --------- | ----------- | --- | ---- | -------- |
-| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  -  |
-| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  -  |
+| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  false  |
+| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  false  |
 
 #### IPv4
 
@@ -544,12 +557,14 @@ interface Loopback1
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
+   no shutdown
    ip address 10.255.251.7/31
    ip ospf network point-to-point
    ip ospf area 0.0.0.0
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.7/31
 ```

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-BL1A.cfg
@@ -38,6 +38,7 @@ vrf instance MGMT
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-BL1B_Po5
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-BL1A.cfg
@@ -38,6 +38,7 @@ vrf instance MGMT
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-BL1B_Po5
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -46,6 +47,7 @@ interface Port-Channel5
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet6
+   no shutdown
    no switchport
    ip address 172.31.255.41/31
    ip ospf network point-to-point
@@ -53,6 +55,7 @@ interface Ethernet1
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet6
+   no shutdown
    no switchport
    ip address 172.31.255.43/31
    ip ospf network point-to-point
@@ -60,6 +63,7 @@ interface Ethernet2
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet6
+   no shutdown
    no switchport
    ip address 172.31.255.45/31
    ip ospf network point-to-point
@@ -67,6 +71,7 @@ interface Ethernet3
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet6
+   no shutdown
    no switchport
    ip address 172.31.255.47/31
    ip ospf network point-to-point
@@ -74,35 +79,42 @@ interface Ethernet4
 !
 interface Ethernet5
    description MLAG_PEER_DC1-BL1B_Ethernet5
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-BL1B_Ethernet6
+   no shutdown
    channel-group 5 mode active
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.10/32
    ip ospf area 0.0.0.0
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.10/32
    ip ospf area 0.0.0.0
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.110/24
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
+   no shutdown
    ip address 10.255.251.10/31
    ip ospf network point-to-point
    ip ospf area 0.0.0.0
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.10/31
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-BL1B.cfg
@@ -38,6 +38,7 @@ vrf instance MGMT
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-BL1A_Po5
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -46,6 +47,7 @@ interface Port-Channel5
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet7
+   no shutdown
    no switchport
    ip address 172.31.255.49/31
    ip ospf network point-to-point
@@ -53,6 +55,7 @@ interface Ethernet1
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet7
+   no shutdown
    no switchport
    ip address 172.31.255.51/31
    ip ospf network point-to-point
@@ -60,6 +63,7 @@ interface Ethernet2
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet7
+   no shutdown
    no switchport
    ip address 172.31.255.53/31
    ip ospf network point-to-point
@@ -67,6 +71,7 @@ interface Ethernet3
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet7
+   no shutdown
    no switchport
    ip address 172.31.255.55/31
    ip ospf network point-to-point
@@ -74,35 +79,42 @@ interface Ethernet4
 !
 interface Ethernet5
    description MLAG_PEER_DC1-BL1A_Ethernet5
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-BL1A_Ethernet6
+   no shutdown
    channel-group 5 mode active
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.11/32
    ip ospf area 0.0.0.0
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.10/32
    ip ospf area 0.0.0.0
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.111/24
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
+   no shutdown
    ip address 10.255.251.11/31
    ip ospf network point-to-point
    ip ospf area 0.0.0.0
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.11/31
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-BL1B.cfg
@@ -38,6 +38,7 @@ vrf instance MGMT
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-BL1A_Po5
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-L2LEAF1A.cfg
@@ -29,20 +29,24 @@ vrf instance MGMT
 !
 interface Port-Channel1
    description DC1-LEAF2A_Po7
+   no shutdown
    switchport
    switchport trunk allowed vlan 
    switchport mode trunk
 !
 interface Ethernet1
    description DC1-LEAF2A_Ethernet7
+   no shutdown
    channel-group 1 mode active
 !
 interface Ethernet2
    description DC1-LEAF2B_Ethernet7
+   no shutdown
    channel-group 1 mode active
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.112/24
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-L2LEAF1A.cfg
@@ -29,9 +29,9 @@ vrf instance MGMT
 !
 interface Port-Channel1
    description DC1-LEAF2A_Po7
+   switchport
    switchport trunk allowed vlan 
    switchport mode trunk
-   mlag 1
 !
 interface Ethernet1
    description DC1-LEAF2A_Ethernet7

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-L2LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-L2LEAF2A.cfg
@@ -34,12 +34,14 @@ vrf instance MGMT
 !
 interface Port-Channel1
    description DC1-SVC3A_Po7
+   switchport
    switchport trunk allowed vlan 
    switchport mode trunk
    mlag 1
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-L2LEAF2B_Po3
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group MLAG

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-L2LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-L2LEAF2A.cfg
@@ -34,6 +34,7 @@ vrf instance MGMT
 !
 interface Port-Channel1
    description DC1-SVC3A_Po7
+   no shutdown
    switchport
    switchport trunk allowed vlan 
    switchport mode trunk
@@ -41,6 +42,7 @@ interface Port-Channel1
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-L2LEAF2B_Po3
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -48,27 +50,33 @@ interface Port-Channel3
 !
 interface Ethernet1
    description DC1-SVC3A_Ethernet7
+   no shutdown
    channel-group 1 mode active
 !
 interface Ethernet2
    description DC1-SVC3B_Ethernet7
+   no shutdown
    channel-group 1 mode active
 !
 interface Ethernet3
    description MLAG_PEER_DC1-L2LEAF2B_Ethernet3
+   no shutdown
    channel-group 3 mode active
 !
 interface Ethernet4
    description MLAG_PEER_DC1-L2LEAF2B_Ethernet4
+   no shutdown
    channel-group 3 mode active
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.113/24
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.16/31
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-L2LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-L2LEAF2B.cfg
@@ -34,12 +34,14 @@ vrf instance MGMT
 !
 interface Port-Channel1
    description DC1-SVC3B_Po7
+   switchport
    switchport trunk allowed vlan 
    switchport mode trunk
    mlag 1
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-L2LEAF2A_Po3
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group MLAG

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-L2LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-L2LEAF2B.cfg
@@ -34,6 +34,7 @@ vrf instance MGMT
 !
 interface Port-Channel1
    description DC1-SVC3B_Po7
+   no shutdown
    switchport
    switchport trunk allowed vlan 
    switchport mode trunk
@@ -41,6 +42,7 @@ interface Port-Channel1
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-L2LEAF2A_Po3
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -48,27 +50,33 @@ interface Port-Channel3
 !
 interface Ethernet1
    description DC1-SVC3A_Ethernet8
+   no shutdown
    channel-group 1 mode active
 !
 interface Ethernet2
    description DC1-SVC3B_Ethernet8
+   no shutdown
    channel-group 1 mode active
 !
 interface Ethernet3
    description MLAG_PEER_DC1-L2LEAF2A_Ethernet3
+   no shutdown
    channel-group 3 mode active
 !
 interface Ethernet4
    description MLAG_PEER_DC1-L2LEAF2A_Ethernet4
+   no shutdown
    channel-group 3 mode active
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.114/24
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.17/31
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
@@ -29,6 +29,7 @@ vrf instance MGMT
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.1/31
    ip ospf network point-to-point
@@ -36,6 +37,7 @@ interface Ethernet1
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.3/31
    ip ospf network point-to-point
@@ -43,6 +45,7 @@ interface Ethernet2
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.5/31
    ip ospf network point-to-point
@@ -50,6 +53,7 @@ interface Ethernet3
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.7/31
    ip ospf network point-to-point
@@ -57,16 +61,19 @@ interface Ethernet4
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.5/32
    ip ospf area 0.0.0.0
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.5/32
    ip ospf area 0.0.0.0
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.105/24
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
@@ -38,6 +38,7 @@ vrf instance MGMT
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-LEAF2B_Po5
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -46,6 +47,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF1_Po1
+   no shutdown
    switchport
    switchport trunk allowed vlan 
    switchport mode trunk
@@ -53,6 +55,7 @@ interface Port-Channel7
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.9/31
    ip ospf network point-to-point
@@ -60,6 +63,7 @@ interface Ethernet1
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.11/31
    ip ospf network point-to-point
@@ -67,6 +71,7 @@ interface Ethernet2
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.13/31
    ip ospf network point-to-point
@@ -74,6 +79,7 @@ interface Ethernet3
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.15/31
    ip ospf network point-to-point
@@ -81,39 +87,47 @@ interface Ethernet4
 !
 interface Ethernet5
    description MLAG_PEER_DC1-LEAF2B_Ethernet5
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-LEAF2B_Ethernet6
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet7
    description DC1-L2LEAF1A_Ethernet1
+   no shutdown
    channel-group 7 mode active
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.6/32
    ip ospf area 0.0.0.0
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.6/32
    ip ospf area 0.0.0.0
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.106/24
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
+   no shutdown
    ip address 10.255.251.2/31
    ip ospf network point-to-point
    ip ospf area 0.0.0.0
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.2/31
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
@@ -38,6 +38,7 @@ vrf instance MGMT
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-LEAF2B_Po5
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -45,6 +46,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF1_Po1
+   switchport
    switchport trunk allowed vlan 
    switchport mode trunk
    mlag 7

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
@@ -38,6 +38,7 @@ vrf instance MGMT
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-LEAF2A_Po5
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -45,6 +46,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF1_Po1
+   switchport
    switchport trunk allowed vlan 
    switchport mode trunk
    mlag 7

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
@@ -38,6 +38,7 @@ vrf instance MGMT
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-LEAF2A_Po5
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -46,6 +47,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF1_Po1
+   no shutdown
    switchport
    switchport trunk allowed vlan 
    switchport mode trunk
@@ -53,6 +55,7 @@ interface Port-Channel7
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.17/31
    ip ospf network point-to-point
@@ -60,6 +63,7 @@ interface Ethernet1
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.19/31
    ip ospf network point-to-point
@@ -67,6 +71,7 @@ interface Ethernet2
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.21/31
    ip ospf network point-to-point
@@ -74,6 +79,7 @@ interface Ethernet3
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.23/31
    ip ospf network point-to-point
@@ -81,39 +87,47 @@ interface Ethernet4
 !
 interface Ethernet5
    description MLAG_PEER_DC1-LEAF2A_Ethernet5
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-LEAF2A_Ethernet6
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet7
    description DC1-L2LEAF1A_Ethernet2
+   no shutdown
    channel-group 7 mode active
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.7/32
    ip ospf area 0.0.0.0
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.6/32
    ip ospf area 0.0.0.0
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.107/24
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
+   no shutdown
    ip address 10.255.251.3/31
    ip ospf network point-to-point
    ip ospf area 0.0.0.0
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.3/31
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SPINE1.cfg
@@ -28,6 +28,7 @@ vrf instance MGMT
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.0/31
    ip ospf network point-to-point
@@ -35,6 +36,7 @@ interface Ethernet1
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-LEAF2A_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.8/31
    ip ospf network point-to-point
@@ -42,6 +44,7 @@ interface Ethernet2
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-LEAF2B_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.16/31
    ip ospf network point-to-point
@@ -49,6 +52,7 @@ interface Ethernet3
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SVC3A_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.24/31
    ip ospf network point-to-point
@@ -56,6 +60,7 @@ interface Ethernet4
 !
 interface Ethernet5
    description P2P_LINK_TO_DC1-SVC3B_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.32/31
    ip ospf network point-to-point
@@ -63,6 +68,7 @@ interface Ethernet5
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-BL1A_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.40/31
    ip ospf network point-to-point
@@ -70,6 +76,7 @@ interface Ethernet6
 !
 interface Ethernet7
    description P2P_LINK_TO_DC1-BL1B_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.48/31
    ip ospf network point-to-point
@@ -77,11 +84,13 @@ interface Ethernet7
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.1/32
    ip ospf area 0.0.0.0
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.101/24
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SPINE2.cfg
@@ -28,6 +28,7 @@ vrf instance MGMT
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.2/31
    ip ospf network point-to-point
@@ -35,6 +36,7 @@ interface Ethernet1
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-LEAF2A_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.10/31
    ip ospf network point-to-point
@@ -42,6 +44,7 @@ interface Ethernet2
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-LEAF2B_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.18/31
    ip ospf network point-to-point
@@ -49,6 +52,7 @@ interface Ethernet3
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SVC3A_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.26/31
    ip ospf network point-to-point
@@ -56,6 +60,7 @@ interface Ethernet4
 !
 interface Ethernet5
    description P2P_LINK_TO_DC1-SVC3B_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.34/31
    ip ospf network point-to-point
@@ -63,6 +68,7 @@ interface Ethernet5
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-BL1A_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.42/31
    ip ospf network point-to-point
@@ -70,6 +76,7 @@ interface Ethernet6
 !
 interface Ethernet7
    description P2P_LINK_TO_DC1-BL1B_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.50/31
    ip ospf network point-to-point
@@ -77,11 +84,13 @@ interface Ethernet7
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.2/32
    ip ospf area 0.0.0.0
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.102/24
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SPINE3.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SPINE3.cfg
@@ -28,6 +28,7 @@ vrf instance MGMT
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.4/31
    ip ospf network point-to-point
@@ -35,6 +36,7 @@ interface Ethernet1
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-LEAF2A_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.12/31
    ip ospf network point-to-point
@@ -42,6 +44,7 @@ interface Ethernet2
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-LEAF2B_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.20/31
    ip ospf network point-to-point
@@ -49,6 +52,7 @@ interface Ethernet3
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SVC3A_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.28/31
    ip ospf network point-to-point
@@ -56,6 +60,7 @@ interface Ethernet4
 !
 interface Ethernet5
    description P2P_LINK_TO_DC1-SVC3B_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.36/31
    ip ospf network point-to-point
@@ -63,6 +68,7 @@ interface Ethernet5
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-BL1A_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.44/31
    ip ospf network point-to-point
@@ -70,6 +76,7 @@ interface Ethernet6
 !
 interface Ethernet7
    description P2P_LINK_TO_DC1-BL1B_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.52/31
    ip ospf network point-to-point
@@ -77,11 +84,13 @@ interface Ethernet7
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.3/32
    ip ospf area 0.0.0.0
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.103/24
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SPINE4.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SPINE4.cfg
@@ -28,6 +28,7 @@ vrf instance MGMT
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.6/31
    ip ospf network point-to-point
@@ -35,6 +36,7 @@ interface Ethernet1
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-LEAF2A_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.14/31
    ip ospf network point-to-point
@@ -42,6 +44,7 @@ interface Ethernet2
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-LEAF2B_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.22/31
    ip ospf network point-to-point
@@ -49,6 +52,7 @@ interface Ethernet3
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SVC3A_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.30/31
    ip ospf network point-to-point
@@ -56,6 +60,7 @@ interface Ethernet4
 !
 interface Ethernet5
    description P2P_LINK_TO_DC1-SVC3B_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.38/31
    ip ospf network point-to-point
@@ -63,6 +68,7 @@ interface Ethernet5
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-BL1A_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.46/31
    ip ospf network point-to-point
@@ -70,6 +76,7 @@ interface Ethernet6
 !
 interface Ethernet7
    description P2P_LINK_TO_DC1-BL1B_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.54/31
    ip ospf network point-to-point
@@ -77,11 +84,13 @@ interface Ethernet7
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.4/32
    ip ospf area 0.0.0.0
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.104/24
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
@@ -38,6 +38,7 @@ vrf instance MGMT
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-SVC3B_Po5
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -45,6 +46,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF2_Po1
+   switchport
    switchport trunk allowed vlan 
    switchport mode trunk
    mlag 7

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
@@ -38,6 +38,7 @@ vrf instance MGMT
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-SVC3B_Po5
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -46,6 +47,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF2_Po1
+   no shutdown
    switchport
    switchport trunk allowed vlan 
    switchport mode trunk
@@ -53,6 +55,7 @@ interface Port-Channel7
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.25/31
    ip ospf network point-to-point
@@ -60,6 +63,7 @@ interface Ethernet1
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.27/31
    ip ospf network point-to-point
@@ -67,6 +71,7 @@ interface Ethernet2
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.29/31
    ip ospf network point-to-point
@@ -74,6 +79,7 @@ interface Ethernet3
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.31/31
    ip ospf network point-to-point
@@ -81,43 +87,52 @@ interface Ethernet4
 !
 interface Ethernet5
    description MLAG_PEER_DC1-SVC3B_Ethernet5
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-SVC3B_Ethernet6
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet7
    description DC1-L2LEAF2A_Ethernet1
+   no shutdown
    channel-group 7 mode active
 !
 interface Ethernet8
    description DC1-L2LEAF2B_Ethernet1
+   no shutdown
    channel-group 7 mode active
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.8/32
    ip ospf area 0.0.0.0
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.8/32
    ip ospf area 0.0.0.0
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.108/24
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
+   no shutdown
    ip address 10.255.251.6/31
    ip ospf network point-to-point
    ip ospf area 0.0.0.0
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.6/31
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
@@ -38,6 +38,7 @@ vrf instance MGMT
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-SVC3A_Po5
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -45,6 +46,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF2_Po1
+   switchport
    switchport trunk allowed vlan 
    switchport mode trunk
    mlag 7

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
@@ -38,6 +38,7 @@ vrf instance MGMT
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-SVC3A_Po5
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -46,6 +47,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF2_Po1
+   no shutdown
    switchport
    switchport trunk allowed vlan 
    switchport mode trunk
@@ -53,6 +55,7 @@ interface Port-Channel7
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet5
+   no shutdown
    no switchport
    ip address 172.31.255.33/31
    ip ospf network point-to-point
@@ -60,6 +63,7 @@ interface Ethernet1
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet5
+   no shutdown
    no switchport
    ip address 172.31.255.35/31
    ip ospf network point-to-point
@@ -67,6 +71,7 @@ interface Ethernet2
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet5
+   no shutdown
    no switchport
    ip address 172.31.255.37/31
    ip ospf network point-to-point
@@ -74,6 +79,7 @@ interface Ethernet3
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet5
+   no shutdown
    no switchport
    ip address 172.31.255.39/31
    ip ospf network point-to-point
@@ -81,43 +87,52 @@ interface Ethernet4
 !
 interface Ethernet5
    description MLAG_PEER_DC1-SVC3A_Ethernet5
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-SVC3A_Ethernet6
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet7
    description DC1-L2LEAF2A_Ethernet2
+   no shutdown
    channel-group 7 mode active
 !
 interface Ethernet8
    description DC1-L2LEAF2B_Ethernet2
+   no shutdown
    channel-group 7 mode active
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.9/32
    ip ospf area 0.0.0.0
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.8/32
    ip ospf area 0.0.0.0
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.109/24
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
+   no shutdown
    ip address 10.255.251.7/31
    ip ospf network point-to-point
    ip ospf area 0.0.0.0
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.7/31
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
@@ -89,6 +89,8 @@ bfd_multihop:
 port_channel_interfaces:
   Port-Channel5:
     description: MLAG_PEER_DC1-BL1B_Po5
+    type: switched
+    shutdown: false
     vlans: 2-4094
     mode: trunk
     trunk_groups:
@@ -102,6 +104,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE1_Ethernet6
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.41/31
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
@@ -112,6 +115,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE2_Ethernet6
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.43/31
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
@@ -122,6 +126,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE3_Ethernet6
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.45/31
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
@@ -132,6 +137,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE4_Ethernet6
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.47/31
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
@@ -140,6 +146,8 @@ ethernet_interfaces:
     peer_interface: Ethernet5
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-BL1B_Ethernet5
+    type: switched
+    shutdown: false
     channel_group:
       id: 5
       mode: active
@@ -148,33 +156,40 @@ ethernet_interfaces:
     peer_interface: Ethernet6
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-BL1B_Ethernet6
+    type: switched
+    shutdown: false
     channel_group:
       id: 5
       mode: active
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: 192.168.255.10/32
     ospf_area: 0.0.0.0
   Loopback1:
     description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
     ip_address: 192.168.254.10/32
     ospf_area: 0.0.0.0
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.110/24
     gateway: 192.168.200.5
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING
+    shutdown: false
     ip_address: 10.255.251.10/31
     mtu: 1500
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
   Vlan4094:
     description: MLAG_PEER
+    shutdown: false
     ip_address: 10.255.252.10/31
     no_autostate: true
     mtu: 1500

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
@@ -89,6 +89,8 @@ bfd_multihop:
 port_channel_interfaces:
   Port-Channel5:
     description: MLAG_PEER_DC1-BL1A_Po5
+    type: switched
+    shutdown: false
     vlans: 2-4094
     mode: trunk
     trunk_groups:
@@ -102,6 +104,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE1_Ethernet7
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.49/31
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
@@ -112,6 +115,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE2_Ethernet7
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.51/31
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
@@ -122,6 +126,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE3_Ethernet7
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.53/31
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
@@ -132,6 +137,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE4_Ethernet7
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.55/31
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
@@ -140,6 +146,8 @@ ethernet_interfaces:
     peer_interface: Ethernet5
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-BL1A_Ethernet5
+    type: switched
+    shutdown: false
     channel_group:
       id: 5
       mode: active
@@ -148,33 +156,40 @@ ethernet_interfaces:
     peer_interface: Ethernet6
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-BL1A_Ethernet6
+    type: switched
+    shutdown: false
     channel_group:
       id: 5
       mode: active
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: 192.168.255.11/32
     ospf_area: 0.0.0.0
   Loopback1:
     description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
     ip_address: 192.168.254.10/32
     ospf_area: 0.0.0.0
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.111/24
     gateway: 192.168.200.5
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING
+    shutdown: false
     ip_address: 10.255.251.11/31
     mtu: 1500
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
   Vlan4094:
     description: MLAG_PEER
+    shutdown: false
     ip_address: 10.255.252.11/31
     no_autostate: true
     mtu: 1500

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -68,6 +68,8 @@ vrfs:
 port_channel_interfaces:
   Port-Channel1:
     description: DC1-LEAF2A_Po7
+    type: switched
+    shutdown: false
     vlans: null
     mode: trunk
 ethernet_interfaces:
@@ -76,6 +78,8 @@ ethernet_interfaces:
     peer_interface: Ethernet7
     peer_type: l3leaf
     description: DC1-LEAF2A_Ethernet7
+    type: switched
+    shutdown: false
     channel_group:
       id: 1
       mode: active
@@ -84,12 +88,15 @@ ethernet_interfaces:
     peer_interface: Ethernet7
     peer_type: l3leaf
     description: DC1-LEAF2B_Ethernet7
+    type: switched
+    shutdown: false
     channel_group:
       id: 1
       mode: active
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.112/24
     gateway: 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -70,7 +70,6 @@ port_channel_interfaces:
     description: DC1-LEAF2A_Po7
     vlans: null
     mode: trunk
-    mlag: 1
 ethernet_interfaces:
   Ethernet1:
     peer: DC1-LEAF2A

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -78,11 +78,15 @@ vrfs:
 port_channel_interfaces:
   Port-Channel1:
     description: DC1-SVC3A_Po7
+    type: switched
+    shutdown: false
     vlans: null
     mode: trunk
     mlag: 1
   Port-Channel3:
     description: MLAG_PEER_DC1-L2LEAF2B_Po3
+    type: switched
+    shutdown: false
     vlans: 2-4094
     mode: trunk
     trunk_groups:
@@ -93,6 +97,8 @@ ethernet_interfaces:
     peer_interface: Ethernet7
     peer_type: l3leaf
     description: DC1-SVC3A_Ethernet7
+    type: switched
+    shutdown: false
     channel_group:
       id: 1
       mode: active
@@ -101,6 +107,8 @@ ethernet_interfaces:
     peer_interface: Ethernet7
     peer_type: l3leaf
     description: DC1-SVC3B_Ethernet7
+    type: switched
+    shutdown: false
     channel_group:
       id: 1
       mode: active
@@ -109,6 +117,8 @@ ethernet_interfaces:
     peer_interface: Ethernet3
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-L2LEAF2B_Ethernet3
+    type: switched
+    shutdown: false
     channel_group:
       id: 3
       mode: active
@@ -117,18 +127,22 @@ ethernet_interfaces:
     peer_interface: Ethernet4
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-L2LEAF2B_Ethernet4
+    type: switched
+    shutdown: false
     channel_group:
       id: 3
       mode: active
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.113/24
     gateway: 192.168.200.5
 vlan_interfaces:
   Vlan4094:
     description: MLAG_PEER
+    shutdown: false
     ip_address: 10.255.252.16/31
     no_autostate: true
     mtu: 1500

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -78,11 +78,15 @@ vrfs:
 port_channel_interfaces:
   Port-Channel1:
     description: DC1-SVC3B_Po7
+    type: switched
+    shutdown: false
     vlans: null
     mode: trunk
     mlag: 1
   Port-Channel3:
     description: MLAG_PEER_DC1-L2LEAF2A_Po3
+    type: switched
+    shutdown: false
     vlans: 2-4094
     mode: trunk
     trunk_groups:
@@ -93,6 +97,8 @@ ethernet_interfaces:
     peer_interface: Ethernet8
     peer_type: l3leaf
     description: DC1-SVC3A_Ethernet8
+    type: switched
+    shutdown: false
     channel_group:
       id: 1
       mode: active
@@ -101,6 +107,8 @@ ethernet_interfaces:
     peer_interface: Ethernet8
     peer_type: l3leaf
     description: DC1-SVC3B_Ethernet8
+    type: switched
+    shutdown: false
     channel_group:
       id: 1
       mode: active
@@ -109,6 +117,8 @@ ethernet_interfaces:
     peer_interface: Ethernet3
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-L2LEAF2A_Ethernet3
+    type: switched
+    shutdown: false
     channel_group:
       id: 3
       mode: active
@@ -117,18 +127,22 @@ ethernet_interfaces:
     peer_interface: Ethernet4
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-L2LEAF2A_Ethernet4
+    type: switched
+    shutdown: false
     channel_group:
       id: 3
       mode: active
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.114/24
     gateway: 192.168.200.5
 vlan_interfaces:
   Vlan4094:
     description: MLAG_PEER
+    shutdown: false
     ip_address: 10.255.252.17/31
     no_autostate: true
     mtu: 1500

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
@@ -79,6 +79,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE1_Ethernet1
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.1/31
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
@@ -89,6 +90,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE2_Ethernet1
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.3/31
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
@@ -99,6 +101,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE3_Ethernet1
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.5/31
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
@@ -109,21 +112,25 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE4_Ethernet1
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.7/31
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: 192.168.255.5/32
     ospf_area: 0.0.0.0
   Loopback1:
     description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
     ip_address: 192.168.254.5/32
     ospf_area: 0.0.0.0
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.105/24
     gateway: 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -96,11 +96,15 @@ bfd_multihop:
 port_channel_interfaces:
   Port-Channel7:
     description: DC1_L2LEAF1_Po1
+    type: switched
+    shutdown: false
     vlans: null
     mode: trunk
     mlag: 7
   Port-Channel5:
     description: MLAG_PEER_DC1-LEAF2B_Po5
+    type: switched
+    shutdown: false
     vlans: 2-4094
     mode: trunk
     trunk_groups:
@@ -114,6 +118,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE1_Ethernet2
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.9/31
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
@@ -124,6 +129,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE2_Ethernet2
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.11/31
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
@@ -134,6 +140,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE3_Ethernet2
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.13/31
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
@@ -144,6 +151,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE4_Ethernet2
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.15/31
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
@@ -152,6 +160,8 @@ ethernet_interfaces:
     peer_interface: Ethernet5
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-LEAF2B_Ethernet5
+    type: switched
+    shutdown: false
     channel_group:
       id: 5
       mode: active
@@ -160,6 +170,8 @@ ethernet_interfaces:
     peer_interface: Ethernet6
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-LEAF2B_Ethernet6
+    type: switched
+    shutdown: false
     channel_group:
       id: 5
       mode: active
@@ -168,33 +180,40 @@ ethernet_interfaces:
     peer_interface: Ethernet1
     peer_type: l2leaf
     description: DC1-L2LEAF1A_Ethernet1
+    type: switched
+    shutdown: false
     channel_group:
       id: 7
       mode: active
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: 192.168.255.6/32
     ospf_area: 0.0.0.0
   Loopback1:
     description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
     ip_address: 192.168.254.6/32
     ospf_area: 0.0.0.0
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.106/24
     gateway: 192.168.200.5
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING
+    shutdown: false
     ip_address: 10.255.251.2/31
     mtu: 1500
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
   Vlan4094:
     description: MLAG_PEER
+    shutdown: false
     ip_address: 10.255.252.2/31
     no_autostate: true
     mtu: 1500

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -96,11 +96,15 @@ bfd_multihop:
 port_channel_interfaces:
   Port-Channel7:
     description: DC1_L2LEAF1_Po1
+    type: switched
+    shutdown: false
     vlans: null
     mode: trunk
     mlag: 7
   Port-Channel5:
     description: MLAG_PEER_DC1-LEAF2A_Po5
+    type: switched
+    shutdown: false
     vlans: 2-4094
     mode: trunk
     trunk_groups:
@@ -114,6 +118,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE1_Ethernet3
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.17/31
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
@@ -124,6 +129,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE2_Ethernet3
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.19/31
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
@@ -134,6 +140,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE3_Ethernet3
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.21/31
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
@@ -144,6 +151,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE4_Ethernet3
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.23/31
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
@@ -152,6 +160,8 @@ ethernet_interfaces:
     peer_interface: Ethernet5
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-LEAF2A_Ethernet5
+    type: switched
+    shutdown: false
     channel_group:
       id: 5
       mode: active
@@ -160,6 +170,8 @@ ethernet_interfaces:
     peer_interface: Ethernet6
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-LEAF2A_Ethernet6
+    type: switched
+    shutdown: false
     channel_group:
       id: 5
       mode: active
@@ -168,33 +180,40 @@ ethernet_interfaces:
     peer_interface: Ethernet2
     peer_type: l2leaf
     description: DC1-L2LEAF1A_Ethernet2
+    type: switched
+    shutdown: false
     channel_group:
       id: 7
       mode: active
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: 192.168.255.7/32
     ospf_area: 0.0.0.0
   Loopback1:
     description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
     ip_address: 192.168.254.6/32
     ospf_area: 0.0.0.0
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.107/24
     gateway: 192.168.200.5
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING
+    shutdown: false
     ip_address: 10.255.251.3/31
     mtu: 1500
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
   Vlan4094:
     description: MLAG_PEER
+    shutdown: false
     ip_address: 10.255.252.3/31
     no_autostate: true
     mtu: 1500

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
@@ -63,6 +63,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-BL1A_Ethernet1
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.40/31
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
@@ -73,6 +74,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-BL1B_Ethernet1
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.48/31
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
@@ -83,6 +85,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF1A_Ethernet1
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.0/31
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
@@ -93,6 +96,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF2A_Ethernet1
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.8/31
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
@@ -103,6 +107,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF2B_Ethernet1
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.16/31
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
@@ -113,6 +118,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SVC3A_Ethernet1
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.24/31
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
@@ -123,17 +129,20 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SVC3B_Ethernet1
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.32/31
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: 192.168.255.1/32
     ospf_area: 0.0.0.0
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.101/24
     gateway: 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
@@ -63,6 +63,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-BL1A_Ethernet2
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.42/31
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
@@ -73,6 +74,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-BL1B_Ethernet2
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.50/31
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
@@ -83,6 +85,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF1A_Ethernet2
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.2/31
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
@@ -93,6 +96,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF2A_Ethernet2
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.10/31
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
@@ -103,6 +107,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF2B_Ethernet2
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.18/31
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
@@ -113,6 +118,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SVC3A_Ethernet2
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.26/31
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
@@ -123,17 +129,20 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SVC3B_Ethernet2
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.34/31
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: 192.168.255.2/32
     ospf_area: 0.0.0.0
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.102/24
     gateway: 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
@@ -63,6 +63,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-BL1A_Ethernet3
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.44/31
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
@@ -73,6 +74,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-BL1B_Ethernet3
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.52/31
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
@@ -83,6 +85,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF1A_Ethernet3
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.4/31
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
@@ -93,6 +96,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF2A_Ethernet3
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.12/31
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
@@ -103,6 +107,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF2B_Ethernet3
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.20/31
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
@@ -113,6 +118,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SVC3A_Ethernet3
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.28/31
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
@@ -123,17 +129,20 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SVC3B_Ethernet3
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.36/31
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: 192.168.255.3/32
     ospf_area: 0.0.0.0
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.103/24
     gateway: 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
@@ -63,6 +63,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-BL1A_Ethernet4
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.46/31
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
@@ -73,6 +74,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-BL1B_Ethernet4
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.54/31
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
@@ -83,6 +85,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF1A_Ethernet4
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.6/31
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
@@ -93,6 +96,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF2A_Ethernet4
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.14/31
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
@@ -103,6 +107,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF2B_Ethernet4
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.22/31
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
@@ -113,6 +118,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SVC3A_Ethernet4
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.30/31
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
@@ -123,17 +129,20 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SVC3B_Ethernet4
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.38/31
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: 192.168.255.4/32
     ospf_area: 0.0.0.0
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.104/24
     gateway: 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -97,11 +97,15 @@ bfd_multihop:
 port_channel_interfaces:
   Port-Channel7:
     description: DC1_L2LEAF2_Po1
+    type: switched
+    shutdown: false
     vlans: null
     mode: trunk
     mlag: 7
   Port-Channel5:
     description: MLAG_PEER_DC1-SVC3B_Po5
+    type: switched
+    shutdown: false
     vlans: 2-4094
     mode: trunk
     trunk_groups:
@@ -115,6 +119,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE1_Ethernet4
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.25/31
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
@@ -125,6 +130,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE2_Ethernet4
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.27/31
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
@@ -135,6 +141,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE3_Ethernet4
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.29/31
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
@@ -145,6 +152,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE4_Ethernet4
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.31/31
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
@@ -153,6 +161,8 @@ ethernet_interfaces:
     peer_interface: Ethernet5
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-SVC3B_Ethernet5
+    type: switched
+    shutdown: false
     channel_group:
       id: 5
       mode: active
@@ -161,6 +171,8 @@ ethernet_interfaces:
     peer_interface: Ethernet6
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-SVC3B_Ethernet6
+    type: switched
+    shutdown: false
     channel_group:
       id: 5
       mode: active
@@ -169,6 +181,8 @@ ethernet_interfaces:
     peer_interface: Ethernet1
     peer_type: l2leaf
     description: DC1-L2LEAF2A_Ethernet1
+    type: switched
+    shutdown: false
     channel_group:
       id: 7
       mode: active
@@ -177,33 +191,40 @@ ethernet_interfaces:
     peer_interface: Ethernet1
     peer_type: l2leaf
     description: DC1-L2LEAF2B_Ethernet1
+    type: switched
+    shutdown: false
     channel_group:
       id: 7
       mode: active
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: 192.168.255.8/32
     ospf_area: 0.0.0.0
   Loopback1:
     description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
     ip_address: 192.168.254.8/32
     ospf_area: 0.0.0.0
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.108/24
     gateway: 192.168.200.5
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING
+    shutdown: false
     ip_address: 10.255.251.6/31
     mtu: 1500
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
   Vlan4094:
     description: MLAG_PEER
+    shutdown: false
     ip_address: 10.255.252.6/31
     no_autostate: true
     mtu: 1500

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -97,11 +97,15 @@ bfd_multihop:
 port_channel_interfaces:
   Port-Channel7:
     description: DC1_L2LEAF2_Po1
+    type: switched
+    shutdown: false
     vlans: null
     mode: trunk
     mlag: 7
   Port-Channel5:
     description: MLAG_PEER_DC1-SVC3A_Po5
+    type: switched
+    shutdown: false
     vlans: 2-4094
     mode: trunk
     trunk_groups:
@@ -115,6 +119,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE1_Ethernet5
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.33/31
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
@@ -125,6 +130,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE2_Ethernet5
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.35/31
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
@@ -135,6 +141,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE3_Ethernet5
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.37/31
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
@@ -145,6 +152,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE4_Ethernet5
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.39/31
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
@@ -153,6 +161,8 @@ ethernet_interfaces:
     peer_interface: Ethernet5
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-SVC3A_Ethernet5
+    type: switched
+    shutdown: false
     channel_group:
       id: 5
       mode: active
@@ -161,6 +171,8 @@ ethernet_interfaces:
     peer_interface: Ethernet6
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-SVC3A_Ethernet6
+    type: switched
+    shutdown: false
     channel_group:
       id: 5
       mode: active
@@ -169,6 +181,8 @@ ethernet_interfaces:
     peer_interface: Ethernet2
     peer_type: l2leaf
     description: DC1-L2LEAF2A_Ethernet2
+    type: switched
+    shutdown: false
     channel_group:
       id: 7
       mode: active
@@ -177,33 +191,40 @@ ethernet_interfaces:
     peer_interface: Ethernet2
     peer_type: l2leaf
     description: DC1-L2LEAF2B_Ethernet2
+    type: switched
+    shutdown: false
     channel_group:
       id: 7
       mode: active
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: 192.168.255.9/32
     ospf_area: 0.0.0.0
   Loopback1:
     description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
     ip_address: 192.168.254.8/32
     ospf_area: 0.0.0.0
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.109/24
     gateway: 192.168.200.5
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING
+    shutdown: false
     ip_address: 10.255.251.7/31
     mtu: 1500
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
   Vlan4094:
     description: MLAG_PEER
+    shutdown: false
     ip_address: 10.255.252.7/31
     no_autostate: true
     mtu: 1500

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-BL1A.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.110/24
 ```
@@ -413,10 +414,10 @@ vlan 4094
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet6  |  routed  | - |  172.31.255.41/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet6  |  routed  | - |  172.31.255.43/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet6  |  routed  | - |  172.31.255.45/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet6  |  routed  | - |  172.31.255.47/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet6  |  routed  | - |  172.31.255.41/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet6  |  routed  | - |  172.31.255.43/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet6  |  routed  | - |  172.31.255.45/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet6  |  routed  | - |  172.31.255.47/31  |  default  |  1500  |  false  |  -  |  -  |
 
 ### Ethernet Interfaces Device Configuration
 
@@ -424,30 +425,36 @@ vlan 4094
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet6
+   no shutdown
    no switchport
    ip address 172.31.255.41/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet6
+   no shutdown
    no switchport
    ip address 172.31.255.43/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet6
+   no shutdown
    no switchport
    ip address 172.31.255.45/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet6
+   no shutdown
    no switchport
    ip address 172.31.255.47/31
 !
 interface Ethernet5
    description MLAG_PEER_DC1-BL1B_Ethernet5
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-BL1B_Ethernet6
+   no shutdown
    channel-group 5 mode active
 ```
 
@@ -459,7 +466,7 @@ interface Ethernet6
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel5 | MLAG_PEER_DC1-BL1B_Po5 | switched | access | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
+| Port-Channel5 | MLAG_PEER_DC1-BL1B_Po5 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -467,6 +474,7 @@ interface Ethernet6
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-BL1B_Po5
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -499,10 +507,12 @@ interface Port-Channel5
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.10/32
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.10/32
 ```
 
@@ -515,11 +525,11 @@ interface Loopback1
 | Vlan150 |  Tenant_A_WAN_Zone_1  |  Tenant_A_WAN_Zone  |  -  |  false  |
 | Vlan250 |  Tenant_B_WAN_Zone_1  |  Tenant_B_WAN_Zone  |  -  |  false  |
 | Vlan350 |  Tenant_C_WAN_Zone_1  |  Tenant_C_WAN_Zone  |  -  |  false  |
-| Vlan3013 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone  |  Tenant_A_WAN_Zone  |  -  |  -  |
-| Vlan3020 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone  |  Tenant_B_WAN_Zone  |  -  |  -  |
-| Vlan3030 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone  |  Tenant_C_WAN_Zone  |  -  |  -  |
-| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  -  |
-| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  -  |
+| Vlan3013 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone  |  Tenant_A_WAN_Zone  |  -  |  false  |
+| Vlan3020 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone  |  Tenant_B_WAN_Zone  |  -  |  false  |
+| Vlan3030 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone  |  Tenant_C_WAN_Zone  |  -  |  false  |
+| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  false  |
+| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  false  |
 
 #### IPv4
 
@@ -560,25 +570,30 @@ interface Vlan350
 !
 interface Vlan3013
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone
+   no shutdown
    vrf Tenant_A_WAN_Zone
    ip address 10.255.251.10/31
 !
 interface Vlan3020
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone
+   no shutdown
    vrf Tenant_B_WAN_Zone
    ip address 10.255.251.10/31
 !
 interface Vlan3030
    description MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone
+   no shutdown
    vrf Tenant_C_WAN_Zone
    ip address 10.255.251.10/31
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
+   no shutdown
    ip address 10.255.251.10/31
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.10/31
 ```

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-BL1A.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -462,6 +467,7 @@ interface Ethernet6
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-BL1B_Po5
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -536,16 +542,19 @@ interface Loopback1
 !
 interface Vlan150
    description Tenant_A_WAN_Zone_1
+   no shutdown
    vrf Tenant_A_WAN_Zone
    ip address virtual 10.1.40.1/24
 !
 interface Vlan250
    description Tenant_B_WAN_Zone_1
+   no shutdown
    vrf Tenant_B_WAN_Zone
    ip address virtual 10.2.50.1/24
 !
 interface Vlan350
    description Tenant_C_WAN_Zone_1
+   no shutdown
    vrf Tenant_C_WAN_Zone
    ip address virtual 10.3.50.1/24
 !
@@ -1020,6 +1029,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-BL1B.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -462,6 +467,7 @@ interface Ethernet6
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-BL1A_Po5
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -536,16 +542,19 @@ interface Loopback1
 !
 interface Vlan150
    description Tenant_A_WAN_Zone_1
+   no shutdown
    vrf Tenant_A_WAN_Zone
    ip address virtual 10.1.40.1/24
 !
 interface Vlan250
    description Tenant_B_WAN_Zone_1
+   no shutdown
    vrf Tenant_B_WAN_Zone
    ip address virtual 10.2.50.1/24
 !
 interface Vlan350
    description Tenant_C_WAN_Zone_1
+   no shutdown
    vrf Tenant_C_WAN_Zone
    ip address virtual 10.3.50.1/24
 !
@@ -1020,6 +1029,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-BL1B.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.111/24
 ```
@@ -413,10 +414,10 @@ vlan 4094
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet7  |  routed  | - |  172.31.255.49/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet7  |  routed  | - |  172.31.255.51/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet7  |  routed  | - |  172.31.255.53/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet7  |  routed  | - |  172.31.255.55/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet7  |  routed  | - |  172.31.255.49/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet7  |  routed  | - |  172.31.255.51/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet7  |  routed  | - |  172.31.255.53/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet7  |  routed  | - |  172.31.255.55/31  |  default  |  1500  |  false  |  -  |  -  |
 
 ### Ethernet Interfaces Device Configuration
 
@@ -424,30 +425,36 @@ vlan 4094
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet7
+   no shutdown
    no switchport
    ip address 172.31.255.49/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet7
+   no shutdown
    no switchport
    ip address 172.31.255.51/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet7
+   no shutdown
    no switchport
    ip address 172.31.255.53/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet7
+   no shutdown
    no switchport
    ip address 172.31.255.55/31
 !
 interface Ethernet5
    description MLAG_PEER_DC1-BL1A_Ethernet5
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-BL1A_Ethernet6
+   no shutdown
    channel-group 5 mode active
 ```
 
@@ -459,7 +466,7 @@ interface Ethernet6
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel5 | MLAG_PEER_DC1-BL1A_Po5 | switched | access | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
+| Port-Channel5 | MLAG_PEER_DC1-BL1A_Po5 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -467,6 +474,7 @@ interface Ethernet6
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-BL1A_Po5
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -499,10 +507,12 @@ interface Port-Channel5
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.11/32
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.10/32
 ```
 
@@ -515,11 +525,11 @@ interface Loopback1
 | Vlan150 |  Tenant_A_WAN_Zone_1  |  Tenant_A_WAN_Zone  |  -  |  false  |
 | Vlan250 |  Tenant_B_WAN_Zone_1  |  Tenant_B_WAN_Zone  |  -  |  false  |
 | Vlan350 |  Tenant_C_WAN_Zone_1  |  Tenant_C_WAN_Zone  |  -  |  false  |
-| Vlan3013 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone  |  Tenant_A_WAN_Zone  |  -  |  -  |
-| Vlan3020 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone  |  Tenant_B_WAN_Zone  |  -  |  -  |
-| Vlan3030 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone  |  Tenant_C_WAN_Zone  |  -  |  -  |
-| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  -  |
-| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  -  |
+| Vlan3013 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone  |  Tenant_A_WAN_Zone  |  -  |  false  |
+| Vlan3020 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone  |  Tenant_B_WAN_Zone  |  -  |  false  |
+| Vlan3030 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone  |  Tenant_C_WAN_Zone  |  -  |  false  |
+| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  false  |
+| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  false  |
 
 #### IPv4
 
@@ -560,25 +570,30 @@ interface Vlan350
 !
 interface Vlan3013
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone
+   no shutdown
    vrf Tenant_A_WAN_Zone
    ip address 10.255.251.11/31
 !
 interface Vlan3020
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone
+   no shutdown
    vrf Tenant_B_WAN_Zone
    ip address 10.255.251.11/31
 !
 interface Vlan3030
    description MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone
+   no shutdown
    vrf Tenant_C_WAN_Zone
    ip address 10.255.251.11/31
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
+   no shutdown
    ip address 10.255.251.11/31
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.11/31
 ```

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-L2LEAF1A.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.112/24
 ```
@@ -380,10 +381,12 @@ vlan 131
 !
 interface Ethernet1
    description DC1-LEAF2A_Ethernet7
+   no shutdown
    channel-group 1 mode active
 !
 interface Ethernet2
    description DC1-LEAF2B_Ethernet7
+   no shutdown
    channel-group 1 mode active
 ```
 
@@ -395,7 +398,7 @@ interface Ethernet2
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel1 | DC1-LEAF2A_Po7 | switched | access | 110-111,120-121,130-131 | - | - | - | - | - | - |
+| Port-Channel1 | DC1-LEAF2A_Po7 | switched | trunk | 110-111,120-121,130-131 | - | - | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -403,6 +406,7 @@ interface Ethernet2
 !
 interface Port-Channel1
    description DC1-LEAF2A_Po7
+   no shutdown
    switchport
    switchport trunk allowed vlan 110-111,120-121,130-131
    switchport mode trunk

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-L2LEAF1A.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -390,7 +395,7 @@ interface Ethernet2
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel1 | DC1-LEAF2A_Po7 | switched | access | 110-111,120-121,130-131 | - | - | - | - | 1 | - |
+| Port-Channel1 | DC1-LEAF2A_Po7 | switched | access | 110-111,120-121,130-131 | - | - | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -398,9 +403,9 @@ interface Ethernet2
 !
 interface Port-Channel1
    description DC1-LEAF2A_Po7
+   switchport
    switchport trunk allowed vlan 110-111,120-121,130-131
    switchport mode trunk
-   mlag 1
 ```
 
 ## Loopback Interfaces
@@ -594,6 +599,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-L2LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-L2LEAF2A.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -472,12 +477,14 @@ interface Ethernet4
 !
 interface Port-Channel1
    description DC1-SVC3A_Po7
+   switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350
    switchport mode trunk
    mlag 1
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-L2LEAF2B_Po3
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group MLAG
@@ -696,6 +703,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-L2LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-L2LEAF2A.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.113/24
 ```
@@ -445,18 +446,22 @@ vlan 4094
 !
 interface Ethernet1
    description DC1-SVC3A_Ethernet7
+   no shutdown
    channel-group 1 mode active
 !
 interface Ethernet2
    description DC1-SVC3B_Ethernet7
+   no shutdown
    channel-group 1 mode active
 !
 interface Ethernet3
    description MLAG_PEER_DC1-L2LEAF2B_Ethernet3
+   no shutdown
    channel-group 3 mode active
 !
 interface Ethernet4
    description MLAG_PEER_DC1-L2LEAF2B_Ethernet4
+   no shutdown
    channel-group 3 mode active
 ```
 
@@ -468,8 +473,8 @@ interface Ethernet4
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel1 | DC1-SVC3A_Po7 | switched | access | 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350 | - | - | - | - | 1 | - |
-| Port-Channel3 | MLAG_PEER_DC1-L2LEAF2B_Po3 | switched | access | 2-4094 | - | ['MLAG'] | - | - | - | - |
+| Port-Channel1 | DC1-SVC3A_Po7 | switched | trunk | 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350 | - | - | - | - | 1 | - |
+| Port-Channel3 | MLAG_PEER_DC1-L2LEAF2B_Po3 | switched | trunk | 2-4094 | - | ['MLAG'] | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -477,6 +482,7 @@ interface Ethernet4
 !
 interface Port-Channel1
    description DC1-SVC3A_Po7
+   no shutdown
    switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350
    switchport mode trunk
@@ -484,6 +490,7 @@ interface Port-Channel1
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-L2LEAF2B_Po3
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -500,7 +507,7 @@ No loopback interfaces defined
 
 | Interface | Description | VRF |  MTU | Shutdown |
 | --------- | ----------- | --- | ---- | -------- |
-| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  -  |
+| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  false  |
 
 #### IPv4
 
@@ -516,6 +523,7 @@ No loopback interfaces defined
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.16/31
 ```

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-L2LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-L2LEAF2B.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.114/24
 ```
@@ -445,18 +446,22 @@ vlan 4094
 !
 interface Ethernet1
    description DC1-SVC3A_Ethernet8
+   no shutdown
    channel-group 1 mode active
 !
 interface Ethernet2
    description DC1-SVC3B_Ethernet8
+   no shutdown
    channel-group 1 mode active
 !
 interface Ethernet3
    description MLAG_PEER_DC1-L2LEAF2A_Ethernet3
+   no shutdown
    channel-group 3 mode active
 !
 interface Ethernet4
    description MLAG_PEER_DC1-L2LEAF2A_Ethernet4
+   no shutdown
    channel-group 3 mode active
 ```
 
@@ -468,8 +473,8 @@ interface Ethernet4
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel1 | DC1-SVC3B_Po7 | switched | access | 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350 | - | - | - | - | 1 | - |
-| Port-Channel3 | MLAG_PEER_DC1-L2LEAF2A_Po3 | switched | access | 2-4094 | - | ['MLAG'] | - | - | - | - |
+| Port-Channel1 | DC1-SVC3B_Po7 | switched | trunk | 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350 | - | - | - | - | 1 | - |
+| Port-Channel3 | MLAG_PEER_DC1-L2LEAF2A_Po3 | switched | trunk | 2-4094 | - | ['MLAG'] | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -477,6 +482,7 @@ interface Ethernet4
 !
 interface Port-Channel1
    description DC1-SVC3B_Po7
+   no shutdown
    switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350
    switchport mode trunk
@@ -484,6 +490,7 @@ interface Port-Channel1
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-L2LEAF2A_Po3
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -500,7 +507,7 @@ No loopback interfaces defined
 
 | Interface | Description | VRF |  MTU | Shutdown |
 | --------- | ----------- | --- | ---- | -------- |
-| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  -  |
+| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  false  |
 
 #### IPv4
 
@@ -516,6 +523,7 @@ No loopback interfaces defined
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.17/31
 ```

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-L2LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-L2LEAF2B.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -472,12 +477,14 @@ interface Ethernet4
 !
 interface Port-Channel1
    description DC1-SVC3B_Po7
+   switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350
    switchport mode trunk
    mlag 1
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-L2LEAF2A_Po3
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group MLAG
@@ -696,6 +703,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-LEAF1A.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -396,11 +401,13 @@ interface Ethernet4
 !
 interface Ethernet5
    description server01_Eth1
+   switchport
    switchport trunk allowed vlan 110
    switchport mode trunk
 !
 interface Ethernet6
    description server02_Eth1
+   switchport
    switchport trunk allowed vlan 110
    switchport mode trunk
 ```
@@ -469,21 +476,25 @@ interface Loopback1
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address virtual 10.1.21.1/24
 !
 interface Vlan130
    description Tenant_A_APP_Zone_1
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.30.1/24
 !
 interface Vlan131
    description Tenant_A_APP_Zone_2
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.31.1/24
 ```
@@ -889,6 +900,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-LEAF1A.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.105/24
 ```
@@ -370,10 +371,10 @@ vlan 131
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet1  |  routed  | - |  172.31.255.1/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet1  |  routed  | - |  172.31.255.3/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet1  |  routed  | - |  172.31.255.5/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet1  |  routed  | - |  172.31.255.7/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet1  |  routed  | - |  172.31.255.1/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet1  |  routed  | - |  172.31.255.3/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet1  |  routed  | - |  172.31.255.5/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet1  |  routed  | - |  172.31.255.7/31  |  default  |  1500  |  false  |  -  |  -  |
 
 ### Ethernet Interfaces Device Configuration
 
@@ -381,32 +382,38 @@ vlan 131
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.1/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.3/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.5/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.7/31
 !
 interface Ethernet5
    description server01_Eth1
+   no shutdown
    switchport
    switchport trunk allowed vlan 110
    switchport mode trunk
 !
 interface Ethernet6
    description server02_Eth1
+   no shutdown
    switchport
    switchport trunk allowed vlan 110
    switchport mode trunk
@@ -441,10 +448,12 @@ No port-channels defined
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.5/32
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.5/32
 ```
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-LEAF2A.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -531,6 +536,7 @@ interface Ethernet11
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-LEAF2B_Po5
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -538,18 +544,21 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF1_Po1
+   switchport
    switchport trunk allowed vlan 110-111,120-121,130-131
    switchport mode trunk
    mlag 7
 !
 interface Port-Channel10
    description server01_PortChanne1
+   switchport
    switchport trunk allowed vlan 210-211
    switchport mode trunk
    mlag 10
 !
 interface Port-Channel11
    description server02_PortChanne1
+   switchport
    switchport trunk allowed vlan 210-211
    switchport mode trunk
    mlag 11
@@ -654,61 +663,73 @@ interface Loopback100
 !
 interface Vlan110
    description Tenant_A_OP_Zone_1
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address virtual 10.1.10.1/24
 !
 interface Vlan111
    description Tenant_A_OP_Zone_2
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address virtual 10.1.21.1/24
 !
 interface Vlan130
    description Tenant_A_APP_Zone_1
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.30.1/24
 !
 interface Vlan131
    description Tenant_A_APP_Zone_2
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.31.1/24
 !
 interface Vlan140
    description Tenant_A_DB_BZone_1
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address virtual 10.1.40.1/24
 !
 interface Vlan141
    description Tenant_A_DB_Zone_2
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address virtual 10.1.41.1/24
 !
 interface Vlan210
    description Tenant_B_OP_Zone_1
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address virtual 10.2.10.1/24
 !
 interface Vlan211
    description Tenant_B_OP_Zone_2
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address virtual 10.2.11.1/24
 !
 interface Vlan310
    description Tenant_C_OP_Zone_1
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address virtual 10.3.10.1/24
 !
 interface Vlan311
    description Tenant_C_OP_Zone_2
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address virtual 10.3.11.1/24
 !
@@ -1299,6 +1320,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-LEAF2A.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.106/24
 ```
@@ -467,10 +468,10 @@ vlan 4094
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet2  |  routed  | - |  172.31.255.9/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet2  |  routed  | - |  172.31.255.11/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet2  |  routed  | - |  172.31.255.13/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet2  |  routed  | - |  172.31.255.15/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet2  |  routed  | - |  172.31.255.9/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet2  |  routed  | - |  172.31.255.11/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet2  |  routed  | - |  172.31.255.13/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet2  |  routed  | - |  172.31.255.15/31  |  default  |  1500  |  false  |  -  |  -  |
 
 ### Ethernet Interfaces Device Configuration
 
@@ -478,42 +479,51 @@ vlan 4094
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.9/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.11/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.13/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.15/31
 !
 interface Ethernet5
    description MLAG_PEER_DC1-LEAF2B_Ethernet5
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-LEAF2B_Ethernet6
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet7
    description DC1-L2LEAF1A_Ethernet1
+   no shutdown
    channel-group 7 mode active
 !
 interface Ethernet10
    description server01_Eth2
+   no shutdown
    channel-group 10 mode active
 !
 interface Ethernet11
    description server02_Eth2
+   no shutdown
    channel-group 11 mode active
 ```
 
@@ -525,10 +535,10 @@ interface Ethernet11
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel5 | MLAG_PEER_DC1-LEAF2B_Po5 | switched | access | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
-| Port-Channel7 | DC1_L2LEAF1_Po1 | switched | access | 110-111,120-121,130-131 | - | - | - | - | 7 | - |
-| Port-Channel10 | server01_PortChanne1 | switched | access | 210-211 | - | - | - | - | 10 | - |
-| Port-Channel11 | server02_PortChanne1 | switched | access | 210-211 | - | - | - | - | 11 | - |
+| Port-Channel5 | MLAG_PEER_DC1-LEAF2B_Po5 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
+| Port-Channel7 | DC1_L2LEAF1_Po1 | switched | trunk | 110-111,120-121,130-131 | - | - | - | - | 7 | - |
+| Port-Channel10 | server01_PortChanne1 | switched | trunk | 210-211 | - | - | - | - | 10 | - |
+| Port-Channel11 | server02_PortChanne1 | switched | trunk | 210-211 | - | - | - | - | 11 | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -536,6 +546,7 @@ interface Ethernet11
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-LEAF2B_Po5
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -544,6 +555,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF1_Po1
+   no shutdown
    switchport
    switchport trunk allowed vlan 110-111,120-121,130-131
    switchport mode trunk
@@ -551,6 +563,7 @@ interface Port-Channel7
 !
 interface Port-Channel10
    description server01_PortChanne1
+   no shutdown
    switchport
    switchport trunk allowed vlan 210-211
    switchport mode trunk
@@ -558,6 +571,7 @@ interface Port-Channel10
 !
 interface Port-Channel11
    description server02_PortChanne1
+   no shutdown
    switchport
    switchport trunk allowed vlan 210-211
    switchport mode trunk
@@ -591,14 +605,17 @@ interface Port-Channel11
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.6/32
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.6/32
 !
 interface Loopback100
    description Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address 10.255.1.6/32
 ```
@@ -621,14 +638,14 @@ interface Loopback100
 | Vlan211 |  Tenant_B_OP_Zone_2  |  Tenant_B_OP_Zone  |  -  |  false  |
 | Vlan310 |  Tenant_C_OP_Zone_1  |  Tenant_C_OP_Zone  |  -  |  false  |
 | Vlan311 |  Tenant_C_OP_Zone_2  |  Tenant_C_OP_Zone  |  -  |  false  |
-| Vlan3009 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone  |  Tenant_A_OP_Zone  |  -  |  -  |
-| Vlan3010 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone  |  Tenant_A_WEB_Zone  |  -  |  -  |
-| Vlan3011 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone  |  Tenant_A_APP_Zone  |  -  |  -  |
-| Vlan3012 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone  |  Tenant_A_DB_Zone  |  -  |  -  |
-| Vlan3019 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone  |  Tenant_B_OP_Zone  |  -  |  -  |
-| Vlan3029 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone  |  Tenant_C_OP_Zone  |  -  |  -  |
-| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  -  |
-| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  -  |
+| Vlan3009 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone  |  Tenant_A_OP_Zone  |  -  |  false  |
+| Vlan3010 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone  |  Tenant_A_WEB_Zone  |  -  |  false  |
+| Vlan3011 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone  |  Tenant_A_APP_Zone  |  -  |  false  |
+| Vlan3012 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone  |  Tenant_A_DB_Zone  |  -  |  false  |
+| Vlan3019 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone  |  Tenant_B_OP_Zone  |  -  |  false  |
+| Vlan3029 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone  |  Tenant_C_OP_Zone  |  -  |  false  |
+| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  false  |
+| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  false  |
 
 #### IPv4
 
@@ -735,40 +752,48 @@ interface Vlan311
 !
 interface Vlan3009
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address 10.255.251.2/31
 !
 interface Vlan3010
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address 10.255.251.2/31
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address 10.255.251.2/31
 !
 interface Vlan3012
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address 10.255.251.2/31
 !
 interface Vlan3019
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address 10.255.251.2/31
 !
 interface Vlan3029
    description MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address 10.255.251.2/31
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
+   no shutdown
    ip address 10.255.251.2/31
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.2/31
 ```

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-LEAF2B.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.107/24
 ```
@@ -467,10 +468,10 @@ vlan 4094
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet3  |  routed  | - |  172.31.255.17/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet3  |  routed  | - |  172.31.255.19/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet3  |  routed  | - |  172.31.255.21/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet3  |  routed  | - |  172.31.255.23/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet3  |  routed  | - |  172.31.255.17/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet3  |  routed  | - |  172.31.255.19/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet3  |  routed  | - |  172.31.255.21/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet3  |  routed  | - |  172.31.255.23/31  |  default  |  1500  |  false  |  -  |  -  |
 
 ### Ethernet Interfaces Device Configuration
 
@@ -478,42 +479,51 @@ vlan 4094
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.17/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.19/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.21/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.23/31
 !
 interface Ethernet5
    description MLAG_PEER_DC1-LEAF2A_Ethernet5
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-LEAF2A_Ethernet6
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet7
    description DC1-L2LEAF1A_Ethernet2
+   no shutdown
    channel-group 7 mode active
 !
 interface Ethernet10
    description server01_Eth3
+   no shutdown
    channel-group 10 mode active
 !
 interface Ethernet11
    description server02_Eth3
+   no shutdown
    channel-group 11 mode active
 ```
 
@@ -525,10 +535,10 @@ interface Ethernet11
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel5 | MLAG_PEER_DC1-LEAF2A_Po5 | switched | access | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
-| Port-Channel7 | DC1_L2LEAF1_Po1 | switched | access | 110-111,120-121,130-131 | - | - | - | - | 7 | - |
-| Port-Channel10 | server01_PortChanne1 | switched | access | 210-211 | - | - | - | - | 10 | - |
-| Port-Channel11 | server02_PortChanne1 | switched | access | 210-211 | - | - | - | - | 11 | - |
+| Port-Channel5 | MLAG_PEER_DC1-LEAF2A_Po5 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
+| Port-Channel7 | DC1_L2LEAF1_Po1 | switched | trunk | 110-111,120-121,130-131 | - | - | - | - | 7 | - |
+| Port-Channel10 | server01_PortChanne1 | switched | trunk | 210-211 | - | - | - | - | 10 | - |
+| Port-Channel11 | server02_PortChanne1 | switched | trunk | 210-211 | - | - | - | - | 11 | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -536,6 +546,7 @@ interface Ethernet11
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-LEAF2A_Po5
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -544,6 +555,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF1_Po1
+   no shutdown
    switchport
    switchport trunk allowed vlan 110-111,120-121,130-131
    switchport mode trunk
@@ -551,6 +563,7 @@ interface Port-Channel7
 !
 interface Port-Channel10
    description server01_PortChanne1
+   no shutdown
    switchport
    switchport trunk allowed vlan 210-211
    switchport mode trunk
@@ -558,6 +571,7 @@ interface Port-Channel10
 !
 interface Port-Channel11
    description server02_PortChanne1
+   no shutdown
    switchport
    switchport trunk allowed vlan 210-211
    switchport mode trunk
@@ -591,14 +605,17 @@ interface Port-Channel11
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.7/32
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.6/32
 !
 interface Loopback100
    description Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address 10.255.1.7/32
 ```
@@ -621,14 +638,14 @@ interface Loopback100
 | Vlan211 |  Tenant_B_OP_Zone_2  |  Tenant_B_OP_Zone  |  -  |  false  |
 | Vlan310 |  Tenant_C_OP_Zone_1  |  Tenant_C_OP_Zone  |  -  |  false  |
 | Vlan311 |  Tenant_C_OP_Zone_2  |  Tenant_C_OP_Zone  |  -  |  false  |
-| Vlan3009 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone  |  Tenant_A_OP_Zone  |  -  |  -  |
-| Vlan3010 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone  |  Tenant_A_WEB_Zone  |  -  |  -  |
-| Vlan3011 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone  |  Tenant_A_APP_Zone  |  -  |  -  |
-| Vlan3012 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone  |  Tenant_A_DB_Zone  |  -  |  -  |
-| Vlan3019 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone  |  Tenant_B_OP_Zone  |  -  |  -  |
-| Vlan3029 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone  |  Tenant_C_OP_Zone  |  -  |  -  |
-| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  -  |
-| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  -  |
+| Vlan3009 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone  |  Tenant_A_OP_Zone  |  -  |  false  |
+| Vlan3010 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone  |  Tenant_A_WEB_Zone  |  -  |  false  |
+| Vlan3011 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone  |  Tenant_A_APP_Zone  |  -  |  false  |
+| Vlan3012 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone  |  Tenant_A_DB_Zone  |  -  |  false  |
+| Vlan3019 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone  |  Tenant_B_OP_Zone  |  -  |  false  |
+| Vlan3029 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone  |  Tenant_C_OP_Zone  |  -  |  false  |
+| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  false  |
+| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  false  |
 
 #### IPv4
 
@@ -735,40 +752,48 @@ interface Vlan311
 !
 interface Vlan3009
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address 10.255.251.3/31
 !
 interface Vlan3010
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address 10.255.251.3/31
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address 10.255.251.3/31
 !
 interface Vlan3012
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address 10.255.251.3/31
 !
 interface Vlan3019
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address 10.255.251.3/31
 !
 interface Vlan3029
    description MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address 10.255.251.3/31
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
+   no shutdown
    ip address 10.255.251.3/31
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.3/31
 ```

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-LEAF2B.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -531,6 +536,7 @@ interface Ethernet11
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-LEAF2A_Po5
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -538,18 +544,21 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF1_Po1
+   switchport
    switchport trunk allowed vlan 110-111,120-121,130-131
    switchport mode trunk
    mlag 7
 !
 interface Port-Channel10
    description server01_PortChanne1
+   switchport
    switchport trunk allowed vlan 210-211
    switchport mode trunk
    mlag 10
 !
 interface Port-Channel11
    description server02_PortChanne1
+   switchport
    switchport trunk allowed vlan 210-211
    switchport mode trunk
    mlag 11
@@ -654,61 +663,73 @@ interface Loopback100
 !
 interface Vlan110
    description Tenant_A_OP_Zone_1
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address virtual 10.1.10.1/24
 !
 interface Vlan111
    description Tenant_A_OP_Zone_2
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address virtual 10.1.21.1/24
 !
 interface Vlan130
    description Tenant_A_APP_Zone_1
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.30.1/24
 !
 interface Vlan131
    description Tenant_A_APP_Zone_2
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.31.1/24
 !
 interface Vlan140
    description Tenant_A_DB_BZone_1
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address virtual 10.1.40.1/24
 !
 interface Vlan141
    description Tenant_A_DB_Zone_2
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address virtual 10.1.41.1/24
 !
 interface Vlan210
    description Tenant_B_OP_Zone_1
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address virtual 10.2.10.1/24
 !
 interface Vlan211
    description Tenant_B_OP_Zone_2
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address virtual 10.2.11.1/24
 !
 interface Vlan310
    description Tenant_C_OP_Zone_1
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address virtual 10.3.10.1/24
 !
 interface Vlan311
    description Tenant_C_OP_Zone_2
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address virtual 10.3.11.1/24
 !
@@ -1299,6 +1320,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-SPINE1.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -731,6 +736,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-SPINE1.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.101/24
 ```
@@ -337,13 +338,13 @@ No VLANs defined
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 |  P2P_LINK_TO_DC1-LEAF1A_Ethernet1  |  routed  | - |  172.31.255.0/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet2 |  P2P_LINK_TO_DC1-LEAF2A_Ethernet1  |  routed  | - |  172.31.255.8/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet3 |  P2P_LINK_TO_DC1-LEAF2B_Ethernet1  |  routed  | - |  172.31.255.16/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet4 |  P2P_LINK_TO_DC1-SVC3A_Ethernet1  |  routed  | - |  172.31.255.24/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet5 |  P2P_LINK_TO_DC1-SVC3B_Ethernet1  |  routed  | - |  172.31.255.32/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet6 |  P2P_LINK_TO_DC1-BL1A_Ethernet1  |  routed  | - |  172.31.255.40/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet7 |  P2P_LINK_TO_DC1-BL1B_Ethernet1  |  routed  | - |  172.31.255.48/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet1 |  P2P_LINK_TO_DC1-LEAF1A_Ethernet1  |  routed  | - |  172.31.255.0/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet2 |  P2P_LINK_TO_DC1-LEAF2A_Ethernet1  |  routed  | - |  172.31.255.8/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet3 |  P2P_LINK_TO_DC1-LEAF2B_Ethernet1  |  routed  | - |  172.31.255.16/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4 |  P2P_LINK_TO_DC1-SVC3A_Ethernet1  |  routed  | - |  172.31.255.24/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet5 |  P2P_LINK_TO_DC1-SVC3B_Ethernet1  |  routed  | - |  172.31.255.32/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet6 |  P2P_LINK_TO_DC1-BL1A_Ethernet1  |  routed  | - |  172.31.255.40/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet7 |  P2P_LINK_TO_DC1-BL1B_Ethernet1  |  routed  | - |  172.31.255.48/31  |  default  |  1500  |  false  |  -  |  -  |
 
 ### Ethernet Interfaces Device Configuration
 
@@ -351,36 +352,43 @@ No VLANs defined
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.0/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-LEAF2A_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.8/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-LEAF2B_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.16/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SVC3A_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.24/31
 !
 interface Ethernet5
    description P2P_LINK_TO_DC1-SVC3B_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.32/31
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-BL1A_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.40/31
 !
 interface Ethernet7
    description P2P_LINK_TO_DC1-BL1B_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.48/31
 ```
@@ -412,6 +420,7 @@ No port-channels defined
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.1/32
 ```
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-SPINE2.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -731,6 +736,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-SPINE2.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.102/24
 ```
@@ -337,13 +338,13 @@ No VLANs defined
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 |  P2P_LINK_TO_DC1-LEAF1A_Ethernet2  |  routed  | - |  172.31.255.2/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet2 |  P2P_LINK_TO_DC1-LEAF2A_Ethernet2  |  routed  | - |  172.31.255.10/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet3 |  P2P_LINK_TO_DC1-LEAF2B_Ethernet2  |  routed  | - |  172.31.255.18/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet4 |  P2P_LINK_TO_DC1-SVC3A_Ethernet2  |  routed  | - |  172.31.255.26/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet5 |  P2P_LINK_TO_DC1-SVC3B_Ethernet2  |  routed  | - |  172.31.255.34/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet6 |  P2P_LINK_TO_DC1-BL1A_Ethernet2  |  routed  | - |  172.31.255.42/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet7 |  P2P_LINK_TO_DC1-BL1B_Ethernet2  |  routed  | - |  172.31.255.50/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet1 |  P2P_LINK_TO_DC1-LEAF1A_Ethernet2  |  routed  | - |  172.31.255.2/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet2 |  P2P_LINK_TO_DC1-LEAF2A_Ethernet2  |  routed  | - |  172.31.255.10/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet3 |  P2P_LINK_TO_DC1-LEAF2B_Ethernet2  |  routed  | - |  172.31.255.18/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4 |  P2P_LINK_TO_DC1-SVC3A_Ethernet2  |  routed  | - |  172.31.255.26/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet5 |  P2P_LINK_TO_DC1-SVC3B_Ethernet2  |  routed  | - |  172.31.255.34/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet6 |  P2P_LINK_TO_DC1-BL1A_Ethernet2  |  routed  | - |  172.31.255.42/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet7 |  P2P_LINK_TO_DC1-BL1B_Ethernet2  |  routed  | - |  172.31.255.50/31  |  default  |  1500  |  false  |  -  |  -  |
 
 ### Ethernet Interfaces Device Configuration
 
@@ -351,36 +352,43 @@ No VLANs defined
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.2/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-LEAF2A_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.10/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-LEAF2B_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.18/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SVC3A_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.26/31
 !
 interface Ethernet5
    description P2P_LINK_TO_DC1-SVC3B_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.34/31
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-BL1A_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.42/31
 !
 interface Ethernet7
    description P2P_LINK_TO_DC1-BL1B_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.50/31
 ```
@@ -412,6 +420,7 @@ No port-channels defined
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.2/32
 ```
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-SPINE3.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -731,6 +736,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-SPINE3.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.103/24
 ```
@@ -337,13 +338,13 @@ No VLANs defined
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 |  P2P_LINK_TO_DC1-LEAF1A_Ethernet3  |  routed  | - |  172.31.255.4/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet2 |  P2P_LINK_TO_DC1-LEAF2A_Ethernet3  |  routed  | - |  172.31.255.12/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet3 |  P2P_LINK_TO_DC1-LEAF2B_Ethernet3  |  routed  | - |  172.31.255.20/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet4 |  P2P_LINK_TO_DC1-SVC3A_Ethernet3  |  routed  | - |  172.31.255.28/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet5 |  P2P_LINK_TO_DC1-SVC3B_Ethernet3  |  routed  | - |  172.31.255.36/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet6 |  P2P_LINK_TO_DC1-BL1A_Ethernet3  |  routed  | - |  172.31.255.44/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet7 |  P2P_LINK_TO_DC1-BL1B_Ethernet3  |  routed  | - |  172.31.255.52/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet1 |  P2P_LINK_TO_DC1-LEAF1A_Ethernet3  |  routed  | - |  172.31.255.4/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet2 |  P2P_LINK_TO_DC1-LEAF2A_Ethernet3  |  routed  | - |  172.31.255.12/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet3 |  P2P_LINK_TO_DC1-LEAF2B_Ethernet3  |  routed  | - |  172.31.255.20/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4 |  P2P_LINK_TO_DC1-SVC3A_Ethernet3  |  routed  | - |  172.31.255.28/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet5 |  P2P_LINK_TO_DC1-SVC3B_Ethernet3  |  routed  | - |  172.31.255.36/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet6 |  P2P_LINK_TO_DC1-BL1A_Ethernet3  |  routed  | - |  172.31.255.44/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet7 |  P2P_LINK_TO_DC1-BL1B_Ethernet3  |  routed  | - |  172.31.255.52/31  |  default  |  1500  |  false  |  -  |  -  |
 
 ### Ethernet Interfaces Device Configuration
 
@@ -351,36 +352,43 @@ No VLANs defined
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.4/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-LEAF2A_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.12/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-LEAF2B_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.20/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SVC3A_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.28/31
 !
 interface Ethernet5
    description P2P_LINK_TO_DC1-SVC3B_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.36/31
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-BL1A_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.44/31
 !
 interface Ethernet7
    description P2P_LINK_TO_DC1-BL1B_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.52/31
 ```
@@ -412,6 +420,7 @@ No port-channels defined
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.3/32
 ```
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-SPINE4.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -731,6 +736,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-SPINE4.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.104/24
 ```
@@ -337,13 +338,13 @@ No VLANs defined
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 |  P2P_LINK_TO_DC1-LEAF1A_Ethernet4  |  routed  | - |  172.31.255.6/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet2 |  P2P_LINK_TO_DC1-LEAF2A_Ethernet4  |  routed  | - |  172.31.255.14/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet3 |  P2P_LINK_TO_DC1-LEAF2B_Ethernet4  |  routed  | - |  172.31.255.22/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet4 |  P2P_LINK_TO_DC1-SVC3A_Ethernet4  |  routed  | - |  172.31.255.30/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet5 |  P2P_LINK_TO_DC1-SVC3B_Ethernet4  |  routed  | - |  172.31.255.38/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet6 |  P2P_LINK_TO_DC1-BL1A_Ethernet4  |  routed  | - |  172.31.255.46/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet7 |  P2P_LINK_TO_DC1-BL1B_Ethernet4  |  routed  | - |  172.31.255.54/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet1 |  P2P_LINK_TO_DC1-LEAF1A_Ethernet4  |  routed  | - |  172.31.255.6/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet2 |  P2P_LINK_TO_DC1-LEAF2A_Ethernet4  |  routed  | - |  172.31.255.14/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet3 |  P2P_LINK_TO_DC1-LEAF2B_Ethernet4  |  routed  | - |  172.31.255.22/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4 |  P2P_LINK_TO_DC1-SVC3A_Ethernet4  |  routed  | - |  172.31.255.30/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet5 |  P2P_LINK_TO_DC1-SVC3B_Ethernet4  |  routed  | - |  172.31.255.38/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet6 |  P2P_LINK_TO_DC1-BL1A_Ethernet4  |  routed  | - |  172.31.255.46/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet7 |  P2P_LINK_TO_DC1-BL1B_Ethernet4  |  routed  | - |  172.31.255.54/31  |  default  |  1500  |  false  |  -  |  -  |
 
 ### Ethernet Interfaces Device Configuration
 
@@ -351,36 +352,43 @@ No VLANs defined
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.6/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-LEAF2A_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.14/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-LEAF2B_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.22/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SVC3A_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.30/31
 !
 interface Ethernet5
    description P2P_LINK_TO_DC1-SVC3B_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.38/31
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-BL1A_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.46/31
 !
 interface Ethernet7
    description P2P_LINK_TO_DC1-BL1B_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.54/31
 ```
@@ -412,6 +420,7 @@ No port-channels defined
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.4/32
 ```
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-SVC3A.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.108/24
 ```
@@ -495,10 +496,10 @@ vlan 4094
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet4  |  routed  | - |  172.31.255.25/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet4  |  routed  | - |  172.31.255.27/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet4  |  routed  | - |  172.31.255.29/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet4  |  routed  | - |  172.31.255.31/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet4  |  routed  | - |  172.31.255.25/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet4  |  routed  | - |  172.31.255.27/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet4  |  routed  | - |  172.31.255.29/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet4  |  routed  | - |  172.31.255.31/31  |  default  |  1500  |  false  |  -  |  -  |
 
 ### Ethernet Interfaces Device Configuration
 
@@ -506,46 +507,56 @@ vlan 4094
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.25/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.27/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.29/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.31/31
 !
 interface Ethernet5
    description MLAG_PEER_DC1-SVC3B_Ethernet5
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-SVC3B_Ethernet6
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet7
    description DC1-L2LEAF2A_Ethernet1
+   no shutdown
    channel-group 7 mode active
 !
 interface Ethernet8
    description DC1-L2LEAF2B_Ethernet1
+   no shutdown
    channel-group 7 mode active
 !
 interface Ethernet10
    description server03_Eth1
+   no shutdown
    channel-group 10 mode active
 !
 interface Ethernet11
    description server04_Eth1
+   no shutdown
    channel-group 11 mode active
 ```
 
@@ -557,10 +568,10 @@ interface Ethernet11
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel5 | MLAG_PEER_DC1-SVC3B_Po5 | switched | access | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
-| Port-Channel7 | DC1_L2LEAF2_Po1 | switched | access | 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350 | - | - | - | - | 7 | - |
-| Port-Channel10 | server03_PortChanne1 | switched | access | 110-111,210-211 | - | - | - | - | 10 | - |
-| Port-Channel11 | server04_PortChanne1 | switched | access | 110-111,210-211 | - | - | - | - | 11 | - |
+| Port-Channel5 | MLAG_PEER_DC1-SVC3B_Po5 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
+| Port-Channel7 | DC1_L2LEAF2_Po1 | switched | trunk | 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350 | - | - | - | - | 7 | - |
+| Port-Channel10 | server03_PortChanne1 | switched | trunk | 110-111,210-211 | - | - | - | - | 10 | - |
+| Port-Channel11 | server04_PortChanne1 | switched | trunk | 110-111,210-211 | - | - | - | - | 11 | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -568,6 +579,7 @@ interface Ethernet11
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-SVC3B_Po5
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -576,6 +588,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF2_Po1
+   no shutdown
    switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350
    switchport mode trunk
@@ -583,6 +596,7 @@ interface Port-Channel7
 !
 interface Port-Channel10
    description server03_PortChanne1
+   no shutdown
    switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
@@ -590,6 +604,7 @@ interface Port-Channel10
 !
 interface Port-Channel11
    description server04_PortChanne1
+   no shutdown
    switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
@@ -623,14 +638,17 @@ interface Port-Channel11
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.8/32
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.8/32
 !
 interface Loopback100
    description Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address 10.255.1.8/32
 ```
@@ -656,17 +674,17 @@ interface Loopback100
 | Vlan310 |  Tenant_C_OP_Zone_1  |  Tenant_C_OP_Zone  |  -  |  false  |
 | Vlan311 |  Tenant_C_OP_Zone_2  |  Tenant_C_OP_Zone  |  -  |  false  |
 | Vlan350 |  Tenant_C_WAN_Zone_1  |  Tenant_C_WAN_Zone  |  -  |  false  |
-| Vlan3009 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone  |  Tenant_A_OP_Zone  |  -  |  -  |
-| Vlan3010 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone  |  Tenant_A_WEB_Zone  |  -  |  -  |
-| Vlan3011 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone  |  Tenant_A_APP_Zone  |  -  |  -  |
-| Vlan3012 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone  |  Tenant_A_DB_Zone  |  -  |  -  |
-| Vlan3013 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone  |  Tenant_A_WAN_Zone  |  -  |  -  |
-| Vlan3019 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone  |  Tenant_B_OP_Zone  |  -  |  -  |
-| Vlan3020 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone  |  Tenant_B_WAN_Zone  |  -  |  -  |
-| Vlan3029 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone  |  Tenant_C_OP_Zone  |  -  |  -  |
-| Vlan3030 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone  |  Tenant_C_WAN_Zone  |  -  |  -  |
-| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  -  |
-| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  -  |
+| Vlan3009 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone  |  Tenant_A_OP_Zone  |  -  |  false  |
+| Vlan3010 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone  |  Tenant_A_WEB_Zone  |  -  |  false  |
+| Vlan3011 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone  |  Tenant_A_APP_Zone  |  -  |  false  |
+| Vlan3012 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone  |  Tenant_A_DB_Zone  |  -  |  false  |
+| Vlan3013 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone  |  Tenant_A_WAN_Zone  |  -  |  false  |
+| Vlan3019 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone  |  Tenant_B_OP_Zone  |  -  |  false  |
+| Vlan3020 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone  |  Tenant_B_WAN_Zone  |  -  |  false  |
+| Vlan3029 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone  |  Tenant_C_OP_Zone  |  -  |  false  |
+| Vlan3030 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone  |  Tenant_C_WAN_Zone  |  -  |  false  |
+| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  false  |
+| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  false  |
 
 #### IPv4
 
@@ -797,55 +815,66 @@ interface Vlan350
 !
 interface Vlan3009
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address 10.255.251.6/31
 !
 interface Vlan3010
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address 10.255.251.6/31
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address 10.255.251.6/31
 !
 interface Vlan3012
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address 10.255.251.6/31
 !
 interface Vlan3013
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone
+   no shutdown
    vrf Tenant_A_WAN_Zone
    ip address 10.255.251.6/31
 !
 interface Vlan3019
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address 10.255.251.6/31
 !
 interface Vlan3020
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone
+   no shutdown
    vrf Tenant_B_WAN_Zone
    ip address 10.255.251.6/31
 !
 interface Vlan3029
    description MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address 10.255.251.6/31
 !
 interface Vlan3030
    description MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone
+   no shutdown
    vrf Tenant_C_WAN_Zone
    ip address 10.255.251.6/31
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
+   no shutdown
    ip address 10.255.251.6/31
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.6/31
 ```

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-SVC3A.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -563,6 +568,7 @@ interface Ethernet11
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-SVC3B_Po5
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -570,18 +576,21 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF2_Po1
+   switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350
    switchport mode trunk
    mlag 7
 !
 interface Port-Channel10
    description server03_PortChanne1
+   switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
    mlag 10
 !
 interface Port-Channel11
    description server04_PortChanne1
+   switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
    mlag 11
@@ -698,76 +707,91 @@ interface Loopback100
 !
 interface Vlan110
    description Tenant_A_OP_Zone_1
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address virtual 10.1.10.1/24
 !
 interface Vlan111
    description Tenant_A_OP_Zone_2
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address virtual 10.1.21.1/24
 !
 interface Vlan130
    description Tenant_A_APP_Zone_1
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.30.1/24
 !
 interface Vlan131
    description Tenant_A_APP_Zone_2
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.31.1/24
 !
 interface Vlan140
    description Tenant_A_DB_BZone_1
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address virtual 10.1.40.1/24
 !
 interface Vlan141
    description Tenant_A_DB_Zone_2
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address virtual 10.1.41.1/24
 !
 interface Vlan150
    description Tenant_A_WAN_Zone_1
+   no shutdown
    vrf Tenant_A_WAN_Zone
    ip address virtual 10.1.40.1/24
 !
 interface Vlan210
    description Tenant_B_OP_Zone_1
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address virtual 10.2.10.1/24
 !
 interface Vlan211
    description Tenant_B_OP_Zone_2
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address virtual 10.2.11.1/24
 !
 interface Vlan250
    description Tenant_B_WAN_Zone_1
+   no shutdown
    vrf Tenant_B_WAN_Zone
    ip address virtual 10.2.50.1/24
 !
 interface Vlan310
    description Tenant_C_OP_Zone_1
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address virtual 10.3.10.1/24
 !
 interface Vlan311
    description Tenant_C_OP_Zone_2
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address virtual 10.3.11.1/24
 !
 interface Vlan350
    description Tenant_C_WAN_Zone_1
+   no shutdown
    vrf Tenant_C_WAN_Zone
    ip address virtual 10.3.50.1/24
 !
@@ -1451,6 +1475,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-SVC3B.md
@@ -71,6 +71,7 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
+- [MAC security](#mac-security)
 
 # Management
 
@@ -147,6 +148,10 @@ DNS domain lookup not defined
 ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 ```
+
+## PTP
+
+PTP is not defined.
 
 ## Management SSH
 
@@ -563,6 +568,7 @@ interface Ethernet11
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-SVC3A_Po5
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -570,18 +576,21 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF2_Po1
+   switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350
    switchport mode trunk
    mlag 7
 !
 interface Port-Channel10
    description server03_PortChanne1
+   switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
    mlag 10
 !
 interface Port-Channel11
    description server04_PortChanne1
+   switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
    mlag 11
@@ -698,76 +707,91 @@ interface Loopback100
 !
 interface Vlan110
    description Tenant_A_OP_Zone_1
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address virtual 10.1.10.1/24
 !
 interface Vlan111
    description Tenant_A_OP_Zone_2
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address virtual 10.1.21.1/24
 !
 interface Vlan130
    description Tenant_A_APP_Zone_1
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.30.1/24
 !
 interface Vlan131
    description Tenant_A_APP_Zone_2
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.31.1/24
 !
 interface Vlan140
    description Tenant_A_DB_BZone_1
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address virtual 10.1.40.1/24
 !
 interface Vlan141
    description Tenant_A_DB_Zone_2
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address virtual 10.1.41.1/24
 !
 interface Vlan150
    description Tenant_A_WAN_Zone_1
+   no shutdown
    vrf Tenant_A_WAN_Zone
    ip address virtual 10.1.40.1/24
 !
 interface Vlan210
    description Tenant_B_OP_Zone_1
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address virtual 10.2.10.1/24
 !
 interface Vlan211
    description Tenant_B_OP_Zone_2
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address virtual 10.2.11.1/24
 !
 interface Vlan250
    description Tenant_B_WAN_Zone_1
+   no shutdown
    vrf Tenant_B_WAN_Zone
    ip address virtual 10.2.50.1/24
 !
 interface Vlan310
    description Tenant_C_OP_Zone_1
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address virtual 10.3.10.1/24
 !
 interface Vlan311
    description Tenant_C_OP_Zone_2
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address virtual 10.3.11.1/24
 !
 interface Vlan350
    description Tenant_C_WAN_Zone_1
+   no shutdown
    vrf Tenant_C_WAN_Zone
    ip address virtual 10.3.50.1/24
 !
@@ -1451,6 +1475,9 @@ IP DHCP relay not defined
 # Errdisable
 
 Errdisable is not defined.
+# MACsec
+
+MACsec not defined
 
 # Custom Templates
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-SVC3B.md
@@ -97,6 +97,7 @@
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.109/24
 ```
@@ -495,10 +496,10 @@ vlan 4094
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet5  |  routed  | - |  172.31.255.33/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet5  |  routed  | - |  172.31.255.35/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet5  |  routed  | - |  172.31.255.37/31  |  default  |  1500  |  -  |  -  |  -  |
-| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet5  |  routed  | - |  172.31.255.39/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet5  |  routed  | - |  172.31.255.33/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet5  |  routed  | - |  172.31.255.35/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet5  |  routed  | - |  172.31.255.37/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet5  |  routed  | - |  172.31.255.39/31  |  default  |  1500  |  false  |  -  |  -  |
 
 ### Ethernet Interfaces Device Configuration
 
@@ -506,46 +507,56 @@ vlan 4094
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet5
+   no shutdown
    no switchport
    ip address 172.31.255.33/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet5
+   no shutdown
    no switchport
    ip address 172.31.255.35/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet5
+   no shutdown
    no switchport
    ip address 172.31.255.37/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet5
+   no shutdown
    no switchport
    ip address 172.31.255.39/31
 !
 interface Ethernet5
    description MLAG_PEER_DC1-SVC3A_Ethernet5
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-SVC3A_Ethernet6
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet7
    description DC1-L2LEAF2A_Ethernet2
+   no shutdown
    channel-group 7 mode active
 !
 interface Ethernet8
    description DC1-L2LEAF2B_Ethernet2
+   no shutdown
    channel-group 7 mode active
 !
 interface Ethernet10
    description server03_Eth2
+   no shutdown
    channel-group 10 mode active
 !
 interface Ethernet11
    description server04_Eth2
+   no shutdown
    channel-group 11 mode active
 ```
 
@@ -557,10 +568,10 @@ interface Ethernet11
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel5 | MLAG_PEER_DC1-SVC3A_Po5 | switched | access | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
-| Port-Channel7 | DC1_L2LEAF2_Po1 | switched | access | 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350 | - | - | - | - | 7 | - |
-| Port-Channel10 | server03_PortChanne1 | switched | access | 110-111,210-211 | - | - | - | - | 10 | - |
-| Port-Channel11 | server04_PortChanne1 | switched | access | 110-111,210-211 | - | - | - | - | 11 | - |
+| Port-Channel5 | MLAG_PEER_DC1-SVC3A_Po5 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
+| Port-Channel7 | DC1_L2LEAF2_Po1 | switched | trunk | 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350 | - | - | - | - | 7 | - |
+| Port-Channel10 | server03_PortChanne1 | switched | trunk | 110-111,210-211 | - | - | - | - | 10 | - |
+| Port-Channel11 | server04_PortChanne1 | switched | trunk | 110-111,210-211 | - | - | - | - | 11 | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -568,6 +579,7 @@ interface Ethernet11
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-SVC3A_Po5
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -576,6 +588,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF2_Po1
+   no shutdown
    switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350
    switchport mode trunk
@@ -583,6 +596,7 @@ interface Port-Channel7
 !
 interface Port-Channel10
    description server03_PortChanne1
+   no shutdown
    switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
@@ -590,6 +604,7 @@ interface Port-Channel10
 !
 interface Port-Channel11
    description server04_PortChanne1
+   no shutdown
    switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
@@ -623,14 +638,17 @@ interface Port-Channel11
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.9/32
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.8/32
 !
 interface Loopback100
    description Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address 10.255.1.9/32
 ```
@@ -656,17 +674,17 @@ interface Loopback100
 | Vlan310 |  Tenant_C_OP_Zone_1  |  Tenant_C_OP_Zone  |  -  |  false  |
 | Vlan311 |  Tenant_C_OP_Zone_2  |  Tenant_C_OP_Zone  |  -  |  false  |
 | Vlan350 |  Tenant_C_WAN_Zone_1  |  Tenant_C_WAN_Zone  |  -  |  false  |
-| Vlan3009 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone  |  Tenant_A_OP_Zone  |  -  |  -  |
-| Vlan3010 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone  |  Tenant_A_WEB_Zone  |  -  |  -  |
-| Vlan3011 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone  |  Tenant_A_APP_Zone  |  -  |  -  |
-| Vlan3012 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone  |  Tenant_A_DB_Zone  |  -  |  -  |
-| Vlan3013 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone  |  Tenant_A_WAN_Zone  |  -  |  -  |
-| Vlan3019 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone  |  Tenant_B_OP_Zone  |  -  |  -  |
-| Vlan3020 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone  |  Tenant_B_WAN_Zone  |  -  |  -  |
-| Vlan3029 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone  |  Tenant_C_OP_Zone  |  -  |  -  |
-| Vlan3030 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone  |  Tenant_C_WAN_Zone  |  -  |  -  |
-| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  -  |
-| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  -  |
+| Vlan3009 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone  |  Tenant_A_OP_Zone  |  -  |  false  |
+| Vlan3010 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone  |  Tenant_A_WEB_Zone  |  -  |  false  |
+| Vlan3011 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone  |  Tenant_A_APP_Zone  |  -  |  false  |
+| Vlan3012 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone  |  Tenant_A_DB_Zone  |  -  |  false  |
+| Vlan3013 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone  |  Tenant_A_WAN_Zone  |  -  |  false  |
+| Vlan3019 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone  |  Tenant_B_OP_Zone  |  -  |  false  |
+| Vlan3020 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone  |  Tenant_B_WAN_Zone  |  -  |  false  |
+| Vlan3029 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone  |  Tenant_C_OP_Zone  |  -  |  false  |
+| Vlan3030 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone  |  Tenant_C_WAN_Zone  |  -  |  false  |
+| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  false  |
+| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  false  |
 
 #### IPv4
 
@@ -797,55 +815,66 @@ interface Vlan350
 !
 interface Vlan3009
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address 10.255.251.7/31
 !
 interface Vlan3010
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address 10.255.251.7/31
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address 10.255.251.7/31
 !
 interface Vlan3012
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address 10.255.251.7/31
 !
 interface Vlan3013
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone
+   no shutdown
    vrf Tenant_A_WAN_Zone
    ip address 10.255.251.7/31
 !
 interface Vlan3019
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address 10.255.251.7/31
 !
 interface Vlan3020
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone
+   no shutdown
    vrf Tenant_B_WAN_Zone
    ip address 10.255.251.7/31
 !
 interface Vlan3029
    description MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address 10.255.251.7/31
 !
 interface Vlan3030
    description MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone
+   no shutdown
    vrf Tenant_C_WAN_Zone
    ip address 10.255.251.7/31
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
+   no shutdown
    ip address 10.255.251.7/31
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.7/31
 ```

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-BL1A.cfg
@@ -65,6 +65,7 @@ vrf instance Tenant_C_WAN_Zone
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-BL1B_Po5
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -73,42 +74,51 @@ interface Port-Channel5
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet6
+   no shutdown
    no switchport
    ip address 172.31.255.41/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet6
+   no shutdown
    no switchport
    ip address 172.31.255.43/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet6
+   no shutdown
    no switchport
    ip address 172.31.255.45/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet6
+   no shutdown
    no switchport
    ip address 172.31.255.47/31
 !
 interface Ethernet5
    description MLAG_PEER_DC1-BL1B_Ethernet5
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-BL1B_Ethernet6
+   no shutdown
    channel-group 5 mode active
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.10/32
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.10/32
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.110/24
 !
@@ -132,25 +142,30 @@ interface Vlan350
 !
 interface Vlan3013
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone
+   no shutdown
    vrf Tenant_A_WAN_Zone
    ip address 10.255.251.10/31
 !
 interface Vlan3020
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone
+   no shutdown
    vrf Tenant_B_WAN_Zone
    ip address 10.255.251.10/31
 !
 interface Vlan3030
    description MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone
+   no shutdown
    vrf Tenant_C_WAN_Zone
    ip address 10.255.251.10/31
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
+   no shutdown
    ip address 10.255.251.10/31
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.10/31
 !

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-BL1A.cfg
@@ -65,6 +65,7 @@ vrf instance Tenant_C_WAN_Zone
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-BL1B_Po5
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -113,16 +114,19 @@ interface Management1
 !
 interface Vlan150
    description Tenant_A_WAN_Zone_1
+   no shutdown
    vrf Tenant_A_WAN_Zone
    ip address virtual 10.1.40.1/24
 !
 interface Vlan250
    description Tenant_B_WAN_Zone_1
+   no shutdown
    vrf Tenant_B_WAN_Zone
    ip address virtual 10.2.50.1/24
 !
 interface Vlan350
    description Tenant_C_WAN_Zone_1
+   no shutdown
    vrf Tenant_C_WAN_Zone
    ip address virtual 10.3.50.1/24
 !

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-BL1B.cfg
@@ -65,6 +65,7 @@ vrf instance Tenant_C_WAN_Zone
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-BL1A_Po5
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -113,16 +114,19 @@ interface Management1
 !
 interface Vlan150
    description Tenant_A_WAN_Zone_1
+   no shutdown
    vrf Tenant_A_WAN_Zone
    ip address virtual 10.1.40.1/24
 !
 interface Vlan250
    description Tenant_B_WAN_Zone_1
+   no shutdown
    vrf Tenant_B_WAN_Zone
    ip address virtual 10.2.50.1/24
 !
 interface Vlan350
    description Tenant_C_WAN_Zone_1
+   no shutdown
    vrf Tenant_C_WAN_Zone
    ip address virtual 10.3.50.1/24
 !

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-BL1B.cfg
@@ -65,6 +65,7 @@ vrf instance Tenant_C_WAN_Zone
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-BL1A_Po5
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -73,42 +74,51 @@ interface Port-Channel5
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet7
+   no shutdown
    no switchport
    ip address 172.31.255.49/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet7
+   no shutdown
    no switchport
    ip address 172.31.255.51/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet7
+   no shutdown
    no switchport
    ip address 172.31.255.53/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet7
+   no shutdown
    no switchport
    ip address 172.31.255.55/31
 !
 interface Ethernet5
    description MLAG_PEER_DC1-BL1A_Ethernet5
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-BL1A_Ethernet6
+   no shutdown
    channel-group 5 mode active
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.11/32
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.10/32
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.111/24
 !
@@ -132,25 +142,30 @@ interface Vlan350
 !
 interface Vlan3013
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone
+   no shutdown
    vrf Tenant_A_WAN_Zone
    ip address 10.255.251.11/31
 !
 interface Vlan3020
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone
+   no shutdown
    vrf Tenant_B_WAN_Zone
    ip address 10.255.251.11/31
 !
 interface Vlan3030
    description MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone
+   no shutdown
    vrf Tenant_C_WAN_Zone
    ip address 10.255.251.11/31
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
+   no shutdown
    ip address 10.255.251.11/31
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.11/31
 !

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-L2LEAF1A.cfg
@@ -47,9 +47,9 @@ vrf instance MGMT
 !
 interface Port-Channel1
    description DC1-LEAF2A_Po7
+   switchport
    switchport trunk allowed vlan 110-111,120-121,130-131
    switchport mode trunk
-   mlag 1
 !
 interface Ethernet1
    description DC1-LEAF2A_Ethernet7

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-L2LEAF1A.cfg
@@ -47,20 +47,24 @@ vrf instance MGMT
 !
 interface Port-Channel1
    description DC1-LEAF2A_Po7
+   no shutdown
    switchport
    switchport trunk allowed vlan 110-111,120-121,130-131
    switchport mode trunk
 !
 interface Ethernet1
    description DC1-LEAF2A_Ethernet7
+   no shutdown
    channel-group 1 mode active
 !
 interface Ethernet2
    description DC1-LEAF2B_Ethernet7
+   no shutdown
    channel-group 1 mode active
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.112/24
 !

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-L2LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-L2LEAF2A.cfg
@@ -79,12 +79,14 @@ vrf instance MGMT
 !
 interface Port-Channel1
    description DC1-SVC3A_Po7
+   switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350
    switchport mode trunk
    mlag 1
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-L2LEAF2B_Po3
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group MLAG

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-L2LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-L2LEAF2A.cfg
@@ -79,6 +79,7 @@ vrf instance MGMT
 !
 interface Port-Channel1
    description DC1-SVC3A_Po7
+   no shutdown
    switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350
    switchport mode trunk
@@ -86,6 +87,7 @@ interface Port-Channel1
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-L2LEAF2B_Po3
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -93,27 +95,33 @@ interface Port-Channel3
 !
 interface Ethernet1
    description DC1-SVC3A_Ethernet7
+   no shutdown
    channel-group 1 mode active
 !
 interface Ethernet2
    description DC1-SVC3B_Ethernet7
+   no shutdown
    channel-group 1 mode active
 !
 interface Ethernet3
    description MLAG_PEER_DC1-L2LEAF2B_Ethernet3
+   no shutdown
    channel-group 3 mode active
 !
 interface Ethernet4
    description MLAG_PEER_DC1-L2LEAF2B_Ethernet4
+   no shutdown
    channel-group 3 mode active
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.113/24
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.16/31
 !

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-L2LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-L2LEAF2B.cfg
@@ -79,6 +79,7 @@ vrf instance MGMT
 !
 interface Port-Channel1
    description DC1-SVC3B_Po7
+   no shutdown
    switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350
    switchport mode trunk
@@ -86,6 +87,7 @@ interface Port-Channel1
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-L2LEAF2A_Po3
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -93,27 +95,33 @@ interface Port-Channel3
 !
 interface Ethernet1
    description DC1-SVC3A_Ethernet8
+   no shutdown
    channel-group 1 mode active
 !
 interface Ethernet2
    description DC1-SVC3B_Ethernet8
+   no shutdown
    channel-group 1 mode active
 !
 interface Ethernet3
    description MLAG_PEER_DC1-L2LEAF2A_Ethernet3
+   no shutdown
    channel-group 3 mode active
 !
 interface Ethernet4
    description MLAG_PEER_DC1-L2LEAF2A_Ethernet4
+   no shutdown
    channel-group 3 mode active
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.114/24
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.17/31
 !

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-L2LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-L2LEAF2B.cfg
@@ -79,12 +79,14 @@ vrf instance MGMT
 !
 interface Port-Channel1
    description DC1-SVC3B_Po7
+   switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350
    switchport mode trunk
    mlag 1
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-L2LEAF2A_Po3
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group MLAG

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-LEAF1A.cfg
@@ -65,11 +65,13 @@ interface Ethernet4
 !
 interface Ethernet5
    description server01_Eth1
+   switchport
    switchport trunk allowed vlan 110
    switchport mode trunk
 !
 interface Ethernet6
    description server02_Eth1
+   switchport
    switchport trunk allowed vlan 110
    switchport mode trunk
 !
@@ -88,21 +90,25 @@ interface Management1
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address virtual 10.1.21.1/24
 !
 interface Vlan130
    description Tenant_A_APP_Zone_1
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.30.1/24
 !
 interface Vlan131
    description Tenant_A_APP_Zone_2
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.31.1/24
 !

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-LEAF1A.cfg
@@ -45,46 +45,55 @@ vrf instance Tenant_A_WEB_Zone
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.1/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.3/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.5/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.7/31
 !
 interface Ethernet5
    description server01_Eth1
+   no shutdown
    switchport
    switchport trunk allowed vlan 110
    switchport mode trunk
 !
 interface Ethernet6
    description server02_Eth1
+   no shutdown
    switchport
    switchport trunk allowed vlan 110
    switchport mode trunk
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.5/32
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.5/32
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.105/24
 !

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-LEAF2A.cfg
@@ -110,6 +110,7 @@ vrf instance Tenant_C_OP_Zone
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-LEAF2B_Po5
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -118,6 +119,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF1_Po1
+   no shutdown
    switchport
    switchport trunk allowed vlan 110-111,120-121,130-131
    switchport mode trunk
@@ -125,6 +127,7 @@ interface Port-Channel7
 !
 interface Port-Channel10
    description server01_PortChanne1
+   no shutdown
    switchport
    switchport trunk allowed vlan 210-211
    switchport mode trunk
@@ -132,6 +135,7 @@ interface Port-Channel10
 !
 interface Port-Channel11
    description server02_PortChanne1
+   no shutdown
    switchport
    switchport trunk allowed vlan 210-211
    switchport mode trunk
@@ -139,59 +143,72 @@ interface Port-Channel11
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.9/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.11/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.13/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.15/31
 !
 interface Ethernet5
    description MLAG_PEER_DC1-LEAF2B_Ethernet5
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-LEAF2B_Ethernet6
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet7
    description DC1-L2LEAF1A_Ethernet1
+   no shutdown
    channel-group 7 mode active
 !
 interface Ethernet10
    description server01_Eth2
+   no shutdown
    channel-group 10 mode active
 !
 interface Ethernet11
    description server02_Eth2
+   no shutdown
    channel-group 11 mode active
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.6/32
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.6/32
 !
 interface Loopback100
    description Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address 10.255.1.6/32
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.106/24
 !
@@ -269,40 +286,48 @@ interface Vlan311
 !
 interface Vlan3009
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address 10.255.251.2/31
 !
 interface Vlan3010
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address 10.255.251.2/31
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address 10.255.251.2/31
 !
 interface Vlan3012
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address 10.255.251.2/31
 !
 interface Vlan3019
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address 10.255.251.2/31
 !
 interface Vlan3029
    description MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address 10.255.251.2/31
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
+   no shutdown
    ip address 10.255.251.2/31
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.2/31
 !

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-LEAF2A.cfg
@@ -110,6 +110,7 @@ vrf instance Tenant_C_OP_Zone
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-LEAF2B_Po5
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -117,18 +118,21 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF1_Po1
+   switchport
    switchport trunk allowed vlan 110-111,120-121,130-131
    switchport mode trunk
    mlag 7
 !
 interface Port-Channel10
    description server01_PortChanne1
+   switchport
    switchport trunk allowed vlan 210-211
    switchport mode trunk
    mlag 10
 !
 interface Port-Channel11
    description server02_PortChanne1
+   switchport
    switchport trunk allowed vlan 210-211
    switchport mode trunk
    mlag 11
@@ -193,61 +197,73 @@ interface Management1
 !
 interface Vlan110
    description Tenant_A_OP_Zone_1
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address virtual 10.1.10.1/24
 !
 interface Vlan111
    description Tenant_A_OP_Zone_2
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address virtual 10.1.21.1/24
 !
 interface Vlan130
    description Tenant_A_APP_Zone_1
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.30.1/24
 !
 interface Vlan131
    description Tenant_A_APP_Zone_2
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.31.1/24
 !
 interface Vlan140
    description Tenant_A_DB_BZone_1
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address virtual 10.1.40.1/24
 !
 interface Vlan141
    description Tenant_A_DB_Zone_2
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address virtual 10.1.41.1/24
 !
 interface Vlan210
    description Tenant_B_OP_Zone_1
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address virtual 10.2.10.1/24
 !
 interface Vlan211
    description Tenant_B_OP_Zone_2
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address virtual 10.2.11.1/24
 !
 interface Vlan310
    description Tenant_C_OP_Zone_1
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address virtual 10.3.10.1/24
 !
 interface Vlan311
    description Tenant_C_OP_Zone_2
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address virtual 10.3.11.1/24
 !

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-LEAF2B.cfg
@@ -110,6 +110,7 @@ vrf instance Tenant_C_OP_Zone
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-LEAF2A_Po5
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -118,6 +119,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF1_Po1
+   no shutdown
    switchport
    switchport trunk allowed vlan 110-111,120-121,130-131
    switchport mode trunk
@@ -125,6 +127,7 @@ interface Port-Channel7
 !
 interface Port-Channel10
    description server01_PortChanne1
+   no shutdown
    switchport
    switchport trunk allowed vlan 210-211
    switchport mode trunk
@@ -132,6 +135,7 @@ interface Port-Channel10
 !
 interface Port-Channel11
    description server02_PortChanne1
+   no shutdown
    switchport
    switchport trunk allowed vlan 210-211
    switchport mode trunk
@@ -139,59 +143,72 @@ interface Port-Channel11
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.17/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.19/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.21/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.23/31
 !
 interface Ethernet5
    description MLAG_PEER_DC1-LEAF2A_Ethernet5
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-LEAF2A_Ethernet6
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet7
    description DC1-L2LEAF1A_Ethernet2
+   no shutdown
    channel-group 7 mode active
 !
 interface Ethernet10
    description server01_Eth3
+   no shutdown
    channel-group 10 mode active
 !
 interface Ethernet11
    description server02_Eth3
+   no shutdown
    channel-group 11 mode active
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.7/32
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.6/32
 !
 interface Loopback100
    description Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address 10.255.1.7/32
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.107/24
 !
@@ -269,40 +286,48 @@ interface Vlan311
 !
 interface Vlan3009
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address 10.255.251.3/31
 !
 interface Vlan3010
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address 10.255.251.3/31
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address 10.255.251.3/31
 !
 interface Vlan3012
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address 10.255.251.3/31
 !
 interface Vlan3019
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address 10.255.251.3/31
 !
 interface Vlan3029
    description MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address 10.255.251.3/31
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
+   no shutdown
    ip address 10.255.251.3/31
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.3/31
 !

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-LEAF2B.cfg
@@ -110,6 +110,7 @@ vrf instance Tenant_C_OP_Zone
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-LEAF2A_Po5
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -117,18 +118,21 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF1_Po1
+   switchport
    switchport trunk allowed vlan 110-111,120-121,130-131
    switchport mode trunk
    mlag 7
 !
 interface Port-Channel10
    description server01_PortChanne1
+   switchport
    switchport trunk allowed vlan 210-211
    switchport mode trunk
    mlag 10
 !
 interface Port-Channel11
    description server02_PortChanne1
+   switchport
    switchport trunk allowed vlan 210-211
    switchport mode trunk
    mlag 11
@@ -193,61 +197,73 @@ interface Management1
 !
 interface Vlan110
    description Tenant_A_OP_Zone_1
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address virtual 10.1.10.1/24
 !
 interface Vlan111
    description Tenant_A_OP_Zone_2
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address virtual 10.1.21.1/24
 !
 interface Vlan130
    description Tenant_A_APP_Zone_1
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.30.1/24
 !
 interface Vlan131
    description Tenant_A_APP_Zone_2
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.31.1/24
 !
 interface Vlan140
    description Tenant_A_DB_BZone_1
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address virtual 10.1.40.1/24
 !
 interface Vlan141
    description Tenant_A_DB_Zone_2
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address virtual 10.1.41.1/24
 !
 interface Vlan210
    description Tenant_B_OP_Zone_1
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address virtual 10.2.10.1/24
 !
 interface Vlan211
    description Tenant_B_OP_Zone_2
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address virtual 10.2.11.1/24
 !
 interface Vlan310
    description Tenant_C_OP_Zone_1
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address virtual 10.3.10.1/24
 !
 interface Vlan311
    description Tenant_C_OP_Zone_2
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address virtual 10.3.11.1/24
 !

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-SPINE1.cfg
@@ -28,45 +28,54 @@ vrf instance MGMT
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.0/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-LEAF2A_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.8/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-LEAF2B_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.16/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SVC3A_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.24/31
 !
 interface Ethernet5
    description P2P_LINK_TO_DC1-SVC3B_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.32/31
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-BL1A_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.40/31
 !
 interface Ethernet7
    description P2P_LINK_TO_DC1-BL1B_Ethernet1
+   no shutdown
    no switchport
    ip address 172.31.255.48/31
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.1/32
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.101/24
 !

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-SPINE2.cfg
@@ -28,45 +28,54 @@ vrf instance MGMT
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.2/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-LEAF2A_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.10/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-LEAF2B_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.18/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SVC3A_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.26/31
 !
 interface Ethernet5
    description P2P_LINK_TO_DC1-SVC3B_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.34/31
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-BL1A_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.42/31
 !
 interface Ethernet7
    description P2P_LINK_TO_DC1-BL1B_Ethernet2
+   no shutdown
    no switchport
    ip address 172.31.255.50/31
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.2/32
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.102/24
 !

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-SPINE3.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-SPINE3.cfg
@@ -28,45 +28,54 @@ vrf instance MGMT
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.4/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-LEAF2A_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.12/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-LEAF2B_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.20/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SVC3A_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.28/31
 !
 interface Ethernet5
    description P2P_LINK_TO_DC1-SVC3B_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.36/31
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-BL1A_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.44/31
 !
 interface Ethernet7
    description P2P_LINK_TO_DC1-BL1B_Ethernet3
+   no shutdown
    no switchport
    ip address 172.31.255.52/31
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.3/32
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.103/24
 !

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-SPINE4.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-SPINE4.cfg
@@ -28,45 +28,54 @@ vrf instance MGMT
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.6/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-LEAF2A_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.14/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-LEAF2B_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.22/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SVC3A_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.30/31
 !
 interface Ethernet5
    description P2P_LINK_TO_DC1-SVC3B_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.38/31
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-BL1A_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.46/31
 !
 interface Ethernet7
    description P2P_LINK_TO_DC1-BL1B_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.54/31
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.4/32
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.104/24
 !

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-SVC3A.cfg
@@ -137,6 +137,7 @@ vrf instance Tenant_C_WAN_Zone
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-SVC3B_Po5
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -145,6 +146,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF2_Po1
+   no shutdown
    switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350
    switchport mode trunk
@@ -152,6 +154,7 @@ interface Port-Channel7
 !
 interface Port-Channel10
    description server03_PortChanne1
+   no shutdown
    switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
@@ -159,6 +162,7 @@ interface Port-Channel10
 !
 interface Port-Channel11
    description server04_PortChanne1
+   no shutdown
    switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
@@ -166,63 +170,77 @@ interface Port-Channel11
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.25/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.27/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.29/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet4
+   no shutdown
    no switchport
    ip address 172.31.255.31/31
 !
 interface Ethernet5
    description MLAG_PEER_DC1-SVC3B_Ethernet5
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-SVC3B_Ethernet6
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet7
    description DC1-L2LEAF2A_Ethernet1
+   no shutdown
    channel-group 7 mode active
 !
 interface Ethernet8
    description DC1-L2LEAF2B_Ethernet1
+   no shutdown
    channel-group 7 mode active
 !
 interface Ethernet10
    description server03_Eth1
+   no shutdown
    channel-group 10 mode active
 !
 interface Ethernet11
    description server04_Eth1
+   no shutdown
    channel-group 11 mode active
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.8/32
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.8/32
 !
 interface Loopback100
    description Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address 10.255.1.8/32
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.108/24
 !
@@ -318,55 +336,66 @@ interface Vlan350
 !
 interface Vlan3009
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address 10.255.251.6/31
 !
 interface Vlan3010
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address 10.255.251.6/31
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address 10.255.251.6/31
 !
 interface Vlan3012
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address 10.255.251.6/31
 !
 interface Vlan3013
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone
+   no shutdown
    vrf Tenant_A_WAN_Zone
    ip address 10.255.251.6/31
 !
 interface Vlan3019
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address 10.255.251.6/31
 !
 interface Vlan3020
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone
+   no shutdown
    vrf Tenant_B_WAN_Zone
    ip address 10.255.251.6/31
 !
 interface Vlan3029
    description MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address 10.255.251.6/31
 !
 interface Vlan3030
    description MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone
+   no shutdown
    vrf Tenant_C_WAN_Zone
    ip address 10.255.251.6/31
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
+   no shutdown
    ip address 10.255.251.6/31
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.6/31
 !

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-SVC3A.cfg
@@ -137,6 +137,7 @@ vrf instance Tenant_C_WAN_Zone
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-SVC3B_Po5
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -144,18 +145,21 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF2_Po1
+   switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350
    switchport mode trunk
    mlag 7
 !
 interface Port-Channel10
    description server03_PortChanne1
+   switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
    mlag 10
 !
 interface Port-Channel11
    description server04_PortChanne1
+   switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
    mlag 11
@@ -224,76 +228,91 @@ interface Management1
 !
 interface Vlan110
    description Tenant_A_OP_Zone_1
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address virtual 10.1.10.1/24
 !
 interface Vlan111
    description Tenant_A_OP_Zone_2
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address virtual 10.1.21.1/24
 !
 interface Vlan130
    description Tenant_A_APP_Zone_1
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.30.1/24
 !
 interface Vlan131
    description Tenant_A_APP_Zone_2
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.31.1/24
 !
 interface Vlan140
    description Tenant_A_DB_BZone_1
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address virtual 10.1.40.1/24
 !
 interface Vlan141
    description Tenant_A_DB_Zone_2
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address virtual 10.1.41.1/24
 !
 interface Vlan150
    description Tenant_A_WAN_Zone_1
+   no shutdown
    vrf Tenant_A_WAN_Zone
    ip address virtual 10.1.40.1/24
 !
 interface Vlan210
    description Tenant_B_OP_Zone_1
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address virtual 10.2.10.1/24
 !
 interface Vlan211
    description Tenant_B_OP_Zone_2
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address virtual 10.2.11.1/24
 !
 interface Vlan250
    description Tenant_B_WAN_Zone_1
+   no shutdown
    vrf Tenant_B_WAN_Zone
    ip address virtual 10.2.50.1/24
 !
 interface Vlan310
    description Tenant_C_OP_Zone_1
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address virtual 10.3.10.1/24
 !
 interface Vlan311
    description Tenant_C_OP_Zone_2
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address virtual 10.3.11.1/24
 !
 interface Vlan350
    description Tenant_C_WAN_Zone_1
+   no shutdown
    vrf Tenant_C_WAN_Zone
    ip address virtual 10.3.50.1/24
 !

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-SVC3B.cfg
@@ -137,6 +137,7 @@ vrf instance Tenant_C_WAN_Zone
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-SVC3A_Po5
+   no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
@@ -145,6 +146,7 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF2_Po1
+   no shutdown
    switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350
    switchport mode trunk
@@ -152,6 +154,7 @@ interface Port-Channel7
 !
 interface Port-Channel10
    description server03_PortChanne1
+   no shutdown
    switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
@@ -159,6 +162,7 @@ interface Port-Channel10
 !
 interface Port-Channel11
    description server04_PortChanne1
+   no shutdown
    switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
@@ -166,63 +170,77 @@ interface Port-Channel11
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet5
+   no shutdown
    no switchport
    ip address 172.31.255.33/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet5
+   no shutdown
    no switchport
    ip address 172.31.255.35/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet5
+   no shutdown
    no switchport
    ip address 172.31.255.37/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet5
+   no shutdown
    no switchport
    ip address 172.31.255.39/31
 !
 interface Ethernet5
    description MLAG_PEER_DC1-SVC3A_Ethernet5
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-SVC3A_Ethernet6
+   no shutdown
    channel-group 5 mode active
 !
 interface Ethernet7
    description DC1-L2LEAF2A_Ethernet2
+   no shutdown
    channel-group 7 mode active
 !
 interface Ethernet8
    description DC1-L2LEAF2B_Ethernet2
+   no shutdown
    channel-group 7 mode active
 !
 interface Ethernet10
    description server03_Eth2
+   no shutdown
    channel-group 10 mode active
 !
 interface Ethernet11
    description server04_Eth2
+   no shutdown
    channel-group 11 mode active
 !
 interface Loopback0
    description EVPN_Overlay_Peering
+   no shutdown
    ip address 192.168.255.9/32
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
+   no shutdown
    ip address 192.168.254.8/32
 !
 interface Loopback100
    description Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address 10.255.1.9/32
 !
 interface Management1
    description oob_management
+   no shutdown
    vrf MGMT
    ip address 192.168.200.109/24
 !
@@ -318,55 +336,66 @@ interface Vlan350
 !
 interface Vlan3009
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address 10.255.251.7/31
 !
 interface Vlan3010
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address 10.255.251.7/31
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address 10.255.251.7/31
 !
 interface Vlan3012
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address 10.255.251.7/31
 !
 interface Vlan3013
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone
+   no shutdown
    vrf Tenant_A_WAN_Zone
    ip address 10.255.251.7/31
 !
 interface Vlan3019
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address 10.255.251.7/31
 !
 interface Vlan3020
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone
+   no shutdown
    vrf Tenant_B_WAN_Zone
    ip address 10.255.251.7/31
 !
 interface Vlan3029
    description MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address 10.255.251.7/31
 !
 interface Vlan3030
    description MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone
+   no shutdown
    vrf Tenant_C_WAN_Zone
    ip address 10.255.251.7/31
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
+   no shutdown
    ip address 10.255.251.7/31
 !
 interface Vlan4094
    description MLAG_PEER
+   no shutdown
    no autostate
    ip address 10.255.252.7/31
 !

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-SVC3B.cfg
@@ -137,6 +137,7 @@ vrf instance Tenant_C_WAN_Zone
 !
 interface Port-Channel5
    description MLAG_PEER_DC1-SVC3A_Po5
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -144,18 +145,21 @@ interface Port-Channel5
 !
 interface Port-Channel7
    description DC1_L2LEAF2_Po1
+   switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350
    switchport mode trunk
    mlag 7
 !
 interface Port-Channel10
    description server03_PortChanne1
+   switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
    mlag 10
 !
 interface Port-Channel11
    description server04_PortChanne1
+   switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
    mlag 11
@@ -224,76 +228,91 @@ interface Management1
 !
 interface Vlan110
    description Tenant_A_OP_Zone_1
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address virtual 10.1.10.1/24
 !
 interface Vlan111
    description Tenant_A_OP_Zone_2
+   no shutdown
    vrf Tenant_A_OP_Zone
    ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2
+   no shutdown
    vrf Tenant_A_WEB_Zone
    ip address virtual 10.1.21.1/24
 !
 interface Vlan130
    description Tenant_A_APP_Zone_1
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.30.1/24
 !
 interface Vlan131
    description Tenant_A_APP_Zone_2
+   no shutdown
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.31.1/24
 !
 interface Vlan140
    description Tenant_A_DB_BZone_1
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address virtual 10.1.40.1/24
 !
 interface Vlan141
    description Tenant_A_DB_Zone_2
+   no shutdown
    vrf Tenant_A_DB_Zone
    ip address virtual 10.1.41.1/24
 !
 interface Vlan150
    description Tenant_A_WAN_Zone_1
+   no shutdown
    vrf Tenant_A_WAN_Zone
    ip address virtual 10.1.40.1/24
 !
 interface Vlan210
    description Tenant_B_OP_Zone_1
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address virtual 10.2.10.1/24
 !
 interface Vlan211
    description Tenant_B_OP_Zone_2
+   no shutdown
    vrf Tenant_B_OP_Zone
    ip address virtual 10.2.11.1/24
 !
 interface Vlan250
    description Tenant_B_WAN_Zone_1
+   no shutdown
    vrf Tenant_B_WAN_Zone
    ip address virtual 10.2.50.1/24
 !
 interface Vlan310
    description Tenant_C_OP_Zone_1
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address virtual 10.3.10.1/24
 !
 interface Vlan311
    description Tenant_C_OP_Zone_2
+   no shutdown
    vrf Tenant_C_OP_Zone
    ip address virtual 10.3.11.1/24
 !
 interface Vlan350
    description Tenant_C_WAN_Zone_1
+   no shutdown
    vrf Tenant_C_WAN_Zone
    ip address virtual 10.3.50.1/24
 !

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-BL1A.yml
@@ -131,6 +131,8 @@ bfd_multihop:
 port_channel_interfaces:
   Port-Channel5:
     description: MLAG_PEER_DC1-BL1B_Po5
+    type: switched
+    shutdown: false
     vlans: 2-4094
     mode: trunk
     trunk_groups:
@@ -144,6 +146,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE1_Ethernet6
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.41/31
   Ethernet2:
     peer: DC1-SPINE2
@@ -152,6 +155,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE2_Ethernet6
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.43/31
   Ethernet3:
     peer: DC1-SPINE3
@@ -160,6 +164,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE3_Ethernet6
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.45/31
   Ethernet4:
     peer: DC1-SPINE4
@@ -168,12 +173,15 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE4_Ethernet6
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.47/31
   Ethernet5:
     peer: DC1-BL1B
     peer_interface: Ethernet5
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-BL1B_Ethernet5
+    type: switched
+    shutdown: false
     channel_group:
       id: 5
       mode: active
@@ -182,29 +190,36 @@ ethernet_interfaces:
     peer_interface: Ethernet6
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-BL1B_Ethernet6
+    type: switched
+    shutdown: false
     channel_group:
       id: 5
       mode: active
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: 192.168.255.10/32
   Loopback1:
     description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
     ip_address: 192.168.254.10/32
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.110/24
     gateway: 192.168.200.5
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING
+    shutdown: false
     ip_address: 10.255.251.10/31
     mtu: 1500
   Vlan4094:
     description: MLAG_PEER
+    shutdown: false
     ip_address: 10.255.252.10/31
     no_autostate: true
     mtu: 1500
@@ -219,6 +234,7 @@ vlan_interfaces:
   Vlan3013:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone'
     vrf: Tenant_A_WAN_Zone
     ip_address: 10.255.251.10/31
@@ -233,6 +249,7 @@ vlan_interfaces:
   Vlan3020:
     tenant: Tenant_B
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone'
     vrf: Tenant_B_WAN_Zone
     ip_address: 10.255.251.10/31
@@ -247,6 +264,7 @@ vlan_interfaces:
   Vlan3030:
     tenant: Tenant_C
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone'
     vrf: Tenant_C_WAN_Zone
     ip_address: 10.255.251.10/31

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-BL1B.yml
@@ -131,6 +131,8 @@ bfd_multihop:
 port_channel_interfaces:
   Port-Channel5:
     description: MLAG_PEER_DC1-BL1A_Po5
+    type: switched
+    shutdown: false
     vlans: 2-4094
     mode: trunk
     trunk_groups:
@@ -144,6 +146,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE1_Ethernet7
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.49/31
   Ethernet2:
     peer: DC1-SPINE2
@@ -152,6 +155,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE2_Ethernet7
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.51/31
   Ethernet3:
     peer: DC1-SPINE3
@@ -160,6 +164,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE3_Ethernet7
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.53/31
   Ethernet4:
     peer: DC1-SPINE4
@@ -168,12 +173,15 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE4_Ethernet7
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.55/31
   Ethernet5:
     peer: DC1-BL1A
     peer_interface: Ethernet5
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-BL1A_Ethernet5
+    type: switched
+    shutdown: false
     channel_group:
       id: 5
       mode: active
@@ -182,29 +190,36 @@ ethernet_interfaces:
     peer_interface: Ethernet6
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-BL1A_Ethernet6
+    type: switched
+    shutdown: false
     channel_group:
       id: 5
       mode: active
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: 192.168.255.11/32
   Loopback1:
     description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
     ip_address: 192.168.254.10/32
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.111/24
     gateway: 192.168.200.5
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING
+    shutdown: false
     ip_address: 10.255.251.11/31
     mtu: 1500
   Vlan4094:
     description: MLAG_PEER
+    shutdown: false
     ip_address: 10.255.252.11/31
     no_autostate: true
     mtu: 1500
@@ -219,6 +234,7 @@ vlan_interfaces:
   Vlan3013:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone'
     vrf: Tenant_A_WAN_Zone
     ip_address: 10.255.251.11/31
@@ -233,6 +249,7 @@ vlan_interfaces:
   Vlan3020:
     tenant: Tenant_B
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone'
     vrf: Tenant_B_WAN_Zone
     ip_address: 10.255.251.11/31
@@ -247,6 +264,7 @@ vlan_interfaces:
   Vlan3030:
     tenant: Tenant_C
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone'
     vrf: Tenant_C_WAN_Zone
     ip_address: 10.255.251.11/31

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -101,6 +101,8 @@ vrfs:
 port_channel_interfaces:
   Port-Channel1:
     description: DC1-LEAF2A_Po7
+    type: switched
+    shutdown: false
     vlans: 110-111,120-121,130-131
     mode: trunk
 ethernet_interfaces:
@@ -109,6 +111,8 @@ ethernet_interfaces:
     peer_interface: Ethernet7
     peer_type: l3leaf
     description: DC1-LEAF2A_Ethernet7
+    type: switched
+    shutdown: false
     channel_group:
       id: 1
       mode: active
@@ -117,12 +121,15 @@ ethernet_interfaces:
     peer_interface: Ethernet7
     peer_type: l3leaf
     description: DC1-LEAF2B_Ethernet7
+    type: switched
+    shutdown: false
     channel_group:
       id: 1
       mode: active
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.112/24
     gateway: 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -103,7 +103,6 @@ port_channel_interfaces:
     description: DC1-LEAF2A_Po7
     vlans: 110-111,120-121,130-131
     mode: trunk
-    mlag: 1
 ethernet_interfaces:
   Ethernet1:
     peer: DC1-LEAF2A

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -162,11 +162,15 @@ vrfs:
 port_channel_interfaces:
   Port-Channel1:
     description: DC1-SVC3A_Po7
+    type: switched
+    shutdown: false
     vlans: 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350
     mode: trunk
     mlag: 1
   Port-Channel3:
     description: MLAG_PEER_DC1-L2LEAF2B_Po3
+    type: switched
+    shutdown: false
     vlans: 2-4094
     mode: trunk
     trunk_groups:
@@ -177,6 +181,8 @@ ethernet_interfaces:
     peer_interface: Ethernet7
     peer_type: l3leaf
     description: DC1-SVC3A_Ethernet7
+    type: switched
+    shutdown: false
     channel_group:
       id: 1
       mode: active
@@ -185,6 +191,8 @@ ethernet_interfaces:
     peer_interface: Ethernet7
     peer_type: l3leaf
     description: DC1-SVC3B_Ethernet7
+    type: switched
+    shutdown: false
     channel_group:
       id: 1
       mode: active
@@ -193,6 +201,8 @@ ethernet_interfaces:
     peer_interface: Ethernet3
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-L2LEAF2B_Ethernet3
+    type: switched
+    shutdown: false
     channel_group:
       id: 3
       mode: active
@@ -201,18 +211,22 @@ ethernet_interfaces:
     peer_interface: Ethernet4
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-L2LEAF2B_Ethernet4
+    type: switched
+    shutdown: false
     channel_group:
       id: 3
       mode: active
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.113/24
     gateway: 192.168.200.5
 vlan_interfaces:
   Vlan4094:
     description: MLAG_PEER
+    shutdown: false
     ip_address: 10.255.252.16/31
     no_autostate: true
     mtu: 1500

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -162,11 +162,15 @@ vrfs:
 port_channel_interfaces:
   Port-Channel1:
     description: DC1-SVC3B_Po7
+    type: switched
+    shutdown: false
     vlans: 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350
     mode: trunk
     mlag: 1
   Port-Channel3:
     description: MLAG_PEER_DC1-L2LEAF2A_Po3
+    type: switched
+    shutdown: false
     vlans: 2-4094
     mode: trunk
     trunk_groups:
@@ -177,6 +181,8 @@ ethernet_interfaces:
     peer_interface: Ethernet8
     peer_type: l3leaf
     description: DC1-SVC3A_Ethernet8
+    type: switched
+    shutdown: false
     channel_group:
       id: 1
       mode: active
@@ -185,6 +191,8 @@ ethernet_interfaces:
     peer_interface: Ethernet8
     peer_type: l3leaf
     description: DC1-SVC3B_Ethernet8
+    type: switched
+    shutdown: false
     channel_group:
       id: 1
       mode: active
@@ -193,6 +201,8 @@ ethernet_interfaces:
     peer_interface: Ethernet3
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-L2LEAF2A_Ethernet3
+    type: switched
+    shutdown: false
     channel_group:
       id: 3
       mode: active
@@ -201,18 +211,22 @@ ethernet_interfaces:
     peer_interface: Ethernet4
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-L2LEAF2A_Ethernet4
+    type: switched
+    shutdown: false
     channel_group:
       id: 3
       mode: active
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.114/24
     gateway: 192.168.200.5
 vlan_interfaces:
   Vlan4094:
     description: MLAG_PEER
+    shutdown: false
     ip_address: 10.255.252.17/31
     no_autostate: true
     mtu: 1500

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-LEAF1A.yml
@@ -107,6 +107,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE1_Ethernet1
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.1/31
   Ethernet2:
     peer: DC1-SPINE2
@@ -115,6 +116,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE2_Ethernet1
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.3/31
   Ethernet3:
     peer: DC1-SPINE3
@@ -123,6 +125,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE3_Ethernet1
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.5/31
   Ethernet4:
     peer: DC1-SPINE4
@@ -131,12 +134,15 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE4_Ethernet1
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.7/31
   Ethernet5:
     peer: server01
     peer_interface: Eth1
     peer_type: server
     description: server01_Eth1
+    type: switched
+    shutdown: false
     mode: trunk
     vlans: 110
     profile: TENANT_A
@@ -145,19 +151,24 @@ ethernet_interfaces:
     peer_interface: Eth1
     peer_type: server
     description: server02_Eth1
+    type: switched
+    shutdown: false
     mode: trunk
     vlans: 110
     profile: TENANT_A
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: 192.168.255.5/32
   Loopback1:
     description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
     ip_address: 192.168.254.5/32
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.105/24
     gateway: 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-LEAF2A.yml
@@ -210,11 +210,15 @@ bfd_multihop:
 port_channel_interfaces:
   Port-Channel7:
     description: DC1_L2LEAF1_Po1
+    type: switched
+    shutdown: false
     vlans: 110-111,120-121,130-131
     mode: trunk
     mlag: 7
   Port-Channel5:
     description: MLAG_PEER_DC1-LEAF2B_Po5
+    type: switched
+    shutdown: false
     vlans: 2-4094
     mode: trunk
     trunk_groups:
@@ -222,11 +226,15 @@ port_channel_interfaces:
     - MLAG
   Port-Channel10:
     description: server01_PortChanne1
+    type: switched
+    shutdown: false
     vlans: 210-211
     mode: trunk
     mlag: 10
   Port-Channel11:
     description: server02_PortChanne1
+    type: switched
+    shutdown: false
     vlans: 210-211
     mode: trunk
     mlag: 11
@@ -238,6 +246,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE1_Ethernet2
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.9/31
   Ethernet2:
     peer: DC1-SPINE2
@@ -246,6 +255,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE2_Ethernet2
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.11/31
   Ethernet3:
     peer: DC1-SPINE3
@@ -254,6 +264,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE3_Ethernet2
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.13/31
   Ethernet4:
     peer: DC1-SPINE4
@@ -262,12 +273,15 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE4_Ethernet2
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.15/31
   Ethernet5:
     peer: DC1-LEAF2B
     peer_interface: Ethernet5
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-LEAF2B_Ethernet5
+    type: switched
+    shutdown: false
     channel_group:
       id: 5
       mode: active
@@ -276,6 +290,8 @@ ethernet_interfaces:
     peer_interface: Ethernet6
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-LEAF2B_Ethernet6
+    type: switched
+    shutdown: false
     channel_group:
       id: 5
       mode: active
@@ -284,6 +300,8 @@ ethernet_interfaces:
     peer_interface: Ethernet1
     peer_type: l2leaf
     description: DC1-L2LEAF1A_Ethernet1
+    type: switched
+    shutdown: false
     channel_group:
       id: 7
       mode: active
@@ -292,6 +310,8 @@ ethernet_interfaces:
     peer_interface: Eth2
     peer_type: server
     description: server01_Eth2
+    type: switched
+    shutdown: false
     mode: trunk
     vlans: 210-211
     channel_group:
@@ -303,6 +323,8 @@ ethernet_interfaces:
     peer_interface: Eth2
     peer_type: server
     description: server02_Eth2
+    type: switched
+    shutdown: false
     mode: trunk
     vlans: 210-211
     channel_group:
@@ -312,27 +334,33 @@ ethernet_interfaces:
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: 192.168.255.6/32
   Loopback1:
     description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
     ip_address: 192.168.254.6/32
   Loopback100:
     description: Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
+    shutdown: false
     vrf: Tenant_A_OP_Zone
     ip_address: 10.255.1.6/32
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.106/24
     gateway: 192.168.200.5
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING
+    shutdown: false
     ip_address: 10.255.251.2/31
     mtu: 1500
   Vlan4094:
     description: MLAG_PEER
+    shutdown: false
     ip_address: 10.255.252.2/31
     no_autostate: true
     mtu: 1500
@@ -356,6 +384,7 @@ vlan_interfaces:
   Vlan3011:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone'
     vrf: Tenant_A_APP_Zone
     ip_address: 10.255.251.2/31
@@ -379,6 +408,7 @@ vlan_interfaces:
   Vlan3012:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone'
     vrf: Tenant_A_DB_Zone
     ip_address: 10.255.251.2/31
@@ -401,6 +431,7 @@ vlan_interfaces:
   Vlan3009:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone'
     vrf: Tenant_A_OP_Zone
     ip_address: 10.255.251.2/31
@@ -424,6 +455,7 @@ vlan_interfaces:
   Vlan3010:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone'
     vrf: Tenant_A_WEB_Zone
     ip_address: 10.255.251.2/31
@@ -446,6 +478,7 @@ vlan_interfaces:
   Vlan3019:
     tenant: Tenant_B
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone'
     vrf: Tenant_B_OP_Zone
     ip_address: 10.255.251.2/31
@@ -468,6 +501,7 @@ vlan_interfaces:
   Vlan3029:
     tenant: Tenant_C
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone'
     vrf: Tenant_C_OP_Zone
     ip_address: 10.255.251.2/31

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-LEAF2B.yml
@@ -210,11 +210,15 @@ bfd_multihop:
 port_channel_interfaces:
   Port-Channel7:
     description: DC1_L2LEAF1_Po1
+    type: switched
+    shutdown: false
     vlans: 110-111,120-121,130-131
     mode: trunk
     mlag: 7
   Port-Channel5:
     description: MLAG_PEER_DC1-LEAF2A_Po5
+    type: switched
+    shutdown: false
     vlans: 2-4094
     mode: trunk
     trunk_groups:
@@ -222,11 +226,15 @@ port_channel_interfaces:
     - MLAG
   Port-Channel10:
     description: server01_PortChanne1
+    type: switched
+    shutdown: false
     vlans: 210-211
     mode: trunk
     mlag: 10
   Port-Channel11:
     description: server02_PortChanne1
+    type: switched
+    shutdown: false
     vlans: 210-211
     mode: trunk
     mlag: 11
@@ -238,6 +246,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE1_Ethernet3
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.17/31
   Ethernet2:
     peer: DC1-SPINE2
@@ -246,6 +255,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE2_Ethernet3
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.19/31
   Ethernet3:
     peer: DC1-SPINE3
@@ -254,6 +264,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE3_Ethernet3
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.21/31
   Ethernet4:
     peer: DC1-SPINE4
@@ -262,12 +273,15 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE4_Ethernet3
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.23/31
   Ethernet5:
     peer: DC1-LEAF2A
     peer_interface: Ethernet5
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-LEAF2A_Ethernet5
+    type: switched
+    shutdown: false
     channel_group:
       id: 5
       mode: active
@@ -276,6 +290,8 @@ ethernet_interfaces:
     peer_interface: Ethernet6
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-LEAF2A_Ethernet6
+    type: switched
+    shutdown: false
     channel_group:
       id: 5
       mode: active
@@ -284,6 +300,8 @@ ethernet_interfaces:
     peer_interface: Ethernet2
     peer_type: l2leaf
     description: DC1-L2LEAF1A_Ethernet2
+    type: switched
+    shutdown: false
     channel_group:
       id: 7
       mode: active
@@ -292,6 +310,8 @@ ethernet_interfaces:
     peer_interface: Eth3
     peer_type: server
     description: server01_Eth3
+    type: switched
+    shutdown: false
     mode: trunk
     vlans: 210-211
     channel_group:
@@ -303,6 +323,8 @@ ethernet_interfaces:
     peer_interface: Eth3
     peer_type: server
     description: server02_Eth3
+    type: switched
+    shutdown: false
     mode: trunk
     vlans: 210-211
     channel_group:
@@ -312,27 +334,33 @@ ethernet_interfaces:
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: 192.168.255.7/32
   Loopback1:
     description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
     ip_address: 192.168.254.6/32
   Loopback100:
     description: Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
+    shutdown: false
     vrf: Tenant_A_OP_Zone
     ip_address: 10.255.1.7/32
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.107/24
     gateway: 192.168.200.5
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING
+    shutdown: false
     ip_address: 10.255.251.3/31
     mtu: 1500
   Vlan4094:
     description: MLAG_PEER
+    shutdown: false
     ip_address: 10.255.252.3/31
     no_autostate: true
     mtu: 1500
@@ -356,6 +384,7 @@ vlan_interfaces:
   Vlan3011:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone'
     vrf: Tenant_A_APP_Zone
     ip_address: 10.255.251.3/31
@@ -379,6 +408,7 @@ vlan_interfaces:
   Vlan3012:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone'
     vrf: Tenant_A_DB_Zone
     ip_address: 10.255.251.3/31
@@ -401,6 +431,7 @@ vlan_interfaces:
   Vlan3009:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone'
     vrf: Tenant_A_OP_Zone
     ip_address: 10.255.251.3/31
@@ -424,6 +455,7 @@ vlan_interfaces:
   Vlan3010:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone'
     vrf: Tenant_A_WEB_Zone
     ip_address: 10.255.251.3/31
@@ -446,6 +478,7 @@ vlan_interfaces:
   Vlan3019:
     tenant: Tenant_B
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone'
     vrf: Tenant_B_OP_Zone
     ip_address: 10.255.251.3/31
@@ -468,6 +501,7 @@ vlan_interfaces:
   Vlan3029:
     tenant: Tenant_C
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone'
     vrf: Tenant_C_OP_Zone
     ip_address: 10.255.251.3/31

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-SPINE1.yml
@@ -63,6 +63,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-BL1A_Ethernet1
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.40/31
   Ethernet7:
     peer: DC1-BL1B
@@ -71,6 +72,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-BL1B_Ethernet1
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.48/31
   Ethernet1:
     peer: DC1-LEAF1A
@@ -79,6 +81,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF1A_Ethernet1
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.0/31
   Ethernet2:
     peer: DC1-LEAF2A
@@ -87,6 +90,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF2A_Ethernet1
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.8/31
   Ethernet3:
     peer: DC1-LEAF2B
@@ -95,6 +99,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF2B_Ethernet1
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.16/31
   Ethernet4:
     peer: DC1-SVC3A
@@ -103,6 +108,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SVC3A_Ethernet1
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.24/31
   Ethernet5:
     peer: DC1-SVC3B
@@ -111,14 +117,17 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SVC3B_Ethernet1
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.32/31
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: 192.168.255.1/32
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.101/24
     gateway: 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-SPINE2.yml
@@ -63,6 +63,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-BL1A_Ethernet2
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.42/31
   Ethernet7:
     peer: DC1-BL1B
@@ -71,6 +72,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-BL1B_Ethernet2
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.50/31
   Ethernet1:
     peer: DC1-LEAF1A
@@ -79,6 +81,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF1A_Ethernet2
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.2/31
   Ethernet2:
     peer: DC1-LEAF2A
@@ -87,6 +90,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF2A_Ethernet2
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.10/31
   Ethernet3:
     peer: DC1-LEAF2B
@@ -95,6 +99,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF2B_Ethernet2
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.18/31
   Ethernet4:
     peer: DC1-SVC3A
@@ -103,6 +108,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SVC3A_Ethernet2
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.26/31
   Ethernet5:
     peer: DC1-SVC3B
@@ -111,14 +117,17 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SVC3B_Ethernet2
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.34/31
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: 192.168.255.2/32
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.102/24
     gateway: 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-SPINE3.yml
@@ -63,6 +63,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-BL1A_Ethernet3
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.44/31
   Ethernet7:
     peer: DC1-BL1B
@@ -71,6 +72,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-BL1B_Ethernet3
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.52/31
   Ethernet1:
     peer: DC1-LEAF1A
@@ -79,6 +81,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF1A_Ethernet3
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.4/31
   Ethernet2:
     peer: DC1-LEAF2A
@@ -87,6 +90,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF2A_Ethernet3
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.12/31
   Ethernet3:
     peer: DC1-LEAF2B
@@ -95,6 +99,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF2B_Ethernet3
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.20/31
   Ethernet4:
     peer: DC1-SVC3A
@@ -103,6 +108,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SVC3A_Ethernet3
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.28/31
   Ethernet5:
     peer: DC1-SVC3B
@@ -111,14 +117,17 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SVC3B_Ethernet3
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.36/31
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: 192.168.255.3/32
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.103/24
     gateway: 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-SPINE4.yml
@@ -63,6 +63,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-BL1A_Ethernet4
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.46/31
   Ethernet7:
     peer: DC1-BL1B
@@ -71,6 +72,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-BL1B_Ethernet4
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.54/31
   Ethernet1:
     peer: DC1-LEAF1A
@@ -79,6 +81,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF1A_Ethernet4
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.6/31
   Ethernet2:
     peer: DC1-LEAF2A
@@ -87,6 +90,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF2A_Ethernet4
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.14/31
   Ethernet3:
     peer: DC1-LEAF2B
@@ -95,6 +99,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-LEAF2B_Ethernet4
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.22/31
   Ethernet4:
     peer: DC1-SVC3A
@@ -103,6 +108,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SVC3A_Ethernet4
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.30/31
   Ethernet5:
     peer: DC1-SVC3B
@@ -111,14 +117,17 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SVC3B_Ethernet4
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.38/31
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: 192.168.255.4/32
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.104/24
     gateway: 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-SVC3A.yml
@@ -253,11 +253,15 @@ bfd_multihop:
 port_channel_interfaces:
   Port-Channel7:
     description: DC1_L2LEAF2_Po1
+    type: switched
+    shutdown: false
     vlans: 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350
     mode: trunk
     mlag: 7
   Port-Channel5:
     description: MLAG_PEER_DC1-SVC3B_Po5
+    type: switched
+    shutdown: false
     vlans: 2-4094
     mode: trunk
     trunk_groups:
@@ -265,11 +269,15 @@ port_channel_interfaces:
     - MLAG
   Port-Channel10:
     description: server03_PortChanne1
+    type: switched
+    shutdown: false
     vlans: 110-111,210-211
     mode: trunk
     mlag: 10
   Port-Channel11:
     description: server04_PortChanne1
+    type: switched
+    shutdown: false
     vlans: 110-111,210-211
     mode: trunk
     mlag: 11
@@ -281,6 +289,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE1_Ethernet4
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.25/31
   Ethernet2:
     peer: DC1-SPINE2
@@ -289,6 +298,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE2_Ethernet4
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.27/31
   Ethernet3:
     peer: DC1-SPINE3
@@ -297,6 +307,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE3_Ethernet4
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.29/31
   Ethernet4:
     peer: DC1-SPINE4
@@ -305,12 +316,15 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE4_Ethernet4
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.31/31
   Ethernet5:
     peer: DC1-SVC3B
     peer_interface: Ethernet5
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-SVC3B_Ethernet5
+    type: switched
+    shutdown: false
     channel_group:
       id: 5
       mode: active
@@ -319,6 +333,8 @@ ethernet_interfaces:
     peer_interface: Ethernet6
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-SVC3B_Ethernet6
+    type: switched
+    shutdown: false
     channel_group:
       id: 5
       mode: active
@@ -327,6 +343,8 @@ ethernet_interfaces:
     peer_interface: Ethernet1
     peer_type: l2leaf
     description: DC1-L2LEAF2A_Ethernet1
+    type: switched
+    shutdown: false
     channel_group:
       id: 7
       mode: active
@@ -335,6 +353,8 @@ ethernet_interfaces:
     peer_interface: Ethernet1
     peer_type: l2leaf
     description: DC1-L2LEAF2B_Ethernet1
+    type: switched
+    shutdown: false
     channel_group:
       id: 7
       mode: active
@@ -343,6 +363,8 @@ ethernet_interfaces:
     peer_interface: Eth1
     peer_type: server
     description: server03_Eth1
+    type: switched
+    shutdown: false
     mode: trunk
     vlans: 110-111,210-211
     channel_group:
@@ -354,6 +376,8 @@ ethernet_interfaces:
     peer_interface: Eth1
     peer_type: server
     description: server04_Eth1
+    type: switched
+    shutdown: false
     mode: trunk
     vlans: 110-111,210-211
     channel_group:
@@ -363,27 +387,33 @@ ethernet_interfaces:
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: 192.168.255.8/32
   Loopback1:
     description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
     ip_address: 192.168.254.8/32
   Loopback100:
     description: Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
+    shutdown: false
     vrf: Tenant_A_OP_Zone
     ip_address: 10.255.1.8/32
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.108/24
     gateway: 192.168.200.5
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING
+    shutdown: false
     ip_address: 10.255.251.6/31
     mtu: 1500
   Vlan4094:
     description: MLAG_PEER
+    shutdown: false
     ip_address: 10.255.252.6/31
     no_autostate: true
     mtu: 1500
@@ -407,6 +437,7 @@ vlan_interfaces:
   Vlan3011:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone'
     vrf: Tenant_A_APP_Zone
     ip_address: 10.255.251.6/31
@@ -430,6 +461,7 @@ vlan_interfaces:
   Vlan3012:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone'
     vrf: Tenant_A_DB_Zone
     ip_address: 10.255.251.6/31
@@ -452,6 +484,7 @@ vlan_interfaces:
   Vlan3009:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone'
     vrf: Tenant_A_OP_Zone
     ip_address: 10.255.251.6/31
@@ -466,6 +499,7 @@ vlan_interfaces:
   Vlan3013:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone'
     vrf: Tenant_A_WAN_Zone
     ip_address: 10.255.251.6/31
@@ -489,6 +523,7 @@ vlan_interfaces:
   Vlan3010:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone'
     vrf: Tenant_A_WEB_Zone
     ip_address: 10.255.251.6/31
@@ -511,6 +546,7 @@ vlan_interfaces:
   Vlan3019:
     tenant: Tenant_B
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone'
     vrf: Tenant_B_OP_Zone
     ip_address: 10.255.251.6/31
@@ -525,6 +561,7 @@ vlan_interfaces:
   Vlan3020:
     tenant: Tenant_B
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone'
     vrf: Tenant_B_WAN_Zone
     ip_address: 10.255.251.6/31
@@ -547,6 +584,7 @@ vlan_interfaces:
   Vlan3029:
     tenant: Tenant_C
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone'
     vrf: Tenant_C_OP_Zone
     ip_address: 10.255.251.6/31
@@ -561,6 +599,7 @@ vlan_interfaces:
   Vlan3030:
     tenant: Tenant_C
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone'
     vrf: Tenant_C_WAN_Zone
     ip_address: 10.255.251.6/31

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-SVC3B.yml
@@ -253,11 +253,15 @@ bfd_multihop:
 port_channel_interfaces:
   Port-Channel7:
     description: DC1_L2LEAF2_Po1
+    type: switched
+    shutdown: false
     vlans: 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350
     mode: trunk
     mlag: 7
   Port-Channel5:
     description: MLAG_PEER_DC1-SVC3A_Po5
+    type: switched
+    shutdown: false
     vlans: 2-4094
     mode: trunk
     trunk_groups:
@@ -265,11 +269,15 @@ port_channel_interfaces:
     - MLAG
   Port-Channel10:
     description: server03_PortChanne1
+    type: switched
+    shutdown: false
     vlans: 110-111,210-211
     mode: trunk
     mlag: 10
   Port-Channel11:
     description: server04_PortChanne1
+    type: switched
+    shutdown: false
     vlans: 110-111,210-211
     mode: trunk
     mlag: 11
@@ -281,6 +289,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE1_Ethernet5
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.33/31
   Ethernet2:
     peer: DC1-SPINE2
@@ -289,6 +298,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE2_Ethernet5
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.35/31
   Ethernet3:
     peer: DC1-SPINE3
@@ -297,6 +307,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE3_Ethernet5
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.37/31
   Ethernet4:
     peer: DC1-SPINE4
@@ -305,12 +316,15 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SPINE4_Ethernet5
     mtu: 1500
     type: routed
+    shutdown: false
     ip_address: 172.31.255.39/31
   Ethernet5:
     peer: DC1-SVC3A
     peer_interface: Ethernet5
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-SVC3A_Ethernet5
+    type: switched
+    shutdown: false
     channel_group:
       id: 5
       mode: active
@@ -319,6 +333,8 @@ ethernet_interfaces:
     peer_interface: Ethernet6
     peer_type: mlag_peer
     description: MLAG_PEER_DC1-SVC3A_Ethernet6
+    type: switched
+    shutdown: false
     channel_group:
       id: 5
       mode: active
@@ -327,6 +343,8 @@ ethernet_interfaces:
     peer_interface: Ethernet2
     peer_type: l2leaf
     description: DC1-L2LEAF2A_Ethernet2
+    type: switched
+    shutdown: false
     channel_group:
       id: 7
       mode: active
@@ -335,6 +353,8 @@ ethernet_interfaces:
     peer_interface: Ethernet2
     peer_type: l2leaf
     description: DC1-L2LEAF2B_Ethernet2
+    type: switched
+    shutdown: false
     channel_group:
       id: 7
       mode: active
@@ -343,6 +363,8 @@ ethernet_interfaces:
     peer_interface: Eth2
     peer_type: server
     description: server03_Eth2
+    type: switched
+    shutdown: false
     mode: trunk
     vlans: 110-111,210-211
     channel_group:
@@ -354,6 +376,8 @@ ethernet_interfaces:
     peer_interface: Eth2
     peer_type: server
     description: server04_Eth2
+    type: switched
+    shutdown: false
     mode: trunk
     vlans: 110-111,210-211
     channel_group:
@@ -363,27 +387,33 @@ ethernet_interfaces:
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: 192.168.255.9/32
   Loopback1:
     description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
     ip_address: 192.168.254.8/32
   Loopback100:
     description: Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
+    shutdown: false
     vrf: Tenant_A_OP_Zone
     ip_address: 10.255.1.9/32
 management_interfaces:
   Management1:
     description: oob_management
+    shutdown: false
     vrf: MGMT
     ip_address: 192.168.200.109/24
     gateway: 192.168.200.5
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING
+    shutdown: false
     ip_address: 10.255.251.7/31
     mtu: 1500
   Vlan4094:
     description: MLAG_PEER
+    shutdown: false
     ip_address: 10.255.252.7/31
     no_autostate: true
     mtu: 1500
@@ -407,6 +437,7 @@ vlan_interfaces:
   Vlan3011:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone'
     vrf: Tenant_A_APP_Zone
     ip_address: 10.255.251.7/31
@@ -430,6 +461,7 @@ vlan_interfaces:
   Vlan3012:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone'
     vrf: Tenant_A_DB_Zone
     ip_address: 10.255.251.7/31
@@ -452,6 +484,7 @@ vlan_interfaces:
   Vlan3009:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone'
     vrf: Tenant_A_OP_Zone
     ip_address: 10.255.251.7/31
@@ -466,6 +499,7 @@ vlan_interfaces:
   Vlan3013:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone'
     vrf: Tenant_A_WAN_Zone
     ip_address: 10.255.251.7/31
@@ -489,6 +523,7 @@ vlan_interfaces:
   Vlan3010:
     tenant: Tenant_A
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone'
     vrf: Tenant_A_WEB_Zone
     ip_address: 10.255.251.7/31
@@ -511,6 +546,7 @@ vlan_interfaces:
   Vlan3019:
     tenant: Tenant_B
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone'
     vrf: Tenant_B_OP_Zone
     ip_address: 10.255.251.7/31
@@ -525,6 +561,7 @@ vlan_interfaces:
   Vlan3020:
     tenant: Tenant_B
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone'
     vrf: Tenant_B_WAN_Zone
     ip_address: 10.255.251.7/31
@@ -547,6 +584,7 @@ vlan_interfaces:
   Vlan3029:
     tenant: Tenant_C
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone'
     vrf: Tenant_C_OP_Zone
     ip_address: 10.255.251.7/31
@@ -561,6 +599,7 @@ vlan_interfaces:
   Vlan3030:
     tenant: Tenant_C
     type: underlay_peering
+    shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone'
     vrf: Tenant_C_WAN_Zone
     ip_address: 10.255.251.7/31

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/port-channel-interfaces.j2
@@ -9,7 +9,7 @@
 {%         if port_channel_interfaces[port_channel_interface].type is not defined or port_channel_interfaces[port_channel_interface].type != "routed" %}
 {%             set description = port_channel_interfaces[port_channel_interface].description | default ("-")%}
 {%             set type = port_channel_interfaces[port_channel_interface].type | default ("switched")%}
-{%             set mode = port_channel_interfaces[port_channel_interface].type | default ("access")%}
+{%             set mode = port_channel_interfaces[port_channel_interface].mode | default ("access")%}
 {%             set vlans = port_channel_interfaces[port_channel_interface].vlans | default ("-")%}
 {%             set native_vlan = port_channel_interfaces[port_channel_interface].native_vlan | default ("-")%}
 {%             if port_channel_interfaces[port_channel_interface].trunk_groups is defined %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -8,6 +8,8 @@ interface {{ ethernet_interface }}
 {%         endif %}
 {%         if ethernet_interfaces[ethernet_interface].shutdown is defined and ethernet_interfaces[ethernet_interface].shutdown == true %}
    shutdown
+{%         elif ethernet_interfaces[ethernet_interface].shutdown is defined and ethernet_interfaces[ethernet_interface].shutdown == false %}
+   no shutdown
 {%         endif %}
 {%         if ethernet_interfaces[ethernet_interface].speed is defined and ethernet_interfaces[ethernet_interface].speed is not none %}
    speed forced {{ ethernet_interfaces[ethernet_interface].speed }}
@@ -20,6 +22,8 @@ interface {{ ethernet_interface }}
 {%             endif %}
 {%             if ethernet_interfaces[ethernet_interface].type is defined and ethernet_interfaces[ethernet_interface].type == "routed" %}
    no switchport
+{%             else %}
+   switchport
 {%             endif %}
 {%             if ethernet_interfaces[ethernet_interface].flowcontrol is defined and ethernet_interfaces[ethernet_interface].flowcontrol is not none %}
 {%                 if ethernet_interfaces[ethernet_interface].flowcontrol.received is defined and ethernet_interfaces[ethernet_interface].flowcontrol.received is not none %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/loopback-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/loopback-interfaces.j2
@@ -8,6 +8,8 @@ interface {{ loopback_interface }}
 {%         endif %}
 {%         if loopback_interfaces[loopback_interface].shutdown is defined and loopback_interfaces[loopback_interface].shutdown == true %}
    shutdown
+{%         elif loopback_interfaces[loopback_interface].shutdown is defined and loopback_interfaces[loopback_interface].shutdown == false %}
+   no shutdown
 {%         endif %}
 {%         if loopback_interfaces[loopback_interface].vrf is defined and loopback_interfaces[loopback_interface].vrf is not none %}
    vrf {{ loopback_interfaces[loopback_interface].vrf }}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-interfaces.j2
@@ -4,6 +4,11 @@
 !
 interface {{ management_interface }}
    description {{ management_interfaces[management_interface].description }}
+{%       if management_interfaces[management_interface].shutdown is defined and management_interfaces[management_interface].shutdown == true %}
+   shutdown
+{%       elif management_interfaces[management_interface].shutdown is defined and management_interfaces[management_interface].shutdown == false %}
+   no shutdown
+{%       endif %}
 {%       if management_interfaces[management_interface].vrf is defined and management_interfaces[management_interface].vrf is ne 'default' %}
    vrf {{ management_interfaces[management_interface].vrf }}
 {%       endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
@@ -8,12 +8,16 @@ interface {{ port_channel_interface }}
 {%         endif %}
 {%         if port_channel_interfaces[port_channel_interface].shutdown is defined and port_channel_interfaces[port_channel_interface].shutdown == true %}
    shutdown
+{%         elif port_channel_interfaces[port_channel_interface].shutdown is defined and port_channel_interfaces[port_channel_interface].shutdown == false %}
+   no shutdown
 {%         endif %}
 {%         if port_channel_interfaces[port_channel_interface].mtu is defined and port_channel_interfaces[port_channel_interface].mtu is not none %}
    mtu {{ port_channel_interfaces[port_channel_interface].mtu }}
 {%         endif %}
 {%         if port_channel_interfaces[port_channel_interface].type is defined and port_channel_interfaces[port_channel_interface].type == "routed" %}
    no switchport
+{%         else %}
+   switchport
 {%         endif %}
 {%         if port_channel_interfaces[port_channel_interface].mode is defined and port_channel_interfaces[port_channel_interface].mode == "access" %}
    switchport access vlan {{ port_channel_interfaces[port_channel_interface].vlans }}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
@@ -8,6 +8,8 @@ interface {{ vlan_interface }}
 {%         endif %}
 {%         if vlan_interfaces[vlan_interface].shutdown is defined and vlan_interfaces[vlan_interface].shutdown == true %}
    shutdown
+{%         elif vlan_interfaces[vlan_interface].shutdown is defined and vlan_interfaces[vlan_interface].shutdown == false %}
+   no shutdown
 {%         endif %}
 {%         if vlan_interfaces[vlan_interface].mtu is defined and vlan_interfaces[vlan_interface].mtu != 1500 %}
    mtu {{ vlan_interfaces[vlan_interface].mtu }}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/base/mgmt-interface.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/base/mgmt-interface.j2
@@ -2,6 +2,7 @@
 {% if mgmt_interface is defined %}
   {{ mgmt_interface }}:
     description: oob_management
+    shutdown: false
     vrf: {{ mgmt_interface_vrf }}
     ip_address: {{ switch.mgmt_ip }}
     gateway: {{ mgmt_gateway }}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/edge_ports/leaf-server-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/edge_ports/leaf-server-interfaces.j2
@@ -13,6 +13,8 @@
 {%                 if adapter.speed is defined %}
     speed: {{ adapter.speed }}
 {%                 endif %}
+    type: switched
+    shutdown: false
     mode: {{ port_profiles[adapter.profile].mode }}
     vlans: {{ port_profiles[adapter.profile].vlans }}
 {%                 if port_profiles[adapter.profile].spanning_tree_portfast is defined %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/edge_ports/leaf-server-port-channels.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/edge_ports/leaf-server-port-channels.j2
@@ -8,6 +8,8 @@
 {%                     set channel_group_id = (adapter.switch_ports[0] | regex_findall("\d") | join ) %}
   Port-Channel{{ channel_group_id }}:
     description: {{ server }}_{{ adapter.port_channel.description }}
+    type: switched
+    shutdown: false
     vlans: {{ port_profiles[adapter.profile].vlans }}
     mode: {{ port_profiles[adapter.profile].mode }}
 {%                 if port_profiles[adapter.profile].native_vlan is defined %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/interfaces/leaf-overlay-loopback.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/interfaces/leaf-overlay-loopback.j2
@@ -1,6 +1,7 @@
 {# leaf overlay loopback interface #}
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: {{ overlay_loopback_network_summary | ipaddr('network') | ipmath(leaf.id + spine.nodes | length) }}/32
 {% if underlay_routing_protocol|lower == "ospf" %}
     ospf_area: {{ underlay_ospf_area }}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/interfaces/leaf-p2p-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/interfaces/leaf-p2p-interfaces.j2
@@ -10,6 +10,7 @@
 {%     endif %}
     mtu: {{ p2p_uplinks_mtu }}
     type: routed
+    shutdown: false
     ip_address: {{ underlay_p2p_network_summary | ipaddr('network') | ipmath(((leaf.id -1) * 2 * spine.nodes | length * max_l3leaf_to_spine_links ) + loop.index0 * 2 + 1) }}/31
 {%     if underlay_routing_protocol|lower == "ospf" %}
     ospf_network_point_to_point: true

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/interfaces/leaf-vtep-vxlan-tunnel-loopback.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/interfaces/leaf-vtep-vxlan-tunnel-loopback.j2
@@ -1,6 +1,7 @@
 {# Leaf VTEP vxlan tunnel loopback source interface #}
   Loopback1:
     description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
 {% if leaf.mlag == true and leaf.mlag_role == "primary" %}
     ip_address: {{ vtep_loopback_network_summary | ipaddr('network') | ipmath(leaf.id + spine.nodes | length) }}/32
 {% elif leaf.mlag == true and leaf.mlag_role == "secondary" %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/interfaces/overlay-controller-loopback.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/interfaces/overlay-controller-loopback.j2
@@ -1,6 +1,7 @@
 {# Overlay Controller loopback interface #}
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: {{ overlay_controller_loopback_network_summary | ipaddr('network') | ipmath(switch.id) }}/32
 {% if underlay_routing_protocol == "OSPF" %}
     ospf_area: {{ underlay_ospf_area }}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/interfaces/overlay-controller-p2p-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/interfaces/overlay-controller-p2p-interfaces.j2
@@ -11,6 +11,7 @@
 {%         endif %}
     mtu: {{ p2p_uplinks_mtu }}
     type: routed
+    shutdown: false
 {# TODO: Validate IP calculation if attached to L3LEAF or SUPER-SPINE #}
     ip_address: {{ overlay_controller_p2p_network_summary | ipaddr('network') | ipmath(((switch.id -1) * 2 * overlay_controller.nodes | length * max_overlay_controller_to_switch_links ) + loop.index0 * 2 + 1) }}/31
 {%         if underlay_routing_protocol|lower == "ospf" %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/interfaces/spine-overlay-loopback.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/interfaces/spine-overlay-loopback.j2
@@ -1,6 +1,7 @@
 {# Spine Loopback Interface for Overlay Peering #}
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: {{ overlay_loopback_network_summary  | ipaddr('network') | ipmath(spine.nodes[inventory_hostname].id) }}/32
 {% if underlay_routing_protocol|lower == "ospf" %}
     ospf_area: {{ underlay_ospf_area }}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/interfaces/spine-p2p-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/interfaces/spine-p2p-interfaces.j2
@@ -29,6 +29,7 @@
 {%                 endif %}
     mtu: {{ p2p_uplinks_mtu }}
     type: routed
+    shutdown: false
     ip_address: {{ underlay_p2p_network_summary | ipaddr('network') | ipmath(((l3leaf.node_groups[l3leaf_node_group].nodes[node].id -1) * 2 * spine.nodes | length * max_l3leaf_to_spine_links ) + loop.index0 * 2) }}/31
 {%                 if underlay_routing_protocol|lower == "ospf" %}
     ospf_network_point_to_point: true
@@ -72,6 +73,7 @@
 {%              endif %}
     mtu: {{ p2p_uplinks_mtu }}
     type: routed
+    shutdown: false
     ip_address: {{
         ip_pool | ipaddr('network') | ipmath(
             (ip_pool_max_hosts_in_subnet / max_super_spines)|int * (s_spine_id-1) + ((spine_id-1) * max_spine_to_super_spine_links + offset) * 2 + 1

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/interfaces/super-spine-overlay-loopback.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/interfaces/super-spine-overlay-loopback.j2
@@ -2,6 +2,7 @@
 {% if switch.overlay_routing_protocol == "ebgp" %}
   Loopback0:
     description: EVPN_Overlay_Peering
+    shutdown: false
     ip_address: {{ super_spine_loopback_network_summary  | ipaddr('network') | ipmath(super_spine.nodes[inventory_hostname].id) }}/32
 {%     if underlay_routing_protocol|lower == "ospf" %}
     ospf_area: {{ underlay_ospf_area }}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/interfaces/super-spine-p2p-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/interfaces/super-spine-p2p-interfaces.j2
@@ -23,6 +23,7 @@
 {%             endif %}
     mtu: {{ p2p_uplinks_mtu }}
     type: routed
+    shutdown: false
     ip_address: {{
         ip_pool | ipaddr('network') | ipmath(
             (ip_pool_max_hosts_in_subnet / max_super_spines)|int * (s_spine_id-1) + ((spine_id-1) * max_spine_to_super_spine_links + offset) * 2

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/interfaces/switch-p2p-interfaces-overlay-controller.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/interfaces/switch-p2p-interfaces-overlay-controller.j2
@@ -30,6 +30,7 @@
 {%                 endif %}
     mtu: {{ p2p_uplinks_mtu }}
     type: routed
+    shutdown: false
     ip_address: {{ overlay_controller_p2p_network_summary | ipaddr('network') | ipmath(((overlay_controller.nodes[overlay_controller_node].id -1) * 2 * overlay_controller_remote_switches | length * max_overlay_controller_to_switch_links ) + loop.index0 * 2) }}/31
 {%                 if underlay_routing_protocol|lower == "ospf" %}
     ospf_network_point_to_point: true

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/mlag/leaf-mlag-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/mlag/leaf-mlag-interfaces.j2
@@ -7,6 +7,8 @@
     peer_interface: {{ mlag_interface }}
     peer_type: mlag_peer
     description: MLAG_PEER_{{ leaf.mlag_peer }}_{{ mlag_interface }}
+    type: switched
+    shutdown: false
     channel_group:
       id: {{ leaf.mlag_interfaces[0] | regex_findall("\d") | join }}
       mode: active

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/mlag/leaf-mlag-peer-link.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/mlag/leaf-mlag-peer-link.j2
@@ -3,6 +3,8 @@
 ## mlag peer-link ##
   Port-Channel{{ leaf.mlag_interfaces[0] | regex_findall("\d") | join }}:
     description: MLAG_PEER_{{ leaf.mlag_peer }}_Po{{ leaf.mlag_interfaces[0] | regex_findall("\d") | join }}
+    type: switched
+    shutdown: false
     vlans: "2-4094"
     mode: trunk
     trunk_groups:

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/mlag/leaf-mlag-vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/mlag/leaf-mlag-vlan-interfaces.j2
@@ -3,6 +3,7 @@
 {%     if type == 'l3leaf' %}
   Vlan4093:
     description: MLAG_PEER_L3_PEERING
+    shutdown: false
     ip_address: {{ mlag_ips.leaf_peer_l3 | ipaddr('network') | ipmath(leaf.mlag_ip ) }}/31
     mtu: {{ p2p_uplinks_mtu }}
 {%         if underlay_routing_protocol|lower == "ospf" %}
@@ -17,6 +18,7 @@
 {%     endif %}
   Vlan4094:
     description: MLAG_PEER
+    shutdown: false
     ip_address: {{ mlag_ips.mlag_peer | ipaddr('network') | ipmath(leaf.mlag_ip) }}/31
     no_autostate: true
     mtu: {{ p2p_uplinks_mtu }}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/l3leaf_l2leafs_uplinks/l2leaf-ethernet-uplinks.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/l3leaf_l2leafs_uplinks/l2leaf-ethernet-uplinks.j2
@@ -28,6 +28,8 @@
 {%                 if p2p_link_interface_speed is defined %}
     speed: {{ p2p_link_interface_speed }}
 {%                 endif %}
+    type: switched
+    shutdown: false
     channel_group:
       id: {{ channel_group_id }}
       mode: active

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/l3leaf_l2leafs_uplinks/l2leaf-port-channel-uplinks.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/l3leaf_l2leafs_uplinks/l2leaf-port-channel-uplinks.j2
@@ -21,6 +21,8 @@
 {%             endif %}
   Port-Channel{{ channel_group_id }}:
     description: {{ parent_l3leafs[loop.index0]}}_{{ 'Po' + l3leaf.channel_group_id }}
+    type: switched
+    shutdown: false
     vlans: {{ leaf.vlans | arista.avd.list_compress }}
     mode: trunk
 {%             if leaf.mlag == true %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/l3leaf_l2leafs_uplinks/l3leaf-ethernet-uplinks.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/l3leaf_l2leafs_uplinks/l3leaf-ethernet-uplinks.j2
@@ -34,6 +34,8 @@
 {%                         if p2p_link_interface_speed is defined %}
     speed: {{ p2p_link_interface_speed }}
 {%                         endif %}
+    type: switched
+    shutdown: false
     channel_group:
       id: {{ l3leaf.channel_group_id }}
       mode: active

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/l3leaf_l2leafs_uplinks/l3leaf-port-channel-uplinks.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/l3leaf_l2leafs_uplinks/l3leaf-port-channel-uplinks.j2
@@ -67,6 +67,8 @@
 ## L2 LEAF Uplink {{ l2leaf_node_group }} ##
   Port-Channel{{ l3_leaf.channel_group_id }}:
     description: {{ l2leaf_node_group }}_{{ 'Po' + l2leaf_uplink_interfaces[loop.index0] | regex_findall("\d") | join }}
+    type: switched
+    shutdown: false
     vlans: {{ l2_leaf.vlans | arista.avd.list_compress }}
     mode: trunk
     mlag: {{ l3_leaf.channel_group_id }}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-vlan-interfaces.j2
@@ -104,6 +104,7 @@
   Vlan{{ mlag_ibgp_peering_vrfs.base_vlan + (tenants[tenant].vrfs[vrf].vrf_vni - 1) }}:
     tenant: {{ tenant }}
     type: underlay_peering
+    shutdown: false
     description: "MLAG_PEER_L3_iBGP: vrf {{ vrf }}"
     vrf: {{ vrf }}
     ip_address: {{ mlag_ips.leaf_peer_l3 | ipaddr('network') | ipmath(leaf.mlag_ip ) }}/31

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-vrf-loopbacks.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-vrf-loopbacks.j2
@@ -8,6 +8,7 @@
 {%                 endif %}
   Loopback{{ tenants[tenant].vrfs[vrf].vtep_diagnostic.loopback }}:
     description: {{ vrf }}_VTEP_DIAGNOSTICS
+    shutdown: false
     vrf: {{ vrf }}
     ip_address: {{ tenants[tenant].vrfs[vrf].vtep_diagnostic.loopback_ip_range | ipaddr('network') | ipmath(leaf.id + spine.nodes | length) }}/32
 {%             endif %}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
In `eos_cli_config_gen`: Ensure that configurations for `no shutdown` and `switchport` are rendered explicitly
In `eos_l3ls_evpn`: Explicitly set `shutdown: false` and `type: switched` instead of relying on expected defaults

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

## Component(s) name
eos_cli_config_gen
eos_l3ls_evpn

## Proposed changes
<!--- Describe your changes in detail -->
### Shutdown
* If `shutdown: false` we _now_ render `no shutdown`
* If `shutdown: true` we _still_ render `shutdown`
* If `shutdown is not defined` we _still_ don't render anything.

This will enable future support for flipping the EOS default to shutdown, protecting unconfigured ports.

### Switchport
* If `type: routed` we _still_ render `no switchport`
* If `type: switched` we _now_ render `switchport`
* If `type is not defined` we _now_ render `switchport`

This will enable future support for flipping the EOS default to `no switchport`, protecting unconfigured ports.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Tested port-channels, members, switchports, routed ports, shutdown, no shutdown combinations.

Test result here:
https://github.com/ClausHolbechArista/claus-l3ls-dev/commit/39f715e132639b775069c001dc04131b3225dbf5
and after updating l3ls with explicit `shutdown:false` and `type: switched` where applicable:
https://github.com/ClausHolbechArista/claus-l3ls-dev/commit/a4d8f5907a9348baf71dc75df4d5cca9e1a4c1ac

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
