### PR TITLE
Fix PEP8 linting and docstring

### DIFF
--- a/.github/workflows/ansible_test_python.yml
+++ b/.github/workflows/ansible_test_python.yml
@@ -1,13 +1,12 @@
-name: Ansible Test for release management
+name: Ansible Test for Python update
 on:
   pull_request:
-    branches:
-      - devel
     paths:
       - 'ansible_collections/arista/avd/plugins/filter/**'
       - 'ansible_collections/arista/avd/plugins/test/**'
+      - '.github/workflows/ansible_test_python.yml'
 jobs:
-  'ansible-test for python content':
+  'ansible-test':
     name: Run ansible-test validation
     runs-on: ubuntu-18.04
     container: ubuntu:18.04

--- a/.github/workflows/ansible_test_python.yml
+++ b/.github/workflows/ansible_test_python.yml
@@ -2,8 +2,10 @@ name: Ansible Test for release management
 on:
   pull_request:
     branches:
+      - devel
     paths:
-      - 'ansible_collections/arista/avd/plugins/**'
+      - 'ansible_collections/arista/avd/plugins/filter/**'
+      - 'ansible_collections/arista/avd/plugins/test/**'
 jobs:
   'ansible-test for python content':
     name: Run ansible-test validation

--- a/.github/workflows/ansible_test_python.yml
+++ b/.github/workflows/ansible_test_python.yml
@@ -1,0 +1,45 @@
+name: Ansible Test for release management
+on:
+  pull_request:
+    branches:
+    paths:
+      - 'ansible_collections/arista/avd/plugins/**'
+jobs:
+  'ansible-test for python content':
+    name: Run ansible-test validation
+    runs-on: ubuntu-18.04
+    container: ubuntu:18.04
+    steps:
+      - uses: actions/checkout@master
+      - name: 'set environment variables'
+        run: |
+          echo "PY_COLORS=1" >> $GITHUB_ENV
+          echo "ANSIBLE_FORCE_COLOR=1" >> $GITHUB_ENV
+      - name: Setup Python 3 on runner
+        uses: actions/setup-python@v2.1.4
+        with:
+          python-version: '3.x'
+
+      - name: update packages
+        run: apt-get update
+
+      - name: 'Install sudo'
+        run: apt-get -q -y install sudo
+
+      - name: 'Install build essentials'
+        run: sudo apt-get install -q -y build-essential
+
+      - name: 'Install requirements'
+        run: make github-configure-ci
+
+      - name: 'Install docker'
+        run: make install-docker
+
+      - name: 'Install Python requirements'
+        run: make install-requirements
+
+      - name: 'ansible-test linting'
+        run: make sanity-lint
+
+      - name: 'ansible-test import'
+        run: make sanity-import

--- a/.github/workflows/ansible_test_releases.yml
+++ b/.github/workflows/ansible_test_releases.yml
@@ -1,4 +1,4 @@
-name: Ansible Test
+name: Ansible Test for release management
 on:
   pull_request:
     branches:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -9,11 +9,12 @@ jobs:
     steps:
       - uses: actions/checkout@master
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
       - name: Install Pre Commit
         run: |
           pip --no-cache-dir install -r development/requirements-dev.txt
       - name: 'Pre Commit run'
         run: |
-          git reset --mixed devel
+          git reset --soft origin/devel
           make pre-commit

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -8,9 +8,12 @@ jobs:
     container: avdteam/base:3.6-v1.0
     steps:
       - uses: actions/checkout@master
+        with:
+          fetch-depth: 0
       - name: Install Pre Commit
         run: |
           pip --no-cache-dir install -r development/requirements-dev.txt
       - name: 'Pre Commit run'
         run: |
+          git reset --mixed devel
           make pre-commit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,15 +10,17 @@ repos:
       - id: check-yaml
       - id: check-added-large-files
       - id: check-merge-conflict
-  - repo: https://github.com/pre-commit/mirrors-pylint
-    rev: 'v2.5.0'
+  - repo: https://github.com/pycqa/pylint
+    rev: 'pylint-2.6.0'
     hooks:
     - id: pylint # Use pylintrc file in repository
       name: Check for Linting error on Python files
       description: This hook runs pylint.
+      types: [python]
       args:
         # Suppress duplicate code for modules header
         - -d duplicate-code
+
   - repo: https://github.com/adrienverge/yamllint.git
     rev: 'v1.23.0'
     hooks:
@@ -29,18 +31,3 @@ repos:
       language: python
       types: [file, yaml]
       args: [-c=.github/yamllintrc]
-  - repo: https://github.com/ansible/ansible-lint.git
-    rev: v4.2.0
-    hooks:
-      - id: ansible-lint
-        name: Check for ansible-lint errors
-        files: \.(yaml|yml)$
-  # - repo: https://github.com/markdownlint/markdownlint.git
-  #   rev: v0.9.0
-  #   hooks:
-  #     - id: markdownlint
-  #       name: Markdownlint
-  #       description: Run markdownlint on your Markdown files
-  #       entry: mdl
-  #       language: ruby
-  #       files: \.(md|mdown|markdown)$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
-        exclude_types:  [jinja]
+        exclude_types:  [jinja, text]
       - id: check-yaml
       - id: check-added-large-files
       - id: check-merge-conflict

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,17 @@ repos:
       - id: check-yaml
       - id: check-added-large-files
       - id: check-merge-conflict
+
+  # - repo: https://github.com/pre-commit/pre-commit-hooks
+  #   rev: v2.3.0
+  #   hooks:
+  #   - id: flake8
+
+  - repo: https://github.com/pre-commit/mirrors-autopep8
+    rev: ''  # Use the sha / tag you want to point at
+    hooks:
+    -   id: autopep8
+
   - repo: https://github.com/pycqa/pylint
     rev: 'pylint-2.6.0'
     hooks:

--- a/ansible_collections/arista/avd/plugins/filter/default.py
+++ b/ansible_collections/arista/avd/plugins/filter/default.py
@@ -11,8 +11,10 @@ def default(primary_value, *default_values):
     """
     default will test value if defined and is not none.
 
-    Arista.avd.default will test value if defined and is not none. If true return value else test default_value1.
-    Test of default_value1 if defined and is not none. If true return default_value1 else test default_value2.
+    Arista.avd.default will test value if defined and is not none. If true
+    return value else test default_value1.
+    Test of default_value1 if defined and is not none. If true return
+    default_value1 else test default_value2.
     If we run out of default values we return none.
 
     Example
@@ -32,7 +34,7 @@ def default(primary_value, *default_values):
     if isinstance(primary_value, Undefined) or primary_value is None:
         # Invalid value - try defaults
         if len(default_values) >= 1:
-            # Return the result of another loop
+            #Return the result of another loop
             return default(default_values[0], *default_values[1:])
         else:
             # Return None

--- a/ansible_collections/arista/avd/plugins/filter/default.py
+++ b/ansible_collections/arista/avd/plugins/filter/default.py
@@ -15,6 +15,10 @@ def default(primary_value, *default_values):
     Test of default_value1 if defined and is not none. If true return default_value1 else test default_value2.
     If we run out of default values we return none.
 
+    Example
+    -------
+    priority: {{ switch.spanning_tree_priority | arista.avd.default("32768") }}
+
     Parameters
     ----------
     primary_value : any

--- a/ansible_collections/arista/avd/plugins/filter/default.py
+++ b/ansible_collections/arista/avd/plugins/filter/default.py
@@ -6,18 +6,37 @@ __metaclass__ = type
 
 from jinja2.runtime import Undefined
 
-def default(primary_value, *default_values ):
+
+def default(primary_value, *default_values):
+    """
+    default will test value if defined and is not none.
+
+    Arista.avd.default will test value if defined and is not none. If true return value else test default_value1.
+    Test of default_value1 if defined and is not none. If true return default_value1 else test default_value2.
+    If we run out of default values we return none.
+
+    Parameters
+    ----------
+    primary_value : any
+        Ansible default value to look for
+
+    Returns
+    -------
+    any
+        Default value
+    """
     if isinstance(primary_value, Undefined) or primary_value is None:
-        #Invalid value - try defaults
+        # Invalid value - try defaults
         if len(default_values) >= 1:
-            #Return the result of another loop
-            return default(default_values[0],*default_values[1:])
+            # Return the result of another loop
+            return default(default_values[0], *default_values[1:])
         else:
-            #Return None
+            # Return None
             return
     else:
-        #Return the valid value
+        # Return the valid value
         return primary_value
+
 
 class FilterModule(object):
     def filters(self):

--- a/ansible_collections/arista/avd/plugins/filter/default.py
+++ b/ansible_collections/arista/avd/plugins/filter/default.py
@@ -34,7 +34,7 @@ def default(primary_value, *default_values):
     if isinstance(primary_value, Undefined) or primary_value is None:
         # Invalid value - try defaults
         if len(default_values) >= 1:
-            #Return the result of another loop
+            # Return the result of another loop
             return default(default_values[0], *default_values[1:])
         else:
             # Return None

--- a/ansible_collections/arista/avd/plugins/test/defined.py
+++ b/ansible_collections/arista/avd/plugins/test/defined.py
@@ -31,6 +31,16 @@ def defined(value, test_value=None):
     Arista.avd.defined will test value if defined and is not none and return true or false.
     If test_value is supplied, the value must also pass == test_value to return true.
 
+    Example:
+    1. Test if var is defined and not none:
+    {% if spanning_tree is arista.avd.defined %}
+    ...
+    {% endif %}
+    2. Test if variable is defined, not none and has value "something"
+    {% if extremely_long_variable_name is arista.avd.defined("something") %}
+    ...
+    {% endif %}
+
     Parameters
     ----------
     value : any

--- a/ansible_collections/arista/avd/plugins/test/defined.py
+++ b/ansible_collections/arista/avd/plugins/test/defined.py
@@ -23,16 +23,36 @@ __metaclass__ = type
 
 from jinja2.runtime import Undefined
 
+
 def defined(value, test_value=None):
+    """
+    defined - Ansible test plugin to test if a variable is defined and not none
+
+    Arista.avd.defined will test value if defined and is not none and return true or false.
+    If test_value is supplied, the value must also pass == test_value to return true.
+
+    Parameters
+    ----------
+    value : any
+        Value to test from ansible
+    test_value : any, optional
+        value to test in addition of defined and not none, by default None
+
+    Returns
+    -------
+    boolean
+        True if variable matches criteria, False in other cases.
+    """
     if isinstance(value, Undefined) or value is None:
-        #Invalid value - return false
+        # Invalid value - return false
         return False
     elif test_value is not None and value != test_value:
-        #Valid value but not matching the optional argument
+        # Valid value but not matching the optional argument
         return False
     else:
-        #Valid value and is matching optional argument if provided - return true
+        # Valid value and is matching optional argument if provided - return true
         return True
+
 
 class TestModule(object):
     def tests(self):


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Bot will manage tag, ownership and code review, you should not update these fields-->
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

N/A

## Component(s) name

- `arista.avd.plugins`
- Continuous Integration

## Proposed changes

- Fix PEP8 linting
- Add docstring to `arista.avd.defined` and `arista.avd.default`
- Add CI to run ansible-test when Python files are updated

## How to test

Check PR CI

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
