### PR TITLE
Bugfix overlay controller ip addressing

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
@@ -1828,7 +1828,9 @@ all:
 
 Defaults:
 ```yaml
-max_overlay_controller_to_switch_links: 1
+# The maximum number of uplinks for each overlay_controller. 
+#This is used to calculate P2P Link IP addresses, and should not be changed after deployment.
+max_overlay_controller_to_switch_links: 2
 ```
 
 Assigned to the DC group:

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/README.md
@@ -1828,7 +1828,7 @@ all:
 
 Defaults:
 ```yaml
-# The maximum number of uplinks for each overlay_controller. 
+# The maximum number of uplinks for each overlay_controller.
 #This is used to calculate P2P Link IP addresses, and should not be changed after deployment.
 max_overlay_controller_to_switch_links: 2
 ```

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/defaults/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/defaults/main.yml
@@ -19,7 +19,7 @@ internal_vlan_order:
 
 max_l3leaf_to_spine_links: 1
 max_spine_to_super_spine_links: 1
-max_overlay_controller_to_switch_links: 1
+max_overlay_controller_to_switch_links: 2
 
 terminattr_ingestgrpcurl_port: 9910
 terminattr_smashexcludes: "ale,flexCounter,hardware,kni,pulse,strata"

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/bgp_base/overlay-controller-router-bgp-neighbors.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/bgp_base/overlay-controller-router-bgp-neighbors.j2
@@ -3,7 +3,7 @@
 {## Underlay network peering #}
 {% if switch.underlay_routing_protocol == "ebgp" %}
 {%     for uplink_to_remote_switches in switch.uplink_to_remote_switches %}
-    {{ overlay_controller_p2p_network_summary | ipaddr('network') | ipmath(((switch.id -1) * overlay_controller.nodes | length * max_overlay_controller_to_switch_links ) + loop.index0 * 2) }}:
+    {{ overlay_controller_p2p_network_summary | ipaddr('network') | ipmath(((switch.id -1) * max_overlay_controller_to_switch_links ) + loop.index0 * 2) }}:
       peer_group: IPv4-UNDERLAY-PEERS
       description: {{ switch.remote_switches[loop.index0] }}
       remote_as: {{ switch.remote_switches_asn[loop.index0] }}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/bgp_base/overlay-controller-router-bgp-neighbors.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/bgp_base/overlay-controller-router-bgp-neighbors.j2
@@ -3,7 +3,7 @@
 {## Underlay network peering #}
 {% if switch.underlay_routing_protocol == "ebgp" %}
 {%     for uplink_to_remote_switches in switch.uplink_to_remote_switches %}
-    {{ overlay_controller_p2p_network_summary | ipaddr('network') | ipmath(((switch.id -1) * 2 * overlay_controller.nodes | length * max_overlay_controller_to_switch_links ) + loop.index0 * 2) }}:
+    {{ overlay_controller_p2p_network_summary | ipaddr('network') | ipmath(((switch.id -1) * overlay_controller.nodes | length * max_overlay_controller_to_switch_links ) + loop.index0 * 2) }}:
       peer_group: IPv4-UNDERLAY-PEERS
       description: {{ switch.remote_switches[loop.index0] }}
       remote_as: {{ switch.remote_switches_asn[loop.index0] }}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/bgp_base/overlay-controller-router-bgp-neighbors.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/bgp_base/overlay-controller-router-bgp-neighbors.j2
@@ -3,7 +3,7 @@
 {## Underlay network peering #}
 {% if switch.underlay_routing_protocol == "ebgp" %}
 {%     for uplink_to_remote_switches in switch.uplink_to_remote_switches %}
-    {{ overlay_controller_p2p_network_summary | ipaddr('network') | ipmath(((switch.id -1) * max_overlay_controller_to_switch_links ) + loop.index0 * 2) }}:
+    {{ overlay_controller_p2p_network_summary | ipaddr('network') | ipmath(((switch.id -1) * 2 * max_overlay_controller_to_switch_links ) + loop.index0 * 2) }}:
       peer_group: IPv4-UNDERLAY-PEERS
       description: {{ switch.remote_switches[loop.index0] }}
       remote_as: {{ switch.remote_switches_asn[loop.index0] }}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/bgp_base/switch-router-bgp-neighbors-overlay-controllers.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/bgp_base/switch-router-bgp-neighbors-overlay-controllers.j2
@@ -4,7 +4,7 @@
 {%         set overlay_controller_remote_switches = overlay_controller.nodes[overlay_controller_node].remote_switches | arista.avd.default( overlay_controller.defaults.remote_switches ) %}
 {%         for overlay_controller_remote_switch in overlay_controller_remote_switches %}
 {%             if overlay_controller_remote_switch == inventory_hostname %}
-    {{ overlay_controller_p2p_network_summary | ipaddr('network') | ipmath(((overlay_controller.nodes[overlay_controller_node].id -1) * max_overlay_controller_to_switch_links ) + loop.index0 * 2 + 1) }}:
+    {{ overlay_controller_p2p_network_summary | ipaddr('network') | ipmath(((overlay_controller.nodes[overlay_controller_node].id -1) * 2 * max_overlay_controller_to_switch_links ) + loop.index0 * 2 + 1) }}:
       peer_group: IPv4-UNDERLAY-PEERS
       description: {{ overlay_controller_node }}
       remote_as: {{ overlay_controller.nodes[overlay_controller_node].bgp_as | arista.avd.default( overlay_controller.defaults.bgp_as ) }}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/bgp_base/switch-router-bgp-neighbors-overlay-controllers.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/bgp_base/switch-router-bgp-neighbors-overlay-controllers.j2
@@ -4,7 +4,7 @@
 {%         set overlay_controller_remote_switches = overlay_controller.nodes[overlay_controller_node].remote_switches | arista.avd.default( overlay_controller.defaults.remote_switches ) %}
 {%         for overlay_controller_remote_switch in overlay_controller_remote_switches %}
 {%             if overlay_controller_remote_switch == inventory_hostname %}
-    {{ overlay_controller_p2p_network_summary | ipaddr('network') | ipmath(((overlay_controller.nodes[overlay_controller_node].id -1) * overlay_controller_remote_switches | length * max_overlay_controller_to_switch_links ) + loop.index0 * 2 + 1) }}:
+    {{ overlay_controller_p2p_network_summary | ipaddr('network') | ipmath(((overlay_controller.nodes[overlay_controller_node].id -1) * max_overlay_controller_to_switch_links ) + loop.index0 * 2 + 1) }}:
       peer_group: IPv4-UNDERLAY-PEERS
       description: {{ overlay_controller_node }}
       remote_as: {{ overlay_controller.nodes[overlay_controller_node].bgp_as | arista.avd.default( overlay_controller.defaults.bgp_as ) }}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/bgp_base/switch-router-bgp-neighbors-overlay-controllers.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/bgp_base/switch-router-bgp-neighbors-overlay-controllers.j2
@@ -4,7 +4,7 @@
 {%         set overlay_controller_remote_switches = overlay_controller.nodes[overlay_controller_node].remote_switches | arista.avd.default( overlay_controller.defaults.remote_switches ) %}
 {%         for overlay_controller_remote_switch in overlay_controller_remote_switches %}
 {%             if overlay_controller_remote_switch == inventory_hostname %}
-    {{ overlay_controller_p2p_network_summary | ipaddr('network') | ipmath(((overlay_controller.nodes[overlay_controller_node].id -1) * 2 * overlay_controller_remote_switches | length * max_overlay_controller_to_switch_links ) + loop.index0 * 2 + 1) }}:
+    {{ overlay_controller_p2p_network_summary | ipaddr('network') | ipmath(((overlay_controller.nodes[overlay_controller_node].id -1) * overlay_controller_remote_switches | length * max_overlay_controller_to_switch_links ) + loop.index0 * 2 + 1) }}:
       peer_group: IPv4-UNDERLAY-PEERS
       description: {{ overlay_controller_node }}
       remote_as: {{ overlay_controller.nodes[overlay_controller_node].bgp_as | arista.avd.default( overlay_controller.defaults.bgp_as ) }}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/interfaces/overlay-controller-p2p-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/interfaces/overlay-controller-p2p-interfaces.j2
@@ -15,7 +15,7 @@
 {%         endif %}
     type: routed
     shutdown: false
-    ip_address: {{ overlay_controller_p2p_network_summary | ipaddr('network') | ipmath(((switch.id -1) * overlay_controller.nodes | length * max_overlay_controller_to_switch_links ) + loop.index0 * 2 + 1) }}/31
+    ip_address: {{ overlay_controller_p2p_network_summary | ipaddr('network') | ipmath(((switch.id -1) * max_overlay_controller_to_switch_links ) + loop.index0 * 2 + 1) }}/31
 {%         if underlay_routing_protocol|lower == "ospf" %}
     ospf_network_point_to_point: true
     ospf_area: {{ underlay_ospf_area }}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/interfaces/overlay-controller-p2p-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/interfaces/overlay-controller-p2p-interfaces.j2
@@ -15,7 +15,7 @@
 {%         endif %}
     type: routed
     shutdown: false
-    ip_address: {{ overlay_controller_p2p_network_summary | ipaddr('network') | ipmath(((switch.id -1) * max_overlay_controller_to_switch_links ) + loop.index0 * 2 + 1) }}/31
+    ip_address: {{ overlay_controller_p2p_network_summary | ipaddr('network') | ipmath(((switch.id -1) * 2 * max_overlay_controller_to_switch_links ) + loop.index0 * 2 + 1) }}/31
 {%         if underlay_routing_protocol|lower == "ospf" %}
     ospf_network_point_to_point: true
     ospf_area: {{ underlay_ospf_area }}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/interfaces/overlay-controller-p2p-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/interfaces/overlay-controller-p2p-interfaces.j2
@@ -15,8 +15,7 @@
 {%         endif %}
     type: routed
     shutdown: false
-{# TODO: Validate IP calculation if attached to L3LEAF or SUPER-SPINE #}
-    ip_address: {{ overlay_controller_p2p_network_summary | ipaddr('network') | ipmath(((switch.id -1) * 2 * overlay_controller.nodes | length * max_overlay_controller_to_switch_links ) + loop.index0 * 2 + 1) }}/31
+    ip_address: {{ overlay_controller_p2p_network_summary | ipaddr('network') | ipmath(((switch.id -1) * overlay_controller.nodes | length * max_overlay_controller_to_switch_links ) + loop.index0 * 2 + 1) }}/31
 {%         if underlay_routing_protocol|lower == "ospf" %}
     ospf_network_point_to_point: true
     ospf_area: {{ underlay_ospf_area }}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/interfaces/switch-p2p-interfaces-overlay-controller.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/interfaces/switch-p2p-interfaces-overlay-controller.j2
@@ -34,7 +34,7 @@
 {%                 endif %}
     type: routed
     shutdown: false
-    ip_address: {{ overlay_controller_p2p_network_summary | ipaddr('network') | ipmath(((overlay_controller.nodes[overlay_controller_node].id -1) * 2 * overlay_controller_remote_switches | length * max_overlay_controller_to_switch_links ) + loop.index0 * 2) }}/31
+    ip_address: {{ overlay_controller_p2p_network_summary | ipaddr('network') | ipmath(((overlay_controller.nodes[overlay_controller_node].id -1) * overlay_controller_remote_switches | length * max_overlay_controller_to_switch_links ) + loop.index0 * 2) }}/31
 {%                 if underlay_routing_protocol|lower == "ospf" %}
     ospf_network_point_to_point: true
     ospf_area: {{ underlay_ospf_area }}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/interfaces/switch-p2p-interfaces-overlay-controller.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/interfaces/switch-p2p-interfaces-overlay-controller.j2
@@ -34,7 +34,7 @@
 {%                 endif %}
     type: routed
     shutdown: false
-    ip_address: {{ overlay_controller_p2p_network_summary | ipaddr('network') | ipmath(((overlay_controller.nodes[overlay_controller_node].id -1) * overlay_controller_remote_switches | length * max_overlay_controller_to_switch_links ) + loop.index0 * 2) }}/31
+    ip_address: {{ overlay_controller_p2p_network_summary | ipaddr('network') | ipmath(((overlay_controller.nodes[overlay_controller_node].id -1) * max_overlay_controller_to_switch_links ) + loop.index0 * 2) }}/31
 {%                 if underlay_routing_protocol|lower == "ospf" %}
     ospf_network_point_to_point: true
     ospf_area: {{ underlay_ospf_area }}

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/interfaces/switch-p2p-interfaces-overlay-controller.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/interfaces/switch-p2p-interfaces-overlay-controller.j2
@@ -34,7 +34,7 @@
 {%                 endif %}
     type: routed
     shutdown: false
-    ip_address: {{ overlay_controller_p2p_network_summary | ipaddr('network') | ipmath(((overlay_controller.nodes[overlay_controller_node].id -1) * max_overlay_controller_to_switch_links ) + loop.index0 * 2) }}/31
+    ip_address: {{ overlay_controller_p2p_network_summary | ipaddr('network') | ipmath(((overlay_controller.nodes[overlay_controller_node].id -1) * 2 * max_overlay_controller_to_switch_links ) + loop.index0 * 2) }}/31
 {%                 if underlay_routing_protocol|lower == "ospf" %}
     ospf_network_point_to_point: true
     ospf_area: {{ underlay_ospf_area }}


### PR DESCRIPTION
## Change Summary

Fix IP calculations for overlay_controller uplinks

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [X] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

## Component(s) name

`arista.avd.eos_l3ls_evpn`

## Proposed changes
<!--- Describe your changes in detail -->

Instead of defining "max_overlay_controller_to_switch_links" as the number of links per uplinks switch, we will define it as the max numbers of total uplinks for one "overlay_controller". This is needed to support different number of uplinks on different overlay_controllers.
Also the old formula didn't work for more than 2 uplinks per overlay_controller

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been rebased from devel before I start
- [ ] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
