### PR TITLE
Add Inband management in fabric documentation

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/fabric/DC1_FABRIC-documentation.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/fabric/DC1_FABRIC-documentation.md
@@ -34,6 +34,10 @@
 
 > Provision status is based on Ansible inventory declaration and do not represent real status from Cloudvision.
 
+### Fabric Switches with inband Management IP
+| POD | Type | Node | Management IP | Inband Interface |
+| --- | ---- | ---- | ------------- | ---------------- |
+
 ## Fabric Topology
 
 | Type | Node | Node Interface | Peer Type | Peer Node | Peer Interface |

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/documentation/fabric/DC1_FABRIC-documentation.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/documentation/fabric/DC1_FABRIC-documentation.md
@@ -34,6 +34,10 @@
 
 > Provision status is based on Ansible inventory declaration and do not represent real status from Cloudvision.
 
+### Fabric Switches with inband Management IP
+| POD | Type | Node | Management IP | Inband Interface |
+| --- | ---- | ---- | ------------- | ---------------- |
+
 ## Fabric Topology
 
 | Type | Node | Node Interface | Peer Type | Peer Node | Peer Interface |

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn-twodc-5stage-clos/documentation/fabric/TWODC_5STAGE_CLOS-documentation.md
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn-twodc-5stage-clos/documentation/fabric/TWODC_5STAGE_CLOS-documentation.md
@@ -43,6 +43,14 @@
 
 > Provision status is based on Ansible inventory declaration and do not represent real status from Cloudvision.
 
+### Fabric Switches with inband Management IP
+| POD | Type | Node | Management IP | Inband Interface |
+| --- | ---- | ---- | ------------- | ---------------- |
+| DC1_POD1 | l2leaf | DC1-POD1-L2LEAF1A | 172.21.110.4/24 | Vlan4085 |
+| DC1_POD1 | l2leaf | DC1-POD1-L2LEAF2A | 172.21.110.5/24 | Vlan4085 |
+| DC1_POD1 | l2leaf | DC1-POD1-L2LEAF2B | 172.21.110.6/24 | Vlan4085 |
+| DC2_POD1 | l2leaf | DC2-POD1-L2LEAF1A | 172.21.210.4/24 | Vlan4092 |
+
 ## Fabric Topology
 
 | Type | Node | Node Interface | Peer Type | Peer Node | Peer Interface |

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/fabric/DC1_FABRIC-documentation.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/fabric/DC1_FABRIC-documentation.md
@@ -34,6 +34,10 @@
 
 > Provision status is based on Ansible inventory declaration and do not represent real status from Cloudvision.
 
+### Fabric Switches with inband Management IP
+| POD | Type | Node | Management IP | Inband Interface |
+| --- | ---- | ---- | ------------- | ---------------- |
+
 ## Fabric Topology
 
 | Type | Node | Node Interface | Peer Type | Peer Node | Peer Interface |

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/fabric/DC1_FABRIC-documentation.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/fabric/DC1_FABRIC-documentation.md
@@ -35,6 +35,10 @@
 
 > Provision status is based on Ansible inventory declaration and do not represent real status from Cloudvision.
 
+### Fabric Switches with inband Management IP
+| POD | Type | Node | Management IP | Inband Interface |
+| --- | ---- | ---- | ------------- | ---------------- |
+
 ## Fabric Topology
 
 | Type | Node | Node Interface | Peer Type | Peer Node | Peer Interface |

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/fabric/DC1_FABRIC-documentation.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/fabric/DC1_FABRIC-documentation.md
@@ -34,6 +34,10 @@
 
 > Provision status is based on Ansible inventory declaration and do not represent real status from Cloudvision.
 
+### Fabric Switches with inband Management IP
+| POD | Type | Node | Management IP | Inband Interface |
+| --- | ---- | ---- | ------------- | ---------------- |
+
 ## Fabric Topology
 
 | Type | Node | Node Interface | Peer Type | Peer Node | Peer Interface |

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/documentation/fabric-documentation.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/documentation/fabric-documentation.j2
@@ -22,6 +22,12 @@
 {%         set fabric_switch.node = node %}
 {%         set fabric_switch.mgmt_ip = hostvars[node].switch_mgmt_ip | arista.avd.default('-') %}
 {%         do assigned_ip_addresses.append(hostvars[node].switch_mgmt_ip) if hostvars[node].switch_mgmt_ip is arista.avd.defined %}
+{%         for interface in hostvars[node].management_interfaces | arista.avd.natural_sort %}
+{%             if 'Management' not in interface %}
+{%                 set fabric_switch.inband_mgmt_ip = hostvars[node].management_interfaces[interface].ip_address %}
+{%                 set fabric_switch.inband_mgmt_interface = interface %}
+{%             endif %}
+{%         endfor %}
 {%         set fabric_switch.platform = hostvars[node].switch_platform | arista.avd.default('-') %}
 {%         set fabric_switch.provisioned = 'Not Available' if hostvars[node].is_deployed is arista.avd.defined(false) else 'Provisioned' %}
 {%         if hostvars[node].loopback_interfaces is arista.avd.defined and hostvars[node].loopback_interfaces.Loopback0 is arista.avd.defined %}
@@ -103,6 +109,15 @@
 {% endfor %}
 
 > Provision status is based on Ansible inventory declaration and do not represent real status from Cloudvision.
+
+### Fabric Switches with inband Management IP
+| POD | Type | Node | Management IP | Inband Interface |
+| --- | ---- | ---- | ------------- | ---------------- |
+{% for fabric_switch in fabric_switches %}
+{%     if fabric_switch.inband_mgmt_ip is arista.avd.defined %}
+| {{ fabric_switch.pod }} | {{ fabric_switch.type }} | {{ fabric_switch.node }} | {{fabric_switch.inband_mgmt_ip }} | {{fabric_switch.inband_mgmt_interface }} |
+{%     endif %}
+{% endfor %}
 
 ## Fabric Topology
 

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/documentation/fabric-documentation.j2
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/templates/documentation/fabric-documentation.j2
@@ -23,7 +23,7 @@
 {%         set fabric_switch.mgmt_ip = hostvars[node].switch_mgmt_ip | arista.avd.default('-') %}
 {%         do assigned_ip_addresses.append(hostvars[node].switch_mgmt_ip) if hostvars[node].switch_mgmt_ip is arista.avd.defined %}
 {%         for interface in hostvars[node].management_interfaces | arista.avd.natural_sort %}
-{%             if 'Management' not in interface %}
+{%             if hostvars[node].management_interfaces[interface].ip_address is arista.avd.defined and hostvars[node].management_interfaces[interface].ip_address != fabric_switch.mgmt_ip %}
 {%                 set fabric_switch.inband_mgmt_ip = hostvars[node].management_interfaces[interface].ip_address %}
 {%                 set fabric_switch.inband_mgmt_interface = interface %}
 {%             endif %}


### PR DESCRIPTION
## Change Summary
Under templates/documentation/fabric-documentation.j2 checking if management_interfaces include more interfaces than whose name starts with something different to "Management". If so, save it in a new variable inband_mgmt_ip and inband_mgmt_interface . While generating documentation, a new table is added where these variables are checked and printed if available.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [x] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes issue #697 

## Component(s) name

`arista.avd.eos_l3ls_evpn`

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Molecule test included

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
