### PR TITLE
Bugfixes for refactor of overlay bgp

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1327,6 +1327,8 @@ router_bgp:
       bfd: < true | false >
       weight: < weight_value >
       timers: < keepalive_hold_timer_values >
+      route_map_in: < inbound route-map >
+      route_map_out: < outbound route-map >
     < IPv4_address_2 >:
       remote_as: < bgp_as >
       next_hop_self: < true | false >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -99,6 +99,12 @@ router bgp {{ router_bgp.as }}
 {%             if router_bgp.neighbors[neighbor].timers is defined and router_bgp.neighbors[neighbor].timers is not none %}
    neighbor {{ neighbor }} timers {{ router_bgp.neighbors[neighbor].timers }}
 {%             endif %}
+{%             if router_bgp.neighbors[neighbor].route_map_in is arista.avd.defined %}
+   neighbor {{ neighbor }} route-map {{ router_bgp.neighbors[neighbor].route_map_in }} in
+{%             endif %}
+{%             if router_bgp.neighbors[neighbor].route_map_out is arista.avd.defined %}
+   neighbor {{ neighbor }} route-map {{ router_bgp.neighbors[neighbor].route_map_out }} out
+{%             endif %}
 {%         endfor %}
 {%     endif %}
 {%     if router_bgp.aggregate_addresses is defined and router_bgp.aggregate_addresses is not none %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
@@ -375,10 +375,9 @@ bfd_multihop:
 # Requires use eBGP as overlay protocol.
 evpn_overlay_bgp_rtc: < true | false , default -> false >
 
-# Configure route-map on eBGP sessions towards route-servers, where the peer's ASN is filtered away.
-# This is very useful in very large scale networks, where convergence will be quicker by not having
-# to return all updates received from Route-server-1 to Router-server-2 just for Route-server-2 to
-# throw them away because of ASN path loop detection.
+# Configure route-map on eBGP sessions towards route-servers, where prefixes with the peer's ASN in the AS Path are filtered away.
+# This is very useful in very large scale networks, where convergence will be quicker by not having to return all updates received 
+# from Route-server-1 to Router-server-2 just for Route-server-2 to throw them away because of AS Path loop detection.
 evpn_prevent_readvertise_to_server : < true | false , default -> false >
 
 # Optional IP subnet assigned to Inband Management SVI on l2leafs in default VRF.
@@ -1837,7 +1836,11 @@ Assigned to the DC group:
 ```yaml
 overlay_controller:
   platform: <platform>   # overlay-controller platform
-  defaults: #Default variables, can be overridden when defined under each node
+
+  # All variables defined under `nodes` dictionary can be defined under the defaults key will be inherited by all overlay-controllers.
+  # The variables defined under a specific node will take precedence over defaults.
+  defaults:
+
   nodes:
     <inventory_hostname>:
       id: <number> # Starting from 1

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
@@ -376,7 +376,7 @@ bfd_multihop:
 evpn_overlay_bgp_rtc: < true | false , default -> false >
 
 # Configure route-map on eBGP sessions towards route-servers, where prefixes with the peer's ASN in the AS Path are filtered away.
-# This is very useful in very large scale networks, where convergence will be quicker by not having to return all updates received 
+# This is very useful in very large scale networks, where convergence will be quicker by not having to return all updates received
 # from Route-server-1 to Router-server-2 just for Route-server-2 to throw them away because of AS Path loop detection.
 evpn_prevent_readvertise_to_server : < true | false , default -> false >
 

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
@@ -1838,14 +1838,15 @@ Assigned to the DC group:
 overlay_controller:
   platform: <platform>   # overlay-controller platform
   defaults: #Default variables, can be overridden when defined under each node
-    remote_switches: [ <switch_inventory_hostname> , <switch_inventory_hostname> ] #Remote Switches connected to uplink interfaces
-    uplink_to_remote_switches: [ <uplink_interface> , <uplink_interface> ]
-    bgp_as: <BGP AS>
   nodes:
     <inventory_hostname>:
       id: <number> # Starting from 1
       mgmt_ip: < IPv4_address/Mask >
       remote_switches_interfaces: [ <remote_switch_interface> , <remote_switch_interface> ] # Interfaces on remote switch
+
+      remote_switches: [ <switch_inventory_hostname> , <switch_inventory_hostname> ] #Remote Switches connected to uplink interfaces
+      uplink_to_remote_switches: [ <uplink_interface> , <uplink_interface> ]
+      bgp_as: <BGP AS>
 
       # EVPN Role for Overlay BGP Peerings | Optional, default is none
       # For IBGP overlay "server" means route-reflector. For EBGP overlay "server" means route-server.

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
@@ -326,7 +326,7 @@ bgp_ecmp: < number_of_ecmp_paths | default -> 4 >
 
 # EVPN ebgp-multihop | Optional
 # Default of 3, the recommended value for a 3 stage spine and leaf topology.
-# Set to 15 to allow for very large and complex topologies.
+# Set to a higher value to allow for very large and complex topologies.
 evpn_ebgp_multihop: < ebgp_multihop | default -> 3 >
 
 # BGP peer groups encrypted password
@@ -374,6 +374,12 @@ bfd_multihop:
 # Enable Route Target Membership Constraint Address Family on EVPN overlay BGP peerings (Min. EOS 4.25.1F)
 # Requires use eBGP as overlay protocol.
 evpn_overlay_bgp_rtc: < true | false , default -> false >
+
+# Configure route-map on eBGP sessions towards route-servers, where the peer's ASN is filtered away.
+# This is very useful in very large scale networks, where convergence will be quicker by not having
+# to return all updates received from Route-server-1 to Router-server-2 just for Route-server-2 to
+# throw them away because of ASN path loop detection.
+evpn_prevent_readvertise_to_server : < true | false , default -> false >
 
 # Optional IP subnet assigned to Inband Management SVI on l2leafs in default VRF.
 # Parent l3leafs will have SVI with "ip virtual-router" and host-route injection based on ARP. This allows all l3leafs to reuse the same subnet

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/logic/switch-evpn-route-clients.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/logic/switch-evpn-route-clients.j2
@@ -9,14 +9,14 @@
 {%                 for node in fabric_switch_vars.l3leaf.node_groups[l3leaf_node_group].nodes | arista.avd.natural_sort %}
 {%                     if node == fabric_switch %}
 {%                         set fabric_switch_evpn_role = fabric_switch_vars.l3leaf.node_groups[l3leaf_node_group].evpn_role | arista.avd.default(
-                                                       fabric_switch_vars.l3leaf.defaults.evpn_role,
-                                                       'client') %}
+                                                         fabric_switch_vars.l3leaf.defaults.evpn_role,
+                                                         'client') %}
 {%                         set fabric_switch_spines = fabric_switch_vars.l3leaf.node_groups[l3leaf_node_group].spines | arista.avd.default(
-                                                    fabric_switch_vars.l3leaf.defaults.spines) %}
+                                                      fabric_switch_vars.l3leaf.defaults.spines) %}
 {%                         set fabric_switch_evpn_route_servers = fabric_switch_vars.l3leaf.node_groups[l3leaf_node_group].evpn_route_servers | arista.avd.default(
-                                                                fabric_switch_vars.l3leaf.defaults.evpn_route_servers,
-                                                                fabric_switch_spines,
-                                                                []) %}
+                                                                  fabric_switch_vars.l3leaf.defaults.evpn_route_servers,
+                                                                  fabric_switch_spines,
+                                                                  []) %}
 {%                         if inventory_hostname in fabric_switch_evpn_route_servers and fabric_switch_evpn_role in ['client', 'server'] %}
 {# Found a matching l3leaf. Gathering information for this client #}
 {%                             set client = namespace() %}
@@ -31,9 +31,9 @@
 {%             endfor %}
 {%         elif fabric_switch_vars.type is arista.avd.defined('spine') %}
 {%             set fabric_switch_evpn_role = fabric_switch_vars.spine.nodes[fabric_switch].evpn_role | arista.avd.default(
-                                           'server') %}
+                                             'server') %}
 {%             set fabric_switch_evpn_route_servers = fabric_switch_vars.spine.nodes[fabric_switch].evpn_route_servers | arista.avd.default(
-                                                    []) %}
+                                                      []) %}
 {%             if inventory_hostname in fabric_switch_evpn_route_servers and fabric_switch_evpn_role in ['client', 'server'] %}
 {# Found a matching spine. Gathering information for this client #}
 {%                 set client = namespace() %}
@@ -46,7 +46,7 @@
 {%         elif fabric_switch_vars.type is arista.avd.defined('super-spine') %}
 {%             set fabric_switch_evpn_role = fabric_switch_vars.super_spine.nodes[fabric_switch].evpn_role | arista.avd.default %}
 {%             set fabric_switch_evpn_route_servers = fabric_switch_vars.super_spine.nodes[fabric_switch].evpn_route_servers | arista.avd.default(
-                                                    []) %}
+                                                      []) %}
 {%             if inventory_hostname in fabric_switch_evpn_route_servers and fabric_switch_evpn_role in ['client', 'server'] %}
 {# Found a matching super-spine. Gathering information for this client #}
 {%                 set client = namespace() %}
@@ -57,16 +57,18 @@
 {%                 do switch.evpn_route_clients.update({ fabric_switch: client }) %}
 {%             endif %}
 {%         elif fabric_switch_vars.type is arista.avd.defined('overlay-controller') %}
-{%             set fabric_switch_evpn_role = fabric_switch_vars.overlay_controller.nodes[fabric_switch].evpn_role | arista.avd.default %}
+{%             set fabric_switch_evpn_role = fabric_switch_vars.overlay_controller.nodes[fabric_switch].evpn_role | arista.avd.default(
+                                             fabric_switch_vars.overlay_controller.defaults.evpn_role) %}
 {%             set fabric_switch_evpn_route_servers = fabric_switch_vars.overlay_controller.nodes[fabric_switch].evpn_route_servers | arista.avd.default(
-                                                    []) %}
+                                                      fabric_switch_vars.overlay_controller.defaults.evpn_route_servers,
+                                                      []) %}
 {%             if inventory_hostname in fabric_switch_evpn_route_servers and fabric_switch_evpn_role in ['client', 'server'] %}
 {# Found a matching overlay-controller. Gathering information for this client #}
 {%                 set client = namespace() %}
 {%                 set client.evpn_role = fabric_switch_evpn_role %}
 {%                 set client.id = fabric_switch_vars.overlay_controller.nodes[fabric_switch].id %}
 {%                 set client.bgp_as = fabric_switch_vars.overlay_controller.nodes[fabric_switch].bgp_as | arista.avd.default(
-                                       overlay_controller.defaults.bgp_as) %}
+                                       fabric_switch_vars.overlay_controller.defaults.bgp_as) %}
 {%                 set client.ip_address = fabric_switch_vars.overlay_controller_loopback_network_summary  | ipaddr('network') | ipmath(client.id) %}
 {%                 do switch.evpn_route_clients.update({ fabric_switch: client }) %}
 {%             endif %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/logic/switch-evpn-route-servers.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/logic/switch-evpn-route-servers.j2
@@ -25,7 +25,7 @@
 {%             endfor %}
 {%         elif route_server_vars.type is arista.avd.defined('spine') %}
 {%             set route_server_evpn_role = route_server_vars.spine.nodes[route_server].evpn_role | arista.avd.default(
-                                           'server') %}
+                                            'server') %}
 {%             if route_server_evpn_role == 'server' %}
 {# Found a matching spine. Gathering information for this server #}
 {%                 set server = namespace() %}
@@ -47,14 +47,15 @@
 {%                 do switch.evpn_route_servers.update({ route_server: server }) %}
 {%             endif %}
 {%         elif route_server_vars.type is arista.avd.defined('overlay-controller') %}
-{%             set route_server_evpn_role = route_server_vars.overlay_controller.nodes[route_server].evpn_role | arista.avd.default %}
+{%             set route_server_evpn_role = route_server_vars.overlay_controller.nodes[route_server].evpn_role | arista.avd.default(
+                                            route_server_vars.overlay_controller.defaults.evpn_role) %}
 {%             if route_server_evpn_role == 'server' %}
 {# Found a matching overlay-controller. Gathering information for this server #}
 {%                 set server = namespace() %}
 {%                 set server.evpn_role = route_server_evpn_role %}
 {%                 set server.id = route_server_vars.overlay_controller.nodes[route_server].id %}
 {%                 set server.bgp_as = route_server_vars.overlay_controller.nodes[route_server].bgp_as | arista.avd.default(
-                                       overlay_controller.defaults.bgp_as) %}
+                                       route_server_vars.overlay_controller.defaults.bgp_as) %}
 {%                 set server.ip_address = route_server_vars.overlay_controller_loopback_network_summary  | ipaddr('network') | ipmath(server.id) %}
 {%                 do switch.evpn_route_servers.update({ route_server: server }) %}
 {%             endif %}


### PR DESCRIPTION
## Change Summary
Bugfixes for refactor of overlay bgp

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [X] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

## Component(s) name

`arista.avd.eos_l3ls_evpn`
`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
### eos_cli_config_gen
- Add support for `route_map_in` and `route_map_out` on BGP neighbors in default VRF
- Update readme accordingly

### eos_l3ls_evpn
- Various spacing to ease readability
- Fix variable inheritance for overlay_controller to all variables can be under `defaults` as well.
- Document `evpn_prevent_readvertise_to_server`
- Update readme accordingly

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Tested with different placement of overlay_controller variables and it produced the same result.
No changes to molecule.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been rebased from devel before I start
- [X] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
