### PR TITLE
SNMP documentation to include ACL support

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/snmp_v3.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/snmp_v3.md
@@ -202,9 +202,18 @@ No logging settings defined
 
 ### SNMP Configuration Summary
 
-| Contact | Location | SNMP Traps | IPv4 ACL | IPv6 ACL |
-| ------- | -------- | ---------- | -------- | -------- |
-| DC1_OPS | DC1 |  Enabled  | - | - |
+| Contact | Location | SNMP Traps |
+| ------- | -------- | ---------- |
+| DC1_OPS | DC1 |  Enabled  |
+
+### SNMP ACLs
+| IP | ACL | VRF |
+| -- | --- | --- |
+| IPv4 | SNMP-MGMT | MGMT |
+| IPv4 | onur | default |
+| IPv6 | SNMP-MGMT | MGMT |
+| IPv6 | onur_v6 | default |
+
 
 ### SNMP Local Interfaces
 
@@ -255,8 +264,10 @@ No logging settings defined
 !
 snmp-server contact DC1_OPS
 snmp-server location DC1
+snmp-server ipv4 access-list SNMP-MGMT vrf MGMT 
 snmp-server ipv4 access-list onur
-snmp-server ipv6 access-list onurv6
+snmp-server ipv6 access-list SNMP-MGMT vrf MGMT 
+snmp-server ipv6 access-list onur_v6
 snmp-server vrf MGMT local-interface Management1
 snmp-server local-interface Loopback0
 snmp-server vrf Tenant_A_APP_Zone local-interface Loopback12

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/snmp_v3.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/snmp_v3.cfg
@@ -6,8 +6,10 @@ hostname snmp_v3
 !
 snmp-server contact DC1_OPS
 snmp-server location DC1
+snmp-server ipv4 access-list SNMP-MGMT vrf MGMT 
 snmp-server ipv4 access-list onur
-snmp-server ipv6 access-list onurv6
+snmp-server ipv6 access-list SNMP-MGMT vrf MGMT 
+snmp-server ipv6 access-list onur_v6
 snmp-server vrf MGMT local-interface Management1
 snmp-server local-interface Loopback0
 snmp-server vrf Tenant_A_APP_Zone local-interface Loopback12

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/snmp_v3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/snmp_v3.yml
@@ -8,8 +8,14 @@ snmp_server:
     Loopback0:
     Loopback12:
       vrf: Tenant_A_APP_Zone
-  ipv4_access_list: onur
-  ipv6_access_list: onurv6
+  ipv4_acls:
+    - name: SNMP-MGMT
+      vrf: MGMT
+    - name: onur
+  ipv6_acls:
+    - name: SNMP-MGMT
+      vrf: MGMT
+    - name: onur_v6
   views:
     - name: VW-WRITE
       MIB_family_name: iso

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -425,11 +425,11 @@ Redundancy:
 snmp_server:
   contact: < contact_name >
   location: < location >
-  ipv4_acls: 
+  ipv4_acls:
     - name: < ipv4-access-list >
       vrf: < vrf >
     - name: < ipv4-access-list >
-  ipv6_acls: 
+  ipv6_acls:
     - name: < ipv6-access-list >
       vrf: < vrf >
     - name: < ipv6-access-list >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -425,16 +425,14 @@ Redundancy:
 snmp_server:
   contact: < contact_name >
   location: < location >
-  ipv4_ACLs: 
+  ipv4_acls: 
     - name: < ipv4-access-list >
       vrf: < vrf >
     - name: < ipv4-access-list >
-      vrf: < vrf >
-  ipv6_ACLs: 
+  ipv6_acls: 
     - name: < ipv6-access-list >
       vrf: < vrf >
     - name: < ipv6-access-list >
-      vrf: < vrf >
   local_interfaces:
     < interface_name_1 >:
       vrf: < vrf_name >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -425,8 +425,16 @@ Redundancy:
 snmp_server:
   contact: < contact_name >
   location: < location >
-  ipv4_access_list: < ipv4-access-list >
-  ipv6_access_list: < ipv6-access-list >
+  ipv4_ACLs: 
+    - name: < ipv4-access-list >
+      vrf: < vrf >
+    - name: < ipv4-access-list >
+      vrf: < vrf >
+  ipv6_ACLs: 
+    - name: < ipv6-access-list >
+      vrf: < vrf >
+    - name: < ipv6-access-list >
+      vrf: < vrf >
   local_interfaces:
     < interface_name_1 >:
       vrf: < vrf_name >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/snmp-settings.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/snmp-settings.j2
@@ -1,9 +1,24 @@
 {% if snmp_server is defined and snmp_server is not none %}
 ### SNMP Configuration Summary
 
-| Contact | Location | SNMP Traps | IPv4 ACL | IPv6 ACL |
-| ------- | -------- | ---------- | -------- | -------- |
-| {{ snmp_server.contact | default('-') }} | {{ snmp_server.location | default('-') }} | {% if snmp_server.traps.enable is defined and snmp_server.traps.enable is not none %}{% if snmp_server.traps.enable %} Enabled {% else %} Disabled {% endif %}{% else %} Disabled {% endif %} | {{ snmp_server.ipv4_access_list | default('-') }} | {{ snmp_server.ipv6_access_list | default('-') }} |
+| Contact | Location | SNMP Traps |
+| ------- | -------- | ---------- |
+| {{ snmp_server.contact | default('-') }} | {{ snmp_server.location | default('-') }} | {% if snmp_server.traps.enable is defined and snmp_server.traps.enable is not none %}{% if snmp_server.traps.enable %} Enabled {% else %} Disabled {% endif %}{% else %} Disabled {% endif %} |
+
+### SNMP ACL
+| IP | ACL | VRF |
+| -- | --- | --- |
+{%     if snmp_server.ipv4_ACLs is defined and snmp_server.ipv4_ACLs is not none %}
+{%         for ACL in snmp_server.ipv4_ACLs %}
+| IPv4 | {{ ACL.name | default('-') }} | {{ ACL.vrf | default('-') }} |
+{%         endfor %}
+{%     endif %}
+{%     if snmp_server.ipv6_ACLs is defined and snmp_server.ipv6_ACLs is not none %}
+{%         for ACL in snmp_server.ipv6_ACLs %}
+| IPv6 | {{ ACL.name | default('-') }} | {{ ACL.vrf | default('-') }} |
+{%         endfor %}
+{%     endif %}
+
 
 ### SNMP Local Interfaces
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/snmp-settings.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/snmp-settings.j2
@@ -5,17 +5,17 @@
 | ------- | -------- | ---------- |
 | {{ snmp_server.contact | default('-') }} | {{ snmp_server.location | default('-') }} | {% if snmp_server.traps.enable is defined and snmp_server.traps.enable is not none %}{% if snmp_server.traps.enable %} Enabled {% else %} Disabled {% endif %}{% else %} Disabled {% endif %} |
 
-### SNMP ACL
+### SNMP ACLs
 | IP | ACL | VRF |
 | -- | --- | --- |
-{%     if snmp_server.ipv4_ACLs is defined and snmp_server.ipv4_ACLs is not none %}
-{%         for ACL in snmp_server.ipv4_ACLs %}
-| IPv4 | {{ ACL.name | default('-') }} | {{ ACL.vrf | default('-') }} |
+{%     if snmp_server.ipv4_acls is defined and snmp_server.ipv4_acls is not none %}
+{%         for acl in snmp_server.ipv4_acls %}
+| IPv4 | {{ acl.name | default('-') }} | {{ acl.vrf | default('default') }} |
 {%         endfor %}
 {%     endif %}
-{%     if snmp_server.ipv6_ACLs is defined and snmp_server.ipv6_ACLs is not none %}
-{%         for ACL in snmp_server.ipv6_ACLs %}
-| IPv6 | {{ ACL.name | default('-') }} | {{ ACL.vrf | default('-') }} |
+{%     if snmp_server.ipv6_acls is defined and snmp_server.ipv6_acls is not none %}
+{%         for acl in snmp_server.ipv6_acls %}
+| IPv6 | {{ acl.name | default('-') }} | {{ acl.vrf | default('default') }} |
 {%         endfor %}
 {%     endif %}
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/snmp-settings.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/snmp-settings.j2
@@ -3,7 +3,7 @@
 
 | Contact | Location | SNMP Traps | IPv4 ACL | IPv6 ACL |
 | ------- | -------- | ---------- | -------- | -------- |
-| {{ snmp_server.contact | default('-') }} | {{ snmp_server.location | default('-') }} | {% if snmp_server.traps.enable is defined and snmp_server.traps.enable is not none %}{% if snmp_server.traps.enable %} Enabled {% else %} Disabled {% endif %}{% endif %} | {{ snmp_server.access_list_v4 | default('-') }} | {{ snmp_server.access_list_v6 | default('-') }} |
+| {{ snmp_server.contact | default('-') }} | {{ snmp_server.location | default('-') }} | {% if snmp_server.traps.enable is defined and snmp_server.traps.enable is not none %}{% if snmp_server.traps.enable %} Enabled {% else %} Disabled {% endif %}{% else %} Disabled {% endif %} | {{ snmp_server.ipv4_access_list | default('-') }} | {{ snmp_server.ipv6_access_list | default('-') }} |
 
 ### SNMP Local Interfaces
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/snmp-settings.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/snmp-settings.j2
@@ -7,15 +7,15 @@ snmp-server contact {{ snmp_server.contact }}
 {%     if snmp_server.location is defined and snmp_server.location is not none %}
 snmp-server location {{ snmp_server.location }}
 {%     endif %}
-{%     if snmp_server.ipv4_ACLs is defined and snmp_server.ipv4_ACLs is not none %}
-{%         for ACL in snmp_server.ipv4_ACLs %}
-snmp-server ipv4 access-list {{ ACL.name }}{% if ACL.vrf is defined and ACL.vrf is not none %} vrf {{ ACL.vrf }} {% endif %}
+{%     if snmp_server.ipv4_acls is defined and snmp_server.ipv4_acls is not none %}
+{%         for acl in snmp_server.ipv4_acls %}
+snmp-server ipv4 access-list {{ acl.name }}{% if acl.vrf is defined and acl.vrf is not none %} vrf {{ acl.vrf }} {% endif %}
 
 {%         endfor %}
 {%     endif %}
-{%     if snmp_server.ipv6_ACLs is defined and snmp_server.ipv6_ACLs is not none %}
-{%         for ACL in snmp_server.ipv6_ACLs %}
-snmp-server ipv6 access-list {{ ACL.name }}{% if ACL.vrf is defined and ACL.vrf is not none %} vrf {{ ACL.vrf }} {% endif %}
+{%     if snmp_server.ipv6_acls is defined and snmp_server.ipv6_acls is not none %}
+{%         for acl in snmp_server.ipv6_acls %}
+snmp-server ipv6 access-list {{ acl.name }}{% if acl.vrf is defined and acl.vrf is not none %} vrf {{ acl.vrf }} {% endif %}
 
 {%         endfor %}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/snmp-settings.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/snmp-settings.j2
@@ -7,11 +7,17 @@ snmp-server contact {{ snmp_server.contact }}
 {%     if snmp_server.location is defined and snmp_server.location is not none %}
 snmp-server location {{ snmp_server.location }}
 {%     endif %}
-{%     if snmp_server.ipv4_access_list is defined and snmp_server.ipv4_access_list is not none %}
-snmp-server ipv4 access-list {{ snmp_server.ipv4_access_list }}
+{%     if snmp_server.ipv4_ACLs is defined and snmp_server.ipv4_ACLs is not none %}
+{%         for ACL in snmp_server.ipv4_ACLs %}
+snmp-server ipv4 access-list {{ ACL.name }}{% if ACL.vrf is defined and ACL.vrf is not none %} vrf {{ ACL.vrf }} {% endif %}
+
+{%         endfor %}
 {%     endif %}
-{%     if snmp_server.ipv6_access_list is defined and snmp_server.ipv6_access_list is not none %}
-snmp-server ipv6 access-list {{ snmp_server.ipv6_access_list }}
+{%     if snmp_server.ipv6_ACLs is defined and snmp_server.ipv6_ACLs is not none %}
+{%         for ACL in snmp_server.ipv6_ACLs %}
+snmp-server ipv6 access-list {{ ACL.name }}{% if ACL.vrf is defined and ACL.vrf is not none %} vrf {{ ACL.vrf }} {% endif %}
+
+{%         endfor %}
 {%     endif %}
 {%     if snmp_server.local_interfaces is defined and snmp_server.local_interfaces is not none %}
 {%          for local_interface in snmp_server.local_interfaces %}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Bot will manage tag, ownership and code review, you should not update these fields-->
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [x] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

- Fixes documentation missing on #377 
- Fixes #377 

## Component(s) name

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
