### PR TITLE
Refactor eos_cli_config - block 09 - TG

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis.md
@@ -388,6 +388,7 @@ interface Vlan4093
 !
 interface Vlan4094
    description MLAG_PEER
+   mtu 1500
    no autostate
    ip address 10.255.252.0/31
 ```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/virtual-source-nat.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/virtual-source-nat.md
@@ -1,4 +1,4 @@
-# vlans
+# virtual-source-nat
 
 # Table of Contents
 
@@ -238,36 +238,7 @@ Spanning-tree not defined
 
 # VLANs
 
-## VLANs Summary
-
-| VLAN ID | Name | Trunk Groups |
-| ------- | ---- | ------------ |
-| 110 | PR01-DMZ | none  |
-| 3010 | MLAG_iBGP_TENANT_A_PROJECT01 | LEAF_PEER_L3  |
-| 3011 | MLAG_iBGP_TENANT_A_PROJECT02 | MY_TRUNK_GROUP  |
-| 3012 | MLAG_iBGP_TENANT_A_PROJECT03 | MY_TRUNK_GROUP  |
-
-## VLANs Device Configuration
-
-```eos
-!
-vlan 110
-   name PR01-DMZ
-!
-vlan 3010
-   name MLAG_iBGP_TENANT_A_PROJECT01
-   trunk group LEAF_PEER_L3
-!
-vlan 3011
-   name MLAG_iBGP_TENANT_A_PROJECT02
-   state active
-   trunk group MY_TRUNK_GROUP
-!
-vlan 3012
-   name MLAG_iBGP_TENANT_A_PROJECT03
-   state suspend
-   trunk group MY_TRUNK_GROUP
-```
+No VLANs defined
 
 # Interfaces
 
@@ -419,7 +390,20 @@ No VRF instances defined
 
 # Virtual Source NAT
 
-Virtual source NAT not defined
+## Virtual Source NAT Summary
+
+| Source NAT VRF | Source NAT IP Address |
+| -------------- | --------------------- |
+| TEST_01 | 1.1.1.1 |
+| TEST_02 | 1.1.1.2 |
+
+## Virtual Source NAT Configuration
+
+```eos
+!
+ip address virtual source-nat vrf TEST_01 address 1.1.1.1
+ip address virtual source-nat vrf TEST_02 address 1.1.1.2
+```
 
 # Platform
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
@@ -271,9 +271,11 @@ No loopback interfaces defined
 | Vlan83 |  SVI Description  |  default  |  -  |  false  |
 | Vlan84 |  SVI Description  |  default  |  -  |  -  |
 | Vlan85 |  SVI Description  |  default  |  -  |  -  |
+| Vlan86 |  SVI Description  |  default  |  -  |  -  |
 | Vlan87 |  SVI Description  |  default  |  -  |  true  |
 | Vlan88 |  SVI Description  |  default  |  -  |  true  |
 | Vlan89 |  SVI Description  |  default  |  -  |  false  |
+| Vlan90 |  SVI Description  |  default  |  -  |  -  |
 | Vlan501 |  SVI Description  |  default  |  -  |  false  |
 | Vlan1001 |  SVI Description  |  Tenant_A  |  -  |  false  |
 | Vlan1002 |  SVI Description  |  Tenant_A  |  -  |  false  |
@@ -292,9 +294,11 @@ No loopback interfaces defined
 | Vlan83 |  default  |  -  |  10.10.83.1/24  |  -  |  -  |  -  |  -  |
 | Vlan84 |  default  |  -  |  10.10.84.1/24  |  -  |  -  |  -  |  -  |
 | Vlan85 |  default  |  10.10.84.1/24  |  -  |  -  |  -  |  -  |  -  |
+| Vlan86 |  default  |  10.10.83.1/24  |  -  |  -  |  -  |  -  |  -  |
 | Vlan87 |  default  |  10.10.87.1/24  |  -  |  -  |  -  |  ACL_IN  |  ACL_OUT  |
 | Vlan88 |  default  |  -  |  10.10.87.1/23  |  -  |  -  |  -  |  -  |
 | Vlan89 |  default  |  -  |  10.10.144.3/20  |  -  |  -  |  -  |  -  |
+| Vlan90 |  default  |  10.10.83.1/24  |  -  |  -  |  -  |  -  |  -  |
 | Vlan501 |  default  |  10.50.26.29/27  |  -  |  -  |  -  |  -  |  -  |
 | Vlan1001 |  Tenant_A  |  -  |  10.1.1.1/24  |  -  |  -  |  -  |  -  |
 | Vlan1002 |  Tenant_A  |  -  |  10.1.2.1/24  |  -  |  -  |  -  |  -  |
@@ -332,9 +336,9 @@ interface Vlan41
    description SVI Description
    no shutdown
    ip address virtual 10.10.41.1/24
-   ip helper-address 10.10.64.150  source-interface Loopback0
-   ip helper-address 10.10.96.150  source-interface Loopback0
-   ip helper-address 10.10.96.151  source-interface Loopback0
+   ip helper-address 10.10.64.150 source-interface Loopback0
+   ip helper-address 10.10.96.150 source-interface Loopback0
+   ip helper-address 10.10.96.151 source-interface Loopback0
 !
 interface Vlan42
    description SVI Description
@@ -363,6 +367,11 @@ interface Vlan85
    description SVI Description
    ip address 10.10.84.1/24
 !
+interface Vlan86
+   description SVI Description
+   ip address 10.10.83.1/24
+   ip attached-host route export 10
+!
 interface Vlan87
    description SVI Description
    shutdown
@@ -386,6 +395,11 @@ interface Vlan89
    pim ipv4 sparse-mode
    pim ipv4 local-interface Loopback0
    ipv6 virtual-router address 1b11:3a00:22b0:5200::3
+!
+interface Vlan90
+   description SVI Description
+   ip address 10.10.83.1/24
+   ip attached-host route export
 !
 interface Vlan501
    description SVI Description

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-internal-order.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-internal-order.md
@@ -1,4 +1,4 @@
-# vlans
+# vlan-internal-order
 
 # Table of Contents
 
@@ -230,44 +230,20 @@ Spanning-tree not defined
 
 ## Internal VLAN Allocation Policy Summary
 
-**Default Allocation Policy**
-
 | Policy Allocation | Range Beginning | Range Ending |
 | ------------------| --------------- | ------------ |
-| ascending | 1006 | 4094 |
+| ascending | 10 | 40 |
 
-# VLANs
-
-## VLANs Summary
-
-| VLAN ID | Name | Trunk Groups |
-| ------- | ---- | ------------ |
-| 110 | PR01-DMZ | none  |
-| 3010 | MLAG_iBGP_TENANT_A_PROJECT01 | LEAF_PEER_L3  |
-| 3011 | MLAG_iBGP_TENANT_A_PROJECT02 | MY_TRUNK_GROUP  |
-| 3012 | MLAG_iBGP_TENANT_A_PROJECT03 | MY_TRUNK_GROUP  |
-
-## VLANs Device Configuration
+## Internal VLAN Allocation Policy Configuration
 
 ```eos
 !
-vlan 110
-   name PR01-DMZ
-!
-vlan 3010
-   name MLAG_iBGP_TENANT_A_PROJECT01
-   trunk group LEAF_PEER_L3
-!
-vlan 3011
-   name MLAG_iBGP_TENANT_A_PROJECT02
-   state active
-   trunk group MY_TRUNK_GROUP
-!
-vlan 3012
-   name MLAG_iBGP_TENANT_A_PROJECT03
-   state suspend
-   trunk group MY_TRUNK_GROUP
+vlan internal order ascending range 10 40
 ```
+
+# VLANs
+
+No VLANs defined
 
 # Interfaces
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-isis.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-isis.cfg
@@ -59,6 +59,7 @@ interface Vlan4093
 !
 interface Vlan4094
    description MLAG_PEER
+   mtu 1500
    no autostate
    ip address 10.255.252.0/31
 router isis EVPN_UNDERLAY

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/virtual-source-nat.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/virtual-source-nat.cfg
@@ -1,0 +1,18 @@
+!RANCID-CONTENT-TYPE: arista
+!
+transceiver qsfp default-mode 4x10G
+!
+hostname virtual-source-nat
+!
+no aaa root
+no enable password
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+!
+ip address virtual source-nat vrf TEST_01 address 1.1.1.1
+ip address virtual source-nat vrf TEST_02 address 1.1.1.2
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
@@ -25,9 +25,9 @@ interface Vlan41
    description SVI Description
    no shutdown
    ip address virtual 10.10.41.1/24
-   ip helper-address 10.10.64.150  source-interface Loopback0
-   ip helper-address 10.10.96.150  source-interface Loopback0
-   ip helper-address 10.10.96.151  source-interface Loopback0
+   ip helper-address 10.10.64.150 source-interface Loopback0
+   ip helper-address 10.10.96.150 source-interface Loopback0
+   ip helper-address 10.10.96.151 source-interface Loopback0
 !
 interface Vlan42
    description SVI Description
@@ -56,6 +56,11 @@ interface Vlan85
    description SVI Description
    ip address 10.10.84.1/24
 !
+interface Vlan86
+   description SVI Description
+   ip address 10.10.83.1/24
+   ip attached-host route export 10
+!
 interface Vlan87
    description SVI Description
    shutdown
@@ -79,6 +84,11 @@ interface Vlan89
    pim ipv4 sparse-mode
    pim ipv4 local-interface Loopback0
    ipv6 virtual-router address 1b11:3a00:22b0:5200::3
+!
+interface Vlan90
+   description SVI Description
+   ip address 10.10.83.1/24
+   ip attached-host route export
 !
 interface Vlan501
    description SVI Description

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-internal-order-incorrect.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-internal-order-incorrect.cfg
@@ -1,0 +1,15 @@
+!RANCID-CONTENT-TYPE: arista
+!
+transceiver qsfp default-mode 4x10G
+!
+hostname vlan-internal-order-incorrect
+!
+no aaa root
+no enable password
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-internal-order.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-internal-order.cfg
@@ -1,0 +1,17 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 10 40
+!
+transceiver qsfp default-mode 4x10G
+!
+hostname vlan-internal-order
+!
+no aaa root
+no enable password
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlans.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlans.cfg
@@ -1,7 +1,5 @@
 !RANCID-CONTENT-TYPE: arista
 !
-vlan internal order ascending range 1006 1199
-!
 transceiver qsfp default-mode 4x10G
 !
 hostname vlans
@@ -15,6 +13,16 @@ vlan 110
 vlan 3010
    name MLAG_iBGP_TENANT_A_PROJECT01
    trunk group LEAF_PEER_L3
+!
+vlan 3011
+   name MLAG_iBGP_TENANT_A_PROJECT02
+   state active
+   trunk group MY_TRUNK_GROUP
+!
+vlan 3012
+   name MLAG_iBGP_TENANT_A_PROJECT03
+   state suspend
+   trunk group MY_TRUNK_GROUP
 !
 interface Management1
    description oob_management

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/virtual-source-nat.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/virtual-source-nat.yml
@@ -1,0 +1,6 @@
+---
+virtual_source_nat_vrfs:
+  TEST_01:
+    ip_address: 1.1.1.1
+  TEST_02:
+    ip_address: 1.1.1.2

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
@@ -24,6 +24,12 @@ vlan_interfaces:
     description: SVI Description
     ip_address: 10.10.84.1/24
 
+  Vlan86:
+    description: SVI Description
+    ip_address: 10.10.83.1/24
+    ip_attached_host_route_export:
+      distance: 10
+
   Vlan87:
     description: SVI Description
     shutdown: true
@@ -36,6 +42,12 @@ vlan_interfaces:
     description: SVI Description
     shutdown: true
     ip_address_virtual: 10.10.87.1/23
+
+  Vlan90:
+    description: SVI Description
+    ip_address: 10.10.83.1/24
+    ip_attached_host_route_export:
+      test: 10
 
 # MCAST Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-internal-order.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-internal-order.yml
@@ -1,0 +1,6 @@
+---
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 10
+    ending: 40

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlans.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlans.yml
@@ -1,9 +1,3 @@
-vlan_internal_order:
-  allocation: ascending
-  range:
-    beginning: 1006
-    ending: 1199
-
 ### VLANs ###
 vlans:
   110:
@@ -14,3 +8,13 @@ vlans:
     name: MLAG_iBGP_TENANT_A_PROJECT01
     trunk_groups:
       - LEAF_PEER_L3
+  3011:
+    name: MLAG_iBGP_TENANT_A_PROJECT02
+    state: active
+    trunk_groups:
+      - MY_TRUNK_GROUP
+  3012:
+    name: MLAG_iBGP_TENANT_A_PROJECT03
+    state: suspend
+    trunk_groups:
+      - MY_TRUNK_GROUP

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts
@@ -44,5 +44,7 @@ terminattr-cloud
 terminattr-prem
 terminattr-prem-disableaaa
 vlan-interfaces
+virtual-source-nat
+vlan-internal-order
 vlans
 vrfs

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/virtual-source-nat.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/virtual-source-nat.j2
@@ -1,5 +1,5 @@
 {# eos - virtual source-nat - introduced in 4.21 #}
-{% if virtual_source_nat_vrfs is defined and virtual_source_nat_vrfs is not none %}
+{% if virtual_source_nat_vrfs is arista.avd.defined %}
 !
 {%     for vrf in virtual_source_nat_vrfs | arista.avd.natural_sort %}
 ip address virtual source-nat vrf {{ vrf }} address {{ virtual_source_nat_vrfs[vrf].ip_address }}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/virtual-source-nat.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/virtual-source-nat.j2
@@ -2,6 +2,8 @@
 {% if virtual_source_nat_vrfs is arista.avd.defined %}
 !
 {%     for vrf in virtual_source_nat_vrfs | arista.avd.natural_sort %}
+{%         if virtual_source_nat_vrfs[vrf].ip_address is arista.avd.defined %}
 ip address virtual source-nat vrf {{ vrf }} address {{ virtual_source_nat_vrfs[vrf].ip_address }}
+{%         endif %}
 {%     endfor %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
@@ -57,7 +57,7 @@ interface {{ vlan_interface }}
 {%     endif %}
 {%     if vlan_interfaces[vlan_interface].ipv6_address_link_local is arista.avd.defined %}
    ipv6 address {{ vlan_interfaces[vlan_interface].ipv6_address_link_local }} link-local
-{%         endif %}
+{%     endif %}
 {%     if vlan_interfaces[vlan_interface].ipv6_nd_ra_disabled is arista.avd.defined(true) %}
    ipv6 nd ra disabled
 {%     endif %}
@@ -125,7 +125,7 @@ interface {{ vlan_interface }}
 {%     if vlan_interfaces[vlan_interface].ipv6_virtual_router_address is arista.avd.defined %}
    ipv6 virtual-router address {{ vlan_interfaces[vlan_interface].ipv6_virtual_router_address }}
 {%     endif %}
-{%     if vlan_interfaces[vlan_interface].isis_enable is defined %}
+{%     if vlan_interfaces[vlan_interface].isis_enable is arista.avd.defined %}
    isis enable {{ vlan_interfaces[vlan_interface].isis_enable }}
 {%     endif %}
 {%     if vlan_interfaces[vlan_interface].isis_passive is arista.avd.defined(true) %}
@@ -144,7 +144,7 @@ interface {{ vlan_interface }}
 {%         if vlan_interfaces[vlan_interface].vrrp.advertisement_interval is arista.avd.defined %}
    vrrp {{ vlan_interfaces[vlan_interface].vrrp.virtual_router }} advertisement interval {{ vlan_interfaces[vlan_interface].vrrp.advertisement_interval }}
 {%         endif %}
-{%        if vlan_interfaces[vlan_interface].vrrp.preempt_delay_minimum is arista.avd.defined %}
+{%         if vlan_interfaces[vlan_interface].vrrp.preempt_delay_minimum is arista.avd.defined %}
    vrrp {{ vlan_interfaces[vlan_interface].vrrp.virtual_router }} preempt delay minimum {{ vlan_interfaces[vlan_interface].vrrp.preempt_delay_minimum }}
 {%         endif %}
 {%         if vlan_interfaces[vlan_interface].vrrp.ipv4 is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
@@ -69,9 +69,9 @@ interface {{ vlan_interface }}
 {%             set ipv6_nd_prefix_cli = "ipv6 nd prefix " ~ prefix %}
 {%             if vlan_interfaces[vlan_interface].ipv6_nd_prefixes[prefix].valid_lifetime is arista.avd.defined %}
 {%                 set ipv6_nd_prefix_cli = ipv6_nd_prefix_cli ~ " " ~ vlan_interfaces[vlan_interface].ipv6_nd_prefixes[prefix].valid_lifetime %}
-{%             endif %}
-{%             if vlan_interfaces[vlan_interface].ipv6_nd_prefixes[prefix].preferred_lifetime is arista.avd.defined %}
-{%                 set ipv6_nd_prefix_cli = ipv6_nd_prefix_cli ~ " " ~ vlan_interfaces[vlan_interface].ipv6_nd_prefixes[prefix].preferred_lifetime %}
+{%                 if vlan_interfaces[vlan_interface].ipv6_nd_prefixes[prefix].preferred_lifetime is arista.avd.defined %}
+{%                     set ipv6_nd_prefix_cli = ipv6_nd_prefix_cli ~ " " ~ vlan_interfaces[vlan_interface].ipv6_nd_prefixes[prefix].preferred_lifetime %}
+{%                 endif %}
 {%             endif %}
 {%             if vlan_interfaces[vlan_interface].ipv6_nd_prefixes[prefix].no_autoconfig_flag is arista.avd.defined(true) %}
 {%                 set ipv6_nd_prefix_cli = ipv6_nd_prefix_cli ~ " no-autoconfig" %}
@@ -118,7 +118,10 @@ interface {{ vlan_interface }}
    ip ospf authentication-key 7 {{ vlan_interfaces[vlan_interface].ospf_authentication_key }}
 {%     endif %}
 {%     for ospf_message_digest_key in vlan_interfaces[vlan_interface].ospf_message_digest_keys | arista.avd.natural_sort %}
+{%         if vlan_interfaces[vlan_interface].ospf_message_digest_keys[ospf_message_digest_key].hash_algorithm is arista.avd.defined and
+              vlan_interfaces[vlan_interface].ospf_message_digest_keys[ospf_message_digest_key].key is arista.avd.defined %}
    ip ospf message-digest-key {{ ospf_message_digest_key }} {{ vlan_interfaces[vlan_interface].ospf_message_digest_keys[ospf_message_digest_key].hash_algorithm }} 7 {{ vlan_interfaces[vlan_interface].ospf_message_digest_keys[ospf_message_digest_key].key }}
+{%         endif %}
 {%     endfor %}
 {%     if vlan_interfaces[vlan_interface].pim.ipv4.sparse_mode is arista.avd.defined(true) %}
    pim ipv4 sparse-mode

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
@@ -81,7 +81,7 @@ interface {{ vlan_interface }}
 {%     endif %}
 {%     if vlan_interfaces[vlan_interface].multicast.ipv4.source_route_export.enabled is arista.avd.defined(true) %}
 {%         if vlan_interfaces[vlan_interface].multicast.ipv4.source_route_export.administrative_distance is arista.avd.defined %}
-   multicast ipv4 source route export {{ vlan_interfaces[vlan_interface].multicast.ipv4.source_route_export.administrative_distance | arista.avd.default('') }}
+   multicast ipv4 source route export {{ vlan_interfaces[vlan_interface].multicast.ipv4.source_route_export.administrative_distance }}
 {%          else %}
    multicast ipv4 source route export
 {%          endif %}
@@ -159,7 +159,7 @@ interface {{ vlan_interface }}
 {%         endif %}
 {%     endif %}
 {%     if vlan_interfaces[vlan_interface].ip_attached_host_route_export.distance is arista.avd.defined %}
-   ip attached-host route export {{ vlan_interfaces[vlan_interface].ip_attached_host_route_export.distance | arista.avd.default("") }}
+   ip attached-host route export {{ vlan_interfaces[vlan_interface].ip_attached_host_route_export.distance }}
 {%     elif vlan_interfaces[vlan_interface].ip_attached_host_route_export is arista.avd.defined %}
    ip attached-host route export
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
@@ -1,155 +1,169 @@
 {# eos - VLAN Interfaces #}
-{% if vlan_interfaces is defined and vlan_interfaces is not none %}
+{% if vlan_interfaces is arista.avd.defined %}
 {%     for vlan_interface in vlan_interfaces | arista.avd.natural_sort %}
 !
 interface {{ vlan_interface }}
-{%         if vlan_interfaces[vlan_interface].description is defined and vlan_interfaces[vlan_interface].description is not none %}
+{%         if vlan_interfaces[vlan_interface].description is arista.avd.defined %}
    description {{ vlan_interfaces[vlan_interface].description }}
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].shutdown is defined and vlan_interfaces[vlan_interface].shutdown == true %}
+{%         if vlan_interfaces[vlan_interface].shutdown is arista.avd.defined(true) %}
    shutdown
-{%         elif vlan_interfaces[vlan_interface].shutdown is defined and vlan_interfaces[vlan_interface].shutdown == false %}
+{%         elif vlan_interfaces[vlan_interface].shutdown is arista.avd.defined(false) %}
    no shutdown
 {%         endif %}
 {%         if vlan_interfaces[vlan_interface].mtu is defined and vlan_interfaces[vlan_interface].mtu != 1500 %}
    mtu {{ vlan_interfaces[vlan_interface].mtu }}
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].no_autostate is defined and vlan_interfaces[vlan_interface].no_autostate == true %}
+{%         if vlan_interfaces[vlan_interface].no_autostate is arista.avd.defined(true) %}
    no autostate
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].vrf is defined and vlan_interfaces[vlan_interface].vrf is not none %}
+{%         if vlan_interfaces[vlan_interface].vrf is arista.avd.defined %}
    vrf {{ vlan_interfaces[vlan_interface].vrf }}
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].arp_aging_timeout is defined and vlan_interfaces[vlan_interface].arp_aging_timeout is not none %}
+{%         if vlan_interfaces[vlan_interface].arp_aging_timeout is arista.avd.defined %}
    arp aging timeout {{ vlan_interfaces[vlan_interface].arp_aging_timeout }}
 {%         endif %}
-{%             if vlan_interfaces[vlan_interface].ip_proxy_arp is defined and vlan_interfaces[vlan_interface].ip_proxy_arp == true %}
+{%             if vlan_interfaces[vlan_interface].ip_proxy_arp is arista.avd.defined(true) %}
    ip proxy-arp
 {%             endif %}
-{%         if vlan_interfaces[vlan_interface].ip_address is defined %}
+{%         if vlan_interfaces[vlan_interface].ip_address is arista.avd.defined %}
    ip address {{ vlan_interfaces[vlan_interface].ip_address }}
-{%             if vlan_interfaces[vlan_interface].ip_address_secondaries is defined and vlan_interfaces[vlan_interface].ip_address_secondaries is not none %}
+{%             if vlan_interfaces[vlan_interface].ip_address_secondaries is arista.avd.defined %}
 {%                 for ip_address_secondary in vlan_interfaces[vlan_interface].ip_address_secondaries %}
    ip address {{ ip_address_secondary }} secondary
 {%                 endfor %}
 {%             endif %}
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].ip_virtual_router_address is defined %}
+{%         if vlan_interfaces[vlan_interface].ip_virtual_router_address is arista.avd.defined %}
    ip virtual-router address {{ vlan_interfaces[vlan_interface].ip_virtual_router_address }}
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].ip_address_virtual is defined %}
+{%         if vlan_interfaces[vlan_interface].ip_address_virtual is arista.avd.defined %}
    ip address virtual {{ vlan_interfaces[vlan_interface].ip_address_virtual }}
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].ip_helpers is defined and vlan_interfaces[vlan_interface].ip_helpers is not none %}
+{%         if vlan_interfaces[vlan_interface].ip_helpers is arista.avd.defined %}
 {%            for ip_helper in vlan_interfaces[vlan_interface].ip_helpers | arista.avd.natural_sort %}
-   ip helper-address {{ ip_helper }} {% if vlan_interfaces[vlan_interface].ip_helpers[ip_helper].vrf is defined and vlan_interfaces[vlan_interface].ip_helpers[ip_helper].vrf is not none %}vrf {{vlan_interfaces[vlan_interface].ip_helpers[ip_helper].vrf }} {% endif %} {% if vlan_interfaces[vlan_interface].ip_helpers[ip_helper].source_interface is defined and vlan_interfaces[vlan_interface].ip_helpers[ip_helper].source_interface is not none %}source-interface {{vlan_interfaces[vlan_interface].ip_helpers[ip_helper].source_interface }}{% endif %}
-
+{%               set ip_helper_cli = "ip helper-address " ~ ip_helper %}
+{%               if vlan_interfaces[vlan_interface].ip_helpers[ip_helper].vrf is arista.avd.defined %}
+{%                   set ip_helper_cli = ip_helper_cli ~ " vrf " ~ vlan_interfaces[vlan_interface].ip_helpers[ip_helper].vrf %}
+{%               endif %}
+{%               if vlan_interfaces[vlan_interface].ip_helpers[ip_helper].source_interface is arista.avd.defined %}
+{%                   set ip_helper_cli = ip_helper_cli ~ " source-interface " ~ vlan_interfaces[vlan_interface].ip_helpers[ip_helper].source_interface %}
+{%               endif %}
+   {{ ip_helper_cli }}
 {%            endfor %}
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].ipv6_enable is defined and vlan_interfaces[vlan_interface].ipv6_enable == true %}
+{%         if vlan_interfaces[vlan_interface].ipv6_enable is arista.avd.defined(true) %}
    ipv6 enable
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].ipv6_address is defined and vlan_interfaces[vlan_interface].ipv6_address is not none %}
+{%         if vlan_interfaces[vlan_interface].ipv6_address is arista.avd.defined %}
    ipv6 address {{ vlan_interfaces[vlan_interface].ipv6_address }}
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].ipv6_address_link_local is defined and vlan_interfaces[vlan_interface].ipv6_address_link_local is not none %}
+{%         if vlan_interfaces[vlan_interface].ipv6_address_link_local is arista.avd.defined %}
    ipv6 address {{ vlan_interfaces[vlan_interface].ipv6_address_link_local }} link-local
 {%             endif %}
-{%         if vlan_interfaces[vlan_interface].ipv6_nd_ra_disabled is defined and vlan_interfaces[vlan_interface].ipv6_nd_ra_disabled == true %}
+{%         if vlan_interfaces[vlan_interface].ipv6_nd_ra_disabled is arista.avd.defined(true) %}
    ipv6 nd ra disabled
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].ipv6_nd_managed_config_flag is defined and vlan_interfaces[vlan_interface].ipv6_nd_managed_config_flag == true %}
+{%         if vlan_interfaces[vlan_interface].ipv6_nd_managed_config_flag is arista.avd.defined(true) %}
    ipv6 nd managed-config-flag
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].ipv6_nd_prefixes is defined and vlan_interfaces[vlan_interface].ipv6_nd_prefixes is not none %}
+{%         if vlan_interfaces[vlan_interface].ipv6_nd_prefixes is arista.avd.defined %}
 {%             for prefix in vlan_interfaces[vlan_interface].ipv6_nd_prefixes %}
-   ipv6 nd prefix {{ prefix }} {% if vlan_interfaces[vlan_interface].ipv6_nd_prefixes[prefix].valid_lifetime is defined and vlan_interfaces[vlan_interface].ipv6_nd_prefixes[prefix].valid_lifetime is not none %}{{ vlan_interfaces[vlan_interface].ipv6_nd_prefixes[prefix].valid_lifetime }} {% endif %}{% if vlan_interfaces[vlan_interface].ipv6_nd_prefixes[prefix].preferred_lifetime is defined and vlan_interfaces[vlan_interface].ipv6_nd_prefixes[prefix].preferred_lifetime is not none %}{{ vlan_interfaces[vlan_interface].ipv6_nd_prefixes[prefix].preferred_lifetime }} {% endif %}{% if vlan_interfaces[vlan_interface].ipv6_nd_prefixes[prefix].no_autoconfig_flag is defined and vlan_interfaces[vlan_interface].ipv6_nd_prefixes[prefix].no_autoconfig_flag == true %}no-autoconfig{% endif %}
-
+{%                 set ipv6_nd_prefix_cli = "ipv6 nd prefix " ~ prefix %}
+{%                 if vlan_interfaces[vlan_interface].ipv6_nd_prefixes[prefix].valid_lifetime is arista.avd.defined %}
+{%                     set ipv6_nd_prefix_cli = ipv6_nd_prefix_cli ~ " " ~ vlan_interfaces[vlan_interface].ipv6_nd_prefixes[prefix].valid_lifetime %}
+{%                 endif %}
+{%                 if vlan_interfaces[vlan_interface].ipv6_nd_prefixes[prefix].preferred_lifetime is arista.avd.defined %}
+{%                     set ipv6_nd_prefix_cli = ipv6_nd_prefix_cli ~ " " ~ vlan_interfaces[vlan_interface].ipv6_nd_prefixes[prefix].preferred_lifetime %}
+{%                 endif %}
+{%                 if vlan_interfaces[vlan_interface].ipv6_nd_prefixes[prefix].no_autoconfig_flag is arista.avd.defined(true) %}
+{%                     set ipv6_nd_prefix_cli = ipv6_nd_prefix_cli ~ " no-autoconfig" %}
+{%                 endif %}
+   {{ ipv6_nd_prefix_cli }}
 {%             endfor %}
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].multicast.ipv4.source_route_export.enabled is defined and vlan_interfaces[vlan_interface].multicast.ipv4.source_route_export.enabled == true %}
-   multicast ipv4 source route export{% if vlan_interfaces[vlan_interface].multicast.ipv4.source_route_export.administrative_distance is defined and vlan_interfaces[vlan_interface].multicast.ipv4.source_route_export.administrative_distance is not none %} {{ vlan_interfaces[vlan_interface].multicast.ipv4.source_route_export.administrative_distance }}{% endif %}
-
+{%         if vlan_interfaces[vlan_interface].multicast.ipv4.source_route_export.enabled is arista.avd.defined(true) %}
+   multicast ipv4 source route export {{ vlan_interfaces[vlan_interface].multicast.ipv4.source_route_export.administrative_distance | arista.avd.default('')}}
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].access_group_in is defined and vlan_interfaces[vlan_interface].access_group_in is not none %}
+{%         if vlan_interfaces[vlan_interface].access_group_in is arista.avd.defined %}
    ip access-group {{ vlan_interfaces[vlan_interface].access_group_in }} in
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].access_group_out is defined and vlan_interfaces[vlan_interface].access_group_out is not none %}
+{%         if vlan_interfaces[vlan_interface].access_group_out is arista.avd.defined %}
    ip access-group {{ vlan_interfaces[vlan_interface].access_group_out }} out
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].ipv6_access_group_in is defined and vlan_interfaces[vlan_interface].ipv6_access_group_in is not none %}
+{%         if vlan_interfaces[vlan_interface].ipv6_access_group_in is arista.avd.defined %}
    ipv6 access-group {{ vlan_interfaces[vlan_interface].ipv6_access_group_in }} in
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].ipv6_access_group_out is defined and vlan_interfaces[vlan_interface].ipv6_access_group_out is not none %}
+{%         if vlan_interfaces[vlan_interface].ipv6_access_group_out is arista.avd.defined %}
    ipv6 access-group {{ vlan_interfaces[vlan_interface].ipv6_access_group_out }} out
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].ospf_network_point_to_point is defined and vlan_interfaces[vlan_interface].ospf_network_point_to_point == true %}
+{%         if vlan_interfaces[vlan_interface].ospf_network_point_to_point is arista.avd.defined(true) %}
    ip ospf network point-to-point
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].ospf_area is defined and vlan_interfaces[vlan_interface].ospf_area is not none %}
+{%         if vlan_interfaces[vlan_interface].ospf_area is arista.avd.defined %}
    ip ospf area {{ vlan_interfaces[vlan_interface].ospf_area }}
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].ospf_cost is defined and vlan_interfaces[vlan_interface].ospf_cost is not none %}
+{%         if vlan_interfaces[vlan_interface].ospf_cost is arista.avd.defined %}
    ip ospf cost {{ vlan_interfaces[vlan_interface].ospf_cost }}
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].ospf_authentication is defined and vlan_interfaces[vlan_interface].ospf_authentication is not none %}
+{%         if vlan_interfaces[vlan_interface].ospf_authentication is arista.avd.defined %}
 {%           if vlan_interfaces[vlan_interface].ospf_authentication == "simple" %}
    ip ospf authentication
 {%           elif vlan_interfaces[vlan_interface].ospf_authentication == "message-digest" %}
    ip ospf authentication message-digest
 {%           endif %}
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].ospf_authentication_key is defined and vlan_interfaces[vlan_interface].ospf_authentication_key is not none %}
+{%         if vlan_interfaces[vlan_interface].ospf_authentication_key is arista.avd.defined %}
    ip ospf authentication-key 7 {{ vlan_interfaces[vlan_interface].ospf_authentication_key }}
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].ospf_message_digest_keys is defined and vlan_interfaces[vlan_interface].ospf_message_digest_keys is not none %}
+{%         if vlan_interfaces[vlan_interface].ospf_message_digest_keys is arista.avd.defined %}
 {%           for ospf_message_digest_key in vlan_interfaces[vlan_interface].ospf_message_digest_keys | arista.avd.natural_sort %}
    ip ospf message-digest-key {{ ospf_message_digest_key }} {{ vlan_interfaces[vlan_interface].ospf_message_digest_keys[ospf_message_digest_key].hash_algorithm }} 7 {{ vlan_interfaces[vlan_interface].ospf_message_digest_keys[ospf_message_digest_key].key }}
 {%           endfor %}
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].pim is defined and vlan_interfaces[vlan_interface].pim is not none %}
-{%            if vlan_interfaces[vlan_interface].pim.ipv4.sparse_mode is defined and vlan_interfaces[vlan_interface].pim.ipv4.sparse_mode == true %}
+{%         if vlan_interfaces[vlan_interface].pim is arista.avd.defined %}
+{%            if vlan_interfaces[vlan_interface].pim.ipv4.sparse_mode is arista.avd.defined(true) %}
    pim ipv4 sparse-mode
 {%            endif %}
-{%            if vlan_interfaces[vlan_interface].pim.ipv4.local_interface is defined and vlan_interfaces[vlan_interface].pim.ipv4.local_interface is not none %}
+{%            if vlan_interfaces[vlan_interface].pim.ipv4.local_interface is arista.avd.defined %}
    pim ipv4 local-interface {{ vlan_interfaces[vlan_interface].pim.ipv4.local_interface }}
 {%            endif %}
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].ipv6_virtual_router_address is defined and vlan_interfaces[vlan_interface].ipv6_virtual_router_address is not none %}
+{%         if vlan_interfaces[vlan_interface].ipv6_virtual_router_address is arista.avd.defined %}
    ipv6 virtual-router address {{ vlan_interfaces[vlan_interface].ipv6_virtual_router_address }}
 {%         endif %}
 {%         if vlan_interfaces[vlan_interface].isis_enable is defined %}
    isis enable {{ vlan_interfaces[vlan_interface].isis_enable }}
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].isis_passive is defined and vlan_interfaces[vlan_interface].isis_passive == true %}
+{%         if vlan_interfaces[vlan_interface].isis_passive is arista.avd.defined(true) %}
    isis passive
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].isis_metric is defined %}
+{%         if vlan_interfaces[vlan_interface].isis_metric is arista.avd.defined %}
    isis metric {{ vlan_interfaces[vlan_interface].isis_metric }}
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].isis_network_point_to_point is defined and vlan_interfaces[vlan_interface].isis_network_point_to_point == true %}
+{%         if vlan_interfaces[vlan_interface].isis_network_point_to_point is arista.avd.defined(true) %}
    isis network point-to-point
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].vrrp is defined and vlan_interfaces[vlan_interface].vrrp is not none %}
-{%           if vlan_interfaces[vlan_interface].vrrp.virtual_router is defined and vlan_interfaces[vlan_interface].vrrp.virtual_router is not none %}
-{%             if vlan_interfaces[vlan_interface].vrrp.priority is defined and vlan_interfaces[vlan_interface].vrrp.priority is not none and vlan_interfaces[vlan_interface].vrrp.priority > 1 %}
+{%         if vlan_interfaces[vlan_interface].vrrp is arista.avd.defined %}
+{%           if vlan_interfaces[vlan_interface].vrrp.virtual_router is arista.avd.defined %}
+{%             if vlan_interfaces[vlan_interface].vrrp.priority is arista.avd.defined and vlan_interfaces[vlan_interface].vrrp.priority | int > 1 %}
    vrrp {{ vlan_interfaces[vlan_interface].vrrp.virtual_router }} priority-level {{ vlan_interfaces[vlan_interface].vrrp.priority }}
 {%             endif %}
-{%             if vlan_interfaces[vlan_interface].vrrp.advertisement_interval is defined and vlan_interfaces[vlan_interface].vrrp.advertisement_interval is not none %}
+{%             if vlan_interfaces[vlan_interface].vrrp.advertisement_interval is arista.avd.defined %}
    vrrp {{ vlan_interfaces[vlan_interface].vrrp.virtual_router }} advertisement interval {{ vlan_interfaces[vlan_interface].vrrp.advertisement_interval }}
 {%             endif %}
-{%             if vlan_interfaces[vlan_interface].vrrp.preempt_delay_minimum is defined and vlan_interfaces[vlan_interface].vrrp.preempt_delay_minimum is not none %}
+{%             if vlan_interfaces[vlan_interface].vrrp.preempt_delay_minimum is arista.avd.defined %}
    vrrp {{ vlan_interfaces[vlan_interface].vrrp.virtual_router }} preempt delay minimum {{ vlan_interfaces[vlan_interface].vrrp.preempt_delay_minimum }}
 {%             endif %}
-{%             if vlan_interfaces[vlan_interface].vrrp.ipv4 is defined and vlan_interfaces[vlan_interface].vrrp.ipv4 is not none %}
+{%             if vlan_interfaces[vlan_interface].vrrp.ipv4 is arista.avd.defined %}
    vrrp {{ vlan_interfaces[vlan_interface].vrrp.virtual_router }} ipv4 {{ vlan_interfaces[vlan_interface].vrrp.ipv4 }}
 {%             endif %}
-{%             if vlan_interfaces[vlan_interface].vrrp.ipv6 is defined and vlan_interfaces[vlan_interface].vrrp.ipv6 is not none %}
+{%             if vlan_interfaces[vlan_interface].vrrp.ipv6 is arista.avd.defined %}
    vrrp {{ vlan_interfaces[vlan_interface].vrrp.virtual_router }} ipv6 {{ vlan_interfaces[vlan_interface].vrrp.ipv6 }}
 {%             endif %}
 {%           endif %}
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].ip_attached_host_route_export is defined and vlan_interfaces[vlan_interface].ip_attached_host_route_export is not none %}
+{%         if vlan_interfaces[vlan_interface].ip_attached_host_route_export is arista.avd.defined %}
    ip attached-host route export {{ vlan_interfaces[vlan_interface].ip_attached_host_route_export.distance | arista.avd.default("") }}
 {%         endif %}
 {%     endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
@@ -1,170 +1,166 @@
 {# eos - VLAN Interfaces #}
-{% if vlan_interfaces is arista.avd.defined %}
-{%     for vlan_interface in vlan_interfaces | arista.avd.natural_sort %}
+{% for vlan_interface in vlan_interfaces | arista.avd.natural_sort %}
 !
 interface {{ vlan_interface }}
-{%         if vlan_interfaces[vlan_interface].description is arista.avd.defined %}
+{%     if vlan_interfaces[vlan_interface].description is arista.avd.defined %}
    description {{ vlan_interfaces[vlan_interface].description }}
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].shutdown is arista.avd.defined(true) %}
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].shutdown is arista.avd.defined(true) %}
    shutdown
-{%         elif vlan_interfaces[vlan_interface].shutdown is arista.avd.defined(false) %}
+{%     elif vlan_interfaces[vlan_interface].shutdown is arista.avd.defined(false) %}
    no shutdown
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].mtu is defined and vlan_interfaces[vlan_interface].mtu != 1500 %}
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].mtu is arista.avd.defined %}
    mtu {{ vlan_interfaces[vlan_interface].mtu }}
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].no_autostate is arista.avd.defined(true) %}
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].no_autostate is arista.avd.defined(true) %}
    no autostate
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].vrf is arista.avd.defined %}
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].vrf is arista.avd.defined %}
    vrf {{ vlan_interfaces[vlan_interface].vrf }}
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].arp_aging_timeout is arista.avd.defined %}
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].arp_aging_timeout is arista.avd.defined %}
    arp aging timeout {{ vlan_interfaces[vlan_interface].arp_aging_timeout }}
-{%         endif %}
-{%             if vlan_interfaces[vlan_interface].ip_proxy_arp is arista.avd.defined(true) %}
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].ip_proxy_arp is arista.avd.defined(true) %}
    ip proxy-arp
-{%             endif %}
-{%         if vlan_interfaces[vlan_interface].ip_address is arista.avd.defined %}
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].ip_address is arista.avd.defined %}
    ip address {{ vlan_interfaces[vlan_interface].ip_address }}
-{%             if vlan_interfaces[vlan_interface].ip_address_secondaries is arista.avd.defined %}
-{%                 for ip_address_secondary in vlan_interfaces[vlan_interface].ip_address_secondaries %}
+{%         if vlan_interfaces[vlan_interface].ip_address_secondaries is arista.avd.defined %}
+{%             for ip_address_secondary in vlan_interfaces[vlan_interface].ip_address_secondaries %}
    ip address {{ ip_address_secondary }} secondary
-{%                 endfor %}
-{%             endif %}
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].ip_virtual_router_address is arista.avd.defined %}
-   ip virtual-router address {{ vlan_interfaces[vlan_interface].ip_virtual_router_address }}
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].ip_address_virtual is arista.avd.defined %}
-   ip address virtual {{ vlan_interfaces[vlan_interface].ip_address_virtual }}
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].ip_helpers is arista.avd.defined %}
-{%            for ip_helper in vlan_interfaces[vlan_interface].ip_helpers | arista.avd.natural_sort %}
-{%               set ip_helper_cli = "ip helper-address " ~ ip_helper %}
-{%               if vlan_interfaces[vlan_interface].ip_helpers[ip_helper].vrf is arista.avd.defined %}
-{%                   set ip_helper_cli = ip_helper_cli ~ " vrf " ~ vlan_interfaces[vlan_interface].ip_helpers[ip_helper].vrf %}
-{%               endif %}
-{%               if vlan_interfaces[vlan_interface].ip_helpers[ip_helper].source_interface is arista.avd.defined %}
-{%                   set ip_helper_cli = ip_helper_cli ~ " source-interface " ~ vlan_interfaces[vlan_interface].ip_helpers[ip_helper].source_interface %}
-{%               endif %}
-   {{ ip_helper_cli }}
-{%            endfor %}
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].ipv6_enable is arista.avd.defined(true) %}
-   ipv6 enable
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].ipv6_address is arista.avd.defined %}
-   ipv6 address {{ vlan_interfaces[vlan_interface].ipv6_address }}
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].ipv6_address_link_local is arista.avd.defined %}
-   ipv6 address {{ vlan_interfaces[vlan_interface].ipv6_address_link_local }} link-local
-{%             endif %}
-{%         if vlan_interfaces[vlan_interface].ipv6_nd_ra_disabled is arista.avd.defined(true) %}
-   ipv6 nd ra disabled
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].ipv6_nd_managed_config_flag is arista.avd.defined(true) %}
-   ipv6 nd managed-config-flag
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].ipv6_nd_prefixes is arista.avd.defined %}
-{%             for prefix in vlan_interfaces[vlan_interface].ipv6_nd_prefixes %}
-{%                 set ipv6_nd_prefix_cli = "ipv6 nd prefix " ~ prefix %}
-{%                 if vlan_interfaces[vlan_interface].ipv6_nd_prefixes[prefix].valid_lifetime is arista.avd.defined %}
-{%                     set ipv6_nd_prefix_cli = ipv6_nd_prefix_cli ~ " " ~ vlan_interfaces[vlan_interface].ipv6_nd_prefixes[prefix].valid_lifetime %}
-{%                 endif %}
-{%                 if vlan_interfaces[vlan_interface].ipv6_nd_prefixes[prefix].preferred_lifetime is arista.avd.defined %}
-{%                     set ipv6_nd_prefix_cli = ipv6_nd_prefix_cli ~ " " ~ vlan_interfaces[vlan_interface].ipv6_nd_prefixes[prefix].preferred_lifetime %}
-{%                 endif %}
-{%                 if vlan_interfaces[vlan_interface].ipv6_nd_prefixes[prefix].no_autoconfig_flag is arista.avd.defined(true) %}
-{%                     set ipv6_nd_prefix_cli = ipv6_nd_prefix_cli ~ " no-autoconfig" %}
-{%                 endif %}
-   {{ ipv6_nd_prefix_cli }}
 {%             endfor %}
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].multicast.ipv4.source_route_export.enabled is arista.avd.defined(true) %}
-   multicast ipv4 source route export {{ vlan_interfaces[vlan_interface].multicast.ipv4.source_route_export.administrative_distance | arista.avd.default('')}}
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].access_group_in is arista.avd.defined %}
-   ip access-group {{ vlan_interfaces[vlan_interface].access_group_in }} in
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].access_group_out is arista.avd.defined %}
-   ip access-group {{ vlan_interfaces[vlan_interface].access_group_out }} out
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].ipv6_access_group_in is arista.avd.defined %}
-   ipv6 access-group {{ vlan_interfaces[vlan_interface].ipv6_access_group_in }} in
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].ipv6_access_group_out is arista.avd.defined %}
-   ipv6 access-group {{ vlan_interfaces[vlan_interface].ipv6_access_group_out }} out
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].ospf_network_point_to_point is arista.avd.defined(true) %}
-   ip ospf network point-to-point
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].ospf_area is arista.avd.defined %}
-   ip ospf area {{ vlan_interfaces[vlan_interface].ospf_area }}
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].ospf_cost is arista.avd.defined %}
-   ip ospf cost {{ vlan_interfaces[vlan_interface].ospf_cost }}
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].ospf_authentication is arista.avd.defined %}
-{%           if vlan_interfaces[vlan_interface].ospf_authentication == "simple" %}
-   ip ospf authentication
-{%           elif vlan_interfaces[vlan_interface].ospf_authentication == "message-digest" %}
-   ip ospf authentication message-digest
-{%           endif %}
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].ospf_authentication_key is arista.avd.defined %}
-   ip ospf authentication-key 7 {{ vlan_interfaces[vlan_interface].ospf_authentication_key }}
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].ospf_message_digest_keys is arista.avd.defined %}
-{%           for ospf_message_digest_key in vlan_interfaces[vlan_interface].ospf_message_digest_keys | arista.avd.natural_sort %}
-   ip ospf message-digest-key {{ ospf_message_digest_key }} {{ vlan_interfaces[vlan_interface].ospf_message_digest_keys[ospf_message_digest_key].hash_algorithm }} 7 {{ vlan_interfaces[vlan_interface].ospf_message_digest_keys[ospf_message_digest_key].key }}
-{%           endfor %}
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].pim is arista.avd.defined %}
-{%            if vlan_interfaces[vlan_interface].pim.ipv4.sparse_mode is arista.avd.defined(true) %}
-   pim ipv4 sparse-mode
-{%            endif %}
-{%            if vlan_interfaces[vlan_interface].pim.ipv4.local_interface is arista.avd.defined %}
-   pim ipv4 local-interface {{ vlan_interfaces[vlan_interface].pim.ipv4.local_interface }}
-{%            endif %}
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].ipv6_virtual_router_address is arista.avd.defined %}
-   ipv6 virtual-router address {{ vlan_interfaces[vlan_interface].ipv6_virtual_router_address }}
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].isis_enable is defined %}
-   isis enable {{ vlan_interfaces[vlan_interface].isis_enable }}
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].isis_passive is arista.avd.defined(true) %}
-   isis passive
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].isis_metric is arista.avd.defined %}
-   isis metric {{ vlan_interfaces[vlan_interface].isis_metric }}
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].isis_network_point_to_point is arista.avd.defined(true) %}
-   isis network point-to-point
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].vrrp is arista.avd.defined %}
-{%           if vlan_interfaces[vlan_interface].vrrp.virtual_router is arista.avd.defined %}
-{%             if vlan_interfaces[vlan_interface].vrrp.priority is arista.avd.defined and vlan_interfaces[vlan_interface].vrrp.priority | int > 1 %}
-   vrrp {{ vlan_interfaces[vlan_interface].vrrp.virtual_router }} priority-level {{ vlan_interfaces[vlan_interface].vrrp.priority }}
-{%             endif %}
-{%             if vlan_interfaces[vlan_interface].vrrp.advertisement_interval is arista.avd.defined %}
-   vrrp {{ vlan_interfaces[vlan_interface].vrrp.virtual_router }} advertisement interval {{ vlan_interfaces[vlan_interface].vrrp.advertisement_interval }}
-{%             endif %}
-{%             if vlan_interfaces[vlan_interface].vrrp.preempt_delay_minimum is arista.avd.defined %}
-   vrrp {{ vlan_interfaces[vlan_interface].vrrp.virtual_router }} preempt delay minimum {{ vlan_interfaces[vlan_interface].vrrp.preempt_delay_minimum }}
-{%             endif %}
-{%             if vlan_interfaces[vlan_interface].vrrp.ipv4 is arista.avd.defined %}
-   vrrp {{ vlan_interfaces[vlan_interface].vrrp.virtual_router }} ipv4 {{ vlan_interfaces[vlan_interface].vrrp.ipv4 }}
-{%             endif %}
-{%             if vlan_interfaces[vlan_interface].vrrp.ipv6 is arista.avd.defined %}
-   vrrp {{ vlan_interfaces[vlan_interface].vrrp.virtual_router }} ipv6 {{ vlan_interfaces[vlan_interface].vrrp.ipv6 }}
-{%             endif %}
-{%           endif %}
-{%         endif %}
-{%         if vlan_interfaces[vlan_interface].ip_attached_host_route_export is arista.avd.defined %}
-   ip attached-host route export {{ vlan_interfaces[vlan_interface].ip_attached_host_route_export.distance | arista.avd.default("") }}
-{%         endif %}
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].ip_virtual_router_address is arista.avd.defined %}
+   ip virtual-router address {{ vlan_interfaces[vlan_interface].ip_virtual_router_address }}
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].ip_address_virtual is arista.avd.defined %}
+   ip address virtual {{ vlan_interfaces[vlan_interface].ip_address_virtual }}
+{%     endif %}
+{%    for ip_helper in vlan_interfaces[vlan_interface].ip_helpers | arista.avd.natural_sort %}
+{%        set ip_helper_cli = "ip helper-address " ~ ip_helper %}
+{%        if vlan_interfaces[vlan_interface].ip_helpers[ip_helper].vrf is arista.avd.defined %}
+{%           set ip_helper_cli = ip_helper_cli ~ " vrf " ~ vlan_interfaces[vlan_interface].ip_helpers[ip_helper].vrf %}
+{%        endif %}
+{%        if vlan_interfaces[vlan_interface].ip_helpers[ip_helper].source_interface is arista.avd.defined %}
+{%            set ip_helper_cli = ip_helper_cli ~ " source-interface " ~ vlan_interfaces[vlan_interface].ip_helpers[ip_helper].source_interface %}
+{%        endif %}
+   {{ ip_helper_cli }}
 {%     endfor %}
-{% endif %}
+{%     if vlan_interfaces[vlan_interface].ipv6_enable is arista.avd.defined(true) %}
+   ipv6 enable
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].ipv6_address is arista.avd.defined %}
+   ipv6 address {{ vlan_interfaces[vlan_interface].ipv6_address }}
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].ipv6_address_link_local is arista.avd.defined %}
+   ipv6 address {{ vlan_interfaces[vlan_interface].ipv6_address_link_local }} link-local
+{%         endif %}
+{%     if vlan_interfaces[vlan_interface].ipv6_nd_ra_disabled is arista.avd.defined(true) %}
+   ipv6 nd ra disabled
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].ipv6_nd_managed_config_flag is arista.avd.defined(true) %}
+   ipv6 nd managed-config-flag
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].ipv6_nd_prefixes is arista.avd.defined %}
+{%         for prefix in vlan_interfaces[vlan_interface].ipv6_nd_prefixes %}
+{%             set ipv6_nd_prefix_cli = "ipv6 nd prefix " ~ prefix %}
+{%             if vlan_interfaces[vlan_interface].ipv6_nd_prefixes[prefix].valid_lifetime is arista.avd.defined %}
+{%                 set ipv6_nd_prefix_cli = ipv6_nd_prefix_cli ~ " " ~ vlan_interfaces[vlan_interface].ipv6_nd_prefixes[prefix].valid_lifetime %}
+{%             endif %}
+{%             if vlan_interfaces[vlan_interface].ipv6_nd_prefixes[prefix].preferred_lifetime is arista.avd.defined %}
+{%                 set ipv6_nd_prefix_cli = ipv6_nd_prefix_cli ~ " " ~ vlan_interfaces[vlan_interface].ipv6_nd_prefixes[prefix].preferred_lifetime %}
+{%             endif %}
+{%             if vlan_interfaces[vlan_interface].ipv6_nd_prefixes[prefix].no_autoconfig_flag is arista.avd.defined(true) %}
+{%                 set ipv6_nd_prefix_cli = ipv6_nd_prefix_cli ~ " no-autoconfig" %}
+{%             endif %}
+   {{ ipv6_nd_prefix_cli }}
+{%         endfor %}
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].multicast.ipv4.source_route_export.enabled is arista.avd.defined(true) %}
+   multicast ipv4 source route export {{ vlan_interfaces[vlan_interface].multicast.ipv4.source_route_export.administrative_distance | arista.avd.default('')}}
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].access_group_in is arista.avd.defined %}
+   ip access-group {{ vlan_interfaces[vlan_interface].access_group_in }} in
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].access_group_out is arista.avd.defined %}
+   ip access-group {{ vlan_interfaces[vlan_interface].access_group_out }} out
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].ipv6_access_group_in is arista.avd.defined %}
+   ipv6 access-group {{ vlan_interfaces[vlan_interface].ipv6_access_group_in }} in
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].ipv6_access_group_out is arista.avd.defined %}
+   ipv6 access-group {{ vlan_interfaces[vlan_interface].ipv6_access_group_out }} out
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].ospf_network_point_to_point is arista.avd.defined(true) %}
+   ip ospf network point-to-point
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].ospf_area is arista.avd.defined %}
+   ip ospf area {{ vlan_interfaces[vlan_interface].ospf_area }}
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].ospf_cost is arista.avd.defined %}
+   ip ospf cost {{ vlan_interfaces[vlan_interface].ospf_cost }}
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].ospf_authentication is arista.avd.defined %}
+{%       if vlan_interfaces[vlan_interface].ospf_authentication == "simple" %}
+   ip ospf authentication
+{%       elif vlan_interfaces[vlan_interface].ospf_authentication == "message-digest" %}
+   ip ospf authentication message-digest
+{%       endif %}
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].ospf_authentication_key is arista.avd.defined %}
+   ip ospf authentication-key 7 {{ vlan_interfaces[vlan_interface].ospf_authentication_key }}
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].ospf_message_digest_keys is arista.avd.defined %}
+{%       for ospf_message_digest_key in vlan_interfaces[vlan_interface].ospf_message_digest_keys | arista.avd.natural_sort %}
+   ip ospf message-digest-key {{ ospf_message_digest_key }} {{ vlan_interfaces[vlan_interface].ospf_message_digest_keys[ospf_message_digest_key].hash_algorithm }} 7 {{ vlan_interfaces[vlan_interface].ospf_message_digest_keys[ospf_message_digest_key].key }}
+{%       endfor %}
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].pim is arista.avd.defined %}
+{%        if vlan_interfaces[vlan_interface].pim.ipv4.sparse_mode is arista.avd.defined(true) %}
+   pim ipv4 sparse-mode
+{%        endif %}
+{%        if vlan_interfaces[vlan_interface].pim.ipv4.local_interface is arista.avd.defined %}
+   pim ipv4 local-interface {{ vlan_interfaces[vlan_interface].pim.ipv4.local_interface }}
+{%        endif %}
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].ipv6_virtual_router_address is arista.avd.defined %}
+   ipv6 virtual-router address {{ vlan_interfaces[vlan_interface].ipv6_virtual_router_address }}
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].isis_enable is defined %}
+   isis enable {{ vlan_interfaces[vlan_interface].isis_enable }}
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].isis_passive is arista.avd.defined(true) %}
+   isis passive
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].isis_metric is arista.avd.defined %}
+   isis metric {{ vlan_interfaces[vlan_interface].isis_metric }}
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].isis_network_point_to_point is arista.avd.defined(true) %}
+   isis network point-to-point
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].vrrp is arista.avd.defined %}
+{%       if vlan_interfaces[vlan_interface].vrrp.virtual_router is arista.avd.defined %}
+{%         if vlan_interfaces[vlan_interface].vrrp.priority is arista.avd.defined %}
+   vrrp {{ vlan_interfaces[vlan_interface].vrrp.virtual_router }} priority-level {{ vlan_interfaces[vlan_interface].vrrp.priority }}
+{%         endif %}
+{%         if vlan_interfaces[vlan_interface].vrrp.advertisement_interval is arista.avd.defined %}
+   vrrp {{ vlan_interfaces[vlan_interface].vrrp.virtual_router }} advertisement interval {{ vlan_interfaces[vlan_interface].vrrp.advertisement_interval }}
+{%         endif %}
+{%         if vlan_interfaces[vlan_interface].vrrp.preempt_delay_minimum is arista.avd.defined %}
+   vrrp {{ vlan_interfaces[vlan_interface].vrrp.virtual_router }} preempt delay minimum {{ vlan_interfaces[vlan_interface].vrrp.preempt_delay_minimum }}
+{%         endif %}
+{%         if vlan_interfaces[vlan_interface].vrrp.ipv4 is arista.avd.defined %}
+   vrrp {{ vlan_interfaces[vlan_interface].vrrp.virtual_router }} ipv4 {{ vlan_interfaces[vlan_interface].vrrp.ipv4 }}
+{%         endif %}
+{%         if vlan_interfaces[vlan_interface].vrrp.ipv6 is arista.avd.defined %}
+   vrrp {{ vlan_interfaces[vlan_interface].vrrp.virtual_router }} ipv6 {{ vlan_interfaces[vlan_interface].vrrp.ipv6 }}
+{%         endif %}
+{%       endif %}
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].ip_attached_host_route_export is arista.avd.defined %}
+   ip attached-host route export {{ vlan_interfaces[vlan_interface].ip_attached_host_route_export.distance | arista.avd.default("") }}
+{%     endif %}
+{% endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
@@ -80,7 +80,11 @@ interface {{ vlan_interface }}
 {%         endfor %}
 {%     endif %}
 {%     if vlan_interfaces[vlan_interface].multicast.ipv4.source_route_export.enabled is arista.avd.defined(true) %}
-   multicast ipv4 source route export {{ vlan_interfaces[vlan_interface].multicast.ipv4.source_route_export.administrative_distance | arista.avd.default('')}}
+{%         if vlan_interfaces[vlan_interface].multicast.ipv4.source_route_export.administrative_distance is arista.avd.defined %}
+   multicast ipv4 source route export {{ vlan_interfaces[vlan_interface].multicast.ipv4.source_route_export.administrative_distance | arista.avd.default('') }}
+{%          else %}
+   multicast ipv4 source route export
+{%          endif %}
 {%     endif %}
 {%     if vlan_interfaces[vlan_interface].access_group_in is arista.avd.defined %}
    ip access-group {{ vlan_interfaces[vlan_interface].access_group_in }} in
@@ -154,7 +158,9 @@ interface {{ vlan_interface }}
    vrrp {{ vlan_interfaces[vlan_interface].vrrp.virtual_router }} ipv6 {{ vlan_interfaces[vlan_interface].vrrp.ipv6 }}
 {%         endif %}
 {%     endif %}
-{%     if vlan_interfaces[vlan_interface].ip_attached_host_route_export is arista.avd.defined %}
+{%     if vlan_interfaces[vlan_interface].ip_attached_host_route_export.distance is arista.avd.defined %}
    ip attached-host route export {{ vlan_interfaces[vlan_interface].ip_attached_host_route_export.distance | arista.avd.default("") }}
+{%     elif vlan_interfaces[vlan_interface].ip_attached_host_route_export is arista.avd.defined %}
+   ip attached-host route export
 {%     endif %}
 {% endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
@@ -39,14 +39,14 @@ interface {{ vlan_interface }}
 {%     if vlan_interfaces[vlan_interface].ip_address_virtual is arista.avd.defined %}
    ip address virtual {{ vlan_interfaces[vlan_interface].ip_address_virtual }}
 {%     endif %}
-{%    for ip_helper in vlan_interfaces[vlan_interface].ip_helpers | arista.avd.natural_sort %}
-{%        set ip_helper_cli = "ip helper-address " ~ ip_helper %}
-{%        if vlan_interfaces[vlan_interface].ip_helpers[ip_helper].vrf is arista.avd.defined %}
-{%           set ip_helper_cli = ip_helper_cli ~ " vrf " ~ vlan_interfaces[vlan_interface].ip_helpers[ip_helper].vrf %}
-{%        endif %}
-{%        if vlan_interfaces[vlan_interface].ip_helpers[ip_helper].source_interface is arista.avd.defined %}
+{%     for ip_helper in vlan_interfaces[vlan_interface].ip_helpers | arista.avd.natural_sort %}
+{%         set ip_helper_cli = "ip helper-address " ~ ip_helper %}
+{%         if vlan_interfaces[vlan_interface].ip_helpers[ip_helper].vrf is arista.avd.defined %}
+{%            set ip_helper_cli = ip_helper_cli ~ " vrf " ~ vlan_interfaces[vlan_interface].ip_helpers[ip_helper].vrf %}
+{%         endif %}
+{%         if vlan_interfaces[vlan_interface].ip_helpers[ip_helper].source_interface is arista.avd.defined %}
 {%            set ip_helper_cli = ip_helper_cli ~ " source-interface " ~ vlan_interfaces[vlan_interface].ip_helpers[ip_helper].source_interface %}
-{%        endif %}
+{%         endif %}
    {{ ip_helper_cli }}
 {%     endfor %}
 {%     if vlan_interfaces[vlan_interface].ipv6_enable is arista.avd.defined(true) %}
@@ -104,27 +104,23 @@ interface {{ vlan_interface }}
    ip ospf cost {{ vlan_interfaces[vlan_interface].ospf_cost }}
 {%     endif %}
 {%     if vlan_interfaces[vlan_interface].ospf_authentication is arista.avd.defined %}
-{%       if vlan_interfaces[vlan_interface].ospf_authentication == "simple" %}
+{%         if vlan_interfaces[vlan_interface].ospf_authentication == "simple" %}
    ip ospf authentication
-{%       elif vlan_interfaces[vlan_interface].ospf_authentication == "message-digest" %}
+{%         elif vlan_interfaces[vlan_interface].ospf_authentication == "message-digest" %}
    ip ospf authentication message-digest
-{%       endif %}
+{%         endif %}
 {%     endif %}
 {%     if vlan_interfaces[vlan_interface].ospf_authentication_key is arista.avd.defined %}
    ip ospf authentication-key 7 {{ vlan_interfaces[vlan_interface].ospf_authentication_key }}
 {%     endif %}
-{%     if vlan_interfaces[vlan_interface].ospf_message_digest_keys is arista.avd.defined %}
-{%       for ospf_message_digest_key in vlan_interfaces[vlan_interface].ospf_message_digest_keys | arista.avd.natural_sort %}
+{%     for ospf_message_digest_key in vlan_interfaces[vlan_interface].ospf_message_digest_keys | arista.avd.natural_sort %}
    ip ospf message-digest-key {{ ospf_message_digest_key }} {{ vlan_interfaces[vlan_interface].ospf_message_digest_keys[ospf_message_digest_key].hash_algorithm }} 7 {{ vlan_interfaces[vlan_interface].ospf_message_digest_keys[ospf_message_digest_key].key }}
-{%       endfor %}
-{%     endif %}
-{%     if vlan_interfaces[vlan_interface].pim is arista.avd.defined %}
-{%        if vlan_interfaces[vlan_interface].pim.ipv4.sparse_mode is arista.avd.defined(true) %}
+{%     endfor %}
+{%     if vlan_interfaces[vlan_interface].pim.ipv4.sparse_mode is arista.avd.defined(true) %}
    pim ipv4 sparse-mode
-{%        endif %}
-{%        if vlan_interfaces[vlan_interface].pim.ipv4.local_interface is arista.avd.defined %}
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].pim.ipv4.local_interface is arista.avd.defined %}
    pim ipv4 local-interface {{ vlan_interfaces[vlan_interface].pim.ipv4.local_interface }}
-{%        endif %}
 {%     endif %}
 {%     if vlan_interfaces[vlan_interface].ipv6_virtual_router_address is arista.avd.defined %}
    ipv6 virtual-router address {{ vlan_interfaces[vlan_interface].ipv6_virtual_router_address }}
@@ -141,15 +137,14 @@ interface {{ vlan_interface }}
 {%     if vlan_interfaces[vlan_interface].isis_network_point_to_point is arista.avd.defined(true) %}
    isis network point-to-point
 {%     endif %}
-{%     if vlan_interfaces[vlan_interface].vrrp is arista.avd.defined %}
-{%       if vlan_interfaces[vlan_interface].vrrp.virtual_router is arista.avd.defined %}
+{%     if vlan_interfaces[vlan_interface].vrrp.virtual_router is arista.avd.defined %}
 {%         if vlan_interfaces[vlan_interface].vrrp.priority is arista.avd.defined %}
    vrrp {{ vlan_interfaces[vlan_interface].vrrp.virtual_router }} priority-level {{ vlan_interfaces[vlan_interface].vrrp.priority }}
 {%         endif %}
 {%         if vlan_interfaces[vlan_interface].vrrp.advertisement_interval is arista.avd.defined %}
    vrrp {{ vlan_interfaces[vlan_interface].vrrp.virtual_router }} advertisement interval {{ vlan_interfaces[vlan_interface].vrrp.advertisement_interval }}
 {%         endif %}
-{%         if vlan_interfaces[vlan_interface].vrrp.preempt_delay_minimum is arista.avd.defined %}
+{%        if vlan_interfaces[vlan_interface].vrrp.preempt_delay_minimum is arista.avd.defined %}
    vrrp {{ vlan_interfaces[vlan_interface].vrrp.virtual_router }} preempt delay minimum {{ vlan_interfaces[vlan_interface].vrrp.preempt_delay_minimum }}
 {%         endif %}
 {%         if vlan_interfaces[vlan_interface].vrrp.ipv4 is arista.avd.defined %}
@@ -158,7 +153,6 @@ interface {{ vlan_interface }}
 {%         if vlan_interfaces[vlan_interface].vrrp.ipv6 is arista.avd.defined %}
    vrrp {{ vlan_interfaces[vlan_interface].vrrp.virtual_router }} ipv6 {{ vlan_interfaces[vlan_interface].vrrp.ipv6 }}
 {%         endif %}
-{%       endif %}
 {%     endif %}
 {%     if vlan_interfaces[vlan_interface].ip_attached_host_route_export is arista.avd.defined %}
    ip attached-host route export {{ vlan_interfaces[vlan_interface].ip_attached_host_route_export.distance | arista.avd.default("") }}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-internal-order.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-internal-order.j2
@@ -1,5 +1,7 @@
 {# Internal VLAN allocation policy  #}
-{% if vlan_internal_order is arista.avd.defined %}
+{% if  vlan_internal_order.allocation is arista.avd.defined
+   and vlan_internal_order.range.beginning is arista.avd.defined
+   and vlan_internal_order.range.ending is arista.avd.defined %}
 !
 vlan internal order {{ vlan_internal_order.allocation }} range {{ vlan_internal_order.range.beginning }} {{ vlan_internal_order.range.ending }}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-internal-order.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-internal-order.j2
@@ -1,5 +1,5 @@
 {# Internal VLAN allocation policy  #}
-{% if vlan_internal_order is defined and vlan_internal_order is not none %}
+{% if vlan_internal_order is arista.avd.defined %}
 !
 vlan internal order {{ vlan_internal_order.allocation }} range {{ vlan_internal_order.range.beginning }} {{ vlan_internal_order.range.ending }}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlans.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlans.j2
@@ -2,7 +2,9 @@
 {% for vlan in vlans | arista.avd.natural_sort %}
 !
 vlan {{ vlan }}
+{%     if vlans[vlan].name is arista.avd.defined %}
    name {{ vlans[vlan].name }}
+{%     endif %}
 {%     if vlans[vlan].state is arista.avd.defined %}
    state {{ vlans[vlan].state }}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlans.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlans.j2
@@ -1,16 +1,12 @@
 {# eos - VLANs #}
-{% if vlans is defined and vlans is not none %}
-{%     for vlan in vlans | arista.avd.natural_sort %}
+{% for vlan in vlans | arista.avd.natural_sort %}
 !
 vlan {{ vlan }}
    name {{ vlans[vlan].name }}
-{%         if vlans[vlan].state is defined and vlans[vlan].state == "suspend" %}
+{%     if vlans[vlan].state is arista.avd.defined %}
    state {{ vlans[vlan].state }}
-{%         endif %}
-{%         if vlans[vlan].trunk_groups is defined %}
-{%             for trunk_group in vlans[vlan].trunk_groups | arista.avd.natural_sort %}
+{%     endif %}
+{%     for trunk_group in vlans[vlan].trunk_groups | arista.avd.natural_sort %}
    trunk group {{ trunk_group }}
-{%             endfor %}
-{%         endif %}
 {%     endfor %}
-{% endif %}
+{% endfor %}


### PR DESCRIPTION
## Change Summary

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

N/A

## Component(s) name

`arista.avd.eos_cli_config_gen`

__Eos Templates__: `vlan-interfaces.j2`

## Proposed changes

- [x] Use `arista.avd.defined` test where possible
- [x] Use `arista.avd.default` filter where possible
- [x] Shorten long EOS CLI
- [x] Remove default values
- [x] Update Molecule to increase coverage
- [ ] Rename tasks to use collection paths: `ansible.builtin.template`
- [x] Move to concatenation using `~` instead of `+` to automatically convert to `string`
- [ ] Use `x in []` instead of multiple `if / elif / else` blocks
- [ ] Use `| join` instead of oneline `for` loop in documentation

## Submitted files

- [x] virtual-source-nat.j2
- [x] vlan-interfaces.j2
- [x] vlan-internal-order.j2
- [x] vlans.j2
- [ ] vmtracer-sessions.j2
- [ ] vrf-instances.j2
- [ ] vxlan-interface.j2

## How to test

Molecule should not introduce change. Only spaces should be updated

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
