### PR TITLE
Fix template to support unknown_unicast key for storm-control in port-channel

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
@@ -314,6 +314,9 @@ interface Port-Channel5
    switchport trunk allowed vlan 110,201
    switchport mode trunk
    mlag 5
+   storm-control broadcast level 1
+   storm-control multicast level 1
+   storm-control unknown-unicast level 1
 !
 interface Port-Channel50
    description SRV-POD03_PortChanne1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
@@ -21,6 +21,9 @@ interface Port-Channel5
    switchport trunk allowed vlan 110,201
    switchport mode trunk
    mlag 5
+   storm-control broadcast level 1
+   storm-control multicast level 1
+   storm-control unknown-unicast level 1
 !
 interface Port-Channel50
    description SRV-POD03_PortChanne1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
@@ -6,6 +6,16 @@ port_channel_interfaces:
     vlans: 110,201
     mode: trunk
     mlag: 5
+    storm_control:
+      broadcast:
+        level: 1
+        unit: percent
+      multicast:
+        level: 1
+        unit: percent
+      unknown_unicast:
+        level: 1
+        unit: percent
 
 
   Port-Channel3:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
@@ -142,9 +142,9 @@ interface {{ port_channel_interface }}
 {%         if port_channel_interfaces[port_channel_interface].storm_control is defined and port_channel_interfaces[port_channel_interface].storm_control is not none %}
 {%             for section in port_channel_interfaces[port_channel_interface].storm_control | arista.avd.natural_sort %}
 {%                if port_channel_interfaces[port_channel_interface].storm_control[section].unit is defined and port_channel_interfaces[port_channel_interface].storm_control[section].unit == "pps" %}
-   storm-control {{ section }} level pps {{port_channel_interfaces[port_channel_interface].storm_control[section].level}}
+   storm-control {{ section | replace("_", "-") }} level pps {{port_channel_interfaces[port_channel_interface].storm_control[section].level}}
 {%                else %}
-   storm-control {{ section }} level {{port_channel_interfaces[port_channel_interface].storm_control[section].level}}
+   storm-control {{ section | replace("_", "-") }} level {{port_channel_interfaces[port_channel_interface].storm_control[section].level}}
 {%                endif %}
 {%             endfor %}
 {%         endif %}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Bot will manage tag, ownership and code review, you should not update these fields-->
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Fixes #642

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Add support for `unknown_unicast` keyword under storm-control for port-channel interfaces since it is already supported for `ethernet_interfaces`

## How to test

Check molecule

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
