### PR TITLE
Ignore molecule path from pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,11 +5,16 @@ repos:
     rev: v2.4.0
     hooks:
       - id: trailing-whitespace
+        exclude: ansible_collections/arista/avd/molecule
       - id: end-of-file-fixer
         exclude_types:  [jinja, text]
+        exclude: ansible_collections/arista/avd/molecule
       - id: check-yaml
+        exclude: ansible_collections/arista/avd/molecule
       - id: check-added-large-files
+        exclude: ansible_collections/arista/avd/molecule
       - id: check-merge-conflict
+        exclude: ansible_collections/arista/avd/molecule
 
   # - repo: https://github.com/pre-commit/pre-commit-hooks
   #   rev: v2.3.0
@@ -41,4 +46,5 @@ repos:
       entry: yamllint
       language: python
       types: [file, yaml]
+      exclude: ansible_collections/arista/avd/molecule
       args: [-c=.github/yamllintrc]


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Bot will manage tag, ownership and code review, you should not update these fields-->
## Change Summary

Deactivate pre-commit for molecule folders

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [x] Other (please describe): Molecule

## Component(s) name

Molecule

## Proposed changes

Exclude molecule path for all items in `.pre-commit.yml` file

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
