### PR TITLE
Fix readme for MACsec keys to be in " "

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1031,8 +1031,8 @@ mac_security:
     < profile >:
       cipher: < valid-cipher-string >
       connection_keys:
-        < connection_key >:
-          encrypted_key: < encrypted_key >
+        "< connection_key >":
+          encrypted_key: "< encrypted_key >"
           fallback: < true | false -> default >
 ```
 


### PR DESCRIPTION
## Change Summary

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [x] Other (please describe):

Fixes MACsec readme so that keys should always be in the "quote" as EOS can read them the wrong way.

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes issue #<ISSUE ID>

## Component(s) name
eos_cli_config_gen
Readme
`arista.avd.<role-name>`

## Proposed changes
<!--- Describe your changes in detail -->

```
      connection_keys:
        "< connection_key >":
          encrypted_key: "< encrypted_key >"
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been rebased from devel before I start
- [ ] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
