### PR TITLE
fix(eos_cli_config_gen): Fix issue on logging interface

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/logging.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/logging.md
@@ -211,10 +211,12 @@ TerminAttr daemon not defined
 
 | VRF | Source Interface |
 | --- | ---------------- |
+| default | Loopback0 |
 | mgt | Management0 |
 
 | VRF | Hosts |
 | --- | ---------------- |
+| default | 20.20.20.7 |
 | mgt | 10.10.10.7 |
 
 ### Logging Servers and Features Device Configuration
@@ -224,6 +226,8 @@ TerminAttr daemon not defined
 logging console debugging
 logging buffered 1000000 informational
 logging trap informational
+logging source-interface Loopback0
+logging host 20.20.20.7
 logging vrf mgt source-interface Management0
 logging vrf mgt host 10.10.10.7
 ```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/logging.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/logging.cfg
@@ -5,6 +5,8 @@ transceiver qsfp default-mode 4x10G
 logging console debugging
 logging buffered 1000000 informational
 logging trap informational
+logging source-interface Loopback0
+logging host 20.20.20.7
 logging vrf mgt source-interface Management0
 logging vrf mgt host 10.10.10.7
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/logging.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/logging.yml
@@ -11,3 +11,7 @@ logging:
       source_interface: Management0
       hosts:
         - 10.10.10.7
+    default:
+      source_interface: Loopback0
+      hosts:
+        - 20.20.20.7

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/logging.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/logging.j2
@@ -30,7 +30,7 @@ logging source-interface {{ logging.source_interface }}
 {%     for vrf in logging.vrfs | arista.avd.natural_sort %}
 {%         if logging.vrfs[vrf].source_interface is arista.avd.defined and vrf != 'default' %}
 logging vrf {{ vrf }} source-interface {{ logging.vrfs[vrf].source_interface }}
-{%         elif logging.vrfs[vrf].source_interface is arista.avd.defined('default') %}
+{%         elif logging.vrfs[vrf].source_interface is arista.avd.defined and vrf == 'default' %}
 logging source-interface {{ logging.vrfs[vrf].source_interface }}
 {%         endif %}
 {%         if logging.vrfs[vrf].hosts is arista.avd.defined and vrf != 'default' %}


### PR DESCRIPTION
## Change Summary

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

N/A

## Component(s) name

`arista.avd.cli_config_gen`

## Proposed changes

Remove constraint for interface == default and add molecule test case

## How to test

Refer to molecule eos_cli_config_gen / logging

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
