### PR TITLE
Fix incorrect send_community for underlay on spines

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE1.md
@@ -533,6 +533,7 @@ Router ISIS not defined
 | Settings | Value |
 | -------- | ----- |
 | Address Family | ipv4 |
+| Send community | true |
 | Maximum routes | 12000 |
 
 ### BGP Neighbors
@@ -579,6 +580,7 @@ router bgp 65001
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor 172.31.255.1 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.31.255.1 remote-as 65101

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE2.md
@@ -533,6 +533,7 @@ Router ISIS not defined
 | Settings | Value |
 | -------- | ----- |
 | Address Family | ipv4 |
+| Send community | true |
 | Maximum routes | 12000 |
 
 ### BGP Neighbors
@@ -579,6 +580,7 @@ router bgp 65001
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor 172.31.255.3 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.31.255.3 remote-as 65101

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE3.md
@@ -533,6 +533,7 @@ Router ISIS not defined
 | Settings | Value |
 | -------- | ----- |
 | Address Family | ipv4 |
+| Send community | true |
 | Maximum routes | 12000 |
 
 ### BGP Neighbors
@@ -579,6 +580,7 @@ router bgp 65001
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor 172.31.255.5 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.31.255.5 remote-as 65101

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE4.md
@@ -533,6 +533,7 @@ Router ISIS not defined
 | Settings | Value |
 | -------- | ----- |
 | Address Family | ipv4 |
+| Send community | true |
 | Maximum routes | 12000 |
 
 ### BGP Neighbors
@@ -579,6 +580,7 @@ router bgp 65001
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor 172.31.255.7 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.31.255.7 remote-as 65101

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SPINE1.cfg
@@ -108,6 +108,7 @@ router bgp 65001
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor 172.31.255.1 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.31.255.1 remote-as 65101

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SPINE2.cfg
@@ -108,6 +108,7 @@ router bgp 65001
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor 172.31.255.3 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.31.255.3 remote-as 65101

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SPINE3.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SPINE3.cfg
@@ -108,6 +108,7 @@ router bgp 65001
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor 172.31.255.5 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.31.255.5 remote-as 65101

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SPINE4.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SPINE4.cfg
@@ -108,6 +108,7 @@ router bgp 65001
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor 172.31.255.7 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.31.255.7 remote-as 65101

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE1.yml
@@ -163,6 +163,7 @@ router_bgp:
       peer_filter: LEAF-AS-RANGE
       password: AQQvKeimxJu+uGQ/yYvv9w==
       maximum_routes: 12000
+      send_community: true
     EVPN-OVERLAY-PEERS:
       type: evpn
       peer_filter: LEAF-AS-RANGE

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE2.yml
@@ -163,6 +163,7 @@ router_bgp:
       peer_filter: LEAF-AS-RANGE
       password: AQQvKeimxJu+uGQ/yYvv9w==
       maximum_routes: 12000
+      send_community: true
     EVPN-OVERLAY-PEERS:
       type: evpn
       peer_filter: LEAF-AS-RANGE

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE3.yml
@@ -163,6 +163,7 @@ router_bgp:
       peer_filter: LEAF-AS-RANGE
       password: AQQvKeimxJu+uGQ/yYvv9w==
       maximum_routes: 12000
+      send_community: true
     EVPN-OVERLAY-PEERS:
       type: evpn
       peer_filter: LEAF-AS-RANGE

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE4.yml
@@ -163,6 +163,7 @@ router_bgp:
       peer_filter: LEAF-AS-RANGE
       password: AQQvKeimxJu+uGQ/yYvv9w==
       maximum_routes: 12000
+      send_community: true
     EVPN-OVERLAY-PEERS:
       type: evpn
       peer_filter: LEAF-AS-RANGE

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/cvp/cv_server_configlets.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/cvp/cv_server_configlets.yml
@@ -754,30 +754,31 @@ CVP_CONFIGLETS:
     \ ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n\
     \   neighbor EVPN-OVERLAY-PEERS send-community\n   neighbor EVPN-OVERLAY-PEERS\
     \ maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS peer group\n   neighbor IPv4-UNDERLAY-PEERS\
-    \ password 7 AQQvKeimxJu+uGQ/yYvv9w==\n   neighbor IPv4-UNDERLAY-PEERS maximum-routes\
-    \ 12000\n   neighbor 172.31.255.1 peer group IPv4-UNDERLAY-PEERS\n   neighbor\
-    \ 172.31.255.1 remote-as 65101\n   neighbor 172.31.255.9 peer group IPv4-UNDERLAY-PEERS\n\
-    \   neighbor 172.31.255.9 remote-as 65102\n   neighbor 172.31.255.17 peer group\
-    \ IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.17 remote-as 65102\n   neighbor\
-    \ 172.31.255.25 peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.25 remote-as\
-    \ 65103\n   neighbor 172.31.255.33 peer group IPv4-UNDERLAY-PEERS\n   neighbor\
-    \ 172.31.255.33 remote-as 65103\n   neighbor 172.31.255.41 peer group IPv4-UNDERLAY-PEERS\n\
-    \   neighbor 172.31.255.41 remote-as 65104\n   neighbor 172.31.255.49 peer group\
-    \ IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.49 remote-as 65104\n   neighbor\
-    \ 192.168.255.5 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.5 remote-as\
-    \ 65101\n   neighbor 192.168.255.6 peer group EVPN-OVERLAY-PEERS\n   neighbor\
-    \ 192.168.255.6 remote-as 65102\n   neighbor 192.168.255.7 peer group EVPN-OVERLAY-PEERS\n\
-    \   neighbor 192.168.255.7 remote-as 65102\n   neighbor 192.168.255.8 peer group\
-    \ EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.8 remote-as 65103\n   neighbor 192.168.255.9\
-    \ peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.9 remote-as 65103\n \
-    \  neighbor 192.168.255.10 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.10\
-    \ remote-as 65104\n   neighbor 192.168.255.11 peer group EVPN-OVERLAY-PEERS\n\
-    \   neighbor 192.168.255.11 remote-as 65104\n   redistribute connected route-map\
-    \ RM-CONN-2-BGP\n   !\n   address-family evpn\n      neighbor EVPN-OVERLAY-PEERS\
-    \ activate\n      no neighbor IPv4-UNDERLAY-PEERS activate\n   !\n   address-family\
-    \ ipv4\n      no neighbor EVPN-OVERLAY-PEERS activate\n      neighbor IPv4-UNDERLAY-PEERS\
-    \ activate\n!\nmanagement api http-commands\n   no shutdown\n   !\n   vrf MGMT\n\
-    \      no shutdown\n!\nend"
+    \ password 7 AQQvKeimxJu+uGQ/yYvv9w==\n   neighbor IPv4-UNDERLAY-PEERS send-community\n\
+    \   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000\n   neighbor 172.31.255.1\
+    \ peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.1 remote-as 65101\n \
+    \  neighbor 172.31.255.9 peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.9\
+    \ remote-as 65102\n   neighbor 172.31.255.17 peer group IPv4-UNDERLAY-PEERS\n\
+    \   neighbor 172.31.255.17 remote-as 65102\n   neighbor 172.31.255.25 peer group\
+    \ IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.25 remote-as 65103\n   neighbor\
+    \ 172.31.255.33 peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.33 remote-as\
+    \ 65103\n   neighbor 172.31.255.41 peer group IPv4-UNDERLAY-PEERS\n   neighbor\
+    \ 172.31.255.41 remote-as 65104\n   neighbor 172.31.255.49 peer group IPv4-UNDERLAY-PEERS\n\
+    \   neighbor 172.31.255.49 remote-as 65104\n   neighbor 192.168.255.5 peer group\
+    \ EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.5 remote-as 65101\n   neighbor 192.168.255.6\
+    \ peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.6 remote-as 65102\n \
+    \  neighbor 192.168.255.7 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.7\
+    \ remote-as 65102\n   neighbor 192.168.255.8 peer group EVPN-OVERLAY-PEERS\n \
+    \  neighbor 192.168.255.8 remote-as 65103\n   neighbor 192.168.255.9 peer group\
+    \ EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.9 remote-as 65103\n   neighbor 192.168.255.10\
+    \ peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.10 remote-as 65104\n\
+    \   neighbor 192.168.255.11 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.11\
+    \ remote-as 65104\n   redistribute connected route-map RM-CONN-2-BGP\n   !\n \
+    \  address-family evpn\n      neighbor EVPN-OVERLAY-PEERS activate\n      no neighbor\
+    \ IPv4-UNDERLAY-PEERS activate\n   !\n   address-family ipv4\n      no neighbor\
+    \ EVPN-OVERLAY-PEERS activate\n      neighbor IPv4-UNDERLAY-PEERS activate\n!\n\
+    management api http-commands\n   no shutdown\n   !\n   vrf MGMT\n      no shutdown\n\
+    !\nend"
   AVD_DC1-SPINE2: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr\
     \ -ingestgrpcurl=192.168.200.11:9910 -cvcompression=gzip -ingestauth=key,telarista\
     \ -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent\
@@ -814,30 +815,31 @@ CVP_CONFIGLETS:
     \ ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n\
     \   neighbor EVPN-OVERLAY-PEERS send-community\n   neighbor EVPN-OVERLAY-PEERS\
     \ maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS peer group\n   neighbor IPv4-UNDERLAY-PEERS\
-    \ password 7 AQQvKeimxJu+uGQ/yYvv9w==\n   neighbor IPv4-UNDERLAY-PEERS maximum-routes\
-    \ 12000\n   neighbor 172.31.255.3 peer group IPv4-UNDERLAY-PEERS\n   neighbor\
-    \ 172.31.255.3 remote-as 65101\n   neighbor 172.31.255.11 peer group IPv4-UNDERLAY-PEERS\n\
-    \   neighbor 172.31.255.11 remote-as 65102\n   neighbor 172.31.255.19 peer group\
-    \ IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.19 remote-as 65102\n   neighbor\
-    \ 172.31.255.27 peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.27 remote-as\
-    \ 65103\n   neighbor 172.31.255.35 peer group IPv4-UNDERLAY-PEERS\n   neighbor\
-    \ 172.31.255.35 remote-as 65103\n   neighbor 172.31.255.43 peer group IPv4-UNDERLAY-PEERS\n\
-    \   neighbor 172.31.255.43 remote-as 65104\n   neighbor 172.31.255.51 peer group\
-    \ IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.51 remote-as 65104\n   neighbor\
-    \ 192.168.255.5 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.5 remote-as\
-    \ 65101\n   neighbor 192.168.255.6 peer group EVPN-OVERLAY-PEERS\n   neighbor\
-    \ 192.168.255.6 remote-as 65102\n   neighbor 192.168.255.7 peer group EVPN-OVERLAY-PEERS\n\
-    \   neighbor 192.168.255.7 remote-as 65102\n   neighbor 192.168.255.8 peer group\
-    \ EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.8 remote-as 65103\n   neighbor 192.168.255.9\
-    \ peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.9 remote-as 65103\n \
-    \  neighbor 192.168.255.10 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.10\
-    \ remote-as 65104\n   neighbor 192.168.255.11 peer group EVPN-OVERLAY-PEERS\n\
-    \   neighbor 192.168.255.11 remote-as 65104\n   redistribute connected route-map\
-    \ RM-CONN-2-BGP\n   !\n   address-family evpn\n      neighbor EVPN-OVERLAY-PEERS\
-    \ activate\n      no neighbor IPv4-UNDERLAY-PEERS activate\n   !\n   address-family\
-    \ ipv4\n      no neighbor EVPN-OVERLAY-PEERS activate\n      neighbor IPv4-UNDERLAY-PEERS\
-    \ activate\n!\nmanagement api http-commands\n   no shutdown\n   !\n   vrf MGMT\n\
-    \      no shutdown\n!\nend"
+    \ password 7 AQQvKeimxJu+uGQ/yYvv9w==\n   neighbor IPv4-UNDERLAY-PEERS send-community\n\
+    \   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000\n   neighbor 172.31.255.3\
+    \ peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.3 remote-as 65101\n \
+    \  neighbor 172.31.255.11 peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.11\
+    \ remote-as 65102\n   neighbor 172.31.255.19 peer group IPv4-UNDERLAY-PEERS\n\
+    \   neighbor 172.31.255.19 remote-as 65102\n   neighbor 172.31.255.27 peer group\
+    \ IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.27 remote-as 65103\n   neighbor\
+    \ 172.31.255.35 peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.35 remote-as\
+    \ 65103\n   neighbor 172.31.255.43 peer group IPv4-UNDERLAY-PEERS\n   neighbor\
+    \ 172.31.255.43 remote-as 65104\n   neighbor 172.31.255.51 peer group IPv4-UNDERLAY-PEERS\n\
+    \   neighbor 172.31.255.51 remote-as 65104\n   neighbor 192.168.255.5 peer group\
+    \ EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.5 remote-as 65101\n   neighbor 192.168.255.6\
+    \ peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.6 remote-as 65102\n \
+    \  neighbor 192.168.255.7 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.7\
+    \ remote-as 65102\n   neighbor 192.168.255.8 peer group EVPN-OVERLAY-PEERS\n \
+    \  neighbor 192.168.255.8 remote-as 65103\n   neighbor 192.168.255.9 peer group\
+    \ EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.9 remote-as 65103\n   neighbor 192.168.255.10\
+    \ peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.10 remote-as 65104\n\
+    \   neighbor 192.168.255.11 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.11\
+    \ remote-as 65104\n   redistribute connected route-map RM-CONN-2-BGP\n   !\n \
+    \  address-family evpn\n      neighbor EVPN-OVERLAY-PEERS activate\n      no neighbor\
+    \ IPv4-UNDERLAY-PEERS activate\n   !\n   address-family ipv4\n      no neighbor\
+    \ EVPN-OVERLAY-PEERS activate\n      neighbor IPv4-UNDERLAY-PEERS activate\n!\n\
+    management api http-commands\n   no shutdown\n   !\n   vrf MGMT\n      no shutdown\n\
+    !\nend"
   AVD_DC1-SPINE3: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr\
     \ -ingestgrpcurl=192.168.200.11:9910 -cvcompression=gzip -ingestauth=key,telarista\
     \ -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent\
@@ -874,30 +876,31 @@ CVP_CONFIGLETS:
     \ ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n\
     \   neighbor EVPN-OVERLAY-PEERS send-community\n   neighbor EVPN-OVERLAY-PEERS\
     \ maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS peer group\n   neighbor IPv4-UNDERLAY-PEERS\
-    \ password 7 AQQvKeimxJu+uGQ/yYvv9w==\n   neighbor IPv4-UNDERLAY-PEERS maximum-routes\
-    \ 12000\n   neighbor 172.31.255.5 peer group IPv4-UNDERLAY-PEERS\n   neighbor\
-    \ 172.31.255.5 remote-as 65101\n   neighbor 172.31.255.13 peer group IPv4-UNDERLAY-PEERS\n\
-    \   neighbor 172.31.255.13 remote-as 65102\n   neighbor 172.31.255.21 peer group\
-    \ IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.21 remote-as 65102\n   neighbor\
-    \ 172.31.255.29 peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.29 remote-as\
-    \ 65103\n   neighbor 172.31.255.37 peer group IPv4-UNDERLAY-PEERS\n   neighbor\
-    \ 172.31.255.37 remote-as 65103\n   neighbor 172.31.255.45 peer group IPv4-UNDERLAY-PEERS\n\
-    \   neighbor 172.31.255.45 remote-as 65104\n   neighbor 172.31.255.53 peer group\
-    \ IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.53 remote-as 65104\n   neighbor\
-    \ 192.168.255.5 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.5 remote-as\
-    \ 65101\n   neighbor 192.168.255.6 peer group EVPN-OVERLAY-PEERS\n   neighbor\
-    \ 192.168.255.6 remote-as 65102\n   neighbor 192.168.255.7 peer group EVPN-OVERLAY-PEERS\n\
-    \   neighbor 192.168.255.7 remote-as 65102\n   neighbor 192.168.255.8 peer group\
-    \ EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.8 remote-as 65103\n   neighbor 192.168.255.9\
-    \ peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.9 remote-as 65103\n \
-    \  neighbor 192.168.255.10 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.10\
-    \ remote-as 65104\n   neighbor 192.168.255.11 peer group EVPN-OVERLAY-PEERS\n\
-    \   neighbor 192.168.255.11 remote-as 65104\n   redistribute connected route-map\
-    \ RM-CONN-2-BGP\n   !\n   address-family evpn\n      neighbor EVPN-OVERLAY-PEERS\
-    \ activate\n      no neighbor IPv4-UNDERLAY-PEERS activate\n   !\n   address-family\
-    \ ipv4\n      no neighbor EVPN-OVERLAY-PEERS activate\n      neighbor IPv4-UNDERLAY-PEERS\
-    \ activate\n!\nmanagement api http-commands\n   no shutdown\n   !\n   vrf MGMT\n\
-    \      no shutdown\n!\nend"
+    \ password 7 AQQvKeimxJu+uGQ/yYvv9w==\n   neighbor IPv4-UNDERLAY-PEERS send-community\n\
+    \   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000\n   neighbor 172.31.255.5\
+    \ peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.5 remote-as 65101\n \
+    \  neighbor 172.31.255.13 peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.13\
+    \ remote-as 65102\n   neighbor 172.31.255.21 peer group IPv4-UNDERLAY-PEERS\n\
+    \   neighbor 172.31.255.21 remote-as 65102\n   neighbor 172.31.255.29 peer group\
+    \ IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.29 remote-as 65103\n   neighbor\
+    \ 172.31.255.37 peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.37 remote-as\
+    \ 65103\n   neighbor 172.31.255.45 peer group IPv4-UNDERLAY-PEERS\n   neighbor\
+    \ 172.31.255.45 remote-as 65104\n   neighbor 172.31.255.53 peer group IPv4-UNDERLAY-PEERS\n\
+    \   neighbor 172.31.255.53 remote-as 65104\n   neighbor 192.168.255.5 peer group\
+    \ EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.5 remote-as 65101\n   neighbor 192.168.255.6\
+    \ peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.6 remote-as 65102\n \
+    \  neighbor 192.168.255.7 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.7\
+    \ remote-as 65102\n   neighbor 192.168.255.8 peer group EVPN-OVERLAY-PEERS\n \
+    \  neighbor 192.168.255.8 remote-as 65103\n   neighbor 192.168.255.9 peer group\
+    \ EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.9 remote-as 65103\n   neighbor 192.168.255.10\
+    \ peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.10 remote-as 65104\n\
+    \   neighbor 192.168.255.11 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.11\
+    \ remote-as 65104\n   redistribute connected route-map RM-CONN-2-BGP\n   !\n \
+    \  address-family evpn\n      neighbor EVPN-OVERLAY-PEERS activate\n      no neighbor\
+    \ IPv4-UNDERLAY-PEERS activate\n   !\n   address-family ipv4\n      no neighbor\
+    \ EVPN-OVERLAY-PEERS activate\n      neighbor IPv4-UNDERLAY-PEERS activate\n!\n\
+    management api http-commands\n   no shutdown\n   !\n   vrf MGMT\n      no shutdown\n\
+    !\nend"
   AVD_DC1-SPINE4: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr\
     \ -ingestgrpcurl=192.168.200.11:9910 -cvcompression=gzip -ingestauth=key,telarista\
     \ -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent\
@@ -934,30 +937,31 @@ CVP_CONFIGLETS:
     \ ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n\
     \   neighbor EVPN-OVERLAY-PEERS send-community\n   neighbor EVPN-OVERLAY-PEERS\
     \ maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS peer group\n   neighbor IPv4-UNDERLAY-PEERS\
-    \ password 7 AQQvKeimxJu+uGQ/yYvv9w==\n   neighbor IPv4-UNDERLAY-PEERS maximum-routes\
-    \ 12000\n   neighbor 172.31.255.7 peer group IPv4-UNDERLAY-PEERS\n   neighbor\
-    \ 172.31.255.7 remote-as 65101\n   neighbor 172.31.255.15 peer group IPv4-UNDERLAY-PEERS\n\
-    \   neighbor 172.31.255.15 remote-as 65102\n   neighbor 172.31.255.23 peer group\
-    \ IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.23 remote-as 65102\n   neighbor\
-    \ 172.31.255.31 peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.31 remote-as\
-    \ 65103\n   neighbor 172.31.255.39 peer group IPv4-UNDERLAY-PEERS\n   neighbor\
-    \ 172.31.255.39 remote-as 65103\n   neighbor 172.31.255.47 peer group IPv4-UNDERLAY-PEERS\n\
-    \   neighbor 172.31.255.47 remote-as 65104\n   neighbor 172.31.255.55 peer group\
-    \ IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.55 remote-as 65104\n   neighbor\
-    \ 192.168.255.5 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.5 remote-as\
-    \ 65101\n   neighbor 192.168.255.6 peer group EVPN-OVERLAY-PEERS\n   neighbor\
-    \ 192.168.255.6 remote-as 65102\n   neighbor 192.168.255.7 peer group EVPN-OVERLAY-PEERS\n\
-    \   neighbor 192.168.255.7 remote-as 65102\n   neighbor 192.168.255.8 peer group\
-    \ EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.8 remote-as 65103\n   neighbor 192.168.255.9\
-    \ peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.9 remote-as 65103\n \
-    \  neighbor 192.168.255.10 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.10\
-    \ remote-as 65104\n   neighbor 192.168.255.11 peer group EVPN-OVERLAY-PEERS\n\
-    \   neighbor 192.168.255.11 remote-as 65104\n   redistribute connected route-map\
-    \ RM-CONN-2-BGP\n   !\n   address-family evpn\n      neighbor EVPN-OVERLAY-PEERS\
-    \ activate\n      no neighbor IPv4-UNDERLAY-PEERS activate\n   !\n   address-family\
-    \ ipv4\n      no neighbor EVPN-OVERLAY-PEERS activate\n      neighbor IPv4-UNDERLAY-PEERS\
-    \ activate\n!\nmanagement api http-commands\n   no shutdown\n   !\n   vrf MGMT\n\
-    \      no shutdown\n!\nend"
+    \ password 7 AQQvKeimxJu+uGQ/yYvv9w==\n   neighbor IPv4-UNDERLAY-PEERS send-community\n\
+    \   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000\n   neighbor 172.31.255.7\
+    \ peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.7 remote-as 65101\n \
+    \  neighbor 172.31.255.15 peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.15\
+    \ remote-as 65102\n   neighbor 172.31.255.23 peer group IPv4-UNDERLAY-PEERS\n\
+    \   neighbor 172.31.255.23 remote-as 65102\n   neighbor 172.31.255.31 peer group\
+    \ IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.31 remote-as 65103\n   neighbor\
+    \ 172.31.255.39 peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.39 remote-as\
+    \ 65103\n   neighbor 172.31.255.47 peer group IPv4-UNDERLAY-PEERS\n   neighbor\
+    \ 172.31.255.47 remote-as 65104\n   neighbor 172.31.255.55 peer group IPv4-UNDERLAY-PEERS\n\
+    \   neighbor 172.31.255.55 remote-as 65104\n   neighbor 192.168.255.5 peer group\
+    \ EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.5 remote-as 65101\n   neighbor 192.168.255.6\
+    \ peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.6 remote-as 65102\n \
+    \  neighbor 192.168.255.7 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.7\
+    \ remote-as 65102\n   neighbor 192.168.255.8 peer group EVPN-OVERLAY-PEERS\n \
+    \  neighbor 192.168.255.8 remote-as 65103\n   neighbor 192.168.255.9 peer group\
+    \ EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.9 remote-as 65103\n   neighbor 192.168.255.10\
+    \ peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.10 remote-as 65104\n\
+    \   neighbor 192.168.255.11 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.11\
+    \ remote-as 65104\n   redistribute connected route-map RM-CONN-2-BGP\n   !\n \
+    \  address-family evpn\n      neighbor EVPN-OVERLAY-PEERS activate\n      no neighbor\
+    \ IPv4-UNDERLAY-PEERS activate\n   !\n   address-family ipv4\n      no neighbor\
+    \ EVPN-OVERLAY-PEERS activate\n      neighbor IPv4-UNDERLAY-PEERS activate\n!\n\
+    management api http-commands\n   no shutdown\n   !\n   vrf MGMT\n      no shutdown\n\
+    !\nend"
   AVD_DC1-SVC3A: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr\
     \ -ingestgrpcurl=192.168.200.11:9910 -cvcompression=gzip -ingestauth=key,telarista\
     \ -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent\

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE1.md
@@ -533,6 +533,7 @@ Router ISIS not defined
 | Settings | Value |
 | -------- | ----- |
 | Address Family | ipv4 |
+| Send community | true |
 | Maximum routes | 12000 |
 
 ### BGP Neighbors
@@ -579,6 +580,7 @@ router bgp 65001
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor 172.31.255.1 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.31.255.1 remote-as 65101

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE2.md
@@ -533,6 +533,7 @@ Router ISIS not defined
 | Settings | Value |
 | -------- | ----- |
 | Address Family | ipv4 |
+| Send community | true |
 | Maximum routes | 12000 |
 
 ### BGP Neighbors
@@ -579,6 +580,7 @@ router bgp 65001
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor 172.31.255.3 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.31.255.3 remote-as 65101

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE3.md
@@ -533,6 +533,7 @@ Router ISIS not defined
 | Settings | Value |
 | -------- | ----- |
 | Address Family | ipv4 |
+| Send community | true |
 | Maximum routes | 12000 |
 
 ### BGP Neighbors
@@ -579,6 +580,7 @@ router bgp 65001
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor 172.31.255.5 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.31.255.5 remote-as 65101

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE4.md
@@ -533,6 +533,7 @@ Router ISIS not defined
 | Settings | Value |
 | -------- | ----- |
 | Address Family | ipv4 |
+| Send community | true |
 | Maximum routes | 12000 |
 
 ### BGP Neighbors
@@ -579,6 +580,7 @@ router bgp 65001
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor 172.31.255.7 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.31.255.7 remote-as 65101

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE1.cfg
@@ -108,6 +108,7 @@ router bgp 65001
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor 172.31.255.1 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.31.255.1 remote-as 65101

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE2.cfg
@@ -108,6 +108,7 @@ router bgp 65001
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor 172.31.255.3 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.31.255.3 remote-as 65101

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE3.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE3.cfg
@@ -108,6 +108,7 @@ router bgp 65001
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor 172.31.255.5 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.31.255.5 remote-as 65101

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE4.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE4.cfg
@@ -108,6 +108,7 @@ router bgp 65001
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor 172.31.255.7 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.31.255.7 remote-as 65101

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
@@ -163,6 +163,7 @@ router_bgp:
       peer_filter: LEAF-AS-RANGE
       password: AQQvKeimxJu+uGQ/yYvv9w==
       maximum_routes: 12000
+      send_community: true
     EVPN-OVERLAY-PEERS:
       type: evpn
       peer_filter: LEAF-AS-RANGE

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
@@ -163,6 +163,7 @@ router_bgp:
       peer_filter: LEAF-AS-RANGE
       password: AQQvKeimxJu+uGQ/yYvv9w==
       maximum_routes: 12000
+      send_community: true
     EVPN-OVERLAY-PEERS:
       type: evpn
       peer_filter: LEAF-AS-RANGE

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
@@ -163,6 +163,7 @@ router_bgp:
       peer_filter: LEAF-AS-RANGE
       password: AQQvKeimxJu+uGQ/yYvv9w==
       maximum_routes: 12000
+      send_community: true
     EVPN-OVERLAY-PEERS:
       type: evpn
       peer_filter: LEAF-AS-RANGE

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
@@ -163,6 +163,7 @@ router_bgp:
       peer_filter: LEAF-AS-RANGE
       password: AQQvKeimxJu+uGQ/yYvv9w==
       maximum_routes: 12000
+      send_community: true
     EVPN-OVERLAY-PEERS:
       type: evpn
       peer_filter: LEAF-AS-RANGE

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/bgp_base/spine-router-bgp-peer-groups.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/bgp_base/spine-router-bgp-peer-groups.j2
@@ -7,6 +7,7 @@
       peer_filter: LEAF-AS-RANGE
       password: "{{ bgp_peer_groups.IPv4_UNDERLAY_PEERS.password }}"
       maximum_routes: 12000
+      send_community: true
 {%     endif %}
 {# Overlay network peering #}
 {%     if switch.overlay_routing_protocol == "ebgp" %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/bgp_base/super-spine-router-bgp-peer-groups.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/bgp_base/super-spine-router-bgp-peer-groups.j2
@@ -5,6 +5,7 @@
       type: ipv4
       password: "{{ bgp_peer_groups.IPv4_UNDERLAY_PEERS.password }}"
       maximum_routes: 12000
+      send_community: true
 {% endif %}
 {% if switch.overlay_routing_protocol == "ebgp" and switch.evpn_overlay_peers | length > 0 %}
     EVPN-OVERLAY-PEERS:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Bot will manage tag, ownership and code review, you should not update these fields-->
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

## Component(s) name

`eos_l3ls_evpn`

## Proposed changes

Add send_community configured to true for `IPv4-UNDERLAY-PEERS`

(Molecule is broken for l3sl_evpn due to PR#151)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
