### PR TITLE
Fix issue with MKDOCS check in CI

### DIFF
--- a/.github/workflows/documentation-check.yml
+++ b/.github/workflows/documentation-check.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: check links for 404
         run: |
-          docker run --network container:webdoc_avd raviqqe/muffet:1.5.7 http://127.0.0.1:8000/ -e ".*fonts.gstatic.com.*" -e ".*edit.*" -f --limit-redirections=3 --timeout=30
+          docker run --network container:webdoc_avd raviqqe/muffet:1.5.7 http://127.0.0.1:8000/ -e ".*fonts.gstatic.com.*" -e ".*tools.ietf.org.*" -e ".*edit.*" -f --limit-redirections=3 --timeout=30
 
       - name: 'stop docker-compose stack'
         run: |

--- a/.github/workflows/documentation-check.yml
+++ b/.github/workflows/documentation-check.yml
@@ -24,7 +24,7 @@ jobs:
       - name: 'test connectivity to mkdoc server'
         run: |
           sleep 30
-          docker run --network container:webdoc_avd appropriate/curl -s -I --retry 10 --retry-connrefused http://localhost:8000/
+          docker run --network container:webdoc_avd titom73/curl -s -I --retry 10 --retry-connrefused http://localhost:8000/
           docker ps
 
       - name: check links for 404


### PR DESCRIPTION
## Change Summary

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [x] Other (please describe): Github Actions

## Related Issue(s)

Fixes issue #671 

## Proposed changes

- Switch to a dedicated cURL image to avoid any contention on hub.docker side
- Exclude tools.ietf.org from link check since GH seems to have issue to resolve this domain.

## How to test

Run CI multiple times as it is a non-permanent issue.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
