### PR TITLE
Add routing table tests in eos_validate_state role (lo0 and lo1 addresses check)

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_validate_state/README.md
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/README.md
@@ -66,7 +66,7 @@ Figure 1 below provides a visualization of the roles inputs, and outputs and tas
    - ([bgp_check](tasks/bgp_check.yml)) Validate ArBGP is configured and operating.
    - ([bgp_check](tasks/bgp_check.yml)) Validate ip bgp and bgp evpn sessions state.
    - ([reload_cause](tasks/reload_cause.yml)) Validate last reload cause. (Optional)
-   - ([routing_table](tasks/routing_table)) Validate remote Lo0 addresses and remote Lo1 addresses are in the routing table (based on devices type).
+   - ([routing_table](tasks/routing_table.yml)) Validate remote Lo0 addresses and remote Lo1 addresses are in the routing table (based on devices type).
 
 3. Create CSV report.
 4. Read CSV file (leveraged to generate summary report).

--- a/ansible_collections/arista/avd/roles/eos_validate_state/README.md
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/README.md
@@ -66,6 +66,7 @@ Figure 1 below provides a visualization of the roles inputs, and outputs and tas
    - ([bgp_check](tasks/bgp_check.yml)) Validate ArBGP is configured and operating.
    - ([bgp_check](tasks/bgp_check.yml)) Validate ip bgp and bgp evpn sessions state.
    - ([reload_cause](tasks/reload_cause.yml)) Validate last reload cause. (Optional)
+   - ([routing_table](tasks/routing_table)) Validate remote Lo0 addresses and remote Lo1 addresses are in the routing table (based on devices type).
 
 3. Create CSV report.
 4. Read CSV file (leveraged to generate summary report).

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/loopback1_reachability.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/loopback1_reachability.yml
@@ -1,0 +1,42 @@
+---
+
+- name: run show ip route lo1
+  eos_command:
+  #   commands: "show ip route {{ loopback1_address | ipaddr('address')}} | json"
+    commands: "show ip route {{ loopback1_address }}"
+  loop: "{{ loopback1_reachability.loopback1_range }}"
+  loop_control:
+    loop_var: loopback1_address
+  ignore_errors: "{{ eos_validate_state_validation_mode_loose }}"
+  when: |
+    (loopback1_reachability.loopback1_range is defined and loopback1_reachability.loopback1_range is not none) and
+    (type is defined and type == "l3leaf")
+  register: loopback1_reachability_state
+  tags:
+    - loopback1_reachability
+
+# - name: test
+#   debug:
+#    msg: "{{ loopback1_reachability_test['stdout'][0]['vrfs']['default']['routes'] }}"
+#   loop: "{{ loopback1_reachability_state.results }}"
+#   loop_control:
+#     loop_var: loopback1_reachability_test
+#   tags:
+#     - loopback1_reachability
+#   when: ( loopback1_reachability_test.skipped is not defined )
+
+- name: Validate lo1 is in routing table
+  assert:
+    that:
+ #     - loopback1_reachability_test['stdout'][0]['vrfs']['default']['routes'] | ipaddr('address') == loopback1_reachability_test.loopback1_address
+      - loopback1_reachability_test['stdout'][0] | regex_search(loopback1_reachability_test.loopback1_address)
+    fail_msg: "lo1 not in routing table"
+    quiet: true
+  loop: "{{ loopback1_reachability_state.results }}"
+  loop_control:
+    loop_var: loopback1_reachability_test
+  ignore_errors: "{{ eos_validate_state_validation_mode_loose }}"
+  when: ( loopback1_reachability_test.skipped is not defined )
+  register: loopback1_reachability_results
+  tags:
+    - loopback1_reachability

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/main.yml
@@ -103,6 +103,11 @@
   tags:
     - loopback0_reachability
 
+- name: Validate loopback1 reachability
+  include_tasks: "loopback1_reachability.yml"
+  tags:
+    - loopback1_reachability
+
   ####################################
   ##       Validation Reports       ##
   ####################################

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/main.yml
@@ -98,15 +98,15 @@
     - optional
     - never
 
+- name: Validate routing table
+  include_tasks: "routing_table.yml"
+  tags:
+    - routing_table
+
 - name: Validate loopback0 reachability
   include_tasks: "loopback0_reachability.yml"
   tags:
     - loopback0_reachability
-
-- name: Validate loopback1 reachability
-  include_tasks: "loopback1_reachability.yml"
-  tags:
-    - loopback1_reachability
 
   ####################################
   ##       Validation Reports       ##

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/main.yml
@@ -108,6 +108,15 @@
   tags:
     - loopback0_reachability
 
+- name: Remove generated vars for testing
+  file:
+    path: "{{ eos_validate_state_dir }}/validate_state_vars.yml"
+    state: absent
+  delegate_to: localhost
+  run_once: true
+  tags:
+    - always
+
   ####################################
   ##       Validation Reports       ##
   ####################################

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/routing_table.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/routing_table.yml
@@ -10,21 +10,50 @@
   when: |
     (loopback1_reachability.loopback1_range is defined and loopback1_reachability.loopback1_range is not none) and
     (type is defined and type == "l3leaf")
-  register: loopback1_reachability_state
+  register: routing_table_loopback1_state
   tags:
-    - loopback1_reachability
+    - routing_table_check
 
 - name: Validate lo1 is in routing table
   assert:
     that:
       - loopback1_reachability_test['stdout'][0] | regex_search(loopback1_reachability_test.loopback1_address)
-    fail_msg: "{{ loopback1_reachability_test.loopback1_address }} is not in the routing table"
+    fail_msg: "Lo1 {{ loopback1_reachability_test.loopback1_address }} is not in the routing table"
     quiet: true
-  loop: "{{ loopback1_reachability_state.results }}"
+  loop: "{{ routing_table_loopback1_state.results }}"
   loop_control:
     loop_var: loopback1_reachability_test
   ignore_errors: "{{ eos_validate_state_validation_mode_loose }}"
   when: ( loopback1_reachability_test.skipped is not defined )
-  register: loopback1_reachability_results
+  register: routing_table_loopback1_results
   tags:
-    - loopback1_reachability
+    - routing_table_check
+
+- name: run show ip route lo0
+  eos_command:
+    commands: "show ip route {{ loopback0_address }}"
+  loop: "{{ loopback0_reachability.loopback0_range }}"
+  loop_control:
+    loop_var: loopback0_address
+  ignore_errors: "{{ eos_validate_state_validation_mode_loose }}"
+  when: |
+    (loopback0_reachability.loopback0_range is defined and loopback0_reachability.loopback0_range is not none) and
+    (type is defined and type != "l2leaf")
+  register: routing_table_loopback0_state
+  tags:
+    - routing_table_check
+
+- name: Validate lo0 is in routing table
+  assert:
+    that:
+      - routing_table_loopback0_test['stdout'][0] | regex_search(routing_table_loopback0_test.loopback0_address)
+    fail_msg: "Lo0 {{ routing_table_loopback0_test.loopback0_address }} is not in the routing table"
+    quiet: true
+  loop: "{{ routing_table_loopback0_state.results }}"
+  loop_control:
+    loop_var: routing_table_loopback0_test
+  ignore_errors: "{{ eos_validate_state_validation_mode_loose }}"
+  when: ( routing_table_loopback0_test.skipped is not defined )
+  register: routing_table_loopback0_results
+  tags:
+    - routing_table_check

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/routing_table.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/routing_table.yml
@@ -2,7 +2,6 @@
 
 - name: run show ip route lo1
   eos_command:
-  #   commands: "show ip route {{ loopback1_address | ipaddr('address')}} | json"
     commands: "show ip route {{ loopback1_address }}"
   loop: "{{ loopback1_reachability.loopback1_range }}"
   loop_control:
@@ -15,22 +14,11 @@
   tags:
     - loopback1_reachability
 
-# - name: test
-#   debug:
-#    msg: "{{ loopback1_reachability_test['stdout'][0]['vrfs']['default']['routes'] }}"
-#   loop: "{{ loopback1_reachability_state.results }}"
-#   loop_control:
-#     loop_var: loopback1_reachability_test
-#   tags:
-#     - loopback1_reachability
-#   when: ( loopback1_reachability_test.skipped is not defined )
-
 - name: Validate lo1 is in routing table
   assert:
     that:
- #     - loopback1_reachability_test['stdout'][0]['vrfs']['default']['routes'] | ipaddr('address') == loopback1_reachability_test.loopback1_address
       - loopback1_reachability_test['stdout'][0] | regex_search(loopback1_reachability_test.loopback1_address)
-    fail_msg: "lo1 not in routing table"
+    fail_msg: "{{ loopback1_reachability_test.loopback1_address }} is not in the routing table"
     quiet: true
   loop: "{{ loopback1_reachability_state.results }}"
   loop_control:

--- a/ansible_collections/arista/avd/roles/eos_validate_state/templates/generate_vars_for_testing.j2
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/templates/generate_vars_for_testing.j2
@@ -9,3 +9,15 @@
 {% endfor %}
 loopback0_reachability:
   loopback0_range: {{ address | unique }}
+
+{# loopback1 reachability test #}
+{% set address = [] %}
+{% for node in groups[fabric_name] | arista.avd.natural_sort %}
+{%     if hostvars[node].type == 'l3leaf' %}
+{%         if hostvars[node].loopback_interfaces.Loopback1.ip_address is defined and hostvars[node].loopback_interfaces.Loopback1.ip_address is not none %}
+{%             do address.append(hostvars[node].loopback_interfaces.Loopback1.ip_address | ipaddr('address')) %}
+{%         endif %}
+{%     endif %}
+{% endfor %}
+loopback1_reachability:
+  loopback1_range: {{ address | unique }}

--- a/ansible_collections/arista/avd/roles/eos_validate_state/templates/validate_state_report-csv.j2
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/templates/validate_state_report-csv.j2
@@ -179,11 +179,23 @@ test_id,node,test_category,test_description,test,result,failure_reason
 {% endfor %}
 {# Routing table check: loopback1 Results #}
 {% for node in groups[fabric_name] | arista.avd.natural_sort %}
-{%     if hostvars[node].loopback1_reachability_results is defined and hostvars[node].loopback1_reachability_results.results is defined %}
-{%         for result in hostvars[node].loopback1_reachability_results.results %}
+{%     if hostvars[node].routing_table_loopback1_results is defined and hostvars[node].routing_table_loopback1_results.results is defined %}
+{%         for result in hostvars[node].routing_table_loopback1_results.results %}
 {%             if result.skipped is not defined %}
 {%                 set test_id.value = test_id.value + 1 %}
-{{ test_id.value }},{{ node }},Routing Table,Remote Lo1 address in routing table,{{ result.loopback1_reachability_test.loopback1_address }},{% if result.failed == false %}PASS{% else %}FAIL,{{ result.msg }}{% endif %}
+{{ test_id.value }},{{ node }},Routing Table,Remote Lo1 address,{{ result.loopback1_reachability_test.loopback1_address }},{% if result.failed == false %}PASS{% else %}FAIL,{{ result.msg }}{% endif %}
+
+{%             endif %}
+{%         endfor %}
+{%    endif %}
+{% endfor %}
+{# Routing table check: loopback0 Results #}
+{% for node in groups[fabric_name] | arista.avd.natural_sort %}
+{%     if hostvars[node].routing_table_loopback0_results is defined and hostvars[node].routing_table_loopback0_results.results is defined %}
+{%         for result in hostvars[node].routing_table_loopback0_results.results %}
+{%             if result.skipped is not defined %}
+{%                 set test_id.value = test_id.value + 1 %}
+{{ test_id.value }},{{ node }},Routing Table,Remote Lo0 address,{{ result.routing_table_loopback0_test.loopback0_address }},{% if result.failed == false %}PASS{% else %}FAIL,{{ result.msg }}{% endif %}
 
 {%             endif %}
 {%         endfor %}

--- a/ansible_collections/arista/avd/roles/eos_validate_state/templates/validate_state_report-csv.j2
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/templates/validate_state_report-csv.j2
@@ -177,6 +177,18 @@ test_id,node,test_category,test_description,test,result,failure_reason
 
 {%    endif %}
 {% endfor %}
+{# Routing table check: loopback1 Results #}
+{% for node in groups[fabric_name] | arista.avd.natural_sort %}
+{%     if hostvars[node].loopback1_reachability_results is defined and hostvars[node].loopback1_reachability_results.results is defined %}
+{%         for result in hostvars[node].loopback1_reachability_results.results %}
+{%             if result.skipped is not defined %}
+{%                 set test_id.value = test_id.value + 1 %}
+{{ test_id.value }},{{ node }},Routing Table,Remote Lo1 address in routing table,{{ result.loopback1_reachability_test.loopback1_address }},{% if result.failed == false %}PASS{% else %}FAIL,{{ result.msg }}{% endif %}
+
+{%             endif %}
+{%         endfor %}
+{%    endif %}
+{% endfor %}
 {# loopback0 reachability Results #}
 {% for node in groups[fabric_name] | arista.avd.natural_sort %}
 {%     if hostvars[node].loopback0_reachability_results is defined and hostvars[node].loopback0_reachability_results.results is defined %}


### PR DESCRIPTION
## Change Summary

Add routing table tests in eos_validate_state role (to check if lo0 and lo1 addresses are in the routing table). 
This is based on devices type.  
This task can be extended to test others IP destination.

 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [x] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
 fixes #560 
## Component(s) name

update roles `eos_validate_state`
- create task routing_table.yml  
- update task main.yml  
- update readme 
- update template generate_vars_for_testing.j2 
- update template validate_state_report-csv.j2 

## How to test

run the role `eos_validate_state` with a working fabric. 
break somnething (routing on a device) and re-run the role `eos_validate_state` (you will see errors reported)   
 
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
