### PR TITLE
Removing conditional for NTP validate role

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/ntp.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/ntp.yml
@@ -5,8 +5,6 @@
 - name: Gather ntp status
   eos_command:
     commands: "show ntp status"
-  when: |
-    (ntp_server.nodes is defined and ntp_server.nodes is not none)
   register: ntp_status
   tags:
     - ntp


### PR DESCRIPTION
## Change Summary

Remove of the conditional statement on the NTP playbook. This allows the first task to execute always, also when it is not configured on the system. Doing this will allow second task to have always a result to validate/invalidate output instead of an empty value.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes issue #761 

## Component(s) name

`arista.avd.validation`

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
