### PR TITLE
fix(eos_config_deploy_cvp): Resolve incorrect variable use in reset workflow

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/absent.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/absent.yml
@@ -7,20 +7,20 @@
 
 # Load tasks when device_filter is string
 - name: Load conditional cv_device execution if device_filter is string.
-  tags: [provision, apply]
+  tags: [reset]
   include_tasks: "./cv-device-filter-string.yml"
   when: "device_filter is string"
 
 # Load tasks when device_filter is list
 - name: Load conditional cv_device execution if device_filter is lsit.
-  tags: [provision, apply]
+  tags: [reset]
   include_tasks: "./cv-device-filter-list.yml"
   when: "device_filter is not string"
 
 - name: "Execute pending tasks on {{ inventory_hostname }}"
   tags: [reset]
   arista.cvp.cv_task:
-    tasks: "{{ devices_result.data.tasks }}"
+    tasks: "{{ CVP_DEVICES_RESULTS.data.tasks }}"
     wait: 720
 
 - name: 'Refreshing facts from CVP {{ inventory_hostname }}.'


### PR DESCRIPTION
## Change Summary

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes #752

## Component(s) name

`arista.avd.eos_config_deploy_cvp`

## Proposed changes

Use the correct variable to execute pending tasks after `cv_device`

## How to test

Run a reset workflow.

__ZTP MUST be configured before to not break setup__

> If tasks are already pending on CV side, role fails.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
