### PR TITLE
Skip l2leaf devices from lo0 reachability tests

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/loopback0_reachability.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/loopback0_reachability.yml
@@ -9,7 +9,8 @@
   ignore_errors: "{{ eos_validate_state_validation_mode_loose }}"
   when: |
     (loopback0_reachability.loopback0_range is defined and loopback0_reachability.loopback0_range is not none) and
-    (loopback_interfaces.Loopback0.ip_address is defined and loopback_interfaces.Loopback0.ip_address is not none)
+    (loopback_interfaces.Loopback0.ip_address is defined and loopback_interfaces.Loopback0.ip_address is not none) and
+    (type is defined and type != "l2leaf")
   register: loopback0_reachability_state
   tags:
     - loopback0_reachability


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
## Change Summary

Skip l2leaf dev from lo0 reachability tests (eos validation role) even if they have lo0 configured

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [x] Other (please describe): enhancement 

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes #561 

## Component(s) name
role eos_validate_state 
task roles/eos_validate_state/tasks/loopback0_reachability.yml 
## Proposed changes
<!--- Describe your changes in detail -->
add ```    (type is defined and type != "l2leaf")``` in the task 

so

replace 
```
- name: Gather ip reachability state between devices (loopback0 <-> loopback0)
  eos_command:
    commands: "ping {{ loopback0_address | ipaddr('address')}} source {{ loopback_interfaces.Loopback0.ip_address | ipaddr('address')}} repeat 1"
  loop: "{{ loopback0_reachability.loopback0_range }}"
  loop_control:
    loop_var: loopback0_address
  ignore_errors: "{{ eos_validate_state_validation_mode_loose }}"
  when: |
    (loopback0_reachability.loopback0_range is defined and loopback0_reachability.loopback0_range is not none) and
    (loopback_interfaces.Loopback0.ip_address is defined and loopback_interfaces.Loopback0.ip_address is not none)
  register: loopback0_reachability_state
  tags:
    - loopback0_reachability
```
with
```
- name: Gather ip reachability state between devices (loopback0 <-> loopback0)
  eos_command:
    commands: "ping {{ loopback0_address | ipaddr('address')}} source {{ loopback_interfaces.Loopback0.ip_address | ipaddr('address')}} repeat 1"
  loop: "{{ loopback0_reachability.loopback0_range }}"
  loop_control:
    loop_var: loopback0_address
  ignore_errors: "{{ eos_validate_state_validation_mode_loose }}"
  when: |
    (loopback0_reachability.loopback0_range is defined and loopback0_reachability.loopback0_range is not none) and
    (loopback_interfaces.Loopback0.ip_address is defined and loopback_interfaces.Loopback0.ip_address is not none) and
    (type is defined and type != "l2leaf")
  register: loopback0_reachability_state
  tags:
    - loopback0_reachability

```
## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
run the role eos_validate_state with  `--tags loopback0_reachability` and verify l2leaf are skept 
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
