### PR TITLE
L2leaf inband management

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/cvp/cv_server.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/cvp/cv_server.yml
@@ -30,6 +30,24 @@ CVP_DEVICES:
     configlets:
       - AVD_DC1-SPINE4
     imageBundle: []
+  DC1-L2LEAF1A:
+    name: DC1-L2LEAF1A
+    parentContainerName: DC1_L2LEAF1
+    configlets:
+      - AVD_DC1-L2LEAF1A
+    imageBundle: []
+  DC1-L2LEAF2A:
+    name: DC1-L2LEAF2A
+    parentContainerName: DC1_L2LEAF2
+    configlets:
+      - AVD_DC1-L2LEAF2A
+    imageBundle: []
+  DC1-L2LEAF2B:
+    name: DC1-L2LEAF2B
+    parentContainerName: DC1_L2LEAF2
+    configlets:
+      - AVD_DC1-L2LEAF2B
+    imageBundle: []
   DC1-LEAF2A:
     name: DC1-LEAF2A
     parentContainerName: DC1_LEAF2
@@ -53,24 +71,6 @@ CVP_DEVICES:
     parentContainerName: DC1_BL1
     configlets:
       - AVD_DC1-BL1B
-    imageBundle: []
-  DC1-L2LEAF1A:
-    name: DC1-L2LEAF1A
-    parentContainerName: DC1_L2LEAF1
-    configlets:
-      - AVD_DC1-L2LEAF1A
-    imageBundle: []
-  DC1-L2LEAF2A:
-    name: DC1-L2LEAF2A
-    parentContainerName: DC1_L2LEAF2
-    configlets:
-      - AVD_DC1-L2LEAF2A
-    imageBundle: []
-  DC1-L2LEAF2B:
-    name: DC1-L2LEAF2B
-    parentContainerName: DC1_L2LEAF2
-    configlets:
-      - AVD_DC1-L2LEAF2B
     imageBundle: []
 CVP_CONTAINERS:
   DC1_FABRIC:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -913,6 +913,8 @@ vlan_interfaces:
       preempt_delay_minimum: < minimum_preemption_delay >
       ipv4: < virtual_ip_address >
       ipv6: < virtual_ip_address >
+    ip_attached_host_route_export:
+      distance: < distance >
 < Vlan_id_2 >:
     description: < description >
     ip_address: < IPv4_address/Mask >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
@@ -149,5 +149,8 @@ interface {{ vlan_interface }}
 {%             endif %}
 {%           endif %}
 {%         endif %}
+{%         if vlan_interfaces[vlan_interface].ip_attached_host_route_export is defined and vlan_interfaces[vlan_interface].ip_attached_host_route_export is not none %}
+   ip attached-host route export {{ vlan_interfaces[vlan_interface].ip_attached_host_route_export.distance | arista.avd.default("") }}
+{%         endif %}
 {%     endfor %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
@@ -362,6 +362,21 @@ bfd_multihop:
   interval: < | default -> 300 >
   min_rx: < | default -> 300 >
   multiplier: < | default -> 3 >
+
+# Optional IP subnet assigned to Inband Management SVI on l2leafs in default VRF.
+# Parent l3leafs will have SVI with "ip virtual-router" and host-route injection based on ARP. This allows all l3leafs to reuse the same subnet
+# SVI IP address will be assigned as follows:
+# virtual-router: <subnet> + 1
+# l3leaf A      : <subnet> + 2 (same IP on all l3leaf A)
+# l3leaf B      : <subnet> + 3 (same IP on all l3leaf B)
+# l2leafs       : <subnet> + 3 + <l2leaf id>
+# GW on l2leafs : <subnet> + 1
+# Assign range larger than total l2leafs + 5
+l2leaf_inband_management_subnet: < IPv4_network/Mask >
+
+# VLAN number assigned to Inband Management SVI on l2leafs in default VRF.
+# Optional - default -> 4092
+l2leaf_inband_management_vlan: < vlan_id >
 ```
 
 **Example:**

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l2leaf-yml.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l2leaf-yml.j2
@@ -252,6 +252,9 @@ vlans:
 {# mlag VLANs #}
 {% include 'fabric/mlag/leaf-mlag-vlans.j2' %}
 
+{# L2leaf Inband Management VLAN #}
+{% include 'l3leaf_l2leafs_uplinks/leaf-l2leaf-inband-management-vlan.j2' %}
+
 {# Tenants L2 VLANs #}
 {% include 'tenant_evpn_vxlan/leaf-tenant-vlans.j2' %}
 
@@ -285,6 +288,8 @@ ethernet_interfaces:
 ### Management Interfaces ###
 management_interfaces:
 {% include 'base/mgmt-interface.j2' %}
+{# L2leaf Inband Management VLAN interfaces #}
+{% include 'l3leaf_l2leafs_uplinks/leaf-l2leaf-inband-management-vlan-interfaces.j2' %}
 
 {# vlan interfaces #}
 ### VLAN Interfaces ###

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l3leaf-yml.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l3leaf-yml.j2
@@ -363,6 +363,9 @@ vlans:
 {# mlag VLANs #}
 {% include 'fabric/mlag/leaf-mlag-vlans.j2' %}
 
+{# L2leaf Inband Management VLAN #}
+{% include 'l3leaf_l2leafs_uplinks/leaf-l2leaf-inband-management-vlan.j2' %}
+
 {# Tenants L2 VLANs #}
 {% include 'tenant_evpn_vxlan/leaf-tenant-vlans.j2' %}
 
@@ -427,6 +430,8 @@ management_interfaces:
 vlan_interfaces:
 {# mlag vlan interfaces #}
 {% include 'fabric/mlag/leaf-mlag-vlan-interfaces.j2' %}
+{# L2leaf Inband Management VLAN interfaces #}
+{% include 'l3leaf_l2leafs_uplinks/leaf-l2leaf-inband-management-vlan-interfaces.j2' %}
 {# Tenant vlan interfaces #}
 {% include 'tenant_evpn_vxlan/leaf-tenant-vlan-interfaces.j2' %}
 

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/bgp_base/leaf-prefix-lists.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/bgp_base/leaf-prefix-lists.j2
@@ -6,4 +6,10 @@
         action: "permit {{ overlay_loopback_network_summary }} eq 32"
       20:
         action: "permit {{ vtep_loopback_network_summary }} eq 32"
+{%     if l2leaf_inband_management_subnet is defined and l2leaf_inband_management_subnet is not none %}
+  PL-L2LEAF-INBAND-MGMT:
+    sequence_numbers:
+      10:
+        action: "permit {{ l2leaf_inband_management_subnet }}"
+{%     endif %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/bgp_base/route-maps.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/bgp_base/route-maps.j2
@@ -6,6 +6,12 @@
         type: permit
         match:
           - "ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY"
+{%     if type == "l3leaf" and l2leaf_inband_management_subnet is defined and l2leaf_inband_management_subnet is not none %}
+      20:
+        type: permit
+        match:
+          - "ip address prefix-list PL-L2LEAF-INBAND-MGMT"
+{%     endif %}
 {% endif %}
 {# Leaf route-maps for the overlay#}
 {% if switch.overlay_routing_protocol == "ibgp" %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/ebgp_underlay/leaf-router-bgp-redistribute-routes.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/ebgp_underlay/leaf-router-bgp-redistribute-routes.j2
@@ -3,5 +3,8 @@
 {%     if switch.underlay_routing_protocol == 'ebgp' %}
     connected:
       route_map: RM-CONN-2-BGP
+{%         if l2leaf_inband_management_subnet is defined and l2leaf_inband_management_subnet is not none %}
+    attached-host:
+{%         endif %}
 {%     endif %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/l3leaf_l2leafs_uplinks/leaf-l2leaf-inband-management-vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/l3leaf_l2leafs_uplinks/leaf-l2leaf-inband-management-vlan-interfaces.j2
@@ -1,0 +1,20 @@
+{# L2leaf Inband Management VLAN interfaces #}
+{% if l2leaf_inband_management_subnet is defined and l2leaf_inband_management_subnet is not none %}
+  Vlan{{ l2leaf_inband_management_vlan|arista.avd.default('4092') }}:
+    description: L2LEAF_INBAND_MGMT
+    shutdown: false
+    mtu: {{ p2p_uplinks_mtu }}
+{%     if type == 'l3leaf' %}
+{%         if leaf.mlag == true and leaf.mlag_role == 'secondary' %}
+    ip_address: {{ l2leaf_inband_management_subnet | ipaddr('network') | ipmath(3) }}/{{ l2leaf_inband_management_subnet | ipaddr('prefix') }}
+{%         else %}
+    ip_address: {{ l2leaf_inband_management_subnet | ipaddr('network') | ipmath(2) }}/{{ l2leaf_inband_management_subnet | ipaddr('prefix') }}
+{%         endif %}
+    ip_virtual_router_address: {{ l2leaf_inband_management_subnet | ipaddr('network') | ipmath(1) }}
+    ip_attached_host_route_export:
+      distance: 19
+{%     elif type == 'l2leaf' %}
+    ip_address: {{ l2leaf_inband_management_subnet | ipaddr('network') | ipmath(3 + leaf.id) }}/{{ l2leaf_inband_management_subnet | ipaddr('prefix') }}
+    gateway: {{ l2leaf_inband_management_subnet | ipaddr('network') | ipmath(1) }}
+{%     endif %}
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/l3leaf_l2leafs_uplinks/leaf-l2leaf-inband-management-vlan.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/l3leaf_l2leafs_uplinks/leaf-l2leaf-inband-management-vlan.j2
@@ -1,0 +1,5 @@
+{# L2leaf Inband Management VLAN #}
+{% if l2leaf_inband_management_subnet is defined and l2leaf_inband_management_subnet is not none %}
+  {{ l2leaf_inband_management_vlan|arista.avd.default('4092') }}:
+    name: L2LEAF_INBAND_MGMT
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/routing/static-routes.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/routing/static-routes.j2
@@ -11,3 +11,9 @@
     destination_address_prefix: 0.0.0.0/0
     gateway: {{ mgmt_gateway }}
 {% endif %}
+{% if type == 'l2leaf' %}
+{%     if l2leaf_inband_management_subnet is defined and l2leaf_inband_management_subnet is not none %}
+  - destination_address_prefix: 0.0.0.0/0
+    gateway: {{ l2leaf_inband_management_subnet | ipaddr('network') | ipmath(1) }}
+{%     endif %}
+{% endif %}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add support for inband management SVI on L2 Leaf switches.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [X] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #371 

## Component(s) name
eos_l3ls_evpn
eos_cli_config_gen

## Proposed changes
<!--- Describe your changes in detail -->
This enhancement will allow l2leafs to have a SVI in underlay used for management. All management configurations are still hardcoded to use the OOB mgmt interface.
- Upstream l3leafs will have SVI with ip virtual-router.
- A single Management IP scope will be assigned to cover all l2leafs per POD
- Same VLAN number will be used for all l2leafs per POD
- No vxlan configured for this vlan.
- Since we use the same Management IP scope but no VXLAN, we will need to inject host-routes on each l3leaf for the ARP entries locally to this leaf.
- Requires support for BGP redistribute attached-hosts in eos_cli_config_gen - OK!
- Requires support for SVI export attached-hosts in eos_cli_config_gen
   - ip_attached_host_route_export:<br>distance: 19
   - CLI: ip attached-host route export 19
   - Distance should be lower than ebgp.
- SVI on l2leaf will also be useful for sflow export to TerminAttr since sflow requires a source interface in default vrf.

I investigated using separate ip scopes per l3leaf pair but we would need a new “id” counter per l3leaf pair to offset the IP addresses correctly. By using a single scope we can use the unique “id” already assigned on l2leafs to offset the SVI IP. Only caveat is that l2leaf cannot communicate with another l2leaf on a different l3leaf pair (would require proxy-ARP on l3leaf)

### New L3LS variables
```yaml
# Optional IP subnet assigned to Inband Management SVI on l2leafs in default VRF.
# Parent l3leafs will have SVI with "ip virtual-router" and host-route injection based on ARP. This allows all l3leafs to reuse the same subnet
# SVI IP address will be assigned as follows:
# virtual-router: <subnet> + 1
# l3leaf A      : <subnet> + 2 (same IP on all l3leaf A)
# l3leaf B      : <subnet> + 3 (same IP on all l3leaf B)
# l2leafs       : <subnet> + 3 + <l2leaf id>
# GW on l2leafs : <subnet> + 1
# Assign range larger than total l2leafs + 5
l2leaf_inband_management_subnet: < IPv4_network/Mask >

# VLAN number assigned to Inband Management SVI on l2leafs in default VRF.
# Optional - default -> 4092
l2leaf_inband_management_vlan: < vlan_id >
```

### New Config_gen variables
```yaml
vlan_interfaces:
  < Vlan_id_1 >:
    <...>
    ip_attached_host_route_export:
      distance: < distance >
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Tested using my test repo https://github.com/ClausHolbechArista/claus-l3ls-dev/tree/superspine-alternative 
- Tested with and without specifying vlan number.
- Tested only adding inband management to one POD.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
- [X] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
