### PR TITLE
Add options to configure SSH ciphers and algorithms for the eos_cli_config_gen role

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-ssh-custom-cipher.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-ssh-custom-cipher.md
@@ -1,4 +1,4 @@
-# base
+# management-ssh-custom-cipher
 
 # Table of Contents
 
@@ -139,13 +139,6 @@ PTP is not defined.
 | ACL-SSH | - |
 | ACL-SSH-VRF | mgt |
 
-### IPv6 ACL
-
-| IPv6 ACL | VRF |
-| -------- | --- |
-| ACL-SSH6 | - |
-| ACL-SSH-VRF6 | mgt |
-
  ### SSH timeout and management
 
 | Idle Timeout | SSH Management |
@@ -156,7 +149,7 @@ PTP is not defined.
 
 | Ciphers | Key-exchange methods | MAC algorithms | Hostkey server algorithms |
 |---------|----------------------|----------------|---------------------------|
-| default | default | default | default |
+| aes256-cbc, aes256-ctr, aes256-gcm@openssh.com | ecdh-sha2-nistp521 | hmac-sha2-512, hmac-sha2-512-etm@openssh.com | ecdsa-nistp256, ecdsa-nistp521 |
 
 ### VRFs
 
@@ -171,9 +164,11 @@ PTP is not defined.
 management ssh
    ip access-group ACL-SSH in
    ip access-group ACL-SSH-VRF vrf mgt in
-   ipv6 access-group ACL-SSH6 in
-   ipv6 access-group ACL-SSH-VRF6 vrf mgt in
    idle-timeout 15
+   cipher aes256-cbc aes256-ctr aes256-gcm@openssh.com
+   key-exchange ecdh-sha2-nistp521
+   mac hmac-sha2-512 hmac-sha2-512-etm@openssh.com
+   hostkey server ecdsa-nistp256 ecdsa-nistp521
    vrf mgt
       no shutdown
 ```
@@ -184,30 +179,7 @@ Management API gnmi is not defined
 
 ## Management API HTTP
 
-### Management API HTTP Summary
-
-| HTTP | HTTPS |
-| ---------- | ---------- |
-|  true  |  true  |
-
-### Management API VRF Access
-
-| VRF Name | IPv4 ACL | IPv6 ACL |
-| -------- | -------- | -------- |
-| mgt |  ACL-API  |  -  |
-
-### Management API HTTP Configuration
-
-```eos
-!
-management api http-commands
-   protocol http
-   no shutdown
-   !
-   vrf mgt
-      no shutdown
-      ip access-group ACL-API
-```
+Management API HTTP not defined
 
 # Authentication
 
@@ -249,18 +221,7 @@ AAA accounting not defined
 
 # Management Security
 
-## Management Security
-
-   Management Security password encryption is common.
-
-
-## Management Security Configuration
-
-```eos
-!
-management security
-   password encryption-key common
-```
+Management security not defined
 
 # Aliases
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-ssh.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-ssh.md
@@ -145,6 +145,12 @@ PTP is not defined.
 | ------------ | -------------- |
 | 15 |  Enabled  |
 
+### Ciphers and algorithms
+
+| Ciphers | Key-exchange methods | MAC algorithms | Hostkey server algorithms |
+|---------|----------------------|----------------|---------------------------|
+| default | default | default | default |
+
 ### VRFs
 
 | VRF | Status |

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-ssh-custom-cipher.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-ssh-custom-cipher.cfg
@@ -1,0 +1,26 @@
+!RANCID-CONTENT-TYPE: arista
+!
+transceiver qsfp default-mode 4x10G
+!
+hostname management-ssh-custom-cipher
+!
+no aaa root
+no enable password
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+!
+management ssh
+   ip access-group ACL-SSH in
+   ip access-group ACL-SSH-VRF vrf mgt in
+   idle-timeout 15
+   cipher aes256-cbc aes256-ctr aes256-gcm@openssh.com
+   key-exchange ecdh-sha2-nistp521
+   mac hmac-sha2-512 hmac-sha2-512-etm@openssh.com
+   hostkey server ecdsa-nistp256 ecdsa-nistp521
+   vrf mgt
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/management-ssh-custom-cipher.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/management-ssh-custom-cipher.yml
@@ -1,0 +1,23 @@
+management_ssh:
+  cipher:
+    - aes256-cbc
+    - aes256-ctr
+    - aes256-gcm@openssh.com
+  key_exchange:
+    - ecdh-sha2-nistp521
+  mac:
+    - hmac-sha2-512
+    - hmac-sha2-512-etm@openssh.com
+  hostkey:
+    server:
+      - ecdsa-nistp256
+      - ecdsa-nistp521
+  access_groups:
+    - name: ACL-SSH
+    - name: ACL-SSH-VRF
+      vrf: mgt
+  idle_timeout: 15
+  enable: true
+  vrfs:
+    mgt:
+      enable: true

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts
@@ -16,6 +16,7 @@ loopbacks-interfaces
 management-api-http
 management-gnmi
 management-ssh
+management-ssh-custom-cipher
 mac-security-eth-po-entropy
 mcast-pim
 none_configuration

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1696,6 +1696,19 @@ management_ssh:
     - name: < standard_acl_name_2 >:
       vrf: < vrf name >
   idle_timeout: < 0-86400 in minutes >
+  cipher:
+    - cipher1
+    - cipher2
+  key-exchange:
+    - method1
+    - method2
+  mac:
+    - mac_algorithm1
+    - mac_algorithm2
+  hostkey:
+    server:
+      - algorithm1
+      - algorithm2
   enable: < true | false >
   vrfs:
     < vrf_name_1 >:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1697,18 +1697,18 @@ management_ssh:
       vrf: < vrf name >
   idle_timeout: < 0-86400 in minutes >
   cipher:
-    - cipher1
-    - cipher2
+    - < cipher1 >
+    - < cipher2 >
   key-exchange:
-    - method1
-    - method2
+    - < method1 >
+    - < method2 >
   mac:
-    - mac_algorithm1
-    - mac_algorithm2
+    - < mac_algorithm1 >
+    - < mac_algorithm2 >
   hostkey:
     server:
-      - algorithm1
-      - algorithm2
+      - < algorithm1 >
+      - < algorithm2 >
   enable: < true | false >
   vrfs:
     < vrf_name_1 >:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-ssh.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-ssh.j2
@@ -29,8 +29,14 @@
 | Idle Timeout | SSH Management |
 | ------------ | -------------- |
 | {{ management_ssh.idle_timeout | arista.avd.default('default') }} | {% if ssh.enable %} Enabled {% else %} Disabled {% endif %} |
-{%  if management_ssh.vrfs is arista.avd.defined %}
 
+### Ciphers and algorithms
+
+| Ciphers | Key-exchange methods | MAC algorithms | Hostkey server algorithms |
+|---------|----------------------|----------------|---------------------------|
+| {{ management_ssh.cipher | arista.avd.default(['default']) | join(", ") }} | {{ management_ssh.key_exchange | arista.avd.default(['default']) | join(", ") }} | {{ management_ssh.mac | arista.avd.default(['default']) | join(", ") }} | {{ management_ssh.hostkey.server | arista.avd.default(['default']) | join(", ") }} |
+
+{%  if management_ssh.vrfs is arista.avd.defined %}
 ### VRFs
 
 | VRF | Status |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-ssh.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-ssh.j2
@@ -16,18 +16,18 @@ management ssh
    idle-timeout {{ management_ssh.idle_timeout }}
 {%     endif %}
 {%     if management_ssh.cipher is arista.avd.defined %}
-   cipher {{ management_ssh.cipher|join(" ") }}
+   cipher {{ management_ssh.cipher | join(" ") }}
 {%     endif %}
 {%     if management_ssh.key_exchange is arista.avd.defined %}
-   key-exchange {{ management_ssh.key_exchange|join(" ") }}
+   key-exchange {{ management_ssh.key_exchange | join(" ") }}
 {%     endif %}
 {%     if management_ssh.mac is arista.avd.defined %}
-   mac {{ management_ssh.mac|join(" ") }}
+   mac {{ management_ssh.mac | join(" ") }}
 {%     endif %}
 {%     if management_ssh.hostkey is arista.avd.defined %}
-{%     if management_ssh.hostkey.server is arista.avd.defined %}
-   hostkey server {{ management_ssh.hostkey.server|join(" ") }}
-{%     endif %}
+{%         if management_ssh.hostkey.server is arista.avd.defined %}
+   hostkey server {{ management_ssh.hostkey.server | join(" ") }}
+{%         endif %}
 {%     endif %}
 {%     if management_ssh.enable is defined and management_ssh.enable == false %}
    shutdown

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-ssh.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-ssh.j2
@@ -15,6 +15,20 @@ management ssh
 {%     if management_ssh.idle_timeout is defined and management_ssh.idle_timeout is not none %}
    idle-timeout {{ management_ssh.idle_timeout }}
 {%     endif %}
+{%     if management_ssh.cipher is arista.avd.defined %}
+   cipher {{ management_ssh.cipher|join(" ") }}
+{%     endif %}
+{%     if management_ssh.key_exchange is arista.avd.defined %}
+   key-exchange {{ management_ssh.key_exchange|join(" ") }}
+{%     endif %}
+{%     if management_ssh.mac is arista.avd.defined %}
+   mac {{ management_ssh.mac|join(" ") }}
+{%     endif %}
+{%     if management_ssh.hostkey is arista.avd.defined %}
+{%     if management_ssh.hostkey.server is arista.avd.defined %}
+   hostkey server {{ management_ssh.hostkey.server|join(" ") }}
+{%     endif %}
+{%     endif %}
 {%     if management_ssh.enable is defined and management_ssh.enable == false %}
    shutdown
    !


### PR DESCRIPTION
## Change Summary

Added options to configure ciphers and algorithms for SSH

Add option to configure
  - ciphers
  - key-exchange methods
  - MAC algorithms
  - Hostkey server algorithms

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)


## Component(s) name

`arista.avd.eos_cli_config_gen role`

## Proposed changes

Added new parameters for `management ssh` so users can configure ciphers and other algorithms.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Tested options (partial and full) and generated configlets.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [x] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
