### PR TITLE
Refactor eos cli config gen

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mac-security-eth-po-entropy.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mac-security-eth-po-entropy.md
@@ -277,6 +277,7 @@ No Interface Defaults defined
 interface Ethernet1
    mac security profile A1
    switchport
+   switchport mode routed
    ip address 1.1.1.1/24
 !
 interface Ethernet3

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-v4-v6-evpn.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-v4-v6-evpn.md
@@ -503,7 +503,7 @@ router bgp 65100
    address-family ipv4 multicast
       neighbor IPV4-UNDERLAY activate
       neighbor IPV4-UNDERLAY-MLAG activate
-      redistribute attached-host 
+      redistribute attached-host
    !
    address-family ipv6
       neighbor IPV6-UNDERLAY route-map RM-HIDE-AS-PATH in

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis.md
@@ -388,6 +388,7 @@ interface Vlan4093
 !
 interface Vlan4094
    description MLAG_PEER
+   mtu 1500
    no autostate
    ip address 10.255.252.0/31
 ```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/unsupported-transceiver.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/unsupported-transceiver.md
@@ -1,0 +1,425 @@
+# unsupported-transceiver
+
+# Table of Contents
+
+- [Management](#management)
+  - [Management Interfaces](#management-interfaces)
+  - [DNS Domain](#dns-domain)
+  - [Name Servers](#name-servers)
+  - [Domain Lookup](#domain-lookup)
+  - [NTP](#ntp)
+  - [Management SSH](#management-ssh)
+  - [Management GNMI](#management-api-gnmi)
+  - [Management API](#Management-api-http)
+- [Authentication](#authentication)
+  - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
+  - [TACACS Servers](#tacacs-servers)
+  - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
+  - [RADIUS Servers](#radius-servers)
+  - [AAA Server Groups](#aaa-server-groups)
+  - [AAA Authentication](#aaa-authentication)
+  - [AAA Authorization](#aaa-authorization)
+  - [AAA Accounting](#aaa-accounting)
+- [Management Security](#management-security)
+- [Aliases](#aliases)
+- [Monitoring](#monitoring)
+  - [TerminAttr Daemon](#terminattr-daemon)
+  - [Logging](#logging)
+  - [SNMP](#snmp)
+  - [SFlow](#sflow)
+  - [Hardware Counters](#hardware-counters)
+  - [VM Tracer Sessions](#vm-tracer-sessions)
+  - [Event Handler](#event-handler)
+- [MLAG](#mlag)
+- [Spanning Tree](#spanning-tree)
+- [Internal VLAN Allocation Policy](#internal-vlan-allocation-policy)
+- [VLANs](#vlans)
+- [Interfaces](#interfaces)
+  - [Interface Defaults](#interface-defaults)
+  - [Ethernet Interfaces](#ethernet-interfaces)
+  - [Port-Channel Interfaces](#port-channel-interfaces)
+  - [Loopback Interfaces](#loopback-interfaces)
+  - [VLAN Interfaces](#vlan-interfaces)
+  - [VXLAN Interface](#vxlan-interface)
+- [Routing](#routing)
+  - [Virtual Router MAC Address](#virtual-router-mac-address)
+  - [IP Routing](#ip-routing)
+  - [IPv6 Routing](#ipv6-routing)
+  - [Static Routes](#static-routes)
+  - [IPv6 Static Routes](#ipv6-static-routes)
+  - [Router OSPF](#router-ospf)
+  - [Router ISIS](#router-isis)
+  - [Router BGP](#router-bgp)
+  - [Router BFD](#router-bfd)
+- [Multicast](#multicast)
+  - [IP IGMP Snooping](#ip-igmp-snooping)
+  - [Router Multicast](#router-multicast)
+  - [Router PIM Sparse Mode](#router-pim-sparse-mode)
+- [Filters](#filters)
+  - [Community-lists](#community-lists)
+  - [Peer Filters](#peer-filters)
+  - [Prefix-lists](#prefix-lists)
+  - [IPv6 Prefix-lists](#ipv6-prefix-lists)
+  - [Route-maps](#route-maps)
+  - [IP Extended Communities](#ip-extended-communities)
+- [ACL](#acl)
+  - [Standard Access-lists](#standard-access-lists)
+  - [Extended Access-lists](#extended-access-lists)
+  - [IPv6 Standard Access-lists](#ipv6-standard-access-lists)
+  - [IPv6 Extended Access-lists](#ipv6-extended-access-lists)
+- [VRF Instances](#vrf-instances)
+- [Virtual Source NAT](#virtual-source-nat)
+- [Platform](#platform)
+- [Router L2 VPN](#router-l2-vpn)
+- [IP DHCP Relay](#ip-dhcp-relay)
+- [Errdisable](#errdisable)
+- [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
+
+# Management
+
+## Management Interfaces
+
+### Management Interfaces Summary
+
+#### IPv4
+
+| Management Interface | description | VRF | IP Address | Gateway |
+| -------------------- | ----------- | --- | ---------- | ------- |
+| Management1 | oob_management | MGMT | 10.73.255.122/24 | 10.73.255.2 |
+
+#### IPv6
+
+| Management Interface | description | VRF | IPv6 Address | IPv6 Gateway |
+| -------------------- | ----------- | --- | ------------ | ------------ |
+| Management1 | oob_management | MGMT | -  | - |
+
+### Management Interfaces Device Configuration
+
+```eos
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+```
+
+## DNS Domain
+
+DNS domain not defined
+
+## Domain-list
+
+Domain-list not defined
+
+## Name Servers
+
+No name servers defined
+
+## Domain Lookup
+
+DNS domain lookup not defined
+
+## NTP
+
+No NTP servers defined
+
+## PTP
+
+PTP is not defined.
+
+## Management SSH
+
+Management SSH not defined
+
+## Management API GNMI
+
+Management API gnmi is not defined
+
+## Management API HTTP
+
+Management API HTTP not defined
+
+# Authentication
+
+## Local Users
+
+No users defined
+
+## Enable Password
+
+Enable password not defined
+
+## TACACS Servers
+
+TACACS servers not defined
+
+## IP TACACS Source Interfaces
+
+IP TACACS source interfaces not defined
+
+## RADIUS Servers
+
+RADIUS servers not defined
+
+## AAA Server Groups
+
+AAA server groups not defined
+
+## AAA Authentication
+
+AAA authentication not defined
+
+## AAA Authorization
+
+AAA authorization not defined
+
+## AAA Accounting
+
+AAA accounting not defined
+
+# Management Security
+
+Management security not defined
+
+# Aliases
+
+Aliases not defined
+
+# Monitoring
+
+## TerminAttr Daemon
+
+TerminAttr daemon not defined
+
+## Logging
+
+No logging settings defined
+
+## SNMP
+
+No SNMP settings defined
+
+## SFlow
+
+No sFlow defined
+
+## Hardware Counters
+
+No hardware counters defined
+
+## VM Tracer Sessions
+
+No VM tracer sessions defined
+
+## Event Handler
+
+No event handler defined
+
+# MLAG
+
+MLAG not defined
+
+# Spanning Tree
+
+Spanning-tree not defined
+
+# Internal VLAN Allocation Policy
+
+## Internal VLAN Allocation Policy Summary
+
+**Default Allocation Policy**
+
+| Policy Allocation | Range Beginning | Range Ending |
+| ------------------| --------------- | ------------ |
+| ascending | 1006 | 4094 |
+
+# VLANs
+
+No VLANs defined
+
+# Interfaces
+
+## Interface Defaults
+
+No Interface Defaults defined
+
+## Ethernet Interfaces
+
+No ethernet interface defined
+
+## Port-Channel Interfaces
+
+No port-channels defined
+
+## Loopback Interfaces
+
+No loopback interfaces defined
+
+## VLAN Interfaces
+
+No VLAN interfaces defined
+
+## VXLAN Interface
+
+No VXLAN interfaces defined
+
+# Routing
+
+## Virtual Router MAC Address
+
+IP virtual router MAC address not defined
+
+## IP Routing
+
+### IP Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | false|
+### IP Routing Device Configuration
+
+```eos
+```
+
+## IPv6 Routing
+
+### IPv6 Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | false |
+
+## Static Routes
+
+Static routes not defined
+
+## IPv6 Static Routes
+
+IPv6 static routes not defined
+
+## ARP
+
+Global ARP timeout not defined.
+
+## Router OSPF
+
+Router OSPF not defined
+
+## Router ISIS
+
+Router ISIS not defined
+
+## Router BGP
+
+Router BGP not defined
+
+## Router BFD
+
+### Router BFD Multihop Summary
+
+| Interval | Minimum RX | Multiplier |
+| -------- | ---------- | ---------- |
+| 300 | 300 | 3 |
+
+*No device configuration required - default values
+
+# Multicast
+
+## IP IGMP Snooping
+
+No IP IGMP configuration
+
+## Router Multicast
+
+Routing multicast not defined
+
+## Router PIM Sparse Mode
+
+Router PIM sparse mode not defined
+
+# Filters
+
+## Community-lists
+
+Community-lists not defined
+
+## Peer Filters
+
+No peer filters defined
+
+## Prefix-lists
+
+Prefix-lists not defined
+
+## IPv6 Prefix-lists
+
+IPv6 prefix-lists not defined
+
+## Route-maps
+
+No route-maps defined
+
+## IP Extended Communities
+
+No extended community defined
+
+# ACL
+
+## Standard Access-lists
+
+Standard access-lists not defined
+
+## Extended Access-lists
+
+Extended access-lists not defined
+
+## IPv6 Standard Access-lists
+
+IPv6 standard access-lists not defined
+
+## IPv6 Extended Access-lists
+
+IPv6 extended access-lists not defined
+
+# VRF Instances
+
+No VRF instances defined
+
+# Virtual Source NAT
+
+Virtual source NAT not defined
+
+# Platform
+
+No platform parameters defined
+
+# Router L2 VPN
+
+Router L2 VPN not defined
+
+# IP DHCP Relay
+
+IP DHCP relay not defined
+
+# Errdisable
+
+Errdisable is not defined.
+
+# MACsec
+
+MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
+
+# Custom Templates
+
+No custom templates defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
@@ -332,9 +332,9 @@ interface Vlan41
    description SVI Description
    no shutdown
    ip address virtual 10.10.41.1/24
-   ip helper-address 10.10.64.150  source-interface Loopback0
-   ip helper-address 10.10.96.150  source-interface Loopback0
-   ip helper-address 10.10.96.151  source-interface Loopback0
+   ip helper-address 10.10.64.150 source-interface Loopback0
+   ip helper-address 10.10.96.150 source-interface Loopback0
+   ip helper-address 10.10.96.151 source-interface Loopback0
 !
 interface Vlan42
    description SVI Description
@@ -382,7 +382,7 @@ interface Vlan89
    ipv6 address 1b11:3a00:22b0:5200::15/64
    ipv6 nd managed-config-flag
    ipv6 nd prefix 1b11:3a00:22b0:5200::/64 infinite infinite no-autoconfig
-   multicast ipv4 source route export
+   multicast ipv4 source route export 
    pim ipv4 sparse-mode
    pim ipv4 local-interface Loopback0
    ipv6 virtual-router address 1b11:3a00:22b0:5200::3

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/mac-security-eth-po-entropy.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/mac-security-eth-po-entropy.cfg
@@ -29,6 +29,7 @@ interface Port-Channel3
 interface Ethernet1
    mac security profile A1
    switchport
+   switchport mode routed
    ip address 1.1.1.1/24
 !
 interface Ethernet3

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-v4-v6-evpn.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-v4-v6-evpn.cfg
@@ -99,7 +99,7 @@ router bgp 65100
    address-family ipv4 multicast
       neighbor IPV4-UNDERLAY activate
       neighbor IPV4-UNDERLAY-MLAG activate
-      redistribute attached-host 
+      redistribute attached-host
    !
    address-family ipv6
       neighbor IPV6-UNDERLAY route-map RM-HIDE-AS-PATH in

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-isis.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-isis.cfg
@@ -59,6 +59,7 @@ interface Vlan4093
 !
 interface Vlan4094
    description MLAG_PEER
+   mtu 1500
    no autostate
    ip address 10.255.252.0/31
 router isis EVPN_UNDERLAY

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/unsupported-transceiver.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/unsupported-transceiver.cfg
@@ -1,0 +1,17 @@
+!RANCID-CONTENT-TYPE: arista
+!
+transceiver qsfp default-mode 4x10G
+!
+hostname unsupported-transceiver
+!
+service unsupported-transceiver abcd efgh
+!
+no aaa root
+no enable password
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
@@ -25,9 +25,9 @@ interface Vlan41
    description SVI Description
    no shutdown
    ip address virtual 10.10.41.1/24
-   ip helper-address 10.10.64.150  source-interface Loopback0
-   ip helper-address 10.10.96.150  source-interface Loopback0
-   ip helper-address 10.10.96.151  source-interface Loopback0
+   ip helper-address 10.10.64.150 source-interface Loopback0
+   ip helper-address 10.10.96.150 source-interface Loopback0
+   ip helper-address 10.10.96.151 source-interface Loopback0
 !
 interface Vlan42
    description SVI Description
@@ -75,7 +75,7 @@ interface Vlan89
    ipv6 address 1b11:3a00:22b0:5200::15/64
    ipv6 nd managed-config-flag
    ipv6 nd prefix 1b11:3a00:22b0:5200::/64 infinite infinite no-autoconfig
-   multicast ipv4 source route export
+   multicast ipv4 source route export 
    pim ipv4 sparse-mode
    pim ipv4 local-interface Loopback0
    ipv6 virtual-router address 1b11:3a00:22b0:5200::3

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/unsupported-transceiver.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/unsupported-transceiver.yml
@@ -1,0 +1,4 @@
+### Unsupported transceiver
+service_unsupported_transceiver:
+  license_name: abcd
+  license_key: efgh

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts
@@ -43,6 +43,7 @@ spanning-tree-rapid-pvst
 terminattr-cloud
 terminattr-prem
 terminattr-prem-disableaaa
+unsupported-transceiver
 vlan-interfaces
 vlans
 vrfs

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
@@ -70,7 +70,7 @@ hostname {{ inventory_hostname }}
 {# platform #}
 {% include 'eos/platform.j2' %}
 {# unsupported transceiver #}
-{% include 'eos/unsupported-transeiver.j2' %}
+{% include 'eos/unsupported-transceiver.j2' %}
 {# tacacs servers #}
 {% include 'eos/tacacs-servers.j2' %}
 {# aaa authentication #}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/aaa-accounting.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/aaa-accounting.j2
@@ -1,16 +1,22 @@
 {# eos - aaa accounting #}
-{% if aaa_accounting is defined and aaa_accounting is not none %}
+{% if aaa_accounting is arista.avd.defined %}
 !
-{%     if aaa_accounting.exec.default is defined and aaa_accounting.exec.default is not none %}
-{%        if aaa_accounting.exec.default.group is defined and aaa_accounting.exec.default.group is not none %}
+{%     if aaa_accounting.exec.default is arista.avd.defined %}
+{%        if aaa_accounting.exec.default.group is arista.avd.defined %}
 aaa accounting exec default {{ aaa_accounting.exec.default.type }} group {{ aaa_accounting.exec.default.group }}
 {%        endif %}
 {%     endif %}
-{%     if aaa_accounting.commands is defined and aaa_accounting.commands is not none %}
-{%        if aaa_accounting.commands.commands_default is defined and aaa_accounting.commands.commands_default is not none %}
+{%     if aaa_accounting.commands is arista.avd.defined %}
+{%        if aaa_accounting.commands.commands_default is arista.avd.defined %}
 {%            for command_default in aaa_accounting.commands.commands_default %}
-aaa accounting commands {{ command_default.commands }} default {{ command_default.type }} {% if command_default.group is defined %}group {{ command_default.group }} {% endif %}{% if command_default.logging is defined and command_default.logging == true %}logging{% endif %}
-
+{%                set aaa_accounting_commands_commands_default_cli = "aaa accounting commands " ~ command_default.commands ~ " default " ~ command_default.type %}
+{%                if command_default.group is arista.avd.defined %}
+{%                    set aaa_accounting_commands_commands_default_cli = aaa_accounting_commands_commands_default_cli ~ " group " ~ command_default.group %}
+{%                endif %}
+{%                if command_default.logging is arista.avd.defined(true) %}
+{%                    set aaa_accounting_commands_commands_default_cli = aaa_accounting_commands_commands_default_cli ~ " logging" %}
+{%                endif %}
+{{ aaa_accounting_commands_commands_default_cli }}
 {%            endfor %}
 {%        endif %}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/aaa-authentication.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/aaa-authentication.j2
@@ -1,24 +1,24 @@
 {# eos - aaa authentication #}
-{% if aaa_authentication is defined and aaa_authentication is not none %}
+{% if aaa_authentication is arista.avd.defined %}
 !
-{%     if aaa_authentication.login.default is defined and aaa_authentication.login.default is not none %}
+{%     if aaa_authentication.login.default is arista.avd.defined %}
 aaa authentication login default {{ aaa_authentication.login.default }}
 {%     endif %}
-{%     if aaa_authentication.login.serial_console is defined and aaa_authentication.login.serial_console is not none %}
+{%     if aaa_authentication.login.serial_console is arista.avd.defined %}
 aaa authentication login serial-console {{ aaa_authentication.login.serial_console }}
 {%     endif %}
-{%     if aaa_authentication.dot1x.default is defined and aaa_authentication.dot1x.default is not none %}
+{%     if aaa_authentication.dot1x.default is arista.avd.defined %}
 aaa authentication dot1x default {{ aaa_authentication.dot1x.default }}
 {%     endif %}
-{%     if aaa_authentication.policies is defined and aaa_authentication.policies is not none %}
-{%         if aaa_authentication.policies.on_failure_log is defined and aaa_authentication.policies.on_failure_log == true %}
+{%     if aaa_authentication.policies is arista.avd.defined %}
+{%         if aaa_authentication.policies.on_failure_log is arista.avd.defined(true) %}
 aaa authentication policy on-failure log
 {%         endif %}
-{%         if aaa_authentication.policies.on_success_log is defined and aaa_authentication.policies.on_success_log == true %}
+{%         if aaa_authentication.policies.on_success_log is arista.avd.defined(true) %}
 aaa authentication policy on-success log
 {%         endif %}
-{%         if aaa_authentication.policies.local is defined %}
-{%             if aaa_authentication.policies.local.allow_nopassword is defined and aaa_authentication.policies.local.allow_nopassword == true %}
+{%         if aaa_authentication.policies.local is arista.avd.defined %}
+{%             if aaa_authentication.policies.local.allow_nopassword is arista.avd.defined(true) %}
 aaa authentication policy local allow-nopassword-remote-login
 {%             endif %}
 {%         endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/aaa-authorization.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/aaa-authorization.j2
@@ -1,15 +1,15 @@
 {# eos - aaa authorization #}
-{% if aaa_authorization is defined and aaa_authorization is not none %}
-{%     if aaa_authorization.exec.default is defined and aaa_authorization.exec.default is not none %}
+{% if aaa_authorization is arista.avd.defined  %}
+{%     if aaa_authorization.exec.default is arista.avd.defined %}
 aaa authorization exec default {{ aaa_authorization.exec.default }}
 {%     endif %}
-{%     if aaa_authorization.serial_console is defined and aaa_authorization.serial_console == true %}
+{%     if aaa_authorization.serial_console is arista.avd.defined(true) %}
 aaa authorization serial-console
 {%     endif %}
-{%     if aaa_authorization.config_commands is defined and aaa_authorization.config_commands == false %}
+{%     if aaa_authorization.config_commands is arista.avd.defined(false) %}
 no aaa authorization config-commands
 {%     endif %}
-{%     if aaa_authorization.commands.all_default is defined and aaa_authorization.commands.all_default is not none %}
+{%     if aaa_authorization.commands.all_default is arista.avd.defined %}
 aaa authorization commands all default {{ aaa_authorization.commands.all_default }}
 {%     endif %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/aaa-root.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/aaa-root.j2
@@ -1,4 +1,5 @@
-{% if aaa_root is defined and aaa_root is not none %}
+{# eos - aaa root #}
+{% if aaa_root is arista.avd.defined %}
 !
 {%     if aaa_root.secret is defined %}
 aaa root secret sha512 {{ aaa_root.secret.sha512_password }}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/aaa-server-groups.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/aaa-server-groups.j2
@@ -1,11 +1,10 @@
 {# eos - AAA Group Servers#}
-{% if aaa_server_groups is defined and aaa_server_groups is not none %}
+{% if aaa_server_groups is arista.avd.defined %}
 !
-{%     for aaa_server_group in aaa_server_groups %}
+{%    for aaa_server_group in aaa_server_groups %}
 aaa group server {{ aaa_server_group['type'] }} {{ aaa_server_group['name'] }}
-{%          for server in aaa_server_group.servers %}
-   server {{ server['server'] }}{% if server['vrf'] is defined and server['vrf'] is not none %} vrf {{ server['vrf'] }}{% endif %}
-
-{%          endfor %}
-{%      endfor %}
+{%       for server in aaa_server_group.servers %}
+   server {{ server['server'] }}{% if server['vrf'] is arista.avd.defined %} vrf {{ server['vrf'] }}{% endif %}
+{%       endfor %}
+{%    endfor %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/access-lists.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/access-lists.j2
@@ -1,5 +1,5 @@
 {# eos - extended access-lists #}
-{% if access_lists is defined and access_lists is not none %}
+{% if access_lists is arista.avd.defined %}
 !
 {%     for access_list in access_lists | arista.avd.natural_sort %}
 ip access-list {{ access_list }}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/aliases.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/aliases.j2
@@ -1,5 +1,5 @@
 {# eos - aliases #}
-{% if aliases is defined and aliases is not none %}
+{% if aliases is arista.avd.defined %}
 !
 {{ aliases }}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/arp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/arp.j2
@@ -1,7 +1,7 @@
 {# eos - ARP settings #}
-{% if arp is defined and arp is not none %}
-{%     if arp.aging is defined and arp.aging is not none %}
-{%         if arp.aging.timeout_default is defined and arp.aging.timeout_default is not none %}
+{% if arp is arista.avd.defined %}
+{%     if arp.aging is arista.avd.defined %}
+{%         if arp.aging.timeout_default is arista.avd.defined %}
 !
 arp aging timeout default {{ arp.aging.timeout_default }}
 {%         endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/banners.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/banners.j2
@@ -1,13 +1,13 @@
-{# banners #}
-{% if banners is defined and banners is not none %}
-{%     if banners.login is defined and banners.login is not none %}
+{# eos - banners #}
+{% if banners is arista.avd.defined %}
+{%     if banners.login is arista.avd.defined %}
 !
 banner login
 {{ banners.login }}
-{%   endif %}
-{%     if banners.motd is defined and banners.motd is not none %}
+{%     endif %}
+{%     if banners.motd is arista.avd.defined %}
 !
 banner motd
 {{ banners.motd }}
-{%    endif %}
+{%     endif %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/clock-timezone.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/clock-timezone.j2
@@ -1,4 +1,5 @@
-{% if clock is defined and clock is not none %}
+{# eos - Clock timezone#}
+{% if clock is arista.avd.defined %}
 !
 clock timezone {{ clock.timezone }}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/community-lists.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/community-lists.j2
@@ -1,5 +1,5 @@
 {# eos - community-lists #}
-{% if community_lists is defined and community_lists is not none %}
+{% if community_lists is arista.avd.defined %}
 !
 {%     for community_list in community_lists | arista.avd.natural_sort %}
 ip community-list {{ community_list }} {{ community_lists[community_list].action }}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/custom-templates.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/custom-templates.j2
@@ -1,4 +1,5 @@
-{% if custom_templates is defined and custom_templates is not none %}
+{# eos - Custom templates #}
+{% if custom_templates is arista.avd.defined %}
 {%     for custom_template in custom_templates %}
 {%         include custom_template %}
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/daemon-terminattr.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/daemon-terminattr.j2
@@ -1,4 +1,5 @@
-{% if daemon_terminattr is defined and daemon_terminattr is not none %}
+{# eos - TerminAttr #}
+{% if daemon_terminattr is arista.avd.defined %}
 !
 {# Create list of non CVaaS server #}
 {% set cvp_on_prem = namespace() %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/dns-domain.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/dns-domain.j2
@@ -1,4 +1,4 @@
 {# eos - dns domain #}
-{% if dns_domain is defined and dns_domain is not none %}
+{% if dns_domain is arista.avd.defined %}
 dns domain {{ dns_domain }}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/domain-list.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/domain-list.j2
@@ -1,5 +1,5 @@
 {# eos - domain-list #}
-{% if domain_list is defined and domain_list is not none %}
+{% if domain_list is arista.avd.defined %}
 {%    for domain in domain_list | sort %}
 ip domain-list {{ domain }}
 {%    endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/domain-lookup.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/domain-lookup.j2
@@ -1,7 +1,7 @@
 {# eos - domain lookup #}
-{% if ip_domain_lookup is defined and ip_domain_lookup is not none %}
+{% if ip_domain_lookup is arista.avd.defined %}
 {%    for source in ip_domain_lookup.source_interfaces | arista.avd.natural_sort %}
-{%              if ip_domain_lookup.source_interfaces[source].vrf is defined and ip_domain_lookup.source_interfaces[source].vrf is not none %}
+{%              if ip_domain_lookup.source_interfaces[source].vrf is arista.avd.defined %}
 ip domain lookup vrf {{ ip_domain_lookup.source_interfaces[source].vrf }} source-interface {{ source }}
 {%              else %}
 ip domain lookup source-interface {{ source }}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/enable-password.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/enable-password.j2
@@ -1,3 +1,4 @@
+{# eos - Enable password #}
 {% if enable_password is arista.avd.defined %}
 {%     if enable_password.key is arista.avd.defined %}
 {%         if enable_password.hash_algorithm is arista.avd.defined("md5") %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/errdisable.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/errdisable.j2
@@ -1,5 +1,5 @@
 {# eos - Errdisable #}
-{% if errdisable is defined and errdisable is not none %}
+{% if errdisable is arista.avd.defined %}
 {%     if errdisable.recovery is defined %}
 {%         if errdisable.detect.causes is defined %}
 {%             for cause in errdisable.detect.causes | arista.avd.natural_sort %}
@@ -59,7 +59,7 @@ errdisable recovery cause {{ cause }}
 {%                 endif %}
 {%             endfor %}
 {%         endif %}
-{%         if errdisable.recovery.interval is defined and errdisable.recovery.interval is not none  %}
+{%         if errdisable.recovery.interval is arista.avd.defined %}
 errdisable recovery interval {{ errdisable.recovery.interval }}
 {%         endif %}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -1,151 +1,153 @@
 {# eos - Ethernet Interfaces #}
-{% if ethernet_interfaces is defined and ethernet_interfaces is not none %}
+{% if ethernet_interfaces is arista.avd.defined %}
 {%     for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort %}
 !
 interface {{ ethernet_interface }}
-{%         if ethernet_interfaces[ethernet_interface].description is defined and ethernet_interfaces[ethernet_interface].description is not none %}
+{%         if ethernet_interfaces[ethernet_interface].description is arista.avd.defined %}
    description {{ ethernet_interfaces[ethernet_interface].description }}
 {%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].logging is defined and ethernet_interfaces[ethernet_interface].logging is not none %}
-{%             if ethernet_interfaces[ethernet_interface].logging.event is defined and ethernet_interfaces[ethernet_interface].logging.event is not none %}
-{%                 if ethernet_interfaces[ethernet_interface].logging.event.link_status is defined and ethernet_interfaces[ethernet_interface].logging.event.link_status == true %}
+{%         if ethernet_interfaces[ethernet_interface].logging is arista.avd.defined %}
+{%             if ethernet_interfaces[ethernet_interface].logging.event is arista.avd.defined %}
+{%                 if ethernet_interfaces[ethernet_interface].logging.event.link_status is arista.avd.defined(true) %}
    logging event link-status
 {%                 endif %}
 {%             endif %}
 {%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].shutdown is defined and ethernet_interfaces[ethernet_interface].shutdown == true %}
+{%         if ethernet_interfaces[ethernet_interface].shutdown is arista.avd.defined(true) %}
    shutdown
-{%         elif ethernet_interfaces[ethernet_interface].shutdown is defined and ethernet_interfaces[ethernet_interface].shutdown == false %}
+{%         elif ethernet_interfaces[ethernet_interface].shutdown is arista.avd.defined(false) %}
    no shutdown
 {%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].speed is defined and ethernet_interfaces[ethernet_interface].speed is not none %}
+{%         if ethernet_interfaces[ethernet_interface].speed is arista.avd.defined %}
    speed {{ ethernet_interfaces[ethernet_interface].speed }}
 {%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].mac_security.profile is defined and ethernet_interfaces[ethernet_interface].mac_security.profile is not none %}
+{%         if ethernet_interfaces[ethernet_interface].mac_security.profile is arista.avd.defined %}
    mac security profile {{ ethernet_interfaces[ethernet_interface].mac_security.profile }}
 {%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].channel_group is defined and ethernet_interfaces[ethernet_interface].channel_group is not none %}
+{%         if ethernet_interfaces[ethernet_interface].channel_group is arista.avd.defined %}
    channel-group {{ ethernet_interfaces[ethernet_interface].channel_group.id }} mode {{ ethernet_interfaces[ethernet_interface].channel_group.mode }}
 {%         else %}
-{%             if ethernet_interfaces[ethernet_interface].mtu is defined and ethernet_interfaces[ethernet_interface].mtu != 1500 %}
+{%             if ethernet_interfaces[ethernet_interface].mtu is arista.avd.defined and ethernet_interfaces[ethernet_interface].mtu != 1500 %}
    mtu {{ ethernet_interfaces[ethernet_interface].mtu }}
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].type is defined and ethernet_interfaces[ethernet_interface].type == "routed" %}
+{%             if ethernet_interfaces[ethernet_interface].type is arista.avd.defined("routed") %}
    no switchport
 {%             else %}
    switchport
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].flowcontrol is defined and ethernet_interfaces[ethernet_interface].flowcontrol is not none %}
-{%                 if ethernet_interfaces[ethernet_interface].flowcontrol.received is defined and ethernet_interfaces[ethernet_interface].flowcontrol.received is not none %}
+{%             if ethernet_interfaces[ethernet_interface].flowcontrol is arista.avd.defined %}
+{%                 if ethernet_interfaces[ethernet_interface].flowcontrol.received is arista.avd.defined %}
    flowcontrol receive {{ ethernet_interfaces[ethernet_interface].flowcontrol.received }}
 {%                 endif %}
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].mode is defined and ethernet_interfaces[ethernet_interface].mode == "access" %}
+{%             if ethernet_interfaces[ethernet_interface].mode is arista.avd.defined("access") %}
    switchport access vlan {{ ethernet_interfaces[ethernet_interface].vlans }}
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].vlans is defined and ethernet_interfaces[ethernet_interface].mode == "trunk" %}
+{%             if ethernet_interfaces[ethernet_interface].mode is arista.avd.defined("trunk") %}
+{%                if ethernet_interfaces[ethernet_interface].vlans is arista.avd.defined %}
    switchport trunk allowed vlan {{ ethernet_interfaces[ethernet_interface].vlans }}
-{%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].native_vlan is defined and ethernet_interfaces[ethernet_interface].mode == "trunk" %}
+{%                endif %}
+{%                if ethernet_interfaces[ethernet_interface].native_vlan is arista.avd.defined %}
    switchport trunk native vlan {{ ethernet_interfaces[ethernet_interface].native_vlan }}
+{%                endif %}
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].mode is defined and ethernet_interfaces[ethernet_interface].mode == "trunk" %}
+{%             if ethernet_interfaces[ethernet_interface].mode is arista.avd.defined %}
    switchport mode {{ ethernet_interfaces[ethernet_interface].mode }}
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].trunk_groups is defined and ethernet_interfaces[ethernet_interface].trunk_groups is not none %}
+{%             if ethernet_interfaces[ethernet_interface].trunk_groups is arista.avd.defined %}
 {%                 for  trunk_group in ethernet_interfaces[ethernet_interface].trunk_groups | arista.avd.natural_sort %}
    switchport trunk group {{ trunk_group }}
 {%                 endfor %}
 {%             endif %}
 {%             if ethernet_interfaces[ethernet_interface].qos is defined %}
-{%                 if ethernet_interfaces[ethernet_interface].qos.trust is defined and ethernet_interfaces[ethernet_interface].qos.trust is not none %}
+{%                 if ethernet_interfaces[ethernet_interface].qos.trust is arista.avd.defined %}
    qos trust {{ ethernet_interfaces[ethernet_interface].qos.trust }}
 {%                 endif %}
-{%                 if ethernet_interfaces[ethernet_interface].qos.dscp is defined and ethernet_interfaces[ethernet_interface].qos.dscp is not none %}
+{%                 if ethernet_interfaces[ethernet_interface].qos.dscp is arista.avd.defined %}
    qos dscp {{ ethernet_interfaces[ethernet_interface].qos.dscp }}
 {%                 endif %}
-{%                 if ethernet_interfaces[ethernet_interface].qos.cos is defined and ethernet_interfaces[ethernet_interface].qos.cos is not none %}
+{%                 if ethernet_interfaces[ethernet_interface].qos.cos is arista.avd.defined %}
    qos cos {{ ethernet_interfaces[ethernet_interface].qos.cos }}
 {%                 endif %}
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].spanning_tree_portfast is defined and ethernet_interfaces[ethernet_interface].spanning_tree_portfast == 'edge' %}
+{%             if ethernet_interfaces[ethernet_interface].spanning_tree_portfast is arista.avd.defined('edge') %}
    spanning-tree portfast
-{%             elif ethernet_interfaces[ethernet_interface].spanning_tree_portfast is defined and ethernet_interfaces[ethernet_interface].spanning_tree_portfast == 'network' %}
+{%             elif ethernet_interfaces[ethernet_interface].spanning_tree_portfast is arista.avd.defined('network') %}
    spanning-tree portfast network
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].spanning_tree_bpdufilter is defined and ethernet_interfaces[ethernet_interface].spanning_tree_bpdufilter == true %}
+{%             if ethernet_interfaces[ethernet_interface].spanning_tree_bpdufilter is arista.avd.defined(true) %}
    spanning-tree bpdufilter enable
 {%             endif%}
-{%             if ethernet_interfaces[ethernet_interface].spanning_tree_bpduguard is defined and ethernet_interfaces[ethernet_interface].spanning_tree_bpduguard == true %}
+{%             if ethernet_interfaces[ethernet_interface].spanning_tree_bpduguard is arista.avd.defined(true) %}
    spanning-tree bpduguard enable
 {%             endif%}
-{%             if ethernet_interfaces[ethernet_interface].vrf is defined and ethernet_interfaces[ethernet_interface].vrf is not none %}
+{%             if ethernet_interfaces[ethernet_interface].vrf is arista.avd.defined %}
    vrf {{ ethernet_interfaces[ethernet_interface].vrf }}
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].ip_proxy_arp is defined and ethernet_interfaces[ethernet_interface].ip_proxy_arp == true %}
+{%             if ethernet_interfaces[ethernet_interface].ip_proxy_arp is arista.avd.defined(true) %}
    ip proxy-arp
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].ip_address is defined and ethernet_interfaces[ethernet_interface].ip_address is not none %}
+{%             if ethernet_interfaces[ethernet_interface].ip_address is arista.avd.defined %}
    ip address {{ ethernet_interfaces[ethernet_interface].ip_address }}
-{%                 if ethernet_interfaces[ethernet_interface].ip_address_secondaries is defined and ethernet_interfaces[ethernet_interface].ip_address_secondaries is not none %}
+{%                 if ethernet_interfaces[ethernet_interface].ip_address_secondaries is arista.avd.defined %}
 {%                     for ip_address_secondary in ethernet_interfaces[ethernet_interface].ip_address_secondaries %}
    ip address {{ ip_address_secondary }} secondary
 {%                     endfor %}
 {%                 endif %}
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].ipv6_enable is defined and ethernet_interfaces[ethernet_interface].ipv6_enable == true %}
+{%             if ethernet_interfaces[ethernet_interface].ipv6_enable is arista.avd.defined(true) %}
    ipv6 enable
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].ipv6_address is defined and ethernet_interfaces[ethernet_interface].ipv6_address is not none %}
+{%             if ethernet_interfaces[ethernet_interface].ipv6_address is arista.avd.defined %}
    ipv6 address {{ ethernet_interfaces[ethernet_interface].ipv6_address }}
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].ipv6_address_link_local is defined and ethernet_interfaces[ethernet_interface].ipv6_address_link_local is not none %}
+{%             if ethernet_interfaces[ethernet_interface].ipv6_address_link_local is arista.avd.defined %}
    ipv6 address {{ ethernet_interfaces[ethernet_interface].ipv6_address_link_local }} link-local
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].ipv6_nd_ra_disabled is defined and ethernet_interfaces[ethernet_interface].ipv6_nd_ra_disabled == true %}
+{%             if ethernet_interfaces[ethernet_interface].ipv6_nd_ra_disabled is arista.avd.defined(true) %}
    ipv6 nd ra disabled
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].ipv6_nd_managed_config_flag is defined and ethernet_interfaces[ethernet_interface].ipv6_nd_managed_config_flag == true %}
+{%             if ethernet_interfaces[ethernet_interface].ipv6_nd_managed_config_flag is arista.avd.defined(true) %}
    ipv6 nd managed-config-flag
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].ipv6_nd_prefixes is defined and ethernet_interfaces[ethernet_interface].ipv6_nd_prefixes is not none %}
+{%             if ethernet_interfaces[ethernet_interface].ipv6_nd_prefixes is arista.avd.defined %}
 {%                 for prefix in ethernet_interfaces[ethernet_interface].ipv6_nd_prefixes %}
-   ipv6 nd prefix {{ prefix }} {% if ethernet_interfaces[ethernet_interface].ipv6_nd_prefixes[prefix].valid_lifetime is defined and ethernet_interfaces[ethernet_interface].ipv6_nd_prefixes[prefix].valid_lifetime is not none %}{{ ethernet_interfaces[ethernet_interface].ipv6_nd_prefixes[prefix].valid_lifetime }} {% endif %}{% if ethernet_interfaces[ethernet_interface].ipv6_nd_prefixes[prefix].preferred_lifetime is defined and ethernet_interfaces[ethernet_interface].ipv6_nd_prefixes[prefix].preferred_lifetime is not none %}{{ ethernet_interfaces[ethernet_interface].ipv6_nd_prefixes[prefix].preferred_lifetime }} {% endif %}{% if ethernet_interfaces[ethernet_interface].ipv6_nd_prefixes[prefix].no_autoconfig_flag is defined and ethernet_interfaces[ethernet_interface].ipv6_nd_prefixes[prefix].no_autoconfig_flag == true %}no-autoconfig{% endif %}
+   ipv6 nd prefix {{ prefix }} {% if ethernet_interfaces[ethernet_interface].ipv6_nd_prefixes[prefix].valid_lifetime is arista.avd.defined %}{{ ethernet_interfaces[ethernet_interface].ipv6_nd_prefixes[prefix].valid_lifetime }} {% endif %}{% if ethernet_interfaces[ethernet_interface].ipv6_nd_prefixes[prefix].preferred_lifetime is arista.avd.defined %}{{ ethernet_interfaces[ethernet_interface].ipv6_nd_prefixes[prefix].preferred_lifetime }} {% endif %}{% if ethernet_interfaces[ethernet_interface].ipv6_nd_prefixes[prefix].no_autoconfig_flag is arista.avd.defined(true) %}no-autoconfig{% endif %}
 
 {%                 endfor %}
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].access_group_in is defined and ethernet_interfaces[ethernet_interface].access_group_in is not none %}
+{%             if ethernet_interfaces[ethernet_interface].access_group_in is arista.avd.defined %}
    ip access-group {{ ethernet_interfaces[ethernet_interface].access_group_in }} in
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].access_group_out is defined and ethernet_interfaces[ethernet_interface].access_group_out is not none %}
+{%             if ethernet_interfaces[ethernet_interface].access_group_out is arista.avd.defined %}
    ip access-group {{ ethernet_interfaces[ethernet_interface].access_group_out }} out
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].ipv6_access_group_in is defined and ethernet_interfaces[ethernet_interface].ipv6_access_group_in is not none %}
+{%             if ethernet_interfaces[ethernet_interface].ipv6_access_group_in is arista.avd.defined %}
    ipv6 access-group {{ ethernet_interfaces[ethernet_interface].ipv6_access_group_in }} in
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].ipv6_access_group_out is defined and ethernet_interfaces[ethernet_interface].ipv6_access_group_out is not none %}
+{%             if ethernet_interfaces[ethernet_interface].ipv6_access_group_out is arista.avd.defined %}
    ipv6 access-group {{ ethernet_interfaces[ethernet_interface].ipv6_access_group_out }} out
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].ospf_network_point_to_point is defined and ethernet_interfaces[ethernet_interface].ospf_network_point_to_point == true %}
+{%             if ethernet_interfaces[ethernet_interface].ospf_network_point_to_point is arista.avd.defined(true) %}
    ip ospf network point-to-point
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].ospf_area is defined and ethernet_interfaces[ethernet_interface].ospf_area is not none %}
+{%             if ethernet_interfaces[ethernet_interface].ospf_area is arista.avd.defined %}
    ip ospf area {{ ethernet_interfaces[ethernet_interface].ospf_area }}
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].ospf_cost is defined and ethernet_interfaces[ethernet_interface].ospf_cost is not none %}
+{%             if ethernet_interfaces[ethernet_interface].ospf_cost is arista.avd.defined %}
    ip ospf cost {{ ethernet_interfaces[ethernet_interface].ospf_cost }}
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].ospf_authentication is defined and ethernet_interfaces[ethernet_interface].ospf_authentication is not none %}
+{%             if ethernet_interfaces[ethernet_interface].ospf_authentication is arista.avd.defined %}
 {%                 if ethernet_interfaces[ethernet_interface].ospf_authentication == "simple" %}
    ip ospf authentication
 {%                 elif ethernet_interfaces[ethernet_interface].ospf_authentication == "message-digest" %}
    ip ospf authentication message-digest
 {%                 endif %}
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].ospf_authentication_key is defined and ethernet_interfaces[ethernet_interface].ospf_authentication_key is not none %}
+{%             if ethernet_interfaces[ethernet_interface].ospf_authentication_key is arista.avd.defined %}
    ip ospf authentication-key 7 {{ ethernet_interfaces[ethernet_interface].ospf_authentication_key }}
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].ospf_message_digest_keys is defined and ethernet_interfaces[ethernet_interface].ospf_message_digest_keys is not none %}
+{%             if ethernet_interfaces[ethernet_interface].ospf_message_digest_keys is arista.avd.defined %}
 {%               for ospf_message_digest_key in ethernet_interfaces[ethernet_interface].ospf_message_digest_keys | arista.avd.natural_sort %}
    ip ospf message-digest-key {{ ospf_message_digest_key }} {{ ethernet_interfaces[ethernet_interface].ospf_message_digest_keys[ospf_message_digest_key].hash_algorithm }} 7 {{ ethernet_interfaces[ethernet_interface].ospf_message_digest_keys[ospf_message_digest_key].key }}
 {%               endfor %}
@@ -153,32 +155,32 @@ interface {{ ethernet_interface }}
 {%             if ethernet_interfaces[ethernet_interface].isis_enable is defined %}
    isis enable {{ ethernet_interfaces[ethernet_interface].isis_enable }}
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].isis_passive is defined and ethernet_interfaces[ethernet_interface].isis_passive == true %}
+{%             if ethernet_interfaces[ethernet_interface].isis_passive is arista.avd.defined(true) %}
    isis passive
 {%             endif %}
 {%             if ethernet_interfaces[ethernet_interface].isis_metric is defined %}
    isis metric {{ ethernet_interfaces[ethernet_interface].isis_metric }}
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].isis_network_point_to_point is defined and ethernet_interfaces[ethernet_interface].isis_network_point_to_point == true %}
+{%             if ethernet_interfaces[ethernet_interface].isis_network_point_to_point is arista.avd.defined(true) %}
    isis network point-to-point
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].pim.ipv4.sparse_mode is defined and ethernet_interfaces[ethernet_interface].pim.ipv4.sparse_mode == true %}
+{%             if ethernet_interfaces[ethernet_interface].pim.ipv4.sparse_mode is arista.avd.defined(true) %}
    pim ipv4 sparse-mode
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].vmtracer is defined and ethernet_interfaces[ethernet_interface].vmtracer == true %}
+{%             if ethernet_interfaces[ethernet_interface].vmtracer is arista.avd.defined(true) %}
    vmtracer vmware-esx
 {%             endif %}
 {%             if ethernet_interfaces[ethernet_interface].ptp is defined %}
-{%                 if ethernet_interfaces[ethernet_interface].ptp.enable is defined and ethernet_interfaces[ethernet_interface].ptp.enable == true %}
+{%                 if ethernet_interfaces[ethernet_interface].ptp.enable is arista.avd.defined(true) %}
    ptp enable
 {%                 endif %}
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].service_profile is defined and ethernet_interfaces[ethernet_interface].service_profile is not none %}
+{%             if ethernet_interfaces[ethernet_interface].service_profile is arista.avd.defined %}
    service-profile {{ ethernet_interfaces[ethernet_interface].service_profile }}
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].storm_control is defined and ethernet_interfaces[ethernet_interface].storm_control is not none %}
+{%             if ethernet_interfaces[ethernet_interface].storm_control is arista.avd.defined %}
 {%                   for section in ethernet_interfaces[ethernet_interface].storm_control | arista.avd.natural_sort %}
-{%                      if ethernet_interfaces[ethernet_interface].storm_control[section].unit is defined and ethernet_interfaces[ethernet_interface].storm_control[section].unit == "pps" %}
+{%                      if ethernet_interfaces[ethernet_interface].storm_control[section].unit is arista.avd.defined("pps") %}
    storm-control {{ section | replace("_", "-") }} level pps {{ethernet_interfaces[ethernet_interface].storm_control[section].level}}
 {%                      else %}
    storm-control {{ section | replace("_", "-") }} level {{ethernet_interfaces[ethernet_interface].storm_control[section].level}}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/event-handler.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/event-handler.j2
@@ -1,4 +1,5 @@
-{% if event_handlers is defined and event_handlers is not none %}
+{# eos - Event handlers #}
+{% if event_handlers is arista.avd.defined %}
 {%     for handler in event_handlers %}
 !
 event-handler {{ handler }}
@@ -14,7 +15,7 @@ event-handler {{ handler }}
 {%         if event_handlers[handler].delay is defined %}
    delay {{ event_handlers[handler].delay }}
 {%         endif %}
-{%         if event_handlers[handler].asynchronous is defined and event_handlers[handler].asynchronous == true %}
+{%         if event_handlers[handler].asynchronous is arista.avd.defined(true) %}
    asynchronous
 {%         endif %}
 {%    endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/event-monitor.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/event-monitor.j2
@@ -1,4 +1,5 @@
-{% if event_monitor is defined and event_monitor is not none %}
+{# eos - Event monitor #}
+{% if event_monitor is arista.avd.defined %}
 {%     if event_monitor.enabled == true %}
 !
 event-monitor

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/hardware-counters.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/hardware-counters.j2
@@ -1,5 +1,5 @@
-{% if hardware_counters is defined and hardware_counters is not none %}
-{%     if hardware_counters.features is defined and hardware_counters.features is not none %}
+{% if hardware_counters is arista.avd.defined %}
+{%     if hardware_counters.features is arista.avd.defined %}
 !
 {%         for feature in hardware_counters.features %}
 {%             for feature, direction in feature.items() %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/hardware.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/hardware.j2
@@ -1,5 +1,5 @@
 {# eos - hardware settings #}
-{% if hardware is defined and hardware.speed_groups is defined and hardware.speed_groups is not none %}
+{% if hardware is defined and hardware.speed_groups is arista.avd.defined %}
 !
 {%   for speed_group in hardware.speed_groups %}
 hardware speed-group{{ speed_group }} serdes {{ hardware.speed_groups[speed_group].serdes }}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/interface-defaults.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/interface-defaults.j2
@@ -1,25 +1,25 @@
 {# eos - interface defaults #}
-{% if interface_defaults is defined and interface_defaults is not none %}
-{%     if ( interface_defaults.mtu is defined and interface_defaults.mtu is not none ) or ( interface_defaults.switchport is defined and interface_defaults.switchport is not none ) %}
+{% if interface_defaults is arista.avd.defined %}
+{%     if ( interface_defaults.mtu is arista.avd.defined ) or ( interface_defaults.switchport is arista.avd.defined ) %}
 !
 interface defaults
-{%         if interface_defaults.ethernet is defined and interface_defaults.ethernet is not none %}
+{%         if interface_defaults.ethernet is arista.avd.defined %}
    ethernet
-{%             if interface_defaults.ethernet.shutdown is defined and interface_defaults.ethernet.shutdown == true %}
+{%             if interface_defaults.ethernet.shutdown is arista.avd.defined(true) %}
       shutdown
-{%             elif interface_defaults.ethernet.shutdown is defined and interface_defaults.ethernet.shutdown == false %}
+{%             elif interface_defaults.ethernet.shutdown is arista.avd.defined(false) %}
       no shutdown
 {%             endif %}
 {%         endif %}
-{%         if interface_defaults.mtu is defined and interface_defaults.mtu is not none %}
+{%         if interface_defaults.mtu is arista.avd.defined %}
    mtu {{ interface_defaults.mtu }}
 {%         endif %}
 {%     endif %}
-{%     if interface_defaults.switchport is defined and interface_defaults.switchport is not none %}
-{%         if interface_defaults.switchport.type is defined and interface_defaults.switchport.type == "routed" %}
+{%     if interface_defaults.switchport is arista.avd.defined %}
+{%         if interface_defaults.switchport.type is arista.avd.defined("routed") %}
 !
 switchport default mode routed
-{%         elif interface_defaults.switchport.type is defined and interface_defaults.switchport.type == "switched" %}
+{%         elif interface_defaults.switchport.type is arista.avd.defined("switched") %}
 !
 switchport default mode access
 {%         endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-dhcp-relay.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-dhcp-relay.j2
@@ -1,6 +1,6 @@
 {# eos - ip dhcp relay #}
-{% if ip_dhcp_relay is defined and ip_dhcp_relay is not none %}
-{%    if ip_dhcp_relay.information_option is defined and ip_dhcp_relay.information_option == true %}
+{% if ip_dhcp_relay is arista.avd.defined %}
+{%    if ip_dhcp_relay.information_option is arista.avd.defined(true) %}
 !
 ip dhcp relay information option
 {%    endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-extended-communities.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-extended-communities.j2
@@ -1,5 +1,5 @@
 {# eos - ip-extended-community #}
-{% if ip_extcommunity_lists is defined and ip_extcommunity_lists is not none %}
+{% if ip_extcommunity_lists is arista.avd.defined %}
 {%     for ip_extcommunity in ip_extcommunity_lists | arista.avd.natural_sort %}
 !
 {%         for sequence in ip_extcommunity_lists[ip_extcommunity] | arista.avd.natural_sort %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-igmp-snooping.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-igmp-snooping.j2
@@ -1,12 +1,12 @@
 {# eos - IP IGMP Snooping #}
-{% if ip_igmp_snooping is defined and ip_igmp_snooping is not none %}
-{%    if ip_igmp_snooping.globally_enabled is defined and ip_igmp_snooping.globally_enabled == false %}
+{% if ip_igmp_snooping is arista.avd.defined %}
+{%    if ip_igmp_snooping.globally_enabled is arista.avd.defined(false) %}
 !
 no ip igmp snooping
-{%    elif ip_igmp_snooping.vlans is defined and ip_igmp_snooping.vlans is not none %}
+{%    elif ip_igmp_snooping.vlans is arista.avd.defined %}
 !
 {%       for vlan in ip_igmp_snooping.vlans | arista.avd.natural_sort %}
-{%          if ip_igmp_snooping.vlans[vlan].enabled is defined and ip_igmp_snooping.vlans[vlan].enabled == false %}
+{%          if ip_igmp_snooping.vlans[vlan].enabled is arista.avd.defined(false) %}
 no ip igmp snooping vlan {{ vlan }}
 {%          endif %}
 {%        endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-routing.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-routing.j2
@@ -1,5 +1,5 @@
 {# eos - IP Routing #}
-{% if ip_routing is defined and ip_routing is not none %}
+{% if ip_routing is arista.avd.defined %}
 {%     if ip_routing == true %}
 !
 ip routing
@@ -8,7 +8,7 @@ ip routing
 no ip routing
 {%     endif %}
 {% endif %}
-{% if vrfs is defined and vrfs is not none %}
+{% if vrfs is arista.avd.defined %}
 {%     for vrf in vrfs | arista.avd.natural_sort %}
 {%             if vrfs[vrf].ip_routing == true and vrf is ne 'default' %}
 ip routing vrf {{ vrf }}
@@ -17,8 +17,6 @@ no ip routing vrf {{ vrf }}
 {%             endif %}
 {%     endfor %}
 {% endif %}
-{% if ip_icmp_redirect is defined and ip_icmp_redirect is not none %}
-{%        if ip_icmp_redirect is defined and ip_icmp_redirect == false %}
+{% if ip_icmp_redirect is arista.avd.defined(false) %}
 no ip icmp redirect
-{%        endif %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -98,12 +98,30 @@ router bgp {{ router_bgp.as }}
 {%         endif %}
 {%     endfor %}
 {%     for aggregate_address in router_bgp.aggregate_addresses | arista.avd.natural_sort %}
-   aggregate-address {{ aggregate_address }}{% if router_bgp.aggregate_addresses[aggregate_address].as_set is arista.avd.defined(true) %} as-set{% endif %}{% if router_bgp.aggregate_addresses[aggregate_address].summary_only is arista.avd.defined(true) %} summary-only{% endif %}{% if router_bgp.aggregate_addresses[aggregate_address].attribute_map is arista.avd.defined %} attribute-map {{ router_bgp.aggregate_addresses[aggregate_address].attribute_map }}{% endif %}{% if router_bgp.aggregate_addresses[aggregate_address].match_map is arista.avd.defined %} match-map {{ router_bgp.aggregate_addresses[aggregate_address].match_map }}{% endif %}{% if router_bgp.aggregate_addresses[aggregate_address].advertise_only is arista.avd.defined(true) %} advertise-only{% endif %}
-
+{%         set aggregate_address_cli = "aggregate-address " ~ aggregate_address %}
+{%         if router_bgp.aggregate_addresses[aggregate_address].as_set is arista.avd.defined(true) %}
+{%             set aggregate_address_cli = aggregate_address_cli ~ " as-set" %}
+{%         endif %}
+{%         if router_bgp.aggregate_addresses[aggregate_address].summary_only is arista.avd.defined(true) %}
+{%             set aggregate_address_cli = aggregate_address_cli ~ " summary-only" %}
+{%         endif %}
+{%         if router_bgp.aggregate_addresses[aggregate_address].attribute_map is arista.avd.defined %}
+{%             set aggregate_address_cli = aggregate_address_cli ~  " attribute-map " ~ router_bgp.aggregate_addresses[aggregate_address].attribute_map %}
+{%         endif %}
+{%         if router_bgp.aggregate_addresses[aggregate_address].match_map is arista.avd.defined %}
+{%             set aggregate_address_cli = aggregate_address_cli ~ " match-map " ~ router_bgp.aggregate_addresses[aggregate_address].match_map %}
+{%         endif %}
+{%         if router_bgp.aggregate_addresses[aggregate_address].advertise_only is arista.avd.defined(true) %}
+{%             set aggregate_address_cli = aggregate_address_cli ~ " advertise-only" %}
+{%         endif %}
+   {{ aggregate_address_cli }}
 {%     endfor %}
 {%     for redistribute_route in router_bgp.redistribute_routes | arista.avd.natural_sort %}
-   redistribute {{ redistribute_route }}{% if router_bgp.redistribute_routes[redistribute_route].route_map is arista.avd.defined %} route-map {{ router_bgp.redistribute_routes[redistribute_route].route_map }}{% endif %}
-
+{%         set redistribute_route_cli = "redistribute " ~ redistribute_route %}
+{%         if router_bgp.redistribute_routes[redistribute_route].route_map is arista.avd.defined %}
+{%             set redistribute_route_cli = redistribute_route_cli ~ " route-map " ~ router_bgp.redistribute_routes[redistribute_route].route_map %}
+{%         endif %}
+   {{ redistribute_route_cli }}
 {%     endfor %}
 {# L2VPNs - (vxlan) vlan based #}
 {%     for vlan in router_bgp.vlans | arista.avd.natural_sort %}
@@ -239,8 +257,14 @@ router bgp {{ router_bgp.as }}
       neighbor {{ neighbor }} prefix-list {{ router_bgp.address_family_ipv4.neighbors[neighbor].prefix_list_out }} out
 {%             endif %}
 {%             if router_bgp.address_family_ipv4.neighbors[neighbor].default_originate is arista.avd.defined %}
-      neighbor {{ neighbor }} default-originate{%if router_bgp.address_family_ipv4.neighbors[neighbor].default_originate.route_map is arista.avd.defined %} route-map {{ router_bgp.address_family_ipv4.neighbors[neighbor].default_originate.route_map }}{% endif %}{%if router_bgp.address_family_ipv4.neighbors[neighbor].default_originate.always is arista.avd.defined(true) %} always{% endif %}
-
+{%                 set neighbor_default_originate_cli = "neighbor " ~ neighbor ~ " default-originate" %}
+{%                 if router_bgp.address_family_ipv4.neighbors[neighbor].default_originate.route_map is arista.avd.defined %}
+{%                     set neighbor_default_originate_cli = neighbor_default_originate_cli ~ " route-map " ~ router_bgp.address_family_ipv4.neighbors[neighbor].default_originate.route_map %}
+{%                 endif %}
+{%                 if router_bgp.address_family_ipv4.neighbors[neighbor].default_originate.always is arista.avd.defined(true) %}
+{%                     set neighbor_default_originate_cli = neighbor_default_originate_cli ~ " always" %}
+{%                 endif %}
+      {{ neighbor_default_originate_cli }}
 {%             endif %}
 {%             if router_bgp.address_family_ipv4.neighbors[neighbor].activate == true %}
       neighbor {{ neighbor }} activate
@@ -280,8 +304,11 @@ router bgp {{ router_bgp.as }}
 {%             endif %}
 {%         endfor %}
 {%         for redistribute_route in router_bgp.address_family_ipv4_multicast.redistribute_routes | arista.avd.natural_sort %}
-      redistribute {{ redistribute_route }} {% if router_bgp.address_family_ipv4_multicast.redistribute_routes[redistribute_route].route_map is arista.avd.defined %}route-map {{ router_bgp.address_family_ipv4_multicast.redistribute_routes[redistribute_route].route_map }}{% endif %}
-
+{%             set redistribute_route_cli = "redistribute " ~ redistribute_route %}
+{%             if router_bgp.address_family_ipv4_multicast.redistribute_routes[redistribute_route].route_map is arista.avd.defined %}
+{%                 set redistribute_route_cli = redistribute_route_cli ~ " route-map " ~ router_bgp.address_family_ipv4_multicast.redistribute_routes[redistribute_route].route_map %}
+{%             endif %}
+      {{ redistribute_route_cli }}
 {%         endfor %}
 {%     endif %}
 {# address family ipv6 activation #}
@@ -315,8 +342,11 @@ router bgp {{ router_bgp.as }}
 {%             endif %}
 {%         endfor %}
 {%         for redistribute_route in router_bgp.address_family_ipv6.redistribute_routes | arista.avd.natural_sort %}
-      redistribute {{ redistribute_route }} {% if router_bgp.address_family_ipv6.redistribute_routes[redistribute_route].route_map is arista.avd.defined %}route-map {{ router_bgp.address_family_ipv6.redistribute_routes[redistribute_route].route_map }}
+{%             set redistribute_route_cli = "redistribute " ~ redistribute_route %}
+{%             if router_bgp.address_family_ipv6.redistribute_routes[redistribute_route].route_map is arista.avd.defined %}
+{%                 set redistribute_route_cli = redistribute_route_cl ~ " route-map " ~ router_bgp.address_family_ipv6.redistribute_routes[redistribute_route].route_map %}
 {%             endif %}
+      {{ redistribute_route_cli }}
 {%         endfor %}
 {%     endif %}
 {# L3VPNs - (vxlan) VRFs #}
@@ -381,8 +411,14 @@ router bgp {{ router_bgp.as }}
       neighbor {{ neighbor }} send-community
 {%                 endif %}
 {%                 if router_bgp.vrfs[vrf].neighbors[neighbor].default_originate is arista.avd.defined %}
-      neighbor {{ neighbor }} default-originate{%if router_bgp.vrfs[vrf].neighbors[neighbor].default_originate.route_map is arista.avd.defined %} route-map {{ router_bgp.vrfs[vrf].neighbors[neighbor].default_originate.route_map }}{% endif %}{%if router_bgp.vrfs[vrf].neighbors[neighbor].default_originate.always is arista.avd.defined(true) %} always{% endif %}
-
+{%                     set neighbor_default_originate_cli = "neighbor " ~ neighbor ~ " default-originate" %}
+{%                     if router_bgp.vrfs[vrf].neighbors[neighbor].default_originate.route_map is arista.avd.defined %}
+{%                         set neighbor_default_originate_cli = neighbor_default_originate_cli ~ " route-map " ~ router_bgp.vrfs[vrf].neighbors[neighbor].default_originate.route_map %}
+{%                     endif %}
+{%                     if router_bgp.vrfs[vrf].neighbors[neighbor].default_originate.always is arista.avd.defined(true) %}
+{%                         set neighbor_default_originate_cli = neighbor_default_originate_cli ~ " always" %}
+{%                     endif %}
+      {{ neighbor_default_originate_cli }}
 {%                 endif %}
 {%                 if router_bgp.vrfs[vrf].neighbors[neighbor].update_source is arista.avd.defined %}
       neighbor {{ neighbor }} update-source {{ router_bgp.vrfs[vrf].neighbors[neighbor].update_source }}
@@ -402,12 +438,30 @@ router bgp {{ router_bgp.as }}
 {%             endfor %}
 {%         endif %}
 {%         for redistribute_route in router_bgp.vrfs[vrf].redistribute_routes | arista.avd.natural_sort %}
-      redistribute {{ redistribute_route }}{% if router_bgp.vrfs[vrf].redistribute_routes[redistribute_route].route_map is arista.avd.defined %} route-map {{ router_bgp.vrfs[vrf].redistribute_routes[redistribute_route].route_map }}{% endif %}
-
+{%             set redistribute_cli = "redistribute " ~ redistribute_route %}
+{%             if router_bgp.vrfs[vrf].redistribute_routes[redistribute_route].route_map is arista.avd.defined %}
+{%                 set redistribute_cli = redistribute_cli + " route-map " ~ router_bgp.vrfs[vrf].redistribute_routes[redistribute_route].route_map %}
+{%            endif %}
+      {{ redistribute_cli }}
 {%         endfor %}
 {%         for aggregate_address in router_bgp.vrfs[vrf].aggregate_addresses | arista.avd.natural_sort %}
-      aggregate-address {{ aggregate_address }}{% if router_bgp.vrfs[vrf].aggregate_addresses[aggregate_address].as_set is arista.avd.defined(true) %} as-set{% endif %}{% if router_bgp.vrfs[vrf].aggregate_addresses[aggregate_address].summary_only is arista.avd.defined(true) %} summary-only{% endif %}{% if router_bgp.vrfs[vrf].aggregate_addresses[aggregate_address].attribute_map is arista.avd.defined %} attribute-map {{ router_bgp.vrfs[vrf].aggregate_addresses[aggregate_address].attribute_map }}{% endif %}{% if router_bgp.vrfs[vrf].aggregate_addresses[aggregate_address].match_map is arista.avd.defined %} match-map {{ router_bgp.vrfs[vrf].aggregate_addresses[aggregate_address].match_map }}{% endif %}{% if router_bgp.vrfs[vrf].aggregate_addresses[aggregate_address].advertise_only is arista.avd.defined(true) %} advertise-only{% endif %}
-
+{%             set aggregate_address_cli = "aggregate-address " ~ aggregate_address %}
+{%             if router_bgp.vrfs[vrf].aggregate_addresses[aggregate_address].as_set is arista.avd.defined(true) %}
+{%                 set  aggregate_address_cli = aggregate_address_cli ~ " as-set" %}
+{%             endif %}
+{%             if router_bgp.vrfs[vrf].aggregate_addresses[aggregate_address].summary_only is arista.avd.defined(true) %}
+{%                  set aggregate_address_cli = aggregate_address_cli ~ " summary-only" %}
+{%             endif %}
+{%             if router_bgp.vrfs[vrf].aggregate_addresses[aggregate_address].attribute_map is arista.avd.defined %}
+{%                 set aggregate_address_cli = aggregate_address_cli ~ " attribute-map " ~ router_bgp.vrfs[vrf].aggregate_addresses[aggregate_address].attribute_map %}
+{%             endif %}
+{%             if router_bgp.vrfs[vrf].aggregate_addresses[aggregate_address].match_map is arista.avd.defined %}
+{%                 set aggregate_address_cli = aggregate_address_cli ~ " match-map " ~ router_bgp.vrfs[vrf].aggregate_addresses[aggregate_address].match_map %}
+{%             endif %}
+{%             if router_bgp.vrfs[vrf].aggregate_addresses[aggregate_address].advertise_only is arista.avd.defined(true) %}
+{%                 set aggregate_address_cli = aggregate_address_cli ~ " advertise-only" %}
+{%             endif %}
+      {{ aggregate_address_cli }}
 {%         endfor %}
 {%     endfor %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -410,6 +410,9 @@ router bgp {{ router_bgp.as }}
 {%                 elif router_bgp.vrfs[vrf].neighbors[neighbor].send_community is defined %}
       neighbor {{ neighbor }} send-community
 {%                 endif %}
+{%                 if router_bgp.vrfs[vrf].neighbors[neighbor].maximum_routes is arista.avd.defined %}
+      neighbor {{ neighbor }} maximum-routes {{ router_bgp.vrfs[vrf].neighbors[neighbor].maximum_routes }}
+{%                 endif %}
 {%                 if router_bgp.vrfs[vrf].neighbors[neighbor].default_originate is arista.avd.defined %}
 {%                     set neighbor_default_originate_cli = "neighbor " ~ neighbor ~ " default-originate" %}
 {%                     if router_bgp.vrfs[vrf].neighbors[neighbor].default_originate.route_map is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -1,62 +1,62 @@
 {# eos - router bgp #}
-{% if router_bgp is defined and router_bgp is not none %}
+{% if router_bgp is arista.avd.defined %}
 !
 router bgp {{ router_bgp.as }}
    router-id {{ router_bgp.router_id }}
-{% if router_bgp.bgp_cluster_id is defined %}
+{% if router_bgp.bgp_cluster_id is arista.avd.defined %}
    bgp cluster-id {{ router_bgp.bgp_cluster_id }}
 {% endif %}
 {%     for bgp_default in router_bgp.bgp_defaults %}
    {{ bgp_default }}
 {%     endfor %}
-{%     if router_bgp.peer_groups is defined and router_bgp.peer_groups is not none%}
+{%     if router_bgp.peer_groups is arista.avd.defined %}
 {%       for peer_group in router_bgp.peer_groups | arista.avd.natural_sort %}
-{%          if router_bgp.peer_groups[peer_group].bgp_listen_range_prefix is defined and router_bgp.peer_groups[peer_group].bgp_listen_range_prefix is not none %}
+{%          if router_bgp.peer_groups[peer_group].bgp_listen_range_prefix is arista.avd.defined %}
    bgp listen range {{ router_bgp.peer_groups[peer_group].bgp_listen_range_prefix }} peer-group {{ peer_group }} peer-filter {{ router_bgp.peer_groups[peer_group].peer_filter }}
 {%          endif %}
 {%       endfor %}
 {%       for peer_group in router_bgp.peer_groups | arista.avd.natural_sort %}
-{%             if router_bgp.peer_groups[peer_group].description is defined and router_bgp.peer_groups[peer_group].description is not none %}
+{%             if router_bgp.peer_groups[peer_group].description is arista.avd.defined %}
    neighbor {{ peer_group }} description {{ router_bgp.peer_groups[peer_group].description }}
 {%             endif %}
-{%             if router_bgp.peer_groups[peer_group].shutdown is defined and router_bgp.peer_groups[peer_group].shutdown == true %}
+{%             if router_bgp.peer_groups[peer_group].shutdown is arista.avd.defined(true) %}
    neighbor {{ peer_group }} shutdown
 {%             endif %}
    neighbor {{ peer_group }} peer group
-{%             if router_bgp.peer_groups[peer_group].remote_as is defined and router_bgp.peer_groups[peer_group].remote_as is not none %}
+{%             if router_bgp.peer_groups[peer_group].remote_as is arista.avd.defined %}
    neighbor {{ peer_group }} remote-as {{ router_bgp.peer_groups[peer_group].remote_as }}
 {%             endif %}
-{%             if router_bgp.peer_groups[peer_group].next_hop_self is defined and router_bgp.peer_groups[peer_group].next_hop_self == true %}
+{%             if router_bgp.peer_groups[peer_group].next_hop_self is arista.avd.defined(true) %}
    neighbor {{ peer_group }} next-hop-self
 {%             endif %}
-{%             if router_bgp.peer_groups[peer_group].next_hop_unchanged is defined and router_bgp.peer_groups[peer_group].next_hop_unchanged == true %}
+{%             if router_bgp.peer_groups[peer_group].next_hop_unchanged is arista.avd.defined(true) %}
    neighbor {{ peer_group }} next-hop-unchanged
 {%             endif %}
-{%             if router_bgp.peer_groups[peer_group].update_source is defined and router_bgp.peer_groups[peer_group].update_source is not none %}
+{%             if router_bgp.peer_groups[peer_group].update_source is arista.avd.defined %}
    neighbor {{ peer_group }} update-source {{ router_bgp.peer_groups[peer_group].update_source }}
 {%             endif %}
-{%             if router_bgp.peer_groups[peer_group].route_reflector_client is defined and router_bgp.peer_groups[peer_group].route_reflector_client == true %}
+{%             if router_bgp.peer_groups[peer_group].route_reflector_client is arista.avd.defined(true) %}
    neighbor {{ peer_group }} route-reflector-client
 {%             endif %}
-{%             if router_bgp.peer_groups[peer_group].bfd is defined and router_bgp.peer_groups[peer_group].bfd == true %}
+{%             if router_bgp.peer_groups[peer_group].bfd is arista.avd.defined(true) %}
    neighbor {{ peer_group }} bfd
 {%             endif %}
-{%             if router_bgp.peer_groups[peer_group].ebgp_multihop is defined and router_bgp.peer_groups[peer_group].ebgp_multihop is not none %}
+{%             if router_bgp.peer_groups[peer_group].ebgp_multihop is arista.avd.defined %}
    neighbor {{ peer_group }} ebgp-multihop {{ router_bgp.peer_groups[peer_group].ebgp_multihop }}
 {%             endif %}
-{%             if router_bgp.peer_groups[peer_group].password is defined and router_bgp.peer_groups[peer_group].password is not none %}
+{%             if router_bgp.peer_groups[peer_group].password is arista.avd.defined %}
    neighbor {{ peer_group }} password 7 {{ router_bgp.peer_groups[peer_group].password }}
 {%             endif %}
-{%             if router_bgp.peer_groups[peer_group].send_community is defined and router_bgp.peer_groups[peer_group].send_community == true %}
+{%             if router_bgp.peer_groups[peer_group].send_community is arista.avd.defined(true) %}
    neighbor {{ peer_group }} send-community
 {%             endif %}
-{%             if router_bgp.peer_groups[peer_group].maximum_routes is defined and router_bgp.peer_groups[peer_group].maximum_routes is not none %}
+{%             if router_bgp.peer_groups[peer_group].maximum_routes is arista.avd.defined %}
    neighbor {{ peer_group }} maximum-routes {{ router_bgp.peer_groups[peer_group].maximum_routes }}
 {%             endif %}
-{%             if router_bgp.peer_groups[peer_group].weight is defined and router_bgp.peer_groups[peer_group].weight is not none %}
+{%             if router_bgp.peer_groups[peer_group].weight is arista.avd.defined %}
    neighbor {{ peer_group }} weight {{ router_bgp.peer_groups[peer_group].weight }}
 {%             endif %}
-{%             if router_bgp.peer_groups[peer_group].timers is defined and router_bgp.peer_groups[peer_group].timers is not none %}
+{%             if router_bgp.peer_groups[peer_group].timers is arista.avd.defined %}
    neighbor {{ peer_group }} timers {{ router_bgp.peer_groups[peer_group].timers }}
 {%             endif %}
 {%             if router_bgp.peer_groups[peer_group].route_map_in is arista.avd.defined %}
@@ -67,69 +67,69 @@ router bgp {{ router_bgp.as }}
 {%             endif %}
 {%       endfor %}
 {%     endif %}
-{%     if router_bgp.neighbors is defined and router_bgp.neighbors is not none %}
+{%     if router_bgp.neighbors is arista.avd.defined %}
 {%         for neighbor in router_bgp.neighbors | arista.avd.natural_sort %}
-{%             if router_bgp.neighbors[neighbor].peer_group is defined and router_bgp.neighbors[neighbor].peer_group is not none %}
+{%             if router_bgp.neighbors[neighbor].peer_group is arista.avd.defined %}
    neighbor {{ neighbor }} peer group {{ router_bgp.neighbors[neighbor].peer_group }}
 {%             endif %}
-{%             if router_bgp.neighbors[neighbor].remote_as is defined and router_bgp.neighbors[neighbor].remote_as is not none %}
+{%             if router_bgp.neighbors[neighbor].remote_as is arista.avd.defined %}
    neighbor {{ neighbor }} remote-as {{ router_bgp.neighbors[neighbor].remote_as }}
 {%             endif %}
-{%             if router_bgp.neighbors[neighbor].next_hop_self is defined and router_bgp.neighbors[neighbor].next_hop_self == true %}
+{%             if router_bgp.neighbors[neighbor].next_hop_self is arista.avd.defined(true) %}
    neighbor {{ neighbor }} next-hop-self
 {%             endif %}
-{%             if router_bgp.neighbors[neighbor].shutdown is defined and router_bgp.neighbors[neighbor].shutdown == true %}
+{%             if router_bgp.neighbors[neighbor].shutdown is arista.avd.defined(true) %}
    neighbor {{ neighbor }} shutdown
 {%             endif %}
-{%             if router_bgp.neighbors[neighbor].description is defined and router_bgp.neighbors[neighbor].description is not none %}
+{%             if router_bgp.neighbors[neighbor].description is arista.avd.defined %}
    neighbor {{ neighbor }} description {{ router_bgp.neighbors[neighbor].description }}
 {%             endif %}
-{%             if router_bgp.neighbors[neighbor].update_source is defined and router_bgp.neighbors[neighbor].update_source is not none %}
+{%             if router_bgp.neighbors[neighbor].update_source is arista.avd.defined %}
    neighbor {{ neighbor }} update-source {{ router_bgp.neighbors[neighbor].update_source }}
 {%             endif %}
-{%             if router_bgp.neighbors[neighbor].bfd is defined and router_bgp.neighbors[neighbor].bfd == true %}
+{%             if router_bgp.neighbors[neighbor].bfd is arista.avd.defined(true) %}
    neighbor {{ neighbor }} bfd
 {%             endif %}
-{%             if router_bgp.neighbors[neighbor].password is defined and router_bgp.neighbors[neighbor].password is not none %}
+{%             if router_bgp.neighbors[neighbor].password is arista.avd.defined %}
    neighbor {{ neighbor }} password 7 {{ router_bgp.neighbors[neighbor].password }}
 {%             endif %}
-{%             if router_bgp.neighbors[neighbor].weight is defined and router_bgp.neighbors[neighbor].weight is not none %}
+{%             if router_bgp.neighbors[neighbor].weight is arista.avd.defined %}
    neighbor {{ neighbor }} weight {{ router_bgp.neighbors[neighbor].weight }}
 {%             endif %}
-{%             if router_bgp.neighbors[neighbor].timers is defined and router_bgp.neighbors[neighbor].timers is not none %}
+{%             if router_bgp.neighbors[neighbor].timers is arista.avd.defined %}
    neighbor {{ neighbor }} timers {{ router_bgp.neighbors[neighbor].timers }}
 {%             endif %}
 {%         endfor %}
 {%     endif %}
-{%     if router_bgp.aggregate_addresses is defined and router_bgp.aggregate_addresses is not none %}
+{%     if router_bgp.aggregate_addresses is arista.avd.defined %}
 {%         for aggregate_address in router_bgp.aggregate_addresses | arista.avd.natural_sort %}
-   aggregate-address {{ aggregate_address }}{% if router_bgp.aggregate_addresses[aggregate_address].as_set is defined and router_bgp.aggregate_addresses[aggregate_address].as_set == true %} as-set{% endif %}{% if router_bgp.aggregate_addresses[aggregate_address].summary_only is defined and router_bgp.aggregate_addresses[aggregate_address].summary_only == true %} summary-only{% endif %}{% if router_bgp.aggregate_addresses[aggregate_address].attribute_map is defined and router_bgp.aggregate_addresses[aggregate_address].attribute_map is not none %} attribute-map {{ router_bgp.aggregate_addresses[aggregate_address].attribute_map }}{% endif %}{% if router_bgp.aggregate_addresses[aggregate_address].match_map is defined and router_bgp.aggregate_addresses[aggregate_address].match_map is not none %} match-map {{ router_bgp.aggregate_addresses[aggregate_address].match_map }}{% endif %}{% if router_bgp.aggregate_addresses[aggregate_address].advertise_only is defined and router_bgp.aggregate_addresses[aggregate_address].advertise_only == true %} advertise-only{% endif %}
+   aggregate-address {{ aggregate_address }}{% if router_bgp.aggregate_addresses[aggregate_address].as_set is arista.avd.defined(true) %} as-set{% endif %}{% if router_bgp.aggregate_addresses[aggregate_address].summary_only is arista.avd.defined(true) %} summary-only{% endif %}{% if router_bgp.aggregate_addresses[aggregate_address].attribute_map is arista.avd.defined %} attribute-map {{ router_bgp.aggregate_addresses[aggregate_address].attribute_map }}{% endif %}{% if router_bgp.aggregate_addresses[aggregate_address].match_map is arista.avd.defined %} match-map {{ router_bgp.aggregate_addresses[aggregate_address].match_map }}{% endif %}{% if router_bgp.aggregate_addresses[aggregate_address].advertise_only is arista.avd.defined(true) %} advertise-only{% endif %}
 
 {%         endfor %}
 {%     endif %}
-{%     if router_bgp.redistribute_routes is defined and router_bgp.redistribute_routes is not none %}
+{%     if router_bgp.redistribute_routes is arista.avd.defined %}
 {%         for redistribute_route in router_bgp.redistribute_routes | arista.avd.natural_sort %}
-   redistribute {{ redistribute_route }}{% if router_bgp.redistribute_routes[redistribute_route].route_map is defined and router_bgp.redistribute_routes[redistribute_route].route_map is not none %} route-map {{ router_bgp.redistribute_routes[redistribute_route].route_map }}{% endif %}
+   redistribute {{ redistribute_route }}{% if router_bgp.redistribute_routes[redistribute_route].route_map is arista.avd.defined %} route-map {{ router_bgp.redistribute_routes[redistribute_route].route_map }}{% endif %}
 
 {%         endfor %}
 {%     endif %}
 {# L2VPNs - (vxlan) vlan based #}
-{%     if router_bgp.vlans is defined and router_bgp.vlans is not none %}
+{%     if router_bgp.vlans is arista.avd.defined %}
 {%        for vlan in router_bgp.vlans | arista.avd.natural_sort %}
    !
    vlan {{ vlan }}
       rd {{ router_bgp.vlans[vlan].rd }}
-{%            if router_bgp.vlans[vlan].route_targets.both is defined and router_bgp.vlans[vlan].route_targets.both is not none %}
+{%            if router_bgp.vlans[vlan].route_targets.both is arista.avd.defined %}
 {%                for route_target in router_bgp.vlans[vlan].route_targets.both %}
       route-target both {{ route_target }}
 {%                endfor %}
 {%            endif %}
-{%            if router_bgp.vlans[vlan].route_targets.import is defined and router_bgp.vlans[vlan].route_targets.import is not none %}
+{%            if router_bgp.vlans[vlan].route_targets.import is arista.avd.defined %}
 {%                for route_target in router_bgp.vlans[vlan].route_targets.import %}
       route-target import {{ route_target }}
 {%                endfor %}
 {%            endif %}
-{%            if router_bgp.vlans[vlan].route_targets.export is defined and router_bgp.vlans[vlan].route_targets.export is not none %}
+{%            if router_bgp.vlans[vlan].route_targets.export is arista.avd.defined %}
 {%                for route_target in router_bgp.vlans[vlan].route_targets.export %}
       route-target export {{ route_target }}
 {%                endfor %}
@@ -140,22 +140,22 @@ router bgp {{ router_bgp.as }}
 {%         endfor %}
 {%     endif %}
 {# vxlan vlan aware bundles #}
-{%     if router_bgp.vlan_aware_bundles is defined and router_bgp.vlan_aware_bundles is not none %}
+{%     if router_bgp.vlan_aware_bundles is arista.avd.defined %}
 {%        for vlan_aware_bundle in router_bgp.vlan_aware_bundles | arista.avd.natural_sort %}
    !
    vlan-aware-bundle {{ vlan_aware_bundle }}
       rd {{ router_bgp.vlan_aware_bundles[vlan_aware_bundle].rd }}
-{%            if router_bgp.vlan_aware_bundles[vlan_aware_bundle].route_targets.both is defined and router_bgp.vlan_aware_bundles[vlan_aware_bundle].route_targets.both is not none %}
+{%            if router_bgp.vlan_aware_bundles[vlan_aware_bundle].route_targets.both is arista.avd.defined %}
 {%                for route_target in router_bgp.vlan_aware_bundles[vlan_aware_bundle].route_targets.both %}
       route-target both {{ route_target }}
 {%                endfor %}
 {%            endif %}
-{%            if router_bgp.vlan_aware_bundles[vlan_aware_bundle].route_targets.import is defined and router_bgp.vlan_aware_bundles[vlan_aware_bundle].route_targets.import is not none %}
+{%            if router_bgp.vlan_aware_bundles[vlan_aware_bundle].route_targets.import is arista.avd.defined %}
 {%                for route_target in router_bgp.vlan_aware_bundles[vlan_aware_bundle].route_targets.import %}
       route-target import {{ route_target }}
 {%                endfor %}
 {%            endif %}
-{%            if router_bgp.vlan_aware_bundles[vlan_aware_bundle].route_targets.export is defined and router_bgp.vlan_aware_bundles[vlan_aware_bundle].route_targets.export is not none %}
+{%            if router_bgp.vlan_aware_bundles[vlan_aware_bundle].route_targets.export is arista.avd.defined %}
 {%                for route_target in router_bgp.vlan_aware_bundles[vlan_aware_bundle].route_targets.export %}
       route-target export {{ route_target }}
 {%                endfor %}
@@ -168,15 +168,15 @@ router bgp {{ router_bgp.as }}
 {%     endif %}
 {# address families activation #}
 {# address family evpn activation #}
-{%     if router_bgp.address_family_evpn is defined and router_bgp.address_family_evpn is not none %}
+{%     if router_bgp.address_family_evpn is arista.avd.defined %}
    !
    address-family evpn
-{%       if router_bgp.address_family_evpn.peer_groups is defined and router_bgp.address_family_evpn.peer_groups is not none %}
+{%       if router_bgp.address_family_evpn.peer_groups is arista.avd.defined %}
 {%          for peer_group in router_bgp.address_family_evpn.peer_groups | arista.avd.natural_sort %}
-{%             if router_bgp.address_family_evpn.peer_groups[peer_group].route_map_in is defined and router_bgp.address_family_evpn.peer_groups[peer_group].route_map_in is not none %}
+{%             if router_bgp.address_family_evpn.peer_groups[peer_group].route_map_in is arista.avd.defined %}
       neighbor {{ peer_group }} route-map {{ router_bgp.address_family_evpn.peer_groups[peer_group].route_map_in }} in
 {%             endif %}
-{%             if router_bgp.address_family_evpn.peer_groups[peer_group].route_map_out is defined and router_bgp.address_family_evpn.peer_groups[peer_group].route_map_out is not none %}
+{%             if router_bgp.address_family_evpn.peer_groups[peer_group].route_map_out is arista.avd.defined %}
       neighbor {{ peer_group }} route-map {{ router_bgp.address_family_evpn.peer_groups[peer_group].route_map_out }} out
 {%             endif %}
 {%             if router_bgp.address_family_evpn.peer_groups[peer_group].activate == true %}
@@ -188,10 +188,10 @@ router bgp {{ router_bgp.as }}
 {%       endif %}
 {%     endif %}
 {# address family rt-membership activation #}
-{%     if router_bgp.address_family_rtc is defined and router_bgp.address_family_rtc is not none %}
+{%     if router_bgp.address_family_rtc is arista.avd.defined %}
    !
    address-family rt-membership
-{%         if router_bgp.address_family_rtc.peer_groups is defined and router_bgp.address_family_rtc.peer_groups is not none %}
+{%         if router_bgp.address_family_rtc.peer_groups is arista.avd.defined %}
 {%            for peer_group in router_bgp.address_family_rtc.peer_groups | arista.avd.natural_sort %}
 {%               if router_bgp.address_family_rtc.peer_groups[peer_group].activate == true %}
       neighbor {{ peer_group }} activate
@@ -199,7 +199,7 @@ router bgp {{ router_bgp.as }}
       no neighbor {{ peer_group }} activate
 {%               endif %}
 {%               if router_bgp.address_family_rtc.peer_groups[peer_group].default_route_target is defined %}
-{%                   if router_bgp.address_family_rtc.peer_groups[peer_group].default_route_target.only is defined and router_bgp.address_family_rtc.peer_groups[peer_group].default_route_target.only == true %}
+{%                   if router_bgp.address_family_rtc.peer_groups[peer_group].default_route_target.only is arista.avd.defined(true) %}
       neighbor {{ peer_group }} default-route-target only
 {%                   else %}
       neighbor {{ peer_group }} default-route-target
@@ -212,30 +212,30 @@ router bgp {{ router_bgp.as }}
 {%         endif %}
 {%       endif %}
 {# address family ipv4 activation #}
-{%     if router_bgp.address_family_ipv4 is defined and router_bgp.address_family_ipv4 is not none %}
+{%     if router_bgp.address_family_ipv4 is arista.avd.defined %}
    !
    address-family ipv4
-{%       if router_bgp.address_family_ipv4.networks is defined and router_bgp.address_family_ipv4.networks is not none %}
+{%       if router_bgp.address_family_ipv4.networks is arista.avd.defined %}
 {%          for network in router_bgp.address_family_ipv4.networks | arista.avd.natural_sort %}
-{%             if router_bgp.address_family_ipv4.networks[network].route_map is defined and router_bgp.address_family_ipv4.networks[network].route_map is not none %}
+{%             if router_bgp.address_family_ipv4.networks[network].route_map is arista.avd.defined %}
       network {{ network }} route-map {{ router_bgp.address_family_ipv4.networks[network].route_map }}
 {%             else %}
       network {{ network }}
 {%             endif %}
 {%          endfor %}
 {%       endif %}
-{%       if router_bgp.address_family_ipv4.peer_groups is defined and router_bgp.address_family_ipv4.peer_groups is not none %}
+{%       if router_bgp.address_family_ipv4.peer_groups is arista.avd.defined %}
 {%          for peer_group in router_bgp.address_family_ipv4.peer_groups | arista.avd.natural_sort %}
-{%             if router_bgp.address_family_ipv4.peer_groups[peer_group].route_map_in is defined and router_bgp.address_family_ipv4.peer_groups[peer_group].route_map_in is not none %}
+{%             if router_bgp.address_family_ipv4.peer_groups[peer_group].route_map_in is arista.avd.defined %}
       neighbor {{ peer_group }} route-map {{ router_bgp.address_family_ipv4.peer_groups[peer_group].route_map_in }} in
 {%             endif %}
-{%             if router_bgp.address_family_ipv4.peer_groups[peer_group].route_map_out is defined and router_bgp.address_family_ipv4.peer_groups[peer_group].route_map_out is not none %}
+{%             if router_bgp.address_family_ipv4.peer_groups[peer_group].route_map_out is arista.avd.defined %}
       neighbor {{ peer_group }} route-map {{ router_bgp.address_family_ipv4.peer_groups[peer_group].route_map_out }} out
 {%             endif %}
-{%             if router_bgp.address_family_ipv4.peer_groups[peer_group].prefix_list_in is defined and router_bgp.address_family_ipv4.peer_groups[peer_group].prefix_list_in is not none %}
+{%             if router_bgp.address_family_ipv4.peer_groups[peer_group].prefix_list_in is arista.avd.defined %}
       neighbor {{ peer_group }} prefix-list {{ router_bgp.address_family_ipv4.peer_groups[peer_group].prefix_list_in }} in
 {%             endif %}
-{%             if router_bgp.address_family_ipv4.peer_groups[peer_group].prefix_list_out is defined and router_bgp.address_family_ipv4.peer_groups[peer_group].prefix_list_out is not none %}
+{%             if router_bgp.address_family_ipv4.peer_groups[peer_group].prefix_list_out is arista.avd.defined %}
       neighbor {{ peer_group }} prefix-list {{ router_bgp.address_family_ipv4.peer_groups[peer_group].prefix_list_out }} out
 {%             endif %}
 {%             if router_bgp.address_family_ipv4.peer_groups[peer_group].activate == true %}
@@ -245,22 +245,22 @@ router bgp {{ router_bgp.as }}
 {%             endif %}
 {%          endfor %}
 {%       endif %}
-{%       if router_bgp.address_family_ipv4.neighbors is defined and router_bgp.address_family_ipv4.neighbors is not none %}
+{%       if router_bgp.address_family_ipv4.neighbors is arista.avd.defined %}
 {%          for neighbor in router_bgp.address_family_ipv4.neighbors | arista.avd.natural_sort %}
-{%             if router_bgp.address_family_ipv4.neighbors[neighbor].route_map_in is defined and router_bgp.address_family_ipv4.neighbors[neighbor].route_map_in is not none %}
+{%             if router_bgp.address_family_ipv4.neighbors[neighbor].route_map_in is arista.avd.defined %}
       neighbor {{ neighbor }} route-map {{ router_bgp.address_family_ipv4.neighbors[neighbor].route_map_in }} in
 {%             endif %}
-{%             if router_bgp.address_family_ipv4.neighbors[neighbor].route_map_out is defined and router_bgp.address_family_ipv4.neighbors[neighbor].route_map_out is not none %}
+{%             if router_bgp.address_family_ipv4.neighbors[neighbor].route_map_out is arista.avd.defined %}
       neighbor {{ neighbor }} route-map {{ router_bgp.address_family_ipv4.neighbors[neighbor].route_map_out }} out
 {%             endif %}
-{%             if router_bgp.address_family_ipv4.neighbors[neighbor].prefix_list_in is defined and router_bgp.address_family_ipv4.neighbors[neighbor].prefix_list_in is not none %}
+{%             if router_bgp.address_family_ipv4.neighbors[neighbor].prefix_list_in is arista.avd.defined %}
       neighbor {{ neighbor }} prefix-list {{ router_bgp.address_family_ipv4.neighbors[neighbor].prefix_list_in }} in
 {%             endif %}
-{%             if router_bgp.address_family_ipv4.neighbors[neighbor].prefix_list_out is defined and router_bgp.address_family_ipv4.neighbors[neighbor].prefix_list_out is not none %}
+{%             if router_bgp.address_family_ipv4.neighbors[neighbor].prefix_list_out is arista.avd.defined %}
       neighbor {{ neighbor }} prefix-list {{ router_bgp.address_family_ipv4.neighbors[neighbor].prefix_list_out }} out
 {%             endif %}
-{%             if router_bgp.address_family_ipv4.neighbors[neighbor].default_originate is defined %}
-      neighbor {{ neighbor }} default-originate{%if router_bgp.address_family_ipv4.neighbors[neighbor].default_originate.route_map is defined and router_bgp.address_family_ipv4.neighbors[neighbor].default_originate.route_map is not none %} route-map {{ router_bgp.address_family_ipv4.neighbors[neighbor].default_originate.route_map }}{% endif %}{%if router_bgp.address_family_ipv4.neighbors[neighbor].default_originate.always is defined and router_bgp.address_family_ipv4.neighbors[neighbor].default_originate.always == true %} always{% endif %}
+{%             if router_bgp.address_family_ipv4.neighbors[neighbor].default_originate is arista.avd.defined %}
+      neighbor {{ neighbor }} default-originate{%if router_bgp.address_family_ipv4.neighbors[neighbor].default_originate.route_map is arista.avd.defined %} route-map {{ router_bgp.address_family_ipv4.neighbors[neighbor].default_originate.route_map }}{% endif %}{%if router_bgp.address_family_ipv4.neighbors[neighbor].default_originate.always is arista.avd.defined(true) %} always{% endif %}
 
 {%             endif %}
 {%             if router_bgp.address_family_ipv4.neighbors[neighbor].activate == true %}
@@ -272,15 +272,15 @@ router bgp {{ router_bgp.as }}
 {%       endif %}
 {%     endif %}
 {# address family ipv4 multicast activation #}
-{%     if router_bgp.address_family_ipv4_multicast is defined and router_bgp.address_family_ipv4_multicast is not none %}
+{%     if router_bgp.address_family_ipv4_multicast is arista.avd.defined %}
    !
    address-family ipv4 multicast
-{%       if router_bgp.address_family_ipv4_multicast.peer_groups is defined and router_bgp.address_family_ipv4_multicast.peer_groups is not none %}
+{%       if router_bgp.address_family_ipv4_multicast.peer_groups is arista.avd.defined %}
 {%          for peer_group in router_bgp.address_family_ipv4_multicast.peer_groups | arista.avd.natural_sort %}
-{%             if router_bgp.address_family_ipv4_multicast.peer_groups[peer_group].route_map_in is defined and router_bgp.address_family_ipv4_multicast.peer_groups[peer_group].route_map_in is not none %}
+{%             if router_bgp.address_family_ipv4_multicast.peer_groups[peer_group].route_map_in is arista.avd.defined %}
       neighbor {{ peer_group }} route-map {{ router_bgp.address_family_ipv4_multicast.peer_groups[peer_group].route_map_in }} in
 {%             endif %}
-{%             if router_bgp.address_family_ipv4_multicast.peer_groups[peer_group].route_map_out is defined and router_bgp.address_family_ipv4_multicast.peer_groups[peer_group].route_map_out is not none %}
+{%             if router_bgp.address_family_ipv4_multicast.peer_groups[peer_group].route_map_out is arista.avd.defined %}
       neighbor {{ peer_group }} route-map {{ router_bgp.address_family_ipv4_multicast.peer_groups[peer_group].route_map_out }} out
 {%             endif %}
 {%             if router_bgp.address_family_ipv4_multicast.peer_groups[peer_group].activate == true %}
@@ -290,12 +290,12 @@ router bgp {{ router_bgp.as }}
 {%             endif %}
 {%          endfor %}
 {%       endif %}
-{%       if router_bgp.address_family_ipv4_multicast.neighbors is defined and router_bgp.address_family_ipv4_multicast.neighbors is not none %}
+{%       if router_bgp.address_family_ipv4_multicast.neighbors is arista.avd.defined %}
 {%          for neighbor in router_bgp.address_family_ipv4_multicast.neighbors | arista.avd.natural_sort %}
-{%             if router_bgp.address_family_ipv4_multicast.neighbors[neighbor].route_map_in is defined and router_bgp.address_family_ipv4_multicast.neighbors[neighbor].route_map_in is not none %}
+{%             if router_bgp.address_family_ipv4_multicast.neighbors[neighbor].route_map_in is arista.avd.defined %}
       neighbor {{ neighbor }} route-map {{ router_bgp.address_family_ipv4_multicast.neighbors[neighbor].route_map_in }} in
 {%             endif %}
-{%             if router_bgp.address_family_ipv4_multicast.neighbors[neighbor].route_map_out is defined and router_bgp.address_family_ipv4_multicast.neighbors[neighbor].route_map_out is not none %}
+{%             if router_bgp.address_family_ipv4_multicast.neighbors[neighbor].route_map_out is arista.avd.defined %}
       neighbor {{ neighbor }} route-map {{ router_bgp.address_family_ipv4_multicast.neighbors[neighbor].route_map_out }} out
 {%             endif %}
 {%             if router_bgp.address_family_ipv4_multicast.neighbors[neighbor].activate == true %}
@@ -305,23 +305,23 @@ router bgp {{ router_bgp.as }}
 {%             endif %}
 {%          endfor %}
 {%       endif %}
-{%       if router_bgp.address_family_ipv4_multicast.redistribute_routes is defined and router_bgp.address_family_ipv4_multicast.redistribute_routes is not none %}
+{%       if router_bgp.address_family_ipv4_multicast.redistribute_routes is arista.avd.defined %}
 {%         for redistribute_route in router_bgp.address_family_ipv4_multicast.redistribute_routes | arista.avd.natural_sort %}
-      redistribute {{ redistribute_route }} {% if router_bgp.address_family_ipv4_multicast.redistribute_routes[redistribute_route].route_map is defined and router_bgp.address_family_ipv4_multicast.redistribute_routes[redistribute_route].route_map is not none %}route-map {{ router_bgp.address_family_ipv4_multicast.redistribute_routes[redistribute_route].route_map }}{% endif %}
+      redistribute {{ redistribute_route }} {% if router_bgp.address_family_ipv4_multicast.redistribute_routes[redistribute_route].route_map is arista.avd.defined %}route-map {{ router_bgp.address_family_ipv4_multicast.redistribute_routes[redistribute_route].route_map }}{% endif %}
 
 {%         endfor %}
 {%       endif %}
 {%     endif %}
 {# address family ipv6 activation #}
-{%     if router_bgp.address_family_ipv6 is defined and router_bgp.address_family_iv6 is not none %}
+{%     if router_bgp.address_family_ipv6 is arista.avd.defined %}
    !
    address-family ipv6
-{%       if router_bgp.address_family_ipv6.peer_groups is defined and router_bgp.address_family_ipv6.peer_groups is not none %}
+{%       if router_bgp.address_family_ipv6.peer_groups is arista.avd.defined %}
 {%          for peer_group in router_bgp.address_family_ipv6.peer_groups | arista.avd.natural_sort %}
-{%             if router_bgp.address_family_ipv6.peer_groups[peer_group].route_map_in is defined and router_bgp.address_family_ipv6.peer_groups[peer_group].route_map_in is not none %}
+{%             if router_bgp.address_family_ipv6.peer_groups[peer_group].route_map_in is arista.avd.defined %}
       neighbor {{ peer_group }} route-map {{ router_bgp.address_family_ipv6.peer_groups[peer_group].route_map_in }} in
 {%             endif %}
-{%             if router_bgp.address_family_ipv6.peer_groups[peer_group].route_map_out is defined and router_bgp.address_family_ipv6.peer_groups[peer_group].route_map_out is not none %}
+{%             if router_bgp.address_family_ipv6.peer_groups[peer_group].route_map_out is arista.avd.defined %}
       neighbor {{ peer_group }} route-map {{ router_bgp.address_family_ipv6.peer_groups[peer_group].route_map_out }} out
 {%             endif %}
 {%             if router_bgp.address_family_ipv6.peer_groups[peer_group].activate == true %}
@@ -331,12 +331,12 @@ router bgp {{ router_bgp.as }}
 {%             endif %}
 {%          endfor %}
 {%       endif %}
-{%       if router_bgp.address_family_ipv6.neighbors is defined and router_bgp.address_family_ipv6.neighbors is not none %}
+{%       if router_bgp.address_family_ipv6.neighbors is arista.avd.defined %}
 {%          for neighbor in router_bgp.address_family_ipv6.neighbors | arista.avd.natural_sort %}
-{%             if router_bgp.address_family_ipv6.neighbors[neighbor].route_map_in is defined and router_bgp.address_family_ipv6.neighbors[neighbor].route_map_in is not none %}
+{%             if router_bgp.address_family_ipv6.neighbors[neighbor].route_map_in is arista.avd.defined %}
       neighbor {{ neighbor }} route-map {{ router_bgp.address_family_ipv6.neighbors[neighbor].route_map_in }} in
 {%             endif %}
-{%             if router_bgp.address_family_ipv6.neighbors[neighbor].route_map_out is defined and router_bgp.address_family_ipv6.neighbors[neighbor].route_map_out is not none %}
+{%             if router_bgp.address_family_ipv6.neighbors[neighbor].route_map_out is arista.avd.defined %}
       neighbor {{ neighbor }} route-map {{ router_bgp.address_family_ipv6.neighbors[neighbor].route_map_out }} out
 {%             endif %}
 {%             if router_bgp.address_family_ipv6.neighbors[neighbor].activate == true %}
@@ -346,53 +346,53 @@ router bgp {{ router_bgp.as }}
 {%             endif %}
 {%          endfor %}
 {%       endif %}
-{%       if router_bgp.address_family_ipv6.redistribute_routes is defined and router_bgp.address_family_ipv6.redistribute_routes is not none %}
+{%       if router_bgp.address_family_ipv6.redistribute_routes is arista.avd.defined %}
 {%         for redistribute_route in router_bgp.address_family_ipv6.redistribute_routes | arista.avd.natural_sort %}
-      redistribute {{ redistribute_route }} {% if router_bgp.address_family_ipv6.redistribute_routes[redistribute_route].route_map is defined and router_bgp.address_family_ipv6.redistribute_routes[redistribute_route].route_map is not none %}route-map {{ router_bgp.address_family_ipv6.redistribute_routes[redistribute_route].route_map }}
+      redistribute {{ redistribute_route }} {% if router_bgp.address_family_ipv6.redistribute_routes[redistribute_route].route_map is arista.avd.defined %}route-map {{ router_bgp.address_family_ipv6.redistribute_routes[redistribute_route].route_map }}
 {%             endif %}
 {%         endfor %}
 {%       endif %}
 {%     endif %}
 {# L3VPNs - (vxlan) VRFs #}
-{%     if router_bgp.vrfs is defined and router_bgp.vrfs is not none %}
+{%     if router_bgp.vrfs is arista.avd.defined %}
 {%         for vrf in router_bgp.vrfs | arista.avd.natural_sort %}
    !
    vrf {{ vrf }}
       rd {{ router_bgp.vrfs[vrf].rd }}
-{%             if router_bgp.vrfs[vrf].route_targets.import is defined and router_bgp.vrfs[vrf].route_targets.import is not none %}
+{%             if router_bgp.vrfs[vrf].route_targets.import is arista.avd.defined %}
 {%                for address_family in router_bgp.vrfs[vrf].route_targets.import %}
 {%                      for route_target in router_bgp.vrfs[vrf].route_targets.import[address_family] %}
       route-target import {{ address_family }} {{ route_target }}
 {%                      endfor %}
 {%                endfor %}
 {%             endif %}
-{%             if router_bgp.vrfs[vrf].route_targets.export is defined and router_bgp.vrfs[vrf].route_targets.export is not none %}
+{%             if router_bgp.vrfs[vrf].route_targets.export is arista.avd.defined %}
 {%                for address_family in router_bgp.vrfs[vrf].route_targets.export %}
 {%                      for route_target in router_bgp.vrfs[vrf].route_targets.export[address_family] %}
       route-target export {{ address_family }} {{ route_target }}
 {%                      endfor %}
 {%                endfor %}
 {%             endif %}
-{%             if router_bgp.vrfs[vrf].router_id is defined %}
+{%             if router_bgp.vrfs[vrf].router_id is arista.avd.defined %}
       router-id {{ router_bgp.vrfs[vrf].router_id }}
 {%             endif %}
-{%             if router_bgp.vrfs[vrf].timers is defined %}
+{%             if router_bgp.vrfs[vrf].timers is arista.avd.defined %}
       timers bgp {{ router_bgp.vrfs[vrf].timers }}
 {%             endif %}
-{%              if router_bgp.vrfs[vrf].networks is defined and router_bgp.vrfs[vrf].networks is not none %}
+{%              if router_bgp.vrfs[vrf].networks is arista.avd.defined %}
 {%                  for network in router_bgp.vrfs[vrf].networks | arista.avd.natural_sort %}
-{%                      if router_bgp.vrfs[vrf].networks[network].route_map is defined and router_bgp.vrfs[vrf].networks[network].route_map is not none %}
+{%                      if router_bgp.vrfs[vrf].networks[network].route_map is arista.avd.defined %}
       network {{ network }} route-map {{ router_bgp.vrfs[vrf].networks[network].route_map }}
 {%                      else %}
       network {{ network }}
 {%                      endif %}
 {%                  endfor %}
 {%              endif %}
-{%             if router_bgp.vrfs[vrf].neighbors is defined and router_bgp.vrfs[vrf].neighbors is not none %}
+{%             if router_bgp.vrfs[vrf].neighbors is arista.avd.defined %}
 {%                 for neighbor in router_bgp.vrfs[vrf].neighbors %}
-{%                      if router_bgp.vrfs[vrf].neighbors[neighbor].remote_as is defined and router_bgp.vrfs[vrf].neighbors[neighbor].remote_as is not none %}
+{%                      if router_bgp.vrfs[vrf].neighbors[neighbor].remote_as is arista.avd.defined %}
       neighbor {{ neighbor }} remote-as {{ router_bgp.vrfs[vrf].neighbors[neighbor].remote_as }}
-{%                      elif router_bgp.vrfs[vrf].neighbors[neighbor].peer_group is defined and router_bgp.vrfs[vrf].neighbors[neighbor].peer_group is not none %}
+{%                      elif router_bgp.vrfs[vrf].neighbors[neighbor].peer_group is arista.avd.defined %}
       neighbor {{ neighbor }} peer group {{ router_bgp.vrfs[vrf].neighbors[neighbor].peer_group }}
 {%                      endif %}
 {%                      if router_bgp.vrfs[vrf].neighbors[neighbor].local_as is arista.avd.defined and router_bgp.vrfs[vrf].neighbors[neighbor].local_as is number %}
@@ -407,7 +407,7 @@ router bgp {{ router_bgp.as }}
 {%                      if router_bgp.vrfs[vrf].neighbors[neighbor].next_hop_self is defined and router_bgp.vrfs[vrf].neighbors[neighbor].next_hop_self == true %}
       neighbor {{ neighbor }} next-hop-self
 {%                      endif %}
-{%                      if router_bgp.vrfs[vrf].neighbors[neighbor].timers is defined and router_bgp.vrfs[vrf].neighbors[neighbor].timers is not none %}
+{%                      if router_bgp.vrfs[vrf].neighbors[neighbor].timers is arista.avd.defined %}
       neighbor {{ neighbor }} timers {{ router_bgp.vrfs[vrf].neighbors[neighbor].timers }}
 {%                      endif %}
 {%                      if router_bgp.vrfs[vrf].neighbors[neighbor].send_community is defined and router_bgp.vrfs[vrf].neighbors[neighbor].send_community == 'None' %}
@@ -420,8 +420,8 @@ router bgp {{ router_bgp.as }}
 {%                      if router_bgp.vrfs[vrf].neighbors[neighbor].maximum_routes is arista.avd.defined %}
       neighbor {{ neighbor }} maximum-routes {{ router_bgp.vrfs[vrf].neighbors[neighbor].maximum_routes }}
 {%                      endif %}
-{%                      if router_bgp.vrfs[vrf].neighbors[neighbor].default_originate is defined %}
-      neighbor {{ neighbor }} default-originate{%if router_bgp.vrfs[vrf].neighbors[neighbor].default_originate.route_map is defined and router_bgp.vrfs[vrf].neighbors[neighbor].default_originate.route_map is not none %} route-map {{ router_bgp.vrfs[vrf].neighbors[neighbor].default_originate.route_map }}{% endif %}{%if router_bgp.vrfs[vrf].neighbors[neighbor].default_originate.always is defined and router_bgp.vrfs[vrf].neighbors[neighbor].default_originate.always == true %} always{% endif %}
+{%                      if router_bgp.vrfs[vrf].neighbors[neighbor].default_originate is arista.avd.defined %}
+      neighbor {{ neighbor }} default-originate{%if router_bgp.vrfs[vrf].neighbors[neighbor].default_originate.route_map is arista.avd.defined %} route-map {{ router_bgp.vrfs[vrf].neighbors[neighbor].default_originate.route_map }}{% endif %}{%if router_bgp.vrfs[vrf].neighbors[neighbor].default_originate.always is arista.avd.defined(true) %} always{% endif %}
 
 {%                      endif %}
 {%                      if router_bgp.vrfs[vrf].neighbors[neighbor].update_source is arista.avd.defined %}
@@ -441,15 +441,15 @@ router bgp {{ router_bgp.as }}
 {%                      endif %}
 {%                 endfor %}
 {%             endif %}
-{%             if router_bgp.vrfs[vrf].redistribute_routes is defined and router_bgp.vrfs[vrf].redistribute_routes is not none %}
+{%             if router_bgp.vrfs[vrf].redistribute_routes is arista.avd.defined %}
 {%                for redistribute_route in router_bgp.vrfs[vrf].redistribute_routes | arista.avd.natural_sort %}
-      redistribute {{ redistribute_route }}{% if router_bgp.vrfs[vrf].redistribute_routes[redistribute_route].route_map is defined and router_bgp.vrfs[vrf].redistribute_routes[redistribute_route].route_map is not none %} route-map {{ router_bgp.vrfs[vrf].redistribute_routes[redistribute_route].route_map }}{% endif %}
+      redistribute {{ redistribute_route }}{% if router_bgp.vrfs[vrf].redistribute_routes[redistribute_route].route_map is arista.avd.defined %} route-map {{ router_bgp.vrfs[vrf].redistribute_routes[redistribute_route].route_map }}{% endif %}
 
 {%                endfor %}
 {%             endif %}
-{%             if router_bgp.vrfs[vrf].aggregate_addresses is defined and router_bgp.vrfs[vrf].aggregate_addresses is not none %}
+{%             if router_bgp.vrfs[vrf].aggregate_addresses is arista.avd.defined %}
 {%                 for aggregate_address in router_bgp.vrfs[vrf].aggregate_addresses | arista.avd.natural_sort %}
-      aggregate-address {{ aggregate_address }}{% if router_bgp.vrfs[vrf].aggregate_addresses[aggregate_address].as_set is defined and router_bgp.vrfs[vrf].aggregate_addresses[aggregate_address].as_set == true %} as-set{% endif %}{% if router_bgp.vrfs[vrf].aggregate_addresses[aggregate_address].summary_only is defined and router_bgp.vrfs[vrf].aggregate_addresses[aggregate_address].summary_only == true %} summary-only{% endif %}{% if router_bgp.vrfs[vrf].aggregate_addresses[aggregate_address].attribute_map is defined and router_bgp.vrfs[vrf].aggregate_addresses[aggregate_address].attribute_map is not none %} attribute-map {{ router_bgp.vrfs[vrf].aggregate_addresses[aggregate_address].attribute_map }}{% endif %}{% if router_bgp.vrfs[vrf].aggregate_addresses[aggregate_address].match_map is defined and router_bgp.vrfs[vrf].aggregate_addresses[aggregate_address].match_map is not none %} match-map {{ router_bgp.vrfs[vrf].aggregate_addresses[aggregate_address].match_map }}{% endif %}{% if router_bgp.vrfs[vrf].aggregate_addresses[aggregate_address].advertise_only is defined and router_bgp.vrfs[vrf].aggregate_addresses[aggregate_address].advertise_only == true %} advertise-only{% endif %}
+      aggregate-address {{ aggregate_address }}{% if router_bgp.vrfs[vrf].aggregate_addresses[aggregate_address].as_set is arista.avd.defined(true) %} as-set{% endif %}{% if router_bgp.vrfs[vrf].aggregate_addresses[aggregate_address].summary_only is arista.avd.defined(true) %} summary-only{% endif %}{% if router_bgp.vrfs[vrf].aggregate_addresses[aggregate_address].attribute_map is arista.avd.defined %} attribute-map {{ router_bgp.vrfs[vrf].aggregate_addresses[aggregate_address].attribute_map }}{% endif %}{% if router_bgp.vrfs[vrf].aggregate_addresses[aggregate_address].match_map is arista.avd.defined %} match-map {{ router_bgp.vrfs[vrf].aggregate_addresses[aggregate_address].match_map }}{% endif %}{% if router_bgp.vrfs[vrf].aggregate_addresses[aggregate_address].advertise_only is arista.avd.defined(true) %} advertise-only{% endif %}
 
 {%                 endfor %}
 {%             endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -3,176 +3,163 @@
 !
 router bgp {{ router_bgp.as }}
    router-id {{ router_bgp.router_id }}
-{% if router_bgp.bgp_cluster_id is arista.avd.defined %}
+{%     if router_bgp.bgp_cluster_id is arista.avd.defined %}
    bgp cluster-id {{ router_bgp.bgp_cluster_id }}
-{% endif %}
+{%     endif %}
 {%     for bgp_default in router_bgp.bgp_defaults %}
    {{ bgp_default }}
 {%     endfor %}
-{%     if router_bgp.peer_groups is arista.avd.defined %}
-{%       for peer_group in router_bgp.peer_groups | arista.avd.natural_sort %}
-{%          if router_bgp.peer_groups[peer_group].bgp_listen_range_prefix is arista.avd.defined %}
+{%     for peer_group in router_bgp.peer_groups | arista.avd.natural_sort %}
+{%         if router_bgp.peer_groups[peer_group].bgp_listen_range_prefix is arista.avd.defined %}
    bgp listen range {{ router_bgp.peer_groups[peer_group].bgp_listen_range_prefix }} peer-group {{ peer_group }} peer-filter {{ router_bgp.peer_groups[peer_group].peer_filter }}
-{%          endif %}
-{%       endfor %}
-{%       for peer_group in router_bgp.peer_groups | arista.avd.natural_sort %}
-{%             if router_bgp.peer_groups[peer_group].description is arista.avd.defined %}
+{%         endif %}
+{%     endfor %}
+{%     for peer_group in router_bgp.peer_groups | arista.avd.natural_sort %}
+{%         if router_bgp.peer_groups[peer_group].description is arista.avd.defined %}
    neighbor {{ peer_group }} description {{ router_bgp.peer_groups[peer_group].description }}
-{%             endif %}
-{%             if router_bgp.peer_groups[peer_group].shutdown is arista.avd.defined(true) %}
+{%         endif %}
+{%         if router_bgp.peer_groups[peer_group].shutdown is arista.avd.defined(true) %}
    neighbor {{ peer_group }} shutdown
-{%             endif %}
+{%         endif %}
    neighbor {{ peer_group }} peer group
-{%             if router_bgp.peer_groups[peer_group].remote_as is arista.avd.defined %}
+{%         if router_bgp.peer_groups[peer_group].remote_as is arista.avd.defined %}
    neighbor {{ peer_group }} remote-as {{ router_bgp.peer_groups[peer_group].remote_as }}
-{%             endif %}
-{%             if router_bgp.peer_groups[peer_group].next_hop_self is arista.avd.defined(true) %}
+{%         endif %}
+{%         if router_bgp.peer_groups[peer_group].next_hop_self is arista.avd.defined(true) %}
    neighbor {{ peer_group }} next-hop-self
-{%             endif %}
-{%             if router_bgp.peer_groups[peer_group].next_hop_unchanged is arista.avd.defined(true) %}
+{%         endif %}
+{%         if router_bgp.peer_groups[peer_group].next_hop_unchanged is arista.avd.defined(true) %}
    neighbor {{ peer_group }} next-hop-unchanged
-{%             endif %}
-{%             if router_bgp.peer_groups[peer_group].update_source is arista.avd.defined %}
+{%         endif %}
+{%         if router_bgp.peer_groups[peer_group].update_source is arista.avd.defined %}
    neighbor {{ peer_group }} update-source {{ router_bgp.peer_groups[peer_group].update_source }}
-{%             endif %}
-{%             if router_bgp.peer_groups[peer_group].route_reflector_client is arista.avd.defined(true) %}
+{%         endif %}
+{%         if router_bgp.peer_groups[peer_group].route_reflector_client is arista.avd.defined(true) %}
    neighbor {{ peer_group }} route-reflector-client
-{%             endif %}
-{%             if router_bgp.peer_groups[peer_group].bfd is arista.avd.defined(true) %}
+{%         endif %}
+{%         if router_bgp.peer_groups[peer_group].bfd is arista.avd.defined(true) %}
    neighbor {{ peer_group }} bfd
-{%             endif %}
-{%             if router_bgp.peer_groups[peer_group].ebgp_multihop is arista.avd.defined %}
+{%         endif %}
+{%         if router_bgp.peer_groups[peer_group].ebgp_multihop is arista.avd.defined %}
    neighbor {{ peer_group }} ebgp-multihop {{ router_bgp.peer_groups[peer_group].ebgp_multihop }}
-{%             endif %}
-{%             if router_bgp.peer_groups[peer_group].password is arista.avd.defined %}
+{%         endif %}
+{%         if router_bgp.peer_groups[peer_group].password is arista.avd.defined %}
    neighbor {{ peer_group }} password 7 {{ router_bgp.peer_groups[peer_group].password }}
-{%             endif %}
-{%             if router_bgp.peer_groups[peer_group].send_community is arista.avd.defined(true) %}
+{%         endif %}
+{%         if router_bgp.peer_groups[peer_group].send_community is arista.avd.defined(true) %}
    neighbor {{ peer_group }} send-community
-{%             endif %}
-{%             if router_bgp.peer_groups[peer_group].maximum_routes is arista.avd.defined %}
+{%         endif %}
+{%         if router_bgp.peer_groups[peer_group].maximum_routes is arista.avd.defined %}
    neighbor {{ peer_group }} maximum-routes {{ router_bgp.peer_groups[peer_group].maximum_routes }}
-{%             endif %}
-{%             if router_bgp.peer_groups[peer_group].weight is arista.avd.defined %}
+{%         endif %}
+{%         if router_bgp.peer_groups[peer_group].weight is arista.avd.defined %}
    neighbor {{ peer_group }} weight {{ router_bgp.peer_groups[peer_group].weight }}
-{%             endif %}
-{%             if router_bgp.peer_groups[peer_group].timers is arista.avd.defined %}
+{%         endif %}
+{%         if router_bgp.peer_groups[peer_group].timers is arista.avd.defined %}
    neighbor {{ peer_group }} timers {{ router_bgp.peer_groups[peer_group].timers }}
-{%             endif %}
-{%             if router_bgp.peer_groups[peer_group].route_map_in is arista.avd.defined %}
+{%         endif %}
+{%         if router_bgp.peer_groups[peer_group].route_map_in is arista.avd.defined %}
    neighbor {{ peer_group }} route-map {{ router_bgp.peer_groups[peer_group].route_map_in }} in
-{%             endif %}
-{%             if router_bgp.peer_groups[peer_group].route_map_out is arista.avd.defined %}
+{%         endif %}
+{%         if router_bgp.peer_groups[peer_group].route_map_out is arista.avd.defined %}
    neighbor {{ peer_group }} route-map {{ router_bgp.peer_groups[peer_group].route_map_out }} out
-{%             endif %}
-{%       endfor %}
-{%     endif %}
-{%     if router_bgp.neighbors is arista.avd.defined %}
-{%         for neighbor in router_bgp.neighbors | arista.avd.natural_sort %}
-{%             if router_bgp.neighbors[neighbor].peer_group is arista.avd.defined %}
+{%         endif %}
+{%     endfor %}
+{%     for neighbor in router_bgp.neighbors | arista.avd.natural_sort %}
+{%         if router_bgp.neighbors[neighbor].peer_group is arista.avd.defined %}
    neighbor {{ neighbor }} peer group {{ router_bgp.neighbors[neighbor].peer_group }}
-{%             endif %}
-{%             if router_bgp.neighbors[neighbor].remote_as is arista.avd.defined %}
+{%         endif %}
+{%         if router_bgp.neighbors[neighbor].remote_as is arista.avd.defined %}
    neighbor {{ neighbor }} remote-as {{ router_bgp.neighbors[neighbor].remote_as }}
-{%             endif %}
-{%             if router_bgp.neighbors[neighbor].next_hop_self is arista.avd.defined(true) %}
+{%         endif %}
+{%         if router_bgp.neighbors[neighbor].next_hop_self is arista.avd.defined(true) %}
    neighbor {{ neighbor }} next-hop-self
-{%             endif %}
-{%             if router_bgp.neighbors[neighbor].shutdown is arista.avd.defined(true) %}
+{%         endif %}
+{%         if router_bgp.neighbors[neighbor].shutdown is arista.avd.defined(true) %}
    neighbor {{ neighbor }} shutdown
-{%             endif %}
-{%             if router_bgp.neighbors[neighbor].description is arista.avd.defined %}
+{%         endif %}
+{%         if router_bgp.neighbors[neighbor].description is arista.avd.defined %}
    neighbor {{ neighbor }} description {{ router_bgp.neighbors[neighbor].description }}
-{%             endif %}
-{%             if router_bgp.neighbors[neighbor].update_source is arista.avd.defined %}
+{%         endif %}
+{%         if router_bgp.neighbors[neighbor].update_source is arista.avd.defined %}
    neighbor {{ neighbor }} update-source {{ router_bgp.neighbors[neighbor].update_source }}
-{%             endif %}
-{%             if router_bgp.neighbors[neighbor].bfd is arista.avd.defined(true) %}
+{%         endif %}
+{%         if router_bgp.neighbors[neighbor].bfd is arista.avd.defined(true) %}
    neighbor {{ neighbor }} bfd
-{%             endif %}
-{%             if router_bgp.neighbors[neighbor].password is arista.avd.defined %}
+{%         endif %}
+{%         if router_bgp.neighbors[neighbor].password is arista.avd.defined %}
    neighbor {{ neighbor }} password 7 {{ router_bgp.neighbors[neighbor].password }}
-{%             endif %}
-{%             if router_bgp.neighbors[neighbor].weight is arista.avd.defined %}
+{%         endif %}
+{%         if router_bgp.neighbors[neighbor].weight is arista.avd.defined %}
    neighbor {{ neighbor }} weight {{ router_bgp.neighbors[neighbor].weight }}
-{%             endif %}
-{%             if router_bgp.neighbors[neighbor].timers is arista.avd.defined %}
+{%         endif %}
+{%         if router_bgp.neighbors[neighbor].timers is arista.avd.defined %}
    neighbor {{ neighbor }} timers {{ router_bgp.neighbors[neighbor].timers }}
-{%             endif %}
-{%         endfor %}
-{%     endif %}
-{%     if router_bgp.aggregate_addresses is arista.avd.defined %}
-{%         for aggregate_address in router_bgp.aggregate_addresses | arista.avd.natural_sort %}
+{%         endif %}
+{%     endfor %}
+{%     for aggregate_address in router_bgp.aggregate_addresses | arista.avd.natural_sort %}
    aggregate-address {{ aggregate_address }}{% if router_bgp.aggregate_addresses[aggregate_address].as_set is arista.avd.defined(true) %} as-set{% endif %}{% if router_bgp.aggregate_addresses[aggregate_address].summary_only is arista.avd.defined(true) %} summary-only{% endif %}{% if router_bgp.aggregate_addresses[aggregate_address].attribute_map is arista.avd.defined %} attribute-map {{ router_bgp.aggregate_addresses[aggregate_address].attribute_map }}{% endif %}{% if router_bgp.aggregate_addresses[aggregate_address].match_map is arista.avd.defined %} match-map {{ router_bgp.aggregate_addresses[aggregate_address].match_map }}{% endif %}{% if router_bgp.aggregate_addresses[aggregate_address].advertise_only is arista.avd.defined(true) %} advertise-only{% endif %}
 
-{%         endfor %}
-{%     endif %}
-{%     if router_bgp.redistribute_routes is arista.avd.defined %}
-{%         for redistribute_route in router_bgp.redistribute_routes | arista.avd.natural_sort %}
+{%     endfor %}
+{%     for redistribute_route in router_bgp.redistribute_routes | arista.avd.natural_sort %}
    redistribute {{ redistribute_route }}{% if router_bgp.redistribute_routes[redistribute_route].route_map is arista.avd.defined %} route-map {{ router_bgp.redistribute_routes[redistribute_route].route_map }}{% endif %}
 
-{%         endfor %}
-{%     endif %}
+{%     endfor %}
 {# L2VPNs - (vxlan) vlan based #}
-{%     if router_bgp.vlans is arista.avd.defined %}
-{%        for vlan in router_bgp.vlans | arista.avd.natural_sort %}
+{%     for vlan in router_bgp.vlans | arista.avd.natural_sort %}
    !
    vlan {{ vlan }}
       rd {{ router_bgp.vlans[vlan].rd }}
-{%            if router_bgp.vlans[vlan].route_targets.both is arista.avd.defined %}
-{%                for route_target in router_bgp.vlans[vlan].route_targets.both %}
+{%         if router_bgp.vlans[vlan].route_targets.both is arista.avd.defined %}
+{%             for route_target in router_bgp.vlans[vlan].route_targets.both %}
       route-target both {{ route_target }}
-{%                endfor %}
-{%            endif %}
-{%            if router_bgp.vlans[vlan].route_targets.import is arista.avd.defined %}
-{%                for route_target in router_bgp.vlans[vlan].route_targets.import %}
+{%             endfor %}
+{%         endif %}
+{%         if router_bgp.vlans[vlan].route_targets.import is arista.avd.defined %}
+{%             for route_target in router_bgp.vlans[vlan].route_targets.import %}
       route-target import {{ route_target }}
-{%                endfor %}
-{%            endif %}
-{%            if router_bgp.vlans[vlan].route_targets.export is arista.avd.defined %}
-{%                for route_target in router_bgp.vlans[vlan].route_targets.export %}
+{%             endfor %}
+{%         endif %}
+{%         if router_bgp.vlans[vlan].route_targets.export is arista.avd.defined %}
+{%             for route_target in router_bgp.vlans[vlan].route_targets.export %}
       route-target export {{ route_target }}
-{%                endfor %}
-{%            endif %}
-{%            for redistribute_route in router_bgp.vlans[vlan].redistribute_routes | arista.avd.natural_sort %}
+{%             endfor %}
+{%         endif %}
+{%         for redistribute_route in router_bgp.vlans[vlan].redistribute_routes | arista.avd.natural_sort %}
       redistribute {{ redistribute_route }}
-{%            endfor %}
 {%         endfor %}
-{%     endif %}
+{%     endfor %}
 {# vxlan vlan aware bundles #}
-{%     if router_bgp.vlan_aware_bundles is arista.avd.defined %}
-{%        for vlan_aware_bundle in router_bgp.vlan_aware_bundles | arista.avd.natural_sort %}
+{%     for vlan_aware_bundle in router_bgp.vlan_aware_bundles | arista.avd.natural_sort %}
    !
    vlan-aware-bundle {{ vlan_aware_bundle }}
       rd {{ router_bgp.vlan_aware_bundles[vlan_aware_bundle].rd }}
-{%            if router_bgp.vlan_aware_bundles[vlan_aware_bundle].route_targets.both is arista.avd.defined %}
-{%                for route_target in router_bgp.vlan_aware_bundles[vlan_aware_bundle].route_targets.both %}
+{%         if router_bgp.vlan_aware_bundles[vlan_aware_bundle].route_targets.both is arista.avd.defined %}
+{%             for route_target in router_bgp.vlan_aware_bundles[vlan_aware_bundle].route_targets.both %}
       route-target both {{ route_target }}
-{%                endfor %}
-{%            endif %}
-{%            if router_bgp.vlan_aware_bundles[vlan_aware_bundle].route_targets.import is arista.avd.defined %}
-{%                for route_target in router_bgp.vlan_aware_bundles[vlan_aware_bundle].route_targets.import %}
+{%             endfor %}
+{%         endif %}
+{%         if router_bgp.vlan_aware_bundles[vlan_aware_bundle].route_targets.import is arista.avd.defined %}
+{%             for route_target in router_bgp.vlan_aware_bundles[vlan_aware_bundle].route_targets.import %}
       route-target import {{ route_target }}
-{%                endfor %}
-{%            endif %}
-{%            if router_bgp.vlan_aware_bundles[vlan_aware_bundle].route_targets.export is arista.avd.defined %}
-{%                for route_target in router_bgp.vlan_aware_bundles[vlan_aware_bundle].route_targets.export %}
+{%             endfor %}
+{%         endif %}
+{%         if router_bgp.vlan_aware_bundles[vlan_aware_bundle].route_targets.export is arista.avd.defined %}
+{%             for route_target in router_bgp.vlan_aware_bundles[vlan_aware_bundle].route_targets.export %}
       route-target export {{ route_target }}
-{%                endfor %}
-{%            endif %}
-{%            for redistribute_route in router_bgp.vlan_aware_bundles[vlan_aware_bundle].redistribute_routes | arista.avd.natural_sort %}
+{%             endfor %}
+{%         endif %}
+{%         for redistribute_route in router_bgp.vlan_aware_bundles[vlan_aware_bundle].redistribute_routes | arista.avd.natural_sort %}
       redistribute {{ redistribute_route }}
-{%            endfor %}
-      vlan {{ router_bgp.vlan_aware_bundles[vlan_aware_bundle].vlan }}
 {%         endfor %}
-{%     endif %}
+      vlan {{ router_bgp.vlan_aware_bundles[vlan_aware_bundle].vlan }}
+{%     endfor %}
 {# address families activation #}
 {# address family evpn activation #}
 {%     if router_bgp.address_family_evpn is arista.avd.defined %}
    !
    address-family evpn
-{%       if router_bgp.address_family_evpn.peer_groups is arista.avd.defined %}
-{%          for peer_group in router_bgp.address_family_evpn.peer_groups | arista.avd.natural_sort %}
+{%         for peer_group in router_bgp.address_family_evpn.peer_groups | arista.avd.natural_sort %}
 {%             if router_bgp.address_family_evpn.peer_groups[peer_group].route_map_in is arista.avd.defined %}
       neighbor {{ peer_group }} route-map {{ router_bgp.address_family_evpn.peer_groups[peer_group].route_map_in }} in
 {%             endif %}
@@ -184,48 +171,42 @@ router bgp {{ router_bgp.as }}
 {%             elif router_bgp.address_family_evpn.peer_groups[peer_group].activate == false %}
       no neighbor {{ peer_group }} activate
 {%             endif %}
-{%          endfor %}
-{%       endif %}
+{%         endfor %}
 {%     endif %}
 {# address family rt-membership activation #}
 {%     if router_bgp.address_family_rtc is arista.avd.defined %}
    !
    address-family rt-membership
-{%         if router_bgp.address_family_rtc.peer_groups is arista.avd.defined %}
-{%            for peer_group in router_bgp.address_family_rtc.peer_groups | arista.avd.natural_sort %}
-{%               if router_bgp.address_family_rtc.peer_groups[peer_group].activate == true %}
+{%         for peer_group in router_bgp.address_family_rtc.peer_groups | arista.avd.natural_sort %}
+{%             if router_bgp.address_family_rtc.peer_groups[peer_group].activate == true %}
       neighbor {{ peer_group }} activate
-{%               elif router_bgp.address_family_rtc.peer_groups[peer_group].activate == false %}
+{%             elif router_bgp.address_family_rtc.peer_groups[peer_group].activate == false %}
       no neighbor {{ peer_group }} activate
-{%               endif %}
-{%               if router_bgp.address_family_rtc.peer_groups[peer_group].default_route_target is defined %}
-{%                   if router_bgp.address_family_rtc.peer_groups[peer_group].default_route_target.only is arista.avd.defined(true) %}
+{%             endif %}
+{%             if router_bgp.address_family_rtc.peer_groups[peer_group].default_route_target is defined %}
+{%                 if router_bgp.address_family_rtc.peer_groups[peer_group].default_route_target.only is arista.avd.defined(true) %}
       neighbor {{ peer_group }} default-route-target only
-{%                   else %}
+{%                 else %}
       neighbor {{ peer_group }} default-route-target
-{%                   endif %}
-{%               endif %}
-{%               if router_bgp.address_family_rtc.peer_groups[peer_group].default_route_target.encoding_origin_as_omit is defined %}
+{%                 endif %}
+{%             endif %}
+{%             if router_bgp.address_family_rtc.peer_groups[peer_group].default_route_target.encoding_origin_as_omit is defined %}
       neighbor {{ peer_group }} default-route-target encoding origin-as omit
-{%               endif %}
-{%            endfor %}
-{%         endif %}
-{%       endif %}
+{%             endif %}
+{%         endfor %}
+{%     endif %}
 {# address family ipv4 activation #}
 {%     if router_bgp.address_family_ipv4 is arista.avd.defined %}
    !
    address-family ipv4
-{%       if router_bgp.address_family_ipv4.networks is arista.avd.defined %}
-{%          for network in router_bgp.address_family_ipv4.networks | arista.avd.natural_sort %}
+{%         for network in router_bgp.address_family_ipv4.networks | arista.avd.natural_sort %}
 {%             if router_bgp.address_family_ipv4.networks[network].route_map is arista.avd.defined %}
       network {{ network }} route-map {{ router_bgp.address_family_ipv4.networks[network].route_map }}
 {%             else %}
       network {{ network }}
 {%             endif %}
-{%          endfor %}
-{%       endif %}
-{%       if router_bgp.address_family_ipv4.peer_groups is arista.avd.defined %}
-{%          for peer_group in router_bgp.address_family_ipv4.peer_groups | arista.avd.natural_sort %}
+{%         endfor %}
+{%         for peer_group in router_bgp.address_family_ipv4.peer_groups | arista.avd.natural_sort %}
 {%             if router_bgp.address_family_ipv4.peer_groups[peer_group].route_map_in is arista.avd.defined %}
       neighbor {{ peer_group }} route-map {{ router_bgp.address_family_ipv4.peer_groups[peer_group].route_map_in }} in
 {%             endif %}
@@ -243,10 +224,8 @@ router bgp {{ router_bgp.as }}
 {%             elif router_bgp.address_family_ipv4.peer_groups[peer_group].activate == false %}
       no neighbor {{ peer_group }} activate
 {%             endif %}
-{%          endfor %}
-{%       endif %}
-{%       if router_bgp.address_family_ipv4.neighbors is arista.avd.defined %}
-{%          for neighbor in router_bgp.address_family_ipv4.neighbors | arista.avd.natural_sort %}
+{%         endfor %}
+{%         for neighbor in router_bgp.address_family_ipv4.neighbors | arista.avd.natural_sort %}
 {%             if router_bgp.address_family_ipv4.neighbors[neighbor].route_map_in is arista.avd.defined %}
       neighbor {{ neighbor }} route-map {{ router_bgp.address_family_ipv4.neighbors[neighbor].route_map_in }} in
 {%             endif %}
@@ -268,15 +247,13 @@ router bgp {{ router_bgp.as }}
 {%             elif router_bgp.address_family_ipv4.neighbors[neighbor].activate == false %}
       no neighbor {{ neighbor }} activate
 {%             endif %}
-{%          endfor %}
-{%       endif %}
+{%         endfor %}
 {%     endif %}
 {# address family ipv4 multicast activation #}
 {%     if router_bgp.address_family_ipv4_multicast is arista.avd.defined %}
    !
    address-family ipv4 multicast
-{%       if router_bgp.address_family_ipv4_multicast.peer_groups is arista.avd.defined %}
-{%          for peer_group in router_bgp.address_family_ipv4_multicast.peer_groups | arista.avd.natural_sort %}
+{%         for peer_group in router_bgp.address_family_ipv4_multicast.peer_groups | arista.avd.natural_sort %}
 {%             if router_bgp.address_family_ipv4_multicast.peer_groups[peer_group].route_map_in is arista.avd.defined %}
       neighbor {{ peer_group }} route-map {{ router_bgp.address_family_ipv4_multicast.peer_groups[peer_group].route_map_in }} in
 {%             endif %}
@@ -288,10 +265,8 @@ router bgp {{ router_bgp.as }}
 {%             elif router_bgp.address_family_ipv4_multicast.peer_groups[peer_group].activate == false %}
       no neighbor {{ peer_group }} activate
 {%             endif %}
-{%          endfor %}
-{%       endif %}
-{%       if router_bgp.address_family_ipv4_multicast.neighbors is arista.avd.defined %}
-{%          for neighbor in router_bgp.address_family_ipv4_multicast.neighbors | arista.avd.natural_sort %}
+{%         endfor %}
+{%         for neighbor in router_bgp.address_family_ipv4_multicast.neighbors | arista.avd.natural_sort %}
 {%             if router_bgp.address_family_ipv4_multicast.neighbors[neighbor].route_map_in is arista.avd.defined %}
       neighbor {{ neighbor }} route-map {{ router_bgp.address_family_ipv4_multicast.neighbors[neighbor].route_map_in }} in
 {%             endif %}
@@ -303,21 +278,17 @@ router bgp {{ router_bgp.as }}
 {%             elif router_bgp.address_family_ipv4_multicast.neighbors[neighbor].activate == false %}
       no neighbor {{ neighbor }} activate
 {%             endif %}
-{%          endfor %}
-{%       endif %}
-{%       if router_bgp.address_family_ipv4_multicast.redistribute_routes is arista.avd.defined %}
+{%         endfor %}
 {%         for redistribute_route in router_bgp.address_family_ipv4_multicast.redistribute_routes | arista.avd.natural_sort %}
       redistribute {{ redistribute_route }} {% if router_bgp.address_family_ipv4_multicast.redistribute_routes[redistribute_route].route_map is arista.avd.defined %}route-map {{ router_bgp.address_family_ipv4_multicast.redistribute_routes[redistribute_route].route_map }}{% endif %}
 
 {%         endfor %}
-{%       endif %}
 {%     endif %}
 {# address family ipv6 activation #}
 {%     if router_bgp.address_family_ipv6 is arista.avd.defined %}
    !
    address-family ipv6
-{%       if router_bgp.address_family_ipv6.peer_groups is arista.avd.defined %}
-{%          for peer_group in router_bgp.address_family_ipv6.peer_groups | arista.avd.natural_sort %}
+{%         for peer_group in router_bgp.address_family_ipv6.peer_groups | arista.avd.natural_sort %}
 {%             if router_bgp.address_family_ipv6.peer_groups[peer_group].route_map_in is arista.avd.defined %}
       neighbor {{ peer_group }} route-map {{ router_bgp.address_family_ipv6.peer_groups[peer_group].route_map_in }} in
 {%             endif %}
@@ -329,10 +300,8 @@ router bgp {{ router_bgp.as }}
 {%             elif router_bgp.address_family_ipv6.peer_groups[peer_group].activate == false %}
       no neighbor {{ peer_group }} activate
 {%             endif %}
-{%          endfor %}
-{%       endif %}
-{%       if router_bgp.address_family_ipv6.neighbors is arista.avd.defined %}
-{%          for neighbor in router_bgp.address_family_ipv6.neighbors | arista.avd.natural_sort %}
+{%         endfor %}
+{%         for neighbor in router_bgp.address_family_ipv6.neighbors | arista.avd.natural_sort %}
 {%             if router_bgp.address_family_ipv6.neighbors[neighbor].route_map_in is arista.avd.defined %}
       neighbor {{ neighbor }} route-map {{ router_bgp.address_family_ipv6.neighbors[neighbor].route_map_in }} in
 {%             endif %}
@@ -344,115 +313,101 @@ router bgp {{ router_bgp.as }}
 {%             elif router_bgp.address_family_ipv6.neighbors[neighbor].activate == false %}
       no neighbor {{ neighbor }} activate
 {%             endif %}
-{%          endfor %}
-{%       endif %}
-{%       if router_bgp.address_family_ipv6.redistribute_routes is arista.avd.defined %}
+{%         endfor %}
 {%         for redistribute_route in router_bgp.address_family_ipv6.redistribute_routes | arista.avd.natural_sort %}
       redistribute {{ redistribute_route }} {% if router_bgp.address_family_ipv6.redistribute_routes[redistribute_route].route_map is arista.avd.defined %}route-map {{ router_bgp.address_family_ipv6.redistribute_routes[redistribute_route].route_map }}
 {%             endif %}
 {%         endfor %}
-{%       endif %}
 {%     endif %}
 {# L3VPNs - (vxlan) VRFs #}
-{%     if router_bgp.vrfs is arista.avd.defined %}
-{%         for vrf in router_bgp.vrfs | arista.avd.natural_sort %}
+{%     for vrf in router_bgp.vrfs | arista.avd.natural_sort %}
    !
    vrf {{ vrf }}
       rd {{ router_bgp.vrfs[vrf].rd }}
-{%             if router_bgp.vrfs[vrf].route_targets.import is arista.avd.defined %}
-{%                for address_family in router_bgp.vrfs[vrf].route_targets.import %}
-{%                      for route_target in router_bgp.vrfs[vrf].route_targets.import[address_family] %}
+{%         if router_bgp.vrfs[vrf].route_targets.import is arista.avd.defined %}
+{%             for address_family in router_bgp.vrfs[vrf].route_targets.import %}
+{%                 for route_target in router_bgp.vrfs[vrf].route_targets.import[address_family] %}
       route-target import {{ address_family }} {{ route_target }}
-{%                      endfor %}
-{%                endfor %}
-{%             endif %}
-{%             if router_bgp.vrfs[vrf].route_targets.export is arista.avd.defined %}
-{%                for address_family in router_bgp.vrfs[vrf].route_targets.export %}
-{%                      for route_target in router_bgp.vrfs[vrf].route_targets.export[address_family] %}
+{%                 endfor %}
+{%             endfor %}
+{%         endif %}
+{%         if router_bgp.vrfs[vrf].route_targets.export is arista.avd.defined %}
+{%             for address_family in router_bgp.vrfs[vrf].route_targets.export %}
+{%                 for route_target in router_bgp.vrfs[vrf].route_targets.export[address_family] %}
       route-target export {{ address_family }} {{ route_target }}
-{%                      endfor %}
-{%                endfor %}
-{%             endif %}
-{%             if router_bgp.vrfs[vrf].router_id is arista.avd.defined %}
+{%                 endfor %}
+{%             endfor %}
+{%         endif %}
+{%         if router_bgp.vrfs[vrf].router_id is arista.avd.defined %}
       router-id {{ router_bgp.vrfs[vrf].router_id }}
-{%             endif %}
-{%             if router_bgp.vrfs[vrf].timers is arista.avd.defined %}
+{%         endif %}
+{%         if router_bgp.vrfs[vrf].timers is arista.avd.defined %}
       timers bgp {{ router_bgp.vrfs[vrf].timers }}
-{%             endif %}
-{%              if router_bgp.vrfs[vrf].networks is arista.avd.defined %}
-{%                  for network in router_bgp.vrfs[vrf].networks | arista.avd.natural_sort %}
-{%                      if router_bgp.vrfs[vrf].networks[network].route_map is arista.avd.defined %}
+{%         endif %}
+{%         for network in router_bgp.vrfs[vrf].networks | arista.avd.natural_sort %}
+{%             if router_bgp.vrfs[vrf].networks[network].route_map is arista.avd.defined %}
       network {{ network }} route-map {{ router_bgp.vrfs[vrf].networks[network].route_map }}
-{%                      else %}
+{%             else %}
       network {{ network }}
-{%                      endif %}
-{%                  endfor %}
-{%              endif %}
-{%             if router_bgp.vrfs[vrf].neighbors is arista.avd.defined %}
-{%                 for neighbor in router_bgp.vrfs[vrf].neighbors %}
-{%                      if router_bgp.vrfs[vrf].neighbors[neighbor].remote_as is arista.avd.defined %}
-      neighbor {{ neighbor }} remote-as {{ router_bgp.vrfs[vrf].neighbors[neighbor].remote_as }}
-{%                      elif router_bgp.vrfs[vrf].neighbors[neighbor].peer_group is arista.avd.defined %}
-      neighbor {{ neighbor }} peer group {{ router_bgp.vrfs[vrf].neighbors[neighbor].peer_group }}
-{%                      endif %}
-{%                      if router_bgp.vrfs[vrf].neighbors[neighbor].local_as is arista.avd.defined and router_bgp.vrfs[vrf].neighbors[neighbor].local_as is number %}
-      neighbor {{ neighbor }} local-as {{ router_bgp.vrfs[vrf].neighbors[neighbor].local_as }} no-prepend replace-as
-{%                      endif %}
-{%                      if router_bgp.vrfs[vrf].neighbors[neighbor].description is defined and router_bgp.vrfs[vrf].neighbors[neighbor].description is not none %}
-      neighbor {{ neighbor }} description {{ router_bgp.vrfs[vrf].neighbors[neighbor].description }}
-{%                      endif %}
-{%                      if router_bgp.vrfs[vrf].neighbors[neighbor].ebgp_multihop is arista.avd.defined %}
-      neighbor {{ neighbor }} ebgp-multihop {{ router_bgp.vrfs[vrf].neighbors[neighbor].ebgp_multihop if router_bgp.vrfs[vrf].neighbors[neighbor].ebgp_multihop is number else none }}
-{%                      endif %}
-{%                      if router_bgp.vrfs[vrf].neighbors[neighbor].next_hop_self is defined and router_bgp.vrfs[vrf].neighbors[neighbor].next_hop_self == true %}
-      neighbor {{ neighbor }} next-hop-self
-{%                      endif %}
-{%                      if router_bgp.vrfs[vrf].neighbors[neighbor].timers is arista.avd.defined %}
-      neighbor {{ neighbor }} timers {{ router_bgp.vrfs[vrf].neighbors[neighbor].timers }}
-{%                      endif %}
-{%                      if router_bgp.vrfs[vrf].neighbors[neighbor].send_community is defined and router_bgp.vrfs[vrf].neighbors[neighbor].send_community == 'None' %}
-      neighbor {{ neighbor }} send-community
-{%                      elif router_bgp.vrfs[vrf].neighbors[neighbor].send_community is arista.avd.defined %}
-      neighbor {{ neighbor }} send-community {{ router_bgp.vrfs[vrf].neighbors[neighbor].send_community }}
-{%                      elif router_bgp.vrfs[vrf].neighbors[neighbor].send_community is defined %}
-      neighbor {{ neighbor }} send-community
-{%                      endif %}
-{%                      if router_bgp.vrfs[vrf].neighbors[neighbor].maximum_routes is arista.avd.defined %}
-      neighbor {{ neighbor }} maximum-routes {{ router_bgp.vrfs[vrf].neighbors[neighbor].maximum_routes }}
-{%                      endif %}
-{%                      if router_bgp.vrfs[vrf].neighbors[neighbor].default_originate is arista.avd.defined %}
-      neighbor {{ neighbor }} default-originate{%if router_bgp.vrfs[vrf].neighbors[neighbor].default_originate.route_map is arista.avd.defined %} route-map {{ router_bgp.vrfs[vrf].neighbors[neighbor].default_originate.route_map }}{% endif %}{%if router_bgp.vrfs[vrf].neighbors[neighbor].default_originate.always is arista.avd.defined(true) %} always{% endif %}
-
-{%                      endif %}
-{%                      if router_bgp.vrfs[vrf].neighbors[neighbor].update_source is arista.avd.defined %}
-      neighbor {{ neighbor }} update-source {{ router_bgp.vrfs[vrf].neighbors[neighbor].update_source }}
-{%                      endif %}
-{%                      if router_bgp.vrfs[vrf].neighbors[neighbor].route_map_out is arista.avd.defined %}
-      neighbor {{ neighbor }} route-map {{ router_bgp.vrfs[vrf].neighbors[neighbor].route_map_out }} out
-{%                      endif %}
-{%                      if router_bgp.vrfs[vrf].neighbors[neighbor].route_map_in is arista.avd.defined %}
-      neighbor {{ neighbor }} route-map {{ router_bgp.vrfs[vrf].neighbors[neighbor].route_map_in }} in
-{%                      endif %}
-{%                      if router_bgp.vrfs[vrf].neighbors[neighbor].address_family is arista.avd.defined %}
-{%                          for family in router_bgp.vrfs[vrf].neighbors[neighbor].address_family %}
-      address-family {{ family }}
-         neighbor {{ neighbor }} activate
-{%                          endfor %}
-{%                      endif %}
-{%                 endfor %}
-{%             endif %}
-{%             if router_bgp.vrfs[vrf].redistribute_routes is arista.avd.defined %}
-{%                for redistribute_route in router_bgp.vrfs[vrf].redistribute_routes | arista.avd.natural_sort %}
-      redistribute {{ redistribute_route }}{% if router_bgp.vrfs[vrf].redistribute_routes[redistribute_route].route_map is arista.avd.defined %} route-map {{ router_bgp.vrfs[vrf].redistribute_routes[redistribute_route].route_map }}{% endif %}
-
-{%                endfor %}
-{%             endif %}
-{%             if router_bgp.vrfs[vrf].aggregate_addresses is arista.avd.defined %}
-{%                 for aggregate_address in router_bgp.vrfs[vrf].aggregate_addresses | arista.avd.natural_sort %}
-      aggregate-address {{ aggregate_address }}{% if router_bgp.vrfs[vrf].aggregate_addresses[aggregate_address].as_set is arista.avd.defined(true) %} as-set{% endif %}{% if router_bgp.vrfs[vrf].aggregate_addresses[aggregate_address].summary_only is arista.avd.defined(true) %} summary-only{% endif %}{% if router_bgp.vrfs[vrf].aggregate_addresses[aggregate_address].attribute_map is arista.avd.defined %} attribute-map {{ router_bgp.vrfs[vrf].aggregate_addresses[aggregate_address].attribute_map }}{% endif %}{% if router_bgp.vrfs[vrf].aggregate_addresses[aggregate_address].match_map is arista.avd.defined %} match-map {{ router_bgp.vrfs[vrf].aggregate_addresses[aggregate_address].match_map }}{% endif %}{% if router_bgp.vrfs[vrf].aggregate_addresses[aggregate_address].advertise_only is arista.avd.defined(true) %} advertise-only{% endif %}
-
-{%                 endfor %}
 {%             endif %}
 {%         endfor %}
-{%     endif %}
+{%         if router_bgp.vrfs[vrf].neighbors is arista.avd.defined %}
+{%             for neighbor in router_bgp.vrfs[vrf].neighbors %}
+{%                 if router_bgp.vrfs[vrf].neighbors[neighbor].remote_as is arista.avd.defined %}
+      neighbor {{ neighbor }} remote-as {{ router_bgp.vrfs[vrf].neighbors[neighbor].remote_as }}
+{%                 elif router_bgp.vrfs[vrf].neighbors[neighbor].peer_group is arista.avd.defined %}
+      neighbor {{ neighbor }} peer group {{ router_bgp.vrfs[vrf].neighbors[neighbor].peer_group }}
+{%                 endif %}
+{%                 if router_bgp.vrfs[vrf].neighbors[neighbor].local_as is arista.avd.defined and router_bgp.vrfs[vrf].neighbors[neighbor].local_as is number %}
+      neighbor {{ neighbor }} local-as {{ router_bgp.vrfs[vrf].neighbors[neighbor].local_as }} no-prepend replace-as
+{%                 endif %}
+{%                 if router_bgp.vrfs[vrf].neighbors[neighbor].description is arista.avd.defined %}
+      neighbor {{ neighbor }} description {{ router_bgp.vrfs[vrf].neighbors[neighbor].description }}
+{%                 endif %}
+{%                 if router_bgp.vrfs[vrf].neighbors[neighbor].ebgp_multihop is arista.avd.defined %}
+      neighbor {{ neighbor }} ebgp-multihop {{ router_bgp.vrfs[vrf].neighbors[neighbor].ebgp_multihop if router_bgp.vrfs[vrf].neighbors[neighbor].ebgp_multihop is number else none }}
+{%                 endif %}
+{%                 if router_bgp.vrfs[vrf].neighbors[neighbor].next_hop_self is arista.avd.defined(true) %}
+      neighbor {{ neighbor }} next-hop-self
+{%                 endif %}
+{%                 if router_bgp.vrfs[vrf].neighbors[neighbor].timers is arista.avd.defined %}
+      neighbor {{ neighbor }} timers {{ router_bgp.vrfs[vrf].neighbors[neighbor].timers }}
+{%                 endif %}
+{%                 if router_bgp.vrfs[vrf].neighbors[neighbor].send_community is arista.avd.defined('None') %}
+      neighbor {{ neighbor }} send-community
+{%                 elif router_bgp.vrfs[vrf].neighbors[neighbor].send_community is arista.avd.defined %}
+      neighbor {{ neighbor }} send-community {{ router_bgp.vrfs[vrf].neighbors[neighbor].send_community }}
+{%                 elif router_bgp.vrfs[vrf].neighbors[neighbor].send_community is defined %}
+      neighbor {{ neighbor }} send-community
+{%                 endif %}
+{%                 if router_bgp.vrfs[vrf].neighbors[neighbor].default_originate is arista.avd.defined %}
+      neighbor {{ neighbor }} default-originate{%if router_bgp.vrfs[vrf].neighbors[neighbor].default_originate.route_map is arista.avd.defined %} route-map {{ router_bgp.vrfs[vrf].neighbors[neighbor].default_originate.route_map }}{% endif %}{%if router_bgp.vrfs[vrf].neighbors[neighbor].default_originate.always is arista.avd.defined(true) %} always{% endif %}
+
+{%                 endif %}
+{%                 if router_bgp.vrfs[vrf].neighbors[neighbor].update_source is arista.avd.defined %}
+      neighbor {{ neighbor }} update-source {{ router_bgp.vrfs[vrf].neighbors[neighbor].update_source }}
+{%                 endif %}
+{%                 if router_bgp.vrfs[vrf].neighbors[neighbor].route_map_out is arista.avd.defined %}
+      neighbor {{ neighbor }} route-map {{ router_bgp.vrfs[vrf].neighbors[neighbor].route_map_out }} out
+{%                 endif %}
+{%                 if router_bgp.vrfs[vrf].neighbors[neighbor].route_map_in is arista.avd.defined %}
+      neighbor {{ neighbor }} route-map {{ router_bgp.vrfs[vrf].neighbors[neighbor].route_map_in }} in
+{%                 endif %}
+{%                 if router_bgp.vrfs[vrf].neighbors[neighbor].address_family is arista.avd.defined %}
+{%                     for family in router_bgp.vrfs[vrf].neighbors[neighbor].address_family %}
+      address-family {{ family }}
+         neighbor {{ neighbor }} activate
+{%                     endfor %}
+{%                 endif %}
+{%             endfor %}
+{%         endif %}
+{%         for redistribute_route in router_bgp.vrfs[vrf].redistribute_routes | arista.avd.natural_sort %}
+      redistribute {{ redistribute_route }}{% if router_bgp.vrfs[vrf].redistribute_routes[redistribute_route].route_map is arista.avd.defined %} route-map {{ router_bgp.vrfs[vrf].redistribute_routes[redistribute_route].route_map }}{% endif %}
+
+{%         endfor %}
+{%         for aggregate_address in router_bgp.vrfs[vrf].aggregate_addresses | arista.avd.natural_sort %}
+      aggregate-address {{ aggregate_address }}{% if router_bgp.vrfs[vrf].aggregate_addresses[aggregate_address].as_set is arista.avd.defined(true) %} as-set{% endif %}{% if router_bgp.vrfs[vrf].aggregate_addresses[aggregate_address].summary_only is arista.avd.defined(true) %} summary-only{% endif %}{% if router_bgp.vrfs[vrf].aggregate_addresses[aggregate_address].attribute_map is arista.avd.defined %} attribute-map {{ router_bgp.vrfs[vrf].aggregate_addresses[aggregate_address].attribute_map }}{% endif %}{% if router_bgp.vrfs[vrf].aggregate_addresses[aggregate_address].match_map is arista.avd.defined %} match-map {{ router_bgp.vrfs[vrf].aggregate_addresses[aggregate_address].match_map }}{% endif %}{% if router_bgp.vrfs[vrf].aggregate_addresses[aggregate_address].advertise_only is arista.avd.defined(true) %} advertise-only{% endif %}
+
+{%         endfor %}
+{%     endfor %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/tcam-profile.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/tcam-profile.j2
@@ -1,4 +1,4 @@
-{% if tcam_profile is arista.avd.defined  %}
+{% if tcam_profile is arista.avd.defined %}
 !
 hardware tcam
    system profile {{ tcam_profile[0] }}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/tcam-profile.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/tcam-profile.j2
@@ -1,4 +1,4 @@
-{% if tcam_profile is defined and tcam_profile is not none %}
+{% if tcam_profile is arista.avd.defined  %}
 !
 hardware tcam
    system profile {{ tcam_profile[0] }}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/terminal-settings.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/terminal-settings.j2
@@ -1,10 +1,10 @@
 {# terminal settings : width and length #}
-{% if terminal is defined and terminal is not none %}
+{% if terminal is arista.avd.defined %}
 !
-{%     if terminal.width is defined and terminal.width is not none %}
+{%     if terminal.width is arista.avd.defined %}
 terminal width {{ terminal.width }}
 {%     endif %}
-{%     if terminal.length is defined and terminal.length is not none %}
+{%     if terminal.length is arista.avd.defined %}
 terminal length {{ terminal.length }}
 {%     endif %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/unsupported-transceiver.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/unsupported-transceiver.j2
@@ -1,4 +1,4 @@
-{% if service_unsupported_transceiver is defined %}
+{% if service_unsupported_transceiver is arista.avd.defined %}
 !
 service unsupported-transceiver {{ service_unsupported_transceiver.license_name }} {{ service_unsupported_transceiver.license_key }}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/virtual-router-mac-address.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/virtual-router-mac-address.j2
@@ -1,5 +1,5 @@
 {# eos - ip virtual router mac #}
-{% if ip_virtual_router_mac_address is defined and ip_virtual_router_mac_address is not none %}
+{% if ip_virtual_router_mac_address is arista.avd.defined %}
 !
 ip virtual-router mac-address {{ ip_virtual_router_mac_address }}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/virtual-source-nat.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/virtual-source-nat.j2
@@ -1,5 +1,5 @@
 {# eos - virtual source-nat - introduced in 4.21 #}
-{% if virtual_source_nat_vrfs is defined and virtual_source_nat_vrfs is not none %}
+{% if virtual_source_nat_vrfs is arista.avd.defined %}
 !
 {%     for vrf in virtual_source_nat_vrfs | arista.avd.natural_sort %}
 ip address virtual source-nat vrf {{ vrf }} address {{ virtual_source_nat_vrfs[vrf].ip_address }}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
@@ -1,155 +1,169 @@
 {# eos - VLAN Interfaces #}
-{% if vlan_interfaces is defined and vlan_interfaces is not none %}
+{% if vlan_interfaces is arista.avd.defined %}
 {%     for vlan_interface in vlan_interfaces | arista.avd.natural_sort %}
 !
 interface {{ vlan_interface }}
-{%         if vlan_interfaces[vlan_interface].description is defined and vlan_interfaces[vlan_interface].description is not none %}
+{%         if vlan_interfaces[vlan_interface].description is arista.avd.defined %}
    description {{ vlan_interfaces[vlan_interface].description }}
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].shutdown is defined and vlan_interfaces[vlan_interface].shutdown == true %}
+{%         if vlan_interfaces[vlan_interface].shutdown is arista.avd.defined(true) %}
    shutdown
-{%         elif vlan_interfaces[vlan_interface].shutdown is defined and vlan_interfaces[vlan_interface].shutdown == false %}
+{%         elif vlan_interfaces[vlan_interface].shutdown is arista.avd.defined(false) %}
    no shutdown
 {%         endif %}
 {%         if vlan_interfaces[vlan_interface].mtu is defined and vlan_interfaces[vlan_interface].mtu != 1500 %}
    mtu {{ vlan_interfaces[vlan_interface].mtu }}
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].no_autostate is defined and vlan_interfaces[vlan_interface].no_autostate == true %}
+{%         if vlan_interfaces[vlan_interface].no_autostate is arista.avd.defined(true) %}
    no autostate
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].vrf is defined and vlan_interfaces[vlan_interface].vrf is not none %}
+{%         if vlan_interfaces[vlan_interface].vrf is arista.avd.defined %}
    vrf {{ vlan_interfaces[vlan_interface].vrf }}
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].arp_aging_timeout is defined and vlan_interfaces[vlan_interface].arp_aging_timeout is not none %}
+{%         if vlan_interfaces[vlan_interface].arp_aging_timeout is arista.avd.defined %}
    arp aging timeout {{ vlan_interfaces[vlan_interface].arp_aging_timeout }}
 {%         endif %}
-{%             if vlan_interfaces[vlan_interface].ip_proxy_arp is defined and vlan_interfaces[vlan_interface].ip_proxy_arp == true %}
+{%             if vlan_interfaces[vlan_interface].ip_proxy_arp is arista.avd.defined(true) %}
    ip proxy-arp
 {%             endif %}
-{%         if vlan_interfaces[vlan_interface].ip_address is defined %}
+{%         if vlan_interfaces[vlan_interface].ip_address is arista.avd.defined %}
    ip address {{ vlan_interfaces[vlan_interface].ip_address }}
-{%             if vlan_interfaces[vlan_interface].ip_address_secondaries is defined and vlan_interfaces[vlan_interface].ip_address_secondaries is not none %}
+{%             if vlan_interfaces[vlan_interface].ip_address_secondaries is arista.avd.defined %}
 {%                 for ip_address_secondary in vlan_interfaces[vlan_interface].ip_address_secondaries %}
    ip address {{ ip_address_secondary }} secondary
 {%                 endfor %}
 {%             endif %}
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].ip_virtual_router_address is defined %}
+{%         if vlan_interfaces[vlan_interface].ip_virtual_router_address is arista.avd.defined %}
    ip virtual-router address {{ vlan_interfaces[vlan_interface].ip_virtual_router_address }}
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].ip_address_virtual is defined %}
+{%         if vlan_interfaces[vlan_interface].ip_address_virtual is arista.avd.defined %}
    ip address virtual {{ vlan_interfaces[vlan_interface].ip_address_virtual }}
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].ip_helpers is defined and vlan_interfaces[vlan_interface].ip_helpers is not none %}
+{%         if vlan_interfaces[vlan_interface].ip_helpers is arista.avd.defined %}
 {%            for ip_helper in vlan_interfaces[vlan_interface].ip_helpers | arista.avd.natural_sort %}
-   ip helper-address {{ ip_helper }} {% if vlan_interfaces[vlan_interface].ip_helpers[ip_helper].vrf is defined and vlan_interfaces[vlan_interface].ip_helpers[ip_helper].vrf is not none %}vrf {{vlan_interfaces[vlan_interface].ip_helpers[ip_helper].vrf }} {% endif %} {% if vlan_interfaces[vlan_interface].ip_helpers[ip_helper].source_interface is defined and vlan_interfaces[vlan_interface].ip_helpers[ip_helper].source_interface is not none %}source-interface {{vlan_interfaces[vlan_interface].ip_helpers[ip_helper].source_interface }}{% endif %}
-
+{%               set ip_helper_cli = "ip helper-address " ~ ip_helper %}
+{%               if vlan_interfaces[vlan_interface].ip_helpers[ip_helper].vrf is arista.avd.defined %}
+{%                   set ip_helper_cli = ip_helper_cli ~ " vrf " ~ vlan_interfaces[vlan_interface].ip_helpers[ip_helper].vrf %}
+{%               endif %}
+{%               if vlan_interfaces[vlan_interface].ip_helpers[ip_helper].source_interface is arista.avd.defined %}
+{%                   set ip_helper_cli = ip_helper_cli ~ " source-interface " ~ vlan_interfaces[vlan_interface].ip_helpers[ip_helper].source_interface %}
+{%               endif %}
+   {{ ip_helper_cli }}
 {%            endfor %}
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].ipv6_enable is defined and vlan_interfaces[vlan_interface].ipv6_enable == true %}
+{%         if vlan_interfaces[vlan_interface].ipv6_enable is arista.avd.defined(true) %}
    ipv6 enable
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].ipv6_address is defined and vlan_interfaces[vlan_interface].ipv6_address is not none %}
+{%         if vlan_interfaces[vlan_interface].ipv6_address is arista.avd.defined %}
    ipv6 address {{ vlan_interfaces[vlan_interface].ipv6_address }}
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].ipv6_address_link_local is defined and vlan_interfaces[vlan_interface].ipv6_address_link_local is not none %}
+{%         if vlan_interfaces[vlan_interface].ipv6_address_link_local is arista.avd.defined %}
    ipv6 address {{ vlan_interfaces[vlan_interface].ipv6_address_link_local }} link-local
 {%             endif %}
-{%         if vlan_interfaces[vlan_interface].ipv6_nd_ra_disabled is defined and vlan_interfaces[vlan_interface].ipv6_nd_ra_disabled == true %}
+{%         if vlan_interfaces[vlan_interface].ipv6_nd_ra_disabled is arista.avd.defined(true) %}
    ipv6 nd ra disabled
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].ipv6_nd_managed_config_flag is defined and vlan_interfaces[vlan_interface].ipv6_nd_managed_config_flag == true %}
+{%         if vlan_interfaces[vlan_interface].ipv6_nd_managed_config_flag is arista.avd.defined(true) %}
    ipv6 nd managed-config-flag
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].ipv6_nd_prefixes is defined and vlan_interfaces[vlan_interface].ipv6_nd_prefixes is not none %}
+{%         if vlan_interfaces[vlan_interface].ipv6_nd_prefixes is arista.avd.defined %}
 {%             for prefix in vlan_interfaces[vlan_interface].ipv6_nd_prefixes %}
-   ipv6 nd prefix {{ prefix }} {% if vlan_interfaces[vlan_interface].ipv6_nd_prefixes[prefix].valid_lifetime is defined and vlan_interfaces[vlan_interface].ipv6_nd_prefixes[prefix].valid_lifetime is not none %}{{ vlan_interfaces[vlan_interface].ipv6_nd_prefixes[prefix].valid_lifetime }} {% endif %}{% if vlan_interfaces[vlan_interface].ipv6_nd_prefixes[prefix].preferred_lifetime is defined and vlan_interfaces[vlan_interface].ipv6_nd_prefixes[prefix].preferred_lifetime is not none %}{{ vlan_interfaces[vlan_interface].ipv6_nd_prefixes[prefix].preferred_lifetime }} {% endif %}{% if vlan_interfaces[vlan_interface].ipv6_nd_prefixes[prefix].no_autoconfig_flag is defined and vlan_interfaces[vlan_interface].ipv6_nd_prefixes[prefix].no_autoconfig_flag == true %}no-autoconfig{% endif %}
-
+{%                 set ipv6_nd_prefix_cli = "ipv6 nd prefix " ~ prefix %}
+{%                 if vlan_interfaces[vlan_interface].ipv6_nd_prefixes[prefix].valid_lifetime is arista.avd.defined %}
+{%                     set ipv6_nd_prefix_cli = ipv6_nd_prefix_cli ~ " " ~ vlan_interfaces[vlan_interface].ipv6_nd_prefixes[prefix].valid_lifetime %}
+{%                 endif %}
+{%                 if vlan_interfaces[vlan_interface].ipv6_nd_prefixes[prefix].preferred_lifetime is arista.avd.defined %}
+{%                     set ipv6_nd_prefix_cli = ipv6_nd_prefix_cli ~ " " ~ vlan_interfaces[vlan_interface].ipv6_nd_prefixes[prefix].preferred_lifetime %}
+{%                 endif %}
+{%                 if vlan_interfaces[vlan_interface].ipv6_nd_prefixes[prefix].no_autoconfig_flag is arista.avd.defined(true) %}
+{%                     set ipv6_nd_prefix_cli = ipv6_nd_prefix_cli ~ " no-autoconfig" %}
+{%                 endif %}
+   {{ ipv6_nd_prefix_cli }}
 {%             endfor %}
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].multicast.ipv4.source_route_export.enabled is defined and vlan_interfaces[vlan_interface].multicast.ipv4.source_route_export.enabled == true %}
-   multicast ipv4 source route export{% if vlan_interfaces[vlan_interface].multicast.ipv4.source_route_export.administrative_distance is defined and vlan_interfaces[vlan_interface].multicast.ipv4.source_route_export.administrative_distance is not none %} {{ vlan_interfaces[vlan_interface].multicast.ipv4.source_route_export.administrative_distance }}{% endif %}
-
+{%         if vlan_interfaces[vlan_interface].multicast.ipv4.source_route_export.enabled is arista.avd.defined(true) %}
+   multicast ipv4 source route export {{ vlan_interfaces[vlan_interface].multicast.ipv4.source_route_export.administrative_distance | arista.avd.default('')}}
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].access_group_in is defined and vlan_interfaces[vlan_interface].access_group_in is not none %}
+{%         if vlan_interfaces[vlan_interface].access_group_in is arista.avd.defined %}
    ip access-group {{ vlan_interfaces[vlan_interface].access_group_in }} in
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].access_group_out is defined and vlan_interfaces[vlan_interface].access_group_out is not none %}
+{%         if vlan_interfaces[vlan_interface].access_group_out is arista.avd.defined %}
    ip access-group {{ vlan_interfaces[vlan_interface].access_group_out }} out
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].ipv6_access_group_in is defined and vlan_interfaces[vlan_interface].ipv6_access_group_in is not none %}
+{%         if vlan_interfaces[vlan_interface].ipv6_access_group_in is arista.avd.defined %}
    ipv6 access-group {{ vlan_interfaces[vlan_interface].ipv6_access_group_in }} in
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].ipv6_access_group_out is defined and vlan_interfaces[vlan_interface].ipv6_access_group_out is not none %}
+{%         if vlan_interfaces[vlan_interface].ipv6_access_group_out is arista.avd.defined %}
    ipv6 access-group {{ vlan_interfaces[vlan_interface].ipv6_access_group_out }} out
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].ospf_network_point_to_point is defined and vlan_interfaces[vlan_interface].ospf_network_point_to_point == true %}
+{%         if vlan_interfaces[vlan_interface].ospf_network_point_to_point is arista.avd.defined(true) %}
    ip ospf network point-to-point
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].ospf_area is defined and vlan_interfaces[vlan_interface].ospf_area is not none %}
+{%         if vlan_interfaces[vlan_interface].ospf_area is arista.avd.defined %}
    ip ospf area {{ vlan_interfaces[vlan_interface].ospf_area }}
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].ospf_cost is defined and vlan_interfaces[vlan_interface].ospf_cost is not none %}
+{%         if vlan_interfaces[vlan_interface].ospf_cost is arista.avd.defined %}
    ip ospf cost {{ vlan_interfaces[vlan_interface].ospf_cost }}
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].ospf_authentication is defined and vlan_interfaces[vlan_interface].ospf_authentication is not none %}
+{%         if vlan_interfaces[vlan_interface].ospf_authentication is arista.avd.defined %}
 {%           if vlan_interfaces[vlan_interface].ospf_authentication == "simple" %}
    ip ospf authentication
 {%           elif vlan_interfaces[vlan_interface].ospf_authentication == "message-digest" %}
    ip ospf authentication message-digest
 {%           endif %}
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].ospf_authentication_key is defined and vlan_interfaces[vlan_interface].ospf_authentication_key is not none %}
+{%         if vlan_interfaces[vlan_interface].ospf_authentication_key is arista.avd.defined %}
    ip ospf authentication-key 7 {{ vlan_interfaces[vlan_interface].ospf_authentication_key }}
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].ospf_message_digest_keys is defined and vlan_interfaces[vlan_interface].ospf_message_digest_keys is not none %}
+{%         if vlan_interfaces[vlan_interface].ospf_message_digest_keys is arista.avd.defined %}
 {%           for ospf_message_digest_key in vlan_interfaces[vlan_interface].ospf_message_digest_keys | arista.avd.natural_sort %}
    ip ospf message-digest-key {{ ospf_message_digest_key }} {{ vlan_interfaces[vlan_interface].ospf_message_digest_keys[ospf_message_digest_key].hash_algorithm }} 7 {{ vlan_interfaces[vlan_interface].ospf_message_digest_keys[ospf_message_digest_key].key }}
 {%           endfor %}
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].pim is defined and vlan_interfaces[vlan_interface].pim is not none %}
-{%            if vlan_interfaces[vlan_interface].pim.ipv4.sparse_mode is defined and vlan_interfaces[vlan_interface].pim.ipv4.sparse_mode == true %}
+{%         if vlan_interfaces[vlan_interface].pim is arista.avd.defined %}
+{%            if vlan_interfaces[vlan_interface].pim.ipv4.sparse_mode is arista.avd.defined(true) %}
    pim ipv4 sparse-mode
 {%            endif %}
-{%            if vlan_interfaces[vlan_interface].pim.ipv4.local_interface is defined and vlan_interfaces[vlan_interface].pim.ipv4.local_interface is not none %}
+{%            if vlan_interfaces[vlan_interface].pim.ipv4.local_interface is arista.avd.defined %}
    pim ipv4 local-interface {{ vlan_interfaces[vlan_interface].pim.ipv4.local_interface }}
 {%            endif %}
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].ipv6_virtual_router_address is defined and vlan_interfaces[vlan_interface].ipv6_virtual_router_address is not none %}
+{%         if vlan_interfaces[vlan_interface].ipv6_virtual_router_address is arista.avd.defined %}
    ipv6 virtual-router address {{ vlan_interfaces[vlan_interface].ipv6_virtual_router_address }}
 {%         endif %}
 {%         if vlan_interfaces[vlan_interface].isis_enable is defined %}
    isis enable {{ vlan_interfaces[vlan_interface].isis_enable }}
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].isis_passive is defined and vlan_interfaces[vlan_interface].isis_passive == true %}
+{%         if vlan_interfaces[vlan_interface].isis_passive is arista.avd.defined(true) %}
    isis passive
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].isis_metric is defined %}
+{%         if vlan_interfaces[vlan_interface].isis_metric is arista.avd.defined %}
    isis metric {{ vlan_interfaces[vlan_interface].isis_metric }}
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].isis_network_point_to_point is defined and vlan_interfaces[vlan_interface].isis_network_point_to_point == true %}
+{%         if vlan_interfaces[vlan_interface].isis_network_point_to_point is arista.avd.defined(true) %}
    isis network point-to-point
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].vrrp is defined and vlan_interfaces[vlan_interface].vrrp is not none %}
-{%           if vlan_interfaces[vlan_interface].vrrp.virtual_router is defined and vlan_interfaces[vlan_interface].vrrp.virtual_router is not none %}
-{%             if vlan_interfaces[vlan_interface].vrrp.priority is defined and vlan_interfaces[vlan_interface].vrrp.priority is not none and vlan_interfaces[vlan_interface].vrrp.priority > 1 %}
+{%         if vlan_interfaces[vlan_interface].vrrp is arista.avd.defined %}
+{%           if vlan_interfaces[vlan_interface].vrrp.virtual_router is arista.avd.defined %}
+{%             if vlan_interfaces[vlan_interface].vrrp.priority is arista.avd.defined and vlan_interfaces[vlan_interface].vrrp.priority | int > 1 %}
    vrrp {{ vlan_interfaces[vlan_interface].vrrp.virtual_router }} priority-level {{ vlan_interfaces[vlan_interface].vrrp.priority }}
 {%             endif %}
-{%             if vlan_interfaces[vlan_interface].vrrp.advertisement_interval is defined and vlan_interfaces[vlan_interface].vrrp.advertisement_interval is not none %}
+{%             if vlan_interfaces[vlan_interface].vrrp.advertisement_interval is arista.avd.defined %}
    vrrp {{ vlan_interfaces[vlan_interface].vrrp.virtual_router }} advertisement interval {{ vlan_interfaces[vlan_interface].vrrp.advertisement_interval }}
 {%             endif %}
-{%             if vlan_interfaces[vlan_interface].vrrp.preempt_delay_minimum is defined and vlan_interfaces[vlan_interface].vrrp.preempt_delay_minimum is not none %}
+{%             if vlan_interfaces[vlan_interface].vrrp.preempt_delay_minimum is arista.avd.defined %}
    vrrp {{ vlan_interfaces[vlan_interface].vrrp.virtual_router }} preempt delay minimum {{ vlan_interfaces[vlan_interface].vrrp.preempt_delay_minimum }}
 {%             endif %}
-{%             if vlan_interfaces[vlan_interface].vrrp.ipv4 is defined and vlan_interfaces[vlan_interface].vrrp.ipv4 is not none %}
+{%             if vlan_interfaces[vlan_interface].vrrp.ipv4 is arista.avd.defined %}
    vrrp {{ vlan_interfaces[vlan_interface].vrrp.virtual_router }} ipv4 {{ vlan_interfaces[vlan_interface].vrrp.ipv4 }}
 {%             endif %}
-{%             if vlan_interfaces[vlan_interface].vrrp.ipv6 is defined and vlan_interfaces[vlan_interface].vrrp.ipv6 is not none %}
+{%             if vlan_interfaces[vlan_interface].vrrp.ipv6 is arista.avd.defined %}
    vrrp {{ vlan_interfaces[vlan_interface].vrrp.virtual_router }} ipv6 {{ vlan_interfaces[vlan_interface].vrrp.ipv6 }}
 {%             endif %}
 {%           endif %}
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].ip_attached_host_route_export is defined and vlan_interfaces[vlan_interface].ip_attached_host_route_export is not none %}
+{%         if vlan_interfaces[vlan_interface].ip_attached_host_route_export is arista.avd.defined %}
    ip attached-host route export {{ vlan_interfaces[vlan_interface].ip_attached_host_route_export.distance | arista.avd.default("") }}
 {%         endif %}
 {%     endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
@@ -1,170 +1,166 @@
 {# eos - VLAN Interfaces #}
-{% if vlan_interfaces is arista.avd.defined %}
-{%     for vlan_interface in vlan_interfaces | arista.avd.natural_sort %}
+{% for vlan_interface in vlan_interfaces | arista.avd.natural_sort %}
 !
 interface {{ vlan_interface }}
-{%         if vlan_interfaces[vlan_interface].description is arista.avd.defined %}
+{%     if vlan_interfaces[vlan_interface].description is arista.avd.defined %}
    description {{ vlan_interfaces[vlan_interface].description }}
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].shutdown is arista.avd.defined(true) %}
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].shutdown is arista.avd.defined(true) %}
    shutdown
-{%         elif vlan_interfaces[vlan_interface].shutdown is arista.avd.defined(false) %}
+{%     elif vlan_interfaces[vlan_interface].shutdown is arista.avd.defined(false) %}
    no shutdown
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].mtu is defined and vlan_interfaces[vlan_interface].mtu != 1500 %}
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].mtu is arista.avd.defined %}
    mtu {{ vlan_interfaces[vlan_interface].mtu }}
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].no_autostate is arista.avd.defined(true) %}
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].no_autostate is arista.avd.defined(true) %}
    no autostate
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].vrf is arista.avd.defined %}
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].vrf is arista.avd.defined %}
    vrf {{ vlan_interfaces[vlan_interface].vrf }}
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].arp_aging_timeout is arista.avd.defined %}
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].arp_aging_timeout is arista.avd.defined %}
    arp aging timeout {{ vlan_interfaces[vlan_interface].arp_aging_timeout }}
-{%         endif %}
-{%             if vlan_interfaces[vlan_interface].ip_proxy_arp is arista.avd.defined(true) %}
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].ip_proxy_arp is arista.avd.defined(true) %}
    ip proxy-arp
-{%             endif %}
-{%         if vlan_interfaces[vlan_interface].ip_address is arista.avd.defined %}
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].ip_address is arista.avd.defined %}
    ip address {{ vlan_interfaces[vlan_interface].ip_address }}
-{%             if vlan_interfaces[vlan_interface].ip_address_secondaries is arista.avd.defined %}
-{%                 for ip_address_secondary in vlan_interfaces[vlan_interface].ip_address_secondaries %}
+{%         if vlan_interfaces[vlan_interface].ip_address_secondaries is arista.avd.defined %}
+{%             for ip_address_secondary in vlan_interfaces[vlan_interface].ip_address_secondaries %}
    ip address {{ ip_address_secondary }} secondary
-{%                 endfor %}
-{%             endif %}
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].ip_virtual_router_address is arista.avd.defined %}
-   ip virtual-router address {{ vlan_interfaces[vlan_interface].ip_virtual_router_address }}
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].ip_address_virtual is arista.avd.defined %}
-   ip address virtual {{ vlan_interfaces[vlan_interface].ip_address_virtual }}
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].ip_helpers is arista.avd.defined %}
-{%            for ip_helper in vlan_interfaces[vlan_interface].ip_helpers | arista.avd.natural_sort %}
-{%               set ip_helper_cli = "ip helper-address " ~ ip_helper %}
-{%               if vlan_interfaces[vlan_interface].ip_helpers[ip_helper].vrf is arista.avd.defined %}
-{%                   set ip_helper_cli = ip_helper_cli ~ " vrf " ~ vlan_interfaces[vlan_interface].ip_helpers[ip_helper].vrf %}
-{%               endif %}
-{%               if vlan_interfaces[vlan_interface].ip_helpers[ip_helper].source_interface is arista.avd.defined %}
-{%                   set ip_helper_cli = ip_helper_cli ~ " source-interface " ~ vlan_interfaces[vlan_interface].ip_helpers[ip_helper].source_interface %}
-{%               endif %}
-   {{ ip_helper_cli }}
-{%            endfor %}
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].ipv6_enable is arista.avd.defined(true) %}
-   ipv6 enable
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].ipv6_address is arista.avd.defined %}
-   ipv6 address {{ vlan_interfaces[vlan_interface].ipv6_address }}
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].ipv6_address_link_local is arista.avd.defined %}
-   ipv6 address {{ vlan_interfaces[vlan_interface].ipv6_address_link_local }} link-local
-{%             endif %}
-{%         if vlan_interfaces[vlan_interface].ipv6_nd_ra_disabled is arista.avd.defined(true) %}
-   ipv6 nd ra disabled
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].ipv6_nd_managed_config_flag is arista.avd.defined(true) %}
-   ipv6 nd managed-config-flag
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].ipv6_nd_prefixes is arista.avd.defined %}
-{%             for prefix in vlan_interfaces[vlan_interface].ipv6_nd_prefixes %}
-{%                 set ipv6_nd_prefix_cli = "ipv6 nd prefix " ~ prefix %}
-{%                 if vlan_interfaces[vlan_interface].ipv6_nd_prefixes[prefix].valid_lifetime is arista.avd.defined %}
-{%                     set ipv6_nd_prefix_cli = ipv6_nd_prefix_cli ~ " " ~ vlan_interfaces[vlan_interface].ipv6_nd_prefixes[prefix].valid_lifetime %}
-{%                 endif %}
-{%                 if vlan_interfaces[vlan_interface].ipv6_nd_prefixes[prefix].preferred_lifetime is arista.avd.defined %}
-{%                     set ipv6_nd_prefix_cli = ipv6_nd_prefix_cli ~ " " ~ vlan_interfaces[vlan_interface].ipv6_nd_prefixes[prefix].preferred_lifetime %}
-{%                 endif %}
-{%                 if vlan_interfaces[vlan_interface].ipv6_nd_prefixes[prefix].no_autoconfig_flag is arista.avd.defined(true) %}
-{%                     set ipv6_nd_prefix_cli = ipv6_nd_prefix_cli ~ " no-autoconfig" %}
-{%                 endif %}
-   {{ ipv6_nd_prefix_cli }}
 {%             endfor %}
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].multicast.ipv4.source_route_export.enabled is arista.avd.defined(true) %}
-   multicast ipv4 source route export {{ vlan_interfaces[vlan_interface].multicast.ipv4.source_route_export.administrative_distance | arista.avd.default('')}}
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].access_group_in is arista.avd.defined %}
-   ip access-group {{ vlan_interfaces[vlan_interface].access_group_in }} in
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].access_group_out is arista.avd.defined %}
-   ip access-group {{ vlan_interfaces[vlan_interface].access_group_out }} out
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].ipv6_access_group_in is arista.avd.defined %}
-   ipv6 access-group {{ vlan_interfaces[vlan_interface].ipv6_access_group_in }} in
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].ipv6_access_group_out is arista.avd.defined %}
-   ipv6 access-group {{ vlan_interfaces[vlan_interface].ipv6_access_group_out }} out
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].ospf_network_point_to_point is arista.avd.defined(true) %}
-   ip ospf network point-to-point
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].ospf_area is arista.avd.defined %}
-   ip ospf area {{ vlan_interfaces[vlan_interface].ospf_area }}
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].ospf_cost is arista.avd.defined %}
-   ip ospf cost {{ vlan_interfaces[vlan_interface].ospf_cost }}
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].ospf_authentication is arista.avd.defined %}
-{%           if vlan_interfaces[vlan_interface].ospf_authentication == "simple" %}
-   ip ospf authentication
-{%           elif vlan_interfaces[vlan_interface].ospf_authentication == "message-digest" %}
-   ip ospf authentication message-digest
-{%           endif %}
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].ospf_authentication_key is arista.avd.defined %}
-   ip ospf authentication-key 7 {{ vlan_interfaces[vlan_interface].ospf_authentication_key }}
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].ospf_message_digest_keys is arista.avd.defined %}
-{%           for ospf_message_digest_key in vlan_interfaces[vlan_interface].ospf_message_digest_keys | arista.avd.natural_sort %}
-   ip ospf message-digest-key {{ ospf_message_digest_key }} {{ vlan_interfaces[vlan_interface].ospf_message_digest_keys[ospf_message_digest_key].hash_algorithm }} 7 {{ vlan_interfaces[vlan_interface].ospf_message_digest_keys[ospf_message_digest_key].key }}
-{%           endfor %}
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].pim is arista.avd.defined %}
-{%            if vlan_interfaces[vlan_interface].pim.ipv4.sparse_mode is arista.avd.defined(true) %}
-   pim ipv4 sparse-mode
-{%            endif %}
-{%            if vlan_interfaces[vlan_interface].pim.ipv4.local_interface is arista.avd.defined %}
-   pim ipv4 local-interface {{ vlan_interfaces[vlan_interface].pim.ipv4.local_interface }}
-{%            endif %}
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].ipv6_virtual_router_address is arista.avd.defined %}
-   ipv6 virtual-router address {{ vlan_interfaces[vlan_interface].ipv6_virtual_router_address }}
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].isis_enable is defined %}
-   isis enable {{ vlan_interfaces[vlan_interface].isis_enable }}
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].isis_passive is arista.avd.defined(true) %}
-   isis passive
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].isis_metric is arista.avd.defined %}
-   isis metric {{ vlan_interfaces[vlan_interface].isis_metric }}
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].isis_network_point_to_point is arista.avd.defined(true) %}
-   isis network point-to-point
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].vrrp is arista.avd.defined %}
-{%           if vlan_interfaces[vlan_interface].vrrp.virtual_router is arista.avd.defined %}
-{%             if vlan_interfaces[vlan_interface].vrrp.priority is arista.avd.defined and vlan_interfaces[vlan_interface].vrrp.priority | int > 1 %}
-   vrrp {{ vlan_interfaces[vlan_interface].vrrp.virtual_router }} priority-level {{ vlan_interfaces[vlan_interface].vrrp.priority }}
-{%             endif %}
-{%             if vlan_interfaces[vlan_interface].vrrp.advertisement_interval is arista.avd.defined %}
-   vrrp {{ vlan_interfaces[vlan_interface].vrrp.virtual_router }} advertisement interval {{ vlan_interfaces[vlan_interface].vrrp.advertisement_interval }}
-{%             endif %}
-{%             if vlan_interfaces[vlan_interface].vrrp.preempt_delay_minimum is arista.avd.defined %}
-   vrrp {{ vlan_interfaces[vlan_interface].vrrp.virtual_router }} preempt delay minimum {{ vlan_interfaces[vlan_interface].vrrp.preempt_delay_minimum }}
-{%             endif %}
-{%             if vlan_interfaces[vlan_interface].vrrp.ipv4 is arista.avd.defined %}
-   vrrp {{ vlan_interfaces[vlan_interface].vrrp.virtual_router }} ipv4 {{ vlan_interfaces[vlan_interface].vrrp.ipv4 }}
-{%             endif %}
-{%             if vlan_interfaces[vlan_interface].vrrp.ipv6 is arista.avd.defined %}
-   vrrp {{ vlan_interfaces[vlan_interface].vrrp.virtual_router }} ipv6 {{ vlan_interfaces[vlan_interface].vrrp.ipv6 }}
-{%             endif %}
-{%           endif %}
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].ip_attached_host_route_export is arista.avd.defined %}
-   ip attached-host route export {{ vlan_interfaces[vlan_interface].ip_attached_host_route_export.distance | arista.avd.default("") }}
-{%         endif %}
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].ip_virtual_router_address is arista.avd.defined %}
+   ip virtual-router address {{ vlan_interfaces[vlan_interface].ip_virtual_router_address }}
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].ip_address_virtual is arista.avd.defined %}
+   ip address virtual {{ vlan_interfaces[vlan_interface].ip_address_virtual }}
+{%     endif %}
+{%    for ip_helper in vlan_interfaces[vlan_interface].ip_helpers | arista.avd.natural_sort %}
+{%        set ip_helper_cli = "ip helper-address " ~ ip_helper %}
+{%        if vlan_interfaces[vlan_interface].ip_helpers[ip_helper].vrf is arista.avd.defined %}
+{%           set ip_helper_cli = ip_helper_cli ~ " vrf " ~ vlan_interfaces[vlan_interface].ip_helpers[ip_helper].vrf %}
+{%        endif %}
+{%        if vlan_interfaces[vlan_interface].ip_helpers[ip_helper].source_interface is arista.avd.defined %}
+{%            set ip_helper_cli = ip_helper_cli ~ " source-interface " ~ vlan_interfaces[vlan_interface].ip_helpers[ip_helper].source_interface %}
+{%        endif %}
+   {{ ip_helper_cli }}
 {%     endfor %}
-{% endif %}
+{%     if vlan_interfaces[vlan_interface].ipv6_enable is arista.avd.defined(true) %}
+   ipv6 enable
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].ipv6_address is arista.avd.defined %}
+   ipv6 address {{ vlan_interfaces[vlan_interface].ipv6_address }}
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].ipv6_address_link_local is arista.avd.defined %}
+   ipv6 address {{ vlan_interfaces[vlan_interface].ipv6_address_link_local }} link-local
+{%         endif %}
+{%     if vlan_interfaces[vlan_interface].ipv6_nd_ra_disabled is arista.avd.defined(true) %}
+   ipv6 nd ra disabled
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].ipv6_nd_managed_config_flag is arista.avd.defined(true) %}
+   ipv6 nd managed-config-flag
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].ipv6_nd_prefixes is arista.avd.defined %}
+{%         for prefix in vlan_interfaces[vlan_interface].ipv6_nd_prefixes %}
+{%             set ipv6_nd_prefix_cli = "ipv6 nd prefix " ~ prefix %}
+{%             if vlan_interfaces[vlan_interface].ipv6_nd_prefixes[prefix].valid_lifetime is arista.avd.defined %}
+{%                 set ipv6_nd_prefix_cli = ipv6_nd_prefix_cli ~ " " ~ vlan_interfaces[vlan_interface].ipv6_nd_prefixes[prefix].valid_lifetime %}
+{%             endif %}
+{%             if vlan_interfaces[vlan_interface].ipv6_nd_prefixes[prefix].preferred_lifetime is arista.avd.defined %}
+{%                 set ipv6_nd_prefix_cli = ipv6_nd_prefix_cli ~ " " ~ vlan_interfaces[vlan_interface].ipv6_nd_prefixes[prefix].preferred_lifetime %}
+{%             endif %}
+{%             if vlan_interfaces[vlan_interface].ipv6_nd_prefixes[prefix].no_autoconfig_flag is arista.avd.defined(true) %}
+{%                 set ipv6_nd_prefix_cli = ipv6_nd_prefix_cli ~ " no-autoconfig" %}
+{%             endif %}
+   {{ ipv6_nd_prefix_cli }}
+{%         endfor %}
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].multicast.ipv4.source_route_export.enabled is arista.avd.defined(true) %}
+   multicast ipv4 source route export {{ vlan_interfaces[vlan_interface].multicast.ipv4.source_route_export.administrative_distance | arista.avd.default('')}}
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].access_group_in is arista.avd.defined %}
+   ip access-group {{ vlan_interfaces[vlan_interface].access_group_in }} in
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].access_group_out is arista.avd.defined %}
+   ip access-group {{ vlan_interfaces[vlan_interface].access_group_out }} out
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].ipv6_access_group_in is arista.avd.defined %}
+   ipv6 access-group {{ vlan_interfaces[vlan_interface].ipv6_access_group_in }} in
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].ipv6_access_group_out is arista.avd.defined %}
+   ipv6 access-group {{ vlan_interfaces[vlan_interface].ipv6_access_group_out }} out
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].ospf_network_point_to_point is arista.avd.defined(true) %}
+   ip ospf network point-to-point
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].ospf_area is arista.avd.defined %}
+   ip ospf area {{ vlan_interfaces[vlan_interface].ospf_area }}
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].ospf_cost is arista.avd.defined %}
+   ip ospf cost {{ vlan_interfaces[vlan_interface].ospf_cost }}
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].ospf_authentication is arista.avd.defined %}
+{%       if vlan_interfaces[vlan_interface].ospf_authentication == "simple" %}
+   ip ospf authentication
+{%       elif vlan_interfaces[vlan_interface].ospf_authentication == "message-digest" %}
+   ip ospf authentication message-digest
+{%       endif %}
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].ospf_authentication_key is arista.avd.defined %}
+   ip ospf authentication-key 7 {{ vlan_interfaces[vlan_interface].ospf_authentication_key }}
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].ospf_message_digest_keys is arista.avd.defined %}
+{%       for ospf_message_digest_key in vlan_interfaces[vlan_interface].ospf_message_digest_keys | arista.avd.natural_sort %}
+   ip ospf message-digest-key {{ ospf_message_digest_key }} {{ vlan_interfaces[vlan_interface].ospf_message_digest_keys[ospf_message_digest_key].hash_algorithm }} 7 {{ vlan_interfaces[vlan_interface].ospf_message_digest_keys[ospf_message_digest_key].key }}
+{%       endfor %}
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].pim is arista.avd.defined %}
+{%        if vlan_interfaces[vlan_interface].pim.ipv4.sparse_mode is arista.avd.defined(true) %}
+   pim ipv4 sparse-mode
+{%        endif %}
+{%        if vlan_interfaces[vlan_interface].pim.ipv4.local_interface is arista.avd.defined %}
+   pim ipv4 local-interface {{ vlan_interfaces[vlan_interface].pim.ipv4.local_interface }}
+{%        endif %}
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].ipv6_virtual_router_address is arista.avd.defined %}
+   ipv6 virtual-router address {{ vlan_interfaces[vlan_interface].ipv6_virtual_router_address }}
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].isis_enable is defined %}
+   isis enable {{ vlan_interfaces[vlan_interface].isis_enable }}
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].isis_passive is arista.avd.defined(true) %}
+   isis passive
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].isis_metric is arista.avd.defined %}
+   isis metric {{ vlan_interfaces[vlan_interface].isis_metric }}
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].isis_network_point_to_point is arista.avd.defined(true) %}
+   isis network point-to-point
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].vrrp is arista.avd.defined %}
+{%       if vlan_interfaces[vlan_interface].vrrp.virtual_router is arista.avd.defined %}
+{%         if vlan_interfaces[vlan_interface].vrrp.priority is arista.avd.defined %}
+   vrrp {{ vlan_interfaces[vlan_interface].vrrp.virtual_router }} priority-level {{ vlan_interfaces[vlan_interface].vrrp.priority }}
+{%         endif %}
+{%         if vlan_interfaces[vlan_interface].vrrp.advertisement_interval is arista.avd.defined %}
+   vrrp {{ vlan_interfaces[vlan_interface].vrrp.virtual_router }} advertisement interval {{ vlan_interfaces[vlan_interface].vrrp.advertisement_interval }}
+{%         endif %}
+{%         if vlan_interfaces[vlan_interface].vrrp.preempt_delay_minimum is arista.avd.defined %}
+   vrrp {{ vlan_interfaces[vlan_interface].vrrp.virtual_router }} preempt delay minimum {{ vlan_interfaces[vlan_interface].vrrp.preempt_delay_minimum }}
+{%         endif %}
+{%         if vlan_interfaces[vlan_interface].vrrp.ipv4 is arista.avd.defined %}
+   vrrp {{ vlan_interfaces[vlan_interface].vrrp.virtual_router }} ipv4 {{ vlan_interfaces[vlan_interface].vrrp.ipv4 }}
+{%         endif %}
+{%         if vlan_interfaces[vlan_interface].vrrp.ipv6 is arista.avd.defined %}
+   vrrp {{ vlan_interfaces[vlan_interface].vrrp.virtual_router }} ipv6 {{ vlan_interfaces[vlan_interface].vrrp.ipv6 }}
+{%         endif %}
+{%       endif %}
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].ip_attached_host_route_export is arista.avd.defined %}
+   ip attached-host route export {{ vlan_interfaces[vlan_interface].ip_attached_host_route_export.distance | arista.avd.default("") }}
+{%     endif %}
+{% endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-internal-order.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-internal-order.j2
@@ -1,5 +1,5 @@
 {# Internal VLAN allocation policy  #}
-{% if vlan_internal_order is defined and vlan_internal_order is not none %}
+{% if vlan_internal_order is arista.avd.defined %}
 !
 vlan internal order {{ vlan_internal_order.allocation }} range {{ vlan_internal_order.range.beginning }} {{ vlan_internal_order.range.ending }}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlans.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlans.j2
@@ -4,10 +4,10 @@
 !
 vlan {{ vlan }}
    name {{ vlans[vlan].name }}
-{%         if vlans[vlan].state is defined and vlans[vlan].state == "suspend" %}
+{%         if vlans[vlan].state is arista.avd.defined("suspend") %}
    state {{ vlans[vlan].state }}
 {%         endif %}
-{%         if vlans[vlan].trunk_groups is defined %}
+{%         if vlans[vlan].trunk_groups is arista.avd.defined %}
 {%             for trunk_group in vlans[vlan].trunk_groups | arista.avd.natural_sort %}
    trunk group {{ trunk_group }}
 {%             endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vmtracer-sessions.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vmtracer-sessions.j2
@@ -1,21 +1,21 @@
 {# eos - vmtracer sessions #}
-{% if vmtracer_sessions is defined and vmtracer_sessions is not none %}
+{% if vmtracer_sessions is arista.avd.defined %}
 {%     for session in vmtracer_sessions | arista.avd.natural_sort %}
 !
 vmtracer session {{ session }}
-{%         if vmtracer_sessions[session].url is defined and vmtracer_sessions[session].url is not none %}
+{%         if vmtracer_sessions[session].url is arista.avd.defined %}
    url {{ vmtracer_sessions[session].url }}
 {%         endif %}
-{%         if vmtracer_sessions[session].username is defined and vmtracer_sessions[session].username is not none %}
+{%         if vmtracer_sessions[session].username is arista.avd.defined %}
    username {{ vmtracer_sessions[session].username}}
 {%         endif %}
-{%         if vmtracer_sessions[session].password is defined and vmtracer_sessions[session].password is not none %}
+{%         if vmtracer_sessions[session].password is arista.avd.defined %}
    password 7 {{ vmtracer_sessions[session].password }}
 {%         endif %}
-{%         if vmtracer_sessions[session].autovlan_disable is defined and vmtracer_sessions[session].autovlan_disable == true %}
+{%         if vmtracer_sessions[session].autovlan_disable is arista.avd.defined(true) %}
    autovlan disable
 {%         endif %}
-{%         if vmtracer_sessions[session].source_interface is defined and vmtracer_sessions[session].source_interface is not none %}
+{%         if vmtracer_sessions[session].source_interface is arista.avd.defined %}
    source-interface {{ vmtracer_sessions[session].source_interface }}
 {%         endif %}
 {%     endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vrf-instances.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vrf-instances.j2
@@ -1,9 +1,9 @@
 {# eos - VRFs #}
-{% if vrfs is defined and vrfs is not none %}
+{% if vrfs is arista.avd.defined %}
 {%     for vrf in vrfs | arista.avd.natural_sort if vrf is ne 'default'%}
 !
 vrf instance {{ vrf }}
-{%         if vrfs[vrf].description is defined and vrfs[vrf].description is not none %}
+{%         if vrfs[vrf].description is arista.avd.defined %}
    description {{ vrfs[vrf].description }}
 {%         endif %}
 {%     endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vxlan-interface.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vxlan-interface.j2
@@ -1,21 +1,20 @@
 {# eos- VxLAN interface #}
-{% if vxlan_tunnel_interface is defined %}
+{% if vxlan_tunnel_interface is arista.avd.defined %}
 !
 interface Vxlan1
    vxlan source-interface {{ vxlan_tunnel_interface.Vxlan1.source_interface }}
-{%     if vxlan_tunnel_interface.Vxlan1.virtual_router is defined %}
+{%     if vxlan_tunnel_interface.Vxlan1.virtual_router is arista.avd.defined %}
    vxlan virtual-router encapsulation mac-address {{ vxlan_tunnel_interface.Vxlan1.virtual_router.encapsulation_mac_address }}
 {%     endif %}
-   vxlan udp-port {{ vxlan_tunnel_interface.Vxlan1.vxlan_udp_port }}
+   vxlan udp-port {{ vxlan_tunnel_interface.Vxlan1.vxlan_udp_port | arista.avd.default('4789') }}
 {%     if vxlan_tunnel_interface.Vxlan1.vxlan_vni_mappings.vlans is iterable %}
 {%          for vlan in vxlan_tunnel_interface.Vxlan1.vxlan_vni_mappings.vlans | arista.avd.natural_sort %}
    vxlan vlan {{ vlan }} vni {{ vxlan_tunnel_interface.Vxlan1.vxlan_vni_mappings.vlans[vlan].vni }}
 {%          endfor %}
 {%     endif %}
-{% if vxlan_tunnel_interface.Vxlan1.vxlan_vni_mappings.vrfs is defined and
-vxlan_tunnel_interface.Vxlan1.vxlan_vni_mappings.vrfs is not none %}
-{%     for vrf in vxlan_tunnel_interface.Vxlan1.vxlan_vni_mappings.vrfs | arista.avd.natural_sort %}
+{%     if vxlan_tunnel_interface.Vxlan1.vxlan_vni_mappings.vrfs is arista.avd.defined %}
+{%         for vrf in vxlan_tunnel_interface.Vxlan1.vxlan_vni_mappings.vrfs | arista.avd.natural_sort %}
    vxlan vrf {{ vrf }} vni {{ vxlan_tunnel_interface.Vxlan1.vxlan_vni_mappings.vrfs[vrf].vni }}
-{%     endfor %}
-{% endif %}
+{%         endfor %}
+{%     endif %}
 {% endif %}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Bot will manage tag, ownership and code review, you should not update these fields-->
## Change Summary

Refactor eos_cli_config_gen to leverage new filters to improve code readability.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

## Component(s) name

eos_cli_config_gen

__EOS templates__

- [x] aaa-accounting.j2 (CB)
  - [X] Review (CH)
  - [ ] Approved (CH)
- [x] aaa-authentication.j2 (CB)
  - [x] Review (CH)
  - [ ] Approved (CH)
- [ ] aaa-authorization.j2 (XR)
  - [x] Review (CH)
  - [ ] Approved (CH)
- [ ] aaa-root.j2(XR)
  - [x] Review (CH)
  - [ ] Approved (CH)
- [ ] aaa-server-groups.j2 (XR)
  - [x] Review (CH)
  - [ ] Approved (CH)
- [ ] access-lists.j2 (XR)
  - [x] Review (CH)
  - [ ] Approved (CH)
- [x] aliases.j2 (XR)
  - [x] Review (CH)
  - [x] Approved (CH)
- [x] arp.j2 (XR)
  - [x] Review (CH)
  - [x] Approved (CH)
- [x] banners.j2 (XR)
  - [x] Review (CH)
  - [x] Approved (CH)
- [ ] clock-timezone.j2 (XR)
  - [x] Review (CH)
  - [ ] Approved (CH)
- [ ] clock-timezone.j2 (XR)
- [ ] community-lists.j2 (XR)
- [ ] custom-templates.j2 (XR)
- [ ] daemon-templates.j2 (XR)
- [ ] daemon-terminattr.j2 (XR)
- [ ] dns-domain.j2 (XR)
- [ ] domain-list.j2 (XR)
- [ ] enable-password.j2 (XR)
- [ ] errdisable.j2 (XR)
- [ ] ethernet-interfaces.j2 (XR)
- [ ] event-handler.j2 (XR)
- [ ] event-monitor.j2 (XR)
- [ ] hardware-counters.j2 (XR)
- [ ] hardware.j2 (XR)
- [ ] interface-defaults.j2 (XR)
- [ ] ip-dhcp-relay.j2 (XR)
- [ ] ip-extended-communities.j2 (XR)
- [ ] ip-igmp-snooping.j2 (XR) 
- [ ] ip-routing.j2 (XR)
- [ ] ip-tacacs-source-interfaces.j2 to mac-security.j2 (XR)
- [x] router-bgp.j2 (CB)
  - [x] Review (CH)
  - [ ] Approved (CH)
- [ ] spanning-tree.j2 (OG)
- [ ] standard-access-lists.j2 (OG)
- [ ] static-routes.j2 (OG)
- [ ] tacacs-servers.j2 (OG)
- [x] tcam-profile.j2 (OG)
- [x] terminal-settings.j2 (OG)
- [x] unsupported-transceiver.j2(OG)
- [x] virtual-router-mac-address.j2 (OG)
  - [x] Review (CH)
  - [x] Approved (CH)
- [x] vlan-internal-order.j2 (OG)
  - [x] Review (CH)
  - [ ] Approved (CH)
- [x] vlans.j2 (OG)
  - [x] Review (CH)
  - [ ] Approved (CH)
- [x] virtual-source-nat.j2 (OG)
  - [x] Review (CH)
  - [ ] Approved (CH)
- [x] vlan-interfaces.j2 (TG)
  - [x] Review (CH)
  - [ ] Approved (CH)
- [x] vmtracer-sessions.j2 (TG)
  - [x] Review (CH)
  - [ ] Approved (CH)
- [x] vrf-instances.j2 (TG)
  - [x] Review (CH)
  - [ ] Approved (CH)
- [x] vxlan-interface.j2 (TG)
  - [x] Review (CH)
  - [ ] Approved (CH)




__Documentation templates__

...

## Proposed changes

- update to leverage arista.avd.defined

## How to test

- Run molecule scenario and ensure no functional changes