### PR TITLE
Fix documentation checksum checks

### DIFF
--- a/ansible_collections/arista/avd/plugins/modules/add_toc.py
+++ b/ansible_collections/arista/avd/plugins/modules/add_toc.py
@@ -107,8 +107,9 @@ def main():
 
         hash_final = hashlib.sha224(open(md_file, 'rb').read()).hexdigest()
 
+        result['checksum'] = hash_final
         if hash_final != hash_origin:
-            result['changed'] = False
+            result['changed'] = True
 
     module.exit_json(**result)
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/tasks/main.yml
@@ -21,16 +21,25 @@
   tags: [build, provision]
 
 - name: Generate device documentation
-  template:
-    src: eos-device-documentation.j2
-    dest: '{{ root_dir }}/documentation/devices/{{ inventory_hostname }}.md'
-  delegate_to: localhost
-  changed_when: false
   tags: [build, provision]
-
-- name: Generate TOC for device documentation
-  add_toc:
-    md_file: '{{ root_dir }}/documentation/devices/{{ inventory_hostname }}.md'
-    skip_lines: 3
   delegate_to: localhost
-  tags: [build, provision]
+  block:
+    - name: Store checksum of existing device documentation
+      ansible.builtin.stat:
+        path: '{{ root_dir }}/documentation/devices/{{ inventory_hostname }}.md'
+        checksum_algorithm: sha224
+        get_attributes: no
+        get_checksum: yes
+        get_mime: no
+      register: doc_stat_result
+    - name: Generate content of device documentation
+      template:
+        src: eos-device-documentation.j2
+        dest: '{{ root_dir }}/documentation/devices/{{ inventory_hostname }}.md'
+      changed_when: false
+    - name: Generate TOC for device documentation
+      add_toc:
+        md_file: '{{ root_dir }}/documentation/devices/{{ inventory_hostname }}.md'
+        skip_lines: 3
+      register: toc_result
+      changed_when: toc_result.checksum | default('1') != doc_stat_result.stat.checksum | default('0')

--- a/ansible_collections/arista/avd/roles/eos_designs/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/tasks/main.yml
@@ -22,24 +22,31 @@
   delegate_to: localhost
   tags: [build, provision]
 
-- name: Generate fabric documentation in Markdown Format.
-  template:
-    src: fabric-documentation.j2
-    dest: '{{ root_dir }}/documentation/fabric/{{ fabric_name }}-documentation.md'
-  delegate_to: localhost
+- name: Generate fabric documentation
   run_once: true
-  check_mode: no
-  changed_when: false
   tags: [build, provision]
-
-- name: Generate TOC for fabric documentation
-  add_toc:
-    md_file: '{{ root_dir }}/documentation/fabric/{{ fabric_name }}-documentation.md'
-    skip_lines: 3
   delegate_to: localhost
-  run_once: true
   check_mode: no
-  tags: [build, provision]
+  block:
+    - name: Store checksum of existing fabric documentation
+      ansible.builtin.stat:
+        path: '{{ root_dir }}/documentation/fabric/{{ fabric_name }}-documentation.md'
+        checksum_algorithm: sha224
+        get_attributes: no
+        get_checksum: yes
+        get_mime: no
+      register: doc_stat_result
+    - name: Generate fabric documentation in Markdown Format.
+      template:
+        src: fabric-documentation.j2
+        dest: '{{ root_dir }}/documentation/fabric/{{ fabric_name }}-documentation.md'
+      changed_when: false
+    - name: Generate TOC for fabric documentation
+      add_toc:
+        md_file: '{{ root_dir }}/documentation/fabric/{{ fabric_name }}-documentation.md'
+        skip_lines: 3
+      register: toc_result
+      changed_when: toc_result.checksum | default('1') != doc_stat_result.stat.checksum | default('0')
 
 - name: Generate fabric point-to-point links summary in csv format.
   template:


### PR DESCRIPTION
## Change Summary
Ensure correct change detection by storing documentation checksum before recreating documentation and comparing after adding dynamic TOC.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

## Component(s) name

`arista.avd.eos_cli_config_gen`
`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->

```ansible
- name: Generate fabric documentation
  run_once: true
  tags: [build, provision]
  delegate_to: localhost
  check_mode: no
  block:
    - name: Store checksum of existing fabric documentation
      ansible.builtin.stat:
        path: '{{ root_dir }}/documentation/fabric/{{ fabric_name }}-documentation.md'
        checksum_algorithm: sha224
        get_attributes: no
        get_checksum: yes
        get_mime: no
      register: doc_stat_result
    - name: Generate fabric documentation in Markdown Format.
      template:
        src: fabric-documentation.j2
        dest: '{{ root_dir }}/documentation/fabric/{{ fabric_name }}-documentation.md'
      changed_when: false
    - name: Generate TOC for fabric documentation
      add_toc:
        md_file: '{{ root_dir }}/documentation/fabric/{{ fabric_name }}-documentation.md'
        skip_lines: 3
      register: toc_result
      changed_when: toc_result.checksum | default('1') != doc_stat_result.stat.checksum | default('0')
```

Similar for device documentation


## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Tested by changing/deleting existing documentation and also tested by changing a variable and see correct documentation changes being detected.
Rerunning playbook several times will not trigger a "changed" on documentation tasks.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [X] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [X] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
