### PR TITLE
Inband management interface type

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1A.yml
@@ -222,6 +222,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.110/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1B.yml
@@ -222,6 +222,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.111/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -138,6 +138,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.112/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces: null
 tcam_profile: null
 platform: null

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -228,6 +228,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.113/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces:
   Vlan4094:
     description: MLAG_PEER

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -228,6 +228,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.114/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces:
   Vlan4094:
     description: MLAG_PEER

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF1A.yml
@@ -183,6 +183,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.105/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces:
   Vlan130:
     tenant: Tenant_A

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2A.yml
@@ -343,6 +343,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.106/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2B.yml
@@ -343,6 +343,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.107/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE1.yml
@@ -144,6 +144,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.101/24
     gateway: 192.168.200.5
+    type: oob
 tcam_profile: null
 platform: null
 mac_address_table: null

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE2.yml
@@ -144,6 +144,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.102/24
     gateway: 192.168.200.5
+    type: oob
 tcam_profile: null
 platform: null
 mac_address_table: null

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE3.yml
@@ -144,6 +144,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.103/24
     gateway: 192.168.200.5
+    type: oob
 tcam_profile: null
 platform: null
 mac_address_table: null

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE4.yml
@@ -144,6 +144,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.104/24
     gateway: 192.168.200.5
+    type: oob
 tcam_profile: null
 platform: null
 mac_address_table: null

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3A.yml
@@ -396,6 +396,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.108/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3B.yml
@@ -376,6 +376,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.109/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/intended/structured_configs/DC1-BL1A.yml
@@ -222,6 +222,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.110/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/intended/structured_configs/DC1-BL1B.yml
@@ -222,6 +222,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.111/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -138,6 +138,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.112/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces: null
 tcam_profile: null
 platform: null

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -228,6 +228,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.113/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces:
   Vlan4094:
     description: MLAG_PEER

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -228,6 +228,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.114/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces:
   Vlan4094:
     description: MLAG_PEER

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/intended/structured_configs/DC1-LEAF1A.yml
@@ -183,6 +183,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.105/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces:
   Vlan130:
     tenant: Tenant_A

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/intended/structured_configs/DC1-LEAF2A.yml
@@ -343,6 +343,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.106/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/intended/structured_configs/DC1-LEAF2B.yml
@@ -343,6 +343,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.107/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/intended/structured_configs/DC1-SPINE1.yml
@@ -144,6 +144,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.101/24
     gateway: 192.168.200.5
+    type: oob
 tcam_profile: null
 platform: null
 mac_address_table: null

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/intended/structured_configs/DC1-SPINE2.yml
@@ -144,6 +144,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.102/24
     gateway: 192.168.200.5
+    type: oob
 tcam_profile: null
 platform: null
 mac_address_table: null

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/intended/structured_configs/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/intended/structured_configs/DC1-SPINE3.yml
@@ -144,6 +144,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.103/24
     gateway: 192.168.200.5
+    type: oob
 tcam_profile: null
 platform: null
 mac_address_table: null

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/intended/structured_configs/DC1-SPINE4.yml
@@ -144,6 +144,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.104/24
     gateway: 192.168.200.5
+    type: oob
 tcam_profile: null
 platform: null
 mac_address_table: null

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/intended/structured_configs/DC1-SVC3A.yml
@@ -396,6 +396,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.108/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/intended/structured_configs/DC1-SVC3B.yml
@@ -376,6 +376,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.109/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF1A.md
@@ -91,14 +91,14 @@
 | Management Interface | description | Type | VRF | IP Address | Gateway |
 | -------------------- | ----------- | ---- | --- | ---------- | ------- |
 | Management1 | oob_management | oob | MGMT | 192.168.1.10/24 | 192.168.1.254 |
-| Vlan4085 | L2LEAF_INBAND_MGMT | oob | default | 172.21.110.4/24 | 172.21.110.1 |
+| Vlan4085 | L2LEAF_INBAND_MGMT | inband | default | 172.21.110.4/24 | 172.21.110.1 |
 
 #### IPv6
 
 | Management Interface | description | Type | VRF | IPv6 Address | IPv6 Gateway |
 | -------------------- | ----------- | ---- | --- | ------------ | ------------ |
 | Management1 | oob_management | oob | MGMT | -  | - |
-| Vlan4085 | L2LEAF_INBAND_MGMT | oob | default | -  | - |
+| Vlan4085 | L2LEAF_INBAND_MGMT | inband | default | -  | - |
 
 ### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF2A.md
@@ -91,14 +91,14 @@
 | Management Interface | description | Type | VRF | IP Address | Gateway |
 | -------------------- | ----------- | ---- | --- | ---------- | ------- |
 | Management1 | oob_management | oob | MGMT | 192.168.1.11/24 | 192.168.1.254 |
-| Vlan4085 | L2LEAF_INBAND_MGMT | oob | default | 172.21.110.5/24 | 172.21.110.1 |
+| Vlan4085 | L2LEAF_INBAND_MGMT | inband | default | 172.21.110.5/24 | 172.21.110.1 |
 
 #### IPv6
 
 | Management Interface | description | Type | VRF | IPv6 Address | IPv6 Gateway |
 | -------------------- | ----------- | ---- | --- | ------------ | ------------ |
 | Management1 | oob_management | oob | MGMT | -  | - |
-| Vlan4085 | L2LEAF_INBAND_MGMT | oob | default | -  | - |
+| Vlan4085 | L2LEAF_INBAND_MGMT | inband | default | -  | - |
 
 ### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF2B.md
@@ -91,14 +91,14 @@
 | Management Interface | description | Type | VRF | IP Address | Gateway |
 | -------------------- | ----------- | ---- | --- | ---------- | ------- |
 | Management1 | oob_management | oob | MGMT | 192.168.1.12/24 | 192.168.1.254 |
-| Vlan4085 | L2LEAF_INBAND_MGMT | oob | default | 172.21.110.6/24 | 172.21.110.1 |
+| Vlan4085 | L2LEAF_INBAND_MGMT | inband | default | 172.21.110.6/24 | 172.21.110.1 |
 
 #### IPv6
 
 | Management Interface | description | Type | VRF | IPv6 Address | IPv6 Gateway |
 | -------------------- | ----------- | ---- | --- | ------------ | ------------ |
 | Management1 | oob_management | oob | MGMT | -  | - |
-| Vlan4085 | L2LEAF_INBAND_MGMT | oob | default | -  | - |
+| Vlan4085 | L2LEAF_INBAND_MGMT | inband | default | -  | - |
 
 ### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-L2LEAF1A.md
@@ -91,14 +91,14 @@
 | Management Interface | description | Type | VRF | IP Address | Gateway |
 | -------------------- | ----------- | ---- | --- | ---------- | ------- |
 | Management1 | oob_management | oob | MGMT | 192.168.1.23/24 | 192.168.1.254 |
-| Vlan4092 | L2LEAF_INBAND_MGMT | oob | default | 172.21.210.4/24 | 172.21.210.1 |
+| Vlan4092 | L2LEAF_INBAND_MGMT | inband | default | 172.21.210.4/24 | 172.21.210.1 |
 
 #### IPv6
 
 | Management Interface | description | Type | VRF | IPv6 Address | IPv6 Gateway |
 | -------------------- | ----------- | ---- | --- | ------------ | ------------ |
 | Management1 | oob_management | oob | MGMT | -  | - |
-| Vlan4092 | L2LEAF_INBAND_MGMT | oob | default | -  | - |
+| Vlan4092 | L2LEAF_INBAND_MGMT | inband | default | -  | - |
 
 ### Management Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF1A.yml
@@ -74,12 +74,14 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.1.10/24
     gateway: 192.168.1.254
+    type: oob
   Vlan4085:
     description: L2LEAF_INBAND_MGMT
     shutdown: false
     mtu: 1500
     ip_address: 172.21.110.4/24
     gateway: 172.21.110.1
+    type: inband
 vlan_interfaces: null
 tcam_profile: null
 platform: null

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF2A.yml
@@ -142,12 +142,14 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.1.11/24
     gateway: 192.168.1.254
+    type: oob
   Vlan4085:
     description: L2LEAF_INBAND_MGMT
     shutdown: false
     mtu: 1500
     ip_address: 172.21.110.5/24
     gateway: 172.21.110.1
+    type: inband
 vlan_interfaces:
   Vlan4094:
     description: MLAG_PEER

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF2B.yml
@@ -142,12 +142,14 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.1.12/24
     gateway: 192.168.1.254
+    type: oob
   Vlan4085:
     description: L2LEAF_INBAND_MGMT
     shutdown: false
     mtu: 1500
     ip_address: 172.21.110.6/24
     gateway: 172.21.110.1
+    type: inband
 vlan_interfaces:
   Vlan4094:
     description: MLAG_PEER

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF1A.yml
@@ -127,6 +127,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.1.7/24
     gateway: 192.168.1.254
+    type: oob
 vlan_interfaces:
   Vlan4085:
     description: L2LEAF_INBAND_MGMT

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2A.yml
@@ -204,6 +204,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.1.8/16
     gateway: 192.168.1.254
+    type: oob
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
@@ -206,6 +206,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.1.9/16
     gateway: 192.168.1.254
+    type: oob
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-SPINE1.yml
@@ -127,6 +127,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.1.5/24
     gateway: 192.168.1.254
+    type: oob
 tcam_profile: null
 platform: null
 mac_address_table: null

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-SPINE2.yml
@@ -111,6 +111,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.1.6/24
     gateway: 192.168.1.254
+    type: oob
 tcam_profile: null
 platform: null
 mac_address_table: null

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-LEAF1A.yml
@@ -126,6 +126,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.1.15/24
     gateway: 192.168.1.254
+    type: oob
 vlan_interfaces:
   Vlan4092:
     description: L2LEAF_INBAND_MGMT

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-SPINE1.yml
@@ -107,6 +107,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.1.13/24
     gateway: 192.168.1.254
+    type: oob
 tcam_profile: null
 platform: null
 mac_address_table: null

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-SPINE2.yml
@@ -99,6 +99,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.1.14/24
     gateway: 192.168.1.254
+    type: oob
 tcam_profile: null
 platform: null
 mac_address_table: null

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-RS1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-RS1.yml
@@ -88,6 +88,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.1.3/24
     gateway: 192.168.1.254
+    type: oob
 tcam_profile: null
 platform: null
 mac_address_table: null

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-RS2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-RS2.yml
@@ -86,6 +86,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.1.4/24
     gateway: 192.168.1.254
+    type: oob
 tcam_profile: null
 platform: null
 mac_address_table: null

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-SUPER-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-SUPER-SPINE1.yml
@@ -123,6 +123,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.1.1/24
     gateway: 192.168.1.254
+    type: oob
 tcam_profile: null
 platform: null
 mac_address_table: null

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-SUPER-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-SUPER-SPINE2.yml
@@ -119,6 +119,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.1.2/24
     gateway: 192.168.1.254
+    type: oob
 tcam_profile: null
 platform: null
 mac_address_table: null

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-L2LEAF1A.yml
@@ -90,12 +90,14 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.1.23/24
     gateway: 192.168.1.254
+    type: oob
   Vlan4092:
     description: L2LEAF_INBAND_MGMT
     shutdown: false
     mtu: 1500
     ip_address: 172.21.210.4/24
     gateway: 172.21.210.1
+    type: inband
 vlan_interfaces: null
 tcam_profile: null
 platform: null

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF1A.yml
@@ -157,6 +157,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.1.22/24
     gateway: 192.168.1.254
+    type: oob
 vlan_interfaces:
   Vlan4092:
     description: L2LEAF_INBAND_MGMT

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-SPINE1.yml
@@ -100,6 +100,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.1.20/24
     gateway: 192.168.1.254
+    type: oob
 tcam_profile: null
 platform: null
 mac_address_table: null

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-SPINE2.yml
@@ -98,6 +98,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.1.21/24
     gateway: 192.168.1.254
+    type: oob
 tcam_profile: null
 platform: null
 mac_address_table: null

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-RS1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-RS1.yml
@@ -76,6 +76,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.1.18/24
     gateway: 192.168.1.254
+    type: oob
 tcam_profile: null
 platform: null
 mac_address_table: null

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-RS2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-RS2.yml
@@ -72,6 +72,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.1.19/24
     gateway: 192.168.1.254
+    type: oob
 tcam_profile: null
 platform: null
 mac_address_table: null

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-SUPER-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-SUPER-SPINE1.yml
@@ -133,6 +133,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.1.16/24
     gateway: 192.168.1.254
+    type: oob
 tcam_profile: null
 platform: null
 mac_address_table: null

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-SUPER-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-SUPER-SPINE2.yml
@@ -85,6 +85,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.1.17/24
     gateway: 192.168.1.254
+    type: oob
 tcam_profile: null
 platform: null
 mac_address_table: null

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-BL1A.yml
@@ -170,6 +170,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.110/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces:
   Vlan150:
     tenant: Tenant_A

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-BL1B.yml
@@ -170,6 +170,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.111/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces:
   Vlan150:
     tenant: Tenant_A

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -146,6 +146,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.112/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces: null
 tcam_profile: null
 platform: null

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -236,6 +236,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.113/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces:
   Vlan4094:
     description: MLAG_PEER

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -236,6 +236,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.114/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces:
   Vlan4094:
     description: MLAG_PEER

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-LEAF1A.yml
@@ -198,6 +198,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.105/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces:
   Vlan130:
     tenant: Tenant_A

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-LEAF2A.yml
@@ -351,6 +351,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.106/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-LEAF2B.yml
@@ -351,6 +351,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.107/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-SPINE1.yml
@@ -144,6 +144,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.101/24
     gateway: 192.168.200.5
+    type: oob
 tcam_profile: null
 platform: null
 mac_address_table: null

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-SPINE2.yml
@@ -144,6 +144,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.102/24
     gateway: 192.168.200.5
+    type: oob
 tcam_profile: null
 platform: null
 mac_address_table: null

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-SPINE3.yml
@@ -144,6 +144,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.103/24
     gateway: 192.168.200.5
+    type: oob
 tcam_profile: null
 platform: null
 mac_address_table: null

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-SPINE4.yml
@@ -144,6 +144,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.104/24
     gateway: 192.168.200.5
+    type: oob
 tcam_profile: null
 platform: null
 mac_address_table: null

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-SVC3A.yml
@@ -602,6 +602,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.108/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-SVC3B.yml
@@ -582,6 +582,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.109/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
@@ -179,6 +179,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.110/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces:
   Vlan150:
     tenant: Tenant_A

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
@@ -179,6 +179,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.111/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces:
   Vlan150:
     tenant: Tenant_A

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -146,6 +146,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.112/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces: null
 tcam_profile: null
 platform: null

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -236,6 +236,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.113/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces:
   Vlan4094:
     description: MLAG_PEER

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -236,6 +236,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.114/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces:
   Vlan4094:
     description: MLAG_PEER

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
@@ -207,6 +207,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.105/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces:
   Vlan130:
     tenant: Tenant_A

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -360,6 +360,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.106/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -360,6 +360,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.107/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
@@ -144,6 +144,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.101/24
     gateway: 192.168.200.5
+    type: oob
 tcam_profile: null
 platform: null
 mac_address_table: null

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
@@ -144,6 +144,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.102/24
     gateway: 192.168.200.5
+    type: oob
 tcam_profile: null
 platform: null
 mac_address_table: null

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
@@ -144,6 +144,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.103/24
     gateway: 192.168.200.5
+    type: oob
 tcam_profile: null
 platform: null
 mac_address_table: null

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
@@ -144,6 +144,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.104/24
     gateway: 192.168.200.5
+    type: oob
 tcam_profile: null
 platform: null
 mac_address_table: null

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -611,6 +611,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.108/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -591,6 +591,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.109/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-BL1A.yml
@@ -194,6 +194,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.110/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-BL1B.yml
@@ -194,6 +194,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.111/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -105,6 +105,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.112/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces: null
 tcam_profile: null
 platform: null

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -144,6 +144,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.113/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces:
   Vlan4094:
     description: MLAG_PEER

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -144,6 +144,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.114/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces:
   Vlan4094:
     description: MLAG_PEER

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF1A.yml
@@ -149,6 +149,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.105/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces: null
 vxlan_tunnel_interface:
   Vxlan1:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -218,6 +218,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.106/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -218,6 +218,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.107/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SPINE1.yml
@@ -167,6 +167,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.101/24
     gateway: 192.168.200.5
+    type: oob
 tcam_profile: null
 platform: null
 mac_address_table: null

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SPINE2.yml
@@ -160,6 +160,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.102/24
     gateway: 192.168.200.5
+    type: oob
 tcam_profile: null
 platform: null
 mac_address_table: null

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SPINE3.yml
@@ -160,6 +160,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.103/24
     gateway: 192.168.200.5
+    type: oob
 tcam_profile: null
 platform: null
 mac_address_table: null

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SPINE4.yml
@@ -167,6 +167,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.104/24
     gateway: 192.168.200.5
+    type: oob
 tcam_profile: null
 platform: null
 mac_address_table: null

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SVC3A.yml
@@ -229,6 +229,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.108/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SVC3B.yml
@@ -229,6 +229,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.109/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
@@ -190,6 +190,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.110/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
@@ -190,6 +190,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.111/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -105,6 +105,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.112/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces: null
 tcam_profile: null
 platform: null

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -144,6 +144,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.113/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces:
   Vlan4094:
     description: MLAG_PEER

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -144,6 +144,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.114/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces:
   Vlan4094:
     description: MLAG_PEER

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
@@ -145,6 +145,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.105/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces: null
 vxlan_tunnel_interface:
   Vxlan1:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -214,6 +214,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.106/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -214,6 +214,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.107/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
@@ -159,6 +159,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.101/24
     gateway: 192.168.200.5
+    type: oob
 tcam_profile: null
 platform: null
 mac_address_table: null

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
@@ -159,6 +159,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.102/24
     gateway: 192.168.200.5
+    type: oob
 tcam_profile: null
 platform: null
 mac_address_table: null

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
@@ -159,6 +159,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.103/24
     gateway: 192.168.200.5
+    type: oob
 tcam_profile: null
 platform: null
 mac_address_table: null

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
@@ -159,6 +159,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.104/24
     gateway: 192.168.200.5
+    type: oob
 tcam_profile: null
 platform: null
 mac_address_table: null

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -225,6 +225,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.108/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -225,6 +225,7 @@ management_interfaces:
     vrf: MGMT
     ip_address: 192.168.200.109/24
     gateway: 192.168.200.5
+    type: oob
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/base/mgmt-interface.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/base/mgmt-interface.j2
@@ -6,4 +6,5 @@
     vrf: {{ mgmt_interface_vrf }}
     ip_address: {{ switch.mgmt_ip }}
     gateway: {{ mgmt_gateway }}
+    type: oob
 {% endif%}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/l3leaf_l2leafs_uplinks/leaf-l2leaf-inband-management-vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/l3leaf_l2leafs_uplinks/leaf-l2leaf-inband-management-vlan-interfaces.j2
@@ -16,5 +16,6 @@
 {%     elif type == 'l2leaf' %}
     ip_address: {{ switch.inband_management_ip }}
     gateway: {{ l2leaf_inband_management_subnet | ipaddr('network') | ipmath(1) }}
+    type: inband
 {%     endif %}
 {% endif %}


### PR DESCRIPTION
## Change Summary
Add `type` to produced `structured_configuration` to be compatible with PR 787 in eos_cli_config_gen.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Relies on PR #787 which must be merged first (this one is branched from 787!)

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
For oob management interfaces we add `type: oob`
For inband management interfaces for l2leaf we add `type: inband`

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Molecule test cases for 5-stage already had inband management, so I reran that and verified produced yml and documentation.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
