### PR TITLE
fix(eos_l3ls_evpn): Fix p2p links profile mtu

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
@@ -381,7 +381,7 @@ No Interface Defaults defined
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
 | Ethernet1 |  P2P_LINK_TO_DC1-POD1-SPINE1_Ethernet5  |  routed  | - |  172.17.110.9/31  |  default  |  1500  |  false  |  -  |  -  |
 | Ethernet2 |  P2P_LINK_TO_DC1-POD1-SPINE2_Ethernet5  |  routed  | - |  172.17.110.11/31  |  default  |  1500  |  false  |  -  |  -  |
-| Ethernet7 |  P2P_LINK_TO_DC2-POD1-LEAF1A_Ethernet7  |  routed  | - |  11.1.0.38/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet7 |  P2P_LINK_TO_DC2-POD1-LEAF1A_Ethernet7  |  routed  | - |  11.1.0.38/31  |  default  |  1499  |  false  |  -  |  -  |
 
 ### Ethernet Interfaces Device Configuration
 
@@ -426,6 +426,7 @@ interface Ethernet6
 interface Ethernet7
    description P2P_LINK_TO_DC2-POD1-LEAF1A_Ethernet7
    no shutdown
+   mtu 1499
    no switchport
    ip address 11.1.0.38/31
 ```

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn-twodc-5stage-clos/documentation/devices/DC1-POD2-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn-twodc-5stage-clos/documentation/devices/DC1-POD2-SPINE2.md
@@ -314,7 +314,7 @@ No Interface Defaults defined
 | Ethernet1 |  P2P_LINK_TO_DC1-SUPER-SPINE1_Ethernet4  |  routed  | - |  172.16.12.3/31  |  default  |  1500  |  false  |  -  |  -  |
 | Ethernet2 |  P2P_LINK_TO_DC1-SUPER-SPINE2_Ethernet4  |  routed  | - |  172.16.12.67/31  |  default  |  1500  |  false  |  -  |  -  |
 | Ethernet3 |  P2P_LINK_TO_DC1-POD2-LEAF1A_Ethernet2  |  routed  | - |  172.17.120.2/31  |  default  |  1500  |  false  |  -  |  -  |
-| Ethernet4 |  P2P_LINK_TO_DC2-POD1-SPINE2_Ethernet5  |  routed  | - |  200.200.200.101/24  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4 |  P2P_LINK_TO_DC2-POD1-SPINE2_Ethernet5  |  routed  | - |  200.200.200.101/24  |  default  |  1498  |  false  |  -  |  -  |
 
 ### Ethernet Interfaces Device Configuration
 
@@ -347,6 +347,7 @@ interface Ethernet3
 interface Ethernet4
    description P2P_LINK_TO_DC2-POD1-SPINE2_Ethernet5
    no shutdown
+   mtu 1498
    no switchport
    ip address 200.200.200.101/24
 ```

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn-twodc-5stage-clos/documentation/devices/DC1-SUPER-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn-twodc-5stage-clos/documentation/devices/DC1-SUPER-SPINE1.md
@@ -316,7 +316,7 @@ No Interface Defaults defined
 | Ethernet3 |  P2P_LINK_TO_DC1-POD2-SPINE1_Ethernet1  |  routed  | - |  172.16.12.0/31  |  default  |  1500  |  false  |  -  |  -  |
 | Ethernet4 |  P2P_LINK_TO_DC1-POD2-SPINE2_Ethernet1  |  routed  | - |  172.16.12.2/31  |  default  |  1500  |  false  |  -  |  -  |
 | Ethernet5 |  P2P_LINK_TO_DC1-RS1_Ethernet1  |  routed  | - |  172.17.10.0/31  |  default  |  1500  |  false  |  -  |  -  |
-| Ethernet6 |  P2P_LINK_TO_DC2-SUPER-SPINE1_Ethernet4  |  routed  | - |  11.1.2.0/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet6 |  P2P_LINK_TO_DC2-SUPER-SPINE1_Ethernet4  |  routed  | - |  11.1.2.0/31  |  default  |  1499  |  false  |  -  |  -  |
 
 ### Ethernet Interfaces Device Configuration
 
@@ -364,6 +364,7 @@ interface Ethernet5
 interface Ethernet6
    description P2P_LINK_TO_DC2-SUPER-SPINE1_Ethernet4
    no shutdown
+   mtu 1499
    no switchport
    ip address 11.1.2.0/31
 ```

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn-twodc-5stage-clos/documentation/devices/DC2-POD1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn-twodc-5stage-clos/documentation/devices/DC2-POD1-LEAF1A.md
@@ -341,7 +341,7 @@ No Interface Defaults defined
 | Ethernet1 |  P2P_LINK_TO_DC2-POD1-SPINE1_Ethernet3  |  routed  | - |  172.17.210.1/31  |  default  |  1500  |  false  |  -  |  -  |
 | Ethernet2 |  P2P_LINK_TO_DC2-POD1-SPINE2_Ethernet3  |  routed  | - |  172.17.210.3/31  |  default  |  1500  |  false  |  -  |  -  |
 | Ethernet6 |  P2P_LINK_TO_DC1-POD1-LEAF2A_Ethernet7  |  routed  | - |  100.100.100.201/24  |  default  |  1500  |  false  |  -  |  -  |
-| Ethernet7 |  P2P_LINK_TO_DC1-POD1-LEAF2B_Ethernet7  |  routed  | - |  11.1.0.39/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet7 |  P2P_LINK_TO_DC1-POD1-LEAF2B_Ethernet7  |  routed  | - |  11.1.0.39/31  |  default  |  1499  |  false  |  -  |  -  |
 
 ### Ethernet Interfaces Device Configuration
 
@@ -377,6 +377,7 @@ interface Ethernet6
 interface Ethernet7
    description P2P_LINK_TO_DC1-POD1-LEAF2B_Ethernet7
    no shutdown
+   mtu 1499
    no switchport
    ip address 11.1.0.39/31
 ```

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn-twodc-5stage-clos/documentation/devices/DC2-POD1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn-twodc-5stage-clos/documentation/devices/DC2-POD1-SPINE2.md
@@ -314,7 +314,7 @@ No Interface Defaults defined
 | Ethernet1 |  P2P_LINK_TO_DC2-SUPER-SPINE1_Ethernet2  |  routed  | - |  172.16.21.3/31  |  default  |  1500  |  false  |  -  |  -  |
 | Ethernet2 |  P2P_LINK_TO_DC2-SUPER-SPINE2_Ethernet2  |  routed  | - |  172.16.21.67/31  |  default  |  1500  |  false  |  -  |  -  |
 | Ethernet3 |  P2P_LINK_TO_DC2-POD1-LEAF1A_Ethernet2  |  routed  | - |  172.17.210.2/31  |  default  |  1500  |  false  |  -  |  -  |
-| Ethernet5 |  P2P_LINK_TO_DC1-POD2-SPINE2_Ethernet4  |  routed  | - |  200.200.200.201/24  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet5 |  P2P_LINK_TO_DC1-POD2-SPINE2_Ethernet4  |  routed  | - |  200.200.200.201/24  |  default  |  1498  |  false  |  -  |  -  |
 
 ### Ethernet Interfaces Device Configuration
 
@@ -347,6 +347,7 @@ interface Ethernet3
 interface Ethernet5
    description P2P_LINK_TO_DC1-POD2-SPINE2_Ethernet4
    no shutdown
+   mtu 1498
    no switchport
    ip address 200.200.200.201/24
 ```

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn-twodc-5stage-clos/documentation/devices/DC2-SUPER-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn-twodc-5stage-clos/documentation/devices/DC2-SUPER-SPINE1.md
@@ -314,7 +314,7 @@ No Interface Defaults defined
 | Ethernet1 |  P2P_LINK_TO_DC2-POD1-SPINE1_Ethernet1  |  routed  | - |  172.16.21.0/31  |  default  |  1500  |  false  |  -  |  -  |
 | Ethernet2 |  P2P_LINK_TO_DC2-POD1-SPINE2_Ethernet1  |  routed  | - |  172.16.21.2/31  |  default  |  1500  |  false  |  -  |  -  |
 | Ethernet3 |  P2P_LINK_TO_DC2-RS1_Ethernet1  |  routed  | - |  172.17.20.0/31  |  default  |  1500  |  false  |  -  |  -  |
-| Ethernet4 |  P2P_LINK_TO_DC1-SUPER-SPINE1_Ethernet6  |  routed  | - |  11.1.2.1/31  |  default  |  1500  |  false  |  -  |  -  |
+| Ethernet4 |  P2P_LINK_TO_DC1-SUPER-SPINE1_Ethernet6  |  routed  | - |  11.1.2.1/31  |  default  |  1499  |  false  |  -  |  -  |
 | Ethernet5 |  P2P_LINK_TO_DC2-RS2_Ethernet1  |  routed  | - |  172.17.20.8/31  |  default  |  1500  |  false  |  -  |  -  |
 | Ethernet6 |  P2P_LINK_TO_DC2-RS1_Ethernet2  |  routed  | - |  172.17.20.2/31  |  default  |  1500  |  false  |  -  |  -  |
 | Ethernet7 |  P2P_LINK_TO_DC2-RS2_Ethernet2  |  routed  | - |  172.17.20.10/31  |  default  |  1500  |  false  |  -  |  -  |
@@ -349,6 +349,7 @@ interface Ethernet3
 interface Ethernet4
    description P2P_LINK_TO_DC1-SUPER-SPINE1_Ethernet6
    no shutdown
+   mtu 1499
    no switchport
    ip address 11.1.2.1/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2B.cfg
@@ -99,6 +99,7 @@ interface Ethernet6
 interface Ethernet7
    description P2P_LINK_TO_DC2-POD1-LEAF1A_Ethernet7
    no shutdown
+   mtu 1499
    no switchport
    ip address 11.1.0.38/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn-twodc-5stage-clos/intended/configs/DC1-POD2-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn-twodc-5stage-clos/intended/configs/DC1-POD2-SPINE2.cfg
@@ -44,6 +44,7 @@ interface Ethernet3
 interface Ethernet4
    description P2P_LINK_TO_DC2-POD1-SPINE2_Ethernet5
    no shutdown
+   mtu 1498
    no switchport
    ip address 200.200.200.101/24
 !

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn-twodc-5stage-clos/intended/configs/DC1-SUPER-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn-twodc-5stage-clos/intended/configs/DC1-SUPER-SPINE1.cfg
@@ -59,6 +59,7 @@ interface Ethernet5
 interface Ethernet6
    description P2P_LINK_TO_DC2-SUPER-SPINE1_Ethernet4
    no shutdown
+   mtu 1499
    no switchport
    ip address 11.1.2.0/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn-twodc-5stage-clos/intended/configs/DC2-POD1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn-twodc-5stage-clos/intended/configs/DC2-POD1-LEAF1A.cfg
@@ -71,6 +71,7 @@ interface Ethernet6
 interface Ethernet7
    description P2P_LINK_TO_DC1-POD1-LEAF2B_Ethernet7
    no shutdown
+   mtu 1499
    no switchport
    ip address 11.1.0.39/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn-twodc-5stage-clos/intended/configs/DC2-POD1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn-twodc-5stage-clos/intended/configs/DC2-POD1-SPINE2.cfg
@@ -44,6 +44,7 @@ interface Ethernet3
 interface Ethernet5
    description P2P_LINK_TO_DC1-POD2-SPINE2_Ethernet4
    no shutdown
+   mtu 1498
    no switchport
    ip address 200.200.200.201/24
 !

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn-twodc-5stage-clos/intended/configs/DC2-SUPER-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn-twodc-5stage-clos/intended/configs/DC2-SUPER-SPINE1.cfg
@@ -43,6 +43,7 @@ interface Ethernet3
 interface Ethernet4
    description P2P_LINK_TO_DC1-SUPER-SPINE1_Ethernet6
    no shutdown
+   mtu 1499
    no switchport
    ip address 11.1.2.1/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
@@ -185,7 +185,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC2-POD1-LEAF1A_Ethernet7
     type: routed
     shutdown: false
-    mtu: 1500
+    mtu: 1499
     ip_address: 11.1.0.38/31
 loopback_interfaces:
   Loopback0:

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn-twodc-5stage-clos/intended/structured_configs/DC1-POD2-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn-twodc-5stage-clos/intended/structured_configs/DC1-POD2-SPINE2.yml
@@ -82,7 +82,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC2-POD1-SPINE2_Ethernet5
     type: routed
     shutdown: false
-    mtu: 1500
+    mtu: 1498
     ip_address: 200.200.200.101/24
 loopback_interfaces:
   Loopback0:

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn-twodc-5stage-clos/intended/structured_configs/DC1-SUPER-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn-twodc-5stage-clos/intended/structured_configs/DC1-SUPER-SPINE1.yml
@@ -104,7 +104,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC2-SUPER-SPINE1_Ethernet4
     type: routed
     shutdown: false
-    mtu: 1500
+    mtu: 1499
     ip_address: 11.1.2.0/31
 loopback_interfaces:
   Loopback0:

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF1A.yml
@@ -136,7 +136,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-POD1-LEAF2B_Ethernet7
     type: routed
     shutdown: false
-    mtu: 1500
+    mtu: 1499
     ip_address: 11.1.0.39/31
 loopback_interfaces:
   Loopback0:

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn-twodc-5stage-clos/intended/structured_configs/DC2-POD1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn-twodc-5stage-clos/intended/structured_configs/DC2-POD1-SPINE2.yml
@@ -81,7 +81,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-POD2-SPINE2_Ethernet4
     type: routed
     shutdown: false
-    mtu: 1500
+    mtu: 1498
     ip_address: 200.200.200.201/24
 loopback_interfaces:
   Loopback0:

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn-twodc-5stage-clos/intended/structured_configs/DC2-SUPER-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn-twodc-5stage-clos/intended/structured_configs/DC2-SUPER-SPINE1.yml
@@ -114,7 +114,7 @@ ethernet_interfaces:
     description: P2P_LINK_TO_DC1-SUPER-SPINE1_Ethernet6
     type: routed
     shutdown: false
-    mtu: 1500
+    mtu: 1499
     ip_address: 11.1.2.1/31
 loopback_interfaces:
   Loopback0:

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn-twodc-5stage-clos/inventory/group_vars/TWODC_5STAGE_CLOS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn-twodc-5stage-clos/inventory/group_vars/TWODC_5STAGE_CLOS.yml
@@ -35,7 +35,7 @@ l3_edge:
     pool-leaf: 11.1.0.0/24
     pool-spine: 11.1.1.0/24
     pool-super-spine: 11.1.2.0/24
-  p2p_profiles:
+  p2p_links_profiles:
     generic-profile:
       mtu: 1500
       bfd: true

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn-twodc-5stage-clos/inventory/group_vars/TWODC_5STAGE_CLOS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn-twodc-5stage-clos/inventory/group_vars/TWODC_5STAGE_CLOS.yml
@@ -37,8 +37,8 @@ l3_edge:
     pool-super-spine: 11.1.2.0/24
   p2p_links_profiles:
     generic-profile:
-      mtu: 1500
-      bfd: true
+      mtu: 1499
+      bfd: false
   p2p_links:
     - nodes: [ DC1-SUPER-SPINE1, DC2-SUPER-SPINE1 ]
       id: 1
@@ -65,6 +65,7 @@ l3_edge:
       interfaces: [ Ethernet4, Ethernet5 ]
       as: [ 65112, 65210 ]
       ip: [ 200.200.200.101/24, 200.200.200.201/24 ]
+      mtu: 1498
       profile: generic-profile
       include_in_underlay_protocol: true
     - nodes: [ DC1-POD1-LEAF2A, DC2-POD1-LEAF1A ]

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn-twodc-5stage-clos/inventory/host_vars/all.yml
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn-twodc-5stage-clos/inventory/host_vars/all.yml
@@ -1,0 +1,2 @@
+---
+root_dir: '{{playbook_dir}}'

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/interfaces/switch-l3-edge-p2p-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/fabric/interfaces/switch-l3-edge-p2p-interfaces.j2
@@ -7,7 +7,7 @@
     description: {{ p2p_interface.description }}
     type: {{ p2p_interface.type }}
     shutdown: {{ p2p_interface.shutdown }}
-    mtu: {{ p2p_uplinks_mtu }}
+    mtu: {{ p2p_interface.mtu }}
 {%     if p2p_interface.ip_address is arista.avd.defined %}
     ip_address: {{ p2p_interface.ip_address }}
 {%     endif %}


### PR DESCRIPTION
## Change Summary

p2p_links_profiles.mtu was not inhireted properly on l3_edge p2p links.
Value was always defaulting to `p2p_uplinks_mtu` setting.

```yaml
l3_edge:
  p2p_links_profiles:
    generic-profile:
      mtu: 1499
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Component(s) name

`arista.avd.eos_l3ls_evpn`

## Proposed changes
<!--- Describe your changes in detail -->

## How to test

Run Molecule test case: `eos_l3ls_evpn-twodc-5stage-clos`
