### PR TITLE
Use flavor latest for Python 3.6 in Makefile

### DIFF
--- a/development/Makefile
+++ b/development/Makefile
@@ -3,7 +3,7 @@
 SHELL := /bin/bash
 # AVD Shell container information
 CONTAINER_NAME = avdteam/base
-DOCKER_TAG ?= 3.6-v2.0
+DOCKER_TAG ?= 3.6
 CONTAINER = $(CONTAINER_NAME):$(DOCKER_TAG)
 # Vscode container information
 VSCODE_CONTAINER_NAME ?= avdteam/vscode
@@ -49,6 +49,7 @@ update: ## Get latest version of AVD runner and MKDOCs server
 
 .PHONY: run
 run: ## Run ansible-avd container
+	docker pull $(CONTAINER) && \
 	docker run --rm -it \
 		-e AVD_REQUIREMENTS=$(PIP_REQ) \
 		-e AVD_ANSIBLE=$(ANSIBLE_VERSION) \

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   ansible:
-    image: avdteam/base:3.6-v2.0
+    image: avdteam/base:3.6
     container_name: ansible_avd
     environment:
       - AVD_GIT_USER=${GIT_USER}


### PR DESCRIPTION
## Change Summary

- Change Makefile and docker-compose to use latest docker version and not
  a static tag

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [x] Other (please describe): CI

## Related Issue(s)

N/A

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

```bash
$ cd ../

# Deploy new Makefile
$ make refresh

# IF make command is not available
$ cp ansible-avd/development/Makefile .

# Run container for testing
$ make run
$ pip list | grep toc
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
