### PR TITLE
Include optional prefix entry for vvtep under leaf to redistribute

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/bgp_base/leaf-prefix-lists.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/bgp_base/leaf-prefix-lists.j2
@@ -6,6 +6,10 @@
         action: "permit {{ overlay_loopback_network_summary }} eq 32"
       20:
         action: "permit {{ vtep_loopback_network_summary }} eq 32"
+{%     if vtep_vvtep_ip is defined and vtep_vvtep_ip is not none and leaf.evpn_services_l2_only == false %}
+      30:
+        action: "permit {{ vtep_vvtep_ip }}"
+{%     endif %}
 {%     if l2leaf_inband_management_subnet is defined and l2leaf_inband_management_subnet is not none %}
   PL-L2LEAF-INBAND-MGMT:
     sequence_numbers:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Make sure we redistribute the Lo1 secondary IP for VVTEP.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes #564 

## Component(s) name

leaf-prefix-lists.j2

```
      20:
        action: "permit {{ vtep_loopback_network_summary }} eq 32"
{%     if vtep_vvtep_ip is defined and vtep_vvtep_ip is not none and leaf.evpn_services_l2_only == false %}
      30:
        action: "permit {{ vtep_vvtep_ip }}"
{%     endif %}
```

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Test case in virtual env
```
node_groups:
    DC1_LEAF1:
      evpn_services_l2_only: true
      bgp_as: 65101
      nodes:
        DC1-LEAF1A:
          id: 1
    DC1_LEAF2:
      bgp_as: 65102
      nodes:
        DC1-LEAF2A:
          id: 3
```

Results with and without:

```
LEAF1A

interface Loopback1
   description VTEP_VXLAN_Tunnel_Source
   no shutdown
   ip address 192.168.254.3/32

ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
   seq 10 permit 192.168.255.0/24 eq 32
   seq 20 permit 192.168.254.0/24 eq 32
```

```
LEAF2A

interface Loopback1
   description VTEP_VXLAN_Tunnel_Source
   no shutdown
   ip address 192.168.254.5/32
   ip address 1.1.1.1/32 secondary

ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
   seq 10 permit 192.168.255.0/24 eq 32
   seq 20 permit 192.168.254.0/24 eq 32
   seq 30 permit 1.1.1.1/32
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
