### PR TITLE
fix(dhcp_provisioner): Fix incorrect mac-address rendering in template

### DIFF
--- a/ansible_collections/arista/avd/molecule/dhcp_configuration/intended/structured_configs/cvp/ztp_configuration.yml
+++ b/ansible_collections/arista/avd/molecule/dhcp_configuration/intended/structured_configs/cvp/ztp_configuration.yml
@@ -22,40 +22,40 @@ ztp:
     # SUPER SPINE
     # SPINE
     - name: DC1-SPINE1
-      mac: 0c:1d:c0:1d:62:01
+      mac: '0c:1d:c0:1d:62:01'
       ip4: 192.168.200.101
     - name: DC1-SPINE2
-      mac: 0c:1d:c0:1d:62:01
+      mac: '0c:1d:c0:1d:62:01'
       ip4: 192.168.200.102
     - name: DC1-SPINE3
-      mac: 0c:1d:c0:1d:62:01
+      mac: '0c:1d:c0:1d:62:01'
       ip4: 192.168.200.103
     - name: DC1-SPINE4
-      mac: 0c:1d:c0:1d:62:01
+      mac: '0c:1d:c0:1d:62:01'
       ip4: 192.168.200.104
     # L3LEAF
     - name: DC1-BL1A
-      mac: 0c:1d:c0:1d:62:01
+      mac: '0c:1d:c0:1d:62:01'
       ip4: 192.168.200.110
     - name: DC1-LEAF1A
-      mac: 0c:1d:c0:1d:62:01
+      mac: '0c:1d:c0:1d:62:01'
       ip4: 192.168.200.105
     - name: DC1-LEAF2A
-      mac: 0c:1d:c0:1d:62:01
+      mac: '0c:1d:c0:1d:62:01'
       ip4: 192.168.200.106
     - name: DC1-LEAF2B
-      mac: 0c:1d:c0:1d:62:01
+      mac: '0c:1d:c0:1d:62:01'
       ip4: 192.168.200.107
     - name: DC1-SVC3A
-      mac: 0c:1d:c0:1d:62:01
+      mac: '0c:1d:c0:1d:62:01'
       ip4: 192.168.200.108
     - name: DC1-SVC3B
-      mac: 0c:1d:c0:1d:62:01
+      mac: '0c:1d:c0:1d:62:01'
       ip4: 192.168.200.109
     # L2LEAF
     - name: DC1-L2LEAF1A
-      mac: 0c:1d:c0:1d:62:01
+      mac: '0c:1d:c0:1d:62:01'
       ip4: 192.168.200.112
     - name: DC1-L2LEAF2B
-      mac: 0c:1d:c0:1d:62:01
+      mac: '0c:1d:c0:1d:62:01'
       ip4: 192.168.200.114

--- a/ansible_collections/arista/avd/molecule/dhcp_provisionning/intended/configs/dhcpd.conf
+++ b/ansible_collections/arista/avd/molecule/dhcp_provisionning/intended/configs/dhcpd.conf
@@ -20,7 +20,7 @@ host DC1-SPINE1 {
 
 host DC1-SPINE2 {
     option host-name "DC1-SPINE2";
-    option dhcp-client-identifier 0c:1d:c0:1d:62:02;
+    option dhcp-client-identifier 50:08:00:06:00:00;
     fixed-address 192.168.200.102;
     option bootfile-name "http://192.168.200.11/ztp/bootstrap";
     option routers 192.168.200.5;

--- a/ansible_collections/arista/avd/molecule/dhcp_provisionning/intended/structured_configs/cvp/ztp_configuration.yml
+++ b/ansible_collections/arista/avd/molecule/dhcp_provisionning/intended/structured_configs/cvp/ztp_configuration.yml
@@ -22,40 +22,40 @@ ztp:
     # SUPER SPINE
     # SPINE
     - name: DC1-SPINE1
-      mac: 0c:1d:c0:1d:62:01
+      mac: '0c:1d:c0:1d:62:01'
       ip4: 192.168.200.101
     - name: DC1-SPINE2
-      mac: 0c:1d:c0:1d:62:02
+      mac: '50:08:00:06:00:00'
       ip4: 192.168.200.102
     - name: DC1-SPINE3
-      mac: 0c:1d:c0:1d:62:03
+      mac: '0c:1d:c0:1d:62:03'
       ip4: 192.168.200.103
     - name: DC1-SPINE4
-      mac: 0c:1d:c0:1d:62:04
+      mac: '0c:1d:c0:1d:62:04'
       ip4: 192.168.200.104
     # L3LEAF
     - name: DC1-BL1A
-      mac: 0c:1d:c0:1d:62:16
+      mac: '0c:1d:c0:1d:62:16'
       ip4: 192.168.200.110
     - name: DC1-LEAF1A
-      mac: 0c:1d:c0:1d:62:11
+      mac: '0c:1d:c0:1d:62:11'
       ip4: 192.168.200.105
     - name: DC1-LEAF2A
-      mac: 0c:1d:c0:1d:62:12
+      mac: '0c:1d:c0:1d:62:12'
       ip4: 192.168.200.106
     - name: DC1-LEAF2B
-      mac: 0c:1d:c0:1d:62:13
+      mac: '0c:1d:c0:1d:62:13'
       ip4: 192.168.200.107
     - name: DC1-SVC3A
-      mac: 0c:1d:c0:1d:62:14
+      mac: '0c:1d:c0:1d:62:14'
       ip4: 192.168.200.108
     - name: DC1-SVC3B
-      mac: 0c:1d:c0:1d:62:15
+      mac: '0c:1d:c0:1d:62:15'
       ip4: 192.168.200.109
     # L2LEAF
     - name: DC1-L2LEAF1A
-      mac: 0c:1d:c0:1d:62:21
+      mac: '0c:1d:c0:1d:62:21'
       ip4: 192.168.200.112
     - name: DC1-L2LEAF2B
-      mac: 0c:1d:c0:1d:62:22
+      mac: '0c:1d:c0:1d:62:22'
       ip4: 192.168.200.114

--- a/ansible_collections/arista/avd/molecule/dhcp_provisionning/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/dhcp_provisionning/inventory/group_vars/DC1_FABRIC.yml
@@ -46,7 +46,7 @@ spine:
     DC1-SPINE2:
       id: 2
       mgmt_ip: 192.168.200.102/24
-      mac_address: '0c:1d:c0:1d:62:02'
+      mac_address: '50:08:00:06:00:00'
     DC1-SPINE3:
       id: 3
       mgmt_ip: 192.168.200.103/24

--- a/ansible_collections/arista/avd/roles/dhcp_provisioner/templates/ztp_configuration.j2
+++ b/ansible_collections/arista/avd/roles/dhcp_provisioner/templates/ztp_configuration.j2
@@ -51,7 +51,7 @@ ztp:
 {%     for node in hostvars[groups[fabric_group][0]].super_spine.node_groups[node_group].nodes | arista.avd.natural_sort %}
 {%         if hostvars[groups[fabric_group][0]].super_spine.node_groups[node_group].nodes[node].mac_address is defined and hostvars[groups[fabric_group][0]].super_spine.node_groups[node_group].nodes[node].mac_address is not none %}
     - name: {{ node }}
-      mac: {{ hostvars[groups[fabric_group][0]].super_spine.node_groups[node_group].nodes[node].mac_address }}
+      mac: '{{ hostvars[groups[fabric_group][0]].super_spine.node_groups[node_group].nodes[node].mac_address }}'
       ip4: {{ hostvars[groups[fabric_group][0]].super_spine.node_groups[node_group].nodes[node].mgmt_ip | ipaddr('address') }}
 {%         endif %}
 {%     endfor %}
@@ -61,7 +61,7 @@ ztp:
 {% for node in hostvars[groups[fabric_group][0]].spine.nodes | arista.avd.natural_sort %}
 {%      if hostvars[groups[fabric_group][0]].spine.nodes[node].mac_address is defined and hostvars[groups[fabric_group][0]].spine.nodes[node].mac_address is not none %}
     - name: {{ node }}
-      mac: {{ hostvars[groups[fabric_group][0]].spine.nodes[node].mac_address }}
+      mac: '{{ hostvars[groups[fabric_group][0]].spine.nodes[node].mac_address }}'
       ip4: {{ hostvars[groups[fabric_group][0]].spine.nodes[node].mgmt_ip | ipaddr('address') }}
 {%      endif %}
 {% endfor %}
@@ -71,7 +71,7 @@ ztp:
 {%     for node in hostvars[groups[fabric_group][0]].l3leaf.node_groups[node_group].nodes | arista.avd.natural_sort %}
 {%         if hostvars[groups[fabric_group][0]].l3leaf.node_groups[node_group].nodes[node].mac_address is defined and hostvars[groups[fabric_group][0]].l3leaf.node_groups[node_group].nodes[node].mac_address is not none %}
     - name: {{ node }}
-      mac: {{ hostvars[groups[fabric_group][0]].l3leaf.node_groups[node_group].nodes[node].mac_address }}
+      mac: '{{ hostvars[groups[fabric_group][0]].l3leaf.node_groups[node_group].nodes[node].mac_address }}'
       ip4: {{ hostvars[groups[fabric_group][0]].l3leaf.node_groups[node_group].nodes[node].mgmt_ip | ipaddr('address') }}
 {%         endif %}
 {%     endfor %}
@@ -82,7 +82,7 @@ ztp:
 {%     for node in hostvars[groups[fabric_group][0]].l2leaf.node_groups[node_group].nodes | arista.avd.natural_sort %}
 {%         if hostvars[groups[fabric_group][0]].l2leaf.node_groups[node_group].nodes[node].mac_address is defined and hostvars[groups[fabric_group][0]].l2leaf.node_groups[node_group].nodes[node].mac_address is not none %}
     - name: {{ node }}
-      mac: {{ hostvars[groups[fabric_group][0]].l2leaf.node_groups[node_group].nodes[node].mac_address }}
+      mac: '{{ hostvars[groups[fabric_group][0]].l2leaf.node_groups[node_group].nodes[node].mac_address }}'
       ip4: {{ hostvars[groups[fabric_group][0]].l2leaf.node_groups[node_group].nodes[node].mgmt_ip | ipaddr('address') }}
 {%         endif %}
 {%     endfor %}


### PR DESCRIPTION
## Change Summary

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes #753 

## Component(s) name

`arista.avd.dhcp_provisioner`

## Proposed changes

Force mac-address rendering to a string to avoid text conversion.

## How to test

Refer to Molecule

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
