### PR TITLE
Feat(eos_cli_config_gen): Management security for TLS and certs

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/base.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/base.md
@@ -190,13 +190,13 @@ Management API gnmi is not defined
 
 | HTTP | HTTPS |
 | ---------- | ---------- |
-|  true  |  true  |
+| true | true |
 
 ### Management API VRF Access
 
 | VRF Name | IPv4 ACL | IPv6 ACL |
 | -------- | -------- | -------- |
-| mgt |  ACL-API  |  -  |
+| mgt | ACL-API | - |
 
 ### Management API HTTP Configuration
 
@@ -254,7 +254,7 @@ AAA accounting not defined
 
 ## Management Security
 
-   Management Security password encryption is common.
+Management Security password encryption is common.
 
 
 ## Management Security Configuration

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/base.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/base.md
@@ -198,6 +198,7 @@ Management API gnmi is not defined
 | -------- | -------- | -------- |
 | mgt | ACL-API | - |
 
+
 ### Management API HTTP Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mac-security-eth-po-entropy.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mac-security-eth-po-entropy.md
@@ -185,8 +185,13 @@ AAA accounting not defined
 
 ## Management Security
 
+Management Security entropy source is hardware
 
- Management Security entropy source is hardware
+Management Security password encryption is common.
+
+| SSL Profile Name | TLS protocol accepted | Certificate filename | Key filename |
+| ------------ | --------------------- | -------------------- | ------------ |
+| SSL_PROFILE | 1.1 1.2 | SSL_CERT | SSL_KEY |
 
 ## Management Security Configuration
 
@@ -194,6 +199,10 @@ AAA accounting not defined
 !
 management security
    entropy source hardware
+   password encryption-key common
+   ssl profile SSL_PROFILE
+      tls versions 1.1 1.2
+      certificate SSL_CERT key SSL_KEY
 ```
 
 # Prompt

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-api-http.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-api-http.md
@@ -2,26 +2,15 @@
 
 # Table of Contents
 
-- [management-api-http](#management-api-http)
-- [Table of Contents](#table-of-contents)
 - [Management](#management)
   - [Management Interfaces](#management-interfaces)
-    - [Management Interfaces Summary](#management-interfaces-summary)
-      - [IPv4](#ipv4)
-      - [IPv6](#ipv6)
-    - [Management Interfaces Device Configuration](#management-interfaces-device-configuration)
   - [DNS Domain](#dns-domain)
-  - [Domain-list](#domain-list)
   - [Name Servers](#name-servers)
   - [Domain Lookup](#domain-lookup)
   - [NTP](#ntp)
-  - [PTP](#ptp)
   - [Management SSH](#management-ssh)
-  - [Management API GNMI](#management-api-gnmi)
-  - [Management API HTTP](#management-api-http-1)
-    - [Management API HTTP Summary](#management-api-http-summary)
-    - [Management API VRF Access](#management-api-vrf-access)
-    - [Management API HTTP Configuration](#management-api-http-configuration)
+  - [Management GNMI](#management-api-gnmi)
+  - [Management API](#Management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
   - [Enable Password](#enable-password)
@@ -46,7 +35,6 @@
 - [MLAG](#mlag)
 - [Spanning Tree](#spanning-tree)
 - [Internal VLAN Allocation Policy](#internal-vlan-allocation-policy)
-  - [Internal VLAN Allocation Policy Summary](#internal-vlan-allocation-policy-summary)
 - [VLANs](#vlans)
 - [Interfaces](#interfaces)
   - [Interface Defaults](#interface-defaults)
@@ -58,18 +46,13 @@
 - [Routing](#routing)
   - [Virtual Router MAC Address](#virtual-router-mac-address)
   - [IP Routing](#ip-routing)
-    - [IP Routing Summary](#ip-routing-summary)
-    - [IP Routing Device Configuration](#ip-routing-device-configuration)
   - [IPv6 Routing](#ipv6-routing)
-    - [IPv6 Routing Summary](#ipv6-routing-summary)
   - [Static Routes](#static-routes)
   - [IPv6 Static Routes](#ipv6-static-routes)
-  - [ARP](#arp)
   - [Router OSPF](#router-ospf)
   - [Router ISIS](#router-isis)
   - [Router BGP](#router-bgp)
   - [Router BFD](#router-bfd)
-    - [Router BFD Multihop Summary](#router-bfd-multihop-summary)
 - [Multicast](#multicast)
   - [IP IGMP Snooping](#ip-igmp-snooping)
   - [Router Multicast](#router-multicast)
@@ -83,9 +66,6 @@
   - [IP Extended Communities](#ip-extended-communities)
 - [ACL](#acl)
   - [Standard Access-lists](#standard-access-lists)
-    - [Standard Access-lists Summary](#standard-access-lists-summary)
-      - [ACL-API](#acl-api)
-    - [Standard Access-lists Device Configuration](#standard-access-lists-device-configuration)
   - [Extended Access-lists](#extended-access-lists)
   - [IPv6 Standard Access-lists](#ipv6-standard-access-lists)
   - [IPv6 Extended Access-lists](#ipv6-extended-access-lists)
@@ -95,10 +75,9 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
-- [MACsec](#macsec)
+- [MAC security](#mac-security)
 - [QOS](#qos)
 - [QOS Profiles](#qos-profiles)
-- [Custom Templates](#custom-templates)
 
 # Management
 
@@ -177,14 +156,15 @@ Management HTTPS is using the SSL profile SSL_PROFILE
 | default | ACL-API | - |
 | MGMT | ACL-API | - |
 
+
 ### Management API HTTP Configuration
 
 ```eos
 !
 management api http-commands
    protocol https
-   no protocol http
    protocol https ssl profile SSL_PROFILE
+   no protocol http
    no shutdown
    !
    vrf default

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-api-http.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-api-http.md
@@ -2,15 +2,26 @@
 
 # Table of Contents
 
+- [management-api-http](#management-api-http)
+- [Table of Contents](#table-of-contents)
 - [Management](#management)
   - [Management Interfaces](#management-interfaces)
+    - [Management Interfaces Summary](#management-interfaces-summary)
+      - [IPv4](#ipv4)
+      - [IPv6](#ipv6)
+    - [Management Interfaces Device Configuration](#management-interfaces-device-configuration)
   - [DNS Domain](#dns-domain)
+  - [Domain-list](#domain-list)
   - [Name Servers](#name-servers)
   - [Domain Lookup](#domain-lookup)
   - [NTP](#ntp)
+  - [PTP](#ptp)
   - [Management SSH](#management-ssh)
-  - [Management GNMI](#management-api-gnmi)
-  - [Management API](#Management-api-http)
+  - [Management API GNMI](#management-api-gnmi)
+  - [Management API HTTP](#management-api-http-1)
+    - [Management API HTTP Summary](#management-api-http-summary)
+    - [Management API VRF Access](#management-api-vrf-access)
+    - [Management API HTTP Configuration](#management-api-http-configuration)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
   - [Enable Password](#enable-password)
@@ -35,6 +46,7 @@
 - [MLAG](#mlag)
 - [Spanning Tree](#spanning-tree)
 - [Internal VLAN Allocation Policy](#internal-vlan-allocation-policy)
+  - [Internal VLAN Allocation Policy Summary](#internal-vlan-allocation-policy-summary)
 - [VLANs](#vlans)
 - [Interfaces](#interfaces)
   - [Interface Defaults](#interface-defaults)
@@ -46,13 +58,18 @@
 - [Routing](#routing)
   - [Virtual Router MAC Address](#virtual-router-mac-address)
   - [IP Routing](#ip-routing)
+    - [IP Routing Summary](#ip-routing-summary)
+    - [IP Routing Device Configuration](#ip-routing-device-configuration)
   - [IPv6 Routing](#ipv6-routing)
+    - [IPv6 Routing Summary](#ipv6-routing-summary)
   - [Static Routes](#static-routes)
   - [IPv6 Static Routes](#ipv6-static-routes)
+  - [ARP](#arp)
   - [Router OSPF](#router-ospf)
   - [Router ISIS](#router-isis)
   - [Router BGP](#router-bgp)
   - [Router BFD](#router-bfd)
+    - [Router BFD Multihop Summary](#router-bfd-multihop-summary)
 - [Multicast](#multicast)
   - [IP IGMP Snooping](#ip-igmp-snooping)
   - [Router Multicast](#router-multicast)
@@ -66,6 +83,9 @@
   - [IP Extended Communities](#ip-extended-communities)
 - [ACL](#acl)
   - [Standard Access-lists](#standard-access-lists)
+    - [Standard Access-lists Summary](#standard-access-lists-summary)
+      - [ACL-API](#acl-api)
+    - [Standard Access-lists Device Configuration](#standard-access-lists-device-configuration)
   - [Extended Access-lists](#extended-access-lists)
   - [IPv6 Standard Access-lists](#ipv6-standard-access-lists)
   - [IPv6 Extended Access-lists](#ipv6-extended-access-lists)
@@ -75,9 +95,10 @@
 - [Router L2 VPN](#router-l2-vpn)
 - [IP DHCP Relay](#ip-dhcp-relay)
 - [Errdisable](#errdisable)
-- [MAC security](#mac-security)
+- [MACsec](#macsec)
 - [QOS](#qos)
 - [QOS Profiles](#qos-profiles)
+- [Custom Templates](#custom-templates)
 
 # Management
 
@@ -145,14 +166,16 @@ Management API gnmi is not defined
 
 | HTTP | HTTPS |
 | ---------- | ---------- |
-|  false  |  true  |
+| false | true |
+
+Management HTTPS is using the SSL profile SSL_PROFILE
 
 ### Management API VRF Access
 
 | VRF Name | IPv4 ACL | IPv6 ACL |
 | -------- | -------- | -------- |
-| default |  ACL-API  |  -  |
-| MGMT |  ACL-API  |  -  |
+| default | ACL-API | - |
+| MGMT | ACL-API | - |
 
 ### Management API HTTP Configuration
 
@@ -161,6 +184,7 @@ Management API gnmi is not defined
 management api http-commands
    protocol https
    no protocol http
+   protocol https ssl profile SSL_PROFILE
    no shutdown
    !
    vrf default

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/mac-security-eth-po-entropy.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/mac-security-eth-po-entropy.cfg
@@ -43,5 +43,9 @@ interface Management1
 !
 management security
    entropy source hardware
+   password encryption-key common
+   ssl profile SSL_PROFILE
+      tls versions 1.1 1.2
+      certificate SSL_CERT key SSL_KEY
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-api-http.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-api-http.cfg
@@ -18,8 +18,8 @@ ip access-list standard ACL-API
 !
 management api http-commands
    protocol https
-   no protocol http
    protocol https ssl profile SSL_PROFILE
+   no protocol http
    no shutdown
    !
    vrf default

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-api-http.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-api-http.cfg
@@ -19,6 +19,7 @@ ip access-list standard ACL-API
 management api http-commands
    protocol https
    no protocol http
+   protocol https ssl profile SSL_PROFILE
    no shutdown
    !
    vrf default

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/mac-security-eth-po-entropy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/mac-security-eth-po-entropy.yml
@@ -28,6 +28,15 @@ mac_security:
 ### Mgmt sec
 management_security:
   entropy_source: hardware
+  password:
+    encryption_key_common: true
+  ssl_profiles:
+    - name: SSL_PROFILE
+      tls_versions: 1.1 1.2
+      certificate: 
+        file: SSL_CERT
+        key: SSL_KEY
+
 
 
 ### L2 portchannel

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/management-api-http.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/management-api-http.yml
@@ -2,6 +2,7 @@
 management_api_http:
   enable_http: false
   enable_https: true
+  https_ssl_profile: SSL_PROFILE
   enable_vrfs:
     default:
       access_group: ACL-API

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1005,6 +1005,7 @@ management_interfaces:
 management_api_http:
   enable_http: < true | false >
   enable_https: < true | false >
+  https_ssl_profile: < SSL Profile Name >
   enable_vrfs:
     < vrf_name_1 >:
       access_group: < Standard IPv4 ACL name >
@@ -1035,9 +1036,17 @@ management_console:
 
 ```yaml
 management_security:
+  entropy_source: < entropy_source >
   password:
     encryption_key_common : < true | false >
-  entropy_source: < entropy_source >
+  ssl_profiles:
+    - name: <ssl_profile_1>
+      tls_versions: < list of allowed tls versions as string >
+      certificate:
+        file: < certificate filename >
+        key: < key filename >
+    - name: <ssl_profile_2>
+      tls_versions: < list of allowed tls versions as string >
 ```
 
 #### Management SSH

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-api-http.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-api-http.j2
@@ -4,21 +4,21 @@
 
 | HTTP | HTTPS |
 | ---------- | ---------- |
-| {% if management_api_http.enable_http is arista.avd.defined %} {{ management_api_http.enable_http | lower }} {% else %} default {% endif %} | {% if management_api_http.enable_https is arista.avd.defined %} {{ management_api_http.enable_https | lower }} {% else %} default {% endif %} |
-{%     if management_api_http.enable_vrfs is arista.avd.defined %}
+| {{ management_api_http.enable_http | lower | default('default') }} | {{ management_api_http.enable_https | lower | default('default') }} |
 
+{%     if management_api_http.enable_https is arista.avd.defined(true) and management_api_http.https_ssl_profile is arista.avd.defined %}
+Management HTTPS is using the SSL profile {{ management_api_http.https_ssl_profile }}
+
+{%     endif %}
+{%     if management_api_http.enable_vrfs is arista.avd.defined %}
 ### Management API VRF Access
 
 | VRF Name | IPv4 ACL | IPv6 ACL |
 | -------- | -------- | -------- |
 {%         for vrf in management_api_http.enable_vrfs | arista.avd.natural_sort %}
-| {{ vrf }} | {% if management_api_http.enable_vrfs[vrf].access_group is arista.avd.defined %} {{ management_api_http.enable_vrfs[vrf].access_group }} {% else %} - {% endif %} | {% if management_api_http.enable_vrfs[vrf].ipv6_access_group is arista.avd.defined %} {{ management_api_http.enable_vrfs[vrf].ipv6_access_group }} {% else %} - {% endif %} |
+| {{ vrf }} | {{ management_api_http.enable_vrfs[vrf].access_group | default('-') }} | {{ management_api_http.enable_vrfs[vrf].ipv6_access_group | default('-') }} |
 {%         endfor %}
 {%     endif %}
-
-{%  if management_api_http.enable_https is arista.avd.defined and management_api_http.enable_https == true and management_api_http.https_ssl_profile is arista.avd.defined %}
-Management HTTPS is using the SSL profile {{ management_api_http.https_ssl_profile }}
-{%  endif %}
 
 ### Management API HTTP Configuration
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-api-http.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-api-http.j2
@@ -20,6 +20,10 @@ Management HTTPS is using the SSL profile {{ management_api_http.https_ssl_profi
 {%         endfor %}
 {%     endif %}
 
+{%     if management_api_http.protocol_https_certificate.certificate is arista.avd.defined and management_api_http.protocol_https_certificate.private_key is arista.avd.defined %}
+HTTPS certificate and private key are configured.
+{%     endif %}
+
 ### Management API HTTP Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-api-http.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-api-http.j2
@@ -1,20 +1,24 @@
 {# Management API HTTP #}
-{% if management_api_http is defined and management_api_http is not none %}
+{% if management_api_http is arista.avd.defined %}
 ### Management API HTTP Summary
 
 | HTTP | HTTPS |
 | ---------- | ---------- |
-| {% if management_api_http.enable_http is defined and management_api_http.enable_http is not none %} {{ management_api_http.enable_http | lower }} {% else %} default {% endif %} | {% if management_api_http.enable_https is defined and management_api_http.enable_https is not none %} {{ management_api_http.enable_https | lower }} {% else %} default {% endif %} |
-{%     if management_api_http.enable_vrfs is defined and management_api_http.enable_vrfs is not none %}
+| {% if management_api_http.enable_http is arista.avd.defined %} {{ management_api_http.enable_http | lower }} {% else %} default {% endif %} | {% if management_api_http.enable_https is arista.avd.defined %} {{ management_api_http.enable_https | lower }} {% else %} default {% endif %} |
+{%     if management_api_http.enable_vrfs is arista.avd.defined %}
 
 ### Management API VRF Access
 
 | VRF Name | IPv4 ACL | IPv6 ACL |
 | -------- | -------- | -------- |
 {%         for vrf in management_api_http.enable_vrfs | arista.avd.natural_sort %}
-| {{ vrf }} | {% if management_api_http.enable_vrfs[vrf].access_group is defined and management_api_http.enable_vrfs[vrf].access_group is not none %} {{ management_api_http.enable_vrfs[vrf].access_group }} {% else %} - {% endif %} | {% if management_api_http.enable_vrfs[vrf].ipv6_access_group is defined and management_api_http.enable_vrfs[vrf].ipv6_access_group is not none %} {{ management_api_http.enable_vrfs[vrf].ipv6_access_group }} {% else %} - {% endif %} |
+| {{ vrf }} | {% if management_api_http.enable_vrfs[vrf].access_group is arista.avd.defined %} {{ management_api_http.enable_vrfs[vrf].access_group }} {% else %} - {% endif %} | {% if management_api_http.enable_vrfs[vrf].ipv6_access_group is arista.avd.defined %} {{ management_api_http.enable_vrfs[vrf].ipv6_access_group }} {% else %} - {% endif %} |
 {%         endfor %}
 {%     endif %}
+
+{%  if management_api_http.enable_https is arista.avd.defined and management_api_http.enable_https == true and management_api_http.https_ssl_profile is arista.avd.defined %}
+Management HTTPS is using the SSL profile {{ management_api_http.https_ssl_profile }}
+{%  endif %}
 
 ### Management API HTTP Configuration
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-security.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-security.j2
@@ -1,14 +1,22 @@
-{% if management_security is defined and management_security is not none %}
+{% if management_security is arista.avd.defined %}
 ## Management Security
 
-{%     if management_security.password is defined and management_security.password is not none %}
+{%     if management_security.entropy_source is arista.avd.defined %}
+ Management Security entropy source is {{ management_security.entropy_source }}
+{%     endif %}
+
+{%     if management_security.password is arista.avd.defined %}
 {%       if management_security.password.encryption_key_common is defined and management_security.password.encryption_key_common == true %}
    Management Security password encryption is common.
 {%       endif %}
 {%     endif %}
 
-{%     if management_security.entropy_source is defined and management_security.entropy_source is not none %}
- Management Security entropy source is {{ management_security.entropy_source }}
+{%     if management_security.ssl_profiles is arista.avd.defined %}
+| SSL Profile Name | TLS protocol accepted | Certificate filename | Key filename |
+| ------------ | --------------------- | -------------------- | ------------ |
+{%       for ssl_profile in management_security.ssl_profiles | arista.avd.natural_sort %}
+| {{ ssl_profile.name }} | {{ssl_profile.tls_versions | arista.avd.default('-')}} | {{ ssl_profile.certificate.file | arista.avd.default('-') }} | {{ ssl_profile.certificate.key | arista.avd.default('-') }} |
+{%       endfor %}
 {%     endif %}
 
 ## Management Security Configuration

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-security.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-security.j2
@@ -2,15 +2,13 @@
 ## Management Security
 
 {%     if management_security.entropy_source is arista.avd.defined %}
- Management Security entropy source is {{ management_security.entropy_source }}
-{%     endif %}
+Management Security entropy source is {{ management_security.entropy_source }}
 
-{%     if management_security.password is arista.avd.defined %}
-{%       if management_security.password.encryption_key_common is defined and management_security.password.encryption_key_common == true %}
-   Management Security password encryption is common.
-{%       endif %}
 {%     endif %}
+{%     if management_security.password.encryption_key_common is arista.avd.defined(true) %}
+Management Security password encryption is common.
 
+{%     endif %}
 {%     if management_security.ssl_profiles is arista.avd.defined %}
 | SSL Profile Name | TLS protocol accepted | Certificate filename | Key filename |
 | ------------ | --------------------- | -------------------- | ------------ |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-api-http.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-api-http.j2
@@ -27,4 +27,11 @@ management api http-commands
       ipv6 access-group {{ management_api_http.enable_vrfs[vrf].ipv6_access_group }}
 {%         endif %}
 {%     endfor %}
+{%     if management_api_http.protocol_https_certificate.certificate is arista.avd.defined and management_api_http.protocol_https_certificate.private_key is arista.avd.defined %}
+   protocol_https_certificate
+   {{ management_api_http.protocol_https_certificate.certificate }}
+   EOF
+   {{ management_api_http.protocol_https_certificate.private_key }}
+   EOF
+{%     endif %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-api-http.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-api-http.j2
@@ -4,6 +4,9 @@
 management api http-commands
 {%     if management_api_http.enable_https is arista.avd.defined(true) %}
    protocol https
+{%         if management_api_http.https_ssl_profile is arista.avd.defined %}
+   protocol https ssl profile {{ management_api_http.https_ssl_profile }}
+{%         endif %}
 {%     elif management_api_http.enable_https is arista.avd.defined(false) %}
    no protocol https
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-security.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-security.j2
@@ -2,10 +2,21 @@
 {% if management_security is arista.avd.defined %}
 !
 management security
+{%     if management_security.entropy_source is arista.avd.defined %}
+   entropy source {{ management_security.entropy_source }}
+{%     endif %}
 {%     if management_security.password.encryption_key_common is arista.avd.defined(true) %}
    password encryption-key common
 {%     endif %}
 {%     if management_security.entropy_source is arista.avd.defined %}
    entropy source {{ management_security.entropy_source }}
-{%     endif %}
+{%     for ssl_profile in management_security.ssl_profiles | arista.avd.natural_sort %}
+   ssl profile {{ ssl_profile.name }}
+{%         if ssl_profile.tls_versions is arista.avd.defined %}
+      tls versions {{ ssl_profile.tls_versions }}
+{%         endif  %}
+{%         if ssl_profile.certificate is arista.avd.defined %}
+      certificate {{ ssl_profile.certificate.file }} key {{ ssl_profile.certificate.key }}
+{%          endif  %}
+{%     endfor %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-security.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-security.j2
@@ -8,8 +8,6 @@ management security
 {%     if management_security.password.encryption_key_common is arista.avd.defined(true) %}
    password encryption-key common
 {%     endif %}
-{%     if management_security.entropy_source is arista.avd.defined %}
-   entropy source {{ management_security.entropy_source }}
 {%     for ssl_profile in management_security.ssl_profiles | arista.avd.natural_sort %}
    ssl profile {{ ssl_profile.name }}
 {%         if ssl_profile.tls_versions is arista.avd.defined %}


### PR DESCRIPTION
## Change Summary
- Management security update to include tls version and certificates under a SSL Profile
- Management API HTTPS update to include SSL Profile
- Code modification for proper order in configuration and use of arista.avd.defined

replaces PR #677 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [x] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes issue #662 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [ ] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
