### PR TITLE
Storm control in l3ls_evpn the unit as optional

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
@@ -1229,16 +1229,16 @@ port_profiles:
     storm_control:
       all:
         level: < Configure maximum storm-control level >
-        unit: < percent | pps >
+        unit: < percent | pps > | Optional var and is hardware dependant - default is percent)
       broadcast:
         level: < Configure maximum storm-control level >
-        unit: < percent | pps >
+        unit: < percent | pps > | Optional var and is hardware dependant - default is percent)
       multicast:
         level: < Configure maximum storm-control level >
-        unit: < percent | pps >
+        unit: < percent | pps > | Optional var and is hardware dependant - default is percent)
       unknown_unicast:
         level: < Configure maximum storm-control level >
-        unit: < percent | pps >
+        unit: < percent | pps > | Optional var and is hardware dependant - default is percent)
 
 # Dictionary of servers, a device attaching to a L2 switched port(s)
 servers:

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/edge_ports/leaf-server-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/edge_ports/leaf-server-interfaces.j2
@@ -26,7 +26,9 @@
 {%                     for section in port_profiles[adapter.profile].storm_control %}
       {{ section }}:
         level: {{ port_profiles[adapter.profile].storm_control[section].level }}
+{%                         if port_profiles[adapter.profile].storm_control[section].unit is defined and port_profiles[adapter.profile].storm_control[section].unit is not none %}
         unit: {{ port_profiles[adapter.profile].storm_control[section].unit }}
+{%                         endif %}
 {%                     endfor %}
 {%                 endif %}
 {%                 if port_profiles[adapter.profile].native_vlan is defined %}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Made changes in the template so that the unit is considered as optional instead of mandatory as some platforms don't support it.

After the changes, tests show positive

```
7280r2...15:05:02(config-if-Et1)#   storm-control broadcast level 10
7280r2...15:05:03(config-if-Et1)#   storm-control multicast level 20
7280r2...15:05:03(config-if-Et1)#   storm-control unknown-unicast level pps 15
% Unavailable command (not supported on this hardware platform)
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [x] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes #534 

## Component(s) name
leaf-server-interfaces.j2
eos_l3ls_evpn

## Proposed changes
<!--- Describe your changes in detail -->

```
{%                         if port_profiles[adapter.profile].storm_control[section].unit is defined and port_profiles[adapter.profile].storm_control[section].unit is not none %}
        unit: {{ port_profiles[adapter.profile].storm_control[section].unit }}
{%                         endif %}
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

```
interface Ethernet4
   description server02_Eth0
   switchport trunk allowed vlan 210-211
   switchport mode trunk
   storm-control broadcast level 10
   storm-control multicast level 20
   storm-control unknown-unicast level pps 15
```

YAML

```
  TENANT_B:
    mode: trunk
    vlans: "210-211"
    storm_control:
      broadcast:
        level: 10
      multicast:
        level: 20
      unknown_unicast:
        level: 15
        unit: pps
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
