### PR TITLE
Add "defined" checks to natural_sort

### DIFF
--- a/ansible_collections/arista/avd/plugins/README.md
+++ b/ansible_collections/arista/avd/plugins/README.md
@@ -30,6 +30,8 @@ To use this filter:
 
 The `natural_sort` filter provides the capabilities to sort a list or a dictionary of integers and/or strings that contain alphanumeric characters naturally. When leveraged on a dictionary, only the key value will be returned.
 
+The filter will return an empty list if the value parsed to `natural_sort` is `none` or `undefined`.
+
 To use this filter:
 
 ```jinja

--- a/ansible_collections/arista/avd/plugins/filter/natural_sort.py
+++ b/ansible_collections/arista/avd/plugins/filter/natural_sort.py
@@ -5,6 +5,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import re
+from jinja2.runtime import Undefined
 
 
 def convert(text):
@@ -18,6 +19,8 @@ def alphanum_key(key):
 class FilterModule(object):
 
     def natural_sort(self, iterable):
+        if isinstance(iterable, Undefined) or iterable is None:
+            return list()
         return sorted(iterable, key=alphanum_key)
 
     def filters(self):


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Bot will manage tag, ownership and code review, you should not update these fields-->
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Add a check for `None` or `not defined` to the natural_sort filter, and return empty list.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

## Component(s) name
ansible-avd collection
natural_sort

## Proposed changes
<!--- Describe your changes in detail -->
The `arista.avd.natural_sort` filter will now return an empty list if the value parsed to `natural_sort` is `none` or `undefined`. This can help simplify the templates, since we no longer need to have a test before the for-loop.

###Before
```jinja
{%     if tenants[tenant].l2vlans is defined %}
{%         for l2vlan in tenants[tenant].l2vlans | arista.avd.natural_sort %}
...
{%         endfor %}
{%     endif %}
```
###After
```jinja
{%     for l2vlan in tenants[tenant].l2vlans | arista.avd.natural_sort %}
...
{%     endfor %}
```
## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
I tested by running my test repo with and without this change. No difference to the produced output. Then I changed the l3leaf template like above. Without this PR change it produced an `Undefined variable` exception for some tenants. With the PR change it worked with no error exactly like before.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been rebased from devel before I start
- [ ] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
