### PR TITLE
BUGFIX: Add Inband management vlan to L2Leaf uplinks

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/l3leaf_l2leafs_uplinks/l2leaf-port-channel-uplinks.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/l3leaf_l2leafs_uplinks/l2leaf-port-channel-uplinks.j2
@@ -19,11 +19,15 @@
 {%             else %}
 {%                 set parent_l3leafs = l2leaf.defaults.parent_l3leafs %}
 {%             endif %}
+{%             set uplink_vlans = leaf.vlans %}
+{%             if l2leaf_inband_management_subnet is defined and l2leaf_inband_management_subnet is not none %}
+{%                 do uplink_vlans.append ( l2leaf_inband_management_vlan | arista.avd.default(4092) | int ) %}
+{%             endif %}
   Port-Channel{{ channel_group_id }}:
     description: {{ parent_l3leafs[loop.index0]}}_{{ 'Po' + l3leaf.channel_group_id }}
     type: switched
     shutdown: false
-    vlans: {{ leaf.vlans | arista.avd.list_compress }}
+    vlans: {{ uplink_vlans | arista.avd.list_compress }}
     mode: trunk
 {%             if leaf.mlag == true %}
     mlag: {{ channel_group_id }}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/l3leaf_l2leafs_uplinks/l3leaf-port-channel-uplinks.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/l3leaf_l2leafs_uplinks/l3leaf-port-channel-uplinks.j2
@@ -32,6 +32,9 @@
 {%             endif %}
 {# Create allowed vlan lan list based on vlans being provisioned on L2 Leaf #}
 {%             set l2_leaf.vlans = []  %}
+{%             if l2leaf_inband_management_subnet is defined and l2leaf_inband_management_subnet is not none %}
+{%                 do l2_leaf.vlans.append ( l2leaf_inband_management_vlan | arista.avd.default(4092) | int ) %}
+{%             endif %}
 {%             for tenant in tenants | arista.avd.natural_sort if tenant in leaf.filter_tenants or "all" in leaf.filter_tenants %}
 {%                 if tenant in l2_leaf.filter_tenants or "all" in l2_leaf.filter_tenants %}
 {%                     if tenants[tenant].vrfs is defined %}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add Inband management vlan to L2Leaf uplinks

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #576 

## Component(s) name
eos_l3ls_evpn

## Proposed changes
<!--- Describe your changes in detail -->
Add l2leaf inband management vlan to uplink port-channel on l3leaf & l2leaf

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Tested with https://github.com/ClausHolbechArista/claus-l3ls-dev/tree/superspine-alternative
before and after the fix and port-channel allowed vlan changed from:
```yaml
port_channel_interfaces:
  Port-Channel1:
    vlans: 12,110-112,120-121,130-131
```
to:
```yaml
port_channel_interfaces:
  Port-Channel1:
    vlans: 12,110-112,120-121,130-131,4092
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
