### PR TITLE
Add qos_profile support to l3ls

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
@@ -377,6 +377,9 @@ l2leaf_inband_management_subnet: < IPv4_network/Mask >
 # VLAN number assigned to Inband Management SVI on l2leafs in default VRF.
 # Optional - default -> 4092
 l2leaf_inband_management_vlan: < vlan_id >
+
+# QOS Profile assigned on all infrastructure links | Optional
+p2p_uplinks_qos_profile: < qos_profile_name >
 ```
 
 **Example:**
@@ -1234,6 +1237,9 @@ port_profiles:
     flowcontrol:
       received: < received | send | on >
 
+    # QOS Profile | Optional
+    qos_profile: < qos_profile_name >
+
   < port_profile_2 >:
     mode: < access | dot1q-tunnel | trunk >
     vlans: < vlans as string >
@@ -1281,6 +1287,9 @@ servers:
 
         # Port-profile name, to inherit configuration.
         profile: < port_profile_name >
+
+        # QOS Profile | Optional
+        qos_profile: < qos_profile_name >
 
       # Example of port-channel adpater
       - server_ports: [ < interface_name_1 > , < interface_name_2 >  ]

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/edge_ports/leaf-server-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/edge_ports/leaf-server-interfaces.j2
@@ -48,6 +48,9 @@
 {%                     endif %}
 {%                 endif %}
     profile: {{ adapter.profile }}
+{%                 if adapter.qos_profile | arista.avd.default(port_profiles[adapter.profile].qos_profile) is arista.avd.defined %}
+    service_profile: {{ adapter.qos_profile | arista.avd.default(port_profiles[adapter.profile].qos_profile) }}
+{%                 endif %}
 {%             endif %}
 {%         endfor %}
 {%     endfor %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/edge_ports/leaf-server-port-channels.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/edge_ports/leaf-server-port-channels.j2
@@ -34,6 +34,9 @@
 {%                     if port_profiles[adapter.profile].spanning_tree_bpdufilter is defined %}
     spanning_tree_bpdufilter: {{ port_profiles[adapter.profile].spanning_tree_bpdufilter }}
 {%                     endif %}
+{%                     if adapter.qos_profile | arista.avd.default(port_profiles[adapter.profile].qos_profile) is arista.avd.defined %}
+    service_profile: {{ adapter.qos_profile | arista.avd.default(port_profiles[adapter.profile].qos_profile) }}
+{%                     endif %}
 {%                 break %}
 {%                 endif %}
 {%             endfor %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/interfaces/leaf-p2p-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/interfaces/leaf-p2p-interfaces.j2
@@ -9,6 +9,9 @@
     speed: {{ leaf.p2p_link_interface_speed }}
 {%     endif %}
     mtu: {{ p2p_uplinks_mtu }}
+{%     if p2p_uplinks_qos_profile is arista.avd.defined %}
+    service_profile: {{ p2p_uplinks_qos_profile }}
+{%     endif %}
     type: routed
     shutdown: false
     ip_address: {{ underlay_p2p_network_summary | ipaddr('network') | ipmath(((leaf.id -1) * 2 * spine.nodes | length * max_l3leaf_to_spine_links ) + loop.index0 * 2 + 1) }}/31

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/interfaces/overlay-controller-p2p-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/interfaces/overlay-controller-p2p-interfaces.j2
@@ -10,6 +10,9 @@
     speed: {{ switch.p2p_link_interface_speed }}
 {%         endif %}
     mtu: {{ p2p_uplinks_mtu }}
+{%         if p2p_uplinks_qos_profile is arista.avd.defined %}
+    service_profile: {{ p2p_uplinks_qos_profile }}
+{%         endif %}
     type: routed
     shutdown: false
 {# TODO: Validate IP calculation if attached to L3LEAF or SUPER-SPINE #}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/interfaces/spine-p2p-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/interfaces/spine-p2p-interfaces.j2
@@ -28,6 +28,9 @@
     speed: {{ p2p_link_interface_speed }}
 {%                 endif %}
     mtu: {{ p2p_uplinks_mtu }}
+{%                 if p2p_uplinks_qos_profile is arista.avd.defined %}
+    service_profile: {{ p2p_uplinks_qos_profile }}
+{%                 endif %}
     type: routed
     shutdown: false
     ip_address: {{ underlay_p2p_network_summary | ipaddr('network') | ipmath(((l3leaf.node_groups[l3leaf_node_group].nodes[node].id -1) * 2 * spine.nodes | length * max_l3leaf_to_spine_links ) + loop.index0 * 2) }}/31
@@ -72,6 +75,9 @@
     speed: {{ p2p_link_interface_speed }}
 {%              endif %}
     mtu: {{ p2p_uplinks_mtu }}
+{%              if p2p_uplinks_qos_profile is arista.avd.defined %}
+    service_profile: {{ p2p_uplinks_qos_profile }}
+{%              endif %}
     type: routed
     shutdown: false
     ip_address: {{

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/interfaces/super-spine-p2p-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/interfaces/super-spine-p2p-interfaces.j2
@@ -22,6 +22,9 @@
     speed: {{ p2p_link_interface_speed }}
 {%             endif %}
     mtu: {{ p2p_uplinks_mtu }}
+{%             if p2p_uplinks_qos_profile is arista.avd.defined %}
+    service_profile: {{ p2p_uplinks_qos_profile }}
+{%             endif %}
     type: routed
     shutdown: false
     ip_address: {{

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/interfaces/switch-p2p-interfaces-overlay-controller.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/interfaces/switch-p2p-interfaces-overlay-controller.j2
@@ -29,6 +29,9 @@
     speed: {{ p2p_link_interface_speed }}
 {%                 endif %}
     mtu: {{ p2p_uplinks_mtu }}
+{%                 if p2p_uplinks_qos_profile is arista.avd.defined %}
+    service_profile: {{ p2p_uplinks_qos_profile }}
+{%                 endif %}
     type: routed
     shutdown: false
     ip_address: {{ overlay_controller_p2p_network_summary | ipaddr('network') | ipmath(((overlay_controller.nodes[overlay_controller_node].id -1) * 2 * overlay_controller_remote_switches | length * max_overlay_controller_to_switch_links ) + loop.index0 * 2) }}/31

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/mlag/leaf-mlag-peer-link.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/mlag/leaf-mlag-peer-link.j2
@@ -7,6 +7,9 @@
     shutdown: false
     vlans: "2-4094"
     mode: trunk
+{%     if p2p_uplinks_qos_profile is arista.avd.defined %}
+    service_profile: {{ p2p_uplinks_qos_profile }}
+{%     endif %}
     trunk_groups:
 {%     if type == 'l3leaf' %}
       - LEAF_PEER_L3

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/l3leaf_l2leafs_uplinks/l2leaf-port-channel-uplinks.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/l3leaf_l2leafs_uplinks/l2leaf-port-channel-uplinks.j2
@@ -29,6 +29,9 @@
     shutdown: false
     vlans: {{ uplink_vlans | arista.avd.list_compress }}
     mode: trunk
+{%             if p2p_uplinks_qos_profile is arista.avd.defined %}
+    service_profile: {{ p2p_uplinks_qos_profile }}
+{%             endif %}
 {%             if leaf.mlag == true %}
     mlag: {{ channel_group_id }}
 {%             endif %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/l3leaf_l2leafs_uplinks/l3leaf-port-channel-uplinks.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/l3leaf_l2leafs_uplinks/l3leaf-port-channel-uplinks.j2
@@ -74,6 +74,9 @@
     shutdown: false
     vlans: {{ l2_leaf.vlans | arista.avd.list_compress }}
     mode: trunk
+{%                 if p2p_uplinks_qos_profile is arista.avd.defined %}
+    service_profile: {{ p2p_uplinks_qos_profile }}
+{%                 endif %}
     mlag: {{ l3_leaf.channel_group_id }}
 {%             break %}
 {%             endfor %}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add support for assigning `qos_profile` to p2p links and server profiles and ports.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

## Component(s) name
eos_l3ls_evpn

## Proposed changes
<!--- Describe your changes in detail -->
Add group_vars:
```yaml
# QOS Profile assigned on all infrastructure links | Optional
p2p_uplinks_qos_profile: < qos_profile_name >

port_profiles:
  < port_profile_1 >:
    # QOS Profile | Optional
    qos_profile: < qos_profile_name >

servers:
  < server_1 >:
    adapters:
      - <...>
        # QOS Profile | Optional
        qos_profile: < qos_profile_name >
```

Assigning `qos_profile` on server adapter will override any `qos_profile` assigned under `port_profile`.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

https://github.com/ClausHolbechArista/claus-l3ls-dev/commit/3a499d708f574e4fb72a3a3305769adcf6b9cf9b

Test data:
```yaml
p2p_uplinks_qos_profile: blah
port_profiles:
  TENANT_A_OPZone:
    qos_profile: "foo"
  TENANT_A_ALL:
    qos_profile: "foo"
servers:

  server-1:
    rack: RackB
    adapters:
      - <...>
        profile: TENANT_A_OPZone
      - <...>
        profile: TENANT_A_ALL
        qos_profile: "bar"
        port_channel:
          state: present
          <...>
```
Verified structured config:
- [x] `blah` on all infrastructure links.
  - [x] super-spine to spine
  - [x] spine to leaf
  - [x] mlag peer-link port-channel
  - [x] l2leaf uplink port-channel
  - [x] l3leaf downlink to l2leaf port-channel
  - [x] route-server uplinks
- [x] `foo` on port with profile `TENANT_A_OPZone`
- [x] `bar`on port-channel to server-1
- [x] `bar`on member-ports to server-1 


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
