### PR TITLE
L2leaf inband management refactor

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/fabric/DC1_FABRIC-documentation.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/fabric/DC1_FABRIC-documentation.md
@@ -34,6 +34,10 @@
 
 > Provision status is based on Ansible inventory declaration and do not represent real status from CloudVision.
 
+### Fabric Switches with inband Management IP
+| POD | Type | Node | Management IP | Inband Interface |
+| --- | ---- | ---- | ------------- | ---------------- |
+
 ## Fabric Topology
 
 | Type | Node | Node Interface | Peer Type | Peer Node | Peer Interface |

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -2,6 +2,8 @@ l2leaf_node_group: DC1_L2LEAF1
 switch_platform: vEOS-LAB
 leaf_id: 8
 switch_mgmt_ip: 192.168.200.112/24
+leaf_inband_management_ip: null
+leaf_inband_management_interface: null
 leaf_filter_tenants:
 - Tenant_A
 leaf_filter_tags:

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -2,8 +2,8 @@ l2leaf_node_group: DC1_L2LEAF1
 switch_platform: vEOS-LAB
 leaf_id: 8
 switch_mgmt_ip: 192.168.200.112/24
-leaf_inband_management_ip: null
-leaf_inband_management_interface: null
+switch_inband_management_ip: null
+switch_inband_management_interface: null
 leaf_filter_tenants:
 - Tenant_A
 leaf_filter_tags:

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -2,8 +2,8 @@ l2leaf_node_group: DC1_L2LEAF2
 switch_platform: vEOS-LAB
 leaf_id: 9
 switch_mgmt_ip: 192.168.200.113/24
-leaf_inband_management_ip: null
-leaf_inband_management_interface: null
+switch_inband_management_ip: null
+switch_inband_management_interface: null
 leaf_filter_tenants:
 - all
 leaf_filter_tags:

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -2,6 +2,8 @@ l2leaf_node_group: DC1_L2LEAF2
 switch_platform: vEOS-LAB
 leaf_id: 9
 switch_mgmt_ip: 192.168.200.113/24
+leaf_inband_management_ip: null
+leaf_inband_management_interface: null
 leaf_filter_tenants:
 - all
 leaf_filter_tags:

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -2,8 +2,8 @@ l2leaf_node_group: DC1_L2LEAF2
 switch_platform: vEOS-LAB
 leaf_id: 10
 switch_mgmt_ip: 192.168.200.114/24
-leaf_inband_management_ip: null
-leaf_inband_management_interface: null
+switch_inband_management_ip: null
+switch_inband_management_interface: null
 leaf_filter_tenants:
 - all
 leaf_filter_tags:

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -2,6 +2,8 @@ l2leaf_node_group: DC1_L2LEAF2
 switch_platform: vEOS-LAB
 leaf_id: 10
 switch_mgmt_ip: 192.168.200.114/24
+leaf_inband_management_ip: null
+leaf_inband_management_interface: null
 leaf_filter_tenants:
 - all
 leaf_filter_tags:

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/documentation/fabric/DC1_FABRIC-documentation.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/documentation/fabric/DC1_FABRIC-documentation.md
@@ -34,6 +34,10 @@
 
 > Provision status is based on Ansible inventory declaration and do not represent real status from CloudVision.
 
+### Fabric Switches with inband Management IP
+| POD | Type | Node | Management IP | Inband Interface |
+| --- | ---- | ---- | ------------- | ---------------- |
+
 ## Fabric Topology
 
 | Type | Node | Node Interface | Peer Type | Peer Node | Peer Interface |

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -2,6 +2,8 @@ l2leaf_node_group: DC1_L2LEAF1
 switch_platform: vEOS-LAB
 leaf_id: 8
 switch_mgmt_ip: 192.168.200.112/24
+leaf_inband_management_ip: null
+leaf_inband_management_interface: null
 leaf_filter_tenants:
 - Tenant_A
 leaf_filter_tags:

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -2,8 +2,8 @@ l2leaf_node_group: DC1_L2LEAF1
 switch_platform: vEOS-LAB
 leaf_id: 8
 switch_mgmt_ip: 192.168.200.112/24
-leaf_inband_management_ip: null
-leaf_inband_management_interface: null
+switch_inband_management_ip: null
+switch_inband_management_interface: null
 leaf_filter_tenants:
 - Tenant_A
 leaf_filter_tags:

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -2,8 +2,8 @@ l2leaf_node_group: DC1_L2LEAF2
 switch_platform: vEOS-LAB
 leaf_id: 9
 switch_mgmt_ip: 192.168.200.113/24
-leaf_inband_management_ip: null
-leaf_inband_management_interface: null
+switch_inband_management_ip: null
+switch_inband_management_interface: null
 leaf_filter_tenants:
 - all
 leaf_filter_tags:

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -2,6 +2,8 @@ l2leaf_node_group: DC1_L2LEAF2
 switch_platform: vEOS-LAB
 leaf_id: 9
 switch_mgmt_ip: 192.168.200.113/24
+leaf_inband_management_ip: null
+leaf_inband_management_interface: null
 leaf_filter_tenants:
 - all
 leaf_filter_tags:

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -2,8 +2,8 @@ l2leaf_node_group: DC1_L2LEAF2
 switch_platform: vEOS-LAB
 leaf_id: 10
 switch_mgmt_ip: 192.168.200.114/24
-leaf_inband_management_ip: null
-leaf_inband_management_interface: null
+switch_inband_management_ip: null
+switch_inband_management_interface: null
 leaf_filter_tenants:
 - all
 leaf_filter_tags:

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -2,6 +2,8 @@ l2leaf_node_group: DC1_L2LEAF2
 switch_platform: vEOS-LAB
 leaf_id: 10
 switch_mgmt_ip: 192.168.200.114/24
+leaf_inband_management_ip: null
+leaf_inband_management_interface: null
 leaf_filter_tenants:
 - all
 leaf_filter_tags:

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/fabric/TWODC_5STAGE_CLOS-documentation.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/fabric/TWODC_5STAGE_CLOS-documentation.md
@@ -43,6 +43,14 @@
 
 > Provision status is based on Ansible inventory declaration and do not represent real status from CloudVision.
 
+### Fabric Switches with inband Management IP
+| POD | Type | Node | Management IP | Inband Interface |
+| --- | ---- | ---- | ------------- | ---------------- |
+| DC1_POD1 | l2leaf | DC1-POD1-L2LEAF1A | 172.21.110.4/24 | Vlan4085 |
+| DC1_POD1 | l2leaf | DC1-POD1-L2LEAF2A | 172.21.110.5/24 | Vlan4085 |
+| DC1_POD1 | l2leaf | DC1-POD1-L2LEAF2B | 172.21.110.6/24 | Vlan4085 |
+| DC2_POD1 | l2leaf | DC2-POD1-L2LEAF1A | 172.21.210.4/24 | Vlan4092 |
+
 ## Fabric Topology
 
 | Type | Node | Node Interface | Peer Type | Peer Node | Peer Interface |

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF1A.yml
@@ -2,8 +2,8 @@ l2leaf_node_group: RACK2_SINGLE
 switch_platform: vEOS-LAB
 leaf_id: 1
 switch_mgmt_ip: 192.168.1.10/24
-leaf_inband_management_ip: 172.21.110.4/24
-leaf_inband_management_interface: Vlan4085
+switch_inband_management_ip: 172.21.110.4/24
+switch_inband_management_interface: Vlan4085
 leaf_filter_tenants:
 - all
 leaf_filter_tags:

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF1A.yml
@@ -2,6 +2,8 @@ l2leaf_node_group: RACK2_SINGLE
 switch_platform: vEOS-LAB
 leaf_id: 1
 switch_mgmt_ip: 192.168.1.10/24
+leaf_inband_management_ip: 172.21.110.4/24
+leaf_inband_management_interface: Vlan4085
 leaf_filter_tenants:
 - all
 leaf_filter_tags:

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF2A.yml
@@ -2,6 +2,8 @@ l2leaf_node_group: RACK2_MLAG
 switch_platform: vEOS-LAB
 leaf_id: 2
 switch_mgmt_ip: 192.168.1.11/24
+leaf_inband_management_ip: 172.21.110.5/24
+leaf_inband_management_interface: Vlan4085
 leaf_filter_tenants:
 - all
 leaf_filter_tags:

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF2A.yml
@@ -2,8 +2,8 @@ l2leaf_node_group: RACK2_MLAG
 switch_platform: vEOS-LAB
 leaf_id: 2
 switch_mgmt_ip: 192.168.1.11/24
-leaf_inband_management_ip: 172.21.110.5/24
-leaf_inband_management_interface: Vlan4085
+switch_inband_management_ip: 172.21.110.5/24
+switch_inband_management_interface: Vlan4085
 leaf_filter_tenants:
 - all
 leaf_filter_tags:

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF2B.yml
@@ -2,8 +2,8 @@ l2leaf_node_group: RACK2_MLAG
 switch_platform: vEOS-LAB
 leaf_id: 3
 switch_mgmt_ip: 192.168.1.12/24
-leaf_inband_management_ip: 172.21.110.6/24
-leaf_inband_management_interface: Vlan4085
+switch_inband_management_ip: 172.21.110.6/24
+switch_inband_management_interface: Vlan4085
 leaf_filter_tenants:
 - all
 leaf_filter_tags:

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF2B.yml
@@ -2,6 +2,8 @@ l2leaf_node_group: RACK2_MLAG
 switch_platform: vEOS-LAB
 leaf_id: 3
 switch_mgmt_ip: 192.168.1.12/24
+leaf_inband_management_ip: 172.21.110.6/24
+leaf_inband_management_interface: Vlan4085
 leaf_filter_tenants:
 - all
 leaf_filter_tags:

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-L2LEAF1A.yml
@@ -2,8 +2,8 @@ l2leaf_node_group: RACK1_SINGLE
 switch_platform: vEOS-LAB
 leaf_id: 1
 switch_mgmt_ip: 192.168.1.23/24
-leaf_inband_management_ip: 172.21.210.4/24
-leaf_inband_management_interface: Vlan4092
+switch_inband_management_ip: 172.21.210.4/24
+switch_inband_management_interface: Vlan4092
 leaf_filter_tenants:
 - all
 leaf_filter_tags:

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-L2LEAF1A.yml
@@ -2,6 +2,8 @@ l2leaf_node_group: RACK1_SINGLE
 switch_platform: vEOS-LAB
 leaf_id: 1
 switch_mgmt_ip: 192.168.1.23/24
+leaf_inband_management_ip: 172.21.210.4/24
+leaf_inband_management_interface: Vlan4092
 leaf_filter_tenants:
 - all
 leaf_filter_tags:

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/documentation/fabric/DC1_FABRIC-documentation.md
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/documentation/fabric/DC1_FABRIC-documentation.md
@@ -34,6 +34,10 @@
 
 > Provision status is based on Ansible inventory declaration and do not represent real status from CloudVision.
 
+### Fabric Switches with inband Management IP
+| POD | Type | Node | Management IP | Inband Interface |
+| --- | ---- | ---- | ------------- | ---------------- |
+
 ## Fabric Topology
 
 | Type | Node | Node Interface | Peer Type | Peer Node | Peer Interface |

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -2,6 +2,8 @@ l2leaf_node_group: DC1_L2LEAF1
 switch_platform: vEOS-LAB
 leaf_id: 8
 switch_mgmt_ip: 192.168.200.112/24
+leaf_inband_management_ip: null
+leaf_inband_management_interface: null
 leaf_filter_tenants:
 - Tenant_A
 leaf_filter_tags:

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -2,8 +2,8 @@ l2leaf_node_group: DC1_L2LEAF1
 switch_platform: vEOS-LAB
 leaf_id: 8
 switch_mgmt_ip: 192.168.200.112/24
-leaf_inband_management_ip: null
-leaf_inband_management_interface: null
+switch_inband_management_ip: null
+switch_inband_management_interface: null
 leaf_filter_tenants:
 - Tenant_A
 leaf_filter_tags:

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -2,8 +2,8 @@ l2leaf_node_group: DC1_L2LEAF2
 switch_platform: vEOS-LAB
 leaf_id: 9
 switch_mgmt_ip: 192.168.200.113/24
-leaf_inband_management_ip: null
-leaf_inband_management_interface: null
+switch_inband_management_ip: null
+switch_inband_management_interface: null
 leaf_filter_tenants:
 - all
 leaf_filter_tags:

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -2,6 +2,8 @@ l2leaf_node_group: DC1_L2LEAF2
 switch_platform: vEOS-LAB
 leaf_id: 9
 switch_mgmt_ip: 192.168.200.113/24
+leaf_inband_management_ip: null
+leaf_inband_management_interface: null
 leaf_filter_tenants:
 - all
 leaf_filter_tags:

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -2,8 +2,8 @@ l2leaf_node_group: DC1_L2LEAF2
 switch_platform: vEOS-LAB
 leaf_id: 10
 switch_mgmt_ip: 192.168.200.114/24
-leaf_inband_management_ip: null
-leaf_inband_management_interface: null
+switch_inband_management_ip: null
+switch_inband_management_interface: null
 leaf_filter_tenants:
 - all
 leaf_filter_tags:

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -2,6 +2,8 @@ l2leaf_node_group: DC1_L2LEAF2
 switch_platform: vEOS-LAB
 leaf_id: 10
 switch_mgmt_ip: 192.168.200.114/24
+leaf_inband_management_ip: null
+leaf_inband_management_interface: null
 leaf_filter_tenants:
 - all
 leaf_filter_tags:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/fabric/DC1_FABRIC-documentation.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/fabric/DC1_FABRIC-documentation.md
@@ -34,6 +34,10 @@
 
 > Provision status is based on Ansible inventory declaration and do not represent real status from CloudVision.
 
+### Fabric Switches with inband Management IP
+| POD | Type | Node | Management IP | Inband Interface |
+| --- | ---- | ---- | ------------- | ---------------- |
+
 ## Fabric Topology
 
 | Type | Node | Node Interface | Peer Type | Peer Node | Peer Interface |

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -2,6 +2,8 @@ l2leaf_node_group: DC1_L2LEAF1
 switch_platform: vEOS-LAB
 leaf_id: 8
 switch_mgmt_ip: 192.168.200.112/24
+leaf_inband_management_ip: null
+leaf_inband_management_interface: null
 leaf_filter_tenants:
 - Tenant_A
 leaf_filter_tags:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -2,8 +2,8 @@ l2leaf_node_group: DC1_L2LEAF1
 switch_platform: vEOS-LAB
 leaf_id: 8
 switch_mgmt_ip: 192.168.200.112/24
-leaf_inband_management_ip: null
-leaf_inband_management_interface: null
+switch_inband_management_ip: null
+switch_inband_management_interface: null
 leaf_filter_tenants:
 - Tenant_A
 leaf_filter_tags:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -2,8 +2,8 @@ l2leaf_node_group: DC1_L2LEAF2
 switch_platform: vEOS-LAB
 leaf_id: 9
 switch_mgmt_ip: 192.168.200.113/24
-leaf_inband_management_ip: null
-leaf_inband_management_interface: null
+switch_inband_management_ip: null
+switch_inband_management_interface: null
 leaf_filter_tenants:
 - all
 leaf_filter_tags:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -2,6 +2,8 @@ l2leaf_node_group: DC1_L2LEAF2
 switch_platform: vEOS-LAB
 leaf_id: 9
 switch_mgmt_ip: 192.168.200.113/24
+leaf_inband_management_ip: null
+leaf_inband_management_interface: null
 leaf_filter_tenants:
 - all
 leaf_filter_tags:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -2,8 +2,8 @@ l2leaf_node_group: DC1_L2LEAF2
 switch_platform: vEOS-LAB
 leaf_id: 10
 switch_mgmt_ip: 192.168.200.114/24
-leaf_inband_management_ip: null
-leaf_inband_management_interface: null
+switch_inband_management_ip: null
+switch_inband_management_interface: null
 leaf_filter_tenants:
 - all
 leaf_filter_tags:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -2,6 +2,8 @@ l2leaf_node_group: DC1_L2LEAF2
 switch_platform: vEOS-LAB
 leaf_id: 10
 switch_mgmt_ip: 192.168.200.114/24
+leaf_inband_management_ip: null
+leaf_inband_management_interface: null
 leaf_filter_tenants:
 - all
 leaf_filter_tags:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/fabric/DC1_FABRIC-documentation.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/fabric/DC1_FABRIC-documentation.md
@@ -35,6 +35,10 @@
 
 > Provision status is based on Ansible inventory declaration and do not represent real status from CloudVision.
 
+### Fabric Switches with inband Management IP
+| POD | Type | Node | Management IP | Inband Interface |
+| --- | ---- | ---- | ------------- | ---------------- |
+
 ## Fabric Topology
 
 | Type | Node | Node Interface | Peer Type | Peer Node | Peer Interface |

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -2,6 +2,8 @@ l2leaf_node_group: DC1_L2LEAF1
 switch_platform: vEOS-LAB
 leaf_id: 8
 switch_mgmt_ip: 192.168.200.112/24
+leaf_inband_management_ip: null
+leaf_inband_management_interface: null
 leaf_filter_tenants:
 - Tenant_A
 leaf_filter_tags:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -2,8 +2,8 @@ l2leaf_node_group: DC1_L2LEAF1
 switch_platform: vEOS-LAB
 leaf_id: 8
 switch_mgmt_ip: 192.168.200.112/24
-leaf_inband_management_ip: null
-leaf_inband_management_interface: null
+switch_inband_management_ip: null
+switch_inband_management_interface: null
 leaf_filter_tenants:
 - Tenant_A
 leaf_filter_tags:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -2,8 +2,8 @@ l2leaf_node_group: DC1_L2LEAF2
 switch_platform: vEOS-LAB
 leaf_id: 9
 switch_mgmt_ip: 192.168.200.113/24
-leaf_inband_management_ip: null
-leaf_inband_management_interface: null
+switch_inband_management_ip: null
+switch_inband_management_interface: null
 leaf_filter_tenants:
 - all
 leaf_filter_tags:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -2,6 +2,8 @@ l2leaf_node_group: DC1_L2LEAF2
 switch_platform: vEOS-LAB
 leaf_id: 9
 switch_mgmt_ip: 192.168.200.113/24
+leaf_inband_management_ip: null
+leaf_inband_management_interface: null
 leaf_filter_tenants:
 - all
 leaf_filter_tags:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -2,8 +2,8 @@ l2leaf_node_group: DC1_L2LEAF2
 switch_platform: vEOS-LAB
 leaf_id: 10
 switch_mgmt_ip: 192.168.200.114/24
-leaf_inband_management_ip: null
-leaf_inband_management_interface: null
+switch_inband_management_ip: null
+switch_inband_management_interface: null
 leaf_filter_tenants:
 - all
 leaf_filter_tags:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -2,6 +2,8 @@ l2leaf_node_group: DC1_L2LEAF2
 switch_platform: vEOS-LAB
 leaf_id: 10
 switch_mgmt_ip: 192.168.200.114/24
+leaf_inband_management_ip: null
+leaf_inband_management_interface: null
 leaf_filter_tenants:
 - all
 leaf_filter_tags:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/fabric/DC1_FABRIC-documentation.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/fabric/DC1_FABRIC-documentation.md
@@ -34,6 +34,10 @@
 
 > Provision status is based on Ansible inventory declaration and do not represent real status from CloudVision.
 
+### Fabric Switches with inband Management IP
+| POD | Type | Node | Management IP | Inband Interface |
+| --- | ---- | ---- | ------------- | ---------------- |
+
 ## Fabric Topology
 
 | Type | Node | Node Interface | Peer Type | Peer Node | Peer Interface |

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -2,6 +2,8 @@ l2leaf_node_group: DC1_L2LEAF1
 switch_platform: vEOS-LAB
 leaf_id: 8
 switch_mgmt_ip: 192.168.200.112/24
+leaf_inband_management_ip: null
+leaf_inband_management_interface: null
 leaf_filter_tenants:
 - Tenant_A
 leaf_filter_tags:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -2,8 +2,8 @@ l2leaf_node_group: DC1_L2LEAF1
 switch_platform: vEOS-LAB
 leaf_id: 8
 switch_mgmt_ip: 192.168.200.112/24
-leaf_inband_management_ip: null
-leaf_inband_management_interface: null
+switch_inband_management_ip: null
+switch_inband_management_interface: null
 leaf_filter_tenants:
 - Tenant_A
 leaf_filter_tags:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -2,8 +2,8 @@ l2leaf_node_group: DC1_L2LEAF2
 switch_platform: vEOS-LAB
 leaf_id: 9
 switch_mgmt_ip: 192.168.200.113/24
-leaf_inband_management_ip: null
-leaf_inband_management_interface: null
+switch_inband_management_ip: null
+switch_inband_management_interface: null
 leaf_filter_tenants:
 - all
 leaf_filter_tags:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -2,6 +2,8 @@ l2leaf_node_group: DC1_L2LEAF2
 switch_platform: vEOS-LAB
 leaf_id: 9
 switch_mgmt_ip: 192.168.200.113/24
+leaf_inband_management_ip: null
+leaf_inband_management_interface: null
 leaf_filter_tenants:
 - all
 leaf_filter_tags:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -2,8 +2,8 @@ l2leaf_node_group: DC1_L2LEAF2
 switch_platform: vEOS-LAB
 leaf_id: 10
 switch_mgmt_ip: 192.168.200.114/24
-leaf_inband_management_ip: null
-leaf_inband_management_interface: null
+switch_inband_management_ip: null
+switch_inband_management_interface: null
 leaf_filter_tenants:
 - all
 leaf_filter_tags:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -2,6 +2,8 @@ l2leaf_node_group: DC1_L2LEAF2
 switch_platform: vEOS-LAB
 leaf_id: 10
 switch_mgmt_ip: 192.168.200.114/24
+leaf_inband_management_ip: null
+leaf_inband_management_interface: null
 leaf_filter_tenants:
 - all
 leaf_filter_tags:

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/documentation/fabric-documentation.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/documentation/fabric-documentation.j2
@@ -22,6 +22,8 @@
 {%         set fabric_switch.node = node %}
 {%         set fabric_switch.mgmt_ip = hostvars[node].switch_mgmt_ip | arista.avd.default('-') %}
 {%         do assigned_ip_addresses.append(hostvars[node].switch_mgmt_ip) if hostvars[node].switch_mgmt_ip is arista.avd.defined %}
+{%         set fabric_switch.inband_management_interface = hostvars[node].leaf_inband_management_interface | arista.avd.default(none) %}
+{%         set fabric_switch.inband_management_ip = hostvars[node].leaf_inband_management_ip | arista.avd.default(none) %}
 {%         set fabric_switch.platform = hostvars[node].switch_platform | arista.avd.default('-') %}
 {%         set fabric_switch.provisioned = 'Not Available' if hostvars[node].is_deployed is arista.avd.defined(false) else 'Provisioned' %}
 {%         if hostvars[node].loopback_interfaces is arista.avd.defined and hostvars[node].loopback_interfaces.Loopback0 is arista.avd.defined %}
@@ -103,6 +105,15 @@
 {% endfor %}
 
 > Provision status is based on Ansible inventory declaration and do not represent real status from CloudVision.
+
+### Fabric Switches with inband Management IP
+| POD | Type | Node | Management IP | Inband Interface |
+| --- | ---- | ---- | ------------- | ---------------- |
+{% for fabric_switch in fabric_switches %}
+{%     if fabric_switch.inband_management_ip is arista.avd.defined and fabric_switch.inband_management_interface is arista.avd.defined %}
+| {{ fabric_switch.pod }} | {{ fabric_switch.type }} | {{ fabric_switch.node }} | {{fabric_switch.inband_management_ip }} | {{fabric_switch.inband_management_interface }} |
+{%     endif %}
+{% endfor %}
 
 ## Fabric Topology
 

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/documentation/fabric-documentation.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/documentation/fabric-documentation.j2
@@ -22,8 +22,8 @@
 {%         set fabric_switch.node = node %}
 {%         set fabric_switch.mgmt_ip = hostvars[node].switch_mgmt_ip | arista.avd.default('-') %}
 {%         do assigned_ip_addresses.append(hostvars[node].switch_mgmt_ip) if hostvars[node].switch_mgmt_ip is arista.avd.defined %}
-{%         set fabric_switch.inband_management_interface = hostvars[node].leaf_inband_management_interface | arista.avd.default(none) %}
-{%         set fabric_switch.inband_management_ip = hostvars[node].leaf_inband_management_ip | arista.avd.default(none) %}
+{%         set fabric_switch.inband_management_interface = hostvars[node].switch_inband_management_interface | arista.avd.default(none) %}
+{%         set fabric_switch.inband_management_ip = hostvars[node].switch_inband_management_ip | arista.avd.default(none) %}
 {%         set fabric_switch.platform = hostvars[node].switch_platform | arista.avd.default('-') %}
 {%         set fabric_switch.provisioned = 'Not Available' if hostvars[node].is_deployed is arista.avd.defined(false) else 'Provisioned' %}
 {%         if hostvars[node].loopback_interfaces is arista.avd.defined and hostvars[node].loopback_interfaces.Loopback0 is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/fabric/bgp_base/leaf-prefix-lists.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/fabric/bgp_base/leaf-prefix-lists.j2
@@ -6,11 +6,11 @@
         action: "permit {{ overlay_loopback_network_summary }} eq 32"
       20:
         action: "permit {{ vtep_loopback_network_summary }} eq 32"
-{%     if vtep_vvtep_ip is defined and vtep_vvtep_ip is not none and leaf.evpn_services_l2_only == false %}
+{%     if vtep_vvtep_ip is arista.avd.defined and leaf.evpn_services_l2_only is arista.avd.defined(false) %}
       30:
         action: "permit {{ vtep_vvtep_ip }}"
 {%     endif %}
-{%     if l2leaf_inband_management_subnet is defined and l2leaf_inband_management_subnet is not none %}
+{%     if l2leaf_inband_management_subnet is arista.avd.defined %}
   PL-L2LEAF-INBAND-MGMT:
     sequence_numbers:
       10:

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/fabric/bgp_base/route-maps.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/fabric/bgp_base/route-maps.j2
@@ -6,7 +6,7 @@
         type: permit
         match:
           - "ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY"
-{%     if type == "l3leaf" and l2leaf_inband_management_subnet is defined and l2leaf_inband_management_subnet is not none %}
+{%     if type == "l3leaf" and l2leaf_inband_management_subnet is arista.avd.defined %}
       20:
         type: permit
         match:

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/fabric/ebgp_underlay/leaf-router-bgp-redistribute-routes.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/fabric/ebgp_underlay/leaf-router-bgp-redistribute-routes.j2
@@ -3,7 +3,7 @@
 {%     if switch.underlay_routing_protocol == 'ebgp' %}
     connected:
       route_map: RM-CONN-2-BGP
-{%         if l2leaf_inband_management_subnet is defined and l2leaf_inband_management_subnet is not none %}
+{%         if l2leaf_inband_management_subnet is arista.avd.defined %}
     attached-host:
 {%         endif %}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/l2leaf.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/l2leaf.j2
@@ -9,12 +9,16 @@
 {% include 'designs/l3ls-evpn/logic/l2leaf.j2' %}
 {# Set tenant network evpn vxlan services vars #}
 {% include 'designs/l3ls-evpn/tenant_evpn_vxlan/l2leaf-logic.j2' %}
+{# Set l2leaf inband management vars #}
+{% include 'designs/l3ls-evpn/logic/l2leaf-inband-management.j2' %}
 
 ### Leaf Info ###
 l2leaf_node_group: {{ leaf.group }}
 switch_platform: {{ switch.platform }}
 leaf_id: {{ leaf.id }}
 switch_mgmt_ip: {{ switch.mgmt_ip }}
+leaf_inband_management_ip: {{ leaf.inband_management_ip }}
+leaf_inband_management_interface: {{ leaf.inband_management_interface }}
 leaf_filter_tenants: {{ leaf.filter_tenants }}
 leaf_filter_tags: {{ leaf.filter_tags }}
 leaf_allowed_vrfs: {{ leaf.vrfs }}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/l2leaf.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/l2leaf.j2
@@ -9,7 +9,7 @@
 {% include 'designs/l3ls-evpn/logic/l2leaf.j2' %}
 {# Set tenant network evpn vxlan services vars #}
 {% include 'designs/l3ls-evpn/tenant_evpn_vxlan/l2leaf-logic.j2' %}
-{# Set l2leaf inband management vars #}
+{# Set switch inband management vars #}
 {% include 'designs/l3ls-evpn/logic/l2leaf-inband-management.j2' %}
 
 ### Leaf Info ###
@@ -17,8 +17,8 @@ l2leaf_node_group: {{ leaf.group }}
 switch_platform: {{ switch.platform }}
 leaf_id: {{ leaf.id }}
 switch_mgmt_ip: {{ switch.mgmt_ip }}
-leaf_inband_management_ip: {{ leaf.inband_management_ip | arista.avd.default(none) }}
-leaf_inband_management_interface: {{ leaf.inband_management_interface | arista.avd.default(none) }}
+switch_inband_management_ip: {{ switch.inband_management_ip | arista.avd.default(none) }}
+switch_inband_management_interface: {{ switch.inband_management_interface | arista.avd.default(none) }}
 leaf_filter_tenants: {{ leaf.filter_tenants }}
 leaf_filter_tags: {{ leaf.filter_tags }}
 leaf_allowed_vrfs: {{ leaf.vrfs }}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/l2leaf.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/l2leaf.j2
@@ -17,8 +17,8 @@ l2leaf_node_group: {{ leaf.group }}
 switch_platform: {{ switch.platform }}
 leaf_id: {{ leaf.id }}
 switch_mgmt_ip: {{ switch.mgmt_ip }}
-leaf_inband_management_ip: {{ leaf.inband_management_ip }}
-leaf_inband_management_interface: {{ leaf.inband_management_interface }}
+leaf_inband_management_ip: {{ leaf.inband_management_ip | arista.avd.default(none) }}
+leaf_inband_management_interface: {{ leaf.inband_management_interface | arista.avd.default(none) }}
 leaf_filter_tenants: {{ leaf.filter_tenants }}
 leaf_filter_tags: {{ leaf.filter_tags }}
 leaf_allowed_vrfs: {{ leaf.vrfs }}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/l3leaf_l2leafs_uplinks/l2leaf-port-channel-uplinks.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/l3leaf_l2leafs_uplinks/l2leaf-port-channel-uplinks.j2
@@ -20,7 +20,7 @@
 {%                 set parent_l3leafs = l2leaf.defaults.parent_l3leafs %}
 {%             endif %}
 {%             set uplink_vlans = leaf.vlans %}
-{%             if l2leaf_inband_management_subnet is defined and l2leaf_inband_management_subnet is not none %}
+{%             if l2leaf_inband_management_subnet is arista.avd.defined %}
 {%                 do uplink_vlans.append ( l2leaf_inband_management_vlan | arista.avd.default(4092) | int ) %}
 {%             endif %}
   Port-Channel{{ channel_group_id }}:

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/l3leaf_l2leafs_uplinks/l3leaf-port-channel-uplinks.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/l3leaf_l2leafs_uplinks/l3leaf-port-channel-uplinks.j2
@@ -32,7 +32,7 @@
 {%             endif %}
 {# Create allowed vlan lan list based on vlans being provisioned on L2 Leaf #}
 {%             set l2_leaf.vlans = []  %}
-{%             if l2leaf_inband_management_subnet is defined and l2leaf_inband_management_subnet is not none %}
+{%             if l2leaf_inband_management_subnet is arista.avd.defined %}
 {%                 do l2_leaf.vlans.append ( l2leaf_inband_management_vlan | arista.avd.default(4092) | int ) %}
 {%             endif %}
 {%             for tenant in tenants | arista.avd.natural_sort if tenant in leaf.filter_tenants or "all" in leaf.filter_tenants %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/l3leaf_l2leafs_uplinks/leaf-l2leaf-inband-management-vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/l3leaf_l2leafs_uplinks/leaf-l2leaf-inband-management-vlan-interfaces.j2
@@ -1,5 +1,5 @@
 {# L2leaf Inband Management VLAN interfaces #}
-{% if l2leaf_inband_management_subnet is defined and l2leaf_inband_management_subnet is not none %}
+{% if l2leaf_inband_management_subnet is arista.avd.defined %}
   Vlan{{ l2leaf_inband_management_vlan|arista.avd.default('4092') }}:
     description: L2LEAF_INBAND_MGMT
     shutdown: false
@@ -14,7 +14,7 @@
     ip_attached_host_route_export:
       distance: 19
 {%     elif type == 'l2leaf' %}
-    ip_address: {{ l2leaf_inband_management_subnet | ipaddr('network') | ipmath(3 + leaf.id) }}/{{ l2leaf_inband_management_subnet | ipaddr('prefix') }}
+    ip_address: {{ leaf.inband_management_ip }}
     gateway: {{ l2leaf_inband_management_subnet | ipaddr('network') | ipmath(1) }}
 {%     endif %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/l3leaf_l2leafs_uplinks/leaf-l2leaf-inband-management-vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/l3leaf_l2leafs_uplinks/leaf-l2leaf-inband-management-vlan-interfaces.j2
@@ -14,7 +14,7 @@
     ip_attached_host_route_export:
       distance: 19
 {%     elif type == 'l2leaf' %}
-    ip_address: {{ leaf.inband_management_ip }}
+    ip_address: {{ switch.inband_management_ip }}
     gateway: {{ l2leaf_inband_management_subnet | ipaddr('network') | ipmath(1) }}
 {%     endif %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/l3leaf_l2leafs_uplinks/leaf-l2leaf-inband-management-vlan.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/l3leaf_l2leafs_uplinks/leaf-l2leaf-inband-management-vlan.j2
@@ -1,5 +1,5 @@
 {# L2leaf Inband Management VLAN #}
-{% if l2leaf_inband_management_subnet is defined and l2leaf_inband_management_subnet is not none %}
+{% if l2leaf_inband_management_subnet is arista.avd.defined %}
   {{ l2leaf_inband_management_vlan|arista.avd.default('4092') }}:
     tenant: system
     name: L2LEAF_INBAND_MGMT

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/logic/l2leaf-inband-management.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/logic/l2leaf-inband-management.j2
@@ -1,0 +1,7 @@
+{# L2leaf Inband Management #}
+{% if l2leaf_inband_management_subnet is arista.avd.defined %}
+{%     set leaf.inband_management_interface = 'Vlan' ~ l2leaf_inband_management_vlan | arista.avd.default('4092') %}
+{%     set tmp_ip = l2leaf_inband_management_subnet | ipaddr('network') | ipmath(3 + leaf.id) %}
+{%     set tmp_mask = l2leaf_inband_management_subnet | ipaddr('prefix') %}
+{%     set leaf.inband_management_ip = tmp_ip ~ '/' ~ tmp_mask %}
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/logic/l2leaf-inband-management.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/logic/l2leaf-inband-management.j2
@@ -1,7 +1,7 @@
 {# L2leaf Inband Management #}
 {% if l2leaf_inband_management_subnet is arista.avd.defined %}
-{%     set leaf.inband_management_interface = 'Vlan' ~ l2leaf_inband_management_vlan | arista.avd.default('4092') %}
+{%     set switch.inband_management_interface = 'Vlan' ~ l2leaf_inband_management_vlan | arista.avd.default('4092') %}
 {%     set tmp_ip = l2leaf_inband_management_subnet | ipaddr('network') | ipmath(3 + leaf.id) %}
 {%     set tmp_mask = l2leaf_inband_management_subnet | ipaddr('prefix') %}
-{%     set leaf.inband_management_ip = tmp_ip ~ '/' ~ tmp_mask %}
+{%     set switch.inband_management_ip = tmp_ip ~ '/' ~ tmp_mask %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/routing/static-routes.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/routing/static-routes.j2
@@ -12,7 +12,7 @@
     gateway: {{ mgmt_gateway }}
 {% endif %}
 {% if type == 'l2leaf' %}
-{%     if l2leaf_inband_management_subnet is defined and l2leaf_inband_management_subnet is not none %}
+{%     if l2leaf_inband_management_subnet is arista.avd.defined %}
   - destination_address_prefix: 0.0.0.0/0
     gateway: {{ l2leaf_inband_management_subnet | ipaddr('network') | ipmath(1) }}
 {%     endif %}


### PR DESCRIPTION
## Change Summary
Add l2leaf inband management to documentation & small refactor

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Code style update (formatting, renaming)
- [X] Refactoring (no functional changes)
- [X] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes issue #697
Fixes issue #771 
Replaces PR #745 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
Add table with inband management information to fabric documentation.
This has been done by adding new structured variables:
`switch_inband_management_interface` and `switch_inband_management_ip`.
This is currently only set for l2leaf, but can be reused later if we add inband management for other device types.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Ran my own test dataset, but also all molecule tests.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
