### PR TITLE
fix(eos_cli_config_gen): Adapt OSPF summary_addresses to match guidelines

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
@@ -214,6 +214,15 @@ interface Vlan24
 | 400 | enabled | enabled | enabled | wait-for-bgp | enabled |
 | 500 | enabled | enabled (123) | disabled | 222 | enabled (456) |
 
+### Router OSPF route summary
+
+| Process ID | Prefix | Tag | Attribute Route Map | Not Advertised |
+|------------|--------|-----|---------------------|----------------|
+| 101 | 10.0.0.0/8 | - | - | - |
+| 101 | 20.0.0.0/8 | 10 | - | - |
+| 101 | 30.0.0.0/8 | - | RM-OSPF_SUMMARY | - |
+| 101 | 40.0.0.0/8 | - | - | True |
+
 ### OSPF Interfaces
 
 | Interface | Area | Cost | Point To Point |

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-ospf.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-ospf.yml
@@ -25,7 +25,7 @@ router_ospf:
       bfd_enable: false
       no_passive_interfaces:
         - Ethernet2.101
-      summary_address:
+      summary_addresses:
         - prefix: 10.0.0.0/8
         - prefix: 20.0.0.0/8
           tag: 10

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-ospf.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-ospf.j2
@@ -123,7 +123,7 @@
 {# Route Summary #}
 {%     set has.found = false %}
 {%     for process in router_ospf.process_ids %}
-{%         if router_ospf.process_ids[process].summary is arista.avd.defined %}
+{%         if router_ospf.process_ids[process].summary_addresses is arista.avd.defined %}
 {%             set has.found = true %}
 {%         endif %}
 {%     endfor %}
@@ -134,12 +134,12 @@
 | Process ID | Prefix | Tag | Attribute Route Map | Not Advertised |
 |------------|--------|-----|---------------------|----------------|
 {%         for process in router_ospf.process_ids | arista.avd.natural_sort %}
-{%             if router_ospf.process_ids[process].summary_address is arista.avd.defined %}
-{%                 for summary in router_ospf.process_ids[process].summary_address %}
-{%                     set summary_prefix = summary.prefix| arista.avd.default('-') %}
-{%                     set summary_tag = summary.tag | arista.avd.default('-') %}
-{%                     set summary_attribute_map = summary.attribute_map | arista.avd.default('-') %}
-{%                     set summary_not_advertise = summary.not_advertise | arista.avd.default('-') %}
+{%             if router_ospf.process_ids[process].summary_addresses is arista.avd.defined %}
+{%                 for summary_address in router_ospf.process_ids[process].summary_addresses %}
+{%                     set summary_prefix = summary_address.prefix| arista.avd.default('-') %}
+{%                     set summary_tag = summary_address.tag | arista.avd.default('-') %}
+{%                     set summary_attribute_map = summary_address.attribute_map | arista.avd.default('-') %}
+{%                     set summary_not_advertise = summary_address.not_advertise | arista.avd.default('-') %}
 | {{ process }} | {{ summary_prefix }} | {{ summary_tag }} | {{ summary_attribute_map }} | {{ summary_not_advertise }} |
 {%                 endfor %}
 {%             endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-ospf.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-ospf.j2
@@ -81,17 +81,17 @@ router ospf {{ process_id }}
 {%     if router_ospf.process_ids[process_id].mpls_ldp_sync_default is arista.avd.defined(true) %}
    mpls ldp sync default
 {%     endif %}
-{%     if router_ospf.process_ids[process_id].summary_address is arista.avd.defined %}
-{%         for summary in router_ospf.process_ids[process_id].summary_address %}
-{%             if summary.prefix is arista.avd.defined %}
-{%                 if summary.tag is arista.avd.defined %}
-   summary-address {{ summary.prefix }} tag {{ summary.tag }}
-{%                 elif summary.attribute_map is arista.avd.defined %}
-   summary-address {{ summary.prefix }} attribute-map {{ summary.attribute_map }}
-{%                 elif summary.not_advertise is arista.avd.defined(true) %}
-   summary-address {{ summary.prefix }} not-advertise
+{%     if router_ospf.process_ids[process_id].summary_addresses is arista.avd.defined %}
+{%         for summary_address in router_ospf.process_ids[process_id].summary_addresses %}
+{%             if summary_address.prefix is arista.avd.defined %}
+{%                 if summary_address.tag is arista.avd.defined %}
+   summary-address {{ summary_address.prefix }} tag {{ summary_address.tag }}
+{%                 elif summary_address.attribute_map is arista.avd.defined %}
+   summary-address {{ summary_address.prefix }} attribute-map {{ summary_address.attribute_map }}
+{%                 elif summary_address.not_advertise is arista.avd.defined(true) %}
+   summary-address {{ summary_address.prefix }} not-advertise
 {%                 else %}
-   summary-address {{ summary.prefix }}
+   summary-address {{ summary_address.prefix }}
 {%                 endif %}
 {%             endif %}
 {%         endfor %}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Update data model to use plural for `summary_addresses`

```yaml
router_ospf:
  process_ids:
    101:
      summary_addresses:
        - prefix: 10.0.0.0/8
        - prefix: 20.0.0.0/8
          tag: 10
        - prefix: 30.0.0.0/8
          attribute_map: RM-OSPF_SUMMARY
        - prefix: 40.0.0.0/8
          not_advertise: true
```

## How to test

See molecule

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
