### PR TITLE
ci(development-stack): Remove mkdoc autoreload function

### DIFF
--- a/development/Makefile
+++ b/development/Makefile
@@ -31,6 +31,8 @@ DOCKER_USER ?= avd
 GIT_USERNAME ?= $(shell git config --get user.name)
 GIT_EMAIL ?= $(shell git config --get user.email)
 MUFFET_TIMEOUT ?= 60
+# Container name to
+WEBDOC_ID ?= avd
 
 .PHONY: help
 help: ## Display help message
@@ -103,8 +105,17 @@ shell: ## Run a shell attached to ansible container
 ansible-upgrade: ## Run a shell attached to ansible container
 	docker-compose -f $(COMPOSE_FILE) exec -u $(DOCKER_USER) ansible pip install --user --upgrade ansible==$(ANSIBLE_VERSION)
 
+.PHONY: restart
+restart: stop start  ## Stop and Start docker-compose stack
+
 .PHONY: reload
-reload: stop start  ## Stop and Start docker-compose stack
+reload:  ## Reload HTTP container available in docker-compose stack
+	docker-compose -f $(COMPOSE_FILE) restart webdoc_$(WEBDOC_ID)
+
+.PHONY: reload-all
+reload-all:  ## Reload HTTP container available in docker-compose stack
+	docker-compose -f $(COMPOSE_FILE) restart webdoc_avd
+	docker-compose -f $(COMPOSE_FILE) restart webdoc_cvp
 
 ###############################################################################
 # 			Documentation target											  #

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     ports:
       - 8001:8000
     entrypoint: ""
-    command: ["sh", "-c", "pip install -r ansible-cvp/ansible_collections/arista/cvp/docs/requirements.txt && mkdocs serve --dev-addr=0.0.0.0:8000 -f ansible-cvp/mkdocs.yml"]
+    command: ["sh", "-c", "pip install -r ansible-cvp/ansible_collections/arista/cvp/docs/requirements.txt && mkdocs serve --no-livereload --dev-addr=0.0.0.0:8000 -f ansible-cvp/mkdocs.yml"]
 
   webdoc_avd:
     image: titom73/mkdocs:latest
@@ -30,4 +30,4 @@ services:
     ports:
       - 8000:8000
     entrypoint: ""
-    command: ["sh", "-c", "pip install -r ansible-avd/ansible_collections/arista/avd/docs/requirements.txt && mkdocs serve --dev-addr=0.0.0.0:8000 -f ansible-avd/mkdocs.yml"]
+    command: ["sh", "-c", "pip install -r ansible-avd/ansible_collections/arista/avd/docs/requirements.txt && mkdocs serve --no-livereload --dev-addr=0.0.0.0:8000 -f ansible-avd/mkdocs.yml"]


### PR DESCRIPTION
## Change Summary

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [x] Other (please describe): development-stack

## Related Issue(s)

N/A

## Component(s) name

development-stack

## Proposed changes

Running mkdoc development server from a container can use high CPU due
to issue on file monitoring.

This commit deactivate this function and add 2 new commands to makefile
to help user:

- `make reload`

```bash
$ make reload

$ make reload WEBDOC_ID=cvp
```

- `make reload-all`: Reload both cvp and avd mkdoc containers

## How to test

```shell
# Copy makefile
$ cp ./ansible-avd/development/Makefile .

# If you have refresh command
$ make refresh

# Start dev stack
$ make start
```

After a while, monitor your docker containers:

```shell
$ docker stats

CONTAINER ID   NAME          CPU %     MEM USAGE / LIMIT     MEM %     NET I/O           BLOCK I/O         PIDS
8a7beb5522ef   ansible_avd   0.00%     5.57MiB / 1.944GiB    0.28%     1.06kB / 0B       2.22MB / 0B       4
224d787eacf4   webdoc_avd    0.00%     122.8MiB / 1.944GiB   6.17%     4.42MB / 99.3kB   12.8MB / 5.13MB   1
06559f8183e8   webdoc_cvp    0.00%     77.18MiB / 1.944GiB   3.88%     10.2MB / 144kB    23.1MB / 10.5MB   1
```

> CPU will remain high until all requirements are installed

A container reload will create a new instance and then will re-download all the requirements

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
