### PR TITLE
feat(eos_cli_config_gen): Implement l3dot1q support for interfaces

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -85,6 +85,7 @@ interface Management1
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
 | Ethernet1 |  P2P_LINK_TO_DC1-SPINE1_Ethernet1  |  routed  | - |  172.31.255.1/31  |  default  |  1500  |  -  |  -  |  -  |
 | Ethernet3 |  P2P_LINK_TO_DC1-SPINE2_Ethernet2  |  routed  | - |  172.31.128.1/31  |  default  |  1500  |  -  |  -  |  -  |
+| Ethernet8.101 |  to WAN-ISP-01 Ethernet2.101 - VRF-C1  |  l3dot1q  | - |  172.31.128.1/31  |  default  |  -  |  -  |  -  |  -  |
 
 #### IPv6
 
@@ -92,6 +93,7 @@ interface Management1
 | --------- | ----------- | ---- | --------------| ------------ | --- | --- | -------- | -------------- | -------------------| ----------- | ------------ |
 | Ethernet3 |  P2P_LINK_TO_DC1-SPINE2_Ethernet2  |  routed  | - |  2002:ABDC::1/64  |  default  |  1500  |  -  | -  |  -  |  -  |  -  |
 | Ethernet4 |  Molecule IPv6  |  switchport  | - |  2020::2020/64  |  default  |  9100  |  true  | true  |  true  |  IPv6_ACL_IN  |  IPv6_ACL_OUT  |
+| Ethernet8.101 |  to WAN-ISP-01 Ethernet2.101 - VRF-C1  |  l3dot1q  | - |  2002:ABDC::1/64  |  default  |  -  |  -  | -  |  -  |  -  |  -  |
 
 #### ISIS
 
@@ -190,6 +192,17 @@ interface Ethernet7
    storm-control broadcast level pps 10
    storm-control multicast level 50
    storm-control unknown-unicast level 10
+!
+interface Ethernet8
+   description to WAN-ISP1-01 Ethernet2
+   no switchport
+!
+interface Ethernet8.101
+   description to WAN-ISP-01 Ethernet2.101 - VRF-C1
+   encapsulation dot1q vlan 101
+   ip address 172.31.128.1/31
+   ipv6 enable
+   ipv6 address 2002:ABDC::1/64
 ```
 
 # Routing

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
@@ -80,6 +80,11 @@ interface Management1
 
 *Inherited from Port-Channel Interface
 
+#### IPv4
+
+| Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
+| --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
+ *Inherited from Port-Channel Interface 
 ### Ethernet Interfaces Device Configuration
 
 ```eos
@@ -95,6 +100,10 @@ interface Ethernet4
 interface Ethernet5
    description DC1-AGG01_Ethernet1
    channel-group 5 mode active
+!
+interface Ethernet8
+   description MLAG_PEER_DC1-LEAF1B_Ethernet8
+   channel-group 8 mode active
 !
 interface Ethernet50
    description SRV-POD03_Eth1
@@ -115,6 +124,12 @@ interface Ethernet50
 | Port-Channel51 | ipv6_prefix | switched | trunk | 1-500 | - | - | - | - | - | - |
 | Port-Channel100.101 | IFL for TENANT01 | switched | access | - | - | - | - | - | - | - |
 | Port-Channel100.102 | IFL for TENANT02 | switched | access | - | - | - | - | - | - | - |
+
+#### IPv4
+
+| Interface | Description | Type | MLAG ID | IP Address | VRF | MTU | Shutdown | ACL In | ACL Out |
+| --------- | ----------- | ---- | ------- | ---------- | --- | --- | -------- | ------ | ------- |
+| Port-Channel8.101 | to Dev02 Port-Channel8.101 - VRF-C1 | routed | - | 10.1.2.3/31 | default | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -137,6 +152,15 @@ interface Port-Channel5
    storm-control broadcast level 1
    storm-control multicast level 1
    storm-control unknown-unicast level 1
+!
+interface Port-Channel8
+   description to Dev02 Port-channel 8
+   no switchport
+!
+interface Port-Channel8.101
+   description to Dev02 Port-Channel8.101 - VRF-C1
+   encapsulation dot1q vlan 101
+   ip address 10.1.2.3/31
 !
 interface Port-Channel50
    description SRV-POD03_PortChanne1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
@@ -95,6 +95,17 @@ interface Ethernet7
    storm-control multicast level 50
    storm-control unknown-unicast level 10
 !
+interface Ethernet8
+   description to WAN-ISP1-01 Ethernet2
+   no switchport
+!
+interface Ethernet8.101
+   description to WAN-ISP-01 Ethernet2.101 - VRF-C1
+   encapsulation dot1q vlan 101
+   ip address 172.31.128.1/31
+   ipv6 enable
+   ipv6 address 2002:ABDC::1/64
+!
 interface Management1
    description oob_management
    vrf MGMT

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
@@ -25,6 +25,15 @@ interface Port-Channel5
    storm-control multicast level 1
    storm-control unknown-unicast level 1
 !
+interface Port-Channel8
+   description to Dev02 Port-channel 8
+   no switchport
+!
+interface Port-Channel8.101
+   description to Dev02 Port-Channel8.101 - VRF-C1
+   encapsulation dot1q vlan 101
+   ip address 10.1.2.3/31
+!
 interface Port-Channel50
    description SRV-POD03_PortChanne1
    switchport
@@ -73,6 +82,10 @@ interface Ethernet4
 interface Ethernet5
    description DC1-AGG01_Ethernet1
    channel-group 5 mode active
+!
+interface Ethernet8
+   description MLAG_PEER_DC1-LEAF1B_Ethernet8
+   channel-group 8 mode active
 !
 interface Ethernet50
    description SRV-POD03_Eth1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
@@ -10,18 +10,6 @@ ethernet_interfaces:
     type: routed
     ip_address: 172.31.255.1/31
 
-  Ethernet6:
-    logging:
-      event:
-        link_status: true
-    peer: SRV-POD02
-    peer_interface: Eth1
-    peer_type: server
-    description: SRV-POD02_Eth1
-    mode: trunk
-    vlans: 110-111,210-211
-    profile: ALL
-
   Ethernet2:
     peer: SRV-POD03
     peer_interface: Eth1
@@ -97,6 +85,18 @@ ethernet_interfaces:
     isis_metric: 99
     isis_network_point_to_point: true
 
+  Ethernet6:
+    logging:
+      event:
+        link_status: true
+    peer: SRV-POD02
+    peer_interface: Eth1
+    peer_type: server
+    description: SRV-POD02_Eth1
+    mode: trunk
+    vlans: 110-111,210-211
+    profile: ALL
+
   Ethernet7:
     description: Molecule L2
     shutdown: false
@@ -131,7 +131,20 @@ ethernet_interfaces:
         unit: pps
       multicast:
         level: 50
-        unit: 
+        unit:
       unknown_unicast:
         level: 10
         unit: percent
+
+  Ethernet8:
+    description: to WAN-ISP1-01 Ethernet2
+    type: routed
+  Ethernet8.101:
+    description: to WAN-ISP-01 Ethernet2.101 - VRF-C1
+    type: l3dot1q
+    encapsulation:
+      dot1q:
+        vlan: 101
+    ip_address: 172.31.128.1/31
+    ipv6_enable: true
+    ipv6_address: 2002:ABDC::1/64

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
@@ -68,6 +68,17 @@ port_channel_interfaces:
       dot1q:
         vlan: 102
 
+  Port-Channel8:
+    description: to Dev02 Port-channel 8
+    type: routed
+  Port-Channel8.101:
+    description: to Dev02 Port-Channel8.101 - VRF-C1
+    type: l3dot1q
+    ip_address: 10.1.2.3/31
+    encapsulation:
+      dot1q:
+        vlan: 101
+
 # Children interfaces
 ethernet_interfaces:
   Ethernet5:
@@ -108,3 +119,11 @@ ethernet_interfaces:
       id: 5
       mode: "active"
     profile: ALL
+
+  Ethernet8:
+    peer: DC1-LEAF1B
+    peer_interface: Ethernet4
+    description: MLAG_PEER_DC1-LEAF1B_Ethernet8
+    channel_group:
+      id: 8
+      mode: active

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -86,7 +86,7 @@
     - [Prompt](#prompt)
     - [Quality of Services](#quality-of-services)
       - [QOS](#qos)
-      - [QOS Class-maps](#class-maps)
+      - [QOS Class-maps](#qos-class-maps)
       - [QOS Policy-map](#qos-policy-map)
       - [QOS Profiles](#qos-profiles)
       - [Queue Monitor Length](#queue-monitor-length)
@@ -586,8 +586,11 @@ ethernet_interfaces:
     shutdown: < true | false >
     speed: < interface_speed | forced interface_speed | auto interface_speed >
     mtu: < mtu >
-    type: < routed | switched >
+    type: < routed | switched | l3dot1q >
     vrf: < vrf_name >
+    encapsulation:
+      dot1q:
+        vlan: < vlan tag to configure on sub-interface >
     ip_address: < IPv4_address/Mask >
     ip_address_secondaries:
       - < IPv4_address/Mask >
@@ -751,6 +754,10 @@ port_channel_interfaces:
     description: < description >
     shutdown: < true | false >
     vlans: "< list of vlans as string >"
+    type: < routed | switched | l3dot1q >
+    encapsulation:
+      dot1q:
+        vlan: < vlan tag to configure on sub-interface >
     mode: < access | dot1q-tunnel | trunk >
     mlag: < mlag_id >
     trunk_groups:
@@ -772,6 +779,7 @@ port_channel_interfaces:
   < Port-Channel_interface_3 >:
     description: < description >
     vlans: "< list of vlans as string >"
+    type: < routed | switched | l3dot1q >
     mode: < access | dot1q-tunnel | trunk >
     spanning_tree_bpdufilter: < true | false >
     spanning_tree_bpduguard: < true | false >
@@ -792,7 +800,7 @@ port_channel_interfaces:
   < Port-Channel_interface_4 >:
     description: < description >
     mtu: < mtu >
-    type: < switched | routed >
+    type: < routed | switched | l3dot1q >
     ip_address:  < IP_address/mask >
     ipv6_enable: < true | false >
     ipv6_address: < IPv6_address/mask >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ethernet-interfaces.j2
@@ -11,7 +11,7 @@
 {% for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort %}
 {%     if ethernet_interfaces[ethernet_interface].channel_group.id is defined and ethernet_interfaces[ethernet_interface].channel_group.id is not none %}
 {%         set port_channel_interface = 'Port-Channel' + ethernet_interfaces[ethernet_interface].channel_group.id | string %}
-{%         if port_channel_interfaces[port_channel_interface].type is not defined or port_channel_interfaces[port_channel_interface].type != "routed" %}
+{%         if port_channel_interfaces[port_channel_interface].type is not defined or port_channel_interfaces[port_channel_interface].type not in ['routed', 'l3dot1q'] %}
 {%             set description = ethernet_interfaces[ethernet_interface].description | default("-") %}
 {%             set mode = port_channel_interfaces[port_channel_interface].mode | default("access") %}
 {%             set vlans = port_channel_interfaces[port_channel_interface].vlans | default ('-') %}
@@ -29,7 +29,7 @@
 {%             endif %}
 | {{ ethernet_interface }} | {{ description }} | *{{ mode }} | *{{ vlans }} | *{{ native_vlan }} | *{{ l2.trunk_groups }} | {{ channel_group }} |
 {%         endif %}
-{%     elif ethernet_interfaces[ethernet_interface].type is not defined or ethernet_interfaces[ethernet_interface].type != "routed" %}
+{%     elif ethernet_interfaces[ethernet_interface].type is not defined or ethernet_interfaces[ethernet_interface].type not in ['routed', 'l3dot1q'] %}
 {%         set description = ethernet_interfaces[ethernet_interface].description | default("-") %}
 {%         set mode = ethernet_interfaces[ethernet_interface].mode | default("access") %}
 {%         set vlans = ethernet_interfaces[ethernet_interface].vlans | default ('-') %}
@@ -53,7 +53,7 @@
 {%     set ethernet_interface_ipv4 = namespace() %}
 {%     set ethernet_interface_ipv4.configured = false %}
 {%     for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort %}
-{%          if ethernet_interfaces[ethernet_interface].type is defined and ethernet_interfaces[ethernet_interface].type == 'routed' and ethernet_interfaces[ethernet_interface].ip_address is defined %}
+{%          if ethernet_interfaces[ethernet_interface].type is defined and ethernet_interfaces[ethernet_interface].type in ['routed', 'l3dot1q'] and ethernet_interfaces[ethernet_interface].ip_address is defined %}
 {%              set ethernet_interface_ipv4.configured = true %}
 {%          endif %}
 {%     endfor %}
@@ -61,7 +61,7 @@
 {%     set port_channel_interface_ipv4.configured = false %}
 {%     if port_channel_interfaces is defined and port_channel_interfaces is not none %}
 {%         for port_channel_interface in port_channel_interfaces | arista.avd.natural_sort %}
-{%              if port_channel_interfaces[port_channel_interface].type is defined and port_channel_interfaces[port_channel_interface].type == 'routed' and port_channel_interfaces[port_channel_interface].ip_address is defined %}
+{%              if port_channel_interfaces[port_channel_interface].type is defined and port_channel_interfaces[port_channel_interface].type in ['routed', 'l3dot1q'] and port_channel_interfaces[port_channel_interface].ip_address is defined %}
 {%                  set port_channel_interface_ipv4.configured = true %}
 {%              endif %}
 {%         endfor %}
@@ -90,7 +90,7 @@
 {%     set ethernet_interface_ipv6 = namespace() %}
 {%     set ethernet_interface_ipv6.configured = false %}
 {%     for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort %}
-{%          if ethernet_interfaces[ethernet_interface].type is defined and ethernet_interfaces[ethernet_interface].type == 'routed' and ethernet_interfaces[ethernet_interface].ipv6_address is defined %}
+{%          if ethernet_interfaces[ethernet_interface].type is defined and ethernet_interfaces[ethernet_interface].type in ['routed', 'l3dot1q'] and ethernet_interfaces[ethernet_interface].ipv6_address is defined %}
 {%              set ethernet_interface_ipv6.configured = true %}
 {%          endif %}
 {%     endfor %}
@@ -98,7 +98,7 @@
 {%     set port_channel_interface_ipv6.configured = false %}
 {%     if port_channel_interfaces is defined and port_channel_interfaces is not none %}
 {%         for port_channel_interface in port_channel_interfaces | arista.avd.natural_sort %}
-{%              if port_channel_interfaces[port_channel_interface].type is defined and port_channel_interfaces[port_channel_interface].type == 'routed' and port_channel_interfaces[port_channel_interface].ipv6_address is defined %}
+{%              if port_channel_interfaces[port_channel_interface].type is defined and port_channel_interfaces[port_channel_interface].type in ['routed', 'l3dot1q'] and port_channel_interfaces[port_channel_interface].ipv6_address is defined %}
 {%                  set port_channel_interface_ipv6.configured = true %}
 {%              endif %}
 {%         endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/port-channel-interfaces.j2
@@ -9,7 +9,7 @@
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
 {%     for port_channel_interface in port_channel_interfaces | arista.avd.natural_sort %}
-{%         if port_channel_interfaces[port_channel_interface].type is not defined or port_channel_interfaces[port_channel_interface].type != "routed" %}
+{%         if port_channel_interfaces[port_channel_interface].type is not defined or port_channel_interfaces[port_channel_interface].type not in ['routed', 'l3dot1q'] %}
 {%             set description = port_channel_interfaces[port_channel_interface].description | default ("-")%}
 {%             set type = port_channel_interfaces[port_channel_interface].type | default ("switched")%}
 {%             set mode = port_channel_interfaces[port_channel_interface].mode | default ("access")%}
@@ -37,7 +37,7 @@
 {%   set port_channel_interface_ipv4.configured = false %}
 {%   if port_channel_interfaces is defined and port_channel_interfaces is not none %}
 {%       for port_channel_interface in port_channel_interfaces | arista.avd.natural_sort %}
-{%           if port_channel_interfaces[port_channel_interface].type is defined and port_channel_interfaces[port_channel_interface].type == 'routed' and port_channel_interfaces[port_channel_interface].ip_address is defined %}
+{%           if port_channel_interfaces[port_channel_interface].type is defined and port_channel_interfaces[port_channel_interface].type in ['routed', 'l3dot1q'] and port_channel_interfaces[port_channel_interface].ip_address is defined %}
 {%               set port_channel_interface_ipv4.configured = true %}
 {%           endif %}
 {%        endfor %}
@@ -49,7 +49,7 @@
 | Interface | Description | Type | MLAG ID | IP Address | VRF | MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | ---- | ------- | ---------- | --- | --- | -------- | ------ | ------- |
 {%        for port_channel_interface in port_channel_interfaces | arista.avd.natural_sort %}
-{%            if port_channel_interfaces[port_channel_interface].type is defined and port_channel_interfaces[port_channel_interface].type == "routed" and port_channel_interfaces[port_channel_interface].ip_address is defined and port_channel_interfaces[port_channel_interface].ip_address is not none %}
+{%            if port_channel_interfaces[port_channel_interface].type is defined and port_channel_interfaces[port_channel_interface].type in ['routed', 'l3dot1q'] and port_channel_interfaces[port_channel_interface].ip_address is defined and port_channel_interfaces[port_channel_interface].ip_address is not none %}
 {%                set description = port_channel_interfaces[port_channel_interface].description | default ("-")%}
 {%                set type = "routed" %}
 {%                set mlag = port_channel_interfaces[port_channel_interface].mlag | default ("-")%}
@@ -68,7 +68,7 @@
 {%   set port_channel_interface_ipv6.configured = false %}
 {%   if port_channel_interfaces is defined and port_channel_interfaces is not none %}
 {%       for port_channel_interface in port_channel_interfaces | arista.avd.natural_sort %}
-{%           if port_channel_interfaces[port_channel_interface].type is defined and port_channel_interfaces[port_channel_interface].type == 'routed' and port_channel_interfaces[port_channel_interface].ipv6_address is defined %}
+{%           if port_channel_interfaces[port_channel_interface].type is defined and port_channel_interfaces[port_channel_interface].type in ['routed', 'l3dot1q'] and port_channel_interfaces[port_channel_interface].ipv6_address is defined %}
 {%               set port_channel_interface_ipv6.configured = true %}
 {%           endif %}
 {%        endfor %}
@@ -80,7 +80,7 @@
 | Interface | Description | Type | MLAG ID | IPv6 Address | VRF | MTU | Shutdown | ND RA Disabled | Managed Config Flag | IPv6 ACL In | IPv6 ACL Out |
 | --------- | ----------- | ---- | ------- | -------------| --- | --- | -------- | -------------- | ------------------- | ----------- | ------------ |
 {%        for port_channel_interface in port_channel_interfaces | arista.avd.natural_sort %}
-{%            if port_channel_interfaces[port_channel_interface].type is defined and port_channel_interfaces[port_channel_interface].type == "routed" and port_channel_interfaces[port_channel_interface].ipv6_address is defined and port_channel_interfaces[port_channel_interface].ipv6_address is not none %}
+{%            if port_channel_interfaces[port_channel_interface].type is defined and port_channel_interfaces[port_channel_interface].type in ['routed', 'l3dot1q'] and port_channel_interfaces[port_channel_interface].ipv6_address is defined and port_channel_interfaces[port_channel_interface].ipv6_address is not none %}
 {%                set description = port_channel_interfaces[port_channel_interface].description | default ("-")%}
 {%                set type = "routed" %}
 {%                set mlag = port_channel_interfaces[port_channel_interface].mlag | default ("-")%}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -30,6 +30,8 @@ interface {{ ethernet_interface }}
 {%         endif %}
 {%         if ethernet_interfaces[ethernet_interface].type is arista.avd.defined('routed') %}
    no switchport
+{%         elif ethernet_interfaces[ethernet_interface].type is arista.avd.defined('l3dot1q') and ethernet_interfaces[ethernet_interface].encapsulation.dot1q.vlan is arista.avd.defined() %}
+   encapsulation dot1q vlan {{ ethernet_interfaces[ethernet_interface].encapsulation.dot1q.vlan }}
 {%         else %}
    switchport
 {%         endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
@@ -18,6 +18,8 @@ interface {{ port_channel_interface }}
 {%     endif %}
 {%     if port_channel_interfaces[port_channel_interface].type is arista.avd.defined("routed") %}
    no switchport
+{%     elif port_channel_interfaces[port_channel_interface].type is arista.avd.defined('l3dot1q') and port_channel_interfaces[port_channel_interface].encapsulation.dot1q.vlan is arista.avd.defined() %}
+   encapsulation dot1q vlan {{ port_channel_interfaces[port_channel_interface].encapsulation.dot1q.vlan }}
 {%     else %}
    switchport
 {%     endif %}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Bot will manage tag, ownership and code review, you should not update these fields-->
## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Fixes #546 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

1. Implement new interface type for both `ethernet_interfaces` and `port_channels`:

```yaml
ethernet_interfaces:
  Ethernet1:
    description: to WAN-ISP1-01 Ethernet2
    type: routed
  Ethernet1.101:
    description: to WAN-ISP-01 Ethernet2.101 - VRF-C1
    type: l3dot1q
    encapsulation:
      dot1q:
        vlan: 101

port_channel_interfaces:
  Port-Channel8:
    description: to Dev02 Port-channel 8
    type: routed
  Port-Channel8.101:
    description: to Dev02 Port-Channel8.101 - VRF-C1
    type: l3dot1q
    encapsulation:
      dot1q:
        vlan: 101
```


## How to test

Molecule for `arista.avd.eos_cli_config_gen`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
