### PR TITLE
Enhance logging event, tacacs timeout and platform sand multicast replication features

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/aaa.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/aaa.md
@@ -165,8 +165,8 @@ username cvpadmin privilege 15 role network-admin secret sha512 $6$.I7/ZR/zlLIUv
 
 ```eos
 !
-tacacs-server host 10.10.10.157 vrf mgt  key 7 071B245F5A 
-tacacs-server host 10.10.10.249  key 7 071B245F5A 
+tacacs-server host 10.10.10.157 vrf mgt timeout 45 key 7 071B245F5A 
+tacacs-server host 10.10.10.249 key 7 071B245F5A 
 ```
 
 ## IP TACACS Source Interfaces

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -246,6 +246,7 @@ No VLANs defined
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet1
+   logging event link-status
    no switchport
    ip address 172.31.255.1/31
 !
@@ -259,6 +260,7 @@ interface Ethernet2
 !
 interface Ethernet6
    description SRV-POD02_Eth1
+   no logging event link-status
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
 ```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/platform.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/platform.md
@@ -378,6 +378,7 @@ Virtual source NAT not defined
 platform trident forwarding-table partition 2
 platform sand lag hardware-only
 platform sand lag mode 512x32
+platform sand multicast replication default ingress
 ```
 
 # Router L2 VPN

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
@@ -285,6 +285,7 @@ interface Port-Channel3
 !
 interface Port-Channel5
    description DC1_L2LEAF1_Po1
+   no logging event link-status
    switchport trunk allowed vlan 110,201
    switchport mode trunk
    mlag 5

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/aaa.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/aaa.cfg
@@ -8,8 +8,8 @@ aaa group server tacacs+ TACACS
    server 10.10.10.157 vrf mgt
    server 10.10.10.249
 !
-tacacs-server host 10.10.10.157 vrf mgt  key 7 071B245F5A 
-tacacs-server host 10.10.10.249  key 7 071B245F5A 
+tacacs-server host 10.10.10.157 vrf mgt timeout 45 key 7 071B245F5A 
+tacacs-server host 10.10.10.249 key 7 071B245F5A 
 !
 aaa authentication login default group TACACS local
 aaa authentication login serial-console local

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
@@ -8,6 +8,7 @@ no aaa root
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet1
+   logging event link-status
    no switchport
    ip address 172.31.255.1/31
 !
@@ -21,6 +22,7 @@ interface Ethernet2
 !
 interface Ethernet6
    description SRV-POD02_Eth1
+   no logging event link-status
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/platform.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/platform.cfg
@@ -7,6 +7,7 @@ hostname platform
 platform trident forwarding-table partition 2
 platform sand lag hardware-only
 platform sand lag mode 512x32
+platform sand multicast replication default ingress
 !
 no aaa root
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
@@ -15,6 +15,7 @@ interface Port-Channel3
 !
 interface Port-Channel5
    description DC1_L2LEAF1_Po1
+   no logging event link-status
    switchport trunk allowed vlan 110,201
    switchport mode trunk
    mlag 5

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/aaa.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/aaa.yml
@@ -4,6 +4,7 @@ tacacs_servers:
     - host: 10.10.10.157
       vrf: mgt
       key: 071B245F5A
+      timeout: 45
     - host: 10.10.10.249
       key: 071B245F5A
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
@@ -7,6 +7,8 @@ ethernet_interfaces:
     peer_type: spine
     description: P2P_LINK_TO_DC1-SPINE1_Ethernet1
     mtu: 1500
+    logging_event:
+      link_status: true
     type: routed
     ip_address: 172.31.255.1/31
 
@@ -15,6 +17,8 @@ ethernet_interfaces:
     peer_interface: Eth1
     peer_type: server
     description: SRV-POD02_Eth1
+    logging_event:
+      link_status: false
     mode: trunk
     vlans: 110-111,210-211
     profile: ALL

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
@@ -7,8 +7,9 @@ ethernet_interfaces:
     peer_type: spine
     description: P2P_LINK_TO_DC1-SPINE1_Ethernet1
     mtu: 1500
-    logging_event:
-      link_status: true
+    logging:
+      event:
+        link_status: true
     type: routed
     ip_address: 172.31.255.1/31
 
@@ -17,8 +18,9 @@ ethernet_interfaces:
     peer_interface: Eth1
     peer_type: server
     description: SRV-POD02_Eth1
-    logging_event:
-      link_status: false
+    logging:
+      event:
+        link_status: false
     mode: trunk
     vlans: 110-111,210-211
     profile: ALL

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/platform.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/platform.yml
@@ -5,3 +5,5 @@ platform:
     lag:
       hardware_only: true
       mode: "512x32"
+    multicast_replication:
+      default: ingress

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
@@ -5,7 +5,8 @@ port_channel_interfaces:
     description: DC1_L2LEAF1_Po1
     logging:
       event:
-        link_status: false
+        link:
+          status: false
     vlans: 110,201
     mode: trunk
     mlag: 5

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
@@ -3,8 +3,9 @@
 port_channel_interfaces:
   Port-Channel5:
     description: DC1_L2LEAF1_Po1
-    logging_event:
-      link_status: false
+    logging:
+      event:
+        link_status: false
     vlans: 110,201
     mode: trunk
     mlag: 5

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
@@ -3,6 +3,8 @@
 port_channel_interfaces:
   Port-Channel5:
     description: DC1_L2LEAF1_Po1
+    logging_event:
+      link_status: false
     vlans: 110,201
     mode: trunk
     mlag: 5

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
@@ -5,8 +5,7 @@ port_channel_interfaces:
     description: DC1_L2LEAF1_Po1
     logging:
       event:
-        link:
-          status: false
+        link_status: false
     vlans: 110,201
     mode: trunk
     mlag: 5

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -617,8 +617,9 @@ port_channel_interfaces:
   < Port-Channel_interface_1 >:
     description: < description >
     shutdown: < true | false >
-    logging_event:
-      link_status: < true | false >
+    logging:
+      event:
+        link_status: < true | false >
     vlans: "< list of vlans as string >"
     mode: < access | dot1q-tunnel | trunk >
     mlag: < mlag_id >
@@ -647,8 +648,9 @@ port_channel_interfaces:
   < Port-Channel_interface_4 >:
     description: < description >
     mtu: < mtu >
-    logging_event:
-      link_status: < true | false >
+    logging:
+      event:
+        link_status: < true | false >
     type: < switched | routed >
     ip_address:  < IP_address/mask >
     ipv6_enable: < true | false >
@@ -682,8 +684,9 @@ ethernet_interfaces:
     speed: < interface_speed >
     mtu: < mtu >
     type: < routed | switched >
-        logging_event:
-    link_status: < true | false >
+    logging:
+      event:
+        link_status: < true | false >
     vrf: < vrf_name >
     ip_address: < IPv4_address/Mask >
     ipv6_enable: < true | false >
@@ -724,8 +727,9 @@ ethernet_interfaces:
     shutdown: < true | false >
     speed: < interface_speed >
     mtu: < mtu >
-    logging_event:
-      link_status: < true | false >
+    logging:
+      event:
+        link_status: < true | false >
     vlans: "< list of vlans as string >"
     native_vlan: <native vlan number>
     mode: < access | dot1q-tunnel | trunk >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -675,6 +675,8 @@ ethernet_interfaces:
     speed: < interface_speed >
     mtu: < mtu >
     type: < routed | switched >
+        logging_event:
+    link_status: < true | false >
     vrf: < vrf_name >
     ip_address: < IPv4_address/Mask >
     ipv6_enable: < true | false >
@@ -715,6 +717,8 @@ ethernet_interfaces:
     shutdown: < true | false >
     speed: < interface_speed >
     mtu: < mtu >
+    logging_event:
+      link_status: < true | false >
     vlans: "< list of vlans as string >"
     native_vlan: <native vlan number>
     mode: < access | dot1q-tunnel | trunk >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -481,6 +481,7 @@ tacacs_servers:
   hosts:
     - host: < host1_ip_address >
       vrf: < vrf_name >
+      timeout: < timeout_in_seconds >
       key: < encypted_key >
     - host: < host2_ip_address >
       key: < encypted_key >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -470,6 +470,8 @@ platform:
     lag:
       hardware_only: < true | false >
       mode: < mode | default -> 1024x16 >
+    multicast_replication:
+      default: < fabric-egress | ingress >
 ```
 
 ### Tacacs+ Servers

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -614,6 +614,8 @@ port_channel_interfaces:
   < Port-Channel_interface_1 >:
     description: < description >
     shutdown: < true | false >
+    logging_event:
+      link_status: < true | false >
     vlans: "< list of vlans as string >"
     mode: < access | dot1q-tunnel | trunk >
     mlag: < mlag_id >
@@ -642,6 +644,8 @@ port_channel_interfaces:
   < Port-Channel_interface_4 >:
     description: < description >
     mtu: < mtu >
+    logging_event:
+      link_status: < true | false >
     type: < switched | routed >
     ip_address:  < IP_address/mask >
     ipv6_enable: < true | false >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -18,11 +18,13 @@ interface {{ ethernet_interface }}
 {%             if ethernet_interfaces[ethernet_interface].mtu is defined and ethernet_interfaces[ethernet_interface].mtu != 1500 %}
    mtu {{ ethernet_interfaces[ethernet_interface].mtu }}
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].logging_event is defined and ethernet_interfaces[ethernet_interface].logging_event is not none %}
-{%                 if ethernet_interfaces[ethernet_interface].logging_event.link_status is defined and ethernet_interfaces[ethernet_interface].logging_event.link_status == true %}
+{%             if ethernet_interfaces[ethernet_interface].logging is defined and ethernet_interfaces[ethernet_interface].logging is not none %}
+{%                 if ethernet_interfaces[ethernet_interface].logging.event is defined and ethernet_interfaces[ethernet_interface].logging.event is not none %}
+{%                     if ethernet_interfaces[ethernet_interface].logging.event.link_status is defined and ethernet_interfaces[ethernet_interface].logging.event.link_status == true %}
    logging event link-status
-{%                 else %}
+{%                     else %}
    no logging event link-status
+{%                     endif %}
 {%                 endif %}
 {%             endif %}
 {%             if ethernet_interfaces[ethernet_interface].type is defined and ethernet_interfaces[ethernet_interface].type == "routed" %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -18,6 +18,13 @@ interface {{ ethernet_interface }}
 {%             if ethernet_interfaces[ethernet_interface].mtu is defined and ethernet_interfaces[ethernet_interface].mtu != 1500 %}
    mtu {{ ethernet_interfaces[ethernet_interface].mtu }}
 {%             endif %}
+{%             if ethernet_interfaces[ethernet_interface].logging_event is defined and ethernet_interfaces[ethernet_interface].logging_event is not none %}
+{%                 if ethernet_interfaces[ethernet_interface].logging_event.link_status is defined and ethernet_interfaces[ethernet_interface].logging_event.link_status == true %}
+   logging event link-status
+{%                 else %}
+   no logging event link-status
+{%                 endif %}
+{%             endif %}
 {%             if ethernet_interfaces[ethernet_interface].type is defined and ethernet_interfaces[ethernet_interface].type == "routed" %}
    no switchport
 {%             endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/platform.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/platform.j2
@@ -15,5 +15,10 @@ platform sand lag hardware-only
 platform sand lag mode {{ platform.sand.lag.mode }}
 {%             endif %}
 {%         endif %}
+{%         if platform.sand.multicast_replication is defined and platform.sand.multicast_replication is not none %}
+{%             if platform.sand.multicast_replication.default is defined and platform.sand.multicast_replication.default is not none %}
+platform sand multicast replication default {{ platform.sand.multicast_replication.default }}
+{%             endif %}
+{%         endif %}
 {%     endif %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
@@ -12,11 +12,13 @@ interface {{ port_channel_interface }}
 {%         if port_channel_interfaces[port_channel_interface].mtu is defined and port_channel_interfaces[port_channel_interface].mtu is not none %}
    mtu {{ port_channel_interfaces[port_channel_interface].mtu }}
 {%         endif %}
-{%         if port_channel_interfaces[port_channel_interface].logging_event is defined and port_channel_interfaces[port_channel_interface].logging_event is not none %}
-{%             if port_channel_interfaces[port_channel_interface].logging_event.link_status is defined and port_channel_interfaces[port_channel_interface].logging_event.link_status == true %}
+{%         if port_channel_interfaces[port_channel_interface].logging is defined and port_channel_interfaces[port_channel_interface].logging is not none %}
+{%             if port_channel_interfaces[port_channel_interface].logging.event is defined and port_channel_interfaces[port_channel_interface].logging.event is not none %}
+{%                 if port_channel_interfaces[port_channel_interface].logging.event.link_status is defined and port_channel_interfaces[port_channel_interface].logging.event.link_status == true %}
    logging event link-status
-{%             else %}
+{%                 else %}
    no logging event link-status
+{%                 endif %}
 {%             endif %}
 {%         endif %}
 {%         if port_channel_interfaces[port_channel_interface].type is defined and port_channel_interfaces[port_channel_interface].type == "routed" %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
@@ -12,6 +12,13 @@ interface {{ port_channel_interface }}
 {%         if port_channel_interfaces[port_channel_interface].mtu is defined and port_channel_interfaces[port_channel_interface].mtu is not none %}
    mtu {{ port_channel_interfaces[port_channel_interface].mtu }}
 {%         endif %}
+{%         if port_channel_interfaces[port_channel_interface].logging_event is defined and port_channel_interfaces[port_channel_interface].logging_event is not none %}
+{%             if port_channel_interfaces[port_channel_interface].logging_event.link_status is defined and port_channel_interfaces[port_channel_interface].logging_event.link_status == true %}
+   logging event link-status
+{%             else %}
+   no logging event link-status
+{%             endif %}
+{%         endif %}
 {%         if port_channel_interfaces[port_channel_interface].type is defined and port_channel_interfaces[port_channel_interface].type == "routed" %}
    no switchport
 {%         endif %}
@@ -71,7 +78,7 @@ interface {{ port_channel_interface }}
    vrf {{ port_channel_interfaces[port_channel_interface].vrf }}
 {%         endif %}
 {%             if port_channel_interfaces[port_channel_interface].ip_proxy_arp is defined and port_channel_interfaces[port_channel_interface].ip_proxy_arp == true %}
-   ip proxy-arp 
+   ip proxy-arp
 {%             endif %}
 {%         if port_channel_interfaces[port_channel_interface].ip_address is defined and port_channel_interfaces[port_channel_interface].ip_address is not none %}
    ip address {{ port_channel_interfaces[port_channel_interface].ip_address }}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/tacacs-servers.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/tacacs-servers.j2
@@ -3,7 +3,7 @@
 !
 {%    if tacacs_servers.hosts is defined and tacacs_servers.hosts is not none %}
 {%       for host in tacacs_servers.hosts %}
-tacacs-server host {{ host['host'] }} {% if host['vrf'] is defined and host['vrf'] is not none %}vrf {{ host['vrf'] }} {% endif %} {% if host['key'] is defined and host['key'] is not none %}key 7 {{ host['key'] }} {% endif %}
+tacacs-server host {{ host['host'] }}{% if host['vrf'] is defined and host['vrf'] is not none %} vrf {{ host['vrf'] }}{% endif %}{% if host['timeout'] is defined and host['timeout'] is not none %} timeout {{ host['timeout'] }}{% endif %}{% if host['key'] is defined and host['key'] is not none %} key 7 {{ host['key'] }} {% endif %}
 
 {%       endfor %}
 {%    endif %}


### PR DESCRIPTION
## Change Summary
3 Configuration Adds-on in Eos_cli_config_gen: logging event, tacacs timeout and platform sand multicast replication

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

## Component(s) name
Eos_cli_config_gen

## Proposed changes
<!--- Describe your changes in detail -->
Added support for the following configuration lines under ethernet and port-channel interfaces:

- no logging event link-status
- logging event link-status

Added support for the following configuration lines for Sand platforms:

- platform sand multicast replication default fabric-egress
- platform sand multicast replication default ingress

Added support for the timeout configuration on a tacacs server:

- tacacs-server host x.x.x.x timeout xx

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Here are examples for the 3 new features:

1. No logging event:

```yaml
  Port-Channel3:
    logging:
      event:
        link_status: false
```


2. Sand multicast replication type

```yaml
platform:
  sand:
    multicast_replication:
      default: fabric-egress
```

3. Timeout for Tacacs:

```yaml
aaa_server_groups:
  - name: TACACS
    type: tacacs+
    servers:
      - server: 10.10.10.157
        vrf: mgt
      - server: 10.10.10.249
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from release v1.1.x before I start
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
