### PR TITLE
Add tenant:system to l2leaf-inband-mgmt vlan

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/l3leaf_l2leafs_uplinks/leaf-l2leaf-inband-management-vlan.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/l3leaf_l2leafs_uplinks/leaf-l2leaf-inband-management-vlan.j2
@@ -1,5 +1,6 @@
 {# L2leaf Inband Management VLAN #}
 {% if l2leaf_inband_management_subnet is defined and l2leaf_inband_management_subnet is not none %}
   {{ l2leaf_inband_management_vlan|arista.avd.default('4092') }}:
+    tenant: system
     name: L2LEAF_INBAND_MGMT
 {% endif %}


### PR DESCRIPTION
## Change Summary

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Missing `tenant` field on inband mgmt vlan 4092 in strucutred configuration. Used for fabric documentation.

## Component(s) name

`arista.avd.eos_l3ls_evpn`

## Proposed changes
<!--- Describe your changes in detail -->
Added `tenant: system` to vlan template. Same as for mlag vlans.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Before change:
```yaml
vlans:
  4092:
    name: L2LEAF_INBAND_MGMT
```
After change:
```yaml
vlans:
  4092:
    tenant: system
    name: L2LEAF_INBAND_MGMT
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been rebased from devel before I start
- [X] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
