### PR TITLE
Refactor eos cli config gen static routes

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ipv6-static-routes.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ipv6-static-routes.md
@@ -1,0 +1,445 @@
+# ipv6-static-routes
+
+# Table of Contents
+
+- [Management](#management)
+  - [Management Interfaces](#management-interfaces)
+  - [DNS Domain](#dns-domain)
+  - [Name Servers](#name-servers)
+  - [Domain Lookup](#domain-lookup)
+  - [NTP](#ntp)
+  - [Management SSH](#management-ssh)
+  - [Management GNMI](#management-api-gnmi)
+  - [Management API](#Management-api-http)
+- [Authentication](#authentication)
+  - [Local Users](#local-users)
+  - [Enable Password](#enable-password)
+  - [TACACS Servers](#tacacs-servers)
+  - [IP TACACS Source Interfaces](#ip-tacacs-source-interfaces)
+  - [RADIUS Servers](#radius-servers)
+  - [AAA Server Groups](#aaa-server-groups)
+  - [AAA Authentication](#aaa-authentication)
+  - [AAA Authorization](#aaa-authorization)
+  - [AAA Accounting](#aaa-accounting)
+- [Management Security](#management-security)
+- [Aliases](#aliases)
+- [Monitoring](#monitoring)
+  - [TerminAttr Daemon](#terminattr-daemon)
+  - [Logging](#logging)
+  - [SNMP](#snmp)
+  - [SFlow](#sflow)
+  - [Hardware Counters](#hardware-counters)
+  - [VM Tracer Sessions](#vm-tracer-sessions)
+  - [Event Handler](#event-handler)
+- [MLAG](#mlag)
+- [Spanning Tree](#spanning-tree)
+- [Internal VLAN Allocation Policy](#internal-vlan-allocation-policy)
+- [VLANs](#vlans)
+- [Interfaces](#interfaces)
+  - [Interface Defaults](#interface-defaults)
+  - [Ethernet Interfaces](#ethernet-interfaces)
+  - [Port-Channel Interfaces](#port-channel-interfaces)
+  - [Loopback Interfaces](#loopback-interfaces)
+  - [VLAN Interfaces](#vlan-interfaces)
+  - [VXLAN Interface](#vxlan-interface)
+- [Routing](#routing)
+  - [Virtual Router MAC Address](#virtual-router-mac-address)
+  - [IP Routing](#ip-routing)
+  - [IPv6 Routing](#ipv6-routing)
+  - [Static Routes](#static-routes)
+  - [IPv6 Static Routes](#ipv6-static-routes)
+  - [Router OSPF](#router-ospf)
+  - [Router ISIS](#router-isis)
+  - [Router BGP](#router-bgp)
+  - [Router BFD](#router-bfd)
+- [Multicast](#multicast)
+  - [IP IGMP Snooping](#ip-igmp-snooping)
+  - [Router Multicast](#router-multicast)
+  - [Router PIM Sparse Mode](#router-pim-sparse-mode)
+- [Filters](#filters)
+  - [Community-lists](#community-lists)
+  - [Peer Filters](#peer-filters)
+  - [Prefix-lists](#prefix-lists)
+  - [IPv6 Prefix-lists](#ipv6-prefix-lists)
+  - [Route-maps](#route-maps)
+  - [IP Extended Communities](#ip-extended-communities)
+- [ACL](#acl)
+  - [Standard Access-lists](#standard-access-lists)
+  - [Extended Access-lists](#extended-access-lists)
+  - [IPv6 Standard Access-lists](#ipv6-standard-access-lists)
+  - [IPv6 Extended Access-lists](#ipv6-extended-access-lists)
+- [VRF Instances](#vrf-instances)
+- [Virtual Source NAT](#virtual-source-nat)
+- [Platform](#platform)
+- [Router L2 VPN](#router-l2-vpn)
+- [IP DHCP Relay](#ip-dhcp-relay)
+- [Errdisable](#errdisable)
+- [MAC security](#mac-security)
+- [QOS](#qos)
+- [QOS Profiles](#qos-profiles)
+
+# Management
+
+## Management Interfaces
+
+### Management Interfaces Summary
+
+#### IPv4
+
+| Management Interface | description | VRF | IP Address | Gateway |
+| -------------------- | ----------- | --- | ---------- | ------- |
+| Management1 | oob_management | MGMT | 10.73.255.122/24 | 10.73.255.2 |
+
+#### IPv6
+
+| Management Interface | description | VRF | IPv6 Address | IPv6 Gateway |
+| -------------------- | ----------- | --- | ------------ | ------------ |
+| Management1 | oob_management | MGMT | -  | - |
+
+### Management Interfaces Device Configuration
+
+```eos
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+```
+
+## DNS Domain
+
+DNS domain not defined
+
+## Domain-list
+
+Domain-list not defined
+
+## Name Servers
+
+No name servers defined
+
+## Domain Lookup
+
+DNS domain lookup not defined
+
+## NTP
+
+No NTP servers defined
+
+## PTP
+
+PTP is not defined.
+
+## Management SSH
+
+Management SSH not defined
+
+## Management API GNMI
+
+Management API gnmi is not defined
+
+## Management API HTTP
+
+Management API HTTP not defined
+
+# Authentication
+
+## Local Users
+
+No users defined
+
+## Enable Password
+
+Enable password not defined
+
+## TACACS Servers
+
+TACACS servers not defined
+
+## IP TACACS Source Interfaces
+
+IP TACACS source interfaces not defined
+
+## RADIUS Servers
+
+RADIUS servers not defined
+
+## AAA Server Groups
+
+AAA server groups not defined
+
+## AAA Authentication
+
+AAA authentication not defined
+
+## AAA Authorization
+
+AAA authorization not defined
+
+## AAA Accounting
+
+AAA accounting not defined
+
+# Management Security
+
+Management security not defined
+
+# Aliases
+
+Aliases not defined
+
+# Monitoring
+
+## TerminAttr Daemon
+
+TerminAttr daemon not defined
+
+## Logging
+
+No logging settings defined
+
+## SNMP
+
+No SNMP settings defined
+
+## SFlow
+
+No sFlow defined
+
+## Hardware Counters
+
+No hardware counters defined
+
+## VM Tracer Sessions
+
+No VM tracer sessions defined
+
+## Event Handler
+
+No event handler defined
+
+# MLAG
+
+MLAG not defined
+
+# Spanning Tree
+
+Spanning-tree not defined
+
+# Internal VLAN Allocation Policy
+
+## Internal VLAN Allocation Policy Summary
+
+**Default Allocation Policy**
+
+| Policy Allocation | Range Beginning | Range Ending |
+| ------------------| --------------- | ------------ |
+| ascending | 1006 | 4094 |
+
+# VLANs
+
+No VLANs defined
+
+# Interfaces
+
+## Interface Defaults
+
+No Interface Defaults defined
+
+## Ethernet Interfaces
+
+No ethernet interface defined
+
+## Port-Channel Interfaces
+
+No port-channels defined
+
+## Loopback Interfaces
+
+No loopback interfaces defined
+
+## VLAN Interfaces
+
+No VLAN interfaces defined
+
+## VXLAN Interface
+
+No VXLAN interfaces defined
+
+# Routing
+
+## Virtual Router MAC Address
+
+IP virtual router MAC address not defined
+
+## IP Routing
+
+### IP Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | false|
+### IP Routing Device Configuration
+
+```eos
+```
+
+## IPv6 Routing
+
+### IPv6 Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | false |
+
+## Static Routes
+
+Static routes not defined
+
+## IPv6 Static Routes
+
+
+### IPv6 Static Routes Summary
+
+| VRF | Destination Prefix | Next Hop IP             | Exit interface      | Administrative Distance       | Tag               | Route Name                    | Metric         |
+| --- | ------------------ | ----------------------- | ------------------- | ----------------------------- | ----------------- | ----------------------------- | -------------- |
+| default  | 2a01:cb04:4e6:d300::/64 |  2a01:cb04:4e6:d100::1  |  vlan101  |  1  |  -  |  -  |  - |
+| default  | 2a01:cb04:4e6:d400::/64 |  2a01:cb04:4e6:d100::1  |  vlan101  |  200  |  666  |  RT-TO-FAKE-DMZ  |  - |
+| default  | 2a01:cb04:4e6:d400::/64 |  2a01:cb04:4e6:d100::1  |  vlan101  |  200  |  666  |  RT-TO-FAKE-DB-ZONE  |  100 |
+| customer01  | 2a01:cb04:4e6:a300::/64 |  2a01:cb04:4e6:100::1  |  vlan101  |  1  |  -  |  -  |  - |
+| customer01  | 2a01:cb04:4e6:a400::/64 |  2a01:cb04:4e6:100::1  |  vlan101  |  201  |  667  |  RT-TO-FAKE-DMZ  |  - |
+
+### Static Routes Device Configuration
+
+```eos
+!
+ipv6 route 2a01:cb04:4e6:d300::/64 Vlan101 2a01:cb04:4e6:d100::1
+ipv6 route 2a01:cb04:4e6:d400::/64 Vlan101 2a01:cb04:4e6:d100::1 200 tag 666 name RT-TO-FAKE-DMZ
+ipv6 route 2a01:cb04:4e6:d400::/64 Vlan101 2a01:cb04:4e6:d100::1 200 tag 666 name RT-TO-FAKE-DB-ZONE metric 100
+ipv6 route vrf customer01 2a01:cb04:4e6:a300::/64 Vlan101 2a01:cb04:4e6:100::1
+ipv6 route vrf customer01 2a01:cb04:4e6:a400::/64 Vlan101 2a01:cb04:4e6:100::1 201 tag 667 name RT-TO-FAKE-DMZ
+```
+
+## ARP
+
+Global ARP timeout not defined.
+
+## Router OSPF
+
+Router OSPF not defined
+
+## Router ISIS
+
+Router ISIS not defined
+
+## Router BGP
+
+Router BGP not defined
+
+## Router BFD
+
+### Router BFD Multihop Summary
+
+| Interval | Minimum RX | Multiplier |
+| -------- | ---------- | ---------- |
+| 300 | 300 | 3 |
+
+*No device configuration required - default values
+
+# Multicast
+
+## IP IGMP Snooping
+
+No IP IGMP configuration
+
+## Router Multicast
+
+Routing multicast not defined
+
+## Router PIM Sparse Mode
+
+Router PIM sparse mode not defined
+
+# Filters
+
+## Community-lists
+
+Community-lists not defined
+
+## Peer Filters
+
+No peer filters defined
+
+## Prefix-lists
+
+Prefix-lists not defined
+
+## IPv6 Prefix-lists
+
+IPv6 prefix-lists not defined
+
+## Route-maps
+
+No route-maps defined
+
+## IP Extended Communities
+
+No extended community defined
+
+# ACL
+
+## Standard Access-lists
+
+Standard access-lists not defined
+
+## Extended Access-lists
+
+Extended access-lists not defined
+
+## IPv6 Standard Access-lists
+
+IPv6 standard access-lists not defined
+
+## IPv6 Extended Access-lists
+
+IPv6 extended access-lists not defined
+
+# VRF Instances
+
+No VRF instances defined
+
+# Virtual Source NAT
+
+Virtual source NAT not defined
+
+# Platform
+
+No platform parameters defined
+
+# Router L2 VPN
+
+Router L2 VPN not defined
+
+# IP DHCP Relay
+
+IP DHCP relay not defined
+
+# Errdisable
+
+Errdisable is not defined.
+
+# MACsec
+
+MACsec not defined
+
+# QOS
+
+QOS is not defined.
+
+# QOS Profiles
+
+QOS Profiles are not defined
+
+# Custom Templates
+
+No custom templates defined

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/static-routes.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/static-routes.md
@@ -303,7 +303,7 @@ IP virtual router MAC address not defined
 | customer01  | 1.2.1.0/24 |  10.1.2.1  |  vlan202  |  1  |  -  |  -  |  - |
 | customer01  | 1.2.2.0/24 |  10.1.2.1  |  vlan101  |  201  |  667  |  RT-TO-FAKE-DMZ  |  - |
 | APP  | 10.3.4.0/24 |  1.2.3.4  |  -  |  1  |  -  |  -  |  - |
-| APP  | 10.3.5.0/24 |  1.2.3.4  |  Null0  |  1  |  -  |  -  |  - |
+| APP  | 10.3.5.0/24 |  -  |  Null0  |  1  |  -  |  -  |  - |
 
 ### Static Routes Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/static-routes.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/static-routes.md
@@ -1,4 +1,4 @@
-# router-static
+# static-routes
 
 # Table of Contents
 
@@ -303,6 +303,7 @@ IP virtual router MAC address not defined
 | customer01  | 1.2.1.0/24 |  10.1.2.1  |  vlan202  |  1  |  -  |  -  |  - |
 | customer01  | 1.2.2.0/24 |  10.1.2.1  |  vlan101  |  201  |  667  |  RT-TO-FAKE-DMZ  |  - |
 | APP  | 10.3.4.0/24 |  1.2.3.4  |  -  |  1  |  -  |  -  |  - |
+| APP  | 10.3.5.0/24 |  1.2.3.4  |  Null0  |  1  |  -  |  -  |  - |
 
 ### Static Routes Device Configuration
 
@@ -313,31 +314,12 @@ ip route 1.1.2.0/24 Vlan101 10.1.1.1 200 tag 666 name RT-TO-FAKE-DMZ
 ip route vrf customer01 1.2.1.0/24 Vlan202 10.1.2.1
 ip route vrf customer01 1.2.2.0/24 Vlan101 10.1.2.1 201 tag 667 name RT-TO-FAKE-DMZ
 ip route vrf APP 10.3.4.0/24 1.2.3.4
+ip route vrf APP 10.3.5.0/24 Null0
 ```
 
 ## IPv6 Static Routes
 
-
-### IPv6 Static Routes Summary
-
-| VRF | Destination Prefix | Next Hop IP             | Exit interface      | Administrative Distance       | Tag               | Route Name                    | Metric         |
-| --- | ------------------ | ----------------------- | ------------------- | ----------------------------- | ----------------- | ----------------------------- | -------------- |
-| default  | 2a01:cb04:4e6:d300::/64 |  2a01:cb04:4e6:d100::1  |  vlan101  |  1  |  -  |  -  |  - |
-| default  | 2a01:cb04:4e6:d400::/64 |  2a01:cb04:4e6:d100::1  |  vlan101  |  200  |  666  |  RT-TO-FAKE-DMZ  |  - |
-| default  | 2a01:cb04:4e6:d400::/64 |  2a01:cb04:4e6:d100::1  |  vlan101  |  200  |  666  |  RT-TO-FAKE-DB-ZONE  |  100 |
-| customer01  | 2a01:cb04:4e6:a300::/64 |  2a01:cb04:4e6:100::1  |  vlan101  |  1  |  -  |  -  |  - |
-| customer01  | 2a01:cb04:4e6:a400::/64 |  2a01:cb04:4e6:100::1  |  vlan101  |  201  |  667  |  RT-TO-FAKE-DMZ  |  - |
-
-### Static Routes Device Configuration
-
-```eos
-!
-ipv6 route 2a01:cb04:4e6:d300::/64 Vlan101 2a01:cb04:4e6:d100::1
-ipv6 route 2a01:cb04:4e6:d400::/64 Vlan101 2a01:cb04:4e6:d100::1 200 tag 666 name RT-TO-FAKE-DMZ
-ipv6 route 2a01:cb04:4e6:d400::/64 Vlan101 2a01:cb04:4e6:d100::1 200 tag 666 name RT-TO-FAKE-DB-ZONE metric 100
-ipv6 route vrf customer01 2a01:cb04:4e6:a300::/64 Vlan101 2a01:cb04:4e6:100::1
-ipv6 route vrf customer01 2a01:cb04:4e6:a400::/64 Vlan101 2a01:cb04:4e6:100::1 201 tag 667 name RT-TO-FAKE-DMZ
-```
+IPv6 static routes not defined
 
 ## ARP
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ipv6-static-routes.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ipv6-static-routes.cfg
@@ -2,7 +2,7 @@
 !
 transceiver qsfp default-mode 4x10G
 !
-hostname router-static
+hostname ipv6-static-routes
 !
 no aaa root
 no enable password
@@ -11,12 +11,6 @@ interface Management1
    description oob_management
    vrf MGMT
    ip address 10.73.255.122/24
-!
-ip route 1.1.1.0/24 Vlan101 10.1.1.1
-ip route 1.1.2.0/24 Vlan101 10.1.1.1 200 tag 666 name RT-TO-FAKE-DMZ
-ip route vrf customer01 1.2.1.0/24 Vlan202 10.1.2.1
-ip route vrf customer01 1.2.2.0/24 Vlan101 10.1.2.1 201 tag 667 name RT-TO-FAKE-DMZ
-ip route vrf APP 10.3.4.0/24 1.2.3.4
 !
 ipv6 route 2a01:cb04:4e6:d300::/64 Vlan101 2a01:cb04:4e6:d100::1
 ipv6 route 2a01:cb04:4e6:d400::/64 Vlan101 2a01:cb04:4e6:d100::1 200 tag 666 name RT-TO-FAKE-DMZ

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/static-routes.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/static-routes.cfg
@@ -1,0 +1,22 @@
+!RANCID-CONTENT-TYPE: arista
+!
+transceiver qsfp default-mode 4x10G
+!
+hostname static-routes
+!
+no aaa root
+no enable password
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+!
+ip route 1.1.1.0/24 Vlan101 10.1.1.1
+ip route 1.1.2.0/24 Vlan101 10.1.1.1 200 tag 666 name RT-TO-FAKE-DMZ
+ip route vrf customer01 1.2.1.0/24 Vlan202 10.1.2.1
+ip route vrf customer01 1.2.2.0/24 Vlan101 10.1.2.1 201 tag 667 name RT-TO-FAKE-DMZ
+ip route vrf APP 10.3.4.0/24 1.2.3.4
+ip route vrf APP 10.3.5.0/24 Null0
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ipv6-static-routes.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ipv6-static-routes.yml
@@ -1,34 +1,4 @@
----
-static_routes:
-  - vrf: default
-    destination_address_prefix: 1.1.1.0/24
-    interface: vlan101
-    gateway: 10.1.1.1
-
-  - vrf: default
-    destination_address_prefix: 1.1.2.0/24
-    interface: vlan101
-    gateway: 10.1.1.1
-    distance: 200
-    tag: 666
-    name: RT-TO-FAKE-DMZ
-
-  - vrf: customer01
-    destination_address_prefix: 1.2.1.0/24
-    interface: vlan202
-    gateway: 10.1.2.1
-
-  - vrf: customer01
-    destination_address_prefix: 1.2.2.0/24
-    interface: vlan101
-    gateway: 10.1.2.1
-    distance: 201
-    tag: 667
-    name: RT-TO-FAKE-DMZ
-
-  - destination_address_prefix: 10.3.4.0/24
-    gateway: 1.2.3.4
-    vrf: APP
+#### ipv6 static routes ####
 
 ipv6_static_routes:
   - vrf: default

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/static-routes.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/static-routes.yml
@@ -32,6 +32,5 @@ static_routes:
     vrf: APP
 
   - destination_address_prefix: 10.3.5.0/24
-    gateway: 1.2.3.4
     vrf: APP
     interface: Null0

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/static-routes.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/static-routes.yml
@@ -1,0 +1,37 @@
+#### static routes ####
+
+static_routes:
+  - vrf: default
+    destination_address_prefix: 1.1.1.0/24
+    interface: vlan101
+    gateway: 10.1.1.1
+
+  - vrf: default
+    destination_address_prefix: 1.1.2.0/24
+    interface: vlan101
+    gateway: 10.1.1.1
+    distance: 200
+    tag: 666
+    name: RT-TO-FAKE-DMZ
+
+  - vrf: customer01
+    destination_address_prefix: 1.2.1.0/24
+    interface: vlan202
+    gateway: 10.1.2.1
+
+  - vrf: customer01
+    destination_address_prefix: 1.2.2.0/24
+    interface: vlan101
+    gateway: 10.1.2.1
+    distance: 201
+    tag: 667
+    name: RT-TO-FAKE-DMZ
+
+  - destination_address_prefix: 10.3.4.0/24
+    gateway: 1.2.3.4
+    vrf: APP
+
+  - destination_address_prefix: 10.3.5.0/24
+    gateway: 1.2.3.4
+    vrf: APP
+    interface: Null0

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts
@@ -10,6 +10,7 @@ errdisable
 ethernet-interfaces
 event-handlers
 igmp-snooping
+ipv6-static-routes
 logging-minimal
 logging
 loopbacks-interfaces
@@ -38,13 +39,13 @@ router-l2-vpn
 router-multicast
 router-ospf
 router-pim-sparse-mode
-router-static
 service-routing-protocols-model
 sflow
 snmp_v3
 spanning-tree
 spanning-tree-rstp
 spanning-tree-rapid-pvst
+static-routes
 terminattr-cloud
 terminattr-prem
 terminattr-prem-disableaaa

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/static-routes.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/static-routes.j2
@@ -1,15 +1,32 @@
 {# static routes#}
-{% if static_routes is defined and static_routes is not none %}
+{% if static_routes is arista.avd.defined %}
 !
 {%     for static_route in static_routes %}
-ip route
-{%- if static_route['vrf'] is defined and static_route['vrf'] != 'default' and static_route['vrf'] is not none%} vrf {{ static_route['vrf'] }}{% endif %} {{ static_route['destination_address_prefix'] }}
-{%- if static_route['interface'] is defined and static_route['interface'] is not none and static_route['interface'] | capitalize != 'Null0' %} {{ static_route['interface'] | capitalize }}{% elif static_route['interface'] is defined and static_route['interface'] is not none and static_route['interface'] | capitalize == 'Null0' %} {{ static_route['interface'] | capitalize }}{%- endif -%}
-{%- if static_route['gateway'] is defined and static_route['gateway'] is not none and (static_route['interface'] is not defined or static_route['interface'] | capitalize != 'Null0') %} {{ static_route['gateway'] }}{% endif -%}
-{%- if static_route['distance'] is defined and static_route['distance'] is not none %} {{ static_route['distance'] }}{% endif -%}
-{%- if static_route['tag'] is defined and static_route['tag'] is not none %} tag {{ static_route['tag'] }}{% endif -%}
-{%- if static_route['name'] is defined and static_route['name'] is not none %} name {{ static_route['name'] }}{% endif %}
-{%- if static_route['metric'] is defined and static_route['metric'] is not none %} metric {{ static_route['metric'] }}{% endif %}
-
+{%         set static_route_cli = "ip route"%}
+{%         if static_route.vrf is arista.avd.defined and static_route.vrf != 'default' %}
+{%             set static_route_cli = static_route_cli ~ " vrf " ~ static_route.vrf %}
+{%         endif %}
+{%         if static_route.destination_address_prefix is arista.avd.defined %}
+{%             set static_route_cli = static_route_cli ~ " " ~ static_route.destination_address_prefix %}
+{%         endif %}
+{%         if  static_route.interface is arista.avd.defined %}
+{%             set static_route_cli = static_route_cli ~ " " ~ static_route.interface | capitalize %}
+{%         endif %}
+{%         if static_route.gateway is arista.avd.defined %}
+{%             set static_route_cli = static_route_cli ~ " " ~ static_route.gateway %}
+{%         endif %}
+{%         if static_route.distance is arista.avd.defined %}
+{%             set static_route_cli = static_route_cli ~ " " ~ static_route.distance %}
+{%         endif %}
+{%         if static_route.tag is arista.avd.defined %}
+{%             set static_route_cli = static_route_cli ~ " tag " ~ static_route.tag %}
+{%         endif %}
+{%         if static_route.name is arista.avd.defined %}
+{%             set static_route_cli = static_route_cli ~ " name " ~ static_route.name %}
+{%         endif %}
+{%         if static_route.metric is arista.avd.defined %}
+{%             set static_route_cli = static_route_cli ~ " metric " ~ static_route.metric %}
+{%         endif %}
+{{ static_route_cli }}
 {%          endfor %}
 {% endif %}


### PR DESCRIPTION
## Change Summary

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

N/A

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Submitted templates

- [x] static-routes.j2

note, I removed some checks from previous template: `static_route['interface'] | capitalize != 'Null0` that prevented incorrect configuration.  This is not required, and not something we should implement in `eos_cli_config_gen` role. I updated molecule tests accordingly.

## Proposed changes

- [x] Use `arista.avd.defined` test where possible
- [ ] Use `arista.avd.default` filter where possible
- [x] Shorten long EOS CLI
- [ ] Remove default values
- [x] Update Molecule to increase coverage
- [ ] Rename tasks to use collection paths: `ansible.builtin.template`
- [ ] Move to concatenation using `~` instead of `+` to automatically convert to `string`
- [ ] Use `x in []` instead of multiple `if / elif / else` blocks
- [ ] Use `| join` instead of oneline `for` loop in documentation

## How to test

Molecule should not introduce change.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
