### PR TITLE
Add support for OSPF summary

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
@@ -214,15 +214,6 @@ interface Vlan24
 | 400 | enabled | enabled | enabled | wait-for-bgp | enabled |
 | 500 | enabled | enabled (123) | disabled | 222 | enabled (456) |
 
-### Router OSPF route summary
-
-| Process ID | Prefix | Tag | Attribute Route Map | Not Advertised |
-|------------|--------|-----|---------------------|----------------|
-| 101 | 10.0.0.0/8 | - | - | - |
-| 101 | 20.0.0.0/8 | 10 | - | - |
-| 101 | 30.0.0.0/8 | - | RM-OSPF_SUMMARY | - |
-| 101 | 40.0.0.0/8 | - | - | True |
-
 ### OSPF Interfaces
 
 | Interface | Area | Cost | Point To Point |

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
@@ -192,12 +192,12 @@ interface Vlan24
 
 | Process ID | Router ID | Default Passive Interface | No Passive Interface | BFD | Max LSA | Default Information Originate | Log Adjacency Changes Detail | Auto Cost Reference Bandwidth | Maximum Paths | MPLS LDP Sync Default |
 | ---------- | --------- | ------------------------- | -------------------- | --- | ------- | ----------------------------- | ---------------------------- | ----------------------------- | ------------- | --------------------- |
-| 100 | 192.168.255.3 | enabled |  Ethernet1 <br> Ethernet2 <br> Vlan4093 <br> | enabled | 12000 | disabled | disabled | 100 | 10 | True |
+| 100 | 192.168.255.3 | enabled | Ethernet1 <br> Ethernet2 <br> Vlan4093 <br> | enabled | 12000 | disabled | disabled | 100 | 10 | True |
 | 101 | 1.0.1.1 | enabled | Ethernet2.101 <br> | disabled | default | disabled | enabled | - | - | - |
-| 200 | 192.168.254.1 | disabled | - | disabled | 5 | Always | enabled | - | - | - |
-| 300 | - | disabled | - | disabled | default | disabled | disabled | - | - | - |
-| 400 | - | disabled | - | disabled | default | disabled | disabled | - | - | - |
-| 500 | - | disabled | - | disabled | default | disabled | disabled | - | - | - |
+| 200 | 192.168.254.1 | disabled |- | disabled | 5 | Always | enabled | - | - | - |
+| 300 | - | disabled |- | disabled | default | disabled | disabled | - | - | - |
+| 400 | - | disabled |- | disabled | default | disabled | disabled | - | - | - |
+| 500 | - | disabled |- | disabled | default | disabled | disabled | - | - | - |
 
 ### Router OSPF Router Redistribution
 
@@ -231,7 +231,6 @@ interface Vlan24
 | Port-Channel12 | 0.0.0.12 | 99 | True |
 | Vlan24 | 0.0.0.24 | 99 | True |
 | Loopback2 | 0.0.0.2 | - | - |
-No redsitribution configured
 
 ### Router OSPF Device Configuration
 
@@ -257,10 +256,10 @@ router ospf 101 vrf CUSTOMER01
    router-id 1.0.1.1
    passive-interface default
    no passive-interface Ethernet2.101
-   summary 10.0.0.0/8
-   summary 20.0.0.0/8 tag 10
-   summary 30.0.0.0/8 attribute-map RM-OSPF_SUMMARY
-   summary 40.0.0.0/8 not-advertise
+   summary-address 10.0.0.0/8
+   summary-address 20.0.0.0/8 tag 10
+   summary-address 30.0.0.0/8 attribute-map RM-OSPF_SUMMARY
+   summary-address 40.0.0.0/8 not-advertise
 !
 router ospf 200 vrf ospf_zone
    log-adjacency-changes detail
@@ -278,7 +277,6 @@ router ospf 400
 !
 router ospf 500
    max-metric router-lsa external-lsa 123 on-startup 222 summary-lsa 456
-
 ```
 
 ## Router BFD

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
@@ -193,6 +193,7 @@ interface Vlan24
 | Process ID | Router ID | Default Passive Interface | No Passive Interface | BFD | Max LSA | Default Information Originate | Log Adjacency Changes Detail | Auto Cost Reference Bandwidth | Maximum Paths | MPLS LDP Sync Default |
 | ---------- | --------- | ------------------------- | -------------------- | --- | ------- | ----------------------------- | ---------------------------- | ----------------------------- | ------------- | --------------------- |
 | 100 | 192.168.255.3 | enabled |  Ethernet1 <br> Ethernet2 <br> Vlan4093 <br> | enabled | 12000 | disabled | disabled | 100 | 10 | True |
+| 101 | 1.0.1.1 | enabled | Ethernet2.101 <br> | disabled | default | disabled | enabled | - | - | - |
 | 200 | 192.168.254.1 | disabled | - | disabled | 5 | Always | enabled | - | - | - |
 | 300 | - | disabled | - | disabled | default | disabled | disabled | - | - | - |
 | 400 | - | disabled | - | disabled | default | disabled | disabled | - | - | - |
@@ -213,6 +214,15 @@ interface Vlan24
 | 400 | enabled | enabled | enabled | wait-for-bgp | enabled |
 | 500 | enabled | enabled (123) | disabled | 222 | enabled (456) |
 
+### Router OSPF route summary
+
+| Process ID | Prefix | Tag | Attribute Route Map | Not Advertised |
+|------------|--------|-----|---------------------|----------------|
+| 101 | 10.0.0.0/8 | - | - | - |
+| 101 | 20.0.0.0/8 | 10 | - | - |
+| 101 | 30.0.0.0/8 | - | RM-OSPF_SUMMARY | - |
+| 101 | 40.0.0.0/8 | - | - | True |
+
 ### OSPF Interfaces
 
 | Interface | Area | Cost | Point To Point |
@@ -221,6 +231,7 @@ interface Vlan24
 | Port-Channel12 | 0.0.0.12 | 99 | True |
 | Vlan24 | 0.0.0.24 | 99 | True |
 | Loopback2 | 0.0.0.2 | - | - |
+No redsitribution configured
 
 ### Router OSPF Device Configuration
 
@@ -241,6 +252,16 @@ router ospf 100
    maximum-paths 10
    mpls ldp sync default
 !
+router ospf 101 vrf CUSTOMER01
+   log-adjacency-changes detail
+   router-id 1.0.1.1
+   passive-interface default
+   no passive-interface Ethernet2.101
+   summary 10.0.0.0/8
+   summary 20.0.0.0/8 tag 10
+   summary 30.0.0.0/8 attribute-map RM-OSPF_SUMMARY
+   summary 40.0.0.0/8 not-advertise
+!
 router ospf 200 vrf ospf_zone
    log-adjacency-changes detail
    router-id 192.168.254.1
@@ -257,6 +278,7 @@ router ospf 400
 !
 router ospf 500
    max-metric router-lsa external-lsa 123 on-startup 222 summary-lsa 456
+
 ```
 
 ## Router BFD

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-ospf.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-ospf.cfg
@@ -58,10 +58,10 @@ router ospf 101 vrf CUSTOMER01
    router-id 1.0.1.1
    passive-interface default
    no passive-interface Ethernet2.101
-   summary 10.0.0.0/8
-   summary 20.0.0.0/8 tag 10
-   summary 30.0.0.0/8 attribute-map RM-OSPF_SUMMARY
-   summary 40.0.0.0/8 not-advertise
+   summary-address 10.0.0.0/8
+   summary-address 20.0.0.0/8 tag 10
+   summary-address 30.0.0.0/8 attribute-map RM-OSPF_SUMMARY
+   summary-address 40.0.0.0/8 not-advertise
 !
 router ospf 200 vrf ospf_zone
    log-adjacency-changes detail
@@ -81,4 +81,3 @@ router ospf 500
    max-metric router-lsa external-lsa 123 on-startup 222 summary-lsa 456
 !
 end
-

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-ospf.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-ospf.cfg
@@ -53,6 +53,16 @@ router ospf 100
    maximum-paths 10
    mpls ldp sync default
 !
+router ospf 101 vrf CUSTOMER01
+   log-adjacency-changes detail
+   router-id 1.0.1.1
+   passive-interface default
+   no passive-interface Ethernet2.101
+   summary 10.0.0.0/8
+   summary 20.0.0.0/8 tag 10
+   summary 30.0.0.0/8 attribute-map RM-OSPF_SUMMARY
+   summary 40.0.0.0/8 not-advertise
+!
 router ospf 200 vrf ospf_zone
    log-adjacency-changes detail
    router-id 192.168.254.1
@@ -71,3 +81,4 @@ router ospf 500
    max-metric router-lsa external-lsa 123 on-startup 222 summary-lsa 456
 !
 end
+

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-ospf.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-ospf.yml
@@ -17,6 +17,22 @@ router_ospf:
       auto_cost_reference_bandwidth: 100
       maximum_paths: 10
       mpls_ldp_sync_default: true
+    101:
+      vrf: CUSTOMER01
+      passive_interface_default: true
+      router_id: 1.0.1.1
+      log_adjacency_changes_detail: true
+      bfd_enable: false
+      no_passive_interfaces:
+        - Ethernet2.101
+      summary:
+        - prefix: 10.0.0.0/8
+        - prefix: 20.0.0.0/8
+          tag: 10
+        - prefix: 30.0.0.0/8
+          attribute_map: RM-OSPF_SUMMARY
+        - prefix: 40.0.0.0/8
+          not_advertise: true
     200:
       vrf: ospf_zone
       passive_interface_default: false
@@ -86,3 +102,4 @@ vlan_interfaces:
       55:
         hash_algorithm: md5
         key: "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-ospf.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-ospf.yml
@@ -25,7 +25,7 @@ router_ospf:
       bfd_enable: false
       no_passive_interfaces:
         - Ethernet2.101
-      summary:
+      summary_address:
         - prefix: 10.0.0.0/8
         - prefix: 20.0.0.0/8
           tag: 10

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -517,10 +517,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | Process ID | Router ID | Default Passive Interface | No Passive Interface | BFD | Max LSA | Default Information Originate | Log Adjacency Changes Detail | Auto Cost Reference Bandwidth | Maximum Paths | MPLS LDP Sync Default |
 | ---------- | --------- | ------------------------- | -------------------- | --- | ------- | ----------------------------- | ---------------------------- | ----------------------------- | ------------- | --------------------- |
-| 101 | 192.168.255.10 | enabled |  Ethernet1 <br> Ethernet2 <br> Ethernet3 <br> Ethernet4 <br> Vlan4093 <br> | enabled | 12000 | disabled | disabled | - | - | - |
-
-### Router OSPF route summary
-
+| 101 | 192.168.255.10 | enabled | Ethernet1 <br> Ethernet2 <br> Ethernet3 <br> Ethernet4 <br> Vlan4093 <br> | enabled | 12000 | disabled | disabled | - | - | - |
 
 ### OSPF Interfaces
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -519,6 +519,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | ---------- | --------- | ------------------------- | -------------------- | --- | ------- | ----------------------------- | ---------------------------- | ----------------------------- | ------------- | --------------------- |
 | 101 | 192.168.255.10 | enabled |  Ethernet1 <br> Ethernet2 <br> Ethernet3 <br> Ethernet4 <br> Vlan4093 <br> | enabled | 12000 | disabled | disabled | - | - | - |
 
+### Router OSPF route summary
+
+
 ### OSPF Interfaces
 
 | Interface | Area | Cost | Point To Point |

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -517,10 +517,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | Process ID | Router ID | Default Passive Interface | No Passive Interface | BFD | Max LSA | Default Information Originate | Log Adjacency Changes Detail | Auto Cost Reference Bandwidth | Maximum Paths | MPLS LDP Sync Default |
 | ---------- | --------- | ------------------------- | -------------------- | --- | ------- | ----------------------------- | ---------------------------- | ----------------------------- | ------------- | --------------------- |
-| 101 | 192.168.255.11 | enabled |  Ethernet1 <br> Ethernet2 <br> Ethernet3 <br> Ethernet4 <br> Vlan4093 <br> | enabled | 12000 | disabled | disabled | - | - | - |
-
-### Router OSPF route summary
-
+| 101 | 192.168.255.11 | enabled | Ethernet1 <br> Ethernet2 <br> Ethernet3 <br> Ethernet4 <br> Vlan4093 <br> | enabled | 12000 | disabled | disabled | - | - | - |
 
 ### OSPF Interfaces
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -519,6 +519,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | ---------- | --------- | ------------------------- | -------------------- | --- | ------- | ----------------------------- | ---------------------------- | ----------------------------- | ------------- | --------------------- |
 | 101 | 192.168.255.11 | enabled |  Ethernet1 <br> Ethernet2 <br> Ethernet3 <br> Ethernet4 <br> Vlan4093 <br> | enabled | 12000 | disabled | disabled | - | - | - |
 
+### Router OSPF route summary
+
+
 ### OSPF Interfaces
 
 | Interface | Area | Cost | Point To Point |

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -390,6 +390,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | ---------- | --------- | ------------------------- | -------------------- | --- | ------- | ----------------------------- | ---------------------------- | ----------------------------- | ------------- | --------------------- |
 | 101 | 192.168.255.5 | enabled |  Ethernet1 <br> Ethernet2 <br> Ethernet3 <br> Ethernet4 <br> | enabled | 12000 | disabled | disabled | - | - | - |
 
+### Router OSPF route summary
+
+
 ### OSPF Interfaces
 
 | Interface | Area | Cost | Point To Point |

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -388,10 +388,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | Process ID | Router ID | Default Passive Interface | No Passive Interface | BFD | Max LSA | Default Information Originate | Log Adjacency Changes Detail | Auto Cost Reference Bandwidth | Maximum Paths | MPLS LDP Sync Default |
 | ---------- | --------- | ------------------------- | -------------------- | --- | ------- | ----------------------------- | ---------------------------- | ----------------------------- | ------------- | --------------------- |
-| 101 | 192.168.255.5 | enabled |  Ethernet1 <br> Ethernet2 <br> Ethernet3 <br> Ethernet4 <br> | enabled | 12000 | disabled | disabled | - | - | - |
-
-### Router OSPF route summary
-
+| 101 | 192.168.255.5 | enabled | Ethernet1 <br> Ethernet2 <br> Ethernet3 <br> Ethernet4 <br> | enabled | 12000 | disabled | disabled | - | - | - |
 
 ### OSPF Interfaces
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -531,10 +531,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | Process ID | Router ID | Default Passive Interface | No Passive Interface | BFD | Max LSA | Default Information Originate | Log Adjacency Changes Detail | Auto Cost Reference Bandwidth | Maximum Paths | MPLS LDP Sync Default |
 | ---------- | --------- | ------------------------- | -------------------- | --- | ------- | ----------------------------- | ---------------------------- | ----------------------------- | ------------- | --------------------- |
-| 101 | 192.168.255.6 | enabled |  Ethernet1 <br> Ethernet2 <br> Ethernet3 <br> Ethernet4 <br> Vlan4093 <br> | enabled | 12000 | disabled | disabled | - | - | - |
-
-### Router OSPF route summary
-
+| 101 | 192.168.255.6 | enabled | Ethernet1 <br> Ethernet2 <br> Ethernet3 <br> Ethernet4 <br> Vlan4093 <br> | enabled | 12000 | disabled | disabled | - | - | - |
 
 ### OSPF Interfaces
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -533,6 +533,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | ---------- | --------- | ------------------------- | -------------------- | --- | ------- | ----------------------------- | ---------------------------- | ----------------------------- | ------------- | --------------------- |
 | 101 | 192.168.255.6 | enabled |  Ethernet1 <br> Ethernet2 <br> Ethernet3 <br> Ethernet4 <br> Vlan4093 <br> | enabled | 12000 | disabled | disabled | - | - | - |
 
+### Router OSPF route summary
+
+
 ### OSPF Interfaces
 
 | Interface | Area | Cost | Point To Point |

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -531,10 +531,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | Process ID | Router ID | Default Passive Interface | No Passive Interface | BFD | Max LSA | Default Information Originate | Log Adjacency Changes Detail | Auto Cost Reference Bandwidth | Maximum Paths | MPLS LDP Sync Default |
 | ---------- | --------- | ------------------------- | -------------------- | --- | ------- | ----------------------------- | ---------------------------- | ----------------------------- | ------------- | --------------------- |
-| 101 | 192.168.255.7 | enabled |  Ethernet1 <br> Ethernet2 <br> Ethernet3 <br> Ethernet4 <br> Vlan4093 <br> | enabled | 12000 | disabled | disabled | - | - | - |
-
-### Router OSPF route summary
-
+| 101 | 192.168.255.7 | enabled | Ethernet1 <br> Ethernet2 <br> Ethernet3 <br> Ethernet4 <br> Vlan4093 <br> | enabled | 12000 | disabled | disabled | - | - | - |
 
 ### OSPF Interfaces
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -533,6 +533,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | ---------- | --------- | ------------------------- | -------------------- | --- | ------- | ----------------------------- | ---------------------------- | ----------------------------- | ------------- | --------------------- |
 | 101 | 192.168.255.7 | enabled |  Ethernet1 <br> Ethernet2 <br> Ethernet3 <br> Ethernet4 <br> Vlan4093 <br> | enabled | 12000 | disabled | disabled | - | - | - |
 
+### Router OSPF route summary
+
+
 ### OSPF Interfaces
 
 | Interface | Area | Cost | Point To Point |

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE1.md
@@ -365,10 +365,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | Process ID | Router ID | Default Passive Interface | No Passive Interface | BFD | Max LSA | Default Information Originate | Log Adjacency Changes Detail | Auto Cost Reference Bandwidth | Maximum Paths | MPLS LDP Sync Default |
 | ---------- | --------- | ------------------------- | -------------------- | --- | ------- | ----------------------------- | ---------------------------- | ----------------------------- | ------------- | --------------------- |
-| 101 | 192.168.255.1 | enabled |  Ethernet6 <br> Ethernet7 <br> Ethernet1 <br> Ethernet2 <br> Ethernet3 <br> Ethernet4 <br> Ethernet5 <br> | enabled | 12000 | disabled | disabled | - | - | - |
-
-### Router OSPF route summary
-
+| 101 | 192.168.255.1 | enabled | Ethernet6 <br> Ethernet7 <br> Ethernet1 <br> Ethernet2 <br> Ethernet3 <br> Ethernet4 <br> Ethernet5 <br> | enabled | 12000 | disabled | disabled | - | - | - |
 
 ### OSPF Interfaces
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE1.md
@@ -367,6 +367,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | ---------- | --------- | ------------------------- | -------------------- | --- | ------- | ----------------------------- | ---------------------------- | ----------------------------- | ------------- | --------------------- |
 | 101 | 192.168.255.1 | enabled |  Ethernet6 <br> Ethernet7 <br> Ethernet1 <br> Ethernet2 <br> Ethernet3 <br> Ethernet4 <br> Ethernet5 <br> | enabled | 12000 | disabled | disabled | - | - | - |
 
+### Router OSPF route summary
+
+
 ### OSPF Interfaces
 
 | Interface | Area | Cost | Point To Point |

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE2.md
@@ -365,10 +365,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | Process ID | Router ID | Default Passive Interface | No Passive Interface | BFD | Max LSA | Default Information Originate | Log Adjacency Changes Detail | Auto Cost Reference Bandwidth | Maximum Paths | MPLS LDP Sync Default |
 | ---------- | --------- | ------------------------- | -------------------- | --- | ------- | ----------------------------- | ---------------------------- | ----------------------------- | ------------- | --------------------- |
-| 101 | 192.168.255.2 | enabled |  Ethernet6 <br> Ethernet7 <br> Ethernet1 <br> Ethernet2 <br> Ethernet3 <br> Ethernet4 <br> Ethernet5 <br> | enabled | 12000 | disabled | disabled | - | - | - |
-
-### Router OSPF route summary
-
+| 101 | 192.168.255.2 | enabled | Ethernet6 <br> Ethernet7 <br> Ethernet1 <br> Ethernet2 <br> Ethernet3 <br> Ethernet4 <br> Ethernet5 <br> | enabled | 12000 | disabled | disabled | - | - | - |
 
 ### OSPF Interfaces
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE2.md
@@ -367,6 +367,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | ---------- | --------- | ------------------------- | -------------------- | --- | ------- | ----------------------------- | ---------------------------- | ----------------------------- | ------------- | --------------------- |
 | 101 | 192.168.255.2 | enabled |  Ethernet6 <br> Ethernet7 <br> Ethernet1 <br> Ethernet2 <br> Ethernet3 <br> Ethernet4 <br> Ethernet5 <br> | enabled | 12000 | disabled | disabled | - | - | - |
 
+### Router OSPF route summary
+
+
 ### OSPF Interfaces
 
 | Interface | Area | Cost | Point To Point |

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE3.md
@@ -367,6 +367,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | ---------- | --------- | ------------------------- | -------------------- | --- | ------- | ----------------------------- | ---------------------------- | ----------------------------- | ------------- | --------------------- |
 | 101 | 192.168.255.3 | enabled |  Ethernet6 <br> Ethernet7 <br> Ethernet1 <br> Ethernet2 <br> Ethernet3 <br> Ethernet4 <br> Ethernet5 <br> | enabled | 12000 | disabled | disabled | - | - | - |
 
+### Router OSPF route summary
+
+
 ### OSPF Interfaces
 
 | Interface | Area | Cost | Point To Point |

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE3.md
@@ -365,10 +365,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | Process ID | Router ID | Default Passive Interface | No Passive Interface | BFD | Max LSA | Default Information Originate | Log Adjacency Changes Detail | Auto Cost Reference Bandwidth | Maximum Paths | MPLS LDP Sync Default |
 | ---------- | --------- | ------------------------- | -------------------- | --- | ------- | ----------------------------- | ---------------------------- | ----------------------------- | ------------- | --------------------- |
-| 101 | 192.168.255.3 | enabled |  Ethernet6 <br> Ethernet7 <br> Ethernet1 <br> Ethernet2 <br> Ethernet3 <br> Ethernet4 <br> Ethernet5 <br> | enabled | 12000 | disabled | disabled | - | - | - |
-
-### Router OSPF route summary
-
+| 101 | 192.168.255.3 | enabled | Ethernet6 <br> Ethernet7 <br> Ethernet1 <br> Ethernet2 <br> Ethernet3 <br> Ethernet4 <br> Ethernet5 <br> | enabled | 12000 | disabled | disabled | - | - | - |
 
 ### OSPF Interfaces
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE4.md
@@ -367,6 +367,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | ---------- | --------- | ------------------------- | -------------------- | --- | ------- | ----------------------------- | ---------------------------- | ----------------------------- | ------------- | --------------------- |
 | 101 | 192.168.255.4 | enabled |  Ethernet6 <br> Ethernet7 <br> Ethernet1 <br> Ethernet2 <br> Ethernet3 <br> Ethernet4 <br> Ethernet5 <br> | enabled | 12000 | disabled | disabled | - | - | - |
 
+### Router OSPF route summary
+
+
 ### OSPF Interfaces
 
 | Interface | Area | Cost | Point To Point |

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SPINE4.md
@@ -365,10 +365,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | Process ID | Router ID | Default Passive Interface | No Passive Interface | BFD | Max LSA | Default Information Originate | Log Adjacency Changes Detail | Auto Cost Reference Bandwidth | Maximum Paths | MPLS LDP Sync Default |
 | ---------- | --------- | ------------------------- | -------------------- | --- | ------- | ----------------------------- | ---------------------------- | ----------------------------- | ------------- | --------------------- |
-| 101 | 192.168.255.4 | enabled |  Ethernet6 <br> Ethernet7 <br> Ethernet1 <br> Ethernet2 <br> Ethernet3 <br> Ethernet4 <br> Ethernet5 <br> | enabled | 12000 | disabled | disabled | - | - | - |
-
-### Router OSPF route summary
-
+| 101 | 192.168.255.4 | enabled | Ethernet6 <br> Ethernet7 <br> Ethernet1 <br> Ethernet2 <br> Ethernet3 <br> Ethernet4 <br> Ethernet5 <br> | enabled | 12000 | disabled | disabled | - | - | - |
 
 ### OSPF Interfaces
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -539,6 +539,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | ---------- | --------- | ------------------------- | -------------------- | --- | ------- | ----------------------------- | ---------------------------- | ----------------------------- | ------------- | --------------------- |
 | 101 | 192.168.255.8 | enabled |  Ethernet1 <br> Ethernet2 <br> Ethernet3 <br> Ethernet4 <br> Vlan4093 <br> | enabled | 12000 | disabled | disabled | - | - | - |
 
+### Router OSPF route summary
+
+
 ### OSPF Interfaces
 
 | Interface | Area | Cost | Point To Point |

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -537,10 +537,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | Process ID | Router ID | Default Passive Interface | No Passive Interface | BFD | Max LSA | Default Information Originate | Log Adjacency Changes Detail | Auto Cost Reference Bandwidth | Maximum Paths | MPLS LDP Sync Default |
 | ---------- | --------- | ------------------------- | -------------------- | --- | ------- | ----------------------------- | ---------------------------- | ----------------------------- | ------------- | --------------------- |
-| 101 | 192.168.255.8 | enabled |  Ethernet1 <br> Ethernet2 <br> Ethernet3 <br> Ethernet4 <br> Vlan4093 <br> | enabled | 12000 | disabled | disabled | - | - | - |
-
-### Router OSPF route summary
-
+| 101 | 192.168.255.8 | enabled | Ethernet1 <br> Ethernet2 <br> Ethernet3 <br> Ethernet4 <br> Vlan4093 <br> | enabled | 12000 | disabled | disabled | - | - | - |
 
 ### OSPF Interfaces
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -539,6 +539,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | ---------- | --------- | ------------------------- | -------------------- | --- | ------- | ----------------------------- | ---------------------------- | ----------------------------- | ------------- | --------------------- |
 | 101 | 192.168.255.9 | enabled |  Ethernet1 <br> Ethernet2 <br> Ethernet3 <br> Ethernet4 <br> Vlan4093 <br> | enabled | 12000 | disabled | disabled | - | - | - |
 
+### Router OSPF route summary
+
+
 ### OSPF Interfaces
 
 | Interface | Area | Cost | Point To Point |

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -537,10 +537,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | Process ID | Router ID | Default Passive Interface | No Passive Interface | BFD | Max LSA | Default Information Originate | Log Adjacency Changes Detail | Auto Cost Reference Bandwidth | Maximum Paths | MPLS LDP Sync Default |
 | ---------- | --------- | ------------------------- | -------------------- | --- | ------- | ----------------------------- | ---------------------------- | ----------------------------- | ------------- | --------------------- |
-| 101 | 192.168.255.9 | enabled |  Ethernet1 <br> Ethernet2 <br> Ethernet3 <br> Ethernet4 <br> Vlan4093 <br> | enabled | 12000 | disabled | disabled | - | - | - |
-
-### Router OSPF route summary
-
+| 101 | 192.168.255.9 | enabled | Ethernet1 <br> Ethernet2 <br> Ethernet3 <br> Ethernet4 <br> Vlan4093 <br> | enabled | 12000 | disabled | disabled | - | - | - |
 
 ### OSPF Interfaces
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1773,6 +1773,15 @@ router_ospf:
       max_lsa: < integer >
       default_information_originate:
         always: true
+      summary:
+        - prefix: < summary_prefix_01 >
+          tag: < string >
+        - prefix: < summary_prefix_02 >
+          attribute_map: < string >
+        - prefix: < summary_prefix_03 >
+          not_advertise: < true >
+        - prefix: < summary_prefix_04 >
+        - prefix: < summary_prefix_05 >
       redistribute:
         static:
           route_map: < route_map_name >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1773,7 +1773,7 @@ router_ospf:
       max_lsa: < integer >
       default_information_originate:
         always: true
-      summary:
+      summary_address:
         - prefix: < summary_prefix_01 >
           tag: < string >
         - prefix: < summary_prefix_02 >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-ospf.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-ospf.j2
@@ -134,8 +134,8 @@
 | Process ID | Prefix | Tag | Attribute Route Map | Not Advertised |
 |------------|--------|-----|---------------------|----------------|
 {%         for process in router_ospf.process_ids | arista.avd.natural_sort %}
-{%             if router_ospf.process_ids[process].summary is arista.avd.defined %}
-{%                 for summary in router_ospf.process_ids[process].summary %}
+{%             if router_ospf.process_ids[process].summary_address is arista.avd.defined %}
+{%                 for summary in router_ospf.process_ids[process].summary_address %}
 {%                     set summary_prefix = summary.prefix| arista.avd.default('-') %}
 {%                     set summary_tag = summary.tag | arista.avd.default('-') %}
 {%                     set summary_attribute_map = summary.attribute_map | arista.avd.default('-') %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-ospf.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-ospf.j2
@@ -127,10 +127,10 @@
 {%             set has.found = true %}
 {%         endif %}
 {%     endfor %}
+{%     if has.found is arista.avd.defined(true) %}
 
 ### Router OSPF route summary
 
-{%     if has.found is arista.avd.defined(true) %}
 | Process ID | Prefix | Tag | Attribute Route Map | Not Advertised |
 |------------|--------|-----|---------------------|----------------|
 {%         for process in router_ospf.process_ids | arista.avd.natural_sort %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-ospf.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-ospf.j2
@@ -47,6 +47,7 @@
 {%         set mpls_ldp_sync_default = router_ospf.process_ids[process].mpls_ldp_sync_default | arista.avd.default('-') %}
 | {{ process }} | {{ router_id }} | {{ passive_interface_default }} | {{ no_passive_interfaces.list }} | {{ bgp_enable }} | {{ max_lsa }} | {{ default_information_originate }} | {{ log_adjacency_changes_detail }} | {{ auto_cost_reference_bandwidth }} | {{ maximum_paths }} | {{ mpls_ldp_sync_default }} |
 {%     endfor %}
+{# Router Redistribution #}
 {%     set has = namespace() %}
 {%     set has.found = false %}
 {%     for process in router_ospf.process_ids %}
@@ -78,6 +79,7 @@
 {%             endif %}
 {%         endfor %}
 {%     endif %}
+{# Max-Metric #}
 {%     set has.found = false %}
 {%     for process in router_ospf.process_ids %}
 {%         if router_ospf.process_ids[process].max_metric is arista.avd.defined %}
@@ -115,6 +117,34 @@
 {%                     set summary_lsa = 'disabled' %}
 {%                 endif %}
 | {{ process }} | enabled | {{ external_lsa }} | {{ include_stub }} | {{ on_startup }} | {{ summary_lsa }} |
+{%             endif %}
+{%         endfor %}
+{%     endif %}
+{%     for process in router_ospf.process_ids %}
+{% if router_ospf.process_ids[process].redistribute is arista.avd.defined %}| {{process}} | {%if router_ospf.process_ids[process].redistribute.connected is defined %} enabled {% else %} disabled {% endif %}| {{ router_ospf.process_ids[process].redistribute.connected.route_map | default('-')}} | {%if router_ospf.process_ids[process].redistribute.static is defined %} enabled {% else %} disabled {% endif %}| {{ router_ospf.process_ids[process].redistribute.static.route_map | default('-')}} |{% endif %}
+{%     endfor %}
+{# Route Summary #}
+{%     set has.found = false %}
+{%     for process in router_ospf.process_ids %}
+{%         if router_ospf.process_ids[process].summary is arista.avd.defined %}
+{%             set has.found = true %}
+{%         endif %}
+{%     endfor %}
+
+### Router OSPF route summary
+
+{%     if has.found is arista.avd.defined(true) %}
+| Process ID | Prefix | Tag | Attribute Route Map | Not Advertised |
+|------------|--------|-----|---------------------|----------------|
+{%         for process in router_ospf.process_ids %}
+{%             if router_ospf.process_ids[process].summary is arista.avd.defined %}
+{%                 for summary in router_ospf.process_ids[process].summary %}
+{%                     set summary_prefix = summary.prefix| arista.avd.default('-') %}
+{%                     set summary_tag = summary.tag | arista.avd.default('-') %}
+{%                     set summary_attribute_map = summary.attribute_map | arista.avd.default('-') %}
+{%                     set summary_not_advertise = summary.not_advertise | arista.avd.default('-') %}
+| {{ process }} | {{ summary_prefix }} | {{ summary_tag }} | {{ summary_attribute_map }} | {{ summary_not_advertise }} |
+{%                 endfor %}
 {%             endif %}
 {%         endfor %}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-ospf.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-ospf.j2
@@ -6,7 +6,7 @@
 
 | Process ID | Router ID | Default Passive Interface | No Passive Interface | BFD | Max LSA | Default Information Originate | Log Adjacency Changes Detail | Auto Cost Reference Bandwidth | Maximum Paths | MPLS LDP Sync Default |
 | ---------- | --------- | ------------------------- | -------------------- | --- | ------- | ----------------------------- | ---------------------------- | ----------------------------- | ------------- | --------------------- |
-{%     for process in router_ospf.process_ids %}
+{%     for process in router_ospf.process_ids | arista.avd.natural_sort %}
 {%         set router_id = router_ospf.process_ids[process].router_id | arista.avd.default ('-') %}
 {%         if router_ospf.process_ids[process].passive_interface_default is arista.avd.defined(true) %}
 {%             set passive_interface_default = 'enabled' %}
@@ -45,7 +45,7 @@
 {%         set auto_cost_reference_bandwidth = router_ospf.process_ids[process].auto_cost_reference_bandwidth | arista.avd.default('-') %}
 {%         set maximum_paths = router_ospf.process_ids[process].maximum_paths | arista.avd.default('-') %}
 {%         set mpls_ldp_sync_default = router_ospf.process_ids[process].mpls_ldp_sync_default | arista.avd.default('-') %}
-| {{ process }} | {{ router_id }} | {{ passive_interface_default }} | {{ no_passive_interfaces.list }} | {{ bgp_enable }} | {{ max_lsa }} | {{ default_information_originate }} | {{ log_adjacency_changes_detail }} | {{ auto_cost_reference_bandwidth }} | {{ maximum_paths }} | {{ mpls_ldp_sync_default }} |
+| {{ process }} | {{ router_id }} | {{ passive_interface_default }} |{{ no_passive_interfaces.list }} | {{ bgp_enable }} | {{ max_lsa }} | {{ default_information_originate }} | {{ log_adjacency_changes_detail }} | {{ auto_cost_reference_bandwidth }} | {{ maximum_paths }} | {{ mpls_ldp_sync_default }} |
 {%     endfor %}
 {# Router Redistribution #}
 {%     set has = namespace() %}
@@ -61,7 +61,7 @@
 
 | Process ID | Redistribute Connected | Redistribute Connected Route-map | Redistribute Static | Redistribute Static Route-map |
 | ---------- | ---------------------- | -------------------------------- | ------------------- | ----------------------------- |
-{%         for process in router_ospf.process_ids %}
+{%         for process in router_ospf.process_ids | arista.avd.natural_sort %}
 {%             if router_ospf.process_ids[process].redistribute is arista.avd.defined %}
 {%                 if router_ospf.process_ids[process].redistribute.connected is defined %}
 {%                     set connected = 'enabled' %}
@@ -92,7 +92,7 @@
 
 | Process ID | Router-LSA | External-LSA (metric) | Include Stub | On Startup Delay | Summary-LSA (metric) |
 | ---------- | ---------- | --------------------- | ------------ | ---------------- | -------------------- |
-{%         for process in router_ospf.process_ids %}
+{%         for process in router_ospf.process_ids | arista.avd.natural_sort %}
 {%             if router_ospf.process_ids[process].max_metric.router_lsa is defined %}
 {%                 if router_ospf.process_ids[process].max_metric.router_lsa.external_lsa is defined %}
 {%                     set external_lsa = 'enabled' %}
@@ -120,9 +120,6 @@
 {%             endif %}
 {%         endfor %}
 {%     endif %}
-{%     for process in router_ospf.process_ids %}
-{% if router_ospf.process_ids[process].redistribute is arista.avd.defined %}| {{process}} | {%if router_ospf.process_ids[process].redistribute.connected is defined %} enabled {% else %} disabled {% endif %}| {{ router_ospf.process_ids[process].redistribute.connected.route_map | default('-')}} | {%if router_ospf.process_ids[process].redistribute.static is defined %} enabled {% else %} disabled {% endif %}| {{ router_ospf.process_ids[process].redistribute.static.route_map | default('-')}} |{% endif %}
-{%     endfor %}
 {# Route Summary #}
 {%     set has.found = false %}
 {%     for process in router_ospf.process_ids %}
@@ -136,7 +133,7 @@
 {%     if has.found is arista.avd.defined(true) %}
 | Process ID | Prefix | Tag | Attribute Route Map | Not Advertised |
 |------------|--------|-----|---------------------|----------------|
-{%         for process in router_ospf.process_ids %}
+{%         for process in router_ospf.process_ids | arista.avd.natural_sort %}
 {%             if router_ospf.process_ids[process].summary is arista.avd.defined %}
 {%                 for summary in router_ospf.process_ids[process].summary %}
 {%                     set summary_prefix = summary.prefix| arista.avd.default('-') %}
@@ -182,28 +179,40 @@
 {%         if ethernet_interface_ospf.configured %}
 {%             for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort %}
 {%                 if ethernet_interfaces[ethernet_interface].ospf_area is arista.avd.defined %}
-| {{ ethernet_interface }} | {{ ethernet_interfaces[ethernet_interface].ospf_area }} | {{ ethernet_interfaces[ethernet_interface].ospf_cost | arista.avd.default('-') }} | {{ ethernet_interfaces[ethernet_interface].ospf_network_point_to_point | arista.avd.default('-') }} |
+{%                     set ospf_area = ethernet_interfaces[ethernet_interface].ospf_area %}
+{%                     set ospf_cost = ethernet_interfaces[ethernet_interface].ospf_cost | arista.avd.default('-') %}
+{%                     set ospf_network_point_to_point = ethernet_interfaces[ethernet_interface].ospf_network_point_to_point | arista.avd.default('-') %}
+| {{ ethernet_interface }} | {{ ospf_area }} | {{ ospf_cost }} | {{ ospf_network_point_to_point }} |
 {%                 endif %}
 {%             endfor %}
 {%         endif %}
 {%         if port_channel_interface_ospf.configured %}
 {%             for port_channel_interface in port_channel_interfaces | arista.avd.natural_sort %}
 {%                 if port_channel_interfaces[port_channel_interface].ospf_area is arista.avd.defined %}
-| {{ port_channel_interface }} | {{ port_channel_interfaces[port_channel_interface].ospf_area }} | {{ port_channel_interfaces[port_channel_interface].ospf_cost | arista.avd.default('-') }} | {{ port_channel_interfaces[port_channel_interface].ospf_network_point_to_point | arista.avd.default('-') }} |
+{%                     set ospf_area = port_channel_interfaces[port_channel_interface].ospf_area %}
+{%                     set ospf_cost = port_channel_interfaces[port_channel_interface].ospf_cost | arista.avd.default('-') %}
+{%                     set ospf_network_point_to_point = port_channel_interfaces[port_channel_interface].ospf_network_point_to_point | arista.avd.default('-') %}
+| {{ port_channel_interface }} | {{ ospf_area }} | {{ ospf_cost }} | {{ ospf_network_point_to_point }} |
 {%                 endif %}
 {%             endfor %}
 {%         endif %}
 {%         if vlan_interface_ospf.configured %}
 {%             for vlan_interface in vlan_interfaces | arista.avd.natural_sort %}
 {%                 if vlan_interfaces[vlan_interface].ospf_area is arista.avd.defined %}
-| {{ vlan_interface }} | {{ vlan_interfaces[vlan_interface].ospf_area }} | {{ vlan_interfaces[vlan_interface].ospf_cost | arista.avd.default('-') }} | {{ vlan_interfaces[vlan_interface].ospf_network_point_to_point | arista.avd.default('-') }} |
+{%                     set ospf_area = vlan_interfaces[vlan_interface].ospf_area %}
+{%                     set ospf_cost = vlan_interfaces[vlan_interface].ospf_cost | arista.avd.default('-') %}
+{%                     set ospf_network_point_to_point = vlan_interfaces[vlan_interface].ospf_network_point_to_point | arista.avd.default('-') %}
+| {{ vlan_interface }} | {{ ospf_area }} | {{ ospf_cost }} | {{ ospf_network_point_to_point }} |
 {%                 endif %}
 {%             endfor %}
 {%         endif %}
 {%         if loopback_interface_ospf.configured %}
 {%             for loopback_interface in loopback_interfaces | arista.avd.natural_sort %}
 {%                 if loopback_interfaces[loopback_interface].ospf_area is arista.avd.defined %}
-| {{ loopback_interface }} | {{ loopback_interfaces[loopback_interface].ospf_area }} | {{ loopback_interfaces[loopback_interface].ospf_cost | arista.avd.default('-') }} | {{ loopback_interfaces[loopback_interface].ospf_network_point_to_point | arista.avd.default('-') }} |
+{%                     set ospf_area = loopback_interfaces[loopback_interface].ospf_area %}
+{%                     set ospf_cost = loopback_interfaces[loopback_interface].ospf_cost | arista.avd.default('-') %}
+{%                     set ospf_network_point_to_point = loopback_interfaces[loopback_interface].ospf_network_point_to_point | arista.avd.default('-') %}
+| {{ loopback_interface }} | {{ ospf_area }} | {{ ospf_cost }} | {{ ospf_network_point_to_point }} |
 {%                 endif %}
 {%             endfor %}
 {%         endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-ospf.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-ospf.j2
@@ -85,13 +85,13 @@ router ospf {{ process_id }}
 {%         for summary in router_ospf.process_ids[process_id].summary %}
 {%             if summary.prefix is arista.avd.defined %}
 {%                 if summary.tag is arista.avd.defined %}
-   summary {{ summary.prefix }} tag {{ summary.tag }}
+   summary-address {{ summary.prefix }} tag {{ summary.tag }}
 {%                 elif summary.attribute_map is arista.avd.defined %}
-   summary {{ summary.prefix }} attribute-map {{ summary.attribute_map }}
+   summary-address {{ summary.prefix }} attribute-map {{ summary.attribute_map }}
 {%                 elif summary.not_advertise is arista.avd.defined(true) %}
-   summary {{ summary.prefix }} not-advertise
+   summary-address {{ summary.prefix }} not-advertise
 {%                 else %}
-   summary {{ summary.prefix }}
+   summary-address {{ summary.prefix }}
 {%                 endif %}
 {%             endif %}
 {%         endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-ospf.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-ospf.j2
@@ -81,4 +81,19 @@ router ospf {{ process_id }}
 {%     if router_ospf.process_ids[process_id].mpls_ldp_sync_default is arista.avd.defined(true) %}
    mpls ldp sync default
 {%     endif %}
+{%     if router_ospf.process_ids[process_id].summary is arista.avd.defined %}
+{%         for summary in router_ospf.process_ids[process_id].summary %}
+{%             if summary.prefix is arista.avd.defined %}
+{%                 if summary.tag is arista.avd.defined %}
+   summary {{ summary.prefix }} tag {{ summary.tag }}
+{%                 elif summary.attribute_map is arista.avd.defined %}
+   summary {{ summary.prefix }} attribute-map {{ summary.attribute_map }}
+{%                 elif summary.not_advertise is arista.avd.defined(true) %}
+   summary {{ summary.prefix }} not-advertise
+{%                 else %}
+   summary {{ summary.prefix }}
+{%                 endif %}
+{%             endif %}
+{%         endfor %}
+{%     endif %}
 {% endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-ospf.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-ospf.j2
@@ -81,8 +81,8 @@ router ospf {{ process_id }}
 {%     if router_ospf.process_ids[process_id].mpls_ldp_sync_default is arista.avd.defined(true) %}
    mpls ldp sync default
 {%     endif %}
-{%     if router_ospf.process_ids[process_id].summary is arista.avd.defined %}
-{%         for summary in router_ospf.process_ids[process_id].summary %}
+{%     if router_ospf.process_ids[process_id].summary_address is arista.avd.defined %}
+{%         for summary in router_ospf.process_ids[process_id].summary_address %}
 {%             if summary.prefix is arista.avd.defined %}
 {%                 if summary.tag is arista.avd.defined %}
    summary-address {{ summary.prefix }} tag {{ summary.tag }}


### PR DESCRIPTION
Add support for the following data model:

## Change Summary

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Fixes issue #634 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

New data model implemented

```yaml
router_ospf:
  process_ids:
    < process_id >:
      summary:
        - prefix: < summary_prefix_01 >
          tag: < string >
          attribute_map: < string >
          not_advertise: < true >
        - prefix: < summary_prefix_02 >
        - prefix: < summary_prefix_03 >
```

## How to test

Check Molecule scenario

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
