### PR TITLE
v1.1.3 - Bug Fix release

### DIFF
--- a/ansible_collections/arista/avd/galaxy.yml
+++ b/ansible_collections/arista/avd/galaxy.yml
@@ -36,7 +36,10 @@ tags: ['arista', 'network', 'networking', 'eos', 'avd', 'cloudvision', 'cvp']
 # collection label 'namespace.name'. The value is a version range
 # L(specifiers,https://python-semanticversion.readthedocs.io/en/latest/#requirement-specification). Multiple version
 # range specifiers can be set and are separated by ','
-dependencies: {}
+dependencies:
+    "arista.cvp": "*"
+    "arista.eos": "*"
+    "ansible.netcommon": "*"
 
 # The URL of the originating SCM repository
 repository: https://github.com/aristanetworks/ansible-avd

--- a/ansible_collections/arista/avd/galaxy.yml
+++ b/ansible_collections/arista/avd/galaxy.yml
@@ -9,7 +9,7 @@ namespace: arista
 name: avd
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.1.2
+version: 1.1.3
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/aaa.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/aaa.md
@@ -165,8 +165,8 @@ username cvpadmin privilege 15 role network-admin secret sha512 $6$.I7/ZR/zlLIUv
 
 ```eos
 !
-tacacs-server host 10.10.10.157 vrf mgt  key 7 071B245F5A 
-tacacs-server host 10.10.10.249  key 7 071B245F5A 
+tacacs-server host 10.10.10.157 vrf mgt key 7 071B245F5A 
+tacacs-server host 10.10.10.249 key 7 071B245F5A 
 ```
 
 ## IP TACACS Source Interfaces

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/aaa.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/aaa.cfg
@@ -8,8 +8,8 @@ aaa group server tacacs+ TACACS
    server 10.10.10.157 vrf mgt
    server 10.10.10.249
 !
-tacacs-server host 10.10.10.157 vrf mgt  key 7 071B245F5A 
-tacacs-server host 10.10.10.249  key 7 071B245F5A 
+tacacs-server host 10.10.10.157 vrf mgt key 7 071B245F5A 
+tacacs-server host 10.10.10.249 key 7 071B245F5A 
 !
 aaa authentication login default group TACACS local
 aaa authentication login serial-console local

--- a/ansible_collections/arista/avd/molecule/evpn_l3leaf_no_mlag/documentation/devices/DC1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_l3leaf_no_mlag/documentation/devices/DC1-L2LEAF1A.md
@@ -386,7 +386,7 @@ interface Ethernet2
 
 | Interface | Description | MTU | Type | Mode | Allowed VLANs (trunk) | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI | VRF | IP Address | IPv6 Address |
 | --------- | ----------- | --- | ---- | ---- | --------------------- | ----------- | --------------------- ! ------------------ | ------- | -------- | --- | ---------- | ------------ |
-| Port-Channel1 | DC1-LEAF2A_Po7 | 1500 | switched | trunk | 110-111,120-121,130-131 | - | - | - | 1 | - | - | - | - |
+| Port-Channel1 | DC1-LEAF2A_Po7 | 1500 | switched | trunk | 110-111,120-121,130-131 | - | - | - | - | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -396,7 +396,6 @@ interface Port-Channel1
    description DC1-LEAF2A_Po7
    switchport trunk allowed vlan 110-111,120-121,130-131
    switchport mode trunk
-   mlag 1
 ```
 
 ## Loopback Interfaces

--- a/ansible_collections/arista/avd/molecule/evpn_l3leaf_no_mlag/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/evpn_l3leaf_no_mlag/documentation/devices/DC1-SPINE1.md
@@ -498,6 +498,7 @@ Router ISIS not defined
 | Settings | Value |
 | -------- | ----- |
 | Address Family | ipv4 |
+| Send community | true |
 | Maximum routes | 12000 |
 
 ### BGP Neighbors
@@ -544,6 +545,7 @@ router bgp 65001
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor 172.31.255.1 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.31.255.1 remote-as 65101

--- a/ansible_collections/arista/avd/molecule/evpn_l3leaf_no_mlag/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/evpn_l3leaf_no_mlag/documentation/devices/DC1-SPINE2.md
@@ -498,6 +498,7 @@ Router ISIS not defined
 | Settings | Value |
 | -------- | ----- |
 | Address Family | ipv4 |
+| Send community | true |
 | Maximum routes | 12000 |
 
 ### BGP Neighbors
@@ -544,6 +545,7 @@ router bgp 65001
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor 172.31.255.3 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.31.255.3 remote-as 65101

--- a/ansible_collections/arista/avd/molecule/evpn_l3leaf_no_mlag/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/evpn_l3leaf_no_mlag/documentation/devices/DC1-SPINE3.md
@@ -498,6 +498,7 @@ Router ISIS not defined
 | Settings | Value |
 | -------- | ----- |
 | Address Family | ipv4 |
+| Send community | true |
 | Maximum routes | 12000 |
 
 ### BGP Neighbors
@@ -544,6 +545,7 @@ router bgp 65001
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor 172.31.255.5 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.31.255.5 remote-as 65101

--- a/ansible_collections/arista/avd/molecule/evpn_l3leaf_no_mlag/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/evpn_l3leaf_no_mlag/documentation/devices/DC1-SPINE4.md
@@ -498,6 +498,7 @@ Router ISIS not defined
 | Settings | Value |
 | -------- | ----- |
 | Address Family | ipv4 |
+| Send community | true |
 | Maximum routes | 12000 |
 
 ### BGP Neighbors
@@ -544,6 +545,7 @@ router bgp 65001
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor 172.31.255.7 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.31.255.7 remote-as 65101

--- a/ansible_collections/arista/avd/molecule/evpn_l3leaf_no_mlag/intended/configs/DC1-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_l3leaf_no_mlag/intended/configs/DC1-L2LEAF1A.cfg
@@ -51,7 +51,6 @@ interface Port-Channel1
    description DC1-LEAF2A_Po7
    switchport trunk allowed vlan 110-111,120-121,130-131
    switchport mode trunk
-   mlag 1
 !
 interface Ethernet1
    description DC1-LEAF2A_Ethernet7

--- a/ansible_collections/arista/avd/molecule/evpn_l3leaf_no_mlag/intended/configs/DC1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_l3leaf_no_mlag/intended/configs/DC1-SPINE1.cfg
@@ -99,6 +99,7 @@ router bgp 65001
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor 172.31.255.1 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.31.255.1 remote-as 65101

--- a/ansible_collections/arista/avd/molecule/evpn_l3leaf_no_mlag/intended/configs/DC1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_l3leaf_no_mlag/intended/configs/DC1-SPINE2.cfg
@@ -99,6 +99,7 @@ router bgp 65001
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor 172.31.255.3 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.31.255.3 remote-as 65101

--- a/ansible_collections/arista/avd/molecule/evpn_l3leaf_no_mlag/intended/configs/DC1-SPINE3.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_l3leaf_no_mlag/intended/configs/DC1-SPINE3.cfg
@@ -99,6 +99,7 @@ router bgp 65001
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor 172.31.255.5 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.31.255.5 remote-as 65101

--- a/ansible_collections/arista/avd/molecule/evpn_l3leaf_no_mlag/intended/configs/DC1-SPINE4.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_l3leaf_no_mlag/intended/configs/DC1-SPINE4.cfg
@@ -99,6 +99,7 @@ router bgp 65001
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor 172.31.255.7 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.31.255.7 remote-as 65101

--- a/ansible_collections/arista/avd/molecule/evpn_l3leaf_no_mlag/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_l3leaf_no_mlag/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -125,7 +125,6 @@ port_channel_interfaces:
     description: DC1-LEAF2A_Po7
     vlans: 110-111,120-121,130-131
     mode: trunk
-    mlag: 1
 
 ### Ethernet Interfaces ###
 ethernet_interfaces:

--- a/ansible_collections/arista/avd/molecule/evpn_l3leaf_no_mlag/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_l3leaf_no_mlag/intended/structured_configs/DC1-SPINE1.yml
@@ -215,6 +215,7 @@ router_bgp:
       peer_filter: LEAF-AS-RANGE
       password: "AQQvKeimxJu+uGQ/yYvv9w=="
       maximum_routes: 12000
+      send_community: true
     EVPN-OVERLAY-PEERS:
       type: evpn
       peer_filter: LEAF-AS-RANGE

--- a/ansible_collections/arista/avd/molecule/evpn_l3leaf_no_mlag/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_l3leaf_no_mlag/intended/structured_configs/DC1-SPINE2.yml
@@ -215,6 +215,7 @@ router_bgp:
       peer_filter: LEAF-AS-RANGE
       password: "AQQvKeimxJu+uGQ/yYvv9w=="
       maximum_routes: 12000
+      send_community: true
     EVPN-OVERLAY-PEERS:
       type: evpn
       peer_filter: LEAF-AS-RANGE

--- a/ansible_collections/arista/avd/molecule/evpn_l3leaf_no_mlag/intended/structured_configs/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_l3leaf_no_mlag/intended/structured_configs/DC1-SPINE3.yml
@@ -215,6 +215,7 @@ router_bgp:
       peer_filter: LEAF-AS-RANGE
       password: "AQQvKeimxJu+uGQ/yYvv9w=="
       maximum_routes: 12000
+      send_community: true
     EVPN-OVERLAY-PEERS:
       type: evpn
       peer_filter: LEAF-AS-RANGE

--- a/ansible_collections/arista/avd/molecule/evpn_l3leaf_no_mlag/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_l3leaf_no_mlag/intended/structured_configs/DC1-SPINE4.yml
@@ -215,6 +215,7 @@ router_bgp:
       peer_filter: LEAF-AS-RANGE
       password: "AQQvKeimxJu+uGQ/yYvv9w=="
       maximum_routes: 12000
+      send_community: true
     EVPN-OVERLAY-PEERS:
       type: evpn
       peer_filter: LEAF-AS-RANGE

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF1A.md
@@ -386,7 +386,7 @@ interface Ethernet2
 
 | Interface | Description | MTU | Type | Mode | Allowed VLANs (trunk) | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI | VRF | IP Address | IPv6 Address |
 | --------- | ----------- | --- | ---- | ---- | --------------------- | ----------- | --------------------- ! ------------------ | ------- | -------- | --- | ---------- | ------------ |
-| Port-Channel1 | DC1-LEAF2A_Po7 | 1500 | switched | trunk | 110-111,120-121,130-131 | - | - | - | 1 | - | - | - | - |
+| Port-Channel1 | DC1-LEAF2A_Po7 | 1500 | switched | trunk | 110-111,120-121,130-131 | - | - | - | - | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -396,7 +396,6 @@ interface Port-Channel1
    description DC1-LEAF2A_Po7
    switchport trunk allowed vlan 110-111,120-121,130-131
    switchport mode trunk
-   mlag 1
 ```
 
 ## Loopback Interfaces

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE1.md
@@ -498,6 +498,7 @@ Router ISIS not defined
 | Settings | Value |
 | -------- | ----- |
 | Address Family | ipv4 |
+| Send community | true |
 | Maximum routes | 12000 |
 
 ### BGP Neighbors
@@ -544,6 +545,7 @@ router bgp 65001
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor 172.31.255.1 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.31.255.1 remote-as 65101

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE2.md
@@ -498,6 +498,7 @@ Router ISIS not defined
 | Settings | Value |
 | -------- | ----- |
 | Address Family | ipv4 |
+| Send community | true |
 | Maximum routes | 12000 |
 
 ### BGP Neighbors
@@ -544,6 +545,7 @@ router bgp 65001
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor 172.31.255.3 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.31.255.3 remote-as 65101

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE3.md
@@ -498,6 +498,7 @@ Router ISIS not defined
 | Settings | Value |
 | -------- | ----- |
 | Address Family | ipv4 |
+| Send community | true |
 | Maximum routes | 12000 |
 
 ### BGP Neighbors
@@ -544,6 +545,7 @@ router bgp 65001
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor 172.31.255.5 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.31.255.5 remote-as 65101

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE4.md
@@ -498,6 +498,7 @@ Router ISIS not defined
 | Settings | Value |
 | -------- | ----- |
 | Address Family | ipv4 |
+| Send community | true |
 | Maximum routes | 12000 |
 
 ### BGP Neighbors
@@ -544,6 +545,7 @@ router bgp 65001
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor 172.31.255.7 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.31.255.7 remote-as 65101

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF1A.cfg
@@ -51,7 +51,6 @@ interface Port-Channel1
    description DC1-LEAF2A_Po7
    switchport trunk allowed vlan 110-111,120-121,130-131
    switchport mode trunk
-   mlag 1
 !
 interface Ethernet1
    description DC1-LEAF2A_Ethernet7

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE1.cfg
@@ -99,6 +99,7 @@ router bgp 65001
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor 172.31.255.1 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.31.255.1 remote-as 65101

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE2.cfg
@@ -99,6 +99,7 @@ router bgp 65001
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor 172.31.255.3 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.31.255.3 remote-as 65101

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE3.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE3.cfg
@@ -99,6 +99,7 @@ router bgp 65001
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor 172.31.255.5 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.31.255.5 remote-as 65101

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE4.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE4.cfg
@@ -99,6 +99,7 @@ router bgp 65001
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor 172.31.255.7 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.31.255.7 remote-as 65101

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
@@ -251,6 +251,7 @@ vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING
     ip_address: 10.255.251.10/31
+    mtu: 1500
   Vlan4094:
     description: MLAG_PEER
     ip_address: 10.255.252.10/31

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
@@ -251,6 +251,7 @@ vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING
     ip_address: 10.255.251.11/31
+    mtu: 1500
   Vlan4094:
     description: MLAG_PEER
     ip_address: 10.255.252.11/31

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -125,7 +125,6 @@ port_channel_interfaces:
     description: DC1-LEAF2A_Po7
     vlans: 110-111,120-121,130-131
     mode: trunk
-    mlag: 1
 
 ### Ethernet Interfaces ###
 ethernet_interfaces:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -337,6 +337,7 @@ vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING
     ip_address: 10.255.251.2/31
+    mtu: 1500
   Vlan4094:
     description: MLAG_PEER
     ip_address: 10.255.252.2/31

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -337,6 +337,7 @@ vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING
     ip_address: 10.255.251.3/31
+    mtu: 1500
   Vlan4094:
     description: MLAG_PEER
     ip_address: 10.255.252.3/31

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
@@ -215,6 +215,7 @@ router_bgp:
       peer_filter: LEAF-AS-RANGE
       password: "AQQvKeimxJu+uGQ/yYvv9w=="
       maximum_routes: 12000
+      send_community: true
     EVPN-OVERLAY-PEERS:
       type: evpn
       peer_filter: LEAF-AS-RANGE

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
@@ -215,6 +215,7 @@ router_bgp:
       peer_filter: LEAF-AS-RANGE
       password: "AQQvKeimxJu+uGQ/yYvv9w=="
       maximum_routes: 12000
+      send_community: true
     EVPN-OVERLAY-PEERS:
       type: evpn
       peer_filter: LEAF-AS-RANGE

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
@@ -215,6 +215,7 @@ router_bgp:
       peer_filter: LEAF-AS-RANGE
       password: "AQQvKeimxJu+uGQ/yYvv9w=="
       maximum_routes: 12000
+      send_community: true
     EVPN-OVERLAY-PEERS:
       type: evpn
       peer_filter: LEAF-AS-RANGE

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
@@ -215,6 +215,7 @@ router_bgp:
       peer_filter: LEAF-AS-RANGE
       password: "AQQvKeimxJu+uGQ/yYvv9w=="
       maximum_routes: 12000
+      send_community: true
     EVPN-OVERLAY-PEERS:
       type: evpn
       peer_filter: LEAF-AS-RANGE

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -379,6 +379,7 @@ vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING
     ip_address: 10.255.251.6/31
+    mtu: 1500
   Vlan4094:
     description: MLAG_PEER
     ip_address: 10.255.252.6/31

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -363,6 +363,7 @@ vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING
     ip_address: 10.255.251.7/31
+    mtu: 1500
   Vlan4094:
     description: MLAG_PEER
     ip_address: 10.255.252.7/31

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
@@ -173,3 +173,5 @@ bfd_multihop:
   interval: 1200
   min_rx: 1200
   multiplier: 3
+
+custom_structured_configuration_prefix: [ 'my_dci_', 'my_special_dci_' ]

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-L2LEAF1A.md
@@ -354,7 +354,7 @@ interface Ethernet2
 
 | Interface | Description | MTU | Type | Mode | Allowed VLANs (trunk) | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI | VRF | IP Address | IPv6 Address |
 | --------- | ----------- | --- | ---- | ---- | --------------------- | ----------- | --------------------- ! ------------------ | ------- | -------- | --- | ---------- | ------------ |
-| Port-Channel1 | DC1-LEAF2A_Po7 | 1500 | switched | trunk |  | - | - | - | 1 | - | - | - | - |
+| Port-Channel1 | DC1-LEAF2A_Po7 | 1500 | switched | trunk |  | - | - | - | - | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -364,7 +364,6 @@ interface Port-Channel1
    description DC1-LEAF2A_Po7
    switchport trunk allowed vlan 
    switchport mode trunk
-   mlag 1
 ```
 
 ## Loopback Interfaces

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-L2LEAF1A.cfg
@@ -31,7 +31,6 @@ interface Port-Channel1
    description DC1-LEAF2A_Po7
    switchport trunk allowed vlan 
    switchport mode trunk
-   mlag 1
 !
 interface Ethernet1
    description DC1-LEAF2A_Ethernet7

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-BL1A.yml
@@ -229,6 +229,7 @@ vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING
     ip_address: 10.255.251.10/31
+    mtu: 1500
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
     isis_network_point_to_point: true

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-BL1B.yml
@@ -229,6 +229,7 @@ vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING
     ip_address: 10.255.251.11/31
+    mtu: 1500
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
     isis_network_point_to_point: true

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -106,7 +106,6 @@ port_channel_interfaces:
     description: DC1-LEAF2A_Po7
     vlans: 
     mode: trunk
-    mlag: 1
 
 ### Ethernet Interfaces ###
 ethernet_interfaces:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -243,6 +243,7 @@ vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING
     ip_address: 10.255.251.2/31
+    mtu: 1500
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
     isis_network_point_to_point: true

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -243,6 +243,7 @@ vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING
     ip_address: 10.255.251.3/31
+    mtu: 1500
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
     isis_network_point_to_point: true

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SVC3A.yml
@@ -252,6 +252,7 @@ vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING
     ip_address: 10.255.251.6/31
+    mtu: 1500
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
     isis_network_point_to_point: true

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SVC3B.yml
@@ -252,6 +252,7 @@ vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING
     ip_address: 10.255.251.7/31
+    mtu: 1500
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
     isis_network_point_to_point: true

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-L2LEAF1A.md
@@ -354,7 +354,7 @@ interface Ethernet2
 
 | Interface | Description | MTU | Type | Mode | Allowed VLANs (trunk) | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI | VRF | IP Address | IPv6 Address |
 | --------- | ----------- | --- | ---- | ---- | --------------------- | ----------- | --------------------- ! ------------------ | ------- | -------- | --- | ---------- | ------------ |
-| Port-Channel1 | DC1-LEAF2A_Po7 | 1500 | switched | trunk |  | - | - | - | 1 | - | - | - | - |
+| Port-Channel1 | DC1-LEAF2A_Po7 | 1500 | switched | trunk |  | - | - | - | - | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -364,7 +364,6 @@ interface Port-Channel1
    description DC1-LEAF2A_Po7
    switchport trunk allowed vlan 
    switchport mode trunk
-   mlag 1
 ```
 
 ## Loopback Interfaces

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-L2LEAF1A.cfg
@@ -31,7 +31,6 @@ interface Port-Channel1
    description DC1-LEAF2A_Po7
    switchport trunk allowed vlan 
    switchport mode trunk
-   mlag 1
 !
 interface Ethernet1
    description DC1-LEAF2A_Ethernet7

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
@@ -223,9 +223,9 @@ vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING
     ip_address: 10.255.251.10/31
+    mtu: 1500
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
-    mtu: 1500
   Vlan4094:
     description: MLAG_PEER
     ip_address: 10.255.252.10/31

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
@@ -223,9 +223,9 @@ vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING
     ip_address: 10.255.251.11/31
+    mtu: 1500
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
-    mtu: 1500
   Vlan4094:
     description: MLAG_PEER
     ip_address: 10.255.252.11/31

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -106,7 +106,6 @@ port_channel_interfaces:
     description: DC1-LEAF2A_Po7
     vlans: 
     mode: trunk
-    mlag: 1
 
 ### Ethernet Interfaces ###
 ethernet_interfaces:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -237,9 +237,9 @@ vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING
     ip_address: 10.255.251.2/31
+    mtu: 1500
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
-    mtu: 1500
   Vlan4094:
     description: MLAG_PEER
     ip_address: 10.255.252.2/31

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -237,9 +237,9 @@ vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING
     ip_address: 10.255.251.3/31
+    mtu: 1500
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
-    mtu: 1500
   Vlan4094:
     description: MLAG_PEER
     ip_address: 10.255.252.3/31

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -246,9 +246,9 @@ vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING
     ip_address: 10.255.251.6/31
+    mtu: 1500
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
-    mtu: 1500
   Vlan4094:
     description: MLAG_PEER
     ip_address: 10.255.252.6/31

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -246,9 +246,9 @@ vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING
     ip_address: 10.255.251.7/31
+    mtu: 1500
     ospf_network_point_to_point: true
     ospf_area: 0.0.0.0
-    mtu: 1500
   Vlan4094:
     description: MLAG_PEER
     ip_address: 10.255.252.7/31

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-L2LEAF1A.md
@@ -386,7 +386,7 @@ interface Ethernet2
 
 | Interface | Description | MTU | Type | Mode | Allowed VLANs (trunk) | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI | VRF | IP Address | IPv6 Address |
 | --------- | ----------- | --- | ---- | ---- | --------------------- | ----------- | --------------------- ! ------------------ | ------- | -------- | --- | ---------- | ------------ |
-| Port-Channel1 | DC1-LEAF2A_Po7 | 1500 | switched | trunk | 110-111,120-121,130-131 | - | - | - | 1 | - | - | - | - |
+| Port-Channel1 | DC1-LEAF2A_Po7 | 1500 | switched | trunk | 110-111,120-121,130-131 | - | - | - | - | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -396,7 +396,6 @@ interface Port-Channel1
    description DC1-LEAF2A_Po7
    switchport trunk allowed vlan 110-111,120-121,130-131
    switchport mode trunk
-   mlag 1
 ```
 
 ## Loopback Interfaces

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-SPINE1.md
@@ -498,6 +498,7 @@ Router ISIS not defined
 | Settings | Value |
 | -------- | ----- |
 | Address Family | ipv4 |
+| Send community | true |
 | Maximum routes | 12000 |
 
 ### BGP Neighbors
@@ -544,6 +545,7 @@ router bgp 65001
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor 172.31.255.1 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.31.255.1 remote-as 65101

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-SPINE2.md
@@ -498,6 +498,7 @@ Router ISIS not defined
 | Settings | Value |
 | -------- | ----- |
 | Address Family | ipv4 |
+| Send community | true |
 | Maximum routes | 12000 |
 
 ### BGP Neighbors
@@ -544,6 +545,7 @@ router bgp 65001
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor 172.31.255.3 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.31.255.3 remote-as 65101

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-SPINE3.md
@@ -498,6 +498,7 @@ Router ISIS not defined
 | Settings | Value |
 | -------- | ----- |
 | Address Family | ipv4 |
+| Send community | true |
 | Maximum routes | 12000 |
 
 ### BGP Neighbors
@@ -544,6 +545,7 @@ router bgp 65001
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor 172.31.255.5 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.31.255.5 remote-as 65101

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/documentation/devices/DC1-SPINE4.md
@@ -498,6 +498,7 @@ Router ISIS not defined
 | Settings | Value |
 | -------- | ----- |
 | Address Family | ipv4 |
+| Send community | true |
 | Maximum routes | 12000 |
 
 ### BGP Neighbors
@@ -544,6 +545,7 @@ router bgp 65001
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor 172.31.255.7 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.31.255.7 remote-as 65101

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-L2LEAF1A.cfg
@@ -49,7 +49,6 @@ interface Port-Channel1
    description DC1-LEAF2A_Po7
    switchport trunk allowed vlan 110-111,120-121,130-131
    switchport mode trunk
-   mlag 1
 !
 interface Ethernet1
    description DC1-LEAF2A_Ethernet7

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-SPINE1.cfg
@@ -99,6 +99,7 @@ router bgp 65001
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor 172.31.255.1 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.31.255.1 remote-as 65101

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-SPINE2.cfg
@@ -99,6 +99,7 @@ router bgp 65001
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor 172.31.255.3 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.31.255.3 remote-as 65101

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-SPINE3.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-SPINE3.cfg
@@ -99,6 +99,7 @@ router bgp 65001
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor 172.31.255.5 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.31.255.5 remote-as 65101

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-SPINE4.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/configs/DC1-SPINE4.cfg
@@ -99,6 +99,7 @@ router bgp 65001
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor 172.31.255.7 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.31.255.7 remote-as 65101

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-BL1A.yml
@@ -251,6 +251,7 @@ vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING
     ip_address: 10.255.251.10/31
+    mtu: 1500
   Vlan4094:
     description: MLAG_PEER
     ip_address: 10.255.252.10/31

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-BL1B.yml
@@ -251,6 +251,7 @@ vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING
     ip_address: 10.255.251.11/31
+    mtu: 1500
   Vlan4094:
     description: MLAG_PEER
     ip_address: 10.255.252.11/31

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -125,7 +125,6 @@ port_channel_interfaces:
     description: DC1-LEAF2A_Po7
     vlans: 110-111,120-121,130-131
     mode: trunk
-    mlag: 1
 
 ### Ethernet Interfaces ###
 ethernet_interfaces:

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-LEAF2A.yml
@@ -353,6 +353,7 @@ vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING
     ip_address: 10.255.251.2/31
+    mtu: 1500
   Vlan4094:
     description: MLAG_PEER
     ip_address: 10.255.252.2/31

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-LEAF2B.yml
@@ -353,6 +353,7 @@ vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING
     ip_address: 10.255.251.3/31
+    mtu: 1500
   Vlan4094:
     description: MLAG_PEER
     ip_address: 10.255.252.3/31

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-SPINE1.yml
@@ -215,6 +215,7 @@ router_bgp:
       peer_filter: LEAF-AS-RANGE
       password: "AQQvKeimxJu+uGQ/yYvv9w=="
       maximum_routes: 12000
+      send_community: true
     EVPN-OVERLAY-PEERS:
       type: evpn
       peer_filter: LEAF-AS-RANGE

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-SPINE2.yml
@@ -215,6 +215,7 @@ router_bgp:
       peer_filter: LEAF-AS-RANGE
       password: "AQQvKeimxJu+uGQ/yYvv9w=="
       maximum_routes: 12000
+      send_community: true
     EVPN-OVERLAY-PEERS:
       type: evpn
       peer_filter: LEAF-AS-RANGE

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-SPINE3.yml
@@ -215,6 +215,7 @@ router_bgp:
       peer_filter: LEAF-AS-RANGE
       password: "AQQvKeimxJu+uGQ/yYvv9w=="
       maximum_routes: 12000
+      send_community: true
     EVPN-OVERLAY-PEERS:
       type: evpn
       peer_filter: LEAF-AS-RANGE

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-SPINE4.yml
@@ -215,6 +215,7 @@ router_bgp:
       peer_filter: LEAF-AS-RANGE
       password: "AQQvKeimxJu+uGQ/yYvv9w=="
       maximum_routes: 12000
+      send_community: true
     EVPN-OVERLAY-PEERS:
       type: evpn
       peer_filter: LEAF-AS-RANGE

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-SVC3A.yml
@@ -395,6 +395,7 @@ vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING
     ip_address: 10.255.251.6/31
+    mtu: 1500
   Vlan4094:
     description: MLAG_PEER
     ip_address: 10.255.252.6/31

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/intended/structured_configs/DC1-SVC3B.yml
@@ -395,6 +395,7 @@ vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING
     ip_address: 10.255.251.7/31
+    mtu: 1500
   Vlan4094:
     description: MLAG_PEER
     ip_address: 10.255.252.7/31

--- a/ansible_collections/arista/avd/plugins/filter/esi_management.py
+++ b/ansible_collections/arista/avd/plugins/filter/esi_management.py
@@ -3,6 +3,7 @@ __metaclass__ = type
 
 import re
 
+
 class FilterModule(object):
 
     def generate_esi(self, esi_short, esi_prefix='0000:0000:'):

--- a/ansible_collections/arista/avd/plugins/filter/esi_management.py
+++ b/ansible_collections/arista/avd/plugins/filter/esi_management.py
@@ -1,10 +1,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from jinja2 import TemplateError
-from ansible.errors import AnsibleFilterError
 import re
-
 
 class FilterModule(object):
 

--- a/ansible_collections/arista/avd/plugins/filter/is_in_filter.py
+++ b/ansible_collections/arista/avd/plugins/filter/is_in_filter.py
@@ -4,11 +4,6 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from jinja2 import TemplateError
-from itertools import count, groupby
-from ansible.errors import AnsibleFilterError
-import re
-
 
 class FilterModule(object):
 

--- a/ansible_collections/arista/avd/plugins/filter/markdown_rendering.py
+++ b/ansible_collections/arista/avd/plugins/filter/markdown_rendering.py
@@ -1,10 +1,6 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from jinja2 import TemplateError
-from ansible.errors import AnsibleFilterError
-import re
-
 
 class FilterModule(object):
     # STATIC EMOJI CODE

--- a/ansible_collections/arista/avd/plugins/modules/inventory_to_container.py
+++ b/ansible_collections/arista/avd/plugins/modules/inventory_to_container.py
@@ -304,7 +304,7 @@ def get_devices(dict_inventory, search_container=None, devices=None, device_filt
 
     for k1, v1 in dict_inventory.items():
         # Read a leaf
-        if k1 == search_container and 'hosts' in v1:
+        if k1 == search_container and isIterable(v1) and 'hosts' in v1:
             for dev, data in v1['hosts'].items():
                 if is_in_filter(
                     hostname_filter=device_filter,

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -617,8 +617,9 @@ port_channel_interfaces:
   < Port-Channel_interface_1 >:
     description: < description >
     shutdown: < true | false >
-    logging_event:
-      link_status: < true | false >
+    logging:
+      event:
+        link_status: < true | false >
     vlans: "< list of vlans as string >"
     mode: < access | dot1q-tunnel | trunk >
     mlag: < mlag_id >
@@ -682,8 +683,9 @@ ethernet_interfaces:
     speed: < interface_speed >
     mtu: < mtu >
     type: < routed | switched >
-        logging_event:
-    link_status: < true | false >
+    logging:
+      event:
+        link_status: < true | false >
     vrf: < vrf_name >
     ip_address: < IPv4_address/Mask >
     ipv6_enable: < true | false >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -675,6 +675,8 @@ ethernet_interfaces:
     speed: < interface_speed >
     mtu: < mtu >
     type: < routed | switched >
+        logging_event:
+    link_status: < true | false >
     vrf: < vrf_name >
     ip_address: < IPv4_address/Mask >
     ipv6_enable: < true | false >
@@ -715,6 +717,8 @@ ethernet_interfaces:
     shutdown: < true | false >
     speed: < interface_speed >
     mtu: < mtu >
+    logging_event:
+      link_status: < true | false >
     vlans: "< list of vlans as string >"
     native_vlan: <native vlan number>
     mode: < access | dot1q-tunnel | trunk >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -481,6 +481,7 @@ tacacs_servers:
   hosts:
     - host: < host1_ip_address >
       vrf: < vrf_name >
+      timeout: < timeout_in_seconds >
       key: < encypted_key >
     - host: < host2_ip_address >
       key: < encypted_key >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -470,6 +470,8 @@ platform:
     lag:
       hardware_only: < true | false >
       mode: < mode | default -> 1024x16 >
+    multicast_replication:
+      default: < fabric-egress | ingress >
 ```
 
 ### Tacacs+ Servers

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -614,6 +614,8 @@ port_channel_interfaces:
   < Port-Channel_interface_1 >:
     description: < description >
     shutdown: < true | false >
+    logging_event:
+      link_status: < true | false >
     vlans: "< list of vlans as string >"
     mode: < access | dot1q-tunnel | trunk >
     mlag: < mlag_id >
@@ -642,6 +644,8 @@ port_channel_interfaces:
   < Port-Channel_interface_4 >:
     description: < description >
     mtu: < mtu >
+    logging_event:
+      link_status: < true | false >
     type: < switched | routed >
     ip_address:  < IP_address/mask >
     ipv6_enable: < true | false >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -18,6 +18,13 @@ interface {{ ethernet_interface }}
 {%             if ethernet_interfaces[ethernet_interface].mtu is defined and ethernet_interfaces[ethernet_interface].mtu != 1500 %}
    mtu {{ ethernet_interfaces[ethernet_interface].mtu }}
 {%             endif %}
+{%             if ethernet_interfaces[ethernet_interface].logging_event is defined and ethernet_interfaces[ethernet_interface].logging_event is not none %}
+{%                 if ethernet_interfaces[ethernet_interface].logging_event.link_status is defined and ethernet_interfaces[ethernet_interface].logging_event.link_status == true %}
+   logging event link-status
+{%                 else %}
+   no logging event link-status
+{%                 endif %}
+{%             endif %}
 {%             if ethernet_interfaces[ethernet_interface].type is defined and ethernet_interfaces[ethernet_interface].type == "routed" %}
    no switchport
 {%             endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -18,10 +18,10 @@ interface {{ ethernet_interface }}
 {%             if ethernet_interfaces[ethernet_interface].mtu is defined and ethernet_interfaces[ethernet_interface].mtu != 1500 %}
    mtu {{ ethernet_interfaces[ethernet_interface].mtu }}
 {%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].logging_event is defined and ethernet_interfaces[ethernet_interface].logging_event is not none %}
-{%                 if ethernet_interfaces[ethernet_interface].logging_event.link_status is defined and ethernet_interfaces[ethernet_interface].logging_event.link_status == true %}
+{%             if ethernet_interfaces[ethernet_interface].logging.event is defined and ethernet_interfaces[ethernet_interface].logging.event is not none %}
+{%                 if ethernet_interfaces[ethernet_interface].logging.event.link_status is defined and ethernet_interfaces[ethernet_interface].logging.event.link_status == true %}
    logging event link-status
-{%                 else %}
+{%                 elif ethernet_interfaces[ethernet_interface].logging.event.link_status is defined and ethernet_interfaces[ethernet_interface].logging.event.link_status == false %}
    no logging event link-status
 {%                 endif %}
 {%             endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-api-http.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-api-http.j2
@@ -11,7 +11,7 @@ management api http-commands
 {%     endif %}
    no shutdown
 {%     if management_api_http.enable_vrfs is defined and management_api_http.enable_vrfs is not none -%}
-{%         for vrf in management_api_http.enable_vrfs | arista.avd.natural_sort if vrf is ne 'default' %}
+{%         for vrf in management_api_http.enable_vrfs | arista.avd.natural_sort %}
    !
    vrf {{ vrf }}
       no shutdown

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/platform.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/platform.j2
@@ -15,5 +15,10 @@ platform sand lag hardware-only
 platform sand lag mode {{ platform.sand.lag.mode }}
 {%             endif %}
 {%         endif %}
+{%         if platform.sand.multicast_replication is defined and platform.sand.multicast_replication is not none %}
+{%             if platform.sand.multicast_replication.default is defined and platform.sand.multicast_replication.default is not none %}
+platform sand multicast replication default {{ platform.sand.multicast_replication.default }}
+{%             endif %}
+{%         endif %}
 {%     endif %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
@@ -12,6 +12,13 @@ interface {{ port_channel_interface }}
 {%         if port_channel_interfaces[port_channel_interface].mtu is defined and port_channel_interfaces[port_channel_interface].mtu is not none %}
    mtu {{ port_channel_interfaces[port_channel_interface].mtu }}
 {%         endif %}
+{%         if port_channel_interfaces[port_channel_interface].logging_event is defined and port_channel_interfaces[port_channel_interface].logging_event is not none %}
+{%             if port_channel_interfaces[port_channel_interface].logging_event.link_status is defined and port_channel_interfaces[port_channel_interface].logging_event.link_status == true %}
+   logging event link-status
+{%             else %}
+   no logging event link-status
+{%             endif %}
+{%         endif %}
 {%         if port_channel_interfaces[port_channel_interface].type is defined and port_channel_interfaces[port_channel_interface].type == "routed" %}
    no switchport
 {%         endif %}
@@ -71,7 +78,7 @@ interface {{ port_channel_interface }}
    vrf {{ port_channel_interfaces[port_channel_interface].vrf }}
 {%         endif %}
 {%             if port_channel_interfaces[port_channel_interface].ip_proxy_arp is defined and port_channel_interfaces[port_channel_interface].ip_proxy_arp == true %}
-   ip proxy-arp 
+   ip proxy-arp
 {%             endif %}
 {%         if port_channel_interfaces[port_channel_interface].ip_address is defined and port_channel_interfaces[port_channel_interface].ip_address is not none %}
    ip address {{ port_channel_interfaces[port_channel_interface].ip_address }}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/tacacs-servers.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/tacacs-servers.j2
@@ -3,7 +3,7 @@
 !
 {%    if tacacs_servers.hosts is defined and tacacs_servers.hosts is not none %}
 {%       for host in tacacs_servers.hosts %}
-tacacs-server host {{ host['host'] }} {% if host['vrf'] is defined and host['vrf'] is not none %}vrf {{ host['vrf'] }} {% endif %} {% if host['key'] is defined and host['key'] is not none %}key 7 {{ host['key'] }} {% endif %}
+tacacs-server host {{ host['host'] }}{% if host['vrf'] is defined and host['vrf'] is not none %} vrf {{ host['vrf'] }}{% endif %}{% if host['timeout'] is defined and host['timeout'] is not none %} timeout {{ host['timeout'] }}{% endif %}{% if host['key'] is defined and host['key'] is not none %} key 7 {{ host['key'] }} {% endif %}
 
 {%       endfor %}
 {%    endif %}

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_eapi/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_eapi/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: replace configuration with intended configuration
   eos_config:
-    src: '{{root_dir}}/intended/configs/{{ inventory_hostname }}.cfg'
+    src: '{{ root_dir }}/intended/configs/{{ inventory_hostname }}.cfg'
     replace: config
     save_when: modified
     backup: "{{ eos_config_deploy_eapi_pre_running_config_backup }}"

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
@@ -340,7 +340,7 @@ vxlan_vlan_aware_bundles: < boolean | default -> false >
 
 # Disable IGMP snooping at fabric level.
 # If set, it overrides per vlan settings
-default_igmp_snooping: < boolean | default -> true >
+default_igmp_snooping_enabled: < boolean | default -> true >
 
 # BFD Multihop tunning | Required.
 bfd_multihop:
@@ -984,7 +984,8 @@ tenants:
       < 1-4096 >:
         name: < description >
         tags: [ < tag_1 >, < tag_2 > ]
-
+        # Activate or deactivate IGMP snooping | Optional, default is true
+        igmp_snooping_enabled: < true | false >
 
   < tenant_a >:
     mac_vrf_vni_base: < 10000-16770000 >

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
@@ -1186,16 +1186,16 @@ port_profiles:
     storm_control:
       all:
         level: < Configure maximum storm-control level >
-        unit: < percent | pps >
+        unit: < percent | pps > | Optional var and is hardware dependant - default is percent)
       broadcast:
         level: < Configure maximum storm-control level >
-        unit: < percent | pps >
+        unit: < percent | pps > | Optional var and is hardware dependant - default is percent)
       multicast:
         level: < Configure maximum storm-control level >
-        unit: < percent | pps >
+        unit: < percent | pps > | Optional var and is hardware dependant - default is percent)
       unknown_unicast:
         level: < Configure maximum storm-control level >
-        unit: < percent | pps >
+        unit: < percent | pps > | Optional var and is hardware dependant - default is percent)
 
 # Dictionary of servers, a device attaching to a L2 switched port(s)
 servers:

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/edge_ports/leaf-server-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/edge_ports/leaf-server-interfaces.j2
@@ -26,7 +26,9 @@
 {%                     for section in port_profiles[adapter.profile].storm_control %}
       {{ section }}:
         level: {{ port_profiles[adapter.profile].storm_control[section].level }}
+{%                         if port_profiles[adapter.profile].storm_control[section].unit is defined and port_profiles[adapter.profile].storm_control[section].unit is not none %}
         unit: {{ port_profiles[adapter.profile].storm_control[section].unit }}
+{%                         endif %}
 {%                     endfor %}
 {%                 endif %}
 {%                 if port_profiles[adapter.profile].native_vlan is defined %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l2leaf-yml.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l2leaf-yml.j2
@@ -115,8 +115,8 @@
 {%                         if svi_tag in leaf.filter_tags or svi_tag == leaf.group or "all" in leaf.filter_tags %}
 {%                             if svi_tag in parentl3leaf.filter_tags or svi_tag == parentl3leaf.group or "all" in parentl3leaf.filter_tags %}
 {%                                 do leaf.vrfs.append( vrf ) %}
-{%                                 do leaf.svis.append( svi | int) %}
-{%                                 do leaf.vlans.append( svi| int ) %}
+{%                                 do leaf.svis.append(svi | int) %}
+{%                                 do leaf.vlans.append( svi | int ) %}
 {%                                 break %}
 {%                             endif %}
 {%                         endif %}
@@ -129,7 +129,7 @@
 {%                 for vlan_tag in tenants[tenant].l2vlans[l2vlan].tags %}
 {%                     if vlan_tag in leaf.filter_tags or vlan_tag == leaf.group or "all" in leaf.filter_tags %}
 {%                         if vlan_tag in parentl3leaf.filter_tags or vlan_tag == leaf.group or "all" in parentl3leaf.filter_tags %}
-{%                             do leaf.vlans.append( l2vlan | int) %}
+{%                             do leaf.vlans.append(l2vlan | int) %}
 {%                             break %}
 {%                         endif %}
 {%                     endif %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l3leaf-yml.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l3leaf-yml.j2
@@ -117,8 +117,8 @@
 {%                 for svi_tag in tenants[tenant].vrfs[vrf].svis[svi].tags %}
 {%                     if svi_tag in leaf.filter_tags or svi_tag == leaf.group or "all" in leaf.filter_tags %}
 {%                         do leaf.vrfs.append( vrf ) %}
-{%                         do leaf.svis.append( svi | int) %}
-{%                         do leaf.vlans.append( svi | int) %}
+{%                         do leaf.svis.append(svi | int) %}
+{%                         do leaf.vlans.append(svi | int) %}
 {%                         break %}
 {%                     endif %}
 {%                 endfor %}
@@ -129,7 +129,7 @@
 {%         for l2vlan in tenants[tenant].l2vlans | arista.avd.natural_sort %}
 {%             for vlan_tag in tenants[tenant].l2vlans[l2vlan].tags %}
 {%                 if vlan_tag in leaf.filter_tags or vlan_tag == leaf.group or "all" in leaf.filter_tags %}
-{%                     do leaf.vlans.append( l2vlan | int) %}
+{%                     do leaf.vlans.append(l2vlan | int) %}
 {%                     break %}
 {%                 endif %}
 {%             endfor %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/bgp_base/spine-router-bgp-peer-groups.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/bgp_base/spine-router-bgp-peer-groups.j2
@@ -7,6 +7,7 @@
       peer_filter: LEAF-AS-RANGE
       password: "{{ bgp_peer_groups.IPv4_UNDERLAY_PEERS.password }}"
       maximum_routes: 12000
+      send_community: true
 {%     endif %}
 {# Overlay network peering #}
 {%     if switch.overlay_routing_protocol == "ebgp" %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/ebgp_underlay/spine-router-bgp-peer-groups.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/ebgp_underlay/spine-router-bgp-peer-groups.j2
@@ -7,7 +7,9 @@
       peer_filter: LEAF-AS-RANGE
       password: "{{ bgp_peer_groups.IPv4_UNDERLAY_PEERS.password }}"
       maximum_routes: 12000
-{%     endif %}
+      send_community: true
+{% endif %}
+{% if switch.overlay_routing_protocol == "ebgp" and switch.evpn_overlay_peers | length > 0 %}
     EVPN-OVERLAY-PEERS:
       type: evpn
       peer_filter: LEAF-AS-RANGE

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/mlag/leaf-mlag-vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/mlag/leaf-mlag-vlan-interfaces.j2
@@ -4,10 +4,10 @@
   Vlan4093:
     description: MLAG_PEER_L3_PEERING
     ip_address: {{ mlag_ips.leaf_peer_l3 | ipaddr('network') | ipmath(leaf.mlag_ip ) }}/31
+    mtu: {{ p2p_uplinks_mtu }}
 {%         if underlay_routing_protocol|lower == "ospf" %}
     ospf_network_point_to_point: true
     ospf_area: {{ underlay_ospf_area }}
-    mtu: {{ p2p_uplinks_mtu }}
 {%         endif %}
 {%         if underlay_routing_protocol|lower == "isis" %}
     isis_enable: EVPN_UNDERLAY

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/l3leaf_l2leafs_uplinks/l2leaf-port-channel-uplinks.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/l3leaf_l2leafs_uplinks/l2leaf-port-channel-uplinks.j2
@@ -23,7 +23,9 @@
     description: {{ parent_l3leafs[loop.index0]}}_{{ 'Po' + l3leaf.channel_group_id }}
     vlans: {{ leaf.vlans | arista.avd.list_compress }}
     mode: trunk
+{%             if leaf.mlag == true %}
     mlag: {{ channel_group_id }}
+{%             endif %}
 {%         endif %}
 {%     endfor %}
 {% endfor %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-igmp-snooping.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-igmp-snooping.j2
@@ -8,7 +8,7 @@
 {% for tenant in tenants | arista.avd.natural_sort if tenant in leaf.filter_tenants or "all" in leaf.filter_tenants %}
 {%     if tenants[tenant].vrfs is defined %}
 {%         for vrf in tenants[tenant].vrfs | arista.avd.natural_sort if leaf.vrfs is not none and vrf in leaf.vrfs %}
-{%             for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if leaf.svis is not none and svi|int in leaf.svis %}
+{%             for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if leaf.svis is not none and svi | int in leaf.svis %}
 {%                  if tenants[tenant].vrfs[vrf].svis[svi].igmp_snooping is defined %}
 {%                      set igmp_snooping.configured = true %}
 {%                  endif %}
@@ -35,7 +35,7 @@
 {%          if tenants[tenant].vrfs is defined %}
 {%              for vrf in tenants[tenant].vrfs | arista.avd.natural_sort if leaf.vrfs is not none and vrf in leaf.vrfs %}
 {# Tenant VLANs w/SVIs #}
-{%                  for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if leaf.svis is not none and svi|int in leaf.svis %}
+{%                  for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if leaf.svis is not none and svi | int in leaf.svis %}
 {# Detect if a svi_profile exists #}
 {# If exists, create a shortpath to access profile data #}
 {%                      set per_svi = namespace() %}
@@ -52,7 +52,7 @@
 {# IGMP SNOOPING detection #}
 {%                      if per_svi.values.igmp_snooping_enabled is defined or profile.values.igmp_snooping_enabled is defined %}
 {%                          if leaf.igmp_snooping_enabled == true %}
-    {{ svi|int }}:
+    {{ svi | int }}:
       enabled: {{ per_svi.values.igmp_snooping_enabled if per_svi.values.igmp_snooping_enabled is defined else profile.values.igmp_snooping_enabled|default(true) }}
 {%                          endif %}
 {%                      endif %}
@@ -66,7 +66,7 @@
 {%              for l2vlan in tenants[tenant].l2vlans | arista.avd.natural_sort %}
 {%                  if tenants[tenant].l2vlans[l2vlan].igmp_snooping_enabled is defined %}
 {%                      if tenants[tenant].l2vlans[l2vlan].igmp_snooping_enabled == false and leaf.igmp_snooping_enabled == true %}
-    {{ l2vlan|int }}:
+    {{ l2vlan | int }}:
       enabled: false
 {%                      endif %}
 {%                  endif %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-igmp-snooping.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-igmp-snooping.j2
@@ -8,7 +8,7 @@
 {% for tenant in tenants | arista.avd.natural_sort if tenant in leaf.filter_tenants or "all" in leaf.filter_tenants %}
 {%     if tenants[tenant].vrfs is defined %}
 {%         for vrf in tenants[tenant].vrfs | arista.avd.natural_sort if leaf.vrfs is not none and vrf in leaf.vrfs %}
-{%             for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if leaf.svis is not none and svi in leaf.svis %}
+{%             for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if leaf.svis is not none and svi|int in leaf.svis %}
 {%                  if tenants[tenant].vrfs[vrf].svis[svi].igmp_snooping is defined %}
 {%                      set igmp_snooping.configured = true %}
 {%                  endif %}
@@ -35,7 +35,7 @@
 {%          if tenants[tenant].vrfs is defined %}
 {%              for vrf in tenants[tenant].vrfs | arista.avd.natural_sort if leaf.vrfs is not none and vrf in leaf.vrfs %}
 {# Tenant VLANs w/SVIs #}
-{%                  for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if leaf.svis is not none and svi in leaf.svis %}
+{%                  for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if leaf.svis is not none and svi|int in leaf.svis %}
 {# Detect if a svi_profile exists #}
 {# If exists, create a shortpath to access profile data #}
 {%                      set per_svi = namespace() %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-router-bgp-evpn-vlan-aware-bundles.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-router-bgp-evpn-vlan-aware-bundles.j2
@@ -13,7 +13,7 @@
         - learned
 {%                 set vlan_range = [] %}
 {%                 for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if leaf.svis is not none and svi | int in leaf.svis %}
-{%                     do vlan_range.append( svi| int ) %}
+{%                     do vlan_range.append( svi | int ) %}
 {%                 endfor %}
       vlan: {{ vlan_range | arista.avd.list_compress }}
 {%             endfor %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-router-bgp-evpn-vlan-aware-bundles.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-router-bgp-evpn-vlan-aware-bundles.j2
@@ -12,14 +12,14 @@
       redistribute_routes:
         - learned
 {%                 set vlan_range = [] %}
-{%                 for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if leaf.svis is not none and svi|int in leaf.svis %}
+{%                 for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if leaf.svis is not none and svi | int in leaf.svis %}
 {%                     do vlan_range.append( svi| int ) %}
 {%                 endfor %}
       vlan: {{ vlan_range | arista.avd.list_compress }}
 {%             endfor %}
 {%         endif %}
 {%         if tenants[tenant].l2vlans is defined %}
-{%             for l2vlan in tenants[tenant].l2vlans | arista.avd.natural_sort if leaf.vlans is not none and l2vlan|int in leaf.vlans %}
+{%             for l2vlan in tenants[tenant].l2vlans | arista.avd.natural_sort if leaf.vlans is not none and l2vlan | int in leaf.vlans %}
 {%                 set l2vlan_int = l2vlan | int %}
 {%                 if tenants[tenant].l2vlans[l2vlan].vni_override is defined %}
 {%                     set vni = tenants[tenant].l2vlans[l2vlan].vni_override %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-router-bgp-evpn-vlan-aware-bundles.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-router-bgp-evpn-vlan-aware-bundles.j2
@@ -12,14 +12,14 @@
       redistribute_routes:
         - learned
 {%                 set vlan_range = [] %}
-{%                 for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if leaf.svis is not none and svi in leaf.svis %}
+{%                 for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if leaf.svis is not none and svi|int in leaf.svis %}
 {%                     do vlan_range.append( svi| int ) %}
 {%                 endfor %}
       vlan: {{ vlan_range | arista.avd.list_compress }}
 {%             endfor %}
 {%         endif %}
 {%         if tenants[tenant].l2vlans is defined %}
-{%             for l2vlan in tenants[tenant].l2vlans | arista.avd.natural_sort if leaf.vlans is not none and l2vlan in leaf.vlans %}
+{%             for l2vlan in tenants[tenant].l2vlans | arista.avd.natural_sort if leaf.vlans is not none and l2vlan|int in leaf.vlans %}
 {%                 set l2vlan_int = l2vlan | int %}
 {%                 if tenants[tenant].l2vlans[l2vlan].vni_override is defined %}
 {%                     set vni = tenants[tenant].l2vlans[l2vlan].vni_override %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-router-bgp-evpn-vlans.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-router-bgp-evpn-vlans.j2
@@ -4,7 +4,7 @@
 ## {{ tenant }} ##
 {%         if tenants[tenant].vrfs is defined %}
 {%             for vrf in tenants[tenant].vrfs | arista.avd.natural_sort if leaf.vrfs is not none and vrf in leaf.vrfs %}
-{%                 for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if svi|int in leaf.svis %}
+{%                 for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if svi | int in leaf.svis %}
 {%                      set svi_int = svi | int %}
 {%                     if tenants[tenant].vrfs[vrf].svis[svi].vni_override is defined %}
 {%                         set vni = tenants[tenant].vrfs[vrf].svis[svi].vni_override %}
@@ -23,7 +23,7 @@
 {%             endfor %}
 {%         endif %}
 {%         if tenants[tenant].l2vlans is defined %}
-{%             for l2vlan in tenants[tenant].l2vlans | arista.avd.natural_sort if leaf.vlans is not none and l2vlan|int in leaf.vlans %}
+{%             for l2vlan in tenants[tenant].l2vlans | arista.avd.natural_sort if leaf.vlans is not none and l2vlan | int in leaf.vlans %}
 {%                 set l2vlan_int = l2vlan | int %}
 {%                 if tenants[tenant].l2vlans[l2vlan].vni_override is defined %}
 {%                     set vni = tenants[tenant].l2vlans[l2vlan].vni_override %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-router-bgp-evpn-vlans.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-router-bgp-evpn-vlans.j2
@@ -4,7 +4,7 @@
 ## {{ tenant }} ##
 {%         if tenants[tenant].vrfs is defined %}
 {%             for vrf in tenants[tenant].vrfs | arista.avd.natural_sort if leaf.vrfs is not none and vrf in leaf.vrfs %}
-{%                 for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if svi in leaf.svis %}
+{%                 for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if svi|int in leaf.svis %}
 {%                      set svi_int = svi | int %}
 {%                     if tenants[tenant].vrfs[vrf].svis[svi].vni_override is defined %}
 {%                         set vni = tenants[tenant].vrfs[vrf].svis[svi].vni_override %}
@@ -23,7 +23,7 @@
 {%             endfor %}
 {%         endif %}
 {%         if tenants[tenant].l2vlans is defined %}
-{%             for l2vlan in tenants[tenant].l2vlans | arista.avd.natural_sort if leaf.vlans is not none and l2vlan in leaf.vlans %}
+{%             for l2vlan in tenants[tenant].l2vlans | arista.avd.natural_sort if leaf.vlans is not none and l2vlan|int in leaf.vlans %}
 {%                 set l2vlan_int = l2vlan | int %}
 {%                 if tenants[tenant].l2vlans[l2vlan].vni_override is defined %}
 {%                     set vni = tenants[tenant].l2vlans[l2vlan].vni_override %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-vlan-interfaces.j2
@@ -5,7 +5,7 @@
 {%             if loop.first %}
 ## {{ tenant }} ##
 {%             endif %}
-{%             for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if svi in leaf.svis %}
+{%             for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if svi|int in leaf.svis %}
 {# Detect if a svi_profile exists #}
 {# If exists, create a shortpath to access profile data #}
 {%                 set per_svi = namespace() %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-vlan-interfaces.j2
@@ -5,7 +5,7 @@
 {%             if loop.first %}
 ## {{ tenant }} ##
 {%             endif %}
-{%             for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if svi|int in leaf.svis %}
+{%             for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if svi | int in leaf.svis %}
 {# Detect if a svi_profile exists #}
 {# If exists, create a shortpath to access profile data #}
 {%                 set per_svi = namespace() %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-vlans.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-vlans.j2
@@ -4,7 +4,7 @@
 {%     if tenants[tenant].vrfs is defined %}
 {%         for vrf in tenants[tenant].vrfs | arista.avd.natural_sort if leaf.vrfs is not none and vrf in leaf.vrfs %}
 {# Tenant VLANs w/SVIs #}
-{%             for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if leaf.svis is not none and svi|int in leaf.svis %}
+{%             for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if leaf.svis is not none and svi | int in leaf.svis %}
   {{ svi| int }}:
     tenant: {{ tenant }}
     name: {{ tenants[tenant].vrfs[vrf].svis[svi].name }}
@@ -21,7 +21,7 @@
 {%     endif %}
 {# Tenant L2 VLANs #}
 {%     if tenants[tenant].l2vlans is defined %}
-{%         for l2vlan in tenants[tenant].l2vlans | arista.avd.natural_sort if leaf.vlans is not none and l2vlan|int in leaf.vlans %}
+{%         for l2vlan in tenants[tenant].l2vlans | arista.avd.natural_sort if leaf.vlans is not none and l2vlan | int in leaf.vlans %}
   {{ l2vlan| int }}:
     tenant: {{ tenant }}
     name: {{ tenants[tenant].l2vlans[l2vlan].name }}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-vlans.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-vlans.j2
@@ -4,7 +4,7 @@
 {%     if tenants[tenant].vrfs is defined %}
 {%         for vrf in tenants[tenant].vrfs | arista.avd.natural_sort if leaf.vrfs is not none and vrf in leaf.vrfs %}
 {# Tenant VLANs w/SVIs #}
-{%             for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if leaf.svis is not none and svi in leaf.svis %}
+{%             for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if leaf.svis is not none and svi|int in leaf.svis %}
   {{ svi| int }}:
     tenant: {{ tenant }}
     name: {{ tenants[tenant].vrfs[vrf].svis[svi].name }}
@@ -21,7 +21,7 @@
 {%     endif %}
 {# Tenant L2 VLANs #}
 {%     if tenants[tenant].l2vlans is defined %}
-{%         for l2vlan in tenants[tenant].l2vlans | arista.avd.natural_sort if leaf.vlans is not none and l2vlan in leaf.vlans %}
+{%         for l2vlan in tenants[tenant].l2vlans | arista.avd.natural_sort if leaf.vlans is not none and l2vlan|int in leaf.vlans %}
   {{ l2vlan| int }}:
     tenant: {{ tenant }}
     name: {{ tenants[tenant].l2vlans[l2vlan].name }}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-vlans.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-tenant-vlans.j2
@@ -5,7 +5,7 @@
 {%         for vrf in tenants[tenant].vrfs | arista.avd.natural_sort if leaf.vrfs is not none and vrf in leaf.vrfs %}
 {# Tenant VLANs w/SVIs #}
 {%             for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if leaf.svis is not none and svi | int in leaf.svis %}
-  {{ svi| int }}:
+  {{ svi | int }}:
     tenant: {{ tenant }}
     name: {{ tenants[tenant].vrfs[vrf].svis[svi].name }}
 {# VLAN for iBGP peering in overlay VRFs #}
@@ -22,7 +22,7 @@
 {# Tenant L2 VLANs #}
 {%     if tenants[tenant].l2vlans is defined %}
 {%         for l2vlan in tenants[tenant].l2vlans | arista.avd.natural_sort if leaf.vlans is not none and l2vlan | int in leaf.vlans %}
-  {{ l2vlan| int }}:
+  {{ l2vlan | int }}:
     tenant: {{ tenant }}
     name: {{ tenants[tenant].l2vlans[l2vlan].name }}
 {%         endfor %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-vxlan-vtep-interface.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-vxlan-vtep-interface.j2
@@ -13,7 +13,7 @@
 ## {{ tenant }} ##
 {%     if tenants[tenant].vrfs is defined %}
 {%         for vrf in tenants[tenant].vrfs | arista.avd.natural_sort if leaf.vrfs is not none and vrf in leaf.vrfs %}
-{%             for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if leaf.svis is not none and svi in leaf.svis %}
+{%             for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if leaf.svis is not none and svi|int in leaf.svis %}
 {%            set svi_int = svi | int %}
         {{ svi_int }}:
 {%                 if tenants[tenant].vrfs[vrf].svis[svi].vni_override is defined %}
@@ -25,7 +25,7 @@
 {%         endfor %}
 {%     endif %}
 {%     if tenants[tenant].l2vlans is defined %}
-{%         for l2vlan in tenants[tenant].l2vlans | arista.avd.natural_sort if leaf.vlans is not none and l2vlan in leaf.vlans %}
+{%         for l2vlan in tenants[tenant].l2vlans | arista.avd.natural_sort if leaf.vlans is not none and l2vlan|int in leaf.vlans %}
 {%            set l2vlan_int = l2vlan | int %}
         {{ l2vlan_int }}:
 {%              if tenants[tenant].l2vlans[l2vlan].vni_override is defined %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-vxlan-vtep-interface.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/tenant_evpn_vxlan/leaf-vxlan-vtep-interface.j2
@@ -13,7 +13,7 @@
 ## {{ tenant }} ##
 {%     if tenants[tenant].vrfs is defined %}
 {%         for vrf in tenants[tenant].vrfs | arista.avd.natural_sort if leaf.vrfs is not none and vrf in leaf.vrfs %}
-{%             for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if leaf.svis is not none and svi|int in leaf.svis %}
+{%             for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if leaf.svis is not none and svi | int in leaf.svis %}
 {%            set svi_int = svi | int %}
         {{ svi_int }}:
 {%                 if tenants[tenant].vrfs[vrf].svis[svi].vni_override is defined %}
@@ -25,7 +25,7 @@
 {%         endfor %}
 {%     endif %}
 {%     if tenants[tenant].l2vlans is defined %}
-{%         for l2vlan in tenants[tenant].l2vlans | arista.avd.natural_sort if leaf.vlans is not none and l2vlan|int in leaf.vlans %}
+{%         for l2vlan in tenants[tenant].l2vlans | arista.avd.natural_sort if leaf.vlans is not none and l2vlan | int in leaf.vlans %}
 {%            set l2vlan_int = l2vlan | int %}
         {{ l2vlan_int }}:
 {%              if tenants[tenant].l2vlans[l2vlan].vni_override is defined %}

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/ip_reachability.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/ip_reachability.yml
@@ -4,8 +4,8 @@
 
 - name: Gather ip reachability state (directly connected interfaces)
   eos_command:
-    commands: "ping {{ hostvars[ethernet_interface.value.peer]['ethernet_interfaces'][ethernet_interface.value.peer_interface]['ip_address'] | ipaddr('address')}} source {{ ethernet_interface.value.ip_address  | ipaddr('address')}} repeat 1"
-  loop: "{{ethernet_interfaces | default({}, true) | dict2items}}"
+    commands: "ping {{ hostvars[ethernet_interface.value.peer]['ethernet_interfaces'][ethernet_interface.value.peer_interface]['ip_address'] | ipaddr('address') }} source {{ ethernet_interface.value.ip_address  | ipaddr('address') }} repeat 1"
+  loop: "{{ ethernet_interfaces | default({}, true) | dict2items }}"
   loop_control:
     loop_var: ethernet_interface
   ignore_errors: "{{ eos_validate_state_validation_mode_loose }}"


### PR DESCRIPTION
## Change Summary

Release v1.1.3

## Release Notes

- Fix exception for passing empty dict (#500)
- Storm control in l3ls_evpn the unit as optional (#557)
- Fix l3ls role documentation about igmp snooping (#545)
- Include default VRF in mgmt api for eos_l3ls_evpn (#533)
- svi and l2vlan keys to check and tested as int (#536)
- Fix L2 leaves uplinks when MLAG is not desired (#544)
- Change location for MTU knob so SVI 4093 uses it (#526)
- Fix incorrect send_community for underlay on spines (#592)
- Enhance logging event, tacacs timeout and platform sand multicast replication features (#650)
- Fix ansible-lint and ansible-test lint issues (#680)
- Add collection dependencies (#663)
- Code readability pep8 style / issue with Ansible Tower (4603e2b)

