### PR TITLE
Refactor eos_cli_config_gen router ospf

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-v4-evpn.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-v4-evpn.md
@@ -469,7 +469,6 @@ router bgp 65101
       router-id 192.168.255.3
       network 10.0.0.0/8
       network 100.64.0.0/10
-      neighbor 10.255.251.1 peer group MLAG-IPv4-UNDERLAY-PEER
       neighbor 10.2.3.4 remote-as 1234
       neighbor 10.2.3.4 local-as 123 no-prepend replace-as
       neighbor 10.2.3.4 description Tenant A BGP Peer
@@ -480,6 +479,7 @@ router bgp 65101
       neighbor 10.2.3.4 route-map RM-10.2.3.4-SET-NEXT-HOP-OUT out
       address-family ipv4
          neighbor 10.2.3.4 activate
+      neighbor 10.255.251.1 peer group MLAG-IPv4-UNDERLAY-PEER
       redistribute connected
       redistribute static
    !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
@@ -310,12 +310,14 @@ Global ARP timeout not defined.
 
 | Process ID | Router ID | Default Passive Interface | No Passive Interface | BFD | Max LSA | Default Information Originate | Log Adjacency Changes Detail |
 | ---------- | --------- | ------------------------- | -------------------- | --- | ------- | ----------------------------- | ---------------------------- |
-| 100 | 192.168.255.3 |  enabled   |   Ethernet1 <br> Ethernet2 <br> Vlan4093 <br>|   enabled   | 12000 |  disabled  |  disabled |
+| 100 | 192.168.255.3 |  enabled   |   Ethernet1 <br> Ethernet2 <br> Vlan4093 <br>|   enabled   | 12000 |   enabled   |  disabled |
+| 200 | 192.168.254.1 |  disabled   |  - |   disabled   | 5 |   Always    |   enabled |
 
 ### Router OSPF Router Redistribution
 
-No redsitribution configured
-
+| Process ID | Redistribute Connected | Redistribute Connected Route-map | Redistribute Static | Redistribute Static Route-map |
+| ---------- | ---------------------- | -------------------------------- | ------------------- | ----------------------------- |
+| 100 |  enabled | - |  enabled | - || 200 |  enabled | rm-ospf-connected |  enabled | rm-ospf-static |
 ### Router OSPF Device Configuration
 
 ```eos
@@ -328,6 +330,17 @@ router ospf 100
    no passive-interface Vlan4093
    bfd default
    max-lsa 12000
+   default-information originate
+   redistribute static
+   redistribute connected
+!
+router ospf 200 vrf ospf_zone
+   log-adjacency-changes detail
+   router-id 192.168.254.1
+   max-lsa 5
+   default-information originate always
+   redistribute static route-map rm-ospf-static
+   redistribute connected route-map rm-ospf-connected
 ```
 
 ## Router ISIS

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-v4-evpn.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-v4-evpn.cfg
@@ -82,7 +82,6 @@ router bgp 65101
       router-id 192.168.255.3
       network 10.0.0.0/8
       network 100.64.0.0/10
-      neighbor 10.255.251.1 peer group MLAG-IPv4-UNDERLAY-PEER
       neighbor 10.2.3.4 remote-as 1234
       neighbor 10.2.3.4 local-as 123 no-prepend replace-as
       neighbor 10.2.3.4 description Tenant A BGP Peer
@@ -93,6 +92,7 @@ router bgp 65101
       neighbor 10.2.3.4 route-map RM-10.2.3.4-SET-NEXT-HOP-OUT out
       address-family ipv4
          neighbor 10.2.3.4 activate
+      neighbor 10.255.251.1 peer group MLAG-IPv4-UNDERLAY-PEER
       redistribute connected
       redistribute static
    !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-ospf.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-ospf.cfg
@@ -20,5 +20,16 @@ router ospf 100
    no passive-interface Vlan4093
    bfd default
    max-lsa 12000
+   default-information originate
+   redistribute static
+   redistribute connected
+!
+router ospf 200 vrf ospf_zone
+   log-adjacency-changes detail
+   router-id 192.168.254.1
+   max-lsa 5
+   default-information originate always
+   redistribute static route-map rm-ospf-static
+   redistribute connected route-map rm-ospf-connected
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-ospf.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-ospf.yml
@@ -10,3 +10,21 @@ router_ospf:
         - Vlan4093
       bfd_enable: true
       max_lsa: 12000
+      default_information_originate:
+      redistribute:
+        static:
+        connected:
+    200:
+      vrf: ospf_zone
+      passive_interface_default: false
+      router_id: 192.168.254.1
+      log_adjacency_changes_detail: true
+      bfd_enable: false
+      max_lsa: 5
+      default_information_originate:
+        always: true
+      redistribute:
+        static:
+          route_map: rm-ospf-static
+        connected:
+          route_map: rm-ospf-connected

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-ospf.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-ospf.j2
@@ -1,54 +1,53 @@
 {# eos - router ospf #}
-{% if router_ospf is defined and router_ospf is not none %}
-{%     for process_id in router_ospf.process_ids | arista.avd.natural_sort %}
+{% for process_id in router_ospf.process_ids | arista.avd.natural_sort %}
 !
-{%         if router_ospf.process_ids[process_id].vrf is defined %}
+{%     if router_ospf.process_ids[process_id].vrf is arista.avd.defined %}
 router ospf {{ process_id }} vrf {{ router_ospf.process_ids[process_id].vrf }}
-{%         else %}
+{%     else %}
 router ospf {{ process_id }}
-{%         endif %}
-{%         if router_ospf.process_ids[process_id].log_adjacency_changes_detail is defined and router_ospf.process_ids[process_id].log_adjacency_changes_detail == true %}
+{%     endif %}
+{%     if router_ospf.process_ids[process_id].log_adjacency_changes_detail is arista.avd.defined(true) %}
    log-adjacency-changes detail
-{%         endif %}
-{%         if router_ospf.process_ids[process_id].router_id is defined %}
+{%     endif %}
+{%     if router_ospf.process_ids[process_id].router_id is arista.avd.defined %}
    router-id {{ router_ospf.process_ids[process_id].router_id }}
-{%         endif %}
-{%         if router_ospf.process_ids[process_id].passive_interface_default is defined and router_ospf.process_ids[process_id].passive_interface_default == true %}
+{%     endif %}
+{%     if router_ospf.process_ids[process_id].passive_interface_default is arista.avd.defined(true) %}
    passive-interface default
-{%         endif %}
-{%         if router_ospf.process_ids[process_id].no_passive_interfaces is defined %}
-{%             for interface in router_ospf.process_ids[process_id].no_passive_interfaces %}
+{%     endif %}
+{%     if router_ospf.process_ids[process_id].no_passive_interfaces is arista.avd.defined %}
+{%         for interface in router_ospf.process_ids[process_id].no_passive_interfaces %}
    no passive-interface {{ interface }}
-{%             endfor %}
-{%         endif %}
-{%         if router_ospf.process_ids[process_id].network_prefixes is defined %}
-{%             for network_prefix in router_ospf.process_ids[process_id].network_prefixes | arista.avd.natural_sort %}
+{%         endfor %}
+{%     endif %}
+{%     for network_prefix in router_ospf.process_ids[process_id].network_prefixes | arista.avd.natural_sort %}
    network {{ network_prefix }} area {{ router_ospf.process_ids[process_id].network_prefixes[network_prefix].area }}
-{%             endfor %}
-{%         endif %}
-{%         if router_ospf.process_ids[process_id].bfd_enable is defined and router_ospf.process_ids[process_id].bfd_enable %}
-   bfd default
-{%         endif %}
-{%         if router_ospf.process_ids[process_id].max_lsa is defined %}
-   max-lsa {{ router_ospf.process_ids[process_id].max_lsa }}
-{%         endif %}
-{%         if router_ospf.process_ids[process_id].default_information_originate is defined %}
-   default-information originate {% if router_ospf.process_ids[process_id].default_information_originate.always is defined and router_ospf.process_ids[process_id].default_information_originate.always == true %} always{% endif %}
-
-{%         endif %}
-{%         if router_ospf.process_ids[process_id].redistribute.static is defined %}
-{%           if router_ospf.process_ids[process_id].redistribute.static.route_map is defined %}
-   redistribute static route-map {{ router_ospf.process_ids[process_id].redistribute.static.route_map }}
-{%           else %}
-   redistribute static
-{%           endif %}
-{%         endif %}
-{%         if router_ospf.process_ids[process_id].redistribute.connected is defined %}
-{%           if router_ospf.process_ids[process_id].redistribute.connected.route_map is defined %}
-   redistribute connected route-map {{ router_ospf.process_ids[process_id].redistribute.connected.route_map }}
-{%           else %}
-   redistribute connected
-{%           endif %}
-{%         endif %}
 {%     endfor %}
-{% endif %}
+{%     if router_ospf.process_ids[process_id].bfd_enable is arista.avd.defined and router_ospf.process_ids[process_id].bfd_enable %}
+   bfd default
+{%     endif %}
+{%     if router_ospf.process_ids[process_id].max_lsa is arista.avd.defined %}
+   max-lsa {{ router_ospf.process_ids[process_id].max_lsa }}
+{%     endif %}
+{%     if router_ospf.process_ids[process_id].default_information_originate is defined %}
+{%         set default_information_originate_cli = "default-information originate"%}
+{%         if router_ospf.process_ids[process_id].default_information_originate.always is arista.avd.defined(true) %}
+{%             set default_information_originate_cli = default_information_originate_cli ~ " always" %}
+{%         endif %}
+   {{ default_information_originate_cli }}
+{%     endif %}
+{%     if router_ospf.process_ids[process_id].redistribute.static is defined %}
+{%         set redistribute_static_cli = "redistribute static" %}
+{%         if router_ospf.process_ids[process_id].redistribute.static.route_map is arista.avd.defined %}
+{%             set redistribute_static_cli = redistribute_static_cli ~ " route-map " ~  router_ospf.process_ids[process_id].redistribute.static.route_map %}
+{%         endif %}
+   {{ redistribute_static_cli}}
+{%     endif %}
+{%     if router_ospf.process_ids[process_id].redistribute.connected is defined %}
+{%         set redistribute_connected_cli = "redistribute connected" %}
+{%         if router_ospf.process_ids[process_id].redistribute.connected.route_map is arista.avd.defined %}
+{%             set redistribute_connected_cli = redistribute_connected_cli ~ " route-map " ~ router_ospf.process_ids[process_id].redistribute.connected.route_map %}
+{%         endif %}
+   {{ redistribute_connected_cli }}
+{%     endif %}
+{% endfor %}


### PR DESCRIPTION
## Change Summary

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

N/A

## Component(s) name

`arista.avd.eos_cli_config_gen`

__Eos Templates__: `router-ospf.j2`

## Proposed changes

- [x] Use `arista.avd.defined` test where possible
- [x] Use `arista.avd.default` filter where possible
- [x] Shorten long EOS CLI
- [ ] Remove default values
- [x] Update Molecule to increase coverage
- [ ] Rename tasks to use collection paths: `ansible.builtin.template`
- [ ] Move to concatenation using `~` instead of `+` to automatically convert to `string`
- [ ] Use `x in []` instead of multiple `if / elif / else` blocks
- [ ] Use `| join` instead of oneline `for` loop in documentation

## Submitted files

- [x] router-ospf.j2


## How to test

Molecule should not introduce change.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
