### PR TITLE
Enable support for flexible speed configurations

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -736,7 +736,7 @@ ethernet_interfaces:
   <Ethernet_interface_1 >:
     description: < description >
     shutdown: < true | false >
-    speed: < interface_speed >
+    speed: < interface_speed | forced interface_speed | auto interface_speed >
     mtu: < mtu >
     type: < routed | switched >
     vrf: < vrf_name >
@@ -792,7 +792,7 @@ ethernet_interfaces:
   <Ethernet_interface_2 >:
     description: < description >
     shutdown: < true | false >
-    speed: < interface_speed >
+    speed: < interface_speed | forced interface_speed | auto interface_speed >
     mtu: < mtu >
     vlans: "< list of vlans as string >"
     native_vlan: <native vlan number>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -19,7 +19,7 @@ interface {{ ethernet_interface }}
    no shutdown
 {%         endif %}
 {%         if ethernet_interfaces[ethernet_interface].speed is defined and ethernet_interfaces[ethernet_interface].speed is not none %}
-   speed forced {{ ethernet_interfaces[ethernet_interface].speed }}
+   speed {{ ethernet_interfaces[ethernet_interface].speed }}
 {%         endif %}
 {%         if ethernet_interfaces[ethernet_interface].channel_group is defined and ethernet_interfaces[ethernet_interface].channel_group is not none %}
    channel-group {{ ethernet_interfaces[ethernet_interface].channel_group.id }} mode {{ ethernet_interfaces[ethernet_interface].channel_group.mode }}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
@@ -573,7 +573,7 @@ l3leaf:
       uplink_to_spine_interfaces: [ < ethernet_interface_1 >, < ethernet_interface_2 > ]
 
       # Point-to-Point interface speed - will apply to L3 Leaf and Spine switches | Optional.
-      p2p_link_interface_speed: < interface_speed >
+      p2p_link_interface_speed: < interface_speed | forced interface_speed | auto interface_speed >
 
       # Enable / Disable auto MLAG, when two nodes are defined in node group.
       mlag: < true | false -> default true >
@@ -738,7 +738,7 @@ l2leaf:
       uplink_interfaces: [ < ethernet_interface_1 >, < ethernet_interface_2 > ]
 
       # Point-to-Point interface speed - will apply to L2 Leaf and L3 Leaf switches | Optional.
-      p2p_link_interface_speed: < interface_speed >
+      p2p_link_interface_speed: < interface_speed | forced interface_speed | auto interface_speed >
 
       # Enable / Disable auto MLAG, when two nodes are defined in node group.
       mlag: < true | false -> default true >
@@ -1274,7 +1274,7 @@ servers:
       # Example of stand-alone adapter
 
         # Adapter speed - if not specified will be auto.
-      - speed: < adapter speed >
+      - speed: < interface_speed | forced interface_speed | auto interface_speed >
 
         # Local server port(s)
         server_ports: [ < interface_name > ]
@@ -1312,7 +1312,7 @@ servers:
   < server_2 >:
     rack: RackC
     adapters:
-      - speed: < adapter speed >
+      - speed: < interface_speed | forced interface_speed | auto interface_speed >
         server_ports: [ < interface_name > ]
         switch_ports: [ < switchport_interface > ]
         switches: [ < device > ]


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Bot will manage tag, ownership and code review, you should not update these fields-->
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Allow any speed configuration accepted by EOS. Ex. `speed; auto`, `speed: auto 1gfull` etc.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #319 

## Component(s) name
eos_cli_config_gen
eos_l3ls_evpn

## Proposed changes
<!--- Describe your changes in detail -->
By removing `forced` from the template rendering interface speeds, we allow any EOS compatible speed setting to be parsed via the `speed` variable.
Updated README.md files accordingly.
Ex:
```yaml
      # Point-to-Point interface speed - will apply to L3 Leaf and Spine switches | Optional.
      p2p_link_interface_speed: < interface_speed | forced interface_speed | auto interface_speed >
```

This change must be flagged as breaking, since someone could be relying on the current `speed forced` hardcoded syntax.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Ran my local test repo and these changes produced no changes.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been rebased from devel before I start
- [ ] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
