### PR TITLE
Add STP bpduguard to port channels and interfaces

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/documentation/devices/DC1-SVC3A.md
@@ -631,6 +631,7 @@ interface Ethernet13
    switchport access vlan 210
    switchport mode access
    spanning-tree portfast network
+   spanning-tree bpduguard enable
    storm-control all level pps 20
    storm-control broadcast level 200
    storm-control multicast level 1
@@ -653,6 +654,7 @@ interface Ethernet16
    switchport access vlan 210
    switchport mode access
    spanning-tree portfast network
+   spanning-tree bpduguard enable
    storm-control all level pps 20
    storm-control broadcast level 200
    storm-control multicast level 1

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/documentation/devices/DC1-SVC3B.md
@@ -625,6 +625,7 @@ interface Ethernet13
    switchport access vlan 210
    switchport mode access
    spanning-tree portfast network
+   spanning-tree bpduguard enable
    storm-control all level pps 20
    storm-control broadcast level 200
    storm-control multicast level 1
@@ -647,6 +648,7 @@ interface Ethernet16
    switchport access vlan 210
    switchport mode access
    spanning-tree portfast network
+   spanning-tree bpduguard enable
    storm-control all level pps 20
    storm-control broadcast level 200
    storm-control multicast level 1

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/configs/DC1-SVC3A.cfg
@@ -285,6 +285,7 @@ interface Ethernet13
    switchport access vlan 210
    switchport mode access
    spanning-tree portfast network
+   spanning-tree bpduguard enable
    storm-control all level pps 20
    storm-control broadcast level 200
    storm-control multicast level 1
@@ -307,6 +308,7 @@ interface Ethernet16
    switchport access vlan 210
    switchport mode access
    spanning-tree portfast network
+   spanning-tree bpduguard enable
    storm-control all level pps 20
    storm-control broadcast level 200
    storm-control multicast level 1

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/configs/DC1-SVC3B.cfg
@@ -272,6 +272,7 @@ interface Ethernet13
    switchport access vlan 210
    switchport mode access
    spanning-tree portfast network
+   spanning-tree bpduguard enable
    storm-control all level pps 20
    storm-control broadcast level 200
    storm-control multicast level 1
@@ -294,6 +295,7 @@ interface Ethernet16
    switchport access vlan 210
    switchport mode access
    spanning-tree portfast network
+   spanning-tree bpduguard enable
    storm-control all level pps 20
    storm-control broadcast level 200
    storm-control multicast level 1

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-LEAF1A.yml
@@ -168,6 +168,7 @@ ethernet_interfaces:
     vlans: 1-4094
     spanning_tree_portfast: edge
     spanning_tree_bpdufilter: true
+    spanning_tree_bpduguard: false
     storm_control:
       all:
         level: 10

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-SVC3A.yml
@@ -301,6 +301,7 @@ port_channel_interfaces:
     vlans: 1-4094
     spanning_tree_portfast: edge
     spanning_tree_bpdufilter: true
+    spanning_tree_bpduguard: false
     storm_control:
       all:
         level: 10
@@ -323,6 +324,7 @@ port_channel_interfaces:
     vlans: 1-4094
     spanning_tree_portfast: edge
     spanning_tree_bpdufilter: true
+    spanning_tree_bpduguard: false
     storm_control:
       all:
         level: 10
@@ -438,6 +440,7 @@ ethernet_interfaces:
     vlans: 1-4094
     spanning_tree_portfast: edge
     spanning_tree_bpdufilter: true
+    spanning_tree_bpduguard: false
     storm_control:
       all:
         level: 10
@@ -463,6 +466,7 @@ ethernet_interfaces:
     vlans: 1-4094
     spanning_tree_portfast: edge
     spanning_tree_bpdufilter: true
+    spanning_tree_bpduguard: false
     storm_control:
       all:
         level: 10
@@ -487,6 +491,7 @@ ethernet_interfaces:
     vlans: 210
     spanning_tree_portfast: network
     spanning_tree_bpdufilter: false
+    spanning_tree_bpduguard: true
     storm_control:
       all:
         level: 20
@@ -512,6 +517,7 @@ ethernet_interfaces:
     vlans: 1-4094
     spanning_tree_portfast: edge
     spanning_tree_bpdufilter: true
+    spanning_tree_bpduguard: false
     storm_control:
       all:
         level: 10
@@ -540,6 +546,7 @@ ethernet_interfaces:
     vlans: 1-4094
     spanning_tree_portfast: edge
     spanning_tree_bpdufilter: true
+    spanning_tree_bpduguard: false
     storm_control:
       all:
         level: 10
@@ -567,6 +574,7 @@ ethernet_interfaces:
     vlans: 210
     spanning_tree_portfast: network
     spanning_tree_bpdufilter: false
+    spanning_tree_bpduguard: true
     storm_control:
       all:
         level: 20

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-SVC3B.yml
@@ -294,6 +294,7 @@ port_channel_interfaces:
     vlans: 1-4094
     spanning_tree_portfast: edge
     spanning_tree_bpdufilter: true
+    spanning_tree_bpduguard: false
     storm_control:
       all:
         level: 10
@@ -316,6 +317,7 @@ port_channel_interfaces:
     vlans: 1-4094
     spanning_tree_portfast: edge
     spanning_tree_bpdufilter: true
+    spanning_tree_bpduguard: false
     storm_control:
       all:
         level: 10
@@ -418,6 +420,7 @@ ethernet_interfaces:
     vlans: 1-4094
     spanning_tree_portfast: edge
     spanning_tree_bpdufilter: true
+    spanning_tree_bpduguard: false
     storm_control:
       all:
         level: 10
@@ -443,6 +446,7 @@ ethernet_interfaces:
     vlans: 1-4094
     spanning_tree_portfast: edge
     spanning_tree_bpdufilter: true
+    spanning_tree_bpduguard: false
     storm_control:
       all:
         level: 10
@@ -467,6 +471,7 @@ ethernet_interfaces:
     vlans: 210
     spanning_tree_portfast: network
     spanning_tree_bpdufilter: false
+    spanning_tree_bpduguard: true
     storm_control:
       all:
         level: 20
@@ -492,6 +497,7 @@ ethernet_interfaces:
     vlans: 1-4094
     spanning_tree_portfast: edge
     spanning_tree_bpdufilter: true
+    spanning_tree_bpduguard: false
     storm_control:
       all:
         level: 10
@@ -520,6 +526,7 @@ ethernet_interfaces:
     vlans: 1-4094
     spanning_tree_portfast: edge
     spanning_tree_bpdufilter: true
+    spanning_tree_bpduguard: false
     storm_control:
       all:
         level: 10
@@ -547,6 +554,7 @@ ethernet_interfaces:
     vlans: 210
     spanning_tree_portfast: network
     spanning_tree_bpdufilter: false
+    spanning_tree_bpduguard: true
     storm_control:
       all:
         level: 20

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -631,6 +631,7 @@ interface Ethernet13
    switchport access vlan 210
    switchport mode access
    spanning-tree portfast network
+   spanning-tree bpduguard enable
    storm-control all level pps 20
    storm-control broadcast level 200
    storm-control multicast level 1
@@ -653,6 +654,7 @@ interface Ethernet16
    switchport access vlan 210
    switchport mode access
    spanning-tree portfast network
+   spanning-tree bpduguard enable
    storm-control all level pps 20
    storm-control broadcast level 200
    storm-control multicast level 1

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -625,6 +625,7 @@ interface Ethernet13
    switchport access vlan 210
    switchport mode access
    spanning-tree portfast network
+   spanning-tree bpduguard enable
    storm-control all level pps 20
    storm-control broadcast level 200
    storm-control multicast level 1
@@ -647,6 +648,7 @@ interface Ethernet16
    switchport access vlan 210
    switchport mode access
    spanning-tree portfast network
+   spanning-tree bpduguard enable
    storm-control all level pps 20
    storm-control broadcast level 200
    storm-control multicast level 1

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
@@ -290,6 +290,7 @@ interface Ethernet13
    switchport access vlan 210
    switchport mode access
    spanning-tree portfast network
+   spanning-tree bpduguard enable
    storm-control all level pps 20
    storm-control broadcast level 200
    storm-control multicast level 1
@@ -312,6 +313,7 @@ interface Ethernet16
    switchport access vlan 210
    switchport mode access
    spanning-tree portfast network
+   spanning-tree bpduguard enable
    storm-control all level pps 20
    storm-control broadcast level 200
    storm-control multicast level 1

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
@@ -277,6 +277,7 @@ interface Ethernet13
    switchport access vlan 210
    switchport mode access
    spanning-tree portfast network
+   spanning-tree bpduguard enable
    storm-control all level pps 20
    storm-control broadcast level 200
    storm-control multicast level 1
@@ -299,6 +300,7 @@ interface Ethernet16
    switchport access vlan 210
    switchport mode access
    spanning-tree portfast network
+   spanning-tree bpduguard enable
    storm-control all level pps 20
    storm-control broadcast level 200
    storm-control multicast level 1

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
@@ -177,6 +177,7 @@ ethernet_interfaces:
     vlans: 1-4094
     spanning_tree_portfast: edge
     spanning_tree_bpdufilter: true
+    spanning_tree_bpduguard: false
     storm_control:
       all:
         level: 10

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -310,6 +310,7 @@ port_channel_interfaces:
     vlans: 1-4094
     spanning_tree_portfast: edge
     spanning_tree_bpdufilter: true
+    spanning_tree_bpduguard: false
     storm_control:
       all:
         level: 10
@@ -332,6 +333,7 @@ port_channel_interfaces:
     vlans: 1-4094
     spanning_tree_portfast: edge
     spanning_tree_bpdufilter: true
+    spanning_tree_bpduguard: false
     storm_control:
       all:
         level: 10
@@ -447,6 +449,7 @@ ethernet_interfaces:
     vlans: 1-4094
     spanning_tree_portfast: edge
     spanning_tree_bpdufilter: true
+    spanning_tree_bpduguard: false
     storm_control:
       all:
         level: 10
@@ -472,6 +475,7 @@ ethernet_interfaces:
     vlans: 1-4094
     spanning_tree_portfast: edge
     spanning_tree_bpdufilter: true
+    spanning_tree_bpduguard: false
     storm_control:
       all:
         level: 10
@@ -496,6 +500,7 @@ ethernet_interfaces:
     vlans: 210
     spanning_tree_portfast: network
     spanning_tree_bpdufilter: false
+    spanning_tree_bpduguard: true
     storm_control:
       all:
         level: 20
@@ -521,6 +526,7 @@ ethernet_interfaces:
     vlans: 1-4094
     spanning_tree_portfast: edge
     spanning_tree_bpdufilter: true
+    spanning_tree_bpduguard: false
     storm_control:
       all:
         level: 10
@@ -549,6 +555,7 @@ ethernet_interfaces:
     vlans: 1-4094
     spanning_tree_portfast: edge
     spanning_tree_bpdufilter: true
+    spanning_tree_bpduguard: false
     storm_control:
       all:
         level: 10
@@ -576,6 +583,7 @@ ethernet_interfaces:
     vlans: 210
     spanning_tree_portfast: network
     spanning_tree_bpdufilter: false
+    spanning_tree_bpduguard: true
     storm_control:
       all:
         level: 20

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -303,6 +303,7 @@ port_channel_interfaces:
     vlans: 1-4094
     spanning_tree_portfast: edge
     spanning_tree_bpdufilter: true
+    spanning_tree_bpduguard: false
     storm_control:
       all:
         level: 10
@@ -325,6 +326,7 @@ port_channel_interfaces:
     vlans: 1-4094
     spanning_tree_portfast: edge
     spanning_tree_bpdufilter: true
+    spanning_tree_bpduguard: false
     storm_control:
       all:
         level: 10
@@ -427,6 +429,7 @@ ethernet_interfaces:
     vlans: 1-4094
     spanning_tree_portfast: edge
     spanning_tree_bpdufilter: true
+    spanning_tree_bpduguard: false
     storm_control:
       all:
         level: 10
@@ -452,6 +455,7 @@ ethernet_interfaces:
     vlans: 1-4094
     spanning_tree_portfast: edge
     spanning_tree_bpdufilter: true
+    spanning_tree_bpduguard: false
     storm_control:
       all:
         level: 10
@@ -476,6 +480,7 @@ ethernet_interfaces:
     vlans: 210
     spanning_tree_portfast: network
     spanning_tree_bpdufilter: false
+    spanning_tree_bpduguard: true
     storm_control:
       all:
         level: 20
@@ -501,6 +506,7 @@ ethernet_interfaces:
     vlans: 1-4094
     spanning_tree_portfast: edge
     spanning_tree_bpdufilter: true
+    spanning_tree_bpduguard: false
     storm_control:
       all:
         level: 10
@@ -529,6 +535,7 @@ ethernet_interfaces:
     vlans: 1-4094
     spanning_tree_portfast: edge
     spanning_tree_bpdufilter: true
+    spanning_tree_bpduguard: false
     storm_control:
       all:
         level: 10
@@ -556,6 +563,7 @@ ethernet_interfaces:
     vlans: 210
     spanning_tree_portfast: network
     spanning_tree_bpdufilter: false
+    spanning_tree_bpduguard: true
     storm_control:
       all:
         level: 20

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/servers.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/servers.md
@@ -18,6 +18,7 @@ port_profiles:
     vlans: < vlans as string >
     spanning_tree_portfast: < edge | network >
     spanning_tree_bpdufilter: < true | false >
+    spanning_tree_bpduguard: < true | false >
     flowcontrol:
       received: < received | send | on >
     qos_profile: < qos_profile_name >
@@ -81,6 +82,7 @@ servers:
         # Spanning Tree
         spanning_tree_portfast: < edge | network >
         spanning_tree_bpdufilter: < true | false >
+        spanning_tree_bpduguard: < true | false >
 
         # Flow control | Optional
         flowcontrol:

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/edge_ports/leaf-server-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/edge_ports/leaf-server-interfaces.j2
@@ -14,6 +14,7 @@
 {%                 set adapter_native_vlan = adapter.native_vlan | arista.avd.default( adapter_profile.native_vlan ) %}
 {%                 set adapter_spanning_tree_portfast = adapter.spanning_tree_portfast | arista.avd.default( adapter_profile.spanning_tree_portfast ) %}
 {%                 set adapter_spanning_tree_bpdufilter = adapter.spanning_tree_bpdufilter | arista.avd.default( adapter_profile.spanning_tree_bpdufilter ) %}
+{%                 set adapter_spanning_tree_bpduguard = adapter.spanning_tree_bpduguard | arista.avd.default( adapter_profile.spanning_tree_bpduguard ) %}
 {%                 set adapter_storm_control = adapter.storm_control | arista.avd.default( adapter_profile.storm_control ) %}
 {%                 set adapter_port_channel = adapter.port_channel | arista.avd.default( adapter_profile.port_channel ) %}
 {%                 set adapter_flowcontrol = adapter.flowcontrol | arista.avd.default( adapter_profile.flowcontrol ) %}
@@ -40,6 +41,9 @@
 {%                 endif %}
 {%                 if adapter_spanning_tree_bpdufilter is arista.avd.defined %}
     spanning_tree_bpdufilter: {{ adapter_spanning_tree_bpdufilter }}
+{%                 endif %}
+{%                 if adapter_spanning_tree_bpduguard is arista.avd.defined %}
+    spanning_tree_bpduguard: {{ adapter_spanning_tree_bpduguard }}
 {%                 endif %}
 {%                 if adapter_storm_control is arista.avd.defined %}
     storm_control:

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/edge_ports/leaf-server-port-channels.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/edge_ports/leaf-server-port-channels.j2
@@ -15,6 +15,7 @@
 {%                     set adapter_native_vlan = adapter.native_vlan | arista.avd.default( adapter_profile.native_vlan ) %}
 {%                     set adapter_spanning_tree_portfast = adapter.spanning_tree_portfast | arista.avd.default( adapter_profile.spanning_tree_portfast ) %}
 {%                     set adapter_spanning_tree_bpdufilter = adapter.spanning_tree_bpdufilter | arista.avd.default( adapter_profile.spanning_tree_bpdufilter ) %}
+{%                     set adapter_spanning_tree_bpduguard = adapter.spanning_tree_bpduguard | arista.avd.default( adapter_profile.spanning_tree_bpduguard ) %}
 {%                     set adapter_storm_control = adapter.storm_control | arista.avd.default( adapter_profile.storm_control ) %}
 {%                     set adapter_flowcontrol = adapter.flowcontrol | arista.avd.default( adapter_profile.flowcontrol ) %}
 {%                     set adapter_qos_profile = adapter.qos_profile | arista.avd.default( adapter_profile.qos_profile ) %}
@@ -33,6 +34,9 @@
 {%                     endif %}
 {%                     if adapter_spanning_tree_bpdufilter is arista.avd.defined %}
     spanning_tree_bpdufilter: {{ adapter_spanning_tree_bpdufilter }}
+{%                     endif %}
+{%                     if adapter_spanning_tree_bpduguard is arista.avd.defined %}
+    spanning_tree_bpduguard: {{ adapter_spanning_tree_bpduguard }}
 {%                     endif %}
 {%                     if adapter_storm_control is arista.avd.defined %}
     storm_control:


### PR DESCRIPTION
## Change Summary
Adds `spanning-tree bpduguard true/false` to port-channels and server interfaces

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #716

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->


## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been rebased from devel before I start
- [X] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [X] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
