### PR TITLE
Add support for multiple custom_structured_configuration prefixes

### DIFF
--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -385,6 +385,7 @@ No Interface Defaults defined
 | Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet6  |  routed  | - |  172.31.255.43/31  |  default  |  1500  |  false  |  -  |  -  |
 | Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet6  |  routed  | - |  172.31.255.45/31  |  default  |  1500  |  false  |  -  |  -  |
 | Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet6  |  routed  | - |  172.31.255.47/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4000 |  My test  |  routed  | - |  10.3.2.1/21  |  default  |  1500  |  false  |  -  |  -  |
 
 ### Ethernet Interfaces Device Configuration
 
@@ -413,6 +414,12 @@ interface Ethernet4
    no shutdown
    no switchport
    ip address 172.31.255.47/31
+!
+interface Ethernet4000
+   description My test
+   no shutdown
+   no switchport
+   ip address 10.3.2.1/21
 ```
 
 ## Port-Channel Interfaces

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -385,6 +385,7 @@ No Interface Defaults defined
 | Ethernet2 |  P2P_LINK_TO_DC1-SPINE2_Ethernet7  |  routed  | - |  172.31.255.51/31  |  default  |  1500  |  false  |  -  |  -  |
 | Ethernet3 |  P2P_LINK_TO_DC1-SPINE3_Ethernet7  |  routed  | - |  172.31.255.53/31  |  default  |  1500  |  false  |  -  |  -  |
 | Ethernet4 |  P2P_LINK_TO_DC1-SPINE4_Ethernet7  |  routed  | - |  172.31.255.55/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4000 |  My test  |  routed  | - |  10.1.2.3/12  |  default  |  1500  |  false  |  -  |  -  |
 
 ### Ethernet Interfaces Device Configuration
 
@@ -413,6 +414,12 @@ interface Ethernet4
    no shutdown
    no switchport
    ip address 172.31.255.55/31
+!
+interface Ethernet4000
+   description My test
+   no shutdown
+   no switchport
+   ip address 10.1.2.3/12
 ```
 
 ## Port-Channel Interfaces

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/fabric/DC1_FABRIC-topology.csv
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/fabric/DC1_FABRIC-topology.csv
@@ -3,10 +3,12 @@ l3leaf,DC1-BL1A,Ethernet1,spine,DC1-SPINE1,Ethernet6
 l3leaf,DC1-BL1A,Ethernet2,spine,DC1-SPINE2,Ethernet6
 l3leaf,DC1-BL1A,Ethernet3,spine,DC1-SPINE3,Ethernet6
 l3leaf,DC1-BL1A,Ethernet4,spine,DC1-SPINE4,Ethernet6
+l3leaf,DC1-BL1A,Ethernet4000,my_precious,MY-own-peer,Ethernet123
 l3leaf,DC1-BL1B,Ethernet1,spine,DC1-SPINE1,Ethernet7
 l3leaf,DC1-BL1B,Ethernet2,spine,DC1-SPINE2,Ethernet7
 l3leaf,DC1-BL1B,Ethernet3,spine,DC1-SPINE3,Ethernet7
 l3leaf,DC1-BL1B,Ethernet4,spine,DC1-SPINE4,Ethernet7
+l3leaf,DC1-BL1B,Ethernet4000,my_precious,MY-own-peer,Ethernet123
 l2leaf,DC1-L2LEAF1A,Ethernet1,l3leaf,DC1-LEAF2A,Ethernet7
 l2leaf,DC1-L2LEAF1A,Ethernet2,l3leaf,DC1-LEAF2B,Ethernet7
 l2leaf,DC1-L2LEAF2A,Ethernet1,l3leaf,DC1-SVC3A,Ethernet7

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1A.cfg
@@ -69,6 +69,12 @@ interface Ethernet4
    no switchport
    ip address 172.31.255.47/31
 !
+interface Ethernet4000
+   description My test
+   no shutdown
+   no switchport
+   ip address 10.3.2.1/21
+!
 interface Loopback0
    description EVPN_Overlay_Peering
    no shutdown

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1B.cfg
@@ -69,6 +69,12 @@ interface Ethernet4
    no switchport
    ip address 172.31.255.55/31
 !
+interface Ethernet4000
+   description My test
+   no shutdown
+   no switchport
+   ip address 10.1.2.3/12
+!
 interface Loopback0
    description EVPN_Overlay_Peering
    no shutdown

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
@@ -136,6 +136,15 @@ ethernet_interfaces:
     type: routed
     shutdown: false
     ip_address: 172.31.255.47/31
+  Ethernet4000:
+    description: My test
+    ip_address: 10.3.2.1/21
+    shutdown: false
+    type: routed
+    mtu: 1500
+    peer: MY-own-peer
+    peer_interface: Ethernet123
+    peer_type: my_precious
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
@@ -136,6 +136,15 @@ ethernet_interfaces:
     type: routed
     shutdown: false
     ip_address: 172.31.255.55/31
+  Ethernet4000:
+    description: My test
+    ip_address: 10.1.2.3/12
+    shutdown: false
+    type: routed
+    mtu: 1500
+    peer: MY-own-peer
+    peer_interface: Ethernet123
+    peer_type: my_precious
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_BL1.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_BL1.yml
@@ -1,0 +1,11 @@
+---
+my_dci_ethernet_interfaces:
+  Ethernet4000:
+    description: My test
+    ip_address: 10.1.2.3/12
+    shutdown: false
+    type: routed
+    mtu: 1500
+    peer: MY-own-peer
+    peer_interface: Ethernet123
+    peer_type: my_precious

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
@@ -189,3 +189,5 @@ bfd_multihop:
   interval: 1200
   min_rx: 1200
   multiplier: 3
+
+custom_structured_configuration_prefix: [ my_dci_ , my_special_dci_ ]

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/host_vars/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/host_vars/DC1-BL1A.yml
@@ -1,0 +1,4 @@
+---
+my_special_dci_ethernet_interfaces:
+  Ethernet4000:
+    ip_address: 10.3.2.1/21

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
@@ -1928,25 +1928,53 @@ Lists are replaced. Dictionaries are updated. The combine is done recursively, s
 ```yaml
 custom_structured_configuration_name_server:
   nodes:
-    - 1.2.3.4
+    - 10.2.3.4
 custom_structured_configuration_ethernet_interfaces:
   Ethernet4000:
     description: My test
-    ip_address: 1.2.3.4/12
+    ip_address: 10.1.2.3/12
+    shutdown: false
+    type: routed
     mtu: 1500
     peer: MY-own-peer
     peer_interface: Ethernet123
     peer_type: my_precious
 ```
-In this example the contents of the `name_server.nodes` variable in the Structured Configuration will be replaced by the list `[ "1.2.3.4" ]`
+In this example the contents of the `name_server.nodes` variable in the Structured Configuration will be replaced by the list `[ "10.2.3.4" ]`
 and `Ethernet4000` will be added to the `ethernet_interfaces` dictionary in the Structured Configuration.
 
 `custom_structured_configuration_prefix` allows the user to customize the prefix for Custom Structured Configuration variables.
-Default value is `custom_structured_configuration_`.
+Default value is `custom_structured_configuration_`. Remember to include any delimiter like the last `_` in this case.
+It is possible to specify a list of prefixes, which will all be merged one by one. The order of merge will start from beginning of the list, which means that keys defined in the later prefixes will be able to override keys defined in previous ones.
 
 ```yaml
 custom_structured_configuration_prefix: < variable_prefix, default -> "custom_structured_configuration_" >
+#or
+custom_structured_configuration_prefix: [ < variable_prefix_1 > , < variable_prefix_2 > , < variable_prefix_3 > ]
 ```
+
+Example using multiple prefixes:
+`
+```yaml
+custom_structured_configuration_prefix: [ my_dci_ , my_special_ ]
+
+my_dci_ethernet_interfaces:
+  Ethernet4000:
+    description: My test
+    ip_address: 10.1.2.3/12
+    shutdown: false
+    type: routed
+    mtu: 1500
+    peer: MY-own-peer
+    peer_interface: Ethernet123
+    peer_type: my_precious
+
+my_special:
+  Ethernet4000:
+    ip_address: 10.3.2.1/21
+```
+
+In this example  `Ethernet4000` will be added to the `ethernet_interfaces` dictionary in the Structured Configuration and the ip_address will be `10.3.2.1/21` since ip_adddress was overridden on the later `custom_scructured_configuration_prefix`
 
 ## License
 

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
@@ -1954,7 +1954,7 @@ custom_structured_configuration_prefix: [ < variable_prefix_1 > , < variable_pre
 ```
 
 Example using multiple prefixes:
-`
+
 ```yaml
 custom_structured_configuration_prefix: [ my_dci_ , my_special_ ]
 

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
@@ -1956,7 +1956,7 @@ custom_structured_configuration_prefix: [ < variable_prefix_1 > , < variable_pre
 Example using multiple prefixes:
 
 ```yaml
-custom_structured_configuration_prefix: [ my_dci_ , my_special_ ]
+custom_structured_configuration_prefix: [ my_dci_ , my_special_dci_ ]
 
 my_dci_ethernet_interfaces:
   Ethernet4000:
@@ -1969,7 +1969,7 @@ my_dci_ethernet_interfaces:
     peer_interface: Ethernet123
     peer_type: my_precious
 
-my_special:
+my_special_dci_ethernet_interfaces:
   Ethernet4000:
     ip_address: 10.3.2.1/21
 ```

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/base/custom_structured_configuration.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/base/custom_structured_configuration.j2
@@ -1,13 +1,26 @@
-{% set tmp_custom_structured_configuration = {} %}
-{% for key_name in hostvars[inventory_hostname].keys() %}
-{%     if key_name | regex_search('^' ~ custom_structured_configuration_prefix) %}
-{%         set tmp_key_name = key_name | regex_replace('^' ~ custom_structured_configuration_prefix) %}
-{%         do tmp_custom_structured_configuration.update( { tmp_key_name : hostvars[inventory_hostname][key_name] } ) %}
+{% set tmp_custom_structured_configurations = [ {} ] %}
+{% if custom_structured_configuration_prefix is arista.avd.defined %}
+{%     if custom_structured_configuration_prefix is string %}
+{%         set tmp_prefixes = [ custom_structured_configuration_prefix ] %}
+{%     else %}
+{%         set tmp_prefixes = custom_structured_configuration_prefix %}
 {%     endif %}
-{% endfor %}
+{%     for tmp_prefix in tmp_prefixes %}
+{%         set tmp_custom_structured_configuration = {} %}
+{%         for key_name in hostvars[inventory_hostname].keys() %}
+{%             if key_name | regex_search('^' ~ tmp_prefix) %}
+{%                 set tmp_key_name = key_name | regex_replace('^' ~ tmp_prefix) %}
+{%                 do tmp_custom_structured_configuration.update( { tmp_key_name : hostvars[inventory_hostname][key_name] } ) %}
+{%             endif %}
+{%         endfor %}
+{%         do tmp_custom_structured_configurations.append( tmp_custom_structured_configuration ) %}
+{%     endfor %}
+{% endif %}
+{# By parsing the list of custom_structured_configurations to the combine filter,    #}
+{# it will apply them one at a time, so the first can be overridden by the next etc. #}
 {{
     lookup('template', root_dir ~ '/intended/structured_configs/' ~ inventory_hostname ~ '.yml') |
     from_yaml |
-    combine(tmp_custom_structured_configuration, recursive=true) |
+    combine(tmp_custom_structured_configurations, recursive=true) |
     to_nice_yaml(indent=2,sort_keys=False)
 }}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Bot will manage tag, ownership and code review, you should not update these fields-->
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Allow multi layered custom_structured_configuration and more flexible naming.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [X] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

## Component(s) name
eos_l3ls_evpn

## Proposed changes
<!--- Describe your changes in detail -->

`custom_structured_configuration_prefix` allows the user to customize the prefix for Custom Structured Configuration variables.
Default value is `custom_structured_configuration_`.	Default value is `custom_structured_configuration_`. Remember to include any delimiter like the last `_` in this case.
It is possible to specify a list of prefixes, which will all be merged one by one. The order of merge will start from beginning of the list, which means that keys defined in the later prefixes will be able to override keys defined in previous ones.

```yaml
custom_structured_configuration_prefix: < variable_prefix, default -> "custom_structured_configuration_" >	custom_structured_configuration_prefix: < variable_prefix, default -> "custom_structured_configuration_" >
#or
custom_structured_configuration_prefix: [ < variable_prefix_1 > , < variable_prefix_2 > , < variable_prefix_3 > ]
```

Example using multiple prefixes:
```yaml
custom_structured_configuration_prefix: [ my_dci_ , my_special_dci_ ]

my_special_dci_ethernet_interfaces:
  Ethernet4000:
    ip_address: 10.3.2.1/21

my_dci_ethernet_interfaces:
  Ethernet4000:
    description: My test
    ip_address: 10.1.2.3/12
    shutdown: false
    type: routed
    mtu: 1500
    peer: MY-own-peer
    peer_interface: Ethernet123
    peer_type: my_precious
```

In this example  `Ethernet4000` will be added to the `ethernet_interfaces` dictionary in the Structured Configuration and the ip_address will be `10.3.2.1/21` since ip_adddress was overridden on the later `custom_scructured_configuration_prefix`


## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Tested with my test repo: https://github.com/ClausHolbechArista/claus-l3ls-dev/commits/superspine-alternative
Following commits show each test scenario.
![image](https://user-images.githubusercontent.com/48674677/105374319-dac80480-5c07-11eb-8f56-34285ca75bbe.png)

- [x] Test without custom config
- [x] Test with default prefix and custom config
- [x] Test with 1 custom prefix but no matching config
- [x] Test with 1 custom prefix and both matching and non-matching custom config (non-matching is just ignored)
- [x] Test with multiple custom prefixes. One using the default name and others using custom names. Also including overrides. 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been rebased from devel before I start
- [X] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
