### PR TITLE
Add support for L3 sub interface for ethernet and port-channel & OSPF support for port-channel

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/aaa.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/aaa.md
@@ -375,6 +375,7 @@ IP virtual router MAC address not defined
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | false|
+
 ### IP Routing Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/acl.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/acl.md
@@ -279,6 +279,7 @@ IP virtual router MAC address not defined
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | false|
+
 ### IP Routing Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/arp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/arp.md
@@ -279,6 +279,7 @@ IP virtual router MAC address not defined
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | false|
+
 ### IP Routing Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/base.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/base.md
@@ -357,6 +357,7 @@ IP virtual router MAC address not defined
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | false|
+
 ### IP Routing Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/dns-ntp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/dns-ntp.md
@@ -326,6 +326,7 @@ IP virtual router MAC address not defined
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | false|
+
 ### IP Routing Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/enable-password.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/enable-password.md
@@ -287,6 +287,7 @@ IP virtual router MAC address not defined
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | false|
+
 ### IP Routing Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/errdisable.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/errdisable.md
@@ -279,6 +279,7 @@ IP virtual router MAC address not defined
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | false|
+
 ### IP Routing Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -277,6 +277,7 @@ interface Ethernet1
 !
 interface Ethernet2
    description SRV-POD02_Eth1
+   switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
    storm-control all level 10
@@ -286,6 +287,7 @@ interface Ethernet2
 interface Ethernet6
    description SRV-POD02_Eth1
    logging event link-status
+   switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -264,6 +264,11 @@ No Interface Defaults defined
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
 | Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet1  |  routed  | - |  172.31.255.1/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet10.101 |  SUB Test  |  l3dot1q  | - |  10.1.1.1/31  |  C1  |  1500  |  -  |  -  |  -  |
+
+
+
+
 
 ### Ethernet Interfaces Device Configuration
 
@@ -276,7 +281,6 @@ interface Ethernet1
 !
 interface Ethernet2
    description SRV-POD02_Eth1
-   switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
    storm-control all level 10
@@ -286,9 +290,20 @@ interface Ethernet2
 interface Ethernet6
    description SRV-POD02_Eth1
    logging event link-status
-   switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
+!
+interface Ethernet10
+   description TEST
+   logging event link-status
+   no switchport
+!
+interface Ethernet10.101
+   description SUB Test
+   logging event link-status
+   encapsulation dot1q vlan 101
+   vrf C1
+   ip address 10.1.1.1/31
 ```
 
 ## Port-Channel Interfaces
@@ -320,6 +335,7 @@ IP virtual router MAC address not defined
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | false|
+
 ### IP Routing Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -266,10 +266,6 @@ No Interface Defaults defined
 | Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet1  |  routed  | - |  172.31.255.1/31  |  default  |  1500  |  -  |  -  |  -  |
 | Ethernet10.101 |  SUB Test  |  l3dot1q  | - |  10.1.1.1/31  |  C1  |  1500  |  -  |  -  |  -  |
 
-
-
-
-
 ### Ethernet Interfaces Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet_interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet_interfaces.md
@@ -279,6 +279,7 @@ IP virtual router MAC address not defined
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | false|
+
 ### IP Routing Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/event-handlers.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/event-handlers.md
@@ -293,6 +293,7 @@ IP virtual router MAC address not defined
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | false|
+
 ### IP Routing Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/igmp-snooping.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/igmp-snooping.md
@@ -301,6 +301,7 @@ IP virtual router MAC address not defined
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | false|
+
 ### IP Routing Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/logging-minimal.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/logging-minimal.md
@@ -292,6 +292,7 @@ IP virtual router MAC address not defined
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | false|
+
 ### IP Routing Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/logging.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/logging.md
@@ -304,6 +304,7 @@ IP virtual router MAC address not defined
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | false|
+
 ### IP Routing Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/loopbacks-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/loopbacks-interfaces.md
@@ -314,6 +314,7 @@ IP virtual router MAC address not defined
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | false|
+
 ### IP Routing Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mac-security-eth-po-entropy.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mac-security-eth-po-entropy.md
@@ -276,6 +276,7 @@ No Interface Defaults defined
 !
 interface Ethernet1
    mac security profile A1
+   switchport
    ip address 1.1.1.1/24
 !
 interface Ethernet3

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mac-security-eth-po-entropy.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mac-security-eth-po-entropy.md
@@ -270,10 +270,6 @@ No Interface Defaults defined
 
 *Inherited from Port-Channel Interface
 
-
-
-
-
 ### Ethernet Interfaces Device Configuration
 
 ```eos
@@ -297,6 +293,7 @@ interface Ethernet3
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
 | Port-Channel3 | L2-PORT | switched | trunk | 1-5 | - | - | - | - | - | - |
+
 
 ### Port-Channel Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mac-security-eth-po-entropy.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mac-security-eth-po-entropy.md
@@ -301,6 +301,7 @@ interface Ethernet3
 !
 interface Port-Channel3
    description L2-PORT
+   switchport
    switchport trunk allowed vlan 1-5
    switchport mode trunk
 ```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mac-security-eth-po-entropy.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mac-security-eth-po-entropy.md
@@ -294,7 +294,6 @@ interface Ethernet3
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
 | Port-Channel3 | L2-PORT | switched | trunk | 1-5 | - | - | - | - | - | - |
 
-
 ### Port-Channel Interfaces Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mac-security-eth-po-entropy.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mac-security-eth-po-entropy.md
@@ -270,13 +270,16 @@ No Interface Defaults defined
 
 *Inherited from Port-Channel Interface
 
+
+
+
+
 ### Ethernet Interfaces Device Configuration
 
 ```eos
 !
 interface Ethernet1
    mac security profile A1
-   switchport
    ip address 1.1.1.1/24
 !
 interface Ethernet3
@@ -301,7 +304,6 @@ interface Ethernet3
 !
 interface Port-Channel3
    description L2-PORT
-   switchport
    switchport trunk allowed vlan 1-5
    switchport mode trunk
 ```
@@ -331,6 +333,7 @@ IP virtual router MAC address not defined
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | false|
+
 ### IP Routing Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-api-http.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-api-http.md
@@ -306,6 +306,7 @@ IP virtual router MAC address not defined
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | false|
+
 ### IP Routing Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-gnmi.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-gnmi.md
@@ -299,6 +299,7 @@ IP virtual router MAC address not defined
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | false|
+
 ### IP Routing Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-ssh-custom-cipher.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-ssh-custom-cipher.md
@@ -318,6 +318,7 @@ IP virtual router MAC address not defined
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | false|
+
 ### IP Routing Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-ssh.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-ssh.md
@@ -314,6 +314,7 @@ IP virtual router MAC address not defined
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | false|
+
 ### IP Routing Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mcast-pim.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mcast-pim.md
@@ -279,6 +279,7 @@ IP virtual router MAC address not defined
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | false|
+
 ### IP Routing Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/none_configuration.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/none_configuration.md
@@ -279,6 +279,7 @@ IP virtual router MAC address not defined
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | false|
+
 ### IP Routing Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/platform.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/platform.md
@@ -279,6 +279,7 @@ IP virtual router MAC address not defined
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | false|
+
 ### IP Routing Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
@@ -331,6 +331,7 @@ interface Ethernet50
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-LEAF1B_Po3
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -338,6 +339,7 @@ interface Port-Channel3
 !
 interface Port-Channel5
    description DC1_L2LEAF1_Po1
+   switchport
    switchport trunk allowed vlan 110,201
    switchport mode trunk
    mlag 5
@@ -362,6 +364,7 @@ interface Port-Channel8.101
 !
 interface Port-Channel50
    description SRV-POD03_PortChanne1
+   switchport
    switchport trunk allowed vlan 1-4000
    switchport mode trunk
    !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
@@ -261,20 +261,6 @@ No Interface Defaults defined
 
 *Inherited from Port-Channel Interface
 
-#### IPv4
-
-| Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
-| --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-
- *Inherited from Port-Channel Interface
- 
-#### OSPF
-
-| Interface | Channel Group | Area | Cost | Mode |
-| --------- | ------------- | ---- | ---- |----- |
-
- *Inherited from Port-Channel Interface
-
 ### Ethernet Interfaces Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
@@ -261,6 +261,20 @@ No Interface Defaults defined
 
 *Inherited from Port-Channel Interface
 
+#### IPv4
+
+| Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
+| --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
+
+ *Inherited from Port-Channel Interface 
+
+#### OSPF
+
+| Interface | Channel Group | Area | Cost | Mode |
+| --------- | ------------- | ---- | ---- |----- |
+
+ *Inherited from Port-Channel Interface 
+
 ### Ethernet Interfaces Device Configuration
 
 ```eos
@@ -276,6 +290,11 @@ interface Ethernet4
 interface Ethernet5
    description DC1-AGG01_Ethernet1
    channel-group 5 mode active
+!
+interface Ethernet8
+   description Child TEST
+   logging event link-status
+   channel-group 8 mode active
 !
 interface Ethernet50
    description SRV-POD03_Eth1
@@ -293,8 +312,18 @@ interface Ethernet50
 | Port-Channel3 | MLAG_PEER_DC1-LEAF1B_Po3 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
 | Port-Channel5 | DC1_L2LEAF1_Po1 | switched | trunk | 110,201 | - | - | - | - | 5 | - |
 | Port-Channel50 | SRV-POD03_PortChanne1 | switched | trunk | 1-4000 | - | - | - | - | - | 0000:0000:0303:0202:0101 |
-| Port-Channel100.101 | IFL for TENANT01 | switched | access | - | - | - | - | - | - | - |
-| Port-Channel100.102 | IFL for TENANT02 | switched | access | - | - | - | - | - | - | - |
+
+#### IPv4
+
+| Interface | Description | Type | MLAG ID | IP Address | VRF | MTU | Shutdown | ACL In | ACL Out |
+| --------- | ----------- | ---- | ------- | ---------- | --- | --- | -------- | ------ | ------- |
+| Port-Channel8.101 | SUB TEST | l3dot1q | - | 10.255.1.0/31 | C1 | 1500 | - | - | - |
+
+#### OSPF
+
+| Interface | Channel Group | Area | Cost | Mode |
+| --------- | ------------- | ---- | ---- |----- |
+| Port-Channel8.101 | - | 0.0.0.0 |  -  |  point-to-point  |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -302,7 +331,6 @@ interface Ethernet50
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-LEAF1B_Po3
-   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -310,7 +338,6 @@ interface Port-Channel3
 !
 interface Port-Channel5
    description DC1_L2LEAF1_Po1
-   switchport
    switchport trunk allowed vlan 110,201
    switchport mode trunk
    mlag 5
@@ -318,9 +345,23 @@ interface Port-Channel5
    storm-control multicast level 1
    storm-control unknown-unicast level 1
 !
+interface Port-Channel8
+   description TEST
+   logging event link-status
+   no switchport
+!
+interface Port-Channel8.101
+   description SUB TEST
+   logging event link-status
+   mtu 1500
+   encapsulation dot1q vlan 101
+   vrf C1
+   ip address 10.255.1.0/31
+   ip ospf network point-to-point
+   ip ospf area 0.0.0.0
+!
 interface Port-Channel50
    description SRV-POD03_PortChanne1
-   switchport
    switchport trunk allowed vlan 1-4000
    switchport mode trunk
    !
@@ -329,24 +370,6 @@ interface Port-Channel50
        route-target import 03:03:02:02:01:01
    !
    lacp system-id 0303.0202.0101
-!
-interface Port-Channel100
-   logging event link-status
-   no switchport
-!
-interface Port-Channel100.101
-   description IFL for TENANT01
-   logging event link-status
-   mtu 1500
-   switchport
-   ip address 10.1.1.3/31
-!
-interface Port-Channel100.102
-   description IFL for TENANT02
-   mtu 1500
-   switchport
-   vrf C2
-   ip address 10.1.2.3/31
 ```
 
 ## Loopback Interfaces
@@ -374,6 +397,7 @@ IP virtual router MAC address not defined
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | false|
+
 ### IP Routing Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
@@ -319,12 +319,11 @@ interface Ethernet50
 | --------- | ----------- | ---- | ------- | ---------- | --- | --- | -------- | ------ | ------- |
 | Port-Channel8.101 | SUB TEST | l3dot1q | - | 10.255.1.0/31 | C1 | 1500 | - | - | - |
 
-
 #### OSPF
 
 | Interface | Channel Group | Area | Cost | Mode |
 | --------- | ------------- | ---- | ---- |----- |
-| Port-Channel8.101 | - | 0.0.0.0 |  -  |  point-to-point  |
+| Port-Channel8.101 | - | 0.0.0.0 | - |  point-to-point  |
 
 ### Port-Channel Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
@@ -266,14 +266,14 @@ No Interface Defaults defined
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
 
- *Inherited from Port-Channel Interface 
-
+ *Inherited from Port-Channel Interface
+ 
 #### OSPF
 
 | Interface | Channel Group | Area | Cost | Mode |
 | --------- | ------------- | ---- | ---- |----- |
 
- *Inherited from Port-Channel Interface 
+ *Inherited from Port-Channel Interface
 
 ### Ethernet Interfaces Device Configuration
 
@@ -318,6 +318,7 @@ interface Ethernet50
 | Interface | Description | Type | MLAG ID | IP Address | VRF | MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | ---- | ------- | ---------- | --- | --- | -------- | ------ | ------- |
 | Port-Channel8.101 | SUB TEST | l3dot1q | - | 10.255.1.0/31 | C1 | 1500 | - | - | - |
+
 
 #### OSPF
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/prefix-lists.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/prefix-lists.md
@@ -279,6 +279,7 @@ IP virtual router MAC address not defined
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | false|
+
 ### IP Routing Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ptp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ptp.md
@@ -290,10 +290,6 @@ No Interface Defaults defined
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
 | Ethernet6 |  P2P_LINK_TO_DC1-SPINE1_Ethernet6  |  routed  | - |  172.31.255.15/31  |  default  |  1500  |  -  |  -  |  -  |
 
-
-
-
-
 ### Ethernet Interfaces Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ptp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ptp.md
@@ -340,7 +340,6 @@ interface Ethernet6
 !
 interface Port-Channel5
    description DC1_L2LEAF1_Po1
-   switchport
    switchport trunk allowed vlan 110,201
    switchport mode trunk
    mlag 5

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ptp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ptp.md
@@ -340,6 +340,7 @@ interface Ethernet6
 !
 interface Port-Channel5
    description DC1_L2LEAF1_Po1
+   switchport
    switchport trunk allowed vlan 110,201
    switchport mode trunk
    mlag 5

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ptp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ptp.md
@@ -290,6 +290,10 @@ No Interface Defaults defined
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
 | Ethernet6 |  P2P_LINK_TO_DC1-SPINE1_Ethernet6  |  routed  | - |  172.31.255.15/31  |  default  |  1500  |  -  |  -  |  -  |
 
+
+
+
+
 ### Ethernet Interfaces Device Configuration
 
 ```eos
@@ -377,6 +381,7 @@ IP virtual router MAC address not defined
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | false|
+
 ### IP Routing Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/qos.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/qos.md
@@ -266,10 +266,6 @@ No Interface Defaults defined
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
 | Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet1  |  routed  | - |  172.31.255.1/31  |  default  |  1500  |  -  |  -  |  -  |
 
-
-
-
-
 ### Ethernet Interfaces Device Configuration
 
 ```eos
@@ -308,6 +304,7 @@ interface Ethernet6
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
 | Port-Channel3 | MLAG_PEER_DC1-LEAF1B_Po3 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
+
 
 ### Port-Channel Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/qos.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/qos.md
@@ -288,6 +288,7 @@ interface Ethernet4
 !
 interface Ethernet6
    description SRV-POD02_Eth1
+   switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
    qos trust cos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/qos.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/qos.md
@@ -266,6 +266,10 @@ No Interface Defaults defined
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
 | Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet1  |  routed  | - |  172.31.255.1/31  |  default  |  1500  |  -  |  -  |  -  |
 
+
+
+
+
 ### Ethernet Interfaces Device Configuration
 
 ```eos
@@ -288,7 +292,6 @@ interface Ethernet4
 !
 interface Ethernet6
    description SRV-POD02_Eth1
-   switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
    qos trust cos
@@ -312,7 +315,6 @@ interface Ethernet6
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-LEAF1B_Po3
-   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -347,6 +349,7 @@ IP virtual router MAC address not defined
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | false|
+
 ### IP Routing Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/qos.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/qos.md
@@ -312,6 +312,7 @@ interface Ethernet6
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-LEAF1B_Po3
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/qos.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/qos.md
@@ -305,7 +305,6 @@ interface Ethernet6
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
 | Port-Channel3 | MLAG_PEER_DC1-LEAF1B_Po3 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
 
-
 ### Port-Channel Interfaces Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/route-maps.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/route-maps.md
@@ -279,6 +279,7 @@ IP virtual router MAC address not defined
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | false|
+
 ### IP Routing Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
@@ -279,6 +279,7 @@ IP virtual router MAC address not defined
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | false|
+
 ### IP Routing Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-evpn.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-evpn.md
@@ -279,6 +279,7 @@ IP virtual router MAC address not defined
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | false|
+
 ### IP Routing Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-rtc.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-rtc.md
@@ -279,6 +279,7 @@ IP virtual router MAC address not defined
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | false|
+
 ### IP Routing Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-v4-evpn.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-v4-evpn.md
@@ -279,6 +279,7 @@ IP virtual router MAC address not defined
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | false|
+
 ### IP Routing Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-v4-v6-evpn.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-v4-v6-evpn.md
@@ -279,6 +279,7 @@ IP virtual router MAC address not defined
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | false|
+
 ### IP Routing Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vrf-lite.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vrf-lite.md
@@ -279,6 +279,7 @@ IP virtual router MAC address not defined
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | false|
+
 ### IP Routing Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis.md
@@ -265,10 +265,6 @@ No Interface Defaults defined
 | Ethernet1 |  P2P_LINK_TO_EAPI-SPINE1_Ethernet1  |  routed  | - |  172.31.255.1/31  |  default  |  1500  |  -  |  -  |  -  |
 | Ethernet2 |  P2P_LINK_TO_EAPI-SPINE2_Ethernet1  |  routed  | - |  172.31.255.3/31  |  default  |  1500  |  -  |  -  |  -  |
 
-
-
-
-
 #### ISIS
 
 | Interface | Channel Group | ISIS Instance | ISIS Metric | Mode |

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis.md
@@ -265,6 +265,10 @@ No Interface Defaults defined
 | Ethernet1 |  P2P_LINK_TO_EAPI-SPINE1_Ethernet1  |  routed  | - |  172.31.255.1/31  |  default  |  1500  |  -  |  -  |  -  |
 | Ethernet2 |  P2P_LINK_TO_EAPI-SPINE2_Ethernet1  |  routed  | - |  172.31.255.3/31  |  default  |  1500  |  -  |  -  |  -  |
 
+
+
+
+
 #### ISIS
 
 | Interface | Channel Group | ISIS Instance | ISIS Metric | Mode |
@@ -409,6 +413,7 @@ IP virtual router MAC address not defined
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | false|
+
 ### IP Routing Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
@@ -279,6 +279,7 @@ IP virtual router MAC address not defined
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | false|
+
 ### IP Routing Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-static.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-static.md
@@ -279,6 +279,7 @@ IP virtual router MAC address not defined
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | false|
+
 ### IP Routing Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/sflow.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/sflow.md
@@ -314,6 +314,7 @@ IP virtual router MAC address not defined
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | false|
+
 ### IP Routing Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/snmp_v3.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/snmp_v3.md
@@ -362,6 +362,7 @@ IP virtual router MAC address not defined
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | false|
+
 ### IP Routing Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/spanning-tree-rapid-pvst.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/spanning-tree-rapid-pvst.md
@@ -302,6 +302,7 @@ IP virtual router MAC address not defined
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | false|
+
 ### IP Routing Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/spanning-tree-rstp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/spanning-tree-rstp.md
@@ -293,6 +293,7 @@ IP virtual router MAC address not defined
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | false|
+
 ### IP Routing Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/spanning-tree.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/spanning-tree.md
@@ -323,6 +323,7 @@ IP virtual router MAC address not defined
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | false|
+
 ### IP Routing Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/terminattr-cloud.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/terminattr-cloud.md
@@ -292,6 +292,7 @@ IP virtual router MAC address not defined
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | false|
+
 ### IP Routing Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/terminattr-prem-disableaaa.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/terminattr-prem-disableaaa.md
@@ -292,6 +292,7 @@ IP virtual router MAC address not defined
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | false|
+
 ### IP Routing Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/terminattr-prem.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/terminattr-prem.md
@@ -292,6 +292,7 @@ IP virtual router MAC address not defined
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | false|
+
 ### IP Routing Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
@@ -448,6 +448,7 @@ IP virtual router MAC address not defined
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | false|
+
 ### IP Routing Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlans.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlans.md
@@ -301,6 +301,7 @@ IP virtual router MAC address not defined
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | false|
+
 ### IP Routing Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vrfs.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vrfs.md
@@ -278,7 +278,8 @@ IP virtual router MAC address not defined
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | false|| MGMT | false |
+| default | false|
+| MGMT | false |
 | TENANT_A_PROJECT01 | true |
 | TENANT_A_PROJECT02 | true |
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
@@ -14,6 +14,7 @@ interface Ethernet1
 !
 interface Ethernet2
    description SRV-POD02_Eth1
+   switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
    storm-control all level 10
@@ -23,6 +24,7 @@ interface Ethernet2
 interface Ethernet6
    description SRV-POD02_Eth1
    logging event link-status
+   switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
@@ -14,7 +14,6 @@ interface Ethernet1
 !
 interface Ethernet2
    description SRV-POD02_Eth1
-   switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
    storm-control all level 10
@@ -24,9 +23,20 @@ interface Ethernet2
 interface Ethernet6
    description SRV-POD02_Eth1
    logging event link-status
-   switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
+!
+interface Ethernet10
+   description TEST
+   logging event link-status
+   no switchport
+!
+interface Ethernet10.101
+   description SUB Test
+   logging event link-status
+   encapsulation dot1q vlan 101
+   vrf C1
+   ip address 10.1.1.1/31
 !
 interface Management1
    description oob_management

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/mac-security-eth-po-entropy.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/mac-security-eth-po-entropy.cfg
@@ -22,6 +22,7 @@ no enable password
 !
 interface Port-Channel3
    description L2-PORT
+   switchport
    switchport trunk allowed vlan 1-5
    switchport mode trunk
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/mac-security-eth-po-entropy.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/mac-security-eth-po-entropy.cfg
@@ -22,13 +22,11 @@ no enable password
 !
 interface Port-Channel3
    description L2-PORT
-   switchport
    switchport trunk allowed vlan 1-5
    switchport mode trunk
 !
 interface Ethernet1
    mac security profile A1
-   switchport
    ip address 1.1.1.1/24
 !
 interface Ethernet3

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/mac-security-eth-po-entropy.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/mac-security-eth-po-entropy.cfg
@@ -27,6 +27,7 @@ interface Port-Channel3
 !
 interface Ethernet1
    mac security profile A1
+   switchport
    ip address 1.1.1.1/24
 !
 interface Ethernet3

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
@@ -9,7 +9,6 @@ no enable password
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-LEAF1B_Po3
-   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -17,7 +16,6 @@ interface Port-Channel3
 !
 interface Port-Channel5
    description DC1_L2LEAF1_Po1
-   switchport
    switchport trunk allowed vlan 110,201
    switchport mode trunk
    mlag 5
@@ -25,9 +23,23 @@ interface Port-Channel5
    storm-control multicast level 1
    storm-control unknown-unicast level 1
 !
+interface Port-Channel8
+   description TEST
+   logging event link-status
+   no switchport
+!
+interface Port-Channel8.101
+   description SUB TEST
+   logging event link-status
+   mtu 1500
+   encapsulation dot1q vlan 101
+   vrf C1
+   ip address 10.255.1.0/31
+   ip ospf network point-to-point
+   ip ospf area 0.0.0.0
+!
 interface Port-Channel50
    description SRV-POD03_PortChanne1
-   switchport
    switchport trunk allowed vlan 1-4000
    switchport mode trunk
    !
@@ -36,24 +48,6 @@ interface Port-Channel50
        route-target import 03:03:02:02:01:01
    !
    lacp system-id 0303.0202.0101
-!
-interface Port-Channel100
-   logging event link-status
-   no switchport
-!
-interface Port-Channel100.101
-   description IFL for TENANT01
-   logging event link-status
-   mtu 1500
-   switchport
-   ip address 10.1.1.3/31
-!
-interface Port-Channel100.102
-   description IFL for TENANT02
-   mtu 1500
-   switchport
-   vrf C2
-   ip address 10.1.2.3/31
 !
 interface Ethernet3
    description MLAG_PEER_DC1-LEAF1B_Ethernet3
@@ -66,6 +60,11 @@ interface Ethernet4
 interface Ethernet5
    description DC1-AGG01_Ethernet1
    channel-group 5 mode active
+!
+interface Ethernet8
+   description Child TEST
+   logging event link-status
+   channel-group 8 mode active
 !
 interface Ethernet50
    description SRV-POD03_Eth1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
@@ -9,6 +9,7 @@ no enable password
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-LEAF1B_Po3
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -16,6 +17,7 @@ interface Port-Channel3
 !
 interface Port-Channel5
    description DC1_L2LEAF1_Po1
+   switchport
    switchport trunk allowed vlan 110,201
    switchport mode trunk
    mlag 5
@@ -40,6 +42,7 @@ interface Port-Channel8.101
 !
 interface Port-Channel50
    description SRV-POD03_PortChanne1
+   switchport
    switchport trunk allowed vlan 1-4000
    switchport mode trunk
    !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ptp.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ptp.cfg
@@ -18,6 +18,7 @@ no enable password
 !
 interface Port-Channel5
    description DC1_L2LEAF1_Po1
+   switchport
    switchport trunk allowed vlan 110,201
    switchport mode trunk
    mlag 5

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ptp.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ptp.cfg
@@ -18,7 +18,6 @@ no enable password
 !
 interface Port-Channel5
    description DC1_L2LEAF1_Po1
-   switchport
    switchport trunk allowed vlan 110,201
    switchport mode trunk
    mlag 5

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/qos.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/qos.cfg
@@ -64,6 +64,7 @@ interface Ethernet4
 !
 interface Ethernet6
    description SRV-POD02_Eth1
+   switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
    qos trust cos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/qos.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/qos.cfg
@@ -38,7 +38,6 @@ no enable password
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-LEAF1B_Po3
-   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
@@ -65,7 +64,6 @@ interface Ethernet4
 !
 interface Ethernet6
    description SRV-POD02_Eth1
-   switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
    qos trust cos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/qos.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/qos.cfg
@@ -38,6 +38,7 @@ no enable password
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-LEAF1B_Po3
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
@@ -39,3 +39,23 @@ ethernet_interfaces:
       unknown_unicast:
         level: 1
         unit: percent
+
+  Ethernet10:
+    description: TEST
+    type: routed
+    logging:
+      event:
+        link_status: true
+
+  Ethernet10.101:
+    description: SUB Test
+    type: l3dot1q
+    logging:
+      event:
+        link_status: true
+    mtu: 1500
+    ip_address: 10.1.1.1/31
+    vrf: C1
+    encapsulation:
+      dot1q:
+        vlan: 101

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
@@ -34,29 +34,27 @@ port_channel_interfaces:
     rt: 03:03:02:02:01:01
     lacp_id: 0303.0202.0101
 
-  Port-Channel100:
+  Port-Channel8:
+    logging:
+      event:
+        link_status: true
+    description: TEST
     type: routed
+
+  Port-Channel8.101:
+    description: SUB TEST
+    type: l3dot1q
     logging:
       event:
         link_status: true
-  Port-Channel100.101:
-    logging:
-      event:
-        link_status: true
-    description: IFL for TENANT01
     mtu: 1500
-    ip_address: 10.1.1.3/31
+    ip_address: 10.255.1.0/31
+    vrf: C1
     encapsulation:
       dot1q:
         vlan: 101
-  Port-Channel100.102:
-    description: IFL for TENANT02
-    mtu: 1500
-    ip_address: 10.1.2.3/31
-    vrf: C2
-    encapsulation:
-      dot1q:
-        vlan: 102
+    ospf_network_point_to_point: true
+    ospf_area: 0.0.0.0
 
 # Children interfaces
 ethernet_interfaces:
@@ -98,3 +96,12 @@ ethernet_interfaces:
       id: 5
       mode: "active"
     profile: ALL
+
+  Ethernet8:
+    logging:
+      event:
+        link_status: true
+    description: Child TEST
+    channel_group:
+      id: 8
+      mode: active

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -845,7 +845,7 @@ ethernet_interfaces:
   <Ethernet_interface_10>:
     description: < description >
     type: < routed >
-  <Ethernet_interface_10:101>:
+  <Ethernet_interface_10.101>:
     description: < description >
     type: < l3dot1q >
     encapsulation:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -781,7 +781,7 @@ ethernet_interfaces:
     shutdown: < true | false >
     speed: < interface_speed | forced interface_speed | auto interface_speed >
     mtu: < mtu >
-    type: < routed | switched >
+    type: < routed | switched | l3dot1q >
     vrf: < vrf_name >
     ip_address: < IPv4_address/Mask >
     ip_address_secondaries:
@@ -841,10 +841,38 @@ ethernet_interfaces:
       dscp: < dscp-value >
       cos: < cos-value >
 
-# Switched Interfaces
+  # Sub L3 interface
+  <Ethernet_interface_10>:
+    description: < description >
+    type: < routed >
+  <Ethernet_interface_10:101>:
+    description: < description >
+    type: < l3dot1q >
+    encapsulation:
+      dot1q:
+        vlan: < dot1q tag to mark packets >
+    vrf: < vrf_name >
+    ip_address: < IPv4_address/Mask >
+    ip_address_secondaries:
+      - < IPv4_address/Mask >
+      - < IPv4_address/Mask >
+    ipv6_enable: < true | false >
+    ipv6_address: < IPv6_address/Mask >
+    ipv6_address_link_local: < link_local_IPv6_address/Mask >
+    ipv6_nd_ra_disabled: < true | false >
+    ipv6_nd_managed_config_flag: < true | false >
+    ipv6_nd_prefixes:
+      < IPv6_address_1/Mask >:
+        valid_lifetime: < infinite or lifetime in seconds >
+        preferred_lifetime: < infinite or lifetime in seconds >
+        no_autoconfig_flag: < true | false >
+      < IPv6_address_2/Mask >:
+
+  # Switched Interfaces
   <Ethernet_interface_2 >:
     description: < description >
     shutdown: < true | false >
+    type: < routed | switched | l3dot1q >
     speed: < interface_speed | forced interface_speed | auto interface_speed >
     mtu: < mtu >
     vlans: "< list of vlans as string >"

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ethernet-interfaces.j2
@@ -46,6 +46,7 @@
 {% endfor %}
 
 *Inherited from Port-Channel Interface
+
 {# IPv4 #}
 {%     set ethernet_interface_ipv4 = namespace() %}
 {%     set ethernet_interface_ipv4.configured = false %}
@@ -64,7 +65,6 @@
 {%         endfor %}
 {%     endif %}
 {%     if ethernet_interface_ipv4.configured == true or port_channel_interface_ipv4.configured == true %}
-
 #### IPv4
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
@@ -81,9 +81,12 @@
 {%                 endif %}
 {%             endif %}
 {%         endfor %}
-{%     endif %}
+{%         if port_channel_interface_ipv4.configured is arista.avd.defined(true) %}
 
-{% if port_channel_interface_ipv4.configured == true %} *Inherited from Port-Channel Interface {% endif %}
+ *Inherited from Port-Channel Interface
+ {%        endif %}
+
+{%     endif %}
 {# IPv6 #}
 {%     set ethernet_interface_ipv6 = namespace() %}
 {%     set ethernet_interface_ipv6.configured = false %}
@@ -102,7 +105,6 @@
 {%         endfor %}
 {%     endif %}
 {%     if ethernet_interface_ipv6.configured == true or port_channel_interface_ipv6.configured == true %}
-
 #### IPv6
 
 | Interface | Description | Type | Channel Group | IPv6 Address | VRF | MTU | Shutdown | ND RA Disabled | Managed Config Flag | IPv6 ACL In | IPv6 ACL Out |
@@ -119,9 +121,12 @@
 {%                 endif %}
 {%             endif %}
 {%         endfor %}
-{%     endif %}
+{%         if port_channel_interface_ipv6.configured is arista.avd.defined(true) %}
 
-{% if port_channel_interface_ipv6.configured == true %} *Inherited from Port-Channel Interface {% endif %}
+ *Inherited from Port-Channel Interface
+{%         endif %}
+
+{%     endif %}
 {# OSPF #}
 {%     set ethernet_interface_ospf = namespace() %}
 {%     set ethernet_interface_ospf.configured = false %}
@@ -140,7 +145,6 @@
 {%         endfor %}
 {%     endif %}
 {%     if ethernet_interface_ospf.configured == true or port_channel_interface_ospf.configured == true %}
-
 #### OSPF
 
 | Interface | Channel Group | Area | Cost | Mode |
@@ -157,10 +161,12 @@
 {%                endif %}
 {%             endif %}
 {%          endfor %}
+{%          if port_channel_interface_ospf.configured is arista.avd.defined(true) %}
+
+ *Inherited from Port-Channel Interface
+{%          endif %}
+
 {%     endif %}
-
-{% if port_channel_interface_ospf.configured == true %} *Inherited from Port-Channel Interface {% endif %}
-
 {# ISIS #}
 {%     set ethernet_interface_isis = namespace() %}
 {%     set ethernet_interface_isis.configured = false %}
@@ -179,7 +185,6 @@
 {%         endfor %}
 {%     endif %}
 {%     if ethernet_interface_isis.configured == true or port_channel_interface_isis.configured == true %}
-
 #### ISIS
 
 | Interface | Channel Group | ISIS Instance | ISIS Metric | Mode |
@@ -196,9 +201,12 @@
 {%                endif %}
 {%             endif %}
 {%         endfor %}
-{%     endif %}
-{% if port_channel_interface_isis.configured == true %} *Inherited from Port-Channel Interface {% endif %}
+{%         if port_channel_interface_isis.configured is arista.avd.defined(true) %}
 
+ *Inherited from Port-Channel Interface
+{%         endif %}
+
+{%     endif %}
 ### Ethernet Interfaces Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ethernet-interfaces.j2
@@ -64,7 +64,7 @@
 {%              endif %}
 {%         endfor %}
 {%     endif %}
-{%     if ethernet_interface_ipv4.configured == true or port_channel_interface_ipv4.configured == true %}
+{%     if ethernet_interface_ipv4.configured == true %}
 #### IPv4
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
@@ -144,7 +144,7 @@
 {%              endif %}
 {%         endfor %}
 {%     endif %}
-{%     if ethernet_interface_ospf.configured == true or port_channel_interface_ospf.configured == true %}
+{%     if ethernet_interface_ospf.configured == true %}
 #### OSPF
 
 | Interface | Channel Group | Area | Cost | Mode |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ethernet-interfaces.j2
@@ -8,7 +8,7 @@
 {% for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort %}
 {%     if ethernet_interfaces[ethernet_interface].channel_group.id is defined and ethernet_interfaces[ethernet_interface].channel_group.id is not none %}
 {%         set port_channel_interface = 'Port-Channel' + ethernet_interfaces[ethernet_interface].channel_group.id | string %}
-{%         if port_channel_interfaces[port_channel_interface].type is not defined or port_channel_interfaces[port_channel_interface].type != "routed" %}
+{%         if port_channel_interfaces[port_channel_interface].type is not defined or port_channel_interfaces[port_channel_interface].type in ["switched", "l2dot1q"]  %}
 {%             set description = ethernet_interfaces[ethernet_interface].description | default("-") %}
 {%             set mode = port_channel_interfaces[port_channel_interface].mode | default("access") %}
 {%             set vlans = port_channel_interfaces[port_channel_interface].vlans | default ('-') %}
@@ -26,7 +26,7 @@
 {%             endif %}
 | {{ ethernet_interface }} | {{ description }} | *{{ mode }} | *{{ vlans }} | *{{ native_vlan }} | *{{ l2.trunk_groups }} | {{ channel_group }} |
 {%         endif %}
-{%     elif ethernet_interfaces[ethernet_interface].type is not defined or ethernet_interfaces[ethernet_interface].type != "routed" %}
+{%     elif ethernet_interfaces[ethernet_interface].type is not defined or ethernet_interfaces[ethernet_interface].type in ["switched", "l2dot1q"]  %}
 {%         set description = ethernet_interfaces[ethernet_interface].description | default("-") %}
 {%         set mode = ethernet_interfaces[ethernet_interface].mode | default("access") %}
 {%         set vlans = ethernet_interfaces[ethernet_interface].vlans | default ('-') %}
@@ -50,7 +50,7 @@
 {%     set ethernet_interface_ipv4 = namespace() %}
 {%     set ethernet_interface_ipv4.configured = false %}
 {%     for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort %}
-{%          if ethernet_interfaces[ethernet_interface].type is defined and ethernet_interfaces[ethernet_interface].type == 'routed' and ethernet_interfaces[ethernet_interface].ip_address is defined %}
+{%          if ethernet_interfaces[ethernet_interface].type is defined and ethernet_interfaces[ethernet_interface].type in ["routed", "l3dot1q"]  and ethernet_interfaces[ethernet_interface].ip_address is defined %}
 {%              set ethernet_interface_ipv4.configured = true %}
 {%          endif %}
 {%     endfor %}
@@ -58,7 +58,7 @@
 {%     set port_channel_interface_ipv4.configured = false %}
 {%     if port_channel_interfaces is defined and port_channel_interfaces is not none %}
 {%         for port_channel_interface in port_channel_interfaces | arista.avd.natural_sort %}
-{%              if port_channel_interfaces[port_channel_interface].type is defined and port_channel_interfaces[port_channel_interface].type == 'routed' and port_channel_interfaces[port_channel_interface].ip_address is defined %}
+{%              if port_channel_interfaces[port_channel_interface].type is defined and port_channel_interfaces[port_channel_interface].type in ["routed", "l3dot1q"] and port_channel_interfaces[port_channel_interface].ip_address is defined %}
 {%                  set port_channel_interface_ipv4.configured = true %}
 {%              endif %}
 {%         endfor %}
@@ -82,12 +82,13 @@
 {%             endif %}
 {%         endfor %}
 {%     endif %}
+
 {% if port_channel_interface_ipv4.configured == true %} *Inherited from Port-Channel Interface {% endif %}
 {# IPv6 #}
 {%     set ethernet_interface_ipv6 = namespace() %}
 {%     set ethernet_interface_ipv6.configured = false %}
 {%     for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort %}
-{%          if ethernet_interfaces[ethernet_interface].type is defined and ethernet_interfaces[ethernet_interface].type == 'routed' and ethernet_interfaces[ethernet_interface].ipv6_address is defined %}
+{%          if ethernet_interfaces[ethernet_interface].type is defined and ethernet_interfaces[ethernet_interface].type in ["routed", "l3dot1q"] and ethernet_interfaces[ethernet_interface].ipv6_address is defined %}
 {%              set ethernet_interface_ipv6.configured = true %}
 {%          endif %}
 {%     endfor %}
@@ -95,7 +96,7 @@
 {%     set port_channel_interface_ipv6.configured = false %}
 {%     if port_channel_interfaces is defined and port_channel_interfaces is not none %}
 {%         for port_channel_interface in port_channel_interfaces | arista.avd.natural_sort %}
-{%              if port_channel_interfaces[port_channel_interface].type is defined and port_channel_interfaces[port_channel_interface].type == 'routed' and port_channel_interfaces[port_channel_interface].ipv6_address is defined %}
+{%              if port_channel_interfaces[port_channel_interface].type is defined and port_channel_interfaces[port_channel_interface].type in ["routed", "l3dot1q"] and port_channel_interfaces[port_channel_interface].ipv6_address is defined %}
 {%                  set port_channel_interface_ipv6.configured = true %}
 {%              endif %}
 {%         endfor %}
@@ -119,6 +120,7 @@
 {%             endif %}
 {%         endfor %}
 {%     endif %}
+
 {% if port_channel_interface_ipv6.configured == true %} *Inherited from Port-Channel Interface {% endif %}
 {# OSPF #}
 {%     set ethernet_interface_ospf = namespace() %}
@@ -140,6 +142,7 @@
 {%     if ethernet_interface_ospf.configured == true or port_channel_interface_ospf.configured == true %}
 
 #### OSPF
+
 | Interface | Channel Group | Area | Cost | Mode |
 | --------- | ------------- | ---- | ---- |----- |
 {%         for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort %}
@@ -155,7 +158,9 @@
 {%             endif %}
 {%          endfor %}
 {%     endif %}
+
 {% if port_channel_interface_ospf.configured == true %} *Inherited from Port-Channel Interface {% endif %}
+
 {# ISIS #}
 {%     set ethernet_interface_isis = namespace() %}
 {%     set ethernet_interface_isis.configured = false %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ethernet-interfaces.j2
@@ -8,7 +8,7 @@
 {% for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort %}
 {%     if ethernet_interfaces[ethernet_interface].channel_group.id is defined and ethernet_interfaces[ethernet_interface].channel_group.id is not none %}
 {%         set port_channel_interface = 'Port-Channel' + ethernet_interfaces[ethernet_interface].channel_group.id | string %}
-{%         if port_channel_interfaces[port_channel_interface].type is not defined or port_channel_interfaces[port_channel_interface].type in ["switched", "l2dot1q"]  %}
+{%         if port_channel_interfaces[port_channel_interface].type is not defined or port_channel_interfaces[port_channel_interface].type not in ["routed", "l3dot1q"] %}
 {%             set description = ethernet_interfaces[ethernet_interface].description | default("-") %}
 {%             set mode = port_channel_interfaces[port_channel_interface].mode | default("access") %}
 {%             set vlans = port_channel_interfaces[port_channel_interface].vlans | default ('-') %}
@@ -26,7 +26,7 @@
 {%             endif %}
 | {{ ethernet_interface }} | {{ description }} | *{{ mode }} | *{{ vlans }} | *{{ native_vlan }} | *{{ l2.trunk_groups }} | {{ channel_group }} |
 {%         endif %}
-{%     elif ethernet_interfaces[ethernet_interface].type is not defined or ethernet_interfaces[ethernet_interface].type in ["switched", "l2dot1q"]  %}
+{%     elif ethernet_interfaces[ethernet_interface].type is not defined or ethernet_interfaces[ethernet_interface].type not in ["routed", "l3dot1q"]  %}
 {%         set description = ethernet_interfaces[ethernet_interface].description | default("-") %}
 {%         set mode = ethernet_interfaces[ethernet_interface].mode | default("access") %}
 {%         set vlans = ethernet_interfaces[ethernet_interface].vlans | default ('-') %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ip-routing.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ip-routing.j2
@@ -2,7 +2,7 @@
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default |{% if ip_routing is defined and ip_routing is not none and ip_routing == true %} true|{% else %} false|{% endif %}
+| default |{% if ip_routing is defined and ip_routing is not none and ip_routing == true %} true{% else %} false{% endif %}|
 {% if vrfs is defined and vrfs is not none %}
 {%     for vrf in vrfs | arista.avd.natural_sort %}
 {%         if vrfs[vrf].ip_routing == true %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/port-channel-interfaces.j2
@@ -98,37 +98,29 @@
 {%        endfor %}
 {%    endif %}
 {# OSPF #}
-{%     set po_interface_ospf = namespace() %}
-{%     set po_interface_ospf.configured = false %}
-{%     for port_channel_interface in port_channel_interfaces | arista.avd.natural_sort %}
-{%          if port_channel_interfaces[port_channel_interface].ospf_area is defined %}
-{%              set po_interface_ospf.configured = true %}
-{%          endif %}
-{%     endfor %}
 {%     set port_channel_interface_ospf = namespace() %}
 {%     set port_channel_interface_ospf.configured = false %}
-{%     if port_channel_interfaces is defined and port_channel_interfaces is not none %}
+{%     if port_channel_interfaces is arista.avd.defined %}
 {%         for port_channel_interface in port_channel_interfaces | arista.avd.natural_sort %}
-{%              if port_channel_interfaces[port_channel_interface].ospf_area is defined %}
+{%              if port_channel_interfaces[port_channel_interface].ospf_area is arista.avd.defined %}
 {%                  set port_channel_interface_ospf.configured = true %}
 {%              endif %}
 {%         endfor %}
-
 {%     endif %}
-{%     if po_interface_ospf.configured == true or port_channel_interface_ospf.configured == true %}
+{%     if port_channel_interface_ospf.configured is arista.avd.defined(true) %}
 #### OSPF
 
 | Interface | Channel Group | Area | Cost | Mode |
 | --------- | ------------- | ---- | ---- |----- |
 {%         for port_channel_interface in port_channel_interfaces | arista.avd.natural_sort %}
-{%             if port_channel_interfaces[port_channel_interface].channel_group.id is defined and port_channel_interfaces[port_channel_interface].channel_group.id is not none %}
+{%             if port_channel_interfaces[port_channel_interface].channel_group.id is arista.avd.defined %}
 {%                 set port_channel_interface = 'Port-Channel' + port_channel_interfaces[port_channel_interface].channel_group.id | string %}
-{%                 if port_channel_interfaces[port_channel_interface].ospf_area is defined and port_channel_interfaces[port_channel_interface].ospf_area is not none %}
-| {{ port_channel_interface }} | {% if port_channel_interfaces[port_channel_interface].channel_group.id is defined and port_channel_interfaces[port_channel_interface].channel_group.id is not none %} {{ port_channel_interfaces[port_channel_interface].channel_group.id }} {% else %} - {% endif %} | *{{ port_channel_interfaces[port_channel_interface].ospf_area }} | {% if port_channel_interfaces[port_channel_interface].ospf_cost is defined and port_channel_interfaces[port_channel_interface].ospf_cost is not none %} *{{ port_channel_interfaces[port_channel_interface].ospf_cost }} {% else %} *- {% endif %} | {% if port_channel_interfaces[port_channel_interface].ospf_network_point_to_point is defined and port_channel_interfaces[port_channel_interface].ospf_network_point_to_point is not none and port_channel_interfaces[port_channel_interface].ospf_network_point_to_point == true %} *point-to-point {% else %} *broadcast {% endif %} |
+{%                 if port_channel_interfaces[port_channel_interface].ospf_area is arista.avd.defined %}
+| {{ port_channel_interface }} | {{ port_channel_interfaces[port_channel_interface].channel_group.id | arista.avd.default('-') }} | *{{ port_channel_interfaces[port_channel_interface].ospf_area }} | *{{ port_channel_interfaces[port_channel_interface].ospf_cost | arista.avd.default('*-') }} | {% if port_channel_interfaces[port_channel_interface].ospf_network_point_to_point is arista.avd.defined(true) %} *point-to-point {% else %} *broadcast {% endif %} |
 {%                 endif %}
 {%             else %}
-{%                 if port_channel_interfaces[port_channel_interface].ospf_area is defined and port_channel_interfaces[port_channel_interface].ospf_area is not none %}
-| {{ port_channel_interface }} | - | {{ port_channel_interfaces[port_channel_interface].ospf_area }} | {% if port_channel_interfaces[port_channel_interface].ospf_cost is defined and port_channel_interfaces[port_channel_interface].ospf_cost is not none %} {{ port_channel_interfaces[port_channel_interface].ospf_cost }} {% else %} - {% endif %} | {% if port_channel_interfaces[port_channel_interface].ospf_network_point_to_point is defined and port_channel_interfaces[port_channel_interface].ospf_network_point_to_point is not none and port_channel_interfaces[port_channel_interface].ospf_network_point_to_point == true %} point-to-point {% else %} broadcast {% endif %} |
+{%                 if port_channel_interfaces[port_channel_interface].ospf_area is arista.avd.defined %}
+| {{ port_channel_interface }} | - | {{ port_channel_interfaces[port_channel_interface].ospf_area }} | {{ port_channel_interfaces[port_channel_interface].ospf_cost | arista.avd.default('-') }} | {% if port_channel_interfaces[port_channel_interface].ospf_network_point_to_point is arista.avd.defined(true) %} point-to-point {% else %} broadcast {% endif %} |
 {%                endif %}
 {%             endif %}
 {%          endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/port-channel-interfaces.j2
@@ -6,7 +6,7 @@
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
 {%     for port_channel_interface in port_channel_interfaces | arista.avd.natural_sort %}
-{%         if port_channel_interfaces[port_channel_interface].type is not defined or port_channel_interfaces[port_channel_interface].type != "routed" %}
+{%         if port_channel_interfaces[port_channel_interface].type is not defined or port_channel_interfaces[port_channel_interface].type in ["switched", "l2dot1q"]  %}
 {%             set description = port_channel_interfaces[port_channel_interface].description | default ("-")%}
 {%             set type = port_channel_interfaces[port_channel_interface].type | default ("switched")%}
 {%             set mode = port_channel_interfaces[port_channel_interface].mode | default ("access")%}
@@ -34,7 +34,7 @@
 {%   set port_channel_interface_ipv4.configured = false %}
 {%   if port_channel_interfaces is defined and port_channel_interfaces is not none %}
 {%       for port_channel_interface in port_channel_interfaces | arista.avd.natural_sort %}
-{%           if port_channel_interfaces[port_channel_interface].type is defined and port_channel_interfaces[port_channel_interface].type == 'routed' and port_channel_interfaces[port_channel_interface].ip_address is defined %}
+{%           if port_channel_interfaces[port_channel_interface].type is defined and port_channel_interfaces[port_channel_interface].type in ["routed", "l3dot1q"] and port_channel_interfaces[port_channel_interface].ip_address is defined %}
 {%               set port_channel_interface_ipv4.configured = true %}
 {%           endif %}
 {%        endfor %}
@@ -46,9 +46,9 @@
 | Interface | Description | Type | MLAG ID | IP Address | VRF | MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | ---- | ------- | ---------- | --- | --- | -------- | ------ | ------- |
 {%        for port_channel_interface in port_channel_interfaces | arista.avd.natural_sort %}
-{%            if port_channel_interfaces[port_channel_interface].type is defined and port_channel_interfaces[port_channel_interface].type == "routed" and port_channel_interfaces[port_channel_interface].ip_address is defined and port_channel_interfaces[port_channel_interface].ip_address is not none %}
+{%            if port_channel_interfaces[port_channel_interface].type is defined and port_channel_interfaces[port_channel_interface].type in ["routed", "l3dot1q"] and port_channel_interfaces[port_channel_interface].ip_address is defined and port_channel_interfaces[port_channel_interface].ip_address is not none %}
 {%                set description = port_channel_interfaces[port_channel_interface].description | default ("-")%}
-{%                set type = "routed" %}
+{%                set type = port_channel_interfaces[port_channel_interface].type %}
 {%                set mlag = port_channel_interfaces[port_channel_interface].mlag | default ("-")%}
 {%                set ip_address = port_channel_interfaces[port_channel_interface].ip_address | default ("-")%}
 {%                set vrf = port_channel_interfaces[port_channel_interface].vrf | default ("default")%}
@@ -77,9 +77,9 @@
 | Interface | Description | Type | MLAG ID | IPv6 Address | VRF | MTU | Shutdown | ND RA Disabled | Managed Config Flag | IPv6 ACL In | IPv6 ACL Out |
 | --------- | ----------- | ---- | ------- | -------------| --- | --- | -------- | -------------- | ------------------- | ----------- | ------------ |
 {%        for port_channel_interface in port_channel_interfaces | arista.avd.natural_sort %}
-{%            if port_channel_interfaces[port_channel_interface].type is defined and port_channel_interfaces[port_channel_interface].type == "routed" and port_channel_interfaces[port_channel_interface].ipv6_address is defined and port_channel_interfaces[port_channel_interface].ipv6_address is not none %}
+{%            if port_channel_interfaces[port_channel_interface].type is defined and port_channel_interfaces[port_channel_interface].type in ["routed", "l3dot1q"] and port_channel_interfaces[port_channel_interface].ipv6_address is defined and port_channel_interfaces[port_channel_interface].ipv6_address is not none %}
 {%                set description = port_channel_interfaces[port_channel_interface].description | default ("-")%}
-{%                set type = "routed" %}
+{%                set type = port_channel_interfaces[port_channel_interface].type %}
 {%                set mlag = port_channel_interfaces[port_channel_interface].mlag | default ("-")%}
 {%                set ipv6_address = port_channel_interfaces[port_channel_interface].ipv6_address | default ("-")%}
 {%                set vrf = port_channel_interfaces[port_channel_interface].vrf | default ("default")%}
@@ -97,6 +97,42 @@
 {%            endif %}
 {%        endfor %}
 {%    endif %}
+{# OSPF #}
+{%     set po_interface_ospf = namespace() %}
+{%     set po_interface_ospf.configured = false %}
+{%     for port_channel_interface in port_channel_interfaces | arista.avd.natural_sort %}
+{%          if port_channel_interfaces[port_channel_interface].ospf_area is defined %}
+{%              set po_interface_ospf.configured = true %}
+{%          endif %}
+{%     endfor %}
+{%     set port_channel_interface_ospf = namespace() %}
+{%     set port_channel_interface_ospf.configured = false %}
+{%     if port_channel_interfaces is defined and port_channel_interfaces is not none %}
+{%         for port_channel_interface in port_channel_interfaces | arista.avd.natural_sort %}
+{%              if port_channel_interfaces[port_channel_interface].ospf_area is defined %}
+{%                  set port_channel_interface_ospf.configured = true %}
+{%              endif %}
+{%         endfor %}
+{%     endif %}
+{%     if po_interface_ospf.configured == true or port_channel_interface_ospf.configured == true %}
+
+#### OSPF
+
+| Interface | Channel Group | Area | Cost | Mode |
+| --------- | ------------- | ---- | ---- |----- |
+{%         for port_channel_interface in port_channel_interfaces | arista.avd.natural_sort %}
+{%             if port_channel_interfaces[port_channel_interface].channel_group.id is defined and port_channel_interfaces[port_channel_interface].channel_group.id is not none %}
+{%                 set port_channel_interface = 'Port-Channel' + port_channel_interfaces[port_channel_interface].channel_group.id | string %}
+{%                 if port_channel_interfaces[port_channel_interface].ospf_area is defined and port_channel_interfaces[port_channel_interface].ospf_area is not none %}
+| {{ port_channel_interface }} | {% if port_channel_interfaces[port_channel_interface].channel_group.id is defined and port_channel_interfaces[port_channel_interface].channel_group.id is not none %} {{ port_channel_interfaces[port_channel_interface].channel_group.id }} {% else %} - {% endif %} | *{{ port_channel_interfaces[port_channel_interface].ospf_area }} | {% if port_channel_interfaces[port_channel_interface].ospf_cost is defined and port_channel_interfaces[port_channel_interface].ospf_cost is not none %} *{{ port_channel_interfaces[port_channel_interface].ospf_cost }} {% else %} *- {% endif %} | {% if port_channel_interfaces[port_channel_interface].ospf_network_point_to_point is defined and port_channel_interfaces[port_channel_interface].ospf_network_point_to_point is not none and port_channel_interfaces[port_channel_interface].ospf_network_point_to_point == true %} *point-to-point {% else %} *broadcast {% endif %} |
+{%                 endif %}
+{%             else %}
+{%                 if port_channel_interfaces[port_channel_interface].ospf_area is defined and port_channel_interfaces[port_channel_interface].ospf_area is not none %}
+| {{ port_channel_interface }} | - | {{ port_channel_interfaces[port_channel_interface].ospf_area }} | {% if port_channel_interfaces[port_channel_interface].ospf_cost is defined and port_channel_interfaces[port_channel_interface].ospf_cost is not none %} {{ port_channel_interfaces[port_channel_interface].ospf_cost }} {% else %} - {% endif %} | {% if port_channel_interfaces[port_channel_interface].ospf_network_point_to_point is defined and port_channel_interfaces[port_channel_interface].ospf_network_point_to_point is not none and port_channel_interfaces[port_channel_interface].ospf_network_point_to_point == true %} point-to-point {% else %} broadcast {% endif %} |
+{%                endif %}
+{%             endif %}
+{%          endfor %}
+{%     endif %}
 
 ### Port-Channel Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/port-channel-interfaces.j2
@@ -29,6 +29,7 @@
 | {{ port_channel_interface }} | {{ description }} | {{ type }} | {{ mode }} | {{ vlans }} | {{ native_vlan }} | {{ l2.trunk_groups }} | {{ lacp_fallback_timeout }} | {{ lacp_fallback_mode }} | {{ mlag }} | {{ esi }} |
 {%         endif %}
 {%   endfor %}
+
 {# IPv4 #}
 {%   set port_channel_interface_ipv4 = namespace() %}
 {%   set port_channel_interface_ipv4.configured = false %}
@@ -40,7 +41,6 @@
 {%        endfor %}
 {%    endif %}
 {%    if port_channel_interface_ipv4.configured == true %}
-
 #### IPv4
 
 | Interface | Description | Type | MLAG ID | IP Address | VRF | MTU | Shutdown | ACL In | ACL Out |
@@ -59,6 +59,7 @@
 | {{ port_channel_interface }} | {{ description }} | {{ type }} | {{ mlag }} | {{ ip_address }} | {{ vrf }} | {{ mtu }} | {{ shutdown | lower }} | {{ acl_in }} | {{ acl_out }} |
 {%            endif %}
 {%        endfor %}
+
 {%    endif %}
 {# IPv6 #}
 {%   set port_channel_interface_ipv6 = namespace() %}
@@ -71,7 +72,6 @@
 {%        endfor %}
 {%    endif %}
 {%    if port_channel_interface_ipv6.configured == true %}
-
 #### IPv6
 
 | Interface | Description | Type | MLAG ID | IPv6 Address | VRF | MTU | Shutdown | ND RA Disabled | Managed Config Flag | IPv6 ACL In | IPv6 ACL Out |
@@ -113,9 +113,9 @@
 {%                  set port_channel_interface_ospf.configured = true %}
 {%              endif %}
 {%         endfor %}
+
 {%     endif %}
 {%     if po_interface_ospf.configured == true or port_channel_interface_ospf.configured == true %}
-
 #### OSPF
 
 | Interface | Channel Group | Area | Cost | Mode |
@@ -132,8 +132,8 @@
 {%                endif %}
 {%             endif %}
 {%          endfor %}
-{%     endif %}
 
+{%     endif %}
 ### Port-Channel Interfaces Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -1,13 +1,13 @@
 {# eos - Ethernet Interfaces #}
-{% if ethernet_interfaces is defined and ethernet_interfaces is not none %}
+{% if ethernet_interfaces is arista.avd.defined %}
 {%     for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort %}
 !
 interface {{ ethernet_interface }}
-{%         if ethernet_interfaces[ethernet_interface].description is defined and ethernet_interfaces[ethernet_interface].description is not none %}
+{%         if ethernet_interfaces[ethernet_interface].description is arista.avd.defined %}
    description {{ ethernet_interfaces[ethernet_interface].description }}
 {%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].logging is defined and ethernet_interfaces[ethernet_interface].logging is not none %}
-{%             if ethernet_interfaces[ethernet_interface].logging.event is defined and ethernet_interfaces[ethernet_interface].logging.event is not none %}
+{%         if ethernet_interfaces[ethernet_interface].logging is arista.avd.defined %}
+{%             if ethernet_interfaces[ethernet_interface].logging.event is arista.avd.defined %}
 {%                 if ethernet_interfaces[ethernet_interface].logging.event.link_status is defined and ethernet_interfaces[ethernet_interface].logging.event.link_status == true %}
    logging event link-status
 {%                 endif %}
@@ -18,134 +18,134 @@ interface {{ ethernet_interface }}
 {%         elif ethernet_interfaces[ethernet_interface].shutdown is defined and ethernet_interfaces[ethernet_interface].shutdown == false %}
    no shutdown
 {%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].speed is defined and ethernet_interfaces[ethernet_interface].speed is not none %}
+{%         if ethernet_interfaces[ethernet_interface].speed is arista.avd.defined %}
    speed {{ ethernet_interfaces[ethernet_interface].speed }}
 {%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].mac_security.profile is defined and ethernet_interfaces[ethernet_interface].mac_security.profile is not none %}
+{%         if ethernet_interfaces[ethernet_interface].mac_security.profile is arista.avd.defined %}
    mac security profile {{ ethernet_interfaces[ethernet_interface].mac_security.profile }}
 {%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].channel_group is defined and ethernet_interfaces[ethernet_interface].channel_group is not none %}
+{%         if ethernet_interfaces[ethernet_interface].channel_group is arista.avd.defined %}
    channel-group {{ ethernet_interfaces[ethernet_interface].channel_group.id }} mode {{ ethernet_interfaces[ethernet_interface].channel_group.mode }}
 {%         else %}
 {%             if ethernet_interfaces[ethernet_interface].mtu is defined and ethernet_interfaces[ethernet_interface].mtu != 1500 %}
    mtu {{ ethernet_interfaces[ethernet_interface].mtu }}
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].type is defined and ethernet_interfaces[ethernet_interface].type == "routed" %}
+{%             if ethernet_interfaces[ethernet_interface].type is arista.avd.defined("routed") %}
    no switchport
 {%             else %}
    switchport
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].flowcontrol is defined and ethernet_interfaces[ethernet_interface].flowcontrol is not none %}
-{%                 if ethernet_interfaces[ethernet_interface].flowcontrol.received is defined and ethernet_interfaces[ethernet_interface].flowcontrol.received is not none %}
+{%             if ethernet_interfaces[ethernet_interface].flowcontrol is arista.avd.defined %}
+{%                 if ethernet_interfaces[ethernet_interface].flowcontrol.received is arista.avd.defined %}
    flowcontrol receive {{ ethernet_interfaces[ethernet_interface].flowcontrol.received }}
 {%                 endif %}
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].mode is defined and ethernet_interfaces[ethernet_interface].mode == "access" %}
+{%             if ethernet_interfaces[ethernet_interface].mode is arista.avd.defined("access") %}
    switchport access vlan {{ ethernet_interfaces[ethernet_interface].vlans }}
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].vlans is defined and ethernet_interfaces[ethernet_interface].mode == "trunk" %}
+{%             if ethernet_interfaces[ethernet_interface].vlans is arista.avd.defined and ethernet_interfaces[ethernet_interface].mode == "trunk" %}
    switchport trunk allowed vlan {{ ethernet_interfaces[ethernet_interface].vlans }}
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].native_vlan is defined and ethernet_interfaces[ethernet_interface].mode == "trunk" %}
+{%             if ethernet_interfaces[ethernet_interface].native_vlan is arista.avd.defined and ethernet_interfaces[ethernet_interface].mode == "trunk" %}
    switchport trunk native vlan {{ ethernet_interfaces[ethernet_interface].native_vlan }}
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].mode is defined and ethernet_interfaces[ethernet_interface].mode == "trunk" %}
+{%             if ethernet_interfaces[ethernet_interface].mode is arista.avd.defined("trunk") %}
    switchport mode {{ ethernet_interfaces[ethernet_interface].mode }}
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].trunk_groups is defined and ethernet_interfaces[ethernet_interface].trunk_groups is not none %}
+{%             if ethernet_interfaces[ethernet_interface].trunk_groups is arista.avd.defined %}
 {%                 for  trunk_group in ethernet_interfaces[ethernet_interface].trunk_groups | arista.avd.natural_sort %}
    switchport trunk group {{ trunk_group }}
 {%                 endfor %}
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].qos is defined %}
-{%                 if ethernet_interfaces[ethernet_interface].qos.trust is defined and ethernet_interfaces[ethernet_interface].qos.trust is not none %}
+{%             if ethernet_interfaces[ethernet_interface].qos is arista.avd.defined %}
+{%                 if ethernet_interfaces[ethernet_interface].qos.trust is arista.avd.defined %}
    qos trust {{ ethernet_interfaces[ethernet_interface].qos.trust }}
 {%                 endif %}
-{%                 if ethernet_interfaces[ethernet_interface].qos.dscp is defined and ethernet_interfaces[ethernet_interface].qos.dscp is not none %}
+{%                 if ethernet_interfaces[ethernet_interface].qos.dscp is arista.avd.defined %}
    qos dscp {{ ethernet_interfaces[ethernet_interface].qos.dscp }}
 {%                 endif %}
-{%                 if ethernet_interfaces[ethernet_interface].qos.cos is defined and ethernet_interfaces[ethernet_interface].qos.cos is not none %}
+{%                 if ethernet_interfaces[ethernet_interface].qos.cos is arista.avd.defined %}
    qos cos {{ ethernet_interfaces[ethernet_interface].qos.cos }}
 {%                 endif %}
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].spanning_tree_portfast is defined and ethernet_interfaces[ethernet_interface].spanning_tree_portfast == 'edge' %}
+{%             if ethernet_interfaces[ethernet_interface].spanning_tree_portfast is arista.avd.defined('edge') %}
    spanning-tree portfast
-{%             elif ethernet_interfaces[ethernet_interface].spanning_tree_portfast is defined and ethernet_interfaces[ethernet_interface].spanning_tree_portfast == 'network' %}
+{%             elif ethernet_interfaces[ethernet_interface].spanning_tree_portfast is arista.avd.defined('network') %}
    spanning-tree portfast network
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].spanning_tree_bpdufilter is defined and ethernet_interfaces[ethernet_interface].spanning_tree_bpdufilter == true %}
+{%             if ethernet_interfaces[ethernet_interface].spanning_tree_bpdufilter is arista.avd.defined(true) %}
    spanning-tree bpdufilter enable
 {%             endif%}
-{%             if ethernet_interfaces[ethernet_interface].spanning_tree_bpduguard is defined and ethernet_interfaces[ethernet_interface].spanning_tree_bpduguard == true %}
+{%             if ethernet_interfaces[ethernet_interface].spanning_tree_bpduguard is arista.avd.defined(true) %}
    spanning-tree bpduguard enable
 {%             endif%}
-{%             if ethernet_interfaces[ethernet_interface].vrf is defined and ethernet_interfaces[ethernet_interface].vrf is not none %}
+{%             if ethernet_interfaces[ethernet_interface].vrf is arista.avd.defined %}
    vrf {{ ethernet_interfaces[ethernet_interface].vrf }}
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].ip_proxy_arp is defined and ethernet_interfaces[ethernet_interface].ip_proxy_arp == true %}
+{%             if ethernet_interfaces[ethernet_interface].ip_proxy_arp is arista.avd.defined(true) %}
    ip proxy-arp
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].ip_address is defined and ethernet_interfaces[ethernet_interface].ip_address is not none %}
+{%             if ethernet_interfaces[ethernet_interface].ip_address is arista.avd.defined %}
    ip address {{ ethernet_interfaces[ethernet_interface].ip_address }}
-{%                 if ethernet_interfaces[ethernet_interface].ip_address_secondaries is defined and ethernet_interfaces[ethernet_interface].ip_address_secondaries is not none %}
+{%                 if ethernet_interfaces[ethernet_interface].ip_address_secondaries is arista.avd.defined %}
 {%                     for ip_address_secondary in ethernet_interfaces[ethernet_interface].ip_address_secondaries %}
    ip address {{ ip_address_secondary }} secondary
 {%                     endfor %}
 {%                 endif %}
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].ipv6_enable is defined and ethernet_interfaces[ethernet_interface].ipv6_enable == true %}
+{%             if ethernet_interfaces[ethernet_interface].ipv6_enable is arista.avd.defined(true) %}
    ipv6 enable
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].ipv6_address is defined and ethernet_interfaces[ethernet_interface].ipv6_address is not none %}
+{%             if ethernet_interfaces[ethernet_interface].ipv6_address is arista.avd.defined %}
    ipv6 address {{ ethernet_interfaces[ethernet_interface].ipv6_address }}
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].ipv6_address_link_local is defined and ethernet_interfaces[ethernet_interface].ipv6_address_link_local is not none %}
+{%             if ethernet_interfaces[ethernet_interface].ipv6_address_link_local is arista.avd.defined %}
    ipv6 address {{ ethernet_interfaces[ethernet_interface].ipv6_address_link_local }} link-local
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].ipv6_nd_ra_disabled is defined and ethernet_interfaces[ethernet_interface].ipv6_nd_ra_disabled == true %}
+{%             if ethernet_interfaces[ethernet_interface].ipv6_nd_ra_disabled is arista.avd.defined(true) %}
    ipv6 nd ra disabled
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].ipv6_nd_managed_config_flag is defined and ethernet_interfaces[ethernet_interface].ipv6_nd_managed_config_flag == true %}
+{%             if ethernet_interfaces[ethernet_interface].ipv6_nd_managed_config_flag is arista.avd.defined(true) %}
    ipv6 nd managed-config-flag
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].ipv6_nd_prefixes is defined and ethernet_interfaces[ethernet_interface].ipv6_nd_prefixes is not none %}
+{%             if ethernet_interfaces[ethernet_interface].ipv6_nd_prefixes is arista.avd.defined %}
 {%                 for prefix in ethernet_interfaces[ethernet_interface].ipv6_nd_prefixes %}
-   ipv6 nd prefix {{ prefix }} {% if ethernet_interfaces[ethernet_interface].ipv6_nd_prefixes[prefix].valid_lifetime is defined and ethernet_interfaces[ethernet_interface].ipv6_nd_prefixes[prefix].valid_lifetime is not none %}{{ ethernet_interfaces[ethernet_interface].ipv6_nd_prefixes[prefix].valid_lifetime }} {% endif %}{% if ethernet_interfaces[ethernet_interface].ipv6_nd_prefixes[prefix].preferred_lifetime is defined and ethernet_interfaces[ethernet_interface].ipv6_nd_prefixes[prefix].preferred_lifetime is not none %}{{ ethernet_interfaces[ethernet_interface].ipv6_nd_prefixes[prefix].preferred_lifetime }} {% endif %}{% if ethernet_interfaces[ethernet_interface].ipv6_nd_prefixes[prefix].no_autoconfig_flag is defined and ethernet_interfaces[ethernet_interface].ipv6_nd_prefixes[prefix].no_autoconfig_flag == true %}no-autoconfig{% endif %}
+   ipv6 nd prefix {{ prefix }} {% if ethernet_interfaces[ethernet_interface].ipv6_nd_prefixes[prefix].valid_lifetime is arista.avd.defined %}{{ ethernet_interfaces[ethernet_interface].ipv6_nd_prefixes[prefix].preferred_lifetime }} {% endif %}{% if ethernet_interfaces[ethernet_interface].ipv6_nd_prefixes[prefix].no_autoconfig_flag is defined and ethernet_interfaces[ethernet_interface].ipv6_nd_prefixes[prefix].no_autoconfig_flag == true %}no-autoconfig{% endif %}
 
 {%                 endfor %}
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].access_group_in is defined and ethernet_interfaces[ethernet_interface].access_group_in is not none %}
+{%             if ethernet_interfaces[ethernet_interface].access_group_in is arista.avd.defined %}
    ip access-group {{ ethernet_interfaces[ethernet_interface].access_group_in }} in
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].access_group_out is defined and ethernet_interfaces[ethernet_interface].access_group_out is not none %}
+{%             if ethernet_interfaces[ethernet_interface].access_group_out is arista.avd.defined %}
    ip access-group {{ ethernet_interfaces[ethernet_interface].access_group_out }} out
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].ipv6_access_group_in is defined and ethernet_interfaces[ethernet_interface].ipv6_access_group_in is not none %}
+{%             if ethernet_interfaces[ethernet_interface].ipv6_access_group_in is arista.avd.defined %}
    ipv6 access-group {{ ethernet_interfaces[ethernet_interface].ipv6_access_group_in }} in
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].ipv6_access_group_out is defined and ethernet_interfaces[ethernet_interface].ipv6_access_group_out is not none %}
+{%             if ethernet_interfaces[ethernet_interface].ipv6_access_group_out is arista.avd.defined %}
    ipv6 access-group {{ ethernet_interfaces[ethernet_interface].ipv6_access_group_out }} out
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].ospf_network_point_to_point is defined and ethernet_interfaces[ethernet_interface].ospf_network_point_to_point == true %}
+{%             if ethernet_interfaces[ethernet_interface].ospf_network_point_to_point is arista.avd.defined(true) %}
    ip ospf network point-to-point
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].ospf_area is defined and ethernet_interfaces[ethernet_interface].ospf_area is not none %}
+{%             if ethernet_interfaces[ethernet_interface].ospf_area is arista.avd.defined %}
    ip ospf area {{ ethernet_interfaces[ethernet_interface].ospf_area }}
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].ospf_cost is defined and ethernet_interfaces[ethernet_interface].ospf_cost is not none %}
+{%             if ethernet_interfaces[ethernet_interface].ospf_cost is arista.avd.defined %}
    ip ospf cost {{ ethernet_interfaces[ethernet_interface].ospf_cost }}
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].ospf_authentication is defined and ethernet_interfaces[ethernet_interface].ospf_authentication is not none %}
+{%             if ethernet_interfaces[ethernet_interface].ospf_authentication is arista.avd.defined %}
 {%                 if ethernet_interfaces[ethernet_interface].ospf_authentication == "simple" %}
    ip ospf authentication
 {%                 elif ethernet_interfaces[ethernet_interface].ospf_authentication == "message-digest" %}
    ip ospf authentication message-digest
 {%                 endif %}
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].ospf_authentication_key is defined and ethernet_interfaces[ethernet_interface].ospf_authentication_key is not none %}
+{%             if ethernet_interfaces[ethernet_interface].ospf_authentication_key is arista.avd.defined %}
    ip ospf authentication-key 7 {{ ethernet_interfaces[ethernet_interface].ospf_authentication_key }}
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].ospf_message_digest_keys is defined and ethernet_interfaces[ethernet_interface].ospf_message_digest_keys is not none %}
+{%             if ethernet_interfaces[ethernet_interface].ospf_message_digest_keys is arista.avd.defined %}
 {%               for ospf_message_digest_key in ethernet_interfaces[ethernet_interface].ospf_message_digest_keys | arista.avd.natural_sort %}
    ip ospf message-digest-key {{ ospf_message_digest_key }} {{ ethernet_interfaces[ethernet_interface].ospf_message_digest_keys[ospf_message_digest_key].hash_algorithm }} 7 {{ ethernet_interfaces[ethernet_interface].ospf_message_digest_keys[ospf_message_digest_key].key }}
 {%               endfor %}
@@ -153,23 +153,23 @@ interface {{ ethernet_interface }}
 {%             if ethernet_interfaces[ethernet_interface].isis_enable is defined %}
    isis enable {{ ethernet_interfaces[ethernet_interface].isis_enable }}
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].isis_passive is defined and ethernet_interfaces[ethernet_interface].isis_passive == true %}
+{%             if ethernet_interfaces[ethernet_interface].isis_passive is arista.avd.defined(true) %}
    isis passive
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].isis_metric is defined %}
+{%             if ethernet_interfaces[ethernet_interface].isis_metric is arista.avd.defined %}
    isis metric {{ ethernet_interfaces[ethernet_interface].isis_metric }}
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].isis_network_point_to_point is defined and ethernet_interfaces[ethernet_interface].isis_network_point_to_point == true %}
+{%             if ethernet_interfaces[ethernet_interface].isis_network_point_to_point is arista.avd.defined(true) %}
    isis network point-to-point
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].pim.ipv4.sparse_mode is defined and ethernet_interfaces[ethernet_interface].pim.ipv4.sparse_mode == true %}
+{%             if ethernet_interfaces[ethernet_interface].pim.ipv4.sparse_mode is arista.avd.defined(true) %}
    pim ipv4 sparse-mode
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].vmtracer is defined and ethernet_interfaces[ethernet_interface].vmtracer == true %}
+{%             if ethernet_interfaces[ethernet_interface].vmtracer is arista.avd.defined(true) %}
    vmtracer vmware-esx
 {%             endif %}
 {%             if ethernet_interfaces[ethernet_interface].ptp is defined %}
-{%                 if ethernet_interfaces[ethernet_interface].ptp.enable is defined and ethernet_interfaces[ethernet_interface].ptp.enable == true %}
+{%                 if ethernet_interfaces[ethernet_interface].ptp.enable is arista.avd.defined(true) %}
    ptp enable
 {%                 endif %}
 {%                 if ethernet_interfaces[ethernet_interface].ptp.announce is defined and ethernet_interfaces[ethernet_interface].ptp.announce is not none %}
@@ -199,12 +199,12 @@ interface {{ ethernet_interface }}
    ptp transport {{ ethernet_interfaces[ethernet_interface].ptp.transport }}
 {%                 endif %}
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].service_profile is defined and ethernet_interfaces[ethernet_interface].service_profile is not none %}
+{%             if ethernet_interfaces[ethernet_interface].service_profile is arista.avd.defined %}
    service-profile {{ ethernet_interfaces[ethernet_interface].service_profile }}
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].storm_control is defined and ethernet_interfaces[ethernet_interface].storm_control is not none %}
+{%             if ethernet_interfaces[ethernet_interface].storm_control is arista.avd.defined %}
 {%                   for section in ethernet_interfaces[ethernet_interface].storm_control | arista.avd.natural_sort %}
-{%                      if ethernet_interfaces[ethernet_interface].storm_control[section].unit is defined and ethernet_interfaces[ethernet_interface].storm_control[section].unit == "pps" %}
+{%                      if ethernet_interfaces[ethernet_interface].storm_control[section].unit is arista.avd.defined("pps") %}
    storm-control {{ section | replace("_", "-") }} level pps {{ethernet_interfaces[ethernet_interface].storm_control[section].level}}
 {%                      else %}
    storm-control {{ section | replace("_", "-") }} level {{ethernet_interfaces[ethernet_interface].storm_control[section].level}}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -32,7 +32,7 @@ interface {{ ethernet_interface }}
 {%             endif %}
 {%             if ethernet_interfaces[ethernet_interface].type is arista.avd.defined("routed") %}
    no switchport
-{%             else %}
+{%             elif ethernet_interfaces[ethernet_interface].type is arista.avd.defined("switched") %}
    switchport
 {%             endif %}
 {%             if ethernet_interfaces[ethernet_interface].flowcontrol is arista.avd.defined %}
@@ -56,6 +56,9 @@ interface {{ ethernet_interface }}
 {%                 for  trunk_group in ethernet_interfaces[ethernet_interface].trunk_groups | arista.avd.natural_sort %}
    switchport trunk group {{ trunk_group }}
 {%                 endfor %}
+{%             endif %}
+{%             if ethernet_interfaces[ethernet_interface].encapsulation.dot1q.vlan is defined %}
+   encapsulation dot1q vlan {{ ethernet_interfaces[ethernet_interface].encapsulation.dot1q.vlan }}
 {%             endif %}
 {%             if ethernet_interfaces[ethernet_interface].qos is arista.avd.defined %}
 {%                 if ethernet_interfaces[ethernet_interface].qos.trust is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -30,9 +30,13 @@ interface {{ ethernet_interface }}
 {%             if ethernet_interfaces[ethernet_interface].mtu is defined and ethernet_interfaces[ethernet_interface].mtu != 1500 %}
    mtu {{ ethernet_interfaces[ethernet_interface].mtu }}
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].type is arista.avd.defined("routed") %}
+{%             if ethernet_interfaces[ethernet_interface].type is arista.avd.defined and ethernet_interfaces[ethernet_interface].type in ["routed"] %}
    no switchport
-{%             elif ethernet_interfaces[ethernet_interface].type is arista.avd.defined("switched") %}
+{%             elif ethernet_interfaces[ethernet_interface].type is arista.avd.defined and ethernet_interfaces[ethernet_interface].type in ['switched'] %}
+   switchport
+{%             elif ethernet_interfaces[ethernet_interface].type is arista.avd.defined and ethernet_interfaces[ethernet_interface].type in ['l3dot1q', 'l2dot1q'] %}
+{#                Just to skip as we don't want to write a CLI in this scenario #}
+{%             else %}
    switchport
 {%             endif %}
 {%             if ethernet_interfaces[ethernet_interface].flowcontrol is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
@@ -23,7 +23,8 @@ interface {{ port_channel_interface }}
 {%         endif %}
 {%         if port_channel_interfaces[port_channel_interface].type is arista.avd.defined("routed") %}
    no switchport
-{%         elif port_channel_interfaces[port_channel_interface].type is arista.avd.defined("switched") %}
+{%         elif port_channel_interfaces[port_channel_interface].type is arista.avd.defined("switched")
+               or port_channel_interfaces[port_channel_interface].type is not defined %}
    switchport
 {%         endif %}
 {%         if port_channel_interfaces[port_channel_interface].mode is arista.avd.defined("access") %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
@@ -1,32 +1,32 @@
 {# eos- Port-Channel Interfaces #}
-{% if port_channel_interfaces is defined and port_channel_interfaces is not none %}
+{% if port_channel_interfaces is arista.avd.defined %}
 {%     for port_channel_interface in port_channel_interfaces | arista.avd.natural_sort %}
 !
 interface {{ port_channel_interface }}
-{%         if port_channel_interfaces[port_channel_interface].description is defined and port_channel_interfaces[port_channel_interface].description is not none %}
+{%         if port_channel_interfaces[port_channel_interface].description is arista.avd.defined %}
    description {{ port_channel_interfaces[port_channel_interface].description }}
 {%         endif %}
-{%         if port_channel_interfaces[port_channel_interface].logging is defined and port_channel_interfaces[port_channel_interface].logging is not none %}
-{%             if port_channel_interfaces[port_channel_interface].logging.event is defined and port_channel_interfaces[port_channel_interface].logging.event is not none %}
+{%         if port_channel_interfaces[port_channel_interface].logging is arista.avd.defined %}
+{%             if port_channel_interfaces[port_channel_interface].logging.event is arista.avd.defined %}
 {%                 if port_channel_interfaces[port_channel_interface].logging.event.link_status is defined and port_channel_interfaces[port_channel_interface].logging.event.link_status == true %}
    logging event link-status
 {%                 endif %}
 {%             endif %}
 {%         endif %}
-{%         if port_channel_interfaces[port_channel_interface].shutdown is defined and port_channel_interfaces[port_channel_interface].shutdown == true %}
+{%         if port_channel_interfaces[port_channel_interface].shutdown is arista.avd.defined(true) %}
    shutdown
-{%         elif port_channel_interfaces[port_channel_interface].shutdown is defined and port_channel_interfaces[port_channel_interface].shutdown == false %}
+{%         elif port_channel_interfaces[port_channel_interface].shutdown is arista.avd.defined(false) %}
    no shutdown
 {%         endif %}
-{%         if port_channel_interfaces[port_channel_interface].mtu is defined and port_channel_interfaces[port_channel_interface].mtu is not none %}
+{%         if port_channel_interfaces[port_channel_interface].mtu is arista.avd.defined %}
    mtu {{ port_channel_interfaces[port_channel_interface].mtu }}
 {%         endif %}
-{%         if port_channel_interfaces[port_channel_interface].type is defined and port_channel_interfaces[port_channel_interface].type == "routed" %}
+{%         if port_channel_interfaces[port_channel_interface].type is arista.avd.defined("routed") %}
    no switchport
-{%         else %}
+{%         elif port_channel_interfaces[port_channel_interface].type is arista.avd.defined("switched") %}
    switchport
 {%         endif %}
-{%         if port_channel_interfaces[port_channel_interface].mode is defined and port_channel_interfaces[port_channel_interface].mode == "access" %}
+{%         if port_channel_interfaces[port_channel_interface].mode is arista.avd.defined("access") %}
    switchport access vlan {{ port_channel_interfaces[port_channel_interface].vlans }}
 {%         endif %}
 {%         if port_channel_interfaces[port_channel_interface].vlans is defined and port_channel_interfaces[port_channel_interface].mode == "trunk" %}
@@ -35,105 +35,132 @@ interface {{ port_channel_interface }}
 {%         if port_channel_interfaces[port_channel_interface].native_vlan is defined and port_channel_interfaces[port_channel_interface].mode == "trunk" %}
    switchport trunk native vlan {{ port_channel_interfaces[port_channel_interface].native_vlan }}
 {%         endif %}
-{%         if port_channel_interfaces[port_channel_interface].mode is defined and port_channel_interfaces[port_channel_interface].mode == "trunk" %}
+{%         if port_channel_interfaces[port_channel_interface].mode is arista.avd.defined("trunk") %}
    switchport mode {{ port_channel_interfaces[port_channel_interface].mode }}
 {%         endif %}
-{%         if port_channel_interfaces[port_channel_interface].trunk_groups is defined %}
+{%         if port_channel_interfaces[port_channel_interface].trunk_groups is arista.avd.defined %}
 {%             for  trunk_group in port_channel_interfaces[port_channel_interface].trunk_groups | arista.avd.natural_sort %}
    switchport trunk group {{ trunk_group }}
 {%             endfor %}
 {%         endif %}
-{%         if port_channel_interfaces[port_channel_interface].mlag is defined and port_channel_interfaces[port_channel_interface].mlag is not none %}
+{%         if port_channel_interfaces[port_channel_interface].encapsulation.dot1q.vlan is defined %}
+   encapsulation dot1q vlan {{ port_channel_interfaces[port_channel_interface].encapsulation.dot1q.vlan }}
+{%         endif %}
+{%         if port_channel_interfaces[port_channel_interface].mlag is arista.avd.defined %}
    mlag {{ port_channel_interfaces[port_channel_interface].mlag }}
 {%         endif %}
-{%         if port_channel_interfaces[port_channel_interface].esi is defined and port_channel_interfaces[port_channel_interface].esi is not none %}
+{%         if port_channel_interfaces[port_channel_interface].esi is arista.avd.defined %}
    !
     evpn ethernet-segment
        identifier {{ port_channel_interfaces[port_channel_interface].esi }}
-{%             if port_channel_interfaces[port_channel_interface].rt is defined and port_channel_interfaces[port_channel_interface].rt is not none %}
+{%             if port_channel_interfaces[port_channel_interface].rt is arista.avd.defined %}
        route-target import {{ port_channel_interfaces[port_channel_interface].rt }}
 {%             endif %}
    !
 {%         endif %}
-{%         if port_channel_interfaces[port_channel_interface].lacp_id is defined and port_channel_interfaces[port_channel_interface].lacp_id is not none %}
+{%         if port_channel_interfaces[port_channel_interface].lacp_id is arista.avd.defined %}
    lacp system-id {{ port_channel_interfaces[port_channel_interface].lacp_id }}
 {%         endif %}
-{%         if port_channel_interfaces[port_channel_interface].lacp_fallback_timeout is defined and port_channel_interfaces[port_channel_interface].lacp_fallback_timeout is not none %}
+{%         if port_channel_interfaces[port_channel_interface].lacp_fallback_timeout is arista.avd.defined %}
    port-channel lacp fallback timeout {{ lacp_fallback_timeout }}
 {%         endif %}
-{%         if port_channel_interfaces[port_channel_interface].lacp_fallback_mode is defined and port_channel_interfaces[port_channel_interface].lacp_fallback_mode is not none %}
+{%         if port_channel_interfaces[port_channel_interface].lacp_fallback_mode is arista.avd.defined %}
    port-channel lacp fallback {{ lacp_fallback_mode }}
 {%         endif %}
 {%         if port_channel_interfaces[port_channel_interface].qos is defined %}
-{%             if port_channel_interfaces[port_channel_interface].qos.trust is defined and port_channel_interfaces[port_channel_interface].qos.trust is not none %}
+{%             if port_channel_interfaces[port_channel_interface].qos.trust is arista.avd.defined %}
    qos trust {{ port_channel_interfaces[port_channel_interface].qos.trust }}
 {%             endif %}
-{%             if port_channel_interfaces[port_channel_interface].qos.dscp is defined and port_channel_interfaces[port_channel_interface].qos.dscp is not none %}
+{%             if port_channel_interfaces[port_channel_interface].qos.dscp is arista.avd.defined %}
    qos dscp {{ port_channel_interfaces[port_channel_interface].qos.dscp }}
 {%             endif %}
-{%             if port_channel_interfaces[port_channel_interface].qos.cos is defined and port_channel_interfaces[port_channel_interface].qos.cos is not none %}
+{%             if port_channel_interfaces[port_channel_interface].qos.cos is arista.avd.defined %}
    qos cos {{ port_channel_interfaces[port_channel_interface].qos.cos }}
 {%             endif %}
 {%         endif %}
-{%         if port_channel_interfaces[port_channel_interface].spanning_tree_portfast is defined and port_channel_interfaces[port_channel_interface].spanning_tree_portfast == 'edge' %}
+{%         if port_channel_interfaces[port_channel_interface].spanning_tree_portfast is arista.avd.defined('edge') %}
    spanning-tree portfast
-{%         elif port_channel_interfaces[port_channel_interface].spanning_tree_portfast is defined and port_channel_interfaces[port_channel_interface].spanning_tree_portfast == 'network' %}
+{%         elif port_channel_interfaces[port_channel_interface].spanning_tree_portfast is arista.avd.defined('network') %}
    spanning-tree portfast network
 {%         endif %}
-{%         if port_channel_interfaces[port_channel_interface].spanning_tree_bpdufilter is defined and port_channel_interfaces[port_channel_interface].spanning_tree_bpdufilter == true %}
+{%         if port_channel_interfaces[port_channel_interface].spanning_tree_bpdufilter is arista.avd.defined(true) %}
    spanning-tree bpdufilter enable
 {%         endif%}
-{%         if port_channel_interfaces[port_channel_interface].spanning_tree_bpduguard is defined and port_channel_interfaces[port_channel_interface].spanning_tree_bpduguard == true %}
+{%         if port_channel_interfaces[port_channel_interface].spanning_tree_bpduguard is arista.avd.defined(true) %}
    spanning-tree bpduguard enable
 {%         endif%}
-{%         if port_channel_interfaces[port_channel_interface].vrf is defined and port_channel_interfaces[port_channel_interface].vrf is not none %}
+{%         if port_channel_interfaces[port_channel_interface].vrf is arista.avd.defined %}
    vrf {{ port_channel_interfaces[port_channel_interface].vrf }}
 {%         endif %}
-{%             if port_channel_interfaces[port_channel_interface].ip_proxy_arp is defined and port_channel_interfaces[port_channel_interface].ip_proxy_arp == true %}
+{%             if port_channel_interfaces[port_channel_interface].ip_proxy_arp is arista.avd.defined(true) %}
    ip proxy-arp
 {%             endif %}
-{%         if port_channel_interfaces[port_channel_interface].ip_address is defined and port_channel_interfaces[port_channel_interface].ip_address is not none %}
+{%         if port_channel_interfaces[port_channel_interface].ip_address is arista.avd.defined %}
    ip address {{ port_channel_interfaces[port_channel_interface].ip_address }}
 {%         endif %}
-{%         if port_channel_interfaces[port_channel_interface].ipv6_enable is defined and port_channel_interfaces[port_channel_interface].ipv6_enable == true %}
+{%         if port_channel_interfaces[port_channel_interface].ipv6_enable is arista.avd.defined(true) %}
    ipv6 enable
 {%         endif %}
-{%         if port_channel_interfaces[port_channel_interface].ipv6_address is defined and port_channel_interfaces[port_channel_interface].ipv6_address is not none %}
+{%         if port_channel_interfaces[port_channel_interface].ipv6_address is arista.avd.defined %}
    ipv6 address {{ port_channel_interfaces[port_channel_interface].ipv6_address }}
 {%         endif %}
-{%         if port_channel_interfaces[port_channel_interface].ipv6_address_link_local is defined and port_channel_interfaces[port_channel_interface].ipv6_address_link_local is not none %}
+{%         if port_channel_interfaces[port_channel_interface].ipv6_address_link_local is arista.avd.defined %}
    ipv6 address {{ port_channel_interfaces[port_channel_interface].ipv6_address_link_local }} link-local
 {%         endif %}
-{%         if port_channel_interfaces[port_channel_interface].ipv6_nd_ra_disabled is defined and port_channel_interfaces[port_channel_interface].ipv6_nd_ra_disabled == true %}
+{%         if port_channel_interfaces[port_channel_interface].ipv6_nd_ra_disabled is arista.avd.defined(true) %}
    ipv6 nd ra disabled
 {%         endif %}
-{%             if port_channel_interfaces[port_channel_interface].ipv6_nd_managed_config_flag is defined and port_channel_interfaces[port_channel_interface].ipv6_nd_managed_config_flag == true %}
+{%             if port_channel_interfaces[port_channel_interface].ipv6_nd_managed_config_flag is arista.avd.defined(true) %}
    ipv6 nd managed-config-flag
 {%             endif %}
-{%             if port_channel_interfaces[port_channel_interface].ipv6_nd_prefixes is defined and port_channel_interfaces[port_channel_interface].ipv6_nd_prefixes is not none %}
+{%             if port_channel_interfaces[port_channel_interface].ipv6_nd_prefixes is arista.avd.defined %}
 {%                 for prefix in port_channel_interfaces[port_channel_interface].ipv6_nd_prefixes %}
-   ipv6 nd prefix {{ prefix }} {% if port_channel_interfaces[port_channel_interface].ipv6_nd_prefixes[prefix].valid_lifetime is defined and port_channel_interfaces[port_channel_interface].ipv6_nd_prefixes[prefix].valid_lifetime is not none %}{{ port_channel_interfaces[port_channel_interface].ipv6_nd_prefixes[prefix].valid_lifetime }} {% endif %}{% if port_channel_interfaces[port_channel_interface].ipv6_nd_prefixes[prefix].preferred_lifetime is defined and port_channel_interfaces[port_channel_interface].ipv6_nd_prefixes[prefix].preferred_lifetime is not none %}{{ port_channel_interfaces[port_channel_interface].ipv6_nd_prefixes[prefix].preferred_lifetime }} {% endif %}{% if port_channel_interfaces[port_channel_interface].ipv6_nd_prefixes[prefix].no_autoconfig_flag is defined and port_channel_interfaces[port_channel_interface].ipv6_nd_prefixes[prefix].no_autoconfig_flag == true %}no-autoconfig{% endif %}
+   ipv6 nd prefix {{ prefix }} {% if port_channel_interfaces[port_channel_interface].ipv6_nd_prefixes[prefix].valid_lifetime is arista.avd.defined %}{{ port_channel_interfaces[port_channel_interface].ipv6_nd_prefixes[prefix].preferred_lifetime }} {% endif %}{% if port_channel_interfaces[port_channel_interface].ipv6_nd_prefixes[prefix].no_autoconfig_flag is arista.avd.defined(true) %}no-autoconfig{% endif %}
 
 {%                 endfor %}
 {%             endif %}
-{%         if port_channel_interfaces[port_channel_interface].access_group_in is defined and port_channel_interfaces[port_channel_interface].access_group_in is not none %}
+{%         if port_channel_interfaces[port_channel_interface].access_group_in is arista.avd.defined %}
    ip access-group {{ port_channel_interfaces[port_channel_interface].access_group_in }} in
 {%            endif %}
-{%         if port_channel_interfaces[port_channel_interface].access_group_out is defined and port_channel_interfaces[port_channel_interface].access_group_out is not none %}
+{%         if port_channel_interfaces[port_channel_interface].access_group_out is arista.avd.defined %}
    ip access-group {{ port_channel_interfaces[port_channel_interface].access_group_out }} out
 {%            endif %}
-{%         if port_channel_interfaces[port_channel_interface].ipv6_access_group_in is defined and port_channel_interfaces[port_channel_interface].ipv6_access_group_in is not none %}
+{%         if port_channel_interfaces[port_channel_interface].ipv6_access_group_in is arista.avd.defined %}
    ipv6 access-group {{ port_channel_interfaces[port_channel_interface].ipv6_access_group_in }} in
 {%            endif %}
-{%         if port_channel_interfaces[port_channel_interface].ipv6_access_group_out is defined and port_channel_interfaces[port_channel_interface].ipv6_access_group_out is not none %}
+{%         if port_channel_interfaces[port_channel_interface].ipv6_access_group_out is arista.avd.defined %}
    ipv6 access-group {{ port_channel_interfaces[port_channel_interface].ipv6_access_group_out }} out
 {%            endif %}
-{%         if port_channel_interfaces[port_channel_interface].pim is defined and port_channel_interfaces[port_channel_interface].pim is not none %}
-{%            if port_channel_interfaces[port_channel_interface].pim.ipv4.sparse_mode is defined and port_channel_interfaces[port_channel_interface].pim.ipv4.sparse_mode == true %}
+{%            if port_channel_interfaces[port_channel_interface].ospf_network_point_to_point is arista.avd.defined(true) %}
+   ip ospf network point-to-point
+{%            endif %}
+{%            if port_channel_interfaces[port_channel_interface].ospf_area is arista.avd.defined %}
+   ip ospf area {{ port_channel_interfaces[port_channel_interface].ospf_area }}
+{%            endif %}
+{%            if port_channel_interfaces[port_channel_interface].ospf_cost is arista.avd.defined %}
+   ip ospf cost {{ port_channel_interfaces[port_channel_interface].ospf_cost }}
+{%            endif %}
+{%            if port_channel_interfaces[port_channel_interface].ospf_authentication is arista.avd.defined %}
+{%                if port_channel_interfaces[port_channel_interface].ospf_authentication == "simple" %}
+   ip ospf authentication
+{%                elif port_channel_interfaces[port_channel_interface].ospf_authentication == "message-digest" %}
+   ip ospf authentication message-digest
+{%                endif %}
+{%            endif %}
+{%            if port_channel_interfaces[port_channel_interface].ospf_authentication_key is arista.avd.defined %}
+   ip ospf authentication-key 7 {{ port_channel_interfaces[port_channel_interface].ospf_authentication_key }}
+{%            endif %}
+{%            if port_channel_interfaces[port_channel_interface].ospf_message_digest_keys is arista.avd.defined %}
+{%              for ospf_message_digest_key in port_channel_interfaces[port_channel_interface].ospf_message_digest_keys | arista.avd.natural_sort %}
+   ip ospf message-digest-key {{ ospf_message_digest_key }} {{ port_channel_interfaces[port_channel_interface].ospf_message_digest_keys[ospf_message_digest_key].hash_algorithm }} 7 {{ port_channel_interfaces[port_channel_interface].ospf_message_digest_keys[ospf_message_digest_key].key }}
+{%              endfor %}
+{%            endif %}
+{%         if port_channel_interfaces[port_channel_interface].pim is arista.avd.defined %}
+{%            if port_channel_interfaces[port_channel_interface].pim.ipv4.sparse_mode is arista.avd.defined(true) %}
    pim ipv4 sparse-mode
 {%            endif %}
 {%         endif %}
-{%         if port_channel_interfaces[port_channel_interface].vmtracer is defined and port_channel_interfaces[port_channel_interface].vmtracer == true %}
+{%         if port_channel_interfaces[port_channel_interface].vmtracer is arista.avd.defined(true) %}
    vmtracer vmware-esx
 {%         endif %}
 {%         if port_channel_interfaces[port_channel_interface].ptp is defined %}
@@ -170,10 +197,10 @@ interface {{ port_channel_interface }}
 {%         if port_channel_interfaces[port_channel_interface].service_profile is defined and port_channel_interfaces[port_channel_interface].service_profile is not none %}
    service-profile {{ port_channel_interfaces[port_channel_interface].service_profile }}
 {%         endif %}
-{%         if port_channel_interfaces[port_channel_interface].storm_control is defined and port_channel_interfaces[port_channel_interface].storm_control is not none %}
+{%         if port_channel_interfaces[port_channel_interface].storm_control is arista.avd.defined %}
 {%             for section in port_channel_interfaces[port_channel_interface].storm_control | arista.avd.natural_sort %}
-{%                if port_channel_interfaces[port_channel_interface].storm_control[section].unit is defined and port_channel_interfaces[port_channel_interface].storm_control[section].unit == "pps" %}
-   storm-control {{ section | replace("_", "-") }} level pps {{port_channel_interfaces[port_channel_interface].storm_control[section].level}}
+{%                if port_channel_interfaces[port_channel_interface].storm_control[section].unit is arista.avd.defined("pps") %}
+   storm-control {{ section }} level pps {{port_channel_interfaces[port_channel_interface].storm_control[section].level}}
 {%                else %}
    storm-control {{ section | replace("_", "-") }} level {{port_channel_interfaces[port_channel_interface].storm_control[section].level}}
 {%                endif %}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Bot will manage tag, ownership and code review, you should not update these fields-->
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Fixes #546 
Fixes #492 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

1. Implement new interface type for both `ethernet_interfaces` and `port_channels`:

```yaml
ethernet_interfaces:
  Ethernet1:
    description: to WAN-ISP1-01 Ethernet2
    type: routed
  Ethernet1.101:
    description: to WAN-ISP-01 Ethernet2.101 - VRF-C1
    type: l3dot1q
    encapsulation:
      dot1q:
        vlan: 101

port_channel_interfaces:
  Port-Channel8:
    description: to Dev02 Port-channel 8
    type: routed
  Port-Channel8.101:
    description: to Dev02 Port-Channel8.101 - VRF-C1
    type: l3dot1q
    encapsulation:
      dot1q:
        vlan: 101
```

2. Implement OSPF on Port Channel interfaces
3. Refactor to use `arista.avd.defined` test plugin

## How to test

Molecule for `arista.avd.eos_cli_config_gen`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
