### PR TITLE
fix(eos_l3ls_evpn): Fix missing support for bgp_as for l3leaf node section

### DIFF
--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -637,7 +637,7 @@ Router ISIS not defined
 
 | BGP AS | Router ID |
 | ------ | --------- |
-| 65104|  192.168.255.11 |
+| 65105|  192.168.255.11 |
 
 | BGP Tuning |
 | ---------- |
@@ -707,7 +707,7 @@ Router ISIS not defined
 
 ```eos
 !
-router bgp 65104
+router bgp 65105
    router-id 192.168.255.11
    no bgp default ipv4-unicast
    distance bgp 20 200 200

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE1.md
@@ -564,14 +564,14 @@ Router ISIS not defined
 | 172.31.255.25 | 65103 | default |
 | 172.31.255.33 | 65103 | default |
 | 172.31.255.41 | 65104 | default |
-| 172.31.255.49 | 65104 | default |
+| 172.31.255.49 | 65105 | default |
 | 192.168.255.5 | 65101 | default |
 | 192.168.255.6 | 65102 | default |
 | 192.168.255.7 | 65102 | default |
 | 192.168.255.8 | 65103 | default |
 | 192.168.255.9 | 65103 | default |
 | 192.168.255.10 | 65104 | default |
-| 192.168.255.11 | 65104 | default |
+| 192.168.255.11 | 65105 | default |
 
 ### Router BGP EVPN Address Family
 
@@ -613,7 +613,7 @@ router bgp 65001
    neighbor 172.31.255.41 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.31.255.41 remote-as 65104
    neighbor 172.31.255.49 peer group IPv4-UNDERLAY-PEERS
-   neighbor 172.31.255.49 remote-as 65104
+   neighbor 172.31.255.49 remote-as 65105
    neighbor 192.168.255.5 peer group EVPN-OVERLAY-PEERS
    neighbor 192.168.255.5 remote-as 65101
    neighbor 192.168.255.5 description DC1-LEAF1A
@@ -633,7 +633,7 @@ router bgp 65001
    neighbor 192.168.255.10 remote-as 65104
    neighbor 192.168.255.10 description DC1-BL1A
    neighbor 192.168.255.11 peer group EVPN-OVERLAY-PEERS
-   neighbor 192.168.255.11 remote-as 65104
+   neighbor 192.168.255.11 remote-as 65105
    neighbor 192.168.255.11 description DC1-BL1B
    redistribute connected route-map RM-CONN-2-BGP
    !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE2.md
@@ -564,14 +564,14 @@ Router ISIS not defined
 | 172.31.255.27 | 65103 | default |
 | 172.31.255.35 | 65103 | default |
 | 172.31.255.43 | 65104 | default |
-| 172.31.255.51 | 65104 | default |
+| 172.31.255.51 | 65105 | default |
 | 192.168.255.5 | 65101 | default |
 | 192.168.255.6 | 65102 | default |
 | 192.168.255.7 | 65102 | default |
 | 192.168.255.8 | 65103 | default |
 | 192.168.255.9 | 65103 | default |
 | 192.168.255.10 | 65104 | default |
-| 192.168.255.11 | 65104 | default |
+| 192.168.255.11 | 65105 | default |
 
 ### Router BGP EVPN Address Family
 
@@ -613,7 +613,7 @@ router bgp 65001
    neighbor 172.31.255.43 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.31.255.43 remote-as 65104
    neighbor 172.31.255.51 peer group IPv4-UNDERLAY-PEERS
-   neighbor 172.31.255.51 remote-as 65104
+   neighbor 172.31.255.51 remote-as 65105
    neighbor 192.168.255.5 peer group EVPN-OVERLAY-PEERS
    neighbor 192.168.255.5 remote-as 65101
    neighbor 192.168.255.5 description DC1-LEAF1A
@@ -633,7 +633,7 @@ router bgp 65001
    neighbor 192.168.255.10 remote-as 65104
    neighbor 192.168.255.10 description DC1-BL1A
    neighbor 192.168.255.11 peer group EVPN-OVERLAY-PEERS
-   neighbor 192.168.255.11 remote-as 65104
+   neighbor 192.168.255.11 remote-as 65105
    neighbor 192.168.255.11 description DC1-BL1B
    redistribute connected route-map RM-CONN-2-BGP
    !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE3.md
@@ -564,14 +564,14 @@ Router ISIS not defined
 | 172.31.255.29 | 65103 | default |
 | 172.31.255.37 | 65103 | default |
 | 172.31.255.45 | 65104 | default |
-| 172.31.255.53 | 65104 | default |
+| 172.31.255.53 | 65105 | default |
 | 192.168.255.5 | 65101 | default |
 | 192.168.255.6 | 65102 | default |
 | 192.168.255.7 | 65102 | default |
 | 192.168.255.8 | 65103 | default |
 | 192.168.255.9 | 65103 | default |
 | 192.168.255.10 | 65104 | default |
-| 192.168.255.11 | 65104 | default |
+| 192.168.255.11 | 65105 | default |
 
 ### Router BGP EVPN Address Family
 
@@ -613,7 +613,7 @@ router bgp 65001
    neighbor 172.31.255.45 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.31.255.45 remote-as 65104
    neighbor 172.31.255.53 peer group IPv4-UNDERLAY-PEERS
-   neighbor 172.31.255.53 remote-as 65104
+   neighbor 172.31.255.53 remote-as 65105
    neighbor 192.168.255.5 peer group EVPN-OVERLAY-PEERS
    neighbor 192.168.255.5 remote-as 65101
    neighbor 192.168.255.5 description DC1-LEAF1A
@@ -633,7 +633,7 @@ router bgp 65001
    neighbor 192.168.255.10 remote-as 65104
    neighbor 192.168.255.10 description DC1-BL1A
    neighbor 192.168.255.11 peer group EVPN-OVERLAY-PEERS
-   neighbor 192.168.255.11 remote-as 65104
+   neighbor 192.168.255.11 remote-as 65105
    neighbor 192.168.255.11 description DC1-BL1B
    redistribute connected route-map RM-CONN-2-BGP
    !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE4.md
@@ -564,14 +564,14 @@ Router ISIS not defined
 | 172.31.255.31 | 65103 | default |
 | 172.31.255.39 | 65103 | default |
 | 172.31.255.47 | 65104 | default |
-| 172.31.255.55 | 65104 | default |
+| 172.31.255.55 | 65105 | default |
 | 192.168.255.5 | 65101 | default |
 | 192.168.255.6 | 65102 | default |
 | 192.168.255.7 | 65102 | default |
 | 192.168.255.8 | 65103 | default |
 | 192.168.255.9 | 65103 | default |
 | 192.168.255.10 | 65104 | default |
-| 192.168.255.11 | 65104 | default |
+| 192.168.255.11 | 65105 | default |
 
 ### Router BGP EVPN Address Family
 
@@ -613,7 +613,7 @@ router bgp 65001
    neighbor 172.31.255.47 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.31.255.47 remote-as 65104
    neighbor 172.31.255.55 peer group IPv4-UNDERLAY-PEERS
-   neighbor 172.31.255.55 remote-as 65104
+   neighbor 172.31.255.55 remote-as 65105
    neighbor 192.168.255.5 peer group EVPN-OVERLAY-PEERS
    neighbor 192.168.255.5 remote-as 65101
    neighbor 192.168.255.5 description DC1-LEAF1A
@@ -633,7 +633,7 @@ router bgp 65001
    neighbor 192.168.255.10 remote-as 65104
    neighbor 192.168.255.10 description DC1-BL1A
    neighbor 192.168.255.11 peer group EVPN-OVERLAY-PEERS
-   neighbor 192.168.255.11 remote-as 65104
+   neighbor 192.168.255.11 remote-as 65105
    neighbor 192.168.255.11 description DC1-BL1B
    redistribute connected route-map RM-CONN-2-BGP
    !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1B.cfg
@@ -154,7 +154,7 @@ route-map RM-Tenant_A_WAN_Zone-fd5a:fe45:8831:06c5::a-SET-NEXT-HOP-OUT permit 10
 router bfd
    multihop interval 1200 min-rx 1200 multiplier 3
 !
-router bgp 65104
+router bgp 65105
    router-id 192.168.255.11
    no bgp default ipv4-unicast
    distance bgp 20 200 200

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE1.cfg
@@ -131,7 +131,7 @@ router bgp 65001
    neighbor 172.31.255.41 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.31.255.41 remote-as 65104
    neighbor 172.31.255.49 peer group IPv4-UNDERLAY-PEERS
-   neighbor 172.31.255.49 remote-as 65104
+   neighbor 172.31.255.49 remote-as 65105
    neighbor 192.168.255.5 peer group EVPN-OVERLAY-PEERS
    neighbor 192.168.255.5 remote-as 65101
    neighbor 192.168.255.5 description DC1-LEAF1A
@@ -151,7 +151,7 @@ router bgp 65001
    neighbor 192.168.255.10 remote-as 65104
    neighbor 192.168.255.10 description DC1-BL1A
    neighbor 192.168.255.11 peer group EVPN-OVERLAY-PEERS
-   neighbor 192.168.255.11 remote-as 65104
+   neighbor 192.168.255.11 remote-as 65105
    neighbor 192.168.255.11 description DC1-BL1B
    redistribute connected route-map RM-CONN-2-BGP
    !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE2.cfg
@@ -131,7 +131,7 @@ router bgp 65001
    neighbor 172.31.255.43 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.31.255.43 remote-as 65104
    neighbor 172.31.255.51 peer group IPv4-UNDERLAY-PEERS
-   neighbor 172.31.255.51 remote-as 65104
+   neighbor 172.31.255.51 remote-as 65105
    neighbor 192.168.255.5 peer group EVPN-OVERLAY-PEERS
    neighbor 192.168.255.5 remote-as 65101
    neighbor 192.168.255.5 description DC1-LEAF1A
@@ -151,7 +151,7 @@ router bgp 65001
    neighbor 192.168.255.10 remote-as 65104
    neighbor 192.168.255.10 description DC1-BL1A
    neighbor 192.168.255.11 peer group EVPN-OVERLAY-PEERS
-   neighbor 192.168.255.11 remote-as 65104
+   neighbor 192.168.255.11 remote-as 65105
    neighbor 192.168.255.11 description DC1-BL1B
    redistribute connected route-map RM-CONN-2-BGP
    !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE3.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE3.cfg
@@ -131,7 +131,7 @@ router bgp 65001
    neighbor 172.31.255.45 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.31.255.45 remote-as 65104
    neighbor 172.31.255.53 peer group IPv4-UNDERLAY-PEERS
-   neighbor 172.31.255.53 remote-as 65104
+   neighbor 172.31.255.53 remote-as 65105
    neighbor 192.168.255.5 peer group EVPN-OVERLAY-PEERS
    neighbor 192.168.255.5 remote-as 65101
    neighbor 192.168.255.5 description DC1-LEAF1A
@@ -151,7 +151,7 @@ router bgp 65001
    neighbor 192.168.255.10 remote-as 65104
    neighbor 192.168.255.10 description DC1-BL1A
    neighbor 192.168.255.11 peer group EVPN-OVERLAY-PEERS
-   neighbor 192.168.255.11 remote-as 65104
+   neighbor 192.168.255.11 remote-as 65105
    neighbor 192.168.255.11 description DC1-BL1B
    redistribute connected route-map RM-CONN-2-BGP
    !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE4.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE4.cfg
@@ -131,7 +131,7 @@ router bgp 65001
    neighbor 172.31.255.47 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.31.255.47 remote-as 65104
    neighbor 172.31.255.55 peer group IPv4-UNDERLAY-PEERS
-   neighbor 172.31.255.55 remote-as 65104
+   neighbor 172.31.255.55 remote-as 65105
    neighbor 192.168.255.5 peer group EVPN-OVERLAY-PEERS
    neighbor 192.168.255.5 remote-as 65101
    neighbor 192.168.255.5 description DC1-LEAF1A
@@ -151,7 +151,7 @@ router bgp 65001
    neighbor 192.168.255.10 remote-as 65104
    neighbor 192.168.255.10 description DC1-BL1A
    neighbor 192.168.255.11 peer group EVPN-OVERLAY-PEERS
-   neighbor 192.168.255.11 remote-as 65104
+   neighbor 192.168.255.11 remote-as 65105
    neighbor 192.168.255.11 description DC1-BL1B
    redistribute connected route-map RM-CONN-2-BGP
    !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
@@ -1,6 +1,6 @@
 l3leaf_node_group: DC1_BL1
 switch_platform: 7280R
-switch_bgp_as: 65104
+switch_bgp_as: 65105
 leaf_id: 7
 switch_mgmt_ip: 192.168.200.111/24
 leaf_evpn_services_l2_only: false
@@ -260,7 +260,7 @@ route_maps:
         set:
         - ipv6 next-hop fd5a:fe45:8831:06c5::1
 router_bgp:
-  as: 65104
+  as: 65105
   router_id: 192.168.255.11
   bgp_defaults:
   - no bgp default ipv4-unicast

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
@@ -192,7 +192,7 @@ router_bgp:
       remote_as: 65104
     172.31.255.49:
       peer_group: IPv4-UNDERLAY-PEERS
-      remote_as: 65104
+      remote_as: 65105
     172.31.255.1:
       peer_group: IPv4-UNDERLAY-PEERS
       remote_as: 65101
@@ -215,7 +215,7 @@ router_bgp:
     192.168.255.11:
       peer_group: EVPN-OVERLAY-PEERS
       description: DC1-BL1B
-      remote_as: 65104
+      remote_as: 65105
     192.168.255.5:
       peer_group: EVPN-OVERLAY-PEERS
       description: DC1-LEAF1A

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
@@ -192,7 +192,7 @@ router_bgp:
       remote_as: 65104
     172.31.255.51:
       peer_group: IPv4-UNDERLAY-PEERS
-      remote_as: 65104
+      remote_as: 65105
     172.31.255.3:
       peer_group: IPv4-UNDERLAY-PEERS
       remote_as: 65101
@@ -215,7 +215,7 @@ router_bgp:
     192.168.255.11:
       peer_group: EVPN-OVERLAY-PEERS
       description: DC1-BL1B
-      remote_as: 65104
+      remote_as: 65105
     192.168.255.5:
       peer_group: EVPN-OVERLAY-PEERS
       description: DC1-LEAF1A

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
@@ -192,7 +192,7 @@ router_bgp:
       remote_as: 65104
     172.31.255.53:
       peer_group: IPv4-UNDERLAY-PEERS
-      remote_as: 65104
+      remote_as: 65105
     172.31.255.5:
       peer_group: IPv4-UNDERLAY-PEERS
       remote_as: 65101
@@ -215,7 +215,7 @@ router_bgp:
     192.168.255.11:
       peer_group: EVPN-OVERLAY-PEERS
       description: DC1-BL1B
-      remote_as: 65104
+      remote_as: 65105
     192.168.255.5:
       peer_group: EVPN-OVERLAY-PEERS
       description: DC1-LEAF1A

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
@@ -192,7 +192,7 @@ router_bgp:
       remote_as: 65104
     172.31.255.55:
       peer_group: IPv4-UNDERLAY-PEERS
-      remote_as: 65104
+      remote_as: 65105
     172.31.255.7:
       peer_group: IPv4-UNDERLAY-PEERS
       remote_as: 65101
@@ -215,7 +215,7 @@ router_bgp:
     192.168.255.11:
       peer_group: EVPN-OVERLAY-PEERS
       description: DC1-BL1B
-      remote_as: 65104
+      remote_as: 65105
     192.168.255.5:
       peer_group: EVPN-OVERLAY-PEERS
       description: DC1-LEAF1A

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
@@ -63,7 +63,7 @@ spine:
 l3leaf:
   defaults:
     platform: 7280R
-    bgp_as: 65100
+    bgp_as: 65101
     spines: [ DC1-SPINE1, DC1-SPINE2, DC1-SPINE3, DC1-SPINE4 ]
     uplink_to_spine_interfaces: [ Ethernet1, Ethernet2, Ethernet3, Ethernet4 ]
     mlag_interfaces: [ Ethernet5, Ethernet6 ]
@@ -75,7 +75,6 @@ l3leaf:
       tags: [ opzone, web, app, db, vmotion, nfs ]
   node_groups:
     DC1_LEAF1:
-      bgp_as: 65101
       filter:
         tenants: [ all ]
         tags: [ web, app ]
@@ -113,7 +112,7 @@ l3leaf:
           mgmt_ip: 192.168.200.109/24
           spine_interfaces: [ Ethernet5, Ethernet5, Ethernet5, Ethernet5 ]
     DC1_BL1:
-      bgp_as: 65104
+      mlag: false
       filter:
         tenants: [ all ]
         tags: [ wan ]
@@ -121,11 +120,13 @@ l3leaf:
       nodes:
         DC1-BL1A:
           id: 6
+          bgp_as: 65104
           mgmt_ip: 192.168.200.110/24
           mac_address: '0c:1d:c0:1d:62:01'
           spine_interfaces: [ Ethernet6, Ethernet6, Ethernet6, Ethernet6 ]
         DC1-BL1B:
           id: 7
+          bgp_as: 65105
           mgmt_ip: 192.168.200.111/24
           mac_address: '0c:1d:c0:1d:62:01'
           spine_interfaces: [ Ethernet7, Ethernet7, Ethernet7, Ethernet7 ]

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
@@ -619,6 +619,7 @@ l3leaf:
       igmp_snooping_enabled: < true | false >
 
       # L3 Leaf BGP AS. | Required.
+      # Inheritence: node > node_group > defaults
       bgp_as: < bgp_as >
 
       # EVPN Role for Overlay BGP Peerings | Optional, default is client
@@ -655,6 +656,10 @@ l3leaf:
           # Spine interfaces (list), interface located on Spine,
           # corresponding to spines and uplink_to_spine_interfaces | Required.
           spine_interfaces: [ < ethernet_interface_1 >, < ethernet_interface_1 > ]
+
+          # L3 Leaf BGP AS. | Required.
+          # Inheritence: node > node_group > defaults
+          bgp_as: < bgp_as >
 
     # node_group_2, will result in MLAG pair.
     < node_group_2 >:

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l3leaf-yml.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-l3leaf-yml.j2
@@ -60,6 +60,8 @@
 {%             endif %}
 {%             if bgp_as is arista.avd.defined and switch.overlay_routing_protocol == 'ibgp' %}
 {%                  set switch.bgp_as = bgp_as %}
+{%             elif l3leaf.node_groups[l3leaf_node_group].nodes[node].bgp_as is defined %}
+{%                 set switch.bgp_as = l3leaf.node_groups[l3leaf_node_group].nodes[node].bgp_as %}
 {%             elif l3leaf.node_groups[l3leaf_node_group].bgp_as is defined %}
 {%                 set switch.bgp_as = l3leaf.node_groups[l3leaf_node_group].bgp_as %}
 {%             elif l3leaf.defaults.bgp_as is defined %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-overlay-controller-yml.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/evpn-fabric-overlay-controller-yml.j2
@@ -37,7 +37,7 @@
 {%             if remote_switch_vars.type == 'l3leaf' %}
 {%                 for l3leaf_node_group in remote_switch_vars.l3leaf.node_groups | arista.avd.natural_sort %}
 {%                     if remote_switch in remote_switch_vars.l3leaf.node_groups[l3leaf_node_group].nodes | arista.avd.natural_sort %}
-{%                         do switch.remote_switches_asn.append( remote_switch_vars.l3leaf.node_groups[l3leaf_node_group].bgp_as | arista.avd.default(remote_switch_vars.l3leaf.defaults.bgp_as)) %}
+{%                         do switch.remote_switches_asn.append( remote_switch_vars.l3leaf.node_groups[l3leaf_node_group].nodes[remote_switch].bgp_as | arista.avd.default( remote_switch_vars.l3leaf.node_groups[l3leaf_node_group].bgp_as , remote_switch_vars.l3leaf.defaults.bgp_as) ) %}
 {%                         break %}
 {%                     endif %}
 {%                 endfor %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/bgp_base/spine-router-bgp-neighbors.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/bgp_base/spine-router-bgp-neighbors.j2
@@ -12,11 +12,9 @@
 {%                 if leaf_spine == inventory_hostname %}
     {{ underlay_p2p_network_summary | ipaddr('network') | ipmath(((l3leaf.node_groups[l3leaf_node_group].nodes[node].id -1) * 2 * spine.nodes | length * max_l3leaf_to_spine_links ) + loop.index0 * 2 + 1) }}:
       peer_group: IPv4-UNDERLAY-PEERS
-{%                     if l3leaf.node_groups[l3leaf_node_group].bgp_as is defined %}
-      remote_as: {{ l3leaf.node_groups[l3leaf_node_group].bgp_as }}
-{%                     else %}
-      remote_as: {{ l3leaf.defaults.bgp_as }}
-{%                     endif %}
+      remote_as: {{ l3leaf.node_groups[l3leaf_node_group].nodes[node].bgp_as | arista.avd.default(
+                    l3leaf.node_groups[l3leaf_node_group].bgp_as,
+                    l3leaf.defaults.bgp_as) }}
 {%                 endif %}
 {%             endfor %}
 {%         endif %}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/logic/switch-evpn-route-clients.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/logic/switch-evpn-route-clients.j2
@@ -21,7 +21,8 @@
 {# Found a matching l3leaf. Gathering information for this client #}
 {%                             set client = namespace() %}
 {%                             set client.id = fabric_switch_vars.l3leaf.node_groups[l3leaf_node_group].nodes[node].id %}
-{%                             set client.bgp_as = fabric_switch_vars.l3leaf.node_groups[l3leaf_node_group].bgp_as | arista.avd.default(
+{%                             set client.bgp_as = fabric_switch_vars.l3leaf.node_groups[l3leaf_node_group].nodes[node].bgp_as | arista.avd.default(
+                                                   fabric_switch_vars.l3leaf.node_groups[l3leaf_node_group].bgp_as,
                                                    fabric_switch_vars.l3leaf.defaults.bgp_as) %}
 {%                             set client.ip_address = fabric_switch_vars.overlay_loopback_network_summary | ipaddr('network') | ipmath(client.id + fabric_switch_vars.spine.nodes | length) %}
 {%                             do switch.evpn_route_clients.update({ fabric_switch: client }) %}


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

- Fixes #703 
- Fixes #707 

## Component(s) name

`arista.avd.eos_l3ls_evpn`

## Proposed changes

Provide support for a bgp_as knob set on a per node approach and not only node_group.

- L3LEAF logic
- Spine Logic
- Overlay Client logic

## How to test

Available in Molecule for 3-stage scenario.

```yaml
l3leaf:
  defaults:
    platform: 7280R
    bgp_as: 65101
    spines: [ DC1-SPINE1, DC1-SPINE2, DC1-SPINE3, DC1-SPINE4 ]
    uplink_to_spine_interfaces: [ Ethernet1, Ethernet2, Ethernet3, Ethernet4 ]
    mlag_interfaces: [ Ethernet5, Ethernet6 ]
    spanning_tree_mode: mstp
    spanning_tree_priority: 4096
    virtual_router_mac_address: 00:dc:00:00:00:0a
    filter:
      tenants: [ Tenant_A, Tenant_B, Tenant_C ]
      tags: [ opzone, web, app, db, vmotion, nfs ]
  node_groups:
    DC1_BL1:
      mlag: false
      filter:
        tenants: [ all ]
        tags: [ wan ]
      mlag: false
      nodes:
        DC1-BL1A:
          id: 6
          bgp_as: 65104
          mgmt_ip: 192.168.200.110/24
          mac_address: '0c:1d:c0:1d:62:01'
          spine_interfaces: [ Ethernet6, Ethernet6, Ethernet6, Ethernet6 ]
        DC1-BL1B:
          id: 7
          bgp_as: 65105
          mgmt_ip: 192.168.200.111/24
          mac_address: '0c:1d:c0:1d:62:01'
          spine_interfaces: [ Ethernet7, Ethernet7, Ethernet7, Ethernet7 ]
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
