### PR TITLE
Updated QOS section in readme file

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -49,6 +49,7 @@
     - [Port-Channel Interfaces](#port-channel-interfaces)
     - [Ethernet Interfaces](#ethernet-interfaces)
     - [Loopback Interfaces](#loopback-interfaces)
+    - [Interface Defaults](#interface-defaults)
     - [Management Interfaces](#management-interfaces)
     - [VLAN Interfaces](#vlan-interfaces)
     - [VxLAN Interface](#vxlan-interface)
@@ -87,6 +88,8 @@
     - [Management Console](#management-console)
     - [Management Security](#management-security)
     - [Management SSH](#management-ssh)
+    - [QOS](#qos)
+    - [QOS Profiles](#qos-profiles)
     - [PTP](#ptp)
     - [Custom Templates](#custom-templates)
   - [License](#license)
@@ -1650,36 +1653,13 @@ qos:
       - "< tc_mapping_to_dscp >"
       - "< tc_mapping_to_tx_queue >"
   rewrite_dscp: < true | false >
-  qos_profiles:
-    < profile-1 >:
-      trust: < dscp or cos >
-      cos: < cos-value >
-      dscp: < dscp-value >
-      tx-queues:
-        < tx-queue-id >:
-          bandwidth_percent: < value >
-          priority: < string >
-        < tx-queue-id >:
-          bandwidth_percent: < value >
-          priority: < string >
-    < profile-2 >:
-      trust: < dscp or cos >
-      cos: < cos-value >
-      dscp: < dscp-value >
-      tx-queues:
-        < tx-queue-id >:
-          bandwidth_percent: < value >
-          priority: < string >
-        < tx-queue-id >:
-          bandwidth_percent: < value >
-          priority: < string >
 ```
 ### QOS Profiles
 
 ```yaml
 qos_profiles:
   < profile-1 >:
-    trust: < dscp or cos >
+    trust: < dscp | cos >
     cos: < cos-value >
     dscp: < dscp-value >
     tx-queues:
@@ -1690,7 +1670,7 @@ qos_profiles:
         bandwidth_percent: < value >
         priority: < string >
   < profile-2 >:
-    trust: < dscp or cos >
+    trust: < dscp | cos >
     cos: < cos-value >
     dscp: < dscp-value >
     tx-queues:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Bot will manage tag, ownership and code review, you should not update these fields-->
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

Trimmed the QOS section as it's now separated.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

## Component(s) name
eos_cli_config_gen

readme.md

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
