### PR TITLE
Add "always_include_vrfs_in_tenants" in l3leaf filter

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-LEAF1A.md
@@ -156,23 +156,11 @@ vlan internal order ascending range 1006 1199
 
 | VLAN ID | Name | Trunk Groups |
 | ------- | ---- | ------------ |
-| 110 | Tenant_A_OP_Zone_1 | none  |
-| 111 | Tenant_A_OP_Zone_2 | none  |
-| 112 | Tenant_A_OP_Zone_3 | none  |
 | 4092 | L2LEAF_INBAND_MGMT | none  |
 
 ## VLANs Device Configuration
 
 ```eos
-!
-vlan 110
-   name Tenant_A_OP_Zone_1
-!
-vlan 111
-   name Tenant_A_OP_Zone_2
-!
-vlan 112
-   name Tenant_A_OP_Zone_3
 !
 vlan 4092
    name L2LEAF_INBAND_MGMT
@@ -188,7 +176,7 @@ vlan 4092
 
 | Interface | Description | Mode | VLANs | Native VLAN | Trunk Group | Channel-Group |
 | --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
-| Ethernet3 | DC2-POD1-L2LEAF1A_Ethernet1 | *trunk | *110-112,4092 | *- | *- | 3 |
+| Ethernet3 | DC2-POD1-L2LEAF1A_Ethernet1 | *trunk | *4092 | *- | *- | 3 |
 
 *Inherited from Port-Channel Interface
 
@@ -252,7 +240,7 @@ interface Ethernet7
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel3 | RACK1_SINGLE_Po1 | switched | trunk | 110-112,4092 | - | - | - | - | 3 | - |
+| Port-Channel3 | RACK1_SINGLE_Po1 | switched | trunk | 4092 | - | - | - | - | 3 | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -262,7 +250,7 @@ interface Port-Channel3
    description RACK1_SINGLE_Po1
    no shutdown
    switchport
-   switchport trunk allowed vlan 110-112,4092
+   switchport trunk allowed vlan 4092
    switchport mode trunk
    mlag 3
    service-profile QOS-PROFILE
@@ -308,42 +296,18 @@ interface Loopback1
 
 | Interface | Description | VRF |  MTU | Shutdown |
 | --------- | ----------- | --- | ---- | -------- |
-| Vlan110 |  Tenant_A_OP_Zone_1  |  Common_VRF  |  -  |  false  |
-| Vlan111 |  Tenant_A_OP_Zone_2  |  Common_VRF  |  -  |  true  |
-| Vlan112 |  Tenant_A_OP_Zone_3  |  Common_VRF  |  -  |  false  |
 | Vlan4092 |  L2LEAF_INBAND_MGMT  |  default  |  1500  |  false  |
 
 #### IPv4
 
 | Interface | VRF | IP Address | IP Address Virtual | IP Router Virtual Address | VRRP | ACL In | ACL Out |
 | --------- | --- | ---------- | ------------------ | ------------------------- | ---- | ------ | ------- |
-| Vlan110 |  Common_VRF  |  -  |  10.1.10.1/24  |  -  |  -  |  -  |  -  |
-| Vlan111 |  Common_VRF  |  -  |  10.1.11.1/24  |  -  |  -  |  -  |  -  |
-| Vlan112 |  Common_VRF  |  -  |  10.1.12.1/24  |  -  |  -  |  -  |  -  |
 | Vlan4092 |  default  |  172.21.210.2/24  |  -  |  172.21.210.1  |  -  |  -  |  -  |
 
 
 ### VLAN Interfaces Device Configuration
 
 ```eos
-!
-interface Vlan110
-   description Tenant_A_OP_Zone_1
-   no shutdown
-   vrf Common_VRF
-   ip address virtual 10.1.10.1/24
-!
-interface Vlan111
-   description Tenant_A_OP_Zone_2
-   shutdown
-   vrf Common_VRF
-   ip address virtual 10.1.11.1/24
-!
-interface Vlan112
-   description Tenant_A_OP_Zone_3
-   no shutdown
-   vrf Common_VRF
-   ip address virtual 10.1.12.1/24
 !
 interface Vlan4092
    description L2LEAF_INBAND_MGMT
@@ -366,9 +330,7 @@ interface Vlan4092
 
 | VLAN | VNI |
 | ---- | --- |
-| 110 | 10110 |
-| 111 | 50111 |
-| 112 | 50112 |
+| N/A | N/A |
 
 #### VRF to VNI Mappings
 
@@ -383,9 +345,6 @@ interface Vlan4092
 interface Vxlan1
    vxlan source-interface Loopback1
    vxlan udp-port 4789
-   vxlan vlan 110 vni 10110
-   vxlan vlan 111 vni 50111
-   vxlan vlan 112 vni 50112
    vxlan vrf Common_VRF vni 1025
 ```
 
@@ -502,14 +461,6 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 
 #### Router BGP EVPN MAC-VRFs
 
-##### VLAN Based
-
-| VLAN | Route-Distinguisher | Both Route-Target | Import Route Target | Export Route-Target | Redistribute |
-| ---- | ------------------- | ----------------- | ------------------- | ------------------- | ------------ |
-| 110 | 172.16.210.3:10110 |  10110:10110 |  -  | -  | learned |
-| 111 | 172.16.210.3:50111 |  50111:50111 |  -  | -  | learned |
-| 112 | 172.16.210.3:50112 |  50112:50112 |  -  | -  | learned |
-
 #### Router BGP EVPN VRFs
 
 | VRF | Route-Distinguisher | Redistribute |
@@ -563,21 +514,6 @@ router bgp 65211
    neighbor 172.17.210.2 peer group IPv4-UNDERLAY-PEERS
    redistribute attached-host
    redistribute connected route-map RM-CONN-2-BGP
-   !
-   vlan 110
-      rd 172.16.210.3:10110
-      route-target both 10110:10110
-      redistribute learned
-   !
-   vlan 111
-      rd 172.16.210.3:50111
-      route-target both 50111:50111
-      redistribute learned
-   !
-   vlan 112
-      rd 172.16.210.3:50112
-      route-target both 50112:50112
-      redistribute learned
    !
    address-family evpn
       neighbor EVPN-OVERLAY-PEERS activate

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-LEAF1A.cfg
@@ -16,15 +16,6 @@ no enable password
 !
 username admin privilege 15 role network-admin secret sha512 $6$eJ5TvI8oru5i9e8G$R1X/SbtGTk9xoEHEBQASc7SC2nHYmi.crVgp2pXuCXwxsXEA81e4E0cXgQ6kX08fIeQzauqhv2kS.RGJFCon5/
 !
-vlan 110
-   name Tenant_A_OP_Zone_1
-!
-vlan 111
-   name Tenant_A_OP_Zone_2
-!
-vlan 112
-   name Tenant_A_OP_Zone_3
-!
 vlan 4092
    name L2LEAF_INBAND_MGMT
 !
@@ -36,7 +27,7 @@ interface Port-Channel3
    description RACK1_SINGLE_Po1
    no shutdown
    switchport
-   switchport trunk allowed vlan 110-112,4092
+   switchport trunk allowed vlan 4092
    switchport mode trunk
    mlag 3
    service-profile QOS-PROFILE
@@ -95,24 +86,6 @@ interface Management1
    vrf MGMT
    ip address 192.168.1.22/24
 !
-interface Vlan110
-   description Tenant_A_OP_Zone_1
-   no shutdown
-   vrf Common_VRF
-   ip address virtual 10.1.10.1/24
-!
-interface Vlan111
-   description Tenant_A_OP_Zone_2
-   shutdown
-   vrf Common_VRF
-   ip address virtual 10.1.11.1/24
-!
-interface Vlan112
-   description Tenant_A_OP_Zone_3
-   no shutdown
-   vrf Common_VRF
-   ip address virtual 10.1.12.1/24
-!
 interface Vlan4092
    description L2LEAF_INBAND_MGMT
    no shutdown
@@ -124,9 +97,6 @@ interface Vlan4092
 interface Vxlan1
    vxlan source-interface Loopback1
    vxlan udp-port 4789
-   vxlan vlan 110 vni 10110
-   vxlan vlan 111 vni 50111
-   vxlan vlan 112 vni 50112
    vxlan vrf Common_VRF vni 1025
 !
 ip virtual-router mac-address 00:1c:73:00:dc:01
@@ -196,21 +166,6 @@ router bgp 65211
    neighbor 172.17.210.2 peer group IPv4-UNDERLAY-PEERS
    redistribute attached-host
    redistribute connected route-map RM-CONN-2-BGP
-   !
-   vlan 110
-      rd 172.16.210.3:10110
-      route-target both 10110:10110
-      redistribute learned
-   !
-   vlan 111
-      rd 172.16.210.3:50111
-      route-target both 50111:50111
-      redistribute learned
-   !
-   vlan 112
-      rd 172.16.210.3:50112
-      route-target both 50112:50112
-      redistribute learned
    !
    address-family evpn
       neighbor EVPN-OVERLAY-PEERS activate

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF1A.yml
@@ -14,18 +14,11 @@ switch_evpn_route_clients:
 - DC1-RS2
 leaf_filter_tenants:
 - all
-leaf_filter_tags:
-- all
+leaf_filter_tags: []
 leaf_allowed_vrfs:
 - Common_VRF
-leaf_allowed_svis:
-- 110
-- 111
-- 112
-leaf_allowed_vlans:
-- 110
-- 111
-- 112
+leaf_allowed_svis: []
+leaf_allowed_vlans: []
 leaf_mlag: false
 service_routing_protocols_model: multi-agent
 ip_routing: true
@@ -58,15 +51,6 @@ vlans:
   4092:
     tenant: system
     name: L2LEAF_INBAND_MGMT
-  110:
-    tenant: Tenant_A
-    name: Tenant_A_OP_Zone_1
-  111:
-    tenant: Tenant_A
-    name: Tenant_A_OP_Zone_2
-  112:
-    tenant: Tenant_A
-    name: Tenant_A_OP_Zone_3
 vrfs:
   MGMT:
     ip_routing: false
@@ -78,7 +62,7 @@ port_channel_interfaces:
     description: RACK1_SINGLE_Po1
     type: switched
     shutdown: false
-    vlans: 110-112,4092
+    vlans: 4092
     mode: trunk
     service_profile: QOS-PROFILE
     mlag: 3
@@ -163,43 +147,13 @@ vlan_interfaces:
     ip_virtual_router_address: 172.21.210.1
     ip_attached_host_route_export:
       distance: 19
-  Vlan110:
-    tenant: Tenant_A
-    tags:
-    - opzone
-    description: Tenant_A_OP_Zone_1
-    shutdown: false
-    vrf: Common_VRF
-    ip_address_virtual: 10.1.10.1/24
-  Vlan111:
-    tenant: Tenant_A
-    tags:
-    - opzone
-    description: Tenant_A_OP_Zone_2
-    shutdown: true
-    vrf: Common_VRF
-    ip_address_virtual: 10.1.11.1/24
-  Vlan112:
-    tenant: Tenant_A
-    tags:
-    - opzone
-    description: Tenant_A_OP_Zone_3
-    shutdown: false
-    vrf: Common_VRF
-    ip_address_virtual: 10.1.12.1/24
 vxlan_tunnel_interface:
   Vxlan1:
     description: DC2-POD1-LEAF1A_VTEP
     source_interface: Loopback1
     vxlan_udp_port: 4789
     vxlan_vni_mappings:
-      vlans:
-        110:
-          vni: 10110
-        111:
-          vni: 50111
-        112:
-          vni: 50112
+      vlans: null
       vrfs:
         Common_VRF:
           vni: 1025
@@ -318,31 +272,7 @@ router_bgp:
         default_route_target:
           only: true
   vlan_aware_bundles: null
-  vlans:
-    110:
-      tenant: Tenant_A
-      rd: 172.16.210.3:10110
-      route_targets:
-        both:
-        - 10110:10110
-      redistribute_routes:
-      - learned
-    111:
-      tenant: Tenant_A
-      rd: 172.16.210.3:50111
-      route_targets:
-        both:
-        - 50111:50111
-      redistribute_routes:
-      - learned
-    112:
-      tenant: Tenant_A
-      rd: 172.16.210.3:50112
-      route_targets:
-        both:
-        - 50112:50112
-      redistribute_routes:
-      - learned
+  vlans: null
   vrfs:
     Common_VRF:
       router_id: 172.16.210.3

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/DC1_POD1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/DC1_POD1.yml
@@ -53,6 +53,7 @@ l3leaf:
       filter:
         tenants: []
         tags: []
+        always_include_vrfs_in_tenants: [ 'all' ] #Testing that we respect the empty tenants list, so no VRFs will be configured.
       nodes:
         DC1-POD1-LEAF1A:
           id: 1

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/DC2_POD1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/DC2_POD1.yml
@@ -33,7 +33,7 @@ spine:
       mgmt_ip: 192.168.1.21/24
       super_spine_interfaces: [ Ethernet2, Ethernet2 ]
 
-# In DC2 we define all variables on specific node / node_group
+# In DC2 we define all variables via defaults
 l3leaf:
   defaults:
     bgp_as: 65555
@@ -46,6 +46,9 @@ l3leaf:
     spanning_tree_priority: 4096
     virtual_router_mac_address: 00:1c:73:00:dc:01
     mlag: false
+    filter:
+      always_include_vrfs_in_tenants: [ 'all' ] #Testing that we configure all VRFs even with no VLANs.
+      tags: []
   node_groups:
     # Single switch working as underlay L3 router and EVPN RS
     RACK1_SINGLE:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -416,6 +416,7 @@ interface Vlan350
 | VLAN | VNI |
 | ---- | --- |
 | Tenant_A_WAN_Zone | 14 |
+| Tenant_B_OP_Zone | 20 |
 | Tenant_B_WAN_Zone | 21 |
 | Tenant_C_WAN_Zone | 31 |
 
@@ -430,6 +431,7 @@ interface Vxlan1
    vxlan vlan 250 vni 20250
    vxlan vlan 350 vni 30350
    vxlan vrf Tenant_A_WAN_Zone vni 14
+   vxlan vrf Tenant_B_OP_Zone vni 20
    vxlan vrf Tenant_B_WAN_Zone vni 21
    vxlan vrf Tenant_C_WAN_Zone vni 31
 ```
@@ -457,6 +459,7 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 | --- | --------------- |
 | default | true|| MGMT | false |
 | Tenant_A_WAN_Zone | true |
+| Tenant_B_OP_Zone | true |
 | Tenant_B_WAN_Zone | true |
 | Tenant_C_WAN_Zone | true |
 
@@ -467,6 +470,7 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 ip routing
 no ip routing vrf MGMT
 ip routing vrf Tenant_A_WAN_Zone
+ip routing vrf Tenant_B_OP_Zone
 ip routing vrf Tenant_B_WAN_Zone
 ip routing vrf Tenant_C_WAN_Zone
 ```
@@ -478,6 +482,7 @@ ip routing vrf Tenant_C_WAN_Zone
 | --- | --------------- |
 | default | false || MGMT | false |
 | Tenant_A_WAN_Zone | false |
+| Tenant_B_OP_Zone | false |
 | Tenant_B_WAN_Zone | false |
 | Tenant_C_WAN_Zone | false |
 
@@ -568,6 +573,7 @@ ip route vrf Tenant_A_WAN_Zone 10.3.4.0/24 1.2.3.4
 | VRF | Route-Distinguisher | Redistribute |
 | --- | ------------------- | ------------ |
 | Tenant_A_WAN_Zone | 192.168.255.10:14 | connected  static |
+| Tenant_B_OP_Zone | 192.168.255.10:20 | connected |
 | Tenant_B_WAN_Zone | 192.168.255.10:21 | connected |
 | Tenant_C_WAN_Zone | 192.168.255.10:31 | connected |
 
@@ -665,6 +671,13 @@ router bgp 65104
          neighbor fd5a:fe45:8831:06c5::b activate
       redistribute connected
       redistribute static
+   !
+   vrf Tenant_B_OP_Zone
+      rd 192.168.255.10:20
+      route-target import evpn 20:20
+      route-target export evpn 20:20
+      router-id 192.168.255.10
+      redistribute connected
    !
    vrf Tenant_B_WAN_Zone
       rd 192.168.255.10:21
@@ -779,6 +792,7 @@ route-map RM-Tenant_A_WAN_Zone-fd5a:fe45:8831:06c5::a-SET-NEXT-HOP-OUT permit 10
 | -------- | ---------- |
 | MGMT | disabled |
 | Tenant_A_WAN_Zone | enabled |
+| Tenant_B_OP_Zone | enabled |
 | Tenant_B_WAN_Zone | enabled |
 | Tenant_C_WAN_Zone | enabled |
 
@@ -789,6 +803,8 @@ route-map RM-Tenant_A_WAN_Zone-fd5a:fe45:8831:06c5::a-SET-NEXT-HOP-OUT permit 10
 vrf instance MGMT
 !
 vrf instance Tenant_A_WAN_Zone
+!
+vrf instance Tenant_B_OP_Zone
 !
 vrf instance Tenant_B_WAN_Zone
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -416,6 +416,7 @@ interface Vlan350
 | VLAN | VNI |
 | ---- | --- |
 | Tenant_A_WAN_Zone | 14 |
+| Tenant_B_OP_Zone | 20 |
 | Tenant_B_WAN_Zone | 21 |
 | Tenant_C_WAN_Zone | 31 |
 
@@ -430,6 +431,7 @@ interface Vxlan1
    vxlan vlan 250 vni 20250
    vxlan vlan 350 vni 30350
    vxlan vrf Tenant_A_WAN_Zone vni 14
+   vxlan vrf Tenant_B_OP_Zone vni 20
    vxlan vrf Tenant_B_WAN_Zone vni 21
    vxlan vrf Tenant_C_WAN_Zone vni 31
 ```
@@ -457,6 +459,7 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 | --- | --------------- |
 | default | true|| MGMT | false |
 | Tenant_A_WAN_Zone | true |
+| Tenant_B_OP_Zone | true |
 | Tenant_B_WAN_Zone | true |
 | Tenant_C_WAN_Zone | true |
 
@@ -467,6 +470,7 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 ip routing
 no ip routing vrf MGMT
 ip routing vrf Tenant_A_WAN_Zone
+ip routing vrf Tenant_B_OP_Zone
 ip routing vrf Tenant_B_WAN_Zone
 ip routing vrf Tenant_C_WAN_Zone
 ```
@@ -478,6 +482,7 @@ ip routing vrf Tenant_C_WAN_Zone
 | --- | --------------- |
 | default | false || MGMT | false |
 | Tenant_A_WAN_Zone | false |
+| Tenant_B_OP_Zone | false |
 | Tenant_B_WAN_Zone | false |
 | Tenant_C_WAN_Zone | false |
 
@@ -568,6 +573,7 @@ ip route vrf Tenant_A_WAN_Zone 10.3.4.0/24 1.2.3.4
 | VRF | Route-Distinguisher | Redistribute |
 | --- | ------------------- | ------------ |
 | Tenant_A_WAN_Zone | 192.168.255.11:14 | connected  static |
+| Tenant_B_OP_Zone | 192.168.255.11:20 | connected |
 | Tenant_B_WAN_Zone | 192.168.255.11:21 | connected |
 | Tenant_C_WAN_Zone | 192.168.255.11:31 | connected |
 
@@ -665,6 +671,13 @@ router bgp 65105
          neighbor fd5a:fe45:8831:06c5::b activate
       redistribute connected
       redistribute static
+   !
+   vrf Tenant_B_OP_Zone
+      rd 192.168.255.11:20
+      route-target import evpn 20:20
+      route-target export evpn 20:20
+      router-id 192.168.255.11
+      redistribute connected
    !
    vrf Tenant_B_WAN_Zone
       rd 192.168.255.11:21
@@ -779,6 +792,7 @@ route-map RM-Tenant_A_WAN_Zone-fd5a:fe45:8831:06c5::a-SET-NEXT-HOP-OUT permit 10
 | -------- | ---------- |
 | MGMT | disabled |
 | Tenant_A_WAN_Zone | enabled |
+| Tenant_B_OP_Zone | enabled |
 | Tenant_B_WAN_Zone | enabled |
 | Tenant_C_WAN_Zone | enabled |
 
@@ -789,6 +803,8 @@ route-map RM-Tenant_A_WAN_Zone-fd5a:fe45:8831:06c5::a-SET-NEXT-HOP-OUT permit 10
 vrf instance MGMT
 !
 vrf instance Tenant_A_WAN_Zone
+!
+vrf instance Tenant_B_OP_Zone
 !
 vrf instance Tenant_B_WAN_Zone
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1A.cfg
@@ -47,6 +47,8 @@ vrf instance MGMT
 !
 vrf instance Tenant_A_WAN_Zone
 !
+vrf instance Tenant_B_OP_Zone
+!
 vrf instance Tenant_B_WAN_Zone
 !
 vrf instance Tenant_C_WAN_Zone
@@ -127,6 +129,7 @@ interface Vxlan1
    vxlan vlan 250 vni 20250
    vxlan vlan 350 vni 30350
    vxlan vrf Tenant_A_WAN_Zone vni 14
+   vxlan vrf Tenant_B_OP_Zone vni 20
    vxlan vrf Tenant_B_WAN_Zone vni 21
    vxlan vrf Tenant_C_WAN_Zone vni 31
 !
@@ -138,6 +141,7 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 ip routing
 no ip routing vrf MGMT
 ip routing vrf Tenant_A_WAN_Zone
+ip routing vrf Tenant_B_OP_Zone
 ip routing vrf Tenant_B_WAN_Zone
 ip routing vrf Tenant_C_WAN_Zone
 !
@@ -250,6 +254,13 @@ router bgp 65104
          neighbor fd5a:fe45:8831:06c5::b activate
       redistribute connected
       redistribute static
+   !
+   vrf Tenant_B_OP_Zone
+      rd 192.168.255.10:20
+      route-target import evpn 20:20
+      route-target export evpn 20:20
+      router-id 192.168.255.10
+      redistribute connected
    !
    vrf Tenant_B_WAN_Zone
       rd 192.168.255.10:21

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1B.cfg
@@ -47,6 +47,8 @@ vrf instance MGMT
 !
 vrf instance Tenant_A_WAN_Zone
 !
+vrf instance Tenant_B_OP_Zone
+!
 vrf instance Tenant_B_WAN_Zone
 !
 vrf instance Tenant_C_WAN_Zone
@@ -127,6 +129,7 @@ interface Vxlan1
    vxlan vlan 250 vni 20250
    vxlan vlan 350 vni 30350
    vxlan vrf Tenant_A_WAN_Zone vni 14
+   vxlan vrf Tenant_B_OP_Zone vni 20
    vxlan vrf Tenant_B_WAN_Zone vni 21
    vxlan vrf Tenant_C_WAN_Zone vni 31
 !
@@ -138,6 +141,7 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 ip routing
 no ip routing vrf MGMT
 ip routing vrf Tenant_A_WAN_Zone
+ip routing vrf Tenant_B_OP_Zone
 ip routing vrf Tenant_B_WAN_Zone
 ip routing vrf Tenant_C_WAN_Zone
 !
@@ -250,6 +254,13 @@ router bgp 65105
          neighbor fd5a:fe45:8831:06c5::b activate
       redistribute connected
       redistribute static
+   !
+   vrf Tenant_B_OP_Zone
+      rd 192.168.255.11:20
+      route-target import evpn 20:20
+      route-target export evpn 20:20
+      router-id 192.168.255.11
+      redistribute connected
    !
    vrf Tenant_B_WAN_Zone
       rd 192.168.255.11:21

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
@@ -20,6 +20,7 @@ leaf_allowed_vrfs:
 - Tenant_A_WAN_Zone
 - Tenant_B_WAN_Zone
 - Tenant_C_WAN_Zone
+- Tenant_B_OP_Zone
 leaf_allowed_svis:
 - 150
 - 250
@@ -106,6 +107,9 @@ vrfs:
     ip_routing: false
   Tenant_A_WAN_Zone:
     tenant: Tenant_A
+    ip_routing: true
+  Tenant_B_OP_Zone:
+    tenant: Tenant_B
     ip_routing: true
   Tenant_B_WAN_Zone:
     tenant: Tenant_B
@@ -218,6 +222,8 @@ vxlan_tunnel_interface:
       vrfs:
         Tenant_A_WAN_Zone:
           vni: 14
+        Tenant_B_OP_Zone:
+          vni: 20
         Tenant_B_WAN_Zone:
           vni: 21
         Tenant_C_WAN_Zone:
@@ -404,6 +410,19 @@ router_bgp:
       redistribute_routes:
       - connected
       - static
+    Tenant_B_OP_Zone:
+      router_id: 192.168.255.10
+      rd: 192.168.255.10:20
+      route_targets:
+        import:
+          evpn:
+          - '20:20'
+        export:
+          evpn:
+          - '20:20'
+      neighbors: null
+      redistribute_routes:
+      - connected
     Tenant_B_WAN_Zone:
       router_id: 192.168.255.10
       rd: 192.168.255.10:21

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
@@ -20,6 +20,7 @@ leaf_allowed_vrfs:
 - Tenant_A_WAN_Zone
 - Tenant_B_WAN_Zone
 - Tenant_C_WAN_Zone
+- Tenant_B_OP_Zone
 leaf_allowed_svis:
 - 150
 - 250
@@ -106,6 +107,9 @@ vrfs:
     ip_routing: false
   Tenant_A_WAN_Zone:
     tenant: Tenant_A
+    ip_routing: true
+  Tenant_B_OP_Zone:
+    tenant: Tenant_B
     ip_routing: true
   Tenant_B_WAN_Zone:
     tenant: Tenant_B
@@ -218,6 +222,8 @@ vxlan_tunnel_interface:
       vrfs:
         Tenant_A_WAN_Zone:
           vni: 14
+        Tenant_B_OP_Zone:
+          vni: 20
         Tenant_B_WAN_Zone:
           vni: 21
         Tenant_C_WAN_Zone:
@@ -404,6 +410,19 @@ router_bgp:
       redistribute_routes:
       - connected
       - static
+    Tenant_B_OP_Zone:
+      router_id: 192.168.255.11
+      rd: 192.168.255.11:20
+      route_targets:
+        import:
+          evpn:
+          - '20:20'
+        export:
+          evpn:
+          - '20:20'
+      neighbors: null
+      redistribute_routes:
+      - connected
     Tenant_B_WAN_Zone:
       router_id: 192.168.255.11
       rd: 192.168.255.11:21

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
@@ -121,6 +121,7 @@ l3leaf:
       filter:
         tenants: [ all ]
         tags: [ wan ]
+        always_include_vrfs_in_tenants: [ 'Tenant_B' ]
       nodes:
         DC1-BL1A:
           id: 6

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/fabric-topology.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/fabric-topology.md
@@ -214,6 +214,10 @@ l3leaf:
         tenants: [ < tenant_1 >, < tenant_2 > | default all ]
         tags: [ < tag_1 >, < tag_2 > | default -> all ]
 
+        # Force VRFs in a tenant to be configured even if VLANs are not included in tags | Optional
+        # Useful for "border" leaf.
+        always_include_vrfs_in_tenants: [ < tenant_1 >, < tenant_2 >, "all" ]
+
       # Possibility to prevent configuration of Tenant VRFs and SVIs | Optional, default is false
       # This allows support for centralized routing.
       evpn_services_l2_only: < false | true >

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/logic/l3leaf.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/logic/l3leaf.j2
@@ -9,6 +9,8 @@
 {%             set leaf.filter_tenants = l3leaf.node_groups[l3leaf_node_group].filter.tenants| arista.avd.default(
                                          l3leaf.defaults.filter.tenants,
                                          [ 'all' ]  ) %}
+{%             set leaf.always_include_vrfs_in_tenants = l3leaf.node_groups[l3leaf_node_group].filter.always_include_vrfs_in_tenants | arista.avd.default(
+                                                         l3leaf.defaults.filter.always_include_vrfs_in_tenants) %}
 {%             set leaf.igmp_snooping_enabled = l3leaf.node_groups[l3leaf_node_group].igmp_snooping_enabled | arista.avd.default(
                                                 l3leaf.defaults.igmp_snooping_enabled,
                                                 default_igmp_snooping_enabled ) %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenant_evpn_vxlan/l3leaf-logic.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenant_evpn_vxlan/l3leaf-logic.j2
@@ -28,6 +28,16 @@
 {%         endfor %}
 {%     endif %}
 {% endfor %}
+{# Append all VRFs for tenants set in "always_include_vrfs_in_tenants" is set #}
+{% if leaf.always_include_vrfs_in_tenants is arista.avd.defined %}
+{%     for tenant in tenants | arista.avd.natural_sort if tenant in leaf.filter_tenants or "all" in leaf.filter_tenants %}
+{%         if tenant in leaf.always_include_vrfs_in_tenants or "all" in leaf.always_include_vrfs_in_tenants %}
+{%             for vrf in tenants[tenant].vrfs | arista.avd.natural_sort %}
+{%                 do leaf.vrfs.append( vrf ) %}
+{%             endfor %}
+{%         endif %}
+{%     endfor %}
+{% endif %}
 {% set leaf.vrfs = leaf.vrfs | unique  %}
 {# Setting tenant static routes #}
 {% set leaf.static_routes = [] %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenant_evpn_vxlan/leaf-tenant-router-bgp-evpn-vlan-aware-bundles.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenant_evpn_vxlan/leaf-tenant-router-bgp-evpn-vlan-aware-bundles.j2
@@ -4,6 +4,11 @@
 ## {{ tenant }} ##
 {%         if tenants[tenant].vrfs is defined %}
 {%             for vrf in tenants[tenant].vrfs | arista.avd.natural_sort if leaf.vrfs is not none and vrf in leaf.vrfs %}
+{%                 set vlan_range = [] %}
+{%                 for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if leaf.svis is not none and svi|int in leaf.svis %}
+{%                     do vlan_range.append( svi| int ) %}
+{%                 endfor %}
+{%                 if vlan_range | length > 0 %}
     {{ vrf }}:
       rd: "{{ leaf.evpn_rd_admin_subfield }}:{{ tenants[tenant].vrfs[vrf].vrf_vni }}"
       route_targets:
@@ -11,11 +16,8 @@
           - "{{ leaf.evpn_rt_admin_subfield or tenants[tenant].vrfs[vrf].vrf_vni }}:{{ tenants[tenant].vrfs[vrf].vrf_vni }}"
       redistribute_routes:
         - learned
-{%                 set vlan_range = [] %}
-{%                 for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort if leaf.svis is not none and svi|int in leaf.svis %}
-{%                     do vlan_range.append( svi| int ) %}
-{%                 endfor %}
       vlan: {{ vlan_range | arista.avd.list_compress }}
+{%                 endif %}
 {%             endfor %}
 {%         endif %}
 {%         if tenants[tenant].l2vlans is defined %}


### PR DESCRIPTION
## Change Summary
Add "always_include_vrfs_in_tenants" in l3leaf filter

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)
<!-- If PR is linked to one or more issues, please list issues below -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes #821 

## Component(s) name

`arista.avd.<role-name>`

## Proposed changes
<!--- Describe your changes in detail -->
```
      # Filter L3 and L2 network services based on tenant and tags ( and operation filter )| Optional
      # If filter is not defined will default to all
      filter:
        tenants: [ < tenant_1 >, < tenant_2 > | default all ]
        tags: [ < tag_1 >, < tag_2 > | default -> all ]

        # Force VRFs in a tenant to be configured even if VLANs are not included in tags | Optional
        # Useful for "border" leaf.
        always_include_vrfs_in_tenants: [ < tenant_1 >, < tenant_2 >, "all" ]
```

Also fixed issue with vlan-bundles being configured for VRF without looking at list of vlans first.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Added various molecule test scenarios to test:
- [x] This will not change anything if not configured
- [x] This will not change anything if no tenants are assigned to l3leaf
- [x] This will include all VRFs for named tenants even if no VLANs are configured
- [x] this will include all VRFs for all assigned tenants even if no VLANs are configured
- [x] This can be configured under `node_group` or under `defaults`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [X] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
