### PR TITLE
Fix readme typos, add lag_hardware command

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
@@ -631,7 +631,7 @@ l3leaf:
       # If filter is not defined will default to all
       filter:
         tenants: [ < tenant_1 >, < tenant_2 > | default all ]
-        tags: [ < tag_1 >, < tag_2 > | default -> all ]]
+        tags: [ < tag_1 >, < tag_2 > | default -> all ]
 
       # Possibility to prevent configuration of Tenant VRFs and SVIs | Optional, default is false
       # This allows support for centralized routing.
@@ -653,7 +653,7 @@ l3leaf:
 
           # Spine interfaces (list), interface located on Spine,
           # corresponding to spines and uplink_to_spine_interfaces | Required.
-          spine_interfaces: [  < ethernet_interface_1 >, < ethernet_interface_1 > ]
+          spine_interfaces: [ < ethernet_interface_1 >, < ethernet_interface_1 > ]
 
     # node_group_2, will result in MLAG pair.
     < node_group_2 >:
@@ -667,13 +667,13 @@ l3leaf:
         < l3_leaf_inventory_hostname_2 >:
           id: < integer >
           mgmt_ip: < IPv4_address/Mask >
-          spine_interfaces: [  < ethernet_interface_2 >, < ethernet_interface_2 > ]
+          spine_interfaces: [ < ethernet_interface_2 >, < ethernet_interface_2 > ]
 
         # Third node
         < l3_leaf_inventory_hostname_3 >:
           id: < integer >
           mgmt_ip: < IPv4_address/Mask >
-          spine_interfaces: [  < ethernet_interface_3 >, < ethernet_interface_3 > ]
+          spine_interfaces: [ < ethernet_interface_3 >, < ethernet_interface_3 > ]
 ```
 
 **Example:**
@@ -794,7 +794,7 @@ l2leaf:
       # If filter is not defined will default to all
       filter:
         tenants: [ < tenant_1 >, < tenant_2 > | default all ]
-        tags: [ < tag_1 >, < tag_2 > | default -> all ]]
+        tags: [ < tag_1 >, < tag_2 > | default -> all ]
 
       # Activate or deactivate IGMP snooping for node groups devices
       igmp_snooping_enabled: < true | false >
@@ -843,7 +843,7 @@ l2leaf:
 l2leaf:
   defaults:
     platform: vEOS-LAB
-    parent_l3leafs: [ DC1-LEAF2A, DC1-LEAF2B]
+    parent_l3leafs: [ DC1-LEAF2A, DC1-LEAF2B ]
     uplink_interfaces: [ Ethernet1, Ethernet2 ]
     mlag_interfaces: [ Ethernet3, Ethernet4 ]
     spanning_tree_mode: mstp
@@ -1248,7 +1248,7 @@ tenants:
         tags: [ vmotion ]
       161:
         name: Tenant_A_NFS
-        tags: [ nfs]
+        tags: [ nfs ]
 
   Tenant_B:
     mac_vrf_vni_base: 20000
@@ -1392,9 +1392,9 @@ servers:
 
 
       # Example of port-channel adpater
-      - server_ports: [ < interface_name_1 > , < interface_name_2 >  ]
+      - server_ports: [ < interface_name_1 > , < interface_name_2 > ]
         switch_ports: [ < switchport_interface_1 >, < switchport_interface_2 > ]
-        switches: [ < device_1 >, < device_2 >  ]
+        switches: [ < device_1 >, < device_2 > ]
         profile: < port_profile_name >
 
         # Port- Channel
@@ -1414,9 +1414,9 @@ servers:
         switch_ports: [ < switchport_interface > ]
         switches: [ < device > ]
         profile: < port_profile_name >
-      - server_ports: [ < interface_name_1 > , < interface_name_2 >  ]
+      - server_ports: [ < interface_name_1 > , < interface_name_2 > ]
         switch_ports: [ < switchport_interface_1 >, < switchport_interface_2 > ]
-        switches: [ < device_1 >, < device_2 >  ]
+        switches: [ < device_1 >, < device_2 > ]
         profile: < port_profile_name >
         port_channel:
           description: < port_channel_description >
@@ -1513,7 +1513,6 @@ servers:
   server01:
     rack: RackB
     adapters:
-
       - server_ports: [ E0, E1 ]
         switch_ports: [ Ethernet10, Ethernet10 ]
         switches: [ DC1-SVC3A, DC1-SVC3B ]
@@ -1535,7 +1534,6 @@ servers:
   server01:
     rack: RackB
     adapters:
-
       - server_ports: [ E0, E1 ]
         switch_ports: [ Ethernet10, Ethernet10 ]
         switches: [ DC1-SVC3A, DC1-SVC4A ]
@@ -1625,6 +1623,7 @@ platform_settings:
       non_mlag: < seconds >
   - platforms: [ < Arista Platform Family >, < Arista Platform Family > ]
     tcam_profile: < tcam_profile >
+    lag_hardware_only: < true | false >
     reload_delay:
       mlag: < seconds >
       non_mlag: < seconds >
@@ -1643,6 +1642,7 @@ note: Recommended default values for Jericho based platform, and all other platf
 #       non_mlag: 330
 #   - platforms: [ 7800R3, 7500R3, 7500R, 7280R3, 7280R2, 7280R ]
 #     tcam_profile: vxlan-routing
+#     lag_hardware_only: true
 #     reload_delay:
 #       mlag: 780
 #       non_mlag: 1020
@@ -1778,14 +1778,14 @@ spine:
   # taking `max_spine_to_super_spine_links` into account
   # for example: spine1, spine2, spine3, ...
   # or spine1, spine1, spine2, spine2, etc.
-  uplinks_to_super_spine_interfaces: ['Ethernet10', 'Ethernet11', 'Ethernet12', 'Ethernet13']
+  uplinks_to_super_spine_interfaces: [ Ethernet10, Ethernet11, Ethernet12, Ethernet13 ]
   nodes:
     <spine-hostname>:
       # super-spine interfaces to spines
       # taking `max_spine_to_super_spine_links` into account
       # for example: super-spine1, super-spine2, super-spine3, ...
       # or super-spine1, super-spine1, super-spine2, super-spine2, etc.
-      super_spine_interfaces: ['Ethernet1', 'Ethernet1', 'Ethernet1', 'Ethernet1']
+      super_spine_interfaces: [ Ethernet1, Ethernet1, Ethernet1, Ethernet1 ]
     <-- etc. -->
 
 # Point to Point Network Summary range, assigned as /31 for each
@@ -1856,7 +1856,7 @@ overlay_controller:
       evpn_role: < client | server | none | default -> none  >
 
       # Peer with these EVPN Route Servers / Route Reflectors | Optional
-      evpn_route_servers: [ < route_server_inventory_hostname >, < route_server_inventory_hostname >]
+      evpn_route_servers: [ < route_server_inventory_hostname >, < route_server_inventory_hostname > ]
 
 # Point to Point Network Summary range, assigned as /31 for each uplink interfaces
 # Assign range larger than [ total overlay_controllers * max_overlay_controller_to_switch_links * 2]
@@ -1907,7 +1907,7 @@ custom_structured_configuration_ethernet_interfaces:
     peer_interface: Ethernet123
     peer_type: my_precious
 ```
-In this example the contents of the `name_server.nodes` variable in the Structured Configuration will be replaced by the list `[ "10.2.3.4" ]`
+In this example the contents of the `name_server.nodes` variable in the Structured Configuration will be replaced by the list `[ 10.2.3.4 ]`
 and `Ethernet4000` will be added to the `ethernet_interfaces` dictionary in the Structured Configuration.
 
 `custom_structured_configuration_prefix` allows the user to customize the prefix for Custom Structured Configuration variables.


### PR DESCRIPTION
## Change Summary

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [x] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Adds lag_hardware and fixes some quotation marks and whitespaces.

## Component(s) name

`arista.avd.eos_l3ls_evpn`

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
