### PR TITLE
Add filter feature in default section for l2leaf and l3leaf devices

### DIFF
--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
@@ -70,6 +70,9 @@ l3leaf:
     spanning_tree_mode: mstp
     spanning_tree_priority: 4096
     virtual_router_mac_address: 00:dc:00:00:00:0a
+    filter:
+      tenants: [ Tenant_A, Tenant_B, Tenant_C ]
+      tags: [ opzone, web, app, db, vmotion, nfs ]
   node_groups:
     DC1_LEAF1:
       bgp_as: 65101
@@ -84,9 +87,6 @@ l3leaf:
           spine_interfaces: [ Ethernet1, Ethernet1, Ethernet1, Ethernet1 ]
     DC1_LEAF2:
       bgp_as: 65102
-      filter:
-        tenants: [ Tenant_A, Tenant_B, Tenant_C ]
-        tags: [ opzone, web, app, db, vmotion, nfs ]
       nodes:
         DC1-LEAF2A:
           id: 2

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
@@ -583,7 +583,6 @@ l3leaf:
 
       # Filter L3 and L2 network services based on tenant and tags ( and operation filter )| Optional
       # If filter is not defined will default to all
-      # This variable can only be set under the node group.
       filter:
         tenants: [ < tenant_1 >, < tenant_2 > | default all ]
         tags: [ < tag_1 >, < tag_2 > | default -> all ]]
@@ -743,7 +742,6 @@ l2leaf:
 
       # Filter L3 and L2 network services based on tenant and tags - and filter | Optional
       # If filter is not defined will default to all
-      # This variable can only be set under the node group.
       filter:
         tenants: [ < tenant_1 >, < tenant_2 > | default all ]
         tags: [ < tag_1 >, < tag_2 > | default -> all ]]

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l2leaf-yml.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l2leaf-yml.j2
@@ -36,11 +36,15 @@
 {%             endif %}
 {%             if l2leaf.node_groups[l2leaf_node_group].filter.tenants is defined %}
 {%                 set leaf.filter_tenants = l2leaf.node_groups[l2leaf_node_group].filter.tenants %}
+{%             elif l2leaf.defaults.filter.tenants is defined %}
+{%                 set leaf.filter_tenants = l2leaf.defaults.filter.tenants %}
 {%             else %}
 {%                 set leaf.filter_tenants = [ 'all' ] %}
 {%             endif %}
 {%             if l2leaf.node_groups[l2leaf_node_group].filter.tags is defined %}
 {%                 set leaf.filter_tags = l2leaf.node_groups[l2leaf_node_group].filter.tags %}
+{%             elif l2leaf.defaults.filter.tags is defined %}
+{%                 set leaf.filter_tags = l2leaf.defaults.filter.tags %}
 {%             else %}
 {%                 set leaf.filter_tags = [ 'all' ] %}
 {%             endif %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l3leaf-yml.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l3leaf-yml.j2
@@ -15,6 +15,8 @@
 {%             set leaf.spine_interfaces = l3leaf.node_groups[l3leaf_node_group].nodes[node].spine_interfaces %}
 {%             if l3leaf.node_groups[l3leaf_node_group].filter.tenants is defined %}
 {%                 set leaf.filter_tenants = l3leaf.node_groups[l3leaf_node_group].filter.tenants %}
+{%             elif l3leaf.defaults.filter.tenants is defined %}
+{%                 set leaf.filter_tenants = l3leaf.defaults.filter.tenants %}
 {%             else %}
 {%                 set leaf.filter_tenants = [ 'all' ] %}
 {%             endif %}
@@ -27,6 +29,8 @@
 {%             endif %}
 {%             if l3leaf.node_groups[l3leaf_node_group].filter.tags is defined %}
 {%                 set leaf.filter_tags = l3leaf.node_groups[l3leaf_node_group].filter.tags %}
+{%             elif l3leaf.defaults.filter.tags is defined %}
+{%                 set leaf.filter_tags = l3leaf.defaults.filter.tags %}
 {%             else %}
 {%                 set leaf.filter_tags = [ 'all' ] %}
 {%             endif %}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
## Change Summary

Add filter (tags and tenants) in default section for l2leaf and l3leaf devices. 
These filters already exist in l2leaf and l3leaf nodes_groups.  
They were missing in default section.  

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [x] Other (please describe): role enhancement

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
#469 
## Component(s) name

role: eos_l3ls_evpn 

Templates: 
- eos_l3ls_evpn/templates/evpn-fabric-l3leaf-yml.j2 
- eos_l3ls_evpn/templates/evpn-fabric-l2leaf-yml.j2
## Proposed changes
<!--- Describe your changes in detail -->

in roles/eos_l3ls_evpn/templates/evpn-fabric-l3leaf-yml.j2  

replaced 
```
{%             if l3leaf.node_groups[l3leaf_node_group].filter.tenants is defined %}
{%                 set leaf.filter_tenants = l3leaf.node_groups[l3leaf_node_group].filter.tenants %}
{%             else %}
{%                 set leaf.filter_tenants = [ 'all' ] %}
{%             endif %}
``` 
with 
```
{%             if l3leaf.node_groups[l3leaf_node_group].filter.tenants is defined %}
{%                 set leaf.filter_tenants = l3leaf.node_groups[l3leaf_node_group].filter.tenants %}
{%             elif l3leaf.defaults.filter.tenants is defined %}
{%                 set leaf.filter_tenants = l3leaf.defaults.filter.tenants %}
{%             else %}
{%                 set leaf.filter_tenants = [ 'all' ] %}
{%             endif %}
``` 

and replaced 
```
{%             if l3leaf.node_groups[l3leaf_node_group].filter.tags is defined %}
{%                 set leaf.filter_tags = l3leaf.node_groups[l3leaf_node_group].filter.tags %}
{%             else %}
{%                 set leaf.filter_tags = [ 'all' ] %}
{%             endif %}
```
with
```
{%             if l3leaf.node_groups[l3leaf_node_group].filter.tags is defined %}
{%                 set leaf.filter_tags = l3leaf.node_groups[l3leaf_node_group].filter.tags %}
{%             elif l3leaf.defaults.filter.tags is defined %}
{%                 set leaf.filter_tags = l3leaf.defaults.filter.tags %}
{%             else %}
{%                 set leaf.filter_tags = [ 'all' ] %}
{%             endif %}
```
and same thing for evpn-fabric-l2leaf-yml.j2  

+ updated molecule  

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

run the role eos_l3ls_evpn  with 
```
      filter:
        tenants: [ a list ]
        tags: [ a list ]
```
at diff levels (l3leaf/defaults, l3leaf/node_groups/group, l2leaf/defaults, l2leaf/node_groups/group).  

Example: 
```
l3leaf:
  defaults:
    virtual_router_mac_address: 00:1c:73:00:dc:01
    platform: vEOS-LAB
    filter:
      tenants: [ Tenant_A, Tenant_D ]
      tags: [ web, app, vm, nfs, erp, db, vmotion ]
    spines: [DC1-SPINE1, DC1-SPINE2]
    uplink_to_spine_interfaces: [Ethernet1, Ethernet2]
    mlag_interfaces: [Ethernet7, Ethernet8]
  node_groups:
    DC1_LEAF1:
      mlag: true
      bgp_as: 65101
      filter:
        tenants: [ Tenant_A, Tenant_D ]
        tags: [ web, app, vm, nfs, erp ]
      nodes:
        DC1-LEAF1A:
          id: 1
          mgmt_ip: 10.73.1.105/24
          spine_interfaces: [Ethernet1, Ethernet1]
        DC1-LEAF1B:
          id: 2
          mgmt_ip: 10.73.1.106/24
          spine_interfaces: [Ethernet2, Ethernet2]
    DC1_LEAF2:
      bgp_as: 65102
      nodes:
        DC1-LEAF2A:
          id: 3
          mgmt_ip: 10.73.1.107/24
          spine_interfaces: [Ethernet4, Ethernet4]
        DC1-LEAF2B:
          id: 4
          mgmt_ip: 10.73.1.108/24
          spine_interfaces: [Ethernet5, Ethernet5]
l2leaf:
  defaults:
    filter:
      tenants: [ Tenant_A ]
      tags: [ app, vm ]
    platform: vEOS-LAB
    parent_l3leafs: [ DC1-LEAF1A, DC1-LEAF1B ]
    uplink_interfaces: [ Ethernet1, Ethernet2 ]
    mlag_interfaces: [ Ethernet7, Ethernet8 ]
    spanning_tree_mode: mstp
    spanning_tree_priority: 16384
  node_groups:
    DC1_L2LEAF:
      parent_l3leafs: [ DC1-LEAF1A, DC1-LEAF1B ]
      nodes:
        DC1-L2LEAF1A:
          id: 5
          mgmt_ip: 10.73.1.117/24
          l3leaf_interfaces: [ Ethernet3, Ethernet3 ]
        DC1-L2LEAF2A:
          id: 7
          mgmt_ip: 10.73.1.118/24
          l3leaf_interfaces: [ Ethernet4, Ethernet4 ]

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
