### PR TITLE
Implement ENABLE password in cli_config_gen

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/aaa.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/aaa.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -160,6 +161,10 @@ username admin privilege 15 role network-admin nopassword
 username ansible privilege 15 role network-admin secret sha512 $6$.I7/ZR/zlLIUv8fr$vR/JvLTbq5amMt6Y1SE4CKlPDv/AzJYlFYHkUZ17BDovm0Oi4aLdBULe1EmZ0Y9xKjVLMKpxCSKmlrAioDxbQ0
 username cvpadmin privilege 15 role network-admin secret sha512 $6$.I7/ZR/zlLIUv8fr$vR/JvLTbq5amMt6Y1SE4CKlPDv/AzJYlFYHkUZ17BDovm0Oi4aLdBULe1EmZ0Y9xKjVLMKpxCSKmlrAioDxbQ0
 ```
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/acl.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/acl.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -145,6 +146,10 @@ Management API HTTP not defined
 ## Local Users
 
 No users defined
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/arp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/arp.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -145,6 +146,10 @@ Management API HTTP not defined
 ## Local Users
 
 No users defined
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/base.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/base.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -178,6 +179,10 @@ management api http-commands
 ## Local Users
 
 No users defined
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/dns-ntp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/dns-ntp.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -192,6 +193,10 @@ Management API HTTP not defined
 ## Local Users
 
 No users defined
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/enable-password.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/enable-password.md
@@ -1,4 +1,4 @@
-# ethernet_interfaces
+# enable-password
 
 # Table of Contents
 
@@ -149,7 +149,15 @@ No users defined
 
 ## Enable Password
 
-Enable password not defined
+sha512 encrypted enable password is configured
+### Enable password configuration
+
+```eos
+!
+enable password sha512 $6$nXycSRhVPaxRINPL$tM1MNjjRCbFD5di4XWsj8CPkm8Pdwmf9fVqRV015y3DXD4t1vi8CAWQpFP8Vbi9Y2i7.JuFey5UaafXvI6quD1
+!
+```
+
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/errdisable.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/errdisable.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -145,6 +146,10 @@ Management API HTTP not defined
 ## Local Users
 
 No users defined
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -145,6 +146,10 @@ Management API HTTP not defined
 ## Local Users
 
 No users defined
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/igmp-snooping.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/igmp-snooping.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -145,6 +146,10 @@ Management API HTTP not defined
 ## Local Users
 
 No users defined
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/logging-minimal.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/logging-minimal.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -145,6 +146,10 @@ Management API HTTP not defined
 ## Local Users
 
 No users defined
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/logging.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/logging.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -145,6 +146,10 @@ Management API HTTP not defined
 ## Local Users
 
 No users defined
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/loopbacks-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/loopbacks-interfaces.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -145,6 +146,10 @@ Management API HTTP not defined
 ## Local Users
 
 No users defined
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mac-security-eth-po-entropy.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mac-security-eth-po-entropy.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -145,6 +146,10 @@ Management API HTTP not defined
 ## Local Users
 
 No users defined
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-api-http.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-api-http.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -172,6 +173,10 @@ management api http-commands
 ## Local Users
 
 No users defined
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-gnmi.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-gnmi.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -165,6 +166,10 @@ Management API HTTP not defined
 ## Local Users
 
 No users defined
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-ssh.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-ssh.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -153,6 +154,10 @@ Management API HTTP not defined
 ## Local Users
 
 No users defined
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mcast-pim.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mcast-pim.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -145,6 +146,10 @@ Management API HTTP not defined
 ## Local Users
 
 No users defined
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/none_configuration.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/none_configuration.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -145,6 +146,10 @@ Management API HTTP not defined
 ## Local Users
 
 No users defined
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/platform.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/platform.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -145,6 +146,10 @@ Management API HTTP not defined
 ## Local Users
 
 No users defined
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -145,6 +146,10 @@ Management API HTTP not defined
 ## Local Users
 
 No users defined
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/prefix-lists.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/prefix-lists.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -145,6 +146,10 @@ Management API HTTP not defined
 ## Local Users
 
 No users defined
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ptp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ptp.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -168,6 +169,10 @@ Management API HTTP not defined
 ## Local Users
 
 No users defined
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/qos.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/qos.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -145,6 +146,10 @@ Management API HTTP not defined
 ## Local Users
 
 No users defined
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/route-maps.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/route-maps.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -145,6 +146,10 @@ Management API HTTP not defined
 ## Local Users
 
 No users defined
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -145,6 +146,10 @@ Management API HTTP not defined
 ## Local Users
 
 No users defined
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-evpn.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-evpn.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -145,6 +146,10 @@ Management API HTTP not defined
 ## Local Users
 
 No users defined
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-rtc.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-rtc.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -145,6 +146,10 @@ Management API HTTP not defined
 ## Local Users
 
 No users defined
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-v4-evpn.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-v4-evpn.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -145,6 +146,10 @@ Management API HTTP not defined
 ## Local Users
 
 No users defined
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-v4-v6-evpn.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-v4-v6-evpn.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -145,6 +146,10 @@ Management API HTTP not defined
 ## Local Users
 
 No users defined
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vrf-lite.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vrf-lite.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -145,6 +146,10 @@ Management API HTTP not defined
 ## Local Users
 
 No users defined
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -145,6 +146,10 @@ Management API HTTP not defined
 ## Local Users
 
 No users defined
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -145,6 +146,10 @@ Management API HTTP not defined
 ## Local Users
 
 No users defined
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-static.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-static.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -145,6 +146,10 @@ Management API HTTP not defined
 ## Local Users
 
 No users defined
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/sflow.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/sflow.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -145,6 +146,10 @@ Management API HTTP not defined
 ## Local Users
 
 No users defined
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/snmp_v3.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/snmp_v3.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -145,6 +146,10 @@ Management API HTTP not defined
 ## Local Users
 
 No users defined
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/spanning-tree-rapid-pvst.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/spanning-tree-rapid-pvst.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -145,6 +146,10 @@ Management API HTTP not defined
 ## Local Users
 
 No users defined
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/spanning-tree-rstp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/spanning-tree-rstp.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -145,6 +146,10 @@ Management API HTTP not defined
 ## Local Users
 
 No users defined
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/spanning-tree.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/spanning-tree.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -145,6 +146,10 @@ Management API HTTP not defined
 ## Local Users
 
 No users defined
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/terminattr-cloud.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/terminattr-cloud.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -145,6 +146,10 @@ Management API HTTP not defined
 ## Local Users
 
 No users defined
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/terminattr-prem-disableaaa.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/terminattr-prem-disableaaa.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -145,6 +146,10 @@ Management API HTTP not defined
 ## Local Users
 
 No users defined
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/terminattr-prem.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/terminattr-prem.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -145,6 +146,10 @@ Management API HTTP not defined
 ## Local Users
 
 No users defined
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -145,6 +146,10 @@ Management API HTTP not defined
 ## Local Users
 
 No users defined
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlans.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlans.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -145,6 +146,10 @@ Management API HTTP not defined
 ## Local Users
 
 No users defined
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vrfs.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vrfs.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -145,6 +146,10 @@ Management API HTTP not defined
 ## Local Users
 
 No users defined
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/aaa.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/aaa.cfg
@@ -24,6 +24,7 @@ aaa accounting commands all default start-stop group TACACS logging
 aaa accounting commands 0 default start-stop logging
 !
 no aaa root
+no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username ansible privilege 15 role network-admin secret sha512 $6$.I7/ZR/zlLIUv8fr$vR/JvLTbq5amMt6Y1SE4CKlPDv/AzJYlFYHkUZ17BDovm0Oi4aLdBULe1EmZ0Y9xKjVLMKpxCSKmlrAioDxbQ0

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/acl.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/acl.cfg
@@ -5,6 +5,7 @@ transceiver qsfp default-mode 4x10G
 hostname acl
 !
 no aaa root
+no enable password
 !
 interface Management1
    description oob_management

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/arp.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/arp.cfg
@@ -5,6 +5,7 @@ transceiver qsfp default-mode 4x10G
 hostname arp
 !
 no aaa root
+no enable password
 !
 interface Management1
    description oob_management

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/base.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/base.cfg
@@ -5,6 +5,7 @@ transceiver qsfp default-mode 4x10G
 hostname base
 !
 no aaa root
+no enable password
 !
 interface Management1
    description oob_management

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/dns-ntp.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/dns-ntp.cfg
@@ -13,6 +13,7 @@ ntp server vrf mgt 10.10.111.1 prefer
 ntp server vrf mgt 10.10.111.2
 !
 no aaa root
+no enable password
 !
 interface Management1
    description oob_management

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/enable-password.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/enable-password.cfg
@@ -2,14 +2,10 @@
 !
 transceiver qsfp default-mode 4x10G
 !
-hostname platform
-!
-platform trident forwarding-table partition 2
-platform sand lag hardware-only
-platform sand lag mode 512x32
+hostname enable-password
 !
 no aaa root
-no enable password
+enable password sha512 $6$nXycSRhVPaxRINPL$tM1MNjjRCbFD5di4XWsj8CPkm8Pdwmf9fVqRV015y3DXD4t1vi8CAWQpFP8Vbi9Y2i7.JuFey5UaafXvI6quD1
 !
 interface Management1
    description oob_management

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/errdisable.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/errdisable.cfg
@@ -28,6 +28,7 @@ errdisable recovery interval 300
 hostname errdisable
 !
 no aaa root
+no enable password
 !
 interface Management1
    description oob_management

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
@@ -5,6 +5,7 @@ transceiver qsfp default-mode 4x10G
 hostname ethernet-interfaces
 !
 no aaa root
+no enable password
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet_interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet_interfaces.cfg
@@ -5,6 +5,7 @@ transceiver qsfp default-mode 4x10G
 hostname ethernet_interfaces
 !
 no aaa root
+no enable password
 !
 interface Management1
    description oob_management

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/igmp-snooping.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/igmp-snooping.cfg
@@ -9,6 +9,7 @@ transceiver qsfp default-mode 4x10G
 hostname igmp-snooping
 !
 no aaa root
+no enable password
 !
 vlan 110
    name PR01-DMZ

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/logging-minimal.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/logging-minimal.cfg
@@ -8,6 +8,7 @@ logging monitor debugging
 hostname logging-minimal
 !
 no aaa root
+no enable password
 !
 interface Management1
    description oob_management

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/logging.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/logging.cfg
@@ -11,6 +11,7 @@ logging vrf mgt host 10.10.10.7
 hostname logging
 !
 no aaa root
+no enable password
 !
 interface Management1
    description oob_management

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/loopbacks-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/loopbacks-interfaces.cfg
@@ -5,6 +5,7 @@ transceiver qsfp default-mode 4x10G
 hostname loopbacks-interfaces
 !
 no aaa root
+no enable password
 !
 interface Loopback0
    description EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/mac-security-eth-po-entropy.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/mac-security-eth-po-entropy.cfg
@@ -18,6 +18,7 @@ mac security
 hostname mac-security-eth-po-entropy
 !
 no aaa root
+no enable password
 !
 interface Port-Channel3
    description L2-PORT

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-api-http.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-api-http.cfg
@@ -5,6 +5,7 @@ transceiver qsfp default-mode 4x10G
 hostname management-api-http
 !
 no aaa root
+no enable password
 !
 interface Management1
    description oob_management

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-gnmi.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-gnmi.cfg
@@ -5,6 +5,7 @@ transceiver qsfp default-mode 4x10G
 hostname management-gnmi
 !
 no aaa root
+no enable password
 !
 interface Management1
    description oob_management

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-ssh.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-ssh.cfg
@@ -5,6 +5,7 @@ transceiver qsfp default-mode 4x10G
 hostname management-ssh
 !
 no aaa root
+no enable password
 !
 interface Management1
    description oob_management

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/mcast-pim.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/mcast-pim.cfg
@@ -5,6 +5,7 @@ transceiver qsfp default-mode 4x10G
 hostname mcast-pim
 !
 no aaa root
+no enable password
 !
 interface Management1
    description oob_management

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/none_configuration.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/none_configuration.cfg
@@ -5,6 +5,7 @@ transceiver qsfp default-mode 4x10G
 hostname none_configuration
 !
 no aaa root
+no enable password
 !
 interface Management1
    description oob_management

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
@@ -5,6 +5,7 @@ transceiver qsfp default-mode 4x10G
 hostname port-channel-interfaces
 !
 no aaa root
+no enable password
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-LEAF1B_Po3

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/prefix-lists.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/prefix-lists.cfg
@@ -5,6 +5,7 @@ transceiver qsfp default-mode 4x10G
 hostname prefix-lists
 !
 no aaa root
+no enable password
 !
 interface Management1
    description oob_management

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ptp.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ptp.cfg
@@ -13,6 +13,7 @@ ptp message-type general dscp 4
 ptp message-type event dscp 8
 !
 no aaa root
+no enable password
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE2_Ethernet5

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/qos.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/qos.cfg
@@ -34,6 +34,7 @@ qos profile test
       bandwidth percent 20
 !
 no aaa root
+no enable password
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-LEAF1B_Po3

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/route-maps.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/route-maps.cfg
@@ -5,6 +5,7 @@ transceiver qsfp default-mode 4x10G
 hostname route-maps
 !
 no aaa root
+no enable password
 !
 interface Management1
    description oob_management

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-base.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-base.cfg
@@ -5,6 +5,7 @@ transceiver qsfp default-mode 4x10G
 hostname router-bgp-base
 !
 no aaa root
+no enable password
 !
 interface Management1
    description oob_management

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-evpn.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-evpn.cfg
@@ -5,6 +5,7 @@ transceiver qsfp default-mode 4x10G
 hostname router-bgp-evpn
 !
 no aaa root
+no enable password
 !
 interface Management1
    description oob_management

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-rtc.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-rtc.cfg
@@ -5,6 +5,7 @@ transceiver qsfp default-mode 4x10G
 hostname router-bgp-rtc
 !
 no aaa root
+no enable password
 !
 interface Management1
    description oob_management

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-v4-evpn.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-v4-evpn.cfg
@@ -5,6 +5,7 @@ transceiver qsfp default-mode 4x10G
 hostname router-bgp-v4-evpn
 !
 no aaa root
+no enable password
 !
 interface Management1
    description oob_management

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-v4-v6-evpn.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-v4-v6-evpn.cfg
@@ -5,6 +5,7 @@ transceiver qsfp default-mode 4x10G
 hostname router-bgp-v4-v6-evpn
 !
 no aaa root
+no enable password
 !
 interface Management1
    description oob_management

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-vrf-lite.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-vrf-lite.cfg
@@ -5,6 +5,7 @@ transceiver qsfp default-mode 4x10G
 hostname router-bgp-vrf-lite
 !
 no aaa root
+no enable password
 !
 interface Management1
    description oob_management

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-isis.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-isis.cfg
@@ -5,6 +5,7 @@ transceiver qsfp default-mode 4x10G
 hostname router-isis
 !
 no aaa root
+no enable password
 !
 interface Ethernet1
    description P2P_LINK_TO_EAPI-SPINE1_Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-ospf.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-ospf.cfg
@@ -5,6 +5,7 @@ transceiver qsfp default-mode 4x10G
 hostname router-ospf
 !
 no aaa root
+no enable password
 !
 interface Management1
    description oob_management

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-static.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-static.cfg
@@ -5,6 +5,7 @@ transceiver qsfp default-mode 4x10G
 hostname router-static
 !
 no aaa root
+no enable password
 !
 interface Management1
    description oob_management

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/sflow.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/sflow.cfg
@@ -18,6 +18,7 @@ sflow source-interface Management0
 sflow run
 !
 no aaa root
+no enable password
 !
 interface Management1
    description oob_management

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/snmp_v3.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/snmp_v3.cfg
@@ -23,6 +23,7 @@ no snmp-server vrf default
 snmp-server vrf mgt
 !
 no aaa root
+no enable password
 !
 interface Management1
    description oob_management

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/spanning-tree-rapid-pvst.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/spanning-tree-rapid-pvst.cfg
@@ -10,6 +10,7 @@ spanning-tree vlan-id 3 priority 8192
 spanning-tree vlan-id 100-500 priority 16384
 !
 no aaa root
+no enable password
 !
 interface Management1
    description oob_management

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/spanning-tree-rstp.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/spanning-tree-rstp.cfg
@@ -8,6 +8,7 @@ spanning-tree mode rstp
 spanning-tree priority 8192
 !
 no aaa root
+no enable password
 !
 interface Management1
    description oob_management

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/spanning-tree.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/spanning-tree.cfg
@@ -19,6 +19,7 @@ spanning-tree mst configuration
    instance 4 vlan 200-300
 !
 no aaa root
+no enable password
 !
 interface Management1
    description oob_management

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/terminattr-cloud.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/terminattr-cloud.cfg
@@ -9,6 +9,7 @@ transceiver qsfp default-mode 4x10G
 hostname terminattr-cloud
 !
 no aaa root
+no enable password
 !
 interface Management1
    description oob_management

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/terminattr-prem-disableaaa.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/terminattr-prem-disableaaa.cfg
@@ -9,6 +9,7 @@ transceiver qsfp default-mode 4x10G
 hostname terminattr-prem-disableaaa
 !
 no aaa root
+no enable password
 !
 interface Management1
    description oob_management

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/terminattr-prem.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/terminattr-prem.cfg
@@ -9,6 +9,7 @@ transceiver qsfp default-mode 4x10G
 hostname terminattr-prem
 !
 no aaa root
+no enable password
 !
 interface Management1
    description oob_management

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
@@ -5,6 +5,7 @@ transceiver qsfp default-mode 4x10G
 hostname vlan-interfaces
 !
 no aaa root
+no enable password
 !
 interface Management1
    description oob_management

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlans.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlans.cfg
@@ -7,6 +7,7 @@ transceiver qsfp default-mode 4x10G
 hostname vlans
 !
 no aaa root
+no enable password
 !
 vlan 110
    name PR01-DMZ

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vrfs.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vrfs.cfg
@@ -5,6 +5,7 @@ transceiver qsfp default-mode 4x10G
 hostname vrfs
 !
 no aaa root
+no enable password
 !
 vrf instance MGMT
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/enable-password.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/enable-password.yml
@@ -1,0 +1,4 @@
+### Enable Password ###
+enable_password:
+  hash_algorithm: sha512
+  key: "$6$nXycSRhVPaxRINPL$tM1MNjjRCbFD5di4XWsj8CPkm8Pdwmf9fVqRV015y3DXD4t1vi8CAWQpFP8Vbi9Y2i7.JuFey5UaafXvI6quD1"

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts
@@ -5,6 +5,7 @@ acl
 arp
 base
 dns-ntp
+enable-password
 errdisable
 ethernet-interfaces
 igmp-snooping

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1A.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -208,6 +209,10 @@ management api http-commands
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 ```
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1B.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -208,6 +209,10 @@ management api http-commands
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 ```
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-L2LEAF1A.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -208,6 +209,10 @@ management api http-commands
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 ```
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-L2LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-L2LEAF2A.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -208,6 +209,10 @@ management api http-commands
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 ```
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-L2LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-L2LEAF2B.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -208,6 +209,10 @@ management api http-commands
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 ```
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF1A.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -208,6 +209,10 @@ management api http-commands
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 ```
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2A.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -208,6 +209,10 @@ management api http-commands
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 ```
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2B.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -208,6 +209,10 @@ management api http-commands
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 ```
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE1.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -208,6 +209,10 @@ management api http-commands
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 ```
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE2.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -208,6 +209,10 @@ management api http-commands
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 ```
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE3.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -208,6 +209,10 @@ management api http-commands
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 ```
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SPINE4.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -208,6 +209,10 @@ management api http-commands
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 ```
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3A.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -208,6 +209,10 @@ management api http-commands
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 ```
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3B.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -208,6 +209,10 @@ management api http-commands
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 ```
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-BL1A.cfg
@@ -22,6 +22,7 @@ no spanning-tree vlan-id 4093-4094
 spanning-tree mst 0 priority 4096
 !
 no aaa root
+no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-BL1B.cfg
@@ -22,6 +22,7 @@ no spanning-tree vlan-id 4093-4094
 spanning-tree mst 0 priority 4096
 !
 no aaa root
+no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-L2LEAF1A.cfg
@@ -23,6 +23,7 @@ spanning-tree mode mstp
 spanning-tree mst 0 priority 16384
 !
 no aaa root
+no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-L2LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-L2LEAF2A.cfg
@@ -24,6 +24,7 @@ no spanning-tree vlan-id 4094
 spanning-tree mst 0 priority 16384
 !
 no aaa root
+no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-L2LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-L2LEAF2B.cfg
@@ -24,6 +24,7 @@ no spanning-tree vlan-id 4094
 spanning-tree mst 0 priority 16384
 !
 no aaa root
+no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-LEAF1A.cfg
@@ -23,6 +23,7 @@ spanning-tree mode mstp
 spanning-tree mst 0 priority 4096
 !
 no aaa root
+no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-LEAF2A.cfg
@@ -24,6 +24,7 @@ no spanning-tree vlan-id 4093-4094
 spanning-tree mst 0 priority 4096
 !
 no aaa root
+no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-LEAF2B.cfg
@@ -24,6 +24,7 @@ no spanning-tree vlan-id 4093-4094
 spanning-tree mst 0 priority 4096
 !
 no aaa root
+no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SPINE1.cfg
@@ -20,6 +20,7 @@ ntp server vrf MGMT 192.168.200.5 prefer
 spanning-tree mode none
 !
 no aaa root
+no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SPINE2.cfg
@@ -20,6 +20,7 @@ ntp server vrf MGMT 192.168.200.5 prefer
 spanning-tree mode none
 !
 no aaa root
+no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SPINE3.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SPINE3.cfg
@@ -20,6 +20,7 @@ ntp server vrf MGMT 192.168.200.5 prefer
 spanning-tree mode none
 !
 no aaa root
+no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SPINE4.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SPINE4.cfg
@@ -20,6 +20,7 @@ ntp server vrf MGMT 192.168.200.5 prefer
 spanning-tree mode none
 !
 no aaa root
+no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SVC3A.cfg
@@ -24,6 +24,7 @@ no spanning-tree vlan-id 4093-4094
 spanning-tree mst 0 priority 4096
 !
 no aaa root
+no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SVC3B.cfg
@@ -24,6 +24,7 @@ no spanning-tree vlan-id 4093-4094
 spanning-tree mst 0 priority 4096
 !
 no aaa root
+no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/cvp/cv_server_configlets.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/cvp/cv_server_configlets.yml
@@ -7,9 +7,9 @@ CVP_CONFIGLETS:
     \ protocols model multi-agent\n!\nhostname DC1-BL1A\nip name-server vrf MGMT 192.168.200.5\n\
     ip name-server vrf MGMT 8.8.8.8\n!\nntp local-interface vrf MGMT Management1\n\
     ntp server vrf MGMT 192.168.200.5 prefer\n!\nspanning-tree mode mstp\nno spanning-tree\
-    \ vlan-id 4093-4094\nspanning-tree mst 0 priority 4096\n!\nno aaa root\n!\nusername\
-    \ admin privilege 15 role network-admin nopassword\nusername cvpadmin privilege\
-    \ 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n\
+    \ vlan-id 4093-4094\nspanning-tree mst 0 priority 4096\n!\nno aaa root\nno enable\
+    \ password\n!\nusername admin privilege 15 role network-admin nopassword\nusername\
+    \ cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n\
     !\nvlan 150\n   name Tenant_A_WAN_Zone_1\n!\nvlan 250\n   name Tenant_B_WAN_Zone_1\n\
     !\nvlan 350\n   name Tenant_C_WAN_Zone_1\n!\nvlan 3013\n   name MLAG_iBGP_Tenant_A_WAN_Zone\n\
     \   trunk group LEAF_PEER_L3\n!\nvlan 3020\n   name MLAG_iBGP_Tenant_B_WAN_Zone\n\
@@ -111,9 +111,9 @@ CVP_CONFIGLETS:
     \ protocols model multi-agent\n!\nhostname DC1-BL1B\nip name-server vrf MGMT 192.168.200.5\n\
     ip name-server vrf MGMT 8.8.8.8\n!\nntp local-interface vrf MGMT Management1\n\
     ntp server vrf MGMT 192.168.200.5 prefer\n!\nspanning-tree mode mstp\nno spanning-tree\
-    \ vlan-id 4093-4094\nspanning-tree mst 0 priority 4096\n!\nno aaa root\n!\nusername\
-    \ admin privilege 15 role network-admin nopassword\nusername cvpadmin privilege\
-    \ 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n\
+    \ vlan-id 4093-4094\nspanning-tree mst 0 priority 4096\n!\nno aaa root\nno enable\
+    \ password\n!\nusername admin privilege 15 role network-admin nopassword\nusername\
+    \ cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n\
     !\nvlan 150\n   name Tenant_A_WAN_Zone_1\n!\nvlan 250\n   name Tenant_B_WAN_Zone_1\n\
     !\nvlan 350\n   name Tenant_C_WAN_Zone_1\n!\nvlan 3013\n   name MLAG_iBGP_Tenant_A_WAN_Zone\n\
     \   trunk group LEAF_PEER_L3\n!\nvlan 3020\n   name MLAG_iBGP_Tenant_B_WAN_Zone\n\
@@ -216,8 +216,8 @@ CVP_CONFIGLETS:
     ip name-server vrf MGMT 192.168.200.5\nip name-server vrf MGMT 8.8.8.8\n!\nntp\
     \ local-interface vrf MGMT Management1\nntp server vrf MGMT 192.168.200.5 prefer\n\
     !\nspanning-tree mode mstp\nspanning-tree mst 0 priority 16384\n!\nno aaa root\n\
-    !\nusername admin privilege 15 role network-admin nopassword\nusername cvpadmin\
-    \ privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n\
+    no enable password\n!\nusername admin privilege 15 role network-admin nopassword\n\
+    username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n\
     !\nvlan 110\n   name Tenant_A_OP_Zone_1\n!\nvlan 111\n   name Tenant_A_OP_Zone_2\n\
     !\nvlan 120\n   name Tenant_A_WEB_Zone_1\n!\nvlan 121\n   name Tenant_A_WEBZone_2\n\
     !\nvlan 130\n   name Tenant_A_APP_Zone_1\n!\nvlan 131\n   name Tenant_A_APP_Zone_2\n\
@@ -240,9 +240,9 @@ CVP_CONFIGLETS:
     ip name-server vrf MGMT 192.168.200.5\nip name-server vrf MGMT 8.8.8.8\n!\nntp\
     \ local-interface vrf MGMT Management1\nntp server vrf MGMT 192.168.200.5 prefer\n\
     !\nspanning-tree mode mstp\nno spanning-tree vlan-id 4094\nspanning-tree mst 0\
-    \ priority 16384\n!\nno aaa root\n!\nusername admin privilege 15 role network-admin\
-    \ nopassword\nusername cvpadmin privilege 15 role network-admin secret sha512\
-    \ $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n\
+    \ priority 16384\n!\nno aaa root\nno enable password\n!\nusername admin privilege\
+    \ 15 role network-admin nopassword\nusername cvpadmin privilege 15 role network-admin\
+    \ secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n\
     !\nvlan 110\n   name Tenant_A_OP_Zone_1\n!\nvlan 111\n   name Tenant_A_OP_Zone_2\n\
     !\nvlan 120\n   name Tenant_A_WEB_Zone_1\n!\nvlan 121\n   name Tenant_A_WEBZone_2\n\
     !\nvlan 130\n   name Tenant_A_APP_Zone_1\n!\nvlan 131\n   name Tenant_A_APP_Zone_2\n\
@@ -281,9 +281,9 @@ CVP_CONFIGLETS:
     ip name-server vrf MGMT 192.168.200.5\nip name-server vrf MGMT 8.8.8.8\n!\nntp\
     \ local-interface vrf MGMT Management1\nntp server vrf MGMT 192.168.200.5 prefer\n\
     !\nspanning-tree mode mstp\nno spanning-tree vlan-id 4094\nspanning-tree mst 0\
-    \ priority 16384\n!\nno aaa root\n!\nusername admin privilege 15 role network-admin\
-    \ nopassword\nusername cvpadmin privilege 15 role network-admin secret sha512\
-    \ $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n\
+    \ priority 16384\n!\nno aaa root\nno enable password\n!\nusername admin privilege\
+    \ 15 role network-admin nopassword\nusername cvpadmin privilege 15 role network-admin\
+    \ secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n\
     !\nvlan 110\n   name Tenant_A_OP_Zone_1\n!\nvlan 111\n   name Tenant_A_OP_Zone_2\n\
     !\nvlan 120\n   name Tenant_A_WEB_Zone_1\n!\nvlan 121\n   name Tenant_A_WEBZone_2\n\
     !\nvlan 130\n   name Tenant_A_APP_Zone_1\n!\nvlan 131\n   name Tenant_A_APP_Zone_2\n\
@@ -322,8 +322,8 @@ CVP_CONFIGLETS:
     ip name-server vrf MGMT 192.168.200.5\nip name-server vrf MGMT 8.8.8.8\n!\nntp\
     \ local-interface vrf MGMT Management1\nntp server vrf MGMT 192.168.200.5 prefer\n\
     !\nspanning-tree mode mstp\nspanning-tree mst 0 priority 4096\n!\nno aaa root\n\
-    !\nusername admin privilege 15 role network-admin nopassword\nusername cvpadmin\
-    \ privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n\
+    no enable password\n!\nusername admin privilege 15 role network-admin nopassword\n\
+    username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n\
     !\nvlan 120\n   name Tenant_A_WEB_Zone_1\n!\nvlan 121\n   name Tenant_A_WEBZone_2\n\
     !\nvlan 130\n   name Tenant_A_APP_Zone_1\n!\nvlan 131\n   name Tenant_A_APP_Zone_2\n\
     !\nvrf instance MGMT\n!\nvrf instance Tenant_A_APP_Zone\n!\nvrf instance Tenant_A_WEB_Zone\n\
@@ -395,9 +395,9 @@ CVP_CONFIGLETS:
     ip name-server vrf MGMT 192.168.200.5\nip name-server vrf MGMT 8.8.8.8\n!\nntp\
     \ local-interface vrf MGMT Management1\nntp server vrf MGMT 192.168.200.5 prefer\n\
     !\nspanning-tree mode mstp\nno spanning-tree vlan-id 4093-4094\nspanning-tree\
-    \ mst 0 priority 4096\n!\nno aaa root\n!\nusername admin privilege 15 role network-admin\
-    \ nopassword\nusername cvpadmin privilege 15 role network-admin secret sha512\
-    \ $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n\
+    \ mst 0 priority 4096\n!\nno aaa root\nno enable password\n!\nusername admin privilege\
+    \ 15 role network-admin nopassword\nusername cvpadmin privilege 15 role network-admin\
+    \ secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n\
     !\nvlan 110\n   name Tenant_A_OP_Zone_1\n!\nvlan 111\n   name Tenant_A_OP_Zone_2\n\
     !\nvlan 120\n   name Tenant_A_WEB_Zone_1\n!\nvlan 121\n   name Tenant_A_WEBZone_2\n\
     !\nvlan 130\n   name Tenant_A_APP_Zone_1\n!\nvlan 131\n   name Tenant_A_APP_Zone_2\n\
@@ -561,9 +561,9 @@ CVP_CONFIGLETS:
     ip name-server vrf MGMT 192.168.200.5\nip name-server vrf MGMT 8.8.8.8\n!\nntp\
     \ local-interface vrf MGMT Management1\nntp server vrf MGMT 192.168.200.5 prefer\n\
     !\nspanning-tree mode mstp\nno spanning-tree vlan-id 4093-4094\nspanning-tree\
-    \ mst 0 priority 4096\n!\nno aaa root\n!\nusername admin privilege 15 role network-admin\
-    \ nopassword\nusername cvpadmin privilege 15 role network-admin secret sha512\
-    \ $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n\
+    \ mst 0 priority 4096\n!\nno aaa root\nno enable password\n!\nusername admin privilege\
+    \ 15 role network-admin nopassword\nusername cvpadmin privilege 15 role network-admin\
+    \ secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n\
     !\nvlan 110\n   name Tenant_A_OP_Zone_1\n!\nvlan 111\n   name Tenant_A_OP_Zone_2\n\
     !\nvlan 120\n   name Tenant_A_WEB_Zone_1\n!\nvlan 121\n   name Tenant_A_WEBZone_2\n\
     !\nvlan 130\n   name Tenant_A_APP_Zone_1\n!\nvlan 131\n   name Tenant_A_APP_Zone_2\n\
@@ -726,8 +726,9 @@ CVP_CONFIGLETS:
     \ protocols model multi-agent\n!\nhostname DC1-SPINE1\nip name-server vrf MGMT\
     \ 192.168.200.5\nip name-server vrf MGMT 8.8.8.8\n!\nntp local-interface vrf MGMT\
     \ Management1\nntp server vrf MGMT 192.168.200.5 prefer\n!\nspanning-tree mode\
-    \ none\n!\nno aaa root\n!\nusername admin privilege 15 role network-admin nopassword\n\
-    username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n\
+    \ none\n!\nno aaa root\nno enable password\n!\nusername admin privilege 15 role\
+    \ network-admin nopassword\nusername cvpadmin privilege 15 role network-admin\
+    \ secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n\
     !\nvrf instance MGMT\n!\ninterface Ethernet1\n   description P2P_LINK_TO_DC1-LEAF1A_Ethernet1\n\
     \   no shutdown\n   no switchport\n   ip address 172.31.255.0/31\n!\ninterface\
     \ Ethernet2\n   description P2P_LINK_TO_DC1-LEAF2A_Ethernet1\n   no shutdown\n\
@@ -787,8 +788,9 @@ CVP_CONFIGLETS:
     \ protocols model multi-agent\n!\nhostname DC1-SPINE2\nip name-server vrf MGMT\
     \ 192.168.200.5\nip name-server vrf MGMT 8.8.8.8\n!\nntp local-interface vrf MGMT\
     \ Management1\nntp server vrf MGMT 192.168.200.5 prefer\n!\nspanning-tree mode\
-    \ none\n!\nno aaa root\n!\nusername admin privilege 15 role network-admin nopassword\n\
-    username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n\
+    \ none\n!\nno aaa root\nno enable password\n!\nusername admin privilege 15 role\
+    \ network-admin nopassword\nusername cvpadmin privilege 15 role network-admin\
+    \ secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n\
     !\nvrf instance MGMT\n!\ninterface Ethernet1\n   description P2P_LINK_TO_DC1-LEAF1A_Ethernet2\n\
     \   no shutdown\n   no switchport\n   ip address 172.31.255.2/31\n!\ninterface\
     \ Ethernet2\n   description P2P_LINK_TO_DC1-LEAF2A_Ethernet2\n   no shutdown\n\
@@ -848,8 +850,9 @@ CVP_CONFIGLETS:
     \ protocols model multi-agent\n!\nhostname DC1-SPINE3\nip name-server vrf MGMT\
     \ 192.168.200.5\nip name-server vrf MGMT 8.8.8.8\n!\nntp local-interface vrf MGMT\
     \ Management1\nntp server vrf MGMT 192.168.200.5 prefer\n!\nspanning-tree mode\
-    \ none\n!\nno aaa root\n!\nusername admin privilege 15 role network-admin nopassword\n\
-    username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n\
+    \ none\n!\nno aaa root\nno enable password\n!\nusername admin privilege 15 role\
+    \ network-admin nopassword\nusername cvpadmin privilege 15 role network-admin\
+    \ secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n\
     !\nvrf instance MGMT\n!\ninterface Ethernet1\n   description P2P_LINK_TO_DC1-LEAF1A_Ethernet3\n\
     \   no shutdown\n   no switchport\n   ip address 172.31.255.4/31\n!\ninterface\
     \ Ethernet2\n   description P2P_LINK_TO_DC1-LEAF2A_Ethernet3\n   no shutdown\n\
@@ -909,8 +912,9 @@ CVP_CONFIGLETS:
     \ protocols model multi-agent\n!\nhostname DC1-SPINE4\nip name-server vrf MGMT\
     \ 192.168.200.5\nip name-server vrf MGMT 8.8.8.8\n!\nntp local-interface vrf MGMT\
     \ Management1\nntp server vrf MGMT 192.168.200.5 prefer\n!\nspanning-tree mode\
-    \ none\n!\nno aaa root\n!\nusername admin privilege 15 role network-admin nopassword\n\
-    username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n\
+    \ none\n!\nno aaa root\nno enable password\n!\nusername admin privilege 15 role\
+    \ network-admin nopassword\nusername cvpadmin privilege 15 role network-admin\
+    \ secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n\
     !\nvrf instance MGMT\n!\ninterface Ethernet1\n   description P2P_LINK_TO_DC1-LEAF1A_Ethernet4\n\
     \   no shutdown\n   no switchport\n   ip address 172.31.255.6/31\n!\ninterface\
     \ Ethernet2\n   description P2P_LINK_TO_DC1-LEAF2A_Ethernet4\n   no shutdown\n\
@@ -971,9 +975,9 @@ CVP_CONFIGLETS:
     ip name-server vrf MGMT 192.168.200.5\nip name-server vrf MGMT 8.8.8.8\n!\nntp\
     \ local-interface vrf MGMT Management1\nntp server vrf MGMT 192.168.200.5 prefer\n\
     !\nspanning-tree mode mstp\nno spanning-tree vlan-id 4093-4094\nspanning-tree\
-    \ mst 0 priority 4096\n!\nno aaa root\n!\nusername admin privilege 15 role network-admin\
-    \ nopassword\nusername cvpadmin privilege 15 role network-admin secret sha512\
-    \ $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n\
+    \ mst 0 priority 4096\n!\nno aaa root\nno enable password\n!\nusername admin privilege\
+    \ 15 role network-admin nopassword\nusername cvpadmin privilege 15 role network-admin\
+    \ secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n\
     !\nvlan 110\n   name Tenant_A_OP_Zone_1\n!\nvlan 111\n   name Tenant_A_OP_Zone_2\n\
     !\nvlan 120\n   name Tenant_A_WEB_Zone_1\n!\nvlan 121\n   name Tenant_A_WEBZone_2\n\
     !\nvlan 130\n   name Tenant_A_APP_Zone_1\n!\nvlan 131\n   name Tenant_A_APP_Zone_2\n\
@@ -1174,9 +1178,9 @@ CVP_CONFIGLETS:
     ip name-server vrf MGMT 192.168.200.5\nip name-server vrf MGMT 8.8.8.8\n!\nntp\
     \ local-interface vrf MGMT Management1\nntp server vrf MGMT 192.168.200.5 prefer\n\
     !\nspanning-tree mode mstp\nno spanning-tree vlan-id 4093-4094\nspanning-tree\
-    \ mst 0 priority 4096\n!\nno aaa root\n!\nusername admin privilege 15 role network-admin\
-    \ nopassword\nusername cvpadmin privilege 15 role network-admin secret sha512\
-    \ $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n\
+    \ mst 0 priority 4096\n!\nno aaa root\nno enable password\n!\nusername admin privilege\
+    \ 15 role network-admin nopassword\nusername cvpadmin privilege 15 role network-admin\
+    \ secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n\
     !\nvlan 110\n   name Tenant_A_OP_Zone_1\n!\nvlan 111\n   name Tenant_A_OP_Zone_2\n\
     !\nvlan 120\n   name Tenant_A_WEB_Zone_1\n!\nvlan 121\n   name Tenant_A_WEBZone_2\n\
     !\nvlan 130\n   name Tenant_A_APP_Zone_1\n!\nvlan 131\n   name Tenant_A_APP_Zone_2\n\

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -208,6 +209,10 @@ management api http-commands
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 ```
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -208,6 +209,10 @@ management api http-commands
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 ```
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF1A.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -208,6 +209,10 @@ management api http-commands
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 ```
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF2A.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -208,6 +209,10 @@ management api http-commands
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 ```
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF2B.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -208,6 +209,10 @@ management api http-commands
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 ```
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -208,6 +209,10 @@ management api http-commands
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 ```
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -208,6 +209,10 @@ management api http-commands
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 ```
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -208,6 +209,10 @@ management api http-commands
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 ```
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE1.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -208,6 +209,10 @@ management api http-commands
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 ```
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE2.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -208,6 +209,10 @@ management api http-commands
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 ```
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE3.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -208,6 +209,10 @@ management api http-commands
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 ```
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE4.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -208,6 +209,10 @@ management api http-commands
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 ```
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -208,6 +209,10 @@ management api http-commands
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 ```
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -208,6 +209,10 @@ management api http-commands
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 ```
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1A.cfg
@@ -23,6 +23,7 @@ spanning-tree mst 0 priority 4096
 platform sand lag hardware-only
 !
 no aaa root
+no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1B.cfg
@@ -23,6 +23,7 @@ spanning-tree mst 0 priority 4096
 platform sand lag hardware-only
 !
 no aaa root
+no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF1A.cfg
@@ -23,6 +23,7 @@ spanning-tree mode mstp
 spanning-tree mst 0 priority 16384
 !
 no aaa root
+no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF2A.cfg
@@ -24,6 +24,7 @@ no spanning-tree vlan-id 4094
 spanning-tree mst 0 priority 16384
 !
 no aaa root
+no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF2B.cfg
@@ -24,6 +24,7 @@ no spanning-tree vlan-id 4094
 spanning-tree mst 0 priority 16384
 !
 no aaa root
+no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
@@ -25,6 +25,7 @@ spanning-tree mst 0 priority 4096
 platform sand lag hardware-only
 !
 no aaa root
+no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
@@ -26,6 +26,7 @@ spanning-tree mst 0 priority 4096
 platform sand lag hardware-only
 !
 no aaa root
+no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
@@ -26,6 +26,7 @@ spanning-tree mst 0 priority 4096
 platform sand lag hardware-only
 !
 no aaa root
+no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE1.cfg
@@ -20,6 +20,7 @@ ntp server vrf MGMT 192.168.200.5 prefer
 spanning-tree mode none
 !
 no aaa root
+no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE2.cfg
@@ -20,6 +20,7 @@ ntp server vrf MGMT 192.168.200.5 prefer
 spanning-tree mode none
 !
 no aaa root
+no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE3.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE3.cfg
@@ -20,6 +20,7 @@ ntp server vrf MGMT 192.168.200.5 prefer
 spanning-tree mode none
 !
 no aaa root
+no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE4.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE4.cfg
@@ -20,6 +20,7 @@ ntp server vrf MGMT 192.168.200.5 prefer
 spanning-tree mode none
 !
 no aaa root
+no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
@@ -26,6 +26,7 @@ spanning-tree mst 0 priority 4096
 platform sand lag hardware-only
 !
 no aaa root
+no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
@@ -26,6 +26,7 @@ spanning-tree mst 0 priority 4096
 platform sand lag hardware-only
 !
 no aaa root
+no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1A.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -208,6 +209,10 @@ management api http-commands
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 ```
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1B.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -208,6 +209,10 @@ management api http-commands
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 ```
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-L2LEAF1A.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -208,6 +209,10 @@ management api http-commands
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 ```
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-L2LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-L2LEAF2A.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -208,6 +209,10 @@ management api http-commands
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 ```
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-L2LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-L2LEAF2B.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -208,6 +209,10 @@ management api http-commands
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 ```
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF1A.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -208,6 +209,10 @@ management api http-commands
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 ```
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2A.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -208,6 +209,10 @@ management api http-commands
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 ```
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2B.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -208,6 +209,10 @@ management api http-commands
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 ```
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE1.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -208,6 +209,10 @@ management api http-commands
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 ```
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE2.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -208,6 +209,10 @@ management api http-commands
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 ```
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE3.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -208,6 +209,10 @@ management api http-commands
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 ```
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE4.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -208,6 +209,10 @@ management api http-commands
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 ```
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3A.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -208,6 +209,10 @@ management api http-commands
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 ```
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3B.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -208,6 +209,10 @@ management api http-commands
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 ```
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-BL1A.cfg
@@ -22,6 +22,7 @@ no spanning-tree vlan-id 4093-4094
 spanning-tree mst 0 priority 4096
 !
 no aaa root
+no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-BL1B.cfg
@@ -22,6 +22,7 @@ no spanning-tree vlan-id 4093-4094
 spanning-tree mst 0 priority 4096
 !
 no aaa root
+no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-L2LEAF1A.cfg
@@ -21,6 +21,7 @@ spanning-tree mode mstp
 spanning-tree mst 0 priority 16384
 !
 no aaa root
+no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-L2LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-L2LEAF2A.cfg
@@ -22,6 +22,7 @@ no spanning-tree vlan-id 4094
 spanning-tree mst 0 priority 16384
 !
 no aaa root
+no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-L2LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-L2LEAF2B.cfg
@@ -22,6 +22,7 @@ no spanning-tree vlan-id 4094
 spanning-tree mst 0 priority 16384
 !
 no aaa root
+no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-LEAF1A.cfg
@@ -21,6 +21,7 @@ spanning-tree mode mstp
 spanning-tree mst 0 priority 4096
 !
 no aaa root
+no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-LEAF2A.cfg
@@ -22,6 +22,7 @@ no spanning-tree vlan-id 4093-4094
 spanning-tree mst 0 priority 4096
 !
 no aaa root
+no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-LEAF2B.cfg
@@ -22,6 +22,7 @@ no spanning-tree vlan-id 4093-4094
 spanning-tree mst 0 priority 4096
 !
 no aaa root
+no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SPINE1.cfg
@@ -20,6 +20,7 @@ ntp server vrf MGMT 192.168.200.5 prefer
 spanning-tree mode none
 !
 no aaa root
+no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SPINE2.cfg
@@ -20,6 +20,7 @@ ntp server vrf MGMT 192.168.200.5 prefer
 spanning-tree mode none
 !
 no aaa root
+no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SPINE3.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SPINE3.cfg
@@ -20,6 +20,7 @@ ntp server vrf MGMT 192.168.200.5 prefer
 spanning-tree mode none
 !
 no aaa root
+no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SPINE4.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SPINE4.cfg
@@ -20,6 +20,7 @@ ntp server vrf MGMT 192.168.200.5 prefer
 spanning-tree mode none
 !
 no aaa root
+no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SVC3A.cfg
@@ -22,6 +22,7 @@ no spanning-tree vlan-id 4093-4094
 spanning-tree mst 0 priority 4096
 !
 no aaa root
+no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SVC3B.cfg
@@ -22,6 +22,7 @@ no spanning-tree vlan-id 4093-4094
 spanning-tree mst 0 priority 4096
 !
 no aaa root
+no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -208,6 +209,10 @@ management api http-commands
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 ```
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -208,6 +209,10 @@ management api http-commands
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 ```
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-L2LEAF1A.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -208,6 +209,10 @@ management api http-commands
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 ```
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-L2LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-L2LEAF2A.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -208,6 +209,10 @@ management api http-commands
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 ```
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-L2LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-L2LEAF2B.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -208,6 +209,10 @@ management api http-commands
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 ```
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -208,6 +209,10 @@ management api http-commands
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 ```
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -208,6 +209,10 @@ management api http-commands
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 ```
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -208,6 +209,10 @@ management api http-commands
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 ```
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE1.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -208,6 +209,10 @@ management api http-commands
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 ```
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE2.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -208,6 +209,10 @@ management api http-commands
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 ```
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE3.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -208,6 +209,10 @@ management api http-commands
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 ```
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE4.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -208,6 +209,10 @@ management api http-commands
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 ```
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -208,6 +209,10 @@ management api http-commands
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 ```
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -208,6 +209,10 @@ management api http-commands
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 ```
+
+## Enable Password
+
+Enable password not defined
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-BL1A.cfg
@@ -22,6 +22,7 @@ no spanning-tree vlan-id 4093-4094
 spanning-tree mst 0 priority 4096
 !
 no aaa root
+no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-BL1B.cfg
@@ -22,6 +22,7 @@ no spanning-tree vlan-id 4093-4094
 spanning-tree mst 0 priority 4096
 !
 no aaa root
+no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-L2LEAF1A.cfg
@@ -21,6 +21,7 @@ spanning-tree mode mstp
 spanning-tree mst 0 priority 16384
 !
 no aaa root
+no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-L2LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-L2LEAF2A.cfg
@@ -22,6 +22,7 @@ no spanning-tree vlan-id 4094
 spanning-tree mst 0 priority 16384
 !
 no aaa root
+no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-L2LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-L2LEAF2B.cfg
@@ -22,6 +22,7 @@ no spanning-tree vlan-id 4094
 spanning-tree mst 0 priority 16384
 !
 no aaa root
+no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
@@ -21,6 +21,7 @@ spanning-tree mode mstp
 spanning-tree mst 0 priority 4096
 !
 no aaa root
+no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
@@ -22,6 +22,7 @@ no spanning-tree vlan-id 4093-4094
 spanning-tree mst 0 priority 4096
 !
 no aaa root
+no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
@@ -22,6 +22,7 @@ no spanning-tree vlan-id 4093-4094
 spanning-tree mst 0 priority 4096
 !
 no aaa root
+no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SPINE1.cfg
@@ -20,6 +20,7 @@ ntp server vrf MGMT 192.168.200.5 prefer
 spanning-tree mode none
 !
 no aaa root
+no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SPINE2.cfg
@@ -20,6 +20,7 @@ ntp server vrf MGMT 192.168.200.5 prefer
 spanning-tree mode none
 !
 no aaa root
+no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SPINE3.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SPINE3.cfg
@@ -20,6 +20,7 @@ ntp server vrf MGMT 192.168.200.5 prefer
 spanning-tree mode none
 !
 no aaa root
+no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SPINE4.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SPINE4.cfg
@@ -20,6 +20,7 @@ ntp server vrf MGMT 192.168.200.5 prefer
 spanning-tree mode none
 !
 no aaa root
+no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
@@ -22,6 +22,7 @@ no spanning-tree vlan-id 4093-4094
 spanning-tree mst 0 priority 4096
 !
 no aaa root
+no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
@@ -22,6 +22,7 @@ no spanning-tree vlan-id 4093-4094
 spanning-tree mst 0 priority 4096
 !
 no aaa root
+no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -42,6 +42,7 @@
     - [AAA Accounting](#aaa-accounting)
     - [AAA Root](#aaa-root)
     - [Local Users](#local-users)
+    - [Enable Password](#enable-password)
     - [Clock Timezone](#clock-timezone)
     - [VLANs](#vlans)
     - [VRF Instances](#vrf-instances)
@@ -633,6 +634,14 @@ local_users:
     role: < role >
     sha512_password: "< sha_512_password >"
     no_password: < true | do not configure a password for given username. sha512_password MUST not be defined for this user. >
+```
+
+### Enable Password
+
+```yaml
+enable_password:
+  hash_algorithm: < md5 | sha512 >
+  key: "< hashed_password >"
 ```
 
 ### Clock Timezone

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/enable-password.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/enable-password.j2
@@ -1,0 +1,20 @@
+
+{% if enable_password is defined and enable_password is not none %}
+{%     if enable_password.key is arista.avd.defined  %}
+{%         if enable_password.hash_algorithm is arista.avd.defined("md5")  %}
+md5 encrypted enable password is configured
+{%         elif enable_password.hash_algorithm is arista.avd.defined("sha512")  %}
+sha512 encrypted enable password is configured
+{%         endif %}
+### Enable password configuration
+
+```eos
+!
+{% include 'eos/enable-password.j2' %}
+!
+```
+
+{%     endif %}
+{% else %}
+Enable password not defined
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/enable-password.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/enable-password.j2
@@ -1,5 +1,4 @@
-
-{% if enable_password is defined and enable_password is not none %}
+{% if enable_password is arista.avd.defined %}
 {%     if enable_password.key is arista.avd.defined  %}
 {%         if enable_password.hash_algorithm is arista.avd.defined("md5")  %}
 md5 encrypted enable password is configured

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-device-documentation.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-device-documentation.j2
@@ -13,6 +13,7 @@
   - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
   - [TACACS Servers](#tacacs-servers)
   - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
   - [RADIUS Servers](#radius-servers)
@@ -123,6 +124,10 @@
 ## Local Users
 
 {% include 'documentation/local-users.j2' %}
+
+## Enable Password
+
+{% include 'documentation/enable-password.j2' %}
 
 ## TACACS Servers
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
@@ -81,6 +81,8 @@ hostname {{ inventory_hostname }}
 {% include 'eos/aaa-accounting.j2' %}
 {# aaa root #}
 {% include 'eos/aaa-root.j2' %}
+{# enable password #}
+{% include 'eos/enable-password.j2' %}
 {# users #}
 {% include 'eos/local-users.j2' %}
 {# clock timezone #}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/enable-password.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/enable-password.j2
@@ -1,0 +1,11 @@
+{% if enable_password is defined and enable_password is not none %}
+{%     if enable_password.key is arista.avd.defined %}
+{%         if enable_password.hash_algorithm is arista.avd.defined("md5") %}
+enable password 5 {{ enable_password.key }}
+{%         elif enable_password.hash_algorithm is arista.avd.defined("sha512") %}
+enable password sha512 {{ enable_password.key }}
+{%         endif %}
+{%     endif %}
+{% else %}
+no enable password
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/enable-password.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/enable-password.j2
@@ -1,4 +1,4 @@
-{% if enable_password is defined and enable_password is not none %}
+{% if enable_password is arista.avd.defined %}
 {%     if enable_password.key is arista.avd.defined %}
 {%         if enable_password.hash_algorithm is arista.avd.defined("md5") %}
 enable password 5 {{ enable_password.key }}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Bot will manage tag, ownership and code review, you should not update these fields-->
## Change Summary

Add support for enable password in eos_cli_config_gen role.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Fixes #202 
Fixes #264 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Implement following data model:

```yaml
enable_password:
  hash_algorithm: < md5 | sha512 >
  key: "< hashed_password >"
```

## How to test

Run Molecule scenario for eos_cli_config_gen

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
