### PR TITLE
fix(dhcp_provisionner): Fix registration not generated

### DIFF
--- a/.github/workflows/molecule-dhcp.yml
+++ b/.github/workflows/molecule-dhcp.yml
@@ -26,24 +26,15 @@ jobs:
         run: |
           echo "PY_COLORS=1" >> $GITHUB_ENV
           echo "ANSIBLE_FORCE_COLOR=1" >> $GITHUB_ENV
+
       - uses: actions/checkout@v1
-      - name: Set up Python 3
-        uses: actions/setup-python@v2.1.4
-        with:
-          python-version: '3.x'
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r development/requirements.txt
-          pip install -r development/requirements-dev.txt
 
-      - name: Execute molecule
-        run: |
-          cd ansible_collections/arista/avd
-          molecule test --destroy=never  --scenario-name ${{ matrix.avd_scenario }}
-          ls -alR molecule
-
-      - uses: actions/upload-artifact@v1
+      - name: Run molecule action
+        uses: arista-netdevops-community/action-molecule-avd@v1.0
         with:
-          name: molecule-results-${{ matrix.avd_scenario }}
-          path: ansible_collections/arista/avd/molecule/${{ matrix.avd_scenario }}
+          molecule_parentdir: 'ansible_collections/arista/avd'
+          molecule_command: 'converge'
+          molecule_args: '--scenario-name ${{ matrix.avd_scenario }}'
+          pip_file: development/requirements.txt
+          check_git: true
+          check_git_enforced: true

--- a/ansible_collections/arista/avd/molecule/dhcp_configuration/intended/structured_configs/cvp/ztp_configuration.yml
+++ b/ansible_collections/arista/avd/molecule/dhcp_configuration/intended/structured_configs/cvp/ztp_configuration.yml
@@ -19,6 +19,7 @@ ztp:
         end: 172.17.255.210
         lease_time: 300
   clients:
+    # SUPER SPINE
     # SPINE
     - name: DC1-SPINE1
       mac: 0c:1d:c0:1d:62:01
@@ -33,6 +34,9 @@ ztp:
       mac: 0c:1d:c0:1d:62:01
       ip4: 192.168.200.104
     # L3LEAF
+    - name: DC1-BL1A
+      mac: 0c:1d:c0:1d:62:01
+      ip4: 192.168.200.110
     - name: DC1-LEAF1A
       mac: 0c:1d:c0:1d:62:01
       ip4: 192.168.200.105
@@ -48,9 +52,6 @@ ztp:
     - name: DC1-SVC3B
       mac: 0c:1d:c0:1d:62:01
       ip4: 192.168.200.109
-    - name: DC1-BL1A
-      mac: 0c:1d:c0:1d:62:01
-      ip4: 192.168.200.110
     # L2LEAF
     - name: DC1-L2LEAF1A
       mac: 0c:1d:c0:1d:62:01

--- a/ansible_collections/arista/avd/molecule/dhcp_provisionning/intended/configs/dhcpd.conf
+++ b/ansible_collections/arista/avd/molecule/dhcp_provisionning/intended/configs/dhcpd.conf
@@ -45,6 +45,15 @@ host DC1-SPINE4 {
     option domain-name-servers 192.168.200.5, 8.8.8.8;
 }
 
+host DC1-BL1A {
+    option host-name "DC1-BL1A";
+    option dhcp-client-identifier 0c:1d:c0:1d:62:16;
+    fixed-address 192.168.200.110;
+    option bootfile-name "http://192.168.200.11/ztp/bootstrap";
+    option routers 192.168.200.5;
+    option domain-name-servers 192.168.200.5, 8.8.8.8;
+}
+
 host DC1-LEAF1A {
     option host-name "DC1-LEAF1A";
     option dhcp-client-identifier 0c:1d:c0:1d:62:11;
@@ -85,15 +94,6 @@ host DC1-SVC3B {
     option host-name "DC1-SVC3B";
     option dhcp-client-identifier 0c:1d:c0:1d:62:15;
     fixed-address 192.168.200.109;
-    option bootfile-name "http://192.168.200.11/ztp/bootstrap";
-    option routers 192.168.200.5;
-    option domain-name-servers 192.168.200.5, 8.8.8.8;
-}
-
-host DC1-BL1A {
-    option host-name "DC1-BL1A";
-    option dhcp-client-identifier 0c:1d:c0:1d:62:16;
-    fixed-address 192.168.200.110;
     option bootfile-name "http://192.168.200.11/ztp/bootstrap";
     option routers 192.168.200.5;
     option domain-name-servers 192.168.200.5, 8.8.8.8;

--- a/ansible_collections/arista/avd/molecule/dhcp_provisionning/intended/structured_configs/cvp/ztp_configuration.yml
+++ b/ansible_collections/arista/avd/molecule/dhcp_provisionning/intended/structured_configs/cvp/ztp_configuration.yml
@@ -19,6 +19,7 @@ ztp:
         end: 172.17.255.210
         lease_time: 300
   clients:
+    # SUPER SPINE
     # SPINE
     - name: DC1-SPINE1
       mac: 0c:1d:c0:1d:62:01
@@ -33,6 +34,9 @@ ztp:
       mac: 0c:1d:c0:1d:62:04
       ip4: 192.168.200.104
     # L3LEAF
+    - name: DC1-BL1A
+      mac: 0c:1d:c0:1d:62:16
+      ip4: 192.168.200.110
     - name: DC1-LEAF1A
       mac: 0c:1d:c0:1d:62:11
       ip4: 192.168.200.105
@@ -48,9 +52,6 @@ ztp:
     - name: DC1-SVC3B
       mac: 0c:1d:c0:1d:62:15
       ip4: 192.168.200.109
-    - name: DC1-BL1A
-      mac: 0c:1d:c0:1d:62:16
-      ip4: 192.168.200.110
     # L2LEAF
     - name: DC1-L2LEAF1A
       mac: 0c:1d:c0:1d:62:21

--- a/ansible_collections/arista/avd/roles/dhcp_provisioner/templates/ztp_configuration.j2
+++ b/ansible_collections/arista/avd/roles/dhcp_provisioner/templates/ztp_configuration.j2
@@ -1,10 +1,10 @@
 ---
 ztp:
   default:
-{% if cvp_instance_ip is defined and cvp_instance_ip is not none %}
-    registration: http://{{ cvp_instance_ip }}/ztp/bootstrap
-{% elif cvp_instance_ips is defined and cvp_instance_ips is not none %}
-    registration: http://{{ cvp_instance_ips[0] }}/ztp/bootstrap
+{% if hostvars[groups[fabric_group][0]].cvp_instance_ip is arista.avd.defined %}
+    registration: http://{{ hostvars[groups[fabric_group][0]].cvp_instance_ip }}/ztp/bootstrap
+{% elif hostvars[groups[fabric_group][0]].cvp_instance_ips is arista.avd.defined %}
+    registration: http://{{ hostvars[groups[fabric_group][0]].cvp_instance_ips[0] }}/ztp/bootstrap
 {% endif %}
 {% if mgmt_gateway is defined and mgmt_gateway is not none %}
     gateway: {{ mgmt_gateway }}

--- a/ansible_collections/arista/avd/roles/dhcp_provisioner/templates/ztp_configuration.j2
+++ b/ansible_collections/arista/avd/roles/dhcp_provisioner/templates/ztp_configuration.j2
@@ -45,9 +45,20 @@ ztp:
         lease_time: 300
 {% endif %}
   clients:
+{# Read L3LEAF devices #}
+    # SUPER SPINE
+{% for node_group in hostvars[groups[fabric_group][0]].super_spine.node_groups | arista.avd.natural_sort %}
+{%     for node in hostvars[groups[fabric_group][0]].super_spine.node_groups[node_group].nodes | arista.avd.natural_sort %}
+{%         if hostvars[groups[fabric_group][0]].super_spine.node_groups[node_group].nodes[node].mac_address is defined and hostvars[groups[fabric_group][0]].super_spine.node_groups[node_group].nodes[node].mac_address is not none %}
+    - name: {{ node }}
+      mac: {{ hostvars[groups[fabric_group][0]].super_spine.node_groups[node_group].nodes[node].mac_address }}
+      ip4: {{ hostvars[groups[fabric_group][0]].super_spine.node_groups[node_group].nodes[node].mgmt_ip | ipaddr('address') }}
+{%         endif %}
+{%     endfor %}
+{% endfor %}
 {# Read SPINE devices #}
     # SPINE
-{% for node in hostvars[groups[fabric_group][0]].spine.nodes %}
+{% for node in hostvars[groups[fabric_group][0]].spine.nodes | arista.avd.natural_sort %}
 {%      if hostvars[groups[fabric_group][0]].spine.nodes[node].mac_address is defined and hostvars[groups[fabric_group][0]].spine.nodes[node].mac_address is not none %}
     - name: {{ node }}
       mac: {{ hostvars[groups[fabric_group][0]].spine.nodes[node].mac_address }}
@@ -56,8 +67,8 @@ ztp:
 {% endfor %}
 {# Read L3LEAF devices #}
     # L3LEAF
-{% for node_group in hostvars[groups[fabric_group][0]].l3leaf.node_groups %}
-{%     for node in hostvars[groups[fabric_group][0]].l3leaf.node_groups[node_group].nodes %}
+{% for node_group in hostvars[groups[fabric_group][0]].l3leaf.node_groups | arista.avd.natural_sort %}
+{%     for node in hostvars[groups[fabric_group][0]].l3leaf.node_groups[node_group].nodes | arista.avd.natural_sort %}
 {%         if hostvars[groups[fabric_group][0]].l3leaf.node_groups[node_group].nodes[node].mac_address is defined and hostvars[groups[fabric_group][0]].l3leaf.node_groups[node_group].nodes[node].mac_address is not none %}
     - name: {{ node }}
       mac: {{ hostvars[groups[fabric_group][0]].l3leaf.node_groups[node_group].nodes[node].mac_address }}
@@ -67,8 +78,8 @@ ztp:
 {% endfor %}
 {# Read L2LEAF devices #}
     # L2LEAF
-{% for node_group in hostvars[groups[fabric_group][0]].l2leaf.node_groups %}
-{%     for node in hostvars[groups[fabric_group][0]].l2leaf.node_groups[node_group].nodes %}
+{% for node_group in hostvars[groups[fabric_group][0]].l2leaf.node_groups | arista.avd.natural_sort %}
+{%     for node in hostvars[groups[fabric_group][0]].l2leaf.node_groups[node_group].nodes | arista.avd.natural_sort %}
 {%         if hostvars[groups[fabric_group][0]].l2leaf.node_groups[node_group].nodes[node].mac_address is defined and hostvars[groups[fabric_group][0]].l2leaf.node_groups[node_group].nodes[node].mac_address is not none %}
     - name: {{ node }}
       mac: {{ hostvars[groups[fabric_group][0]].l2leaf.node_groups[node_group].nodes[node].mac_address }}


### PR DESCRIPTION

## Change Summary

Path to access `cvp_instance_ip` field was not correct and worked only if DHCP was part of the fabric group

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

N/A

## Component(s) name

`arista.avd.dhcp_provisionner`

## Proposed changes

Path updated and now uses information from option `fabric_group` from
DHCP host to locate correct information

## How to test

```yaml
TOOLS:
    hosts:
        DHCP_SERVER:
          ztp_network_summary: 10.73.255.0/24
          ztp_pool_start: 10.73.255.200
          ztp_pool_end: 10.73.255.210
          ztp_lease_time: 300
          fabric_group: 'DC1'
          ztp_mac_source: system
          ztp_mode: offline
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
