### PR TITLE
Fix bug SS and Overlay C support bgp max-path/ecmp

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/bgp_base/overlay-controller-router-bgp-base.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/bgp_base/overlay-controller-router-bgp-base.j2
@@ -6,5 +6,11 @@
 {%     for bgp_default in overlay_controller_bgp_defaults %}
     - {{ bgp_default }}
 {%     endfor %}
+{%     if bgp_maximum_paths is defined and bgp_maximum_paths is not none and bgp_ecmp is defined and bgp_ecmp is not none %}
+    - maximum-paths {{ bgp_maximum_paths }} ecmp {{ bgp_ecmp }}
+{%     elif bgp_maximum_paths is defined and bgp_maximum_paths is not none %}
+    - maximum-paths {{ bgp_maximum_paths }}
+{%     else %}
     - maximum-paths {{ switch.remote_switches_interfaces | length }} ecmp {{ switch.remote_switches_interfaces | length }}
+{%     endif %}
 {% endif%}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/bgp_base/super-spine-router-bgp-base.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/bgp_base/super-spine-router-bgp-base.j2
@@ -1,10 +1,16 @@
-{# Spine router bgp base configuration #}
+{# Super-Spine router bgp base configuration #}
   as: {{ super_spine.bgp_as }}
   router_id: {{ super_spine_loopback_network_summary  | ipaddr('network') | ipmath(super_spine.nodes[inventory_hostname].id) }}
   bgp_defaults:
-{%    if super_spine_bgp_defaults is defined %}
-{%        for bgp_default in super_spine_bgp_defaults %}
+{%     if super_spine_bgp_defaults is defined %}
+{%         for bgp_default in super_spine_bgp_defaults %}
     - {{ bgp_default }}
-{%     endfor %}
+{%         endfor %}
+{%         if bgp_maximum_paths is defined and bgp_maximum_paths is not none and bgp_ecmp is defined and bgp_ecmp is not none %}
+    - maximum-paths {{ bgp_maximum_paths }} ecmp {{ bgp_ecmp }}
+{%         elif bgp_maximum_paths is defined and bgp_maximum_paths is not none %}
+    - maximum-paths {{ bgp_maximum_paths }}
+{%         else %}
     - maximum-paths {{ super_spine.nodes | length }} ecmp {{ super_spine.nodes | length }}
-{%    endif%}
+{%         endif %}
+{%     endif%}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

This fixes the bug so we factor in the Super Spine and Overlay Controller to configure bgp max-paths and ecmp

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes #537 

## Component(s) name
eos_l3ls_evpn

## Proposed changes
<!--- Describe your changes in detail -->

super-spine-router-bgp-base.j2

```
{%         if bgp_maximum_paths is defined and bgp_maximum_paths is not none and bgp_ecmp is defined and bgp_ecmp is not none %}
    - maximum-paths {{ bgp_maximum_paths }} ecmp {{ bgp_ecmp }}
{%         elif bgp_maximum_paths is defined and bgp_maximum_paths is not none %}
    - maximum-paths {{ bgp_maximum_paths }}
{%         else %}
    - maximum-paths {{ super_spine.nodes | length }} ecmp {{ super_spine.nodes | length }}
{%         endif %}
```

overlay-controller-router-bgp-base.j2

```
{%         if bgp_maximum_paths is defined and bgp_maximum_paths is not none and bgp_ecmp is defined and bgp_ecmp is not none %}
    - maximum-paths {{ bgp_maximum_paths }} ecmp {{ bgp_ecmp }}
{%         elif bgp_maximum_paths is defined and bgp_maximum_paths is not none %}
    - maximum-paths {{ bgp_maximum_paths }}
{%         else %}
    - maximum-paths {{ switch.remote_switches_interfaces | length }} ecmp {{ switch.remote_switches_interfaces | length }}
{%         endif %}
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Default takes into account the math, if we use the knobs, we override the math

bgp_maximum_paths: 4
bgp_ecmp: 4

Super Spine

```
router bgp 65001
   router-id 192.168.100.1
   no bgp default ipv4-unicast
   distance bgp 20 200 200
   graceful-restart restart-time 300
   graceful-restart
   maximum-paths 4 ecmp 4
```

Route Server

```
router bgp 65100
   router-id 172.32.250.1
   no bgp default ipv4-unicast
   distance bgp 20 200 200
   graceful-restart restart-time 300
   graceful-restart
   maximum-paths 4 ecmp 4
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
