### PR TITLE
refactor router_bgp vrf address-families

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-v4-evpn.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-v4-evpn.md
@@ -282,8 +282,6 @@ router bgp 65101
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.3
-      network 10.0.0.0/8
-      network 100.64.0.0/10
       neighbor 10.2.3.4 remote-as 1234
       neighbor 10.2.3.4 local-as 123 no-prepend replace-as
       neighbor 10.2.3.4 description Tenant A BGP Peer
@@ -292,11 +290,14 @@ router bgp 65101
       neighbor 10.2.3.4 maximum-routes 0
       neighbor 10.2.3.4 default-originate route-map RM-10.2.3.4-SET-NEXT-HOP-OUT always
       neighbor 10.2.3.4 route-map RM-10.2.3.4-SET-NEXT-HOP-OUT out
-      address-family ipv4
-         neighbor 10.2.3.4 activate
       neighbor 10.255.251.1 peer group MLAG-IPv4-UNDERLAY-PEER
       redistribute connected
       redistribute static
+      !
+      address-family ipv4
+         neighbor 10.2.3.4 activate
+         network 10.0.0.0/8
+         network 100.64.0.0/10 route-map RM-10.2.3.4
    !
    vrf TENANT_A_PROJECT02
       rd 192.168.255.3:12

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-v4-evpn.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-v4-evpn.md
@@ -282,6 +282,8 @@ router bgp 65101
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.3
+      network 10.0.0.0/8
+      network 100.64.0.0/10
       neighbor 10.2.3.4 remote-as 1234
       neighbor 10.2.3.4 local-as 123 no-prepend replace-as
       neighbor 10.2.3.4 description Tenant A BGP Peer

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-v4-evpn.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-v4-evpn.cfg
@@ -89,8 +89,6 @@ router bgp 65101
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.3
-      network 10.0.0.0/8
-      network 100.64.0.0/10
       neighbor 10.2.3.4 remote-as 1234
       neighbor 10.2.3.4 local-as 123 no-prepend replace-as
       neighbor 10.2.3.4 description Tenant A BGP Peer
@@ -99,11 +97,14 @@ router bgp 65101
       neighbor 10.2.3.4 maximum-routes 0
       neighbor 10.2.3.4 default-originate route-map RM-10.2.3.4-SET-NEXT-HOP-OUT always
       neighbor 10.2.3.4 route-map RM-10.2.3.4-SET-NEXT-HOP-OUT out
-      address-family ipv4
-         neighbor 10.2.3.4 activate
       neighbor 10.255.251.1 peer group MLAG-IPv4-UNDERLAY-PEER
       redistribute connected
       redistribute static
+      !
+      address-family ipv4
+         neighbor 10.2.3.4 activate
+         network 10.0.0.0/8
+         network 100.64.0.0/10 route-map RM-10.2.3.4
    !
    vrf TENANT_A_PROJECT02
       rd 192.168.255.3:12

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-v4-evpn.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-v4-evpn.cfg
@@ -89,6 +89,8 @@ router bgp 65101
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.3
+      network 10.0.0.0/8
+      network 100.64.0.0/10
       neighbor 10.2.3.4 remote-as 1234
       neighbor 10.2.3.4 local-as 123 no-prepend replace-as
       neighbor 10.2.3.4 description Tenant A BGP Peer

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-v4-evpn.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-v4-evpn.yml
@@ -113,6 +113,9 @@ router_bgp:
     TENANT_A_PROJECT01:
       router_id: 192.168.255.3
       rd: "192.168.255.3:11"
+      networks:
+        10.0.0.0/8:
+        100.64.0.0/10:
       route_targets:
         import:
           evpn:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-v4-evpn.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-v4-evpn.yml
@@ -113,9 +113,6 @@ router_bgp:
     TENANT_A_PROJECT01:
       router_id: 192.168.255.3
       rd: "192.168.255.3:11"
-      networks:
-        10.0.0.0/8:
-        100.64.0.0/10:
       route_targets:
         import:
           evpn:
@@ -137,8 +134,15 @@ router_bgp:
             always: true
             route_map: RM-10.2.3.4-SET-NEXT-HOP-OUT
           route_map_out: RM-10.2.3.4-SET-NEXT-HOP-OUT
-          address_family:
-            - ipv4
+      address_families:
+        ipv4:
+          neighbors:
+            10.2.3.4:
+              activate: true
+          networks:
+            10.0.0.0/8:
+            100.64.0.0/10:
+              route_map: RM-10.2.3.4
       redistribute_routes:
         - connected
         - static

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1A.yml
@@ -470,6 +470,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_B_WAN_Zone:
       router_id: 192.168.255.10
       rd: 192.168.255.10:21
@@ -485,6 +486,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_C_WAN_Zone:
       router_id: 192.168.255.10
       rd: 192.168.255.10:31
@@ -500,6 +502,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
 ip_extcommunity_lists: null
 router_ospf: null
 router_isis: null

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1B.yml
@@ -470,6 +470,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_B_WAN_Zone:
       router_id: 192.168.255.11
       rd: 192.168.255.11:21
@@ -485,6 +486,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_C_WAN_Zone:
       router_id: 192.168.255.11
       rd: 192.168.255.11:31
@@ -500,6 +502,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
 ip_extcommunity_lists: null
 router_ospf: null
 router_isis: null

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF1A.yml
@@ -372,6 +372,7 @@ router_bgp:
           - '12:12'
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_WEB_Zone:
       router_id: 192.168.255.5
       rd: 192.168.255.5:11
@@ -384,6 +385,7 @@ router_bgp:
           - '11:11'
       redistribute_routes:
       - connected
+      address_families: null
 ip_extcommunity_lists: null
 router_ospf: null
 router_isis: null

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2A.yml
@@ -751,6 +751,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_DB_Zone:
       router_id: 192.168.255.6
       rd: 192.168.255.6:13
@@ -766,6 +767,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_OP_Zone:
       router_id: 192.168.255.6
       rd: 192.168.255.6:10
@@ -781,6 +783,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_WEB_Zone:
       router_id: 192.168.255.6
       rd: 192.168.255.6:11
@@ -796,6 +799,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_B_OP_Zone:
       router_id: 192.168.255.6
       rd: 192.168.255.6:20
@@ -811,6 +815,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_C_OP_Zone:
       router_id: 192.168.255.6
       rd: 192.168.255.6:30
@@ -826,6 +831,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
 ip_extcommunity_lists: null
 router_ospf: null
 router_isis: null

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2B.yml
@@ -751,6 +751,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_DB_Zone:
       router_id: 192.168.255.7
       rd: 192.168.255.7:13
@@ -766,6 +767,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_OP_Zone:
       router_id: 192.168.255.7
       rd: 192.168.255.7:10
@@ -781,6 +783,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_WEB_Zone:
       router_id: 192.168.255.7
       rd: 192.168.255.7:11
@@ -796,6 +799,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_B_OP_Zone:
       router_id: 192.168.255.7
       rd: 192.168.255.7:20
@@ -811,6 +815,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_C_OP_Zone:
       router_id: 192.168.255.7
       rd: 192.168.255.7:30
@@ -826,6 +831,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
 ip_extcommunity_lists: null
 router_ospf: null
 router_isis: null

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3A.yml
@@ -888,6 +888,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_DB_Zone:
       router_id: 192.168.255.8
       rd: 192.168.255.8:13
@@ -903,6 +904,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_OP_Zone:
       router_id: 192.168.255.8
       rd: 192.168.255.8:10
@@ -918,6 +920,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_WAN_Zone:
       router_id: 192.168.255.8
       rd: 192.168.255.8:14
@@ -933,6 +936,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_WEB_Zone:
       router_id: 192.168.255.8
       rd: 192.168.255.8:11
@@ -948,6 +952,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_B_OP_Zone:
       router_id: 192.168.255.8
       rd: 192.168.255.8:20
@@ -963,6 +968,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_B_WAN_Zone:
       router_id: 192.168.255.8
       rd: 192.168.255.8:21
@@ -978,6 +984,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_C_OP_Zone:
       router_id: 192.168.255.8
       rd: 192.168.255.8:30
@@ -993,6 +1000,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_C_WAN_Zone:
       router_id: 192.168.255.8
       rd: 192.168.255.8:31
@@ -1008,6 +1016,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
 ip_extcommunity_lists: null
 router_ospf: null
 router_isis: null

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3B.yml
@@ -868,6 +868,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_DB_Zone:
       router_id: 192.168.255.9
       rd: 192.168.255.9:13
@@ -883,6 +884,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_OP_Zone:
       router_id: 192.168.255.9
       rd: 192.168.255.9:10
@@ -898,6 +900,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_WAN_Zone:
       router_id: 192.168.255.9
       rd: 192.168.255.9:14
@@ -913,6 +916,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_WEB_Zone:
       router_id: 192.168.255.9
       rd: 192.168.255.9:11
@@ -928,6 +932,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_B_OP_Zone:
       router_id: 192.168.255.9
       rd: 192.168.255.9:20
@@ -943,6 +948,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_B_WAN_Zone:
       router_id: 192.168.255.9
       rd: 192.168.255.9:21
@@ -958,6 +964,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_C_OP_Zone:
       router_id: 192.168.255.9
       rd: 192.168.255.9:30
@@ -973,6 +980,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_C_WAN_Zone:
       router_id: 192.168.255.9
       rd: 192.168.255.9:31
@@ -988,6 +996,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
 ip_extcommunity_lists: null
 router_ospf: null
 router_isis: null

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/intended/structured_configs/DC1-BL1A.yml
@@ -470,6 +470,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_B_WAN_Zone:
       router_id: 192.168.255.10
       rd: 192.168.255.10:21
@@ -485,6 +486,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_C_WAN_Zone:
       router_id: 192.168.255.10
       rd: 192.168.255.10:31
@@ -500,6 +502,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
 ip_extcommunity_lists: null
 router_ospf: null
 router_isis: null

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/intended/structured_configs/DC1-BL1B.yml
@@ -470,6 +470,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_B_WAN_Zone:
       router_id: 192.168.255.11
       rd: 192.168.255.11:21
@@ -485,6 +486,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_C_WAN_Zone:
       router_id: 192.168.255.11
       rd: 192.168.255.11:31
@@ -500,6 +502,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
 ip_extcommunity_lists: null
 router_ospf: null
 router_isis: null

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/intended/structured_configs/DC1-LEAF1A.yml
@@ -372,6 +372,7 @@ router_bgp:
           - '12:12'
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_WEB_Zone:
       router_id: 192.168.255.5
       rd: 192.168.255.5:11
@@ -384,6 +385,7 @@ router_bgp:
           - '11:11'
       redistribute_routes:
       - connected
+      address_families: null
 ip_extcommunity_lists: null
 router_ospf: null
 router_isis: null

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/intended/structured_configs/DC1-LEAF2A.yml
@@ -751,6 +751,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_DB_Zone:
       router_id: 192.168.255.6
       rd: 192.168.255.6:13
@@ -766,6 +767,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_OP_Zone:
       router_id: 192.168.255.6
       rd: 192.168.255.6:10
@@ -781,6 +783,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_WEB_Zone:
       router_id: 192.168.255.6
       rd: 192.168.255.6:11
@@ -796,6 +799,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_B_OP_Zone:
       router_id: 192.168.255.6
       rd: 192.168.255.6:20
@@ -811,6 +815,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_C_OP_Zone:
       router_id: 192.168.255.6
       rd: 192.168.255.6:30
@@ -826,6 +831,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
 ip_extcommunity_lists: null
 router_ospf: null
 router_isis: null

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/intended/structured_configs/DC1-LEAF2B.yml
@@ -751,6 +751,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_DB_Zone:
       router_id: 192.168.255.7
       rd: 192.168.255.7:13
@@ -766,6 +767,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_OP_Zone:
       router_id: 192.168.255.7
       rd: 192.168.255.7:10
@@ -781,6 +783,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_WEB_Zone:
       router_id: 192.168.255.7
       rd: 192.168.255.7:11
@@ -796,6 +799,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_B_OP_Zone:
       router_id: 192.168.255.7
       rd: 192.168.255.7:20
@@ -811,6 +815,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_C_OP_Zone:
       router_id: 192.168.255.7
       rd: 192.168.255.7:30
@@ -826,6 +831,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
 ip_extcommunity_lists: null
 router_ospf: null
 router_isis: null

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/intended/structured_configs/DC1-SVC3A.yml
@@ -888,6 +888,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_DB_Zone:
       router_id: 192.168.255.8
       rd: 192.168.255.8:13
@@ -903,6 +904,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_OP_Zone:
       router_id: 192.168.255.8
       rd: 192.168.255.8:10
@@ -918,6 +920,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_WAN_Zone:
       router_id: 192.168.255.8
       rd: 192.168.255.8:14
@@ -933,6 +936,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_WEB_Zone:
       router_id: 192.168.255.8
       rd: 192.168.255.8:11
@@ -948,6 +952,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_B_OP_Zone:
       router_id: 192.168.255.8
       rd: 192.168.255.8:20
@@ -963,6 +968,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_B_WAN_Zone:
       router_id: 192.168.255.8
       rd: 192.168.255.8:21
@@ -978,6 +984,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_C_OP_Zone:
       router_id: 192.168.255.8
       rd: 192.168.255.8:30
@@ -993,6 +1000,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_C_WAN_Zone:
       router_id: 192.168.255.8
       rd: 192.168.255.8:31
@@ -1008,6 +1016,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
 ip_extcommunity_lists: null
 router_ospf: null
 router_isis: null

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/intended/structured_configs/DC1-SVC3B.yml
@@ -868,6 +868,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_DB_Zone:
       router_id: 192.168.255.9
       rd: 192.168.255.9:13
@@ -883,6 +884,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_OP_Zone:
       router_id: 192.168.255.9
       rd: 192.168.255.9:10
@@ -898,6 +900,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_WAN_Zone:
       router_id: 192.168.255.9
       rd: 192.168.255.9:14
@@ -913,6 +916,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_WEB_Zone:
       router_id: 192.168.255.9
       rd: 192.168.255.9:11
@@ -928,6 +932,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_B_OP_Zone:
       router_id: 192.168.255.9
       rd: 192.168.255.9:20
@@ -943,6 +948,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_B_WAN_Zone:
       router_id: 192.168.255.9
       rd: 192.168.255.9:21
@@ -958,6 +964,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_C_OP_Zone:
       router_id: 192.168.255.9
       rd: 192.168.255.9:30
@@ -973,6 +980,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_C_WAN_Zone:
       router_id: 192.168.255.9
       rd: 192.168.255.9:31
@@ -988,6 +996,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
 ip_extcommunity_lists: null
 router_ospf: null
 router_isis: null

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2A.yml
@@ -469,6 +469,7 @@ router_bgp:
           - 1025:1025
       redistribute_routes:
       - connected
+      address_families: null
 ip_extcommunity_lists: null
 router_ospf: null
 router_isis: null

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
@@ -473,6 +473,7 @@ router_bgp:
           - 1025:1025
       redistribute_routes:
       - connected
+      address_families: null
 ip_extcommunity_lists: null
 router_ospf: null
 router_isis: null

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-LEAF1A.yml
@@ -326,6 +326,7 @@ router_bgp:
           - 1025:1025
       redistribute_routes:
       - connected
+      address_families: null
 ip_extcommunity_lists: null
 router_ospf: null
 router_isis: null

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF1A.yml
@@ -292,6 +292,7 @@ router_bgp:
           - 1025:1025
       redistribute_routes:
       - connected
+      address_families: null
 ip_extcommunity_lists: null
 router_ospf: null
 router_isis: null

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/documentation/devices/DC1-BL1A.md
@@ -651,18 +651,19 @@ router bgp 65104
       neighbor 123.1.1.10 default-originate
       neighbor 123.1.1.10 update-source Loopback123
       neighbor 123.1.1.10 route-map RM-Tenant_A_WAN_Zone-123.1.1.10-SET-NEXT-HOP-OUT out
-      address-family ipv4
-         neighbor 123.1.1.10 activate
       neighbor fd5a:fe45:8831:06c5::a remote-as 12345
       neighbor fd5a:fe45:8831:06c5::a send-community
       neighbor fd5a:fe45:8831:06c5::a route-map RM-Tenant_A_WAN_Zone-fd5a:fe45:8831:06c5::a-SET-NEXT-HOP-OUT out
-      address-family ipv6
-         neighbor fd5a:fe45:8831:06c5::a activate
       neighbor fd5a:fe45:8831:06c5::b remote-as 12345
-      address-family ipv6
-         neighbor fd5a:fe45:8831:06c5::b activate
       redistribute connected
       redistribute static
+      !
+      address-family ipv4
+         neighbor 123.1.1.10 activate
+      !
+      address-family ipv6
+         neighbor fd5a:fe45:8831:06c5::a activate
+         neighbor fd5a:fe45:8831:06c5::b activate
    !
    vrf Tenant_B_WAN_Zone
       rd 192.168.255.10:21

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/documentation/devices/DC1-BL1B.md
@@ -651,18 +651,19 @@ router bgp 65105
       neighbor 123.1.1.10 default-originate
       neighbor 123.1.1.10 update-source Loopback123
       neighbor 123.1.1.10 route-map RM-Tenant_A_WAN_Zone-123.1.1.10-SET-NEXT-HOP-OUT out
-      address-family ipv4
-         neighbor 123.1.1.10 activate
       neighbor fd5a:fe45:8831:06c5::a remote-as 12345
       neighbor fd5a:fe45:8831:06c5::a send-community
       neighbor fd5a:fe45:8831:06c5::a route-map RM-Tenant_A_WAN_Zone-fd5a:fe45:8831:06c5::a-SET-NEXT-HOP-OUT out
-      address-family ipv6
-         neighbor fd5a:fe45:8831:06c5::a activate
       neighbor fd5a:fe45:8831:06c5::b remote-as 12345
-      address-family ipv6
-         neighbor fd5a:fe45:8831:06c5::b activate
       redistribute connected
       redistribute static
+      !
+      address-family ipv4
+         neighbor 123.1.1.10 activate
+      !
+      address-family ipv6
+         neighbor fd5a:fe45:8831:06c5::a activate
+         neighbor fd5a:fe45:8831:06c5::b activate
    !
    vrf Tenant_B_WAN_Zone
       rd 192.168.255.11:21

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/configs/DC1-BL1A.cfg
@@ -232,18 +232,19 @@ router bgp 65104
       neighbor 123.1.1.10 default-originate
       neighbor 123.1.1.10 update-source Loopback123
       neighbor 123.1.1.10 route-map RM-Tenant_A_WAN_Zone-123.1.1.10-SET-NEXT-HOP-OUT out
-      address-family ipv4
-         neighbor 123.1.1.10 activate
       neighbor fd5a:fe45:8831:06c5::a remote-as 12345
       neighbor fd5a:fe45:8831:06c5::a send-community
       neighbor fd5a:fe45:8831:06c5::a route-map RM-Tenant_A_WAN_Zone-fd5a:fe45:8831:06c5::a-SET-NEXT-HOP-OUT out
-      address-family ipv6
-         neighbor fd5a:fe45:8831:06c5::a activate
       neighbor fd5a:fe45:8831:06c5::b remote-as 12345
-      address-family ipv6
-         neighbor fd5a:fe45:8831:06c5::b activate
       redistribute connected
       redistribute static
+      !
+      address-family ipv4
+         neighbor 123.1.1.10 activate
+      !
+      address-family ipv6
+         neighbor fd5a:fe45:8831:06c5::a activate
+         neighbor fd5a:fe45:8831:06c5::b activate
    !
    vrf Tenant_B_WAN_Zone
       rd 192.168.255.10:21

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/configs/DC1-BL1B.cfg
@@ -232,18 +232,19 @@ router bgp 65105
       neighbor 123.1.1.10 default-originate
       neighbor 123.1.1.10 update-source Loopback123
       neighbor 123.1.1.10 route-map RM-Tenant_A_WAN_Zone-123.1.1.10-SET-NEXT-HOP-OUT out
-      address-family ipv4
-         neighbor 123.1.1.10 activate
       neighbor fd5a:fe45:8831:06c5::a remote-as 12345
       neighbor fd5a:fe45:8831:06c5::a send-community
       neighbor fd5a:fe45:8831:06c5::a route-map RM-Tenant_A_WAN_Zone-fd5a:fe45:8831:06c5::a-SET-NEXT-HOP-OUT out
-      address-family ipv6
-         neighbor fd5a:fe45:8831:06c5::a activate
       neighbor fd5a:fe45:8831:06c5::b remote-as 12345
-      address-family ipv6
-         neighbor fd5a:fe45:8831:06c5::b activate
       redistribute connected
       redistribute static
+      !
+      address-family ipv4
+         neighbor 123.1.1.10 activate
+      !
+      address-family ipv6
+         neighbor fd5a:fe45:8831:06c5::a activate
+         neighbor fd5a:fe45:8831:06c5::b activate
    !
    vrf Tenant_B_WAN_Zone
       rd 192.168.255.11:21

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-BL1A.yml
@@ -378,23 +378,28 @@ router_bgp:
             route_map_out: RM-Tenant_A_WAN_Zone-123.1.1.10-SET-NEXT-HOP-OUT
           update_source: Loopback123
           ebgp_multihop: 3
-          address_family:
-          - ipv4
           local_as: 123
           route_map_out: RM-Tenant_A_WAN_Zone-123.1.1.10-SET-NEXT-HOP-OUT
         fd5a:fe45:8831:06c5::a:
           remote_as: 12345
           send_community: all
-          address_family:
-          - ipv6
           route_map_out: RM-Tenant_A_WAN_Zone-fd5a:fe45:8831:06c5::a-SET-NEXT-HOP-OUT
         fd5a:fe45:8831:06c5::b:
           remote_as: 12345
-          address_family:
-          - ipv6
       redistribute_routes:
       - connected
       - static
+      address_families:
+        ipv4:
+          neighbors:
+            123.1.1.10:
+              activate: true
+        ipv6:
+          neighbors:
+            fd5a:fe45:8831:06c5::a:
+              activate: true
+            fd5a:fe45:8831:06c5::b:
+              activate: true
     Tenant_B_WAN_Zone:
       router_id: 192.168.255.10
       rd: 192.168.255.10:21
@@ -408,6 +413,7 @@ router_bgp:
       neighbors: null
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_C_WAN_Zone:
       router_id: 192.168.255.10
       rd: 192.168.255.10:31
@@ -421,6 +427,7 @@ router_bgp:
       neighbors: null
       redistribute_routes:
       - connected
+      address_families: null
 ip_extcommunity_lists: null
 router_ospf: null
 router_isis: null

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-BL1B.yml
@@ -378,23 +378,28 @@ router_bgp:
             route_map_out: RM-Tenant_A_WAN_Zone-123.1.1.10-SET-NEXT-HOP-OUT
           update_source: Loopback123
           ebgp_multihop: 3
-          address_family:
-          - ipv4
           local_as: 123
           route_map_out: RM-Tenant_A_WAN_Zone-123.1.1.10-SET-NEXT-HOP-OUT
         fd5a:fe45:8831:06c5::a:
           remote_as: 12345
           send_community: all
-          address_family:
-          - ipv6
           route_map_out: RM-Tenant_A_WAN_Zone-fd5a:fe45:8831:06c5::a-SET-NEXT-HOP-OUT
         fd5a:fe45:8831:06c5::b:
           remote_as: 12345
-          address_family:
-          - ipv6
       redistribute_routes:
       - connected
       - static
+      address_families:
+        ipv4:
+          neighbors:
+            123.1.1.10:
+              activate: true
+        ipv6:
+          neighbors:
+            fd5a:fe45:8831:06c5::a:
+              activate: true
+            fd5a:fe45:8831:06c5::b:
+              activate: true
     Tenant_B_WAN_Zone:
       router_id: 192.168.255.11
       rd: 192.168.255.11:21
@@ -408,6 +413,7 @@ router_bgp:
       neighbors: null
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_C_WAN_Zone:
       router_id: 192.168.255.11
       rd: 192.168.255.11:31
@@ -421,6 +427,7 @@ router_bgp:
       neighbors: null
       redistribute_routes:
       - connected
+      address_families: null
 ip_extcommunity_lists: null
 router_ospf: null
 router_isis: null

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-LEAF1A.yml
@@ -392,6 +392,7 @@ router_bgp:
           - '12:12'
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_WEB_Zone:
       router_id: 192.168.255.5
       rd: 192.168.255.5:11
@@ -404,6 +405,7 @@ router_bgp:
           - '11:11'
       redistribute_routes:
       - connected
+      address_families: null
 ip_extcommunity_lists: null
 router_ospf: null
 router_isis: null

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-LEAF2A.yml
@@ -785,6 +785,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_DB_Zone:
       router_id: 192.168.255.6
       rd: 192.168.255.6:13
@@ -800,6 +801,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_OP_Zone:
       router_id: 192.168.255.6
       rd: 192.168.255.6:10
@@ -815,6 +817,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_WEB_Zone:
       router_id: 192.168.255.6
       rd: 192.168.255.6:11
@@ -830,6 +833,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_B_OP_Zone:
       router_id: 192.168.255.6
       rd: 192.168.255.6:20
@@ -845,6 +849,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_C_OP_Zone:
       router_id: 192.168.255.6
       rd: 192.168.255.6:30
@@ -860,6 +865,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
 ip_extcommunity_lists: null
 router_ospf: null
 router_isis: null

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-LEAF2B.yml
@@ -785,6 +785,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_DB_Zone:
       router_id: 192.168.255.7
       rd: 192.168.255.7:13
@@ -800,6 +801,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_OP_Zone:
       router_id: 192.168.255.7
       rd: 192.168.255.7:10
@@ -815,6 +817,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_WEB_Zone:
       router_id: 192.168.255.7
       rd: 192.168.255.7:11
@@ -830,6 +833,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_B_OP_Zone:
       router_id: 192.168.255.7
       rd: 192.168.255.7:20
@@ -845,6 +849,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_C_OP_Zone:
       router_id: 192.168.255.7
       rd: 192.168.255.7:30
@@ -860,6 +865,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
 ip_extcommunity_lists: null
 router_ospf: null
 router_isis: null

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-SVC3A.yml
@@ -1128,6 +1128,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_DB_Zone:
       router_id: 192.168.255.8
       rd: 192.168.255.8:13
@@ -1143,6 +1144,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_OP_Zone:
       router_id: 192.168.255.8
       rd: 192.168.255.8:10
@@ -1158,6 +1160,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_WAN_Zone:
       router_id: 192.168.255.8
       rd: 192.168.255.8:14
@@ -1173,6 +1176,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_WEB_Zone:
       router_id: 192.168.255.8
       rd: 192.168.255.8:11
@@ -1188,6 +1192,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_B_OP_Zone:
       router_id: 192.168.255.8
       rd: 192.168.255.8:20
@@ -1203,6 +1208,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_B_WAN_Zone:
       router_id: 192.168.255.8
       rd: 192.168.255.8:21
@@ -1218,6 +1224,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_C_OP_Zone:
       router_id: 192.168.255.8
       rd: 192.168.255.8:30
@@ -1233,6 +1240,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_C_WAN_Zone:
       router_id: 192.168.255.8
       rd: 192.168.255.8:31
@@ -1248,6 +1256,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
 ip_extcommunity_lists: null
 router_ospf: null
 router_isis: null

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/intended/structured_configs/DC1-SVC3B.yml
@@ -1108,6 +1108,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_DB_Zone:
       router_id: 192.168.255.9
       rd: 192.168.255.9:13
@@ -1123,6 +1124,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_OP_Zone:
       router_id: 192.168.255.9
       rd: 192.168.255.9:10
@@ -1138,6 +1140,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_WAN_Zone:
       router_id: 192.168.255.9
       rd: 192.168.255.9:14
@@ -1153,6 +1156,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_WEB_Zone:
       router_id: 192.168.255.9
       rd: 192.168.255.9:11
@@ -1168,6 +1172,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_B_OP_Zone:
       router_id: 192.168.255.9
       rd: 192.168.255.9:20
@@ -1183,6 +1188,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_B_WAN_Zone:
       router_id: 192.168.255.9
       rd: 192.168.255.9:21
@@ -1198,6 +1204,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_C_OP_Zone:
       router_id: 192.168.255.9
       rd: 192.168.255.9:30
@@ -1213,6 +1220,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_C_WAN_Zone:
       router_id: 192.168.255.9
       rd: 192.168.255.9:31
@@ -1228,6 +1236,7 @@ router_bgp:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
       redistribute_routes:
       - connected
+      address_families: null
 ip_extcommunity_lists: null
 router_ospf: null
 router_isis: null

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/inventory/group_vars/DC1_TENANTS_NETWORKS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/inventory/group_vars/DC1_TENANTS_NETWORKS.yml
@@ -110,22 +110,16 @@ tenants:
               always: false
             update_source: Loopback123
             ebgp_multihop: 3
-            address_family:
-              - ipv4
             nodes: [DC1-BL1A, DC1-BL1B]
             set_ipv4_next_hop: 123.1.1.1
             local_as: 123
           fd5a:fe45:8831:06c5::a:
             remote_as: 12345
             send_community: all
-            address_family:
-              - ipv6
             nodes: [DC1-BL1A, DC1-BL1B]
             set_ipv6_next_hop: fd5a:fe45:8831:06c5::1
           fd5a:fe45:8831:06c5::b:
             remote_as: 12345
-            address_family:
-              - ipv6
             nodes: [DC1-BL1A, DC1-BL1B]
         svis:
           150:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -739,6 +739,7 @@ router bgp 65104
       neighbor 123.1.1.10 default-originate
       neighbor 123.1.1.10 update-source Loopback123
       neighbor 123.1.1.10 route-map RM-Tenant_A_WAN_Zone-123.1.1.10-SET-NEXT-HOP-OUT out
+      neighbor 123.1.1.10 route-map RM-123-1-1-10-OUT in
       neighbor fd5a:fe45:8831:06c5::a remote-as 12345
       neighbor fd5a:fe45:8831:06c5::a send-community
       neighbor fd5a:fe45:8831:06c5::a route-map RM-Tenant_A_WAN_Zone-fd5a:fe45:8831:06c5::a-SET-NEXT-HOP-OUT out

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -739,18 +739,19 @@ router bgp 65104
       neighbor 123.1.1.10 default-originate
       neighbor 123.1.1.10 update-source Loopback123
       neighbor 123.1.1.10 route-map RM-Tenant_A_WAN_Zone-123.1.1.10-SET-NEXT-HOP-OUT out
-      address-family ipv4
-         neighbor 123.1.1.10 activate
       neighbor fd5a:fe45:8831:06c5::a remote-as 12345
       neighbor fd5a:fe45:8831:06c5::a send-community
       neighbor fd5a:fe45:8831:06c5::a route-map RM-Tenant_A_WAN_Zone-fd5a:fe45:8831:06c5::a-SET-NEXT-HOP-OUT out
-      address-family ipv6
-         neighbor fd5a:fe45:8831:06c5::a activate
       neighbor fd5a:fe45:8831:06c5::b remote-as 12345
-      address-family ipv6
-         neighbor fd5a:fe45:8831:06c5::b activate
       redistribute connected
       redistribute static
+      !
+      address-family ipv4
+         neighbor 123.1.1.10 activate
+      !
+      address-family ipv6
+         neighbor fd5a:fe45:8831:06c5::a activate
+         neighbor fd5a:fe45:8831:06c5::b activate
    !
    vrf Tenant_B_OP_Zone
       rd 192.168.255.14:20

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -627,6 +627,7 @@ ip route vrf Tenant_A_WAN_Zone 10.3.4.0/24 1.2.3.4
 | 192.168.255.3 | 65001 | default |
 | 192.168.255.4 | 65001 | default |
 | 123.1.1.10 | 1234 | Tenant_A_WAN_Zone |
+| 123.1.1.11 | 1234 | Tenant_A_WAN_Zone |
 | fd5a:fe45:8831:06c5::a | 12345 | Tenant_A_WAN_Zone |
 | fd5a:fe45:8831:06c5::b | 12345 | Tenant_A_WAN_Zone |
 
@@ -739,7 +740,18 @@ router bgp 65104
       neighbor 123.1.1.10 default-originate
       neighbor 123.1.1.10 update-source Loopback123
       neighbor 123.1.1.10 route-map RM-Tenant_A_WAN_Zone-123.1.1.10-SET-NEXT-HOP-OUT out
-      neighbor 123.1.1.10 route-map RM-123-1-1-10-OUT in
+      neighbor 123.1.1.10 route-map RM-123-1-1-10-IN in
+      neighbor 123.1.1.11 remote-as 1234
+      neighbor 123.1.1.11 password 7 AQQvKeimxJu+uGQ/yYvv9w==
+      neighbor 123.1.1.11 local-as 123 no-prepend replace-as
+      neighbor 123.1.1.11 description External IPv4 BGP peer
+      neighbor 123.1.1.11 ebgp-multihop 3
+      neighbor 123.1.1.11 send-community standard extended
+      neighbor 123.1.1.11 maximum-routes 0
+      neighbor 123.1.1.11 default-originate
+      neighbor 123.1.1.11 update-source Loopback123
+      neighbor 123.1.1.11 route-map RM-123-1-1-11-OUT out
+      neighbor 123.1.1.11 route-map RM-123-1-1-11-IN in
       neighbor fd5a:fe45:8831:06c5::a remote-as 12345
       neighbor fd5a:fe45:8831:06c5::a send-community
       neighbor fd5a:fe45:8831:06c5::a route-map RM-Tenant_A_WAN_Zone-fd5a:fe45:8831:06c5::a-SET-NEXT-HOP-OUT out
@@ -749,6 +761,7 @@ router bgp 65104
       !
       address-family ipv4
          neighbor 123.1.1.10 activate
+         neighbor 123.1.1.11 activate
       !
       address-family ipv6
          neighbor fd5a:fe45:8831:06c5::a activate

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -627,6 +627,7 @@ ip route vrf Tenant_A_WAN_Zone 10.3.4.0/24 1.2.3.4
 | 192.168.255.3 | 65001 | default |
 | 192.168.255.4 | 65001 | default |
 | 123.1.1.10 | 1234 | Tenant_A_WAN_Zone |
+| 123.1.1.11 | 1234 | Tenant_A_WAN_Zone |
 | fd5a:fe45:8831:06c5::a | 12345 | Tenant_A_WAN_Zone |
 | fd5a:fe45:8831:06c5::b | 12345 | Tenant_A_WAN_Zone |
 
@@ -739,7 +740,18 @@ router bgp 65105
       neighbor 123.1.1.10 default-originate
       neighbor 123.1.1.10 update-source Loopback123
       neighbor 123.1.1.10 route-map RM-Tenant_A_WAN_Zone-123.1.1.10-SET-NEXT-HOP-OUT out
-      neighbor 123.1.1.10 route-map RM-123-1-1-10-OUT in
+      neighbor 123.1.1.10 route-map RM-123-1-1-10-IN in
+      neighbor 123.1.1.11 remote-as 1234
+      neighbor 123.1.1.11 password 7 AQQvKeimxJu+uGQ/yYvv9w==
+      neighbor 123.1.1.11 local-as 123 no-prepend replace-as
+      neighbor 123.1.1.11 description External IPv4 BGP peer
+      neighbor 123.1.1.11 ebgp-multihop 3
+      neighbor 123.1.1.11 send-community standard extended
+      neighbor 123.1.1.11 maximum-routes 0
+      neighbor 123.1.1.11 default-originate
+      neighbor 123.1.1.11 update-source Loopback123
+      neighbor 123.1.1.11 route-map RM-123-1-1-11-OUT out
+      neighbor 123.1.1.11 route-map RM-123-1-1-11-IN in
       neighbor fd5a:fe45:8831:06c5::a remote-as 12345
       neighbor fd5a:fe45:8831:06c5::a send-community
       neighbor fd5a:fe45:8831:06c5::a route-map RM-Tenant_A_WAN_Zone-fd5a:fe45:8831:06c5::a-SET-NEXT-HOP-OUT out
@@ -749,6 +761,7 @@ router bgp 65105
       !
       address-family ipv4
          neighbor 123.1.1.10 activate
+         neighbor 123.1.1.11 activate
       !
       address-family ipv6
          neighbor fd5a:fe45:8831:06c5::a activate

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -739,6 +739,7 @@ router bgp 65105
       neighbor 123.1.1.10 default-originate
       neighbor 123.1.1.10 update-source Loopback123
       neighbor 123.1.1.10 route-map RM-Tenant_A_WAN_Zone-123.1.1.10-SET-NEXT-HOP-OUT out
+      neighbor 123.1.1.10 route-map RM-123-1-1-10-OUT in
       neighbor fd5a:fe45:8831:06c5::a remote-as 12345
       neighbor fd5a:fe45:8831:06c5::a send-community
       neighbor fd5a:fe45:8831:06c5::a route-map RM-Tenant_A_WAN_Zone-fd5a:fe45:8831:06c5::a-SET-NEXT-HOP-OUT out

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -739,18 +739,19 @@ router bgp 65105
       neighbor 123.1.1.10 default-originate
       neighbor 123.1.1.10 update-source Loopback123
       neighbor 123.1.1.10 route-map RM-Tenant_A_WAN_Zone-123.1.1.10-SET-NEXT-HOP-OUT out
-      address-family ipv4
-         neighbor 123.1.1.10 activate
       neighbor fd5a:fe45:8831:06c5::a remote-as 12345
       neighbor fd5a:fe45:8831:06c5::a send-community
       neighbor fd5a:fe45:8831:06c5::a route-map RM-Tenant_A_WAN_Zone-fd5a:fe45:8831:06c5::a-SET-NEXT-HOP-OUT out
-      address-family ipv6
-         neighbor fd5a:fe45:8831:06c5::a activate
       neighbor fd5a:fe45:8831:06c5::b remote-as 12345
-      address-family ipv6
-         neighbor fd5a:fe45:8831:06c5::b activate
       redistribute connected
       redistribute static
+      !
+      address-family ipv4
+         neighbor 123.1.1.10 activate
+      !
+      address-family ipv6
+         neighbor fd5a:fe45:8831:06c5::a activate
+         neighbor fd5a:fe45:8831:06c5::b activate
    !
    vrf Tenant_B_OP_Zone
       rd 192.168.255.15:20

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1A.cfg
@@ -282,6 +282,7 @@ router bgp 65104
       neighbor 123.1.1.10 default-originate
       neighbor 123.1.1.10 update-source Loopback123
       neighbor 123.1.1.10 route-map RM-Tenant_A_WAN_Zone-123.1.1.10-SET-NEXT-HOP-OUT out
+      neighbor 123.1.1.10 route-map RM-123-1-1-10-OUT in
       neighbor fd5a:fe45:8831:06c5::a remote-as 12345
       neighbor fd5a:fe45:8831:06c5::a send-community
       neighbor fd5a:fe45:8831:06c5::a route-map RM-Tenant_A_WAN_Zone-fd5a:fe45:8831:06c5::a-SET-NEXT-HOP-OUT out

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1A.cfg
@@ -282,18 +282,19 @@ router bgp 65104
       neighbor 123.1.1.10 default-originate
       neighbor 123.1.1.10 update-source Loopback123
       neighbor 123.1.1.10 route-map RM-Tenant_A_WAN_Zone-123.1.1.10-SET-NEXT-HOP-OUT out
-      address-family ipv4
-         neighbor 123.1.1.10 activate
       neighbor fd5a:fe45:8831:06c5::a remote-as 12345
       neighbor fd5a:fe45:8831:06c5::a send-community
       neighbor fd5a:fe45:8831:06c5::a route-map RM-Tenant_A_WAN_Zone-fd5a:fe45:8831:06c5::a-SET-NEXT-HOP-OUT out
-      address-family ipv6
-         neighbor fd5a:fe45:8831:06c5::a activate
       neighbor fd5a:fe45:8831:06c5::b remote-as 12345
-      address-family ipv6
-         neighbor fd5a:fe45:8831:06c5::b activate
       redistribute connected
       redistribute static
+      !
+      address-family ipv4
+         neighbor 123.1.1.10 activate
+      !
+      address-family ipv6
+         neighbor fd5a:fe45:8831:06c5::a activate
+         neighbor fd5a:fe45:8831:06c5::b activate
    !
    vrf Tenant_B_OP_Zone
       rd 192.168.255.14:20

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1A.cfg
@@ -282,7 +282,18 @@ router bgp 65104
       neighbor 123.1.1.10 default-originate
       neighbor 123.1.1.10 update-source Loopback123
       neighbor 123.1.1.10 route-map RM-Tenant_A_WAN_Zone-123.1.1.10-SET-NEXT-HOP-OUT out
-      neighbor 123.1.1.10 route-map RM-123-1-1-10-OUT in
+      neighbor 123.1.1.10 route-map RM-123-1-1-10-IN in
+      neighbor 123.1.1.11 remote-as 1234
+      neighbor 123.1.1.11 password 7 AQQvKeimxJu+uGQ/yYvv9w==
+      neighbor 123.1.1.11 local-as 123 no-prepend replace-as
+      neighbor 123.1.1.11 description External IPv4 BGP peer
+      neighbor 123.1.1.11 ebgp-multihop 3
+      neighbor 123.1.1.11 send-community standard extended
+      neighbor 123.1.1.11 maximum-routes 0
+      neighbor 123.1.1.11 default-originate
+      neighbor 123.1.1.11 update-source Loopback123
+      neighbor 123.1.1.11 route-map RM-123-1-1-11-OUT out
+      neighbor 123.1.1.11 route-map RM-123-1-1-11-IN in
       neighbor fd5a:fe45:8831:06c5::a remote-as 12345
       neighbor fd5a:fe45:8831:06c5::a send-community
       neighbor fd5a:fe45:8831:06c5::a route-map RM-Tenant_A_WAN_Zone-fd5a:fe45:8831:06c5::a-SET-NEXT-HOP-OUT out
@@ -292,6 +303,7 @@ router bgp 65104
       !
       address-family ipv4
          neighbor 123.1.1.10 activate
+         neighbor 123.1.1.11 activate
       !
       address-family ipv6
          neighbor fd5a:fe45:8831:06c5::a activate

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1B.cfg
@@ -282,18 +282,19 @@ router bgp 65105
       neighbor 123.1.1.10 default-originate
       neighbor 123.1.1.10 update-source Loopback123
       neighbor 123.1.1.10 route-map RM-Tenant_A_WAN_Zone-123.1.1.10-SET-NEXT-HOP-OUT out
-      address-family ipv4
-         neighbor 123.1.1.10 activate
       neighbor fd5a:fe45:8831:06c5::a remote-as 12345
       neighbor fd5a:fe45:8831:06c5::a send-community
       neighbor fd5a:fe45:8831:06c5::a route-map RM-Tenant_A_WAN_Zone-fd5a:fe45:8831:06c5::a-SET-NEXT-HOP-OUT out
-      address-family ipv6
-         neighbor fd5a:fe45:8831:06c5::a activate
       neighbor fd5a:fe45:8831:06c5::b remote-as 12345
-      address-family ipv6
-         neighbor fd5a:fe45:8831:06c5::b activate
       redistribute connected
       redistribute static
+      !
+      address-family ipv4
+         neighbor 123.1.1.10 activate
+      !
+      address-family ipv6
+         neighbor fd5a:fe45:8831:06c5::a activate
+         neighbor fd5a:fe45:8831:06c5::b activate
    !
    vrf Tenant_B_OP_Zone
       rd 192.168.255.15:20

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1B.cfg
@@ -282,6 +282,7 @@ router bgp 65105
       neighbor 123.1.1.10 default-originate
       neighbor 123.1.1.10 update-source Loopback123
       neighbor 123.1.1.10 route-map RM-Tenant_A_WAN_Zone-123.1.1.10-SET-NEXT-HOP-OUT out
+      neighbor 123.1.1.10 route-map RM-123-1-1-10-OUT in
       neighbor fd5a:fe45:8831:06c5::a remote-as 12345
       neighbor fd5a:fe45:8831:06c5::a send-community
       neighbor fd5a:fe45:8831:06c5::a route-map RM-Tenant_A_WAN_Zone-fd5a:fe45:8831:06c5::a-SET-NEXT-HOP-OUT out

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1B.cfg
@@ -282,7 +282,18 @@ router bgp 65105
       neighbor 123.1.1.10 default-originate
       neighbor 123.1.1.10 update-source Loopback123
       neighbor 123.1.1.10 route-map RM-Tenant_A_WAN_Zone-123.1.1.10-SET-NEXT-HOP-OUT out
-      neighbor 123.1.1.10 route-map RM-123-1-1-10-OUT in
+      neighbor 123.1.1.10 route-map RM-123-1-1-10-IN in
+      neighbor 123.1.1.11 remote-as 1234
+      neighbor 123.1.1.11 password 7 AQQvKeimxJu+uGQ/yYvv9w==
+      neighbor 123.1.1.11 local-as 123 no-prepend replace-as
+      neighbor 123.1.1.11 description External IPv4 BGP peer
+      neighbor 123.1.1.11 ebgp-multihop 3
+      neighbor 123.1.1.11 send-community standard extended
+      neighbor 123.1.1.11 maximum-routes 0
+      neighbor 123.1.1.11 default-originate
+      neighbor 123.1.1.11 update-source Loopback123
+      neighbor 123.1.1.11 route-map RM-123-1-1-11-OUT out
+      neighbor 123.1.1.11 route-map RM-123-1-1-11-IN in
       neighbor fd5a:fe45:8831:06c5::a remote-as 12345
       neighbor fd5a:fe45:8831:06c5::a send-community
       neighbor fd5a:fe45:8831:06c5::a route-map RM-Tenant_A_WAN_Zone-fd5a:fe45:8831:06c5::a-SET-NEXT-HOP-OUT out
@@ -292,6 +303,7 @@ router bgp 65105
       !
       address-family ipv4
          neighbor 123.1.1.10 activate
+         neighbor 123.1.1.11 activate
       !
       address-family ipv6
          neighbor fd5a:fe45:8831:06c5::a activate

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
@@ -449,6 +449,17 @@ router_bgp:
       redistribute_routes:
       - connected
       - static
+      address_families:
+        ipv4:
+          neighbors:
+            123.1.1.10:
+              activate: true
+        ipv6:
+          neighbors:
+            fd5a:fe45:8831:06c5::a:
+              activate: true
+            fd5a:fe45:8831:06c5::b:
+              activate: true
     Tenant_L3_VRF_Zone:
       router_id: 192.168.255.14
       rd: 192.168.255.14:15
@@ -462,6 +473,7 @@ router_bgp:
       neighbors: null
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_B_OP_Zone:
       router_id: 192.168.255.14
       rd: 192.168.255.14:20

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
@@ -438,9 +438,22 @@ router_bgp:
             route_map_out: RM-Tenant_A_WAN_Zone-123.1.1.10-SET-NEXT-HOP-OUT
           update_source: Loopback123
           ebgp_multihop: 3
-          route_map_in: RM-123-1-1-10-OUT
-          local_as: 123
+          route_map_in: RM-123-1-1-10-IN
           route_map_out: RM-Tenant_A_WAN_Zone-123.1.1.10-SET-NEXT-HOP-OUT
+          local_as: 123
+        123.1.1.11:
+          remote_as: 1234
+          password: AQQvKeimxJu+uGQ/yYvv9w==
+          description: External IPv4 BGP peer
+          send_community: standard extended
+          maximum_routes: 0
+          default_originate:
+            always: false
+          update_source: Loopback123
+          ebgp_multihop: 3
+          route_map_in: RM-123-1-1-11-IN
+          route_map_out: RM-123-1-1-11-OUT
+          local_as: 123
         fd5a:fe45:8831:06c5::a:
           remote_as: 12345
           send_community: all
@@ -454,6 +467,8 @@ router_bgp:
         ipv4:
           neighbors:
             123.1.1.10:
+              activate: true
+            123.1.1.11:
               activate: true
         ipv6:
           neighbors:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
@@ -438,6 +438,7 @@ router_bgp:
             route_map_out: RM-Tenant_A_WAN_Zone-123.1.1.10-SET-NEXT-HOP-OUT
           update_source: Loopback123
           ebgp_multihop: 3
+          route_map_in: RM-123-1-1-10-OUT
           local_as: 123
           route_map_out: RM-Tenant_A_WAN_Zone-123.1.1.10-SET-NEXT-HOP-OUT
         fd5a:fe45:8831:06c5::a:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
@@ -438,20 +438,14 @@ router_bgp:
             route_map_out: RM-Tenant_A_WAN_Zone-123.1.1.10-SET-NEXT-HOP-OUT
           update_source: Loopback123
           ebgp_multihop: 3
-          address_family:
-          - ipv4
           local_as: 123
           route_map_out: RM-Tenant_A_WAN_Zone-123.1.1.10-SET-NEXT-HOP-OUT
         fd5a:fe45:8831:06c5::a:
           remote_as: 12345
           send_community: all
-          address_family:
-          - ipv6
           route_map_out: RM-Tenant_A_WAN_Zone-fd5a:fe45:8831:06c5::a-SET-NEXT-HOP-OUT
         fd5a:fe45:8831:06c5::b:
           remote_as: 12345
-          address_family:
-          - ipv6
       redistribute_routes:
       - connected
       - static
@@ -481,6 +475,7 @@ router_bgp:
       neighbors: null
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_B_WAN_Zone:
       router_id: 192.168.255.14
       rd: 192.168.255.14:21
@@ -494,6 +489,7 @@ router_bgp:
       neighbors: null
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_C_WAN_Zone:
       router_id: 192.168.255.14
       rd: 192.168.255.14:31
@@ -507,6 +503,7 @@ router_bgp:
       neighbors: null
       redistribute_routes:
       - connected
+      address_families: null
 ip_extcommunity_lists: null
 router_ospf: null
 router_isis: null

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
@@ -438,9 +438,22 @@ router_bgp:
             route_map_out: RM-Tenant_A_WAN_Zone-123.1.1.10-SET-NEXT-HOP-OUT
           update_source: Loopback123
           ebgp_multihop: 3
-          route_map_in: RM-123-1-1-10-OUT
-          local_as: 123
+          route_map_in: RM-123-1-1-10-IN
           route_map_out: RM-Tenant_A_WAN_Zone-123.1.1.10-SET-NEXT-HOP-OUT
+          local_as: 123
+        123.1.1.11:
+          remote_as: 1234
+          password: AQQvKeimxJu+uGQ/yYvv9w==
+          description: External IPv4 BGP peer
+          send_community: standard extended
+          maximum_routes: 0
+          default_originate:
+            always: false
+          update_source: Loopback123
+          ebgp_multihop: 3
+          route_map_in: RM-123-1-1-11-IN
+          route_map_out: RM-123-1-1-11-OUT
+          local_as: 123
         fd5a:fe45:8831:06c5::a:
           remote_as: 12345
           send_community: all
@@ -454,6 +467,8 @@ router_bgp:
         ipv4:
           neighbors:
             123.1.1.10:
+              activate: true
+            123.1.1.11:
               activate: true
         ipv6:
           neighbors:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
@@ -449,6 +449,17 @@ router_bgp:
       redistribute_routes:
       - connected
       - static
+      address_families:
+        ipv4:
+          neighbors:
+            123.1.1.10:
+              activate: true
+        ipv6:
+          neighbors:
+            fd5a:fe45:8831:06c5::a:
+              activate: true
+            fd5a:fe45:8831:06c5::b:
+              activate: true
     Tenant_L3_VRF_Zone:
       router_id: 192.168.255.15
       rd: 192.168.255.15:15
@@ -462,6 +473,7 @@ router_bgp:
       neighbors: null
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_B_OP_Zone:
       router_id: 192.168.255.15
       rd: 192.168.255.15:20

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
@@ -438,6 +438,7 @@ router_bgp:
             route_map_out: RM-Tenant_A_WAN_Zone-123.1.1.10-SET-NEXT-HOP-OUT
           update_source: Loopback123
           ebgp_multihop: 3
+          route_map_in: RM-123-1-1-10-OUT
           local_as: 123
           route_map_out: RM-Tenant_A_WAN_Zone-123.1.1.10-SET-NEXT-HOP-OUT
         fd5a:fe45:8831:06c5::a:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
@@ -438,20 +438,14 @@ router_bgp:
             route_map_out: RM-Tenant_A_WAN_Zone-123.1.1.10-SET-NEXT-HOP-OUT
           update_source: Loopback123
           ebgp_multihop: 3
-          address_family:
-          - ipv4
           local_as: 123
           route_map_out: RM-Tenant_A_WAN_Zone-123.1.1.10-SET-NEXT-HOP-OUT
         fd5a:fe45:8831:06c5::a:
           remote_as: 12345
           send_community: all
-          address_family:
-          - ipv6
           route_map_out: RM-Tenant_A_WAN_Zone-fd5a:fe45:8831:06c5::a-SET-NEXT-HOP-OUT
         fd5a:fe45:8831:06c5::b:
           remote_as: 12345
-          address_family:
-          - ipv6
       redistribute_routes:
       - connected
       - static
@@ -481,6 +475,7 @@ router_bgp:
       neighbors: null
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_B_WAN_Zone:
       router_id: 192.168.255.15
       rd: 192.168.255.15:21
@@ -494,6 +489,7 @@ router_bgp:
       neighbors: null
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_C_WAN_Zone:
       router_id: 192.168.255.15
       rd: 192.168.255.15:31
@@ -507,6 +503,7 @@ router_bgp:
       neighbors: null
       redistribute_routes:
       - connected
+      address_families: null
 ip_extcommunity_lists: null
 router_ospf: null
 router_isis: null

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
@@ -396,6 +396,7 @@ router_bgp:
           - '12:12'
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_WEB_Zone:
       router_id: 192.168.255.9
       rd: 192.168.255.9:11
@@ -408,6 +409,7 @@ router_bgp:
           - '11:11'
       redistribute_routes:
       - connected
+      address_families: null
 ip_extcommunity_lists: null
 router_ospf: null
 router_isis: null

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -844,6 +844,7 @@ router_bgp:
           peer_group: MLAG-PEERS
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_DB_Zone:
       router_id: 192.168.255.10
       rd: 192.168.255.10:13
@@ -859,6 +860,7 @@ router_bgp:
           peer_group: MLAG-PEERS
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_OP_Zone:
       router_id: 192.168.255.10
       rd: 192.168.255.10:10
@@ -874,6 +876,7 @@ router_bgp:
           peer_group: MLAG-PEERS
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_WEB_Zone:
       router_id: 192.168.255.10
       rd: 192.168.255.10:11
@@ -889,6 +892,7 @@ router_bgp:
           peer_group: MLAG-PEERS
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_B_OP_Zone:
       router_id: 192.168.255.10
       rd: 192.168.255.10:20
@@ -904,6 +908,7 @@ router_bgp:
           peer_group: MLAG-PEERS
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_C_OP_Zone:
       router_id: 192.168.255.10
       rd: 192.168.255.10:30
@@ -919,6 +924,7 @@ router_bgp:
           peer_group: MLAG-PEERS
       redistribute_routes:
       - connected
+      address_families: null
 ip_extcommunity_lists: null
 router_ospf: null
 router_isis: null

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -844,6 +844,7 @@ router_bgp:
           peer_group: MLAG-PEERS
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_DB_Zone:
       router_id: 192.168.255.11
       rd: 192.168.255.11:13
@@ -859,6 +860,7 @@ router_bgp:
           peer_group: MLAG-PEERS
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_OP_Zone:
       router_id: 192.168.255.11
       rd: 192.168.255.11:10
@@ -874,6 +876,7 @@ router_bgp:
           peer_group: MLAG-PEERS
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_WEB_Zone:
       router_id: 192.168.255.11
       rd: 192.168.255.11:11
@@ -889,6 +892,7 @@ router_bgp:
           peer_group: MLAG-PEERS
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_B_OP_Zone:
       router_id: 192.168.255.11
       rd: 192.168.255.11:20
@@ -904,6 +908,7 @@ router_bgp:
           peer_group: MLAG-PEERS
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_C_OP_Zone:
       router_id: 192.168.255.11
       rd: 192.168.255.11:30
@@ -919,6 +924,7 @@ router_bgp:
           peer_group: MLAG-PEERS
       redistribute_routes:
       - connected
+      address_families: null
 ip_extcommunity_lists: null
 router_ospf: null
 router_isis: null

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -1247,6 +1247,7 @@ router_bgp:
           peer_group: MLAG-PEERS
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_DB_Zone:
       router_id: 192.168.255.12
       rd: 192.168.255.12:13
@@ -1262,6 +1263,7 @@ router_bgp:
           peer_group: MLAG-PEERS
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_OP_Zone:
       router_id: 192.168.255.12
       rd: 192.168.255.12:10
@@ -1277,6 +1279,7 @@ router_bgp:
           peer_group: MLAG-PEERS
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_WAN_Zone:
       router_id: 192.168.255.12
       rd: 192.168.255.12:14
@@ -1294,6 +1297,7 @@ router_bgp:
           peer_group: MLAG-PEERS
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_WEB_Zone:
       router_id: 192.168.255.12
       rd: 192.168.255.12:11
@@ -1309,6 +1313,7 @@ router_bgp:
           peer_group: MLAG-PEERS
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_B_OP_Zone:
       router_id: 192.168.255.12
       rd: 192.168.255.12:20
@@ -1324,6 +1329,7 @@ router_bgp:
           peer_group: MLAG-PEERS
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_B_WAN_Zone:
       router_id: 192.168.255.12
       rd: 192.168.255.12:21
@@ -1339,6 +1345,7 @@ router_bgp:
           peer_group: MLAG-PEERS
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_C_OP_Zone:
       router_id: 192.168.255.12
       rd: 192.168.255.12:30
@@ -1354,6 +1361,7 @@ router_bgp:
           peer_group: MLAG-PEERS
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_C_WAN_Zone:
       router_id: 192.168.255.12
       rd: 192.168.255.12:31
@@ -1369,6 +1377,7 @@ router_bgp:
           peer_group: MLAG-PEERS
       redistribute_routes:
       - connected
+      address_families: null
 ip_extcommunity_lists: null
 router_ospf: null
 router_isis: null

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -1227,6 +1227,7 @@ router_bgp:
           peer_group: MLAG-PEERS
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_DB_Zone:
       router_id: 192.168.255.13
       rd: 192.168.255.13:13
@@ -1242,6 +1243,7 @@ router_bgp:
           peer_group: MLAG-PEERS
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_OP_Zone:
       router_id: 192.168.255.13
       rd: 192.168.255.13:10
@@ -1257,6 +1259,7 @@ router_bgp:
           peer_group: MLAG-PEERS
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_WAN_Zone:
       router_id: 192.168.255.13
       rd: 192.168.255.13:14
@@ -1274,6 +1277,7 @@ router_bgp:
           peer_group: MLAG-PEERS
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_WEB_Zone:
       router_id: 192.168.255.13
       rd: 192.168.255.13:11
@@ -1289,6 +1293,7 @@ router_bgp:
           peer_group: MLAG-PEERS
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_B_OP_Zone:
       router_id: 192.168.255.13
       rd: 192.168.255.13:20
@@ -1304,6 +1309,7 @@ router_bgp:
           peer_group: MLAG-PEERS
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_B_WAN_Zone:
       router_id: 192.168.255.13
       rd: 192.168.255.13:21
@@ -1319,6 +1325,7 @@ router_bgp:
           peer_group: MLAG-PEERS
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_C_OP_Zone:
       router_id: 192.168.255.13
       rd: 192.168.255.13:30
@@ -1334,6 +1341,7 @@ router_bgp:
           peer_group: MLAG-PEERS
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_C_WAN_Zone:
       router_id: 192.168.255.13
       rd: 192.168.255.13:31
@@ -1349,6 +1357,7 @@ router_bgp:
           peer_group: MLAG-PEERS
       redistribute_routes:
       - connected
+      address_families: null
 ip_extcommunity_lists: null
 router_ospf: null
 router_isis: null

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_TENANTS_NETWORKS.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_TENANTS_NETWORKS.yml
@@ -124,22 +124,16 @@ tenants:
               always: false
             update_source: Loopback123
             ebgp_multihop: 3
-            address_family:
-              - ipv4
             nodes: [DC1-BL1A, DC1-BL1B]
             set_ipv4_next_hop: 123.1.1.1
             local_as: 123
           fd5a:fe45:8831:06c5::a:
             remote_as: 12345
             send_community: all
-            address_family:
-              - ipv6
             nodes: [DC1-BL1A, DC1-BL1B]
             set_ipv6_next_hop: fd5a:fe45:8831:06c5::1
           fd5a:fe45:8831:06c5::b:
             remote_as: 12345
-            address_family:
-              - ipv6
             nodes: [DC1-BL1A, DC1-BL1B]
         svis:
           150:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_TENANTS_NETWORKS.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_TENANTS_NETWORKS.yml
@@ -126,6 +126,8 @@ tenants:
             ebgp_multihop: 3
             nodes: [DC1-BL1A, DC1-BL1B]
             set_ipv4_next_hop: 123.1.1.1
+            route_map_in: RM-123-1-1-10-IN
+            route_map_in: RM-123-1-1-10-OUT
             local_as: 123
           fd5a:fe45:8831:06c5::a:
             remote_as: 12345

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_TENANTS_NETWORKS.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_TENANTS_NETWORKS.yml
@@ -127,7 +127,22 @@ tenants:
             nodes: [DC1-BL1A, DC1-BL1B]
             set_ipv4_next_hop: 123.1.1.1
             route_map_in: RM-123-1-1-10-IN
-            route_map_in: RM-123-1-1-10-OUT
+            # we don't expect this in the output, next_hop takes precedence
+            route_map_out: RM-123-1-1-10-OUT
+            local_as: 123
+          123.1.1.11:
+            remote_as: 1234
+            password: "AQQvKeimxJu+uGQ/yYvv9w=="
+            description: External IPv4 BGP peer
+            send_community: standard extended
+            maximum_routes: 0
+            default_originate:
+              always: false
+            update_source: Loopback123
+            ebgp_multihop: 3
+            nodes: [DC1-BL1A, DC1-BL1B]
+            route_map_in: RM-123-1-1-11-IN
+            route_map_out: RM-123-1-1-11-OUT
             local_as: 123
           fd5a:fe45:8831:06c5::a:
             remote_as: 12345

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -685,18 +685,19 @@ router bgp 65104
       neighbor 123.1.1.10 default-originate
       neighbor 123.1.1.10 update-source Loopback123
       neighbor 123.1.1.10 route-map RM-Tenant_A_WAN_Zone-123.1.1.10-SET-NEXT-HOP-OUT out
-      address-family ipv4
-         neighbor 123.1.1.10 activate
       neighbor fd5a:fe45:8831:06c5::a remote-as 12345
       neighbor fd5a:fe45:8831:06c5::a send-community None
       neighbor fd5a:fe45:8831:06c5::a route-map RM-Tenant_A_WAN_Zone-fd5a:fe45:8831:06c5::a-SET-NEXT-HOP-OUT out
-      address-family ipv6
-         neighbor fd5a:fe45:8831:06c5::a activate
       neighbor fd5a:fe45:8831:06c5::b remote-as 12345
-      address-family ipv6
-         neighbor fd5a:fe45:8831:06c5::b activate
       redistribute connected
       redistribute static
+      !
+      address-family ipv4
+         neighbor 123.1.1.10 activate
+      !
+      address-family ipv6
+         neighbor fd5a:fe45:8831:06c5::a activate
+         neighbor fd5a:fe45:8831:06c5::b activate
    !
    vrf Tenant_B_WAN_Zone
       rd 192.168.255.10:21

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -666,18 +666,19 @@ router bgp 65105
       neighbor 123.1.1.10 default-originate
       neighbor 123.1.1.10 update-source Loopback123
       neighbor 123.1.1.10 route-map RM-Tenant_A_WAN_Zone-123.1.1.10-SET-NEXT-HOP-OUT out
-      address-family ipv4
-         neighbor 123.1.1.10 activate
       neighbor fd5a:fe45:8831:06c5::a remote-as 12345
       neighbor fd5a:fe45:8831:06c5::a send-community None
       neighbor fd5a:fe45:8831:06c5::a route-map RM-Tenant_A_WAN_Zone-fd5a:fe45:8831:06c5::a-SET-NEXT-HOP-OUT out
-      address-family ipv6
-         neighbor fd5a:fe45:8831:06c5::a activate
       neighbor fd5a:fe45:8831:06c5::b remote-as 12345
-      address-family ipv6
-         neighbor fd5a:fe45:8831:06c5::b activate
       redistribute connected
       redistribute static
+      !
+      address-family ipv4
+         neighbor 123.1.1.10 activate
+      !
+      address-family ipv6
+         neighbor fd5a:fe45:8831:06c5::a activate
+         neighbor fd5a:fe45:8831:06c5::b activate
    !
    vrf Tenant_B_WAN_Zone
       rd 192.168.255.11:21

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-BL1A.cfg
@@ -233,18 +233,19 @@ router bgp 65104
       neighbor 123.1.1.10 default-originate
       neighbor 123.1.1.10 update-source Loopback123
       neighbor 123.1.1.10 route-map RM-Tenant_A_WAN_Zone-123.1.1.10-SET-NEXT-HOP-OUT out
-      address-family ipv4
-         neighbor 123.1.1.10 activate
       neighbor fd5a:fe45:8831:06c5::a remote-as 12345
       neighbor fd5a:fe45:8831:06c5::a send-community None
       neighbor fd5a:fe45:8831:06c5::a route-map RM-Tenant_A_WAN_Zone-fd5a:fe45:8831:06c5::a-SET-NEXT-HOP-OUT out
-      address-family ipv6
-         neighbor fd5a:fe45:8831:06c5::a activate
       neighbor fd5a:fe45:8831:06c5::b remote-as 12345
-      address-family ipv6
-         neighbor fd5a:fe45:8831:06c5::b activate
       redistribute connected
       redistribute static
+      !
+      address-family ipv4
+         neighbor 123.1.1.10 activate
+      !
+      address-family ipv6
+         neighbor fd5a:fe45:8831:06c5::a activate
+         neighbor fd5a:fe45:8831:06c5::b activate
    !
    vrf Tenant_B_WAN_Zone
       rd 192.168.255.10:21

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-BL1B.cfg
@@ -233,18 +233,19 @@ router bgp 65105
       neighbor 123.1.1.10 default-originate
       neighbor 123.1.1.10 update-source Loopback123
       neighbor 123.1.1.10 route-map RM-Tenant_A_WAN_Zone-123.1.1.10-SET-NEXT-HOP-OUT out
-      address-family ipv4
-         neighbor 123.1.1.10 activate
       neighbor fd5a:fe45:8831:06c5::a remote-as 12345
       neighbor fd5a:fe45:8831:06c5::a send-community None
       neighbor fd5a:fe45:8831:06c5::a route-map RM-Tenant_A_WAN_Zone-fd5a:fe45:8831:06c5::a-SET-NEXT-HOP-OUT out
-      address-family ipv6
-         neighbor fd5a:fe45:8831:06c5::a activate
       neighbor fd5a:fe45:8831:06c5::b remote-as 12345
-      address-family ipv6
-         neighbor fd5a:fe45:8831:06c5::b activate
       redistribute connected
       redistribute static
+      !
+      address-family ipv4
+         neighbor 123.1.1.10 activate
+      !
+      address-family ipv6
+         neighbor fd5a:fe45:8831:06c5::a activate
+         neighbor fd5a:fe45:8831:06c5::b activate
    !
    vrf Tenant_B_WAN_Zone
       rd 192.168.255.11:21

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
@@ -384,23 +384,28 @@ router_bgp:
             route_map_out: RM-Tenant_A_WAN_Zone-123.1.1.10-SET-NEXT-HOP-OUT
           update_source: Loopback123
           ebgp_multihop: 3
-          address_family:
-          - ipv4
           local_as: 123
           route_map_out: RM-Tenant_A_WAN_Zone-123.1.1.10-SET-NEXT-HOP-OUT
         fd5a:fe45:8831:06c5::a:
           remote_as: 12345
           send_community: None
-          address_family:
-          - ipv6
           route_map_out: RM-Tenant_A_WAN_Zone-fd5a:fe45:8831:06c5::a-SET-NEXT-HOP-OUT
         fd5a:fe45:8831:06c5::b:
           remote_as: 12345
-          address_family:
-          - ipv6
       redistribute_routes:
       - connected
       - static
+      address_families:
+        ipv4:
+          neighbors:
+            123.1.1.10:
+              activate: true
+        ipv6:
+          neighbors:
+            fd5a:fe45:8831:06c5::a:
+              activate: true
+            fd5a:fe45:8831:06c5::b:
+              activate: true
     Tenant_B_WAN_Zone:
       router_id: 192.168.255.10
       rd: 192.168.255.10:21
@@ -414,6 +419,7 @@ router_bgp:
       neighbors: null
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_C_WAN_Zone:
       router_id: 192.168.255.10
       rd: 192.168.255.10:31
@@ -427,6 +433,7 @@ router_bgp:
       neighbors: null
       redistribute_routes:
       - connected
+      address_families: null
 ip_extcommunity_lists: null
 router_ospf: null
 router_isis: null

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
@@ -384,23 +384,28 @@ router_bgp:
             route_map_out: RM-Tenant_A_WAN_Zone-123.1.1.10-SET-NEXT-HOP-OUT
           update_source: Loopback123
           ebgp_multihop: 3
-          address_family:
-          - ipv4
           local_as: 123
           route_map_out: RM-Tenant_A_WAN_Zone-123.1.1.10-SET-NEXT-HOP-OUT
         fd5a:fe45:8831:06c5::a:
           remote_as: 12345
           send_community: None
-          address_family:
-          - ipv6
           route_map_out: RM-Tenant_A_WAN_Zone-fd5a:fe45:8831:06c5::a-SET-NEXT-HOP-OUT
         fd5a:fe45:8831:06c5::b:
           remote_as: 12345
-          address_family:
-          - ipv6
       redistribute_routes:
       - connected
       - static
+      address_families:
+        ipv4:
+          neighbors:
+            123.1.1.10:
+              activate: true
+        ipv6:
+          neighbors:
+            fd5a:fe45:8831:06c5::a:
+              activate: true
+            fd5a:fe45:8831:06c5::b:
+              activate: true
     Tenant_B_WAN_Zone:
       router_id: 192.168.255.11
       rd: 192.168.255.11:21
@@ -414,6 +419,7 @@ router_bgp:
       neighbors: null
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_C_WAN_Zone:
       router_id: 192.168.255.11
       rd: 192.168.255.11:31
@@ -427,6 +433,7 @@ router_bgp:
       neighbors: null
       redistribute_routes:
       - connected
+      address_families: null
 ip_extcommunity_lists: null
 router_ospf: null
 router_isis: null

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
@@ -398,6 +398,7 @@ router_bgp:
           - '12:12'
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_WEB_Zone:
       router_id: 192.168.255.5
       rd: 192.168.255.5:11
@@ -410,6 +411,7 @@ router_bgp:
           - '11:11'
       redistribute_routes:
       - connected
+      address_families: null
 ip_extcommunity_lists: null
 router_ospf: null
 router_isis: null

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -835,6 +835,7 @@ router_bgp:
           peer_group: MLAG_PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_DB_Zone:
       router_id: 192.168.255.6
       rd: 192.168.255.6:13
@@ -850,6 +851,7 @@ router_bgp:
           peer_group: MLAG_PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_OP_Zone:
       router_id: 192.168.255.6
       rd: 192.168.255.6:10
@@ -865,6 +867,7 @@ router_bgp:
           peer_group: MLAG_PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_WEB_Zone:
       router_id: 192.168.255.6
       rd: 192.168.255.6:11
@@ -880,6 +883,7 @@ router_bgp:
           peer_group: MLAG_PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_B_OP_Zone:
       router_id: 192.168.255.6
       rd: 192.168.255.6:20
@@ -895,6 +899,7 @@ router_bgp:
           peer_group: MLAG_PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_C_OP_Zone:
       router_id: 192.168.255.6
       rd: 192.168.255.6:30
@@ -910,6 +915,7 @@ router_bgp:
           peer_group: MLAG_PEER
       redistribute_routes:
       - connected
+      address_families: null
 ip_extcommunity_lists: null
 router_ospf: null
 router_isis: null

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -835,6 +835,7 @@ router_bgp:
           peer_group: MLAG_PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_DB_Zone:
       router_id: 192.168.255.7
       rd: 192.168.255.7:13
@@ -850,6 +851,7 @@ router_bgp:
           peer_group: MLAG_PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_OP_Zone:
       router_id: 192.168.255.7
       rd: 192.168.255.7:10
@@ -865,6 +867,7 @@ router_bgp:
           peer_group: MLAG_PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_WEB_Zone:
       router_id: 192.168.255.7
       rd: 192.168.255.7:11
@@ -880,6 +883,7 @@ router_bgp:
           peer_group: MLAG_PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_B_OP_Zone:
       router_id: 192.168.255.7
       rd: 192.168.255.7:20
@@ -895,6 +899,7 @@ router_bgp:
           peer_group: MLAG_PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_C_OP_Zone:
       router_id: 192.168.255.7
       rd: 192.168.255.7:30
@@ -910,6 +915,7 @@ router_bgp:
           peer_group: MLAG_PEER
       redistribute_routes:
       - connected
+      address_families: null
 ip_extcommunity_lists: null
 router_ospf: null
 router_isis: null

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -1135,6 +1135,7 @@ router_bgp:
           peer_group: MLAG_PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_DB_Zone:
       router_id: 192.168.255.8
       rd: 192.168.255.8:13
@@ -1150,6 +1151,7 @@ router_bgp:
           peer_group: MLAG_PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_OP_Zone:
       router_id: 192.168.255.8
       rd: 192.168.255.8:10
@@ -1165,6 +1167,7 @@ router_bgp:
           peer_group: MLAG_PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_WAN_Zone:
       router_id: 192.168.255.8
       rd: 192.168.255.8:14
@@ -1180,6 +1183,7 @@ router_bgp:
           peer_group: MLAG_PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_WEB_Zone:
       router_id: 192.168.255.8
       rd: 192.168.255.8:11
@@ -1195,6 +1199,7 @@ router_bgp:
           peer_group: MLAG_PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_B_OP_Zone:
       router_id: 192.168.255.8
       rd: 192.168.255.8:20
@@ -1210,6 +1215,7 @@ router_bgp:
           peer_group: MLAG_PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_B_WAN_Zone:
       router_id: 192.168.255.8
       rd: 192.168.255.8:21
@@ -1225,6 +1231,7 @@ router_bgp:
           peer_group: MLAG_PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_C_OP_Zone:
       router_id: 192.168.255.8
       rd: 192.168.255.8:30
@@ -1240,6 +1247,7 @@ router_bgp:
           peer_group: MLAG_PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_C_WAN_Zone:
       router_id: 192.168.255.8
       rd: 192.168.255.8:31
@@ -1255,6 +1263,7 @@ router_bgp:
           peer_group: MLAG_PEER
       redistribute_routes:
       - connected
+      address_families: null
 ip_extcommunity_lists: null
 router_ospf: null
 router_isis: null

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -1115,6 +1115,7 @@ router_bgp:
           peer_group: MLAG_PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_DB_Zone:
       router_id: 192.168.255.9
       rd: 192.168.255.9:13
@@ -1130,6 +1131,7 @@ router_bgp:
           peer_group: MLAG_PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_OP_Zone:
       router_id: 192.168.255.9
       rd: 192.168.255.9:10
@@ -1145,6 +1147,7 @@ router_bgp:
           peer_group: MLAG_PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_WAN_Zone:
       router_id: 192.168.255.9
       rd: 192.168.255.9:14
@@ -1160,6 +1163,7 @@ router_bgp:
           peer_group: MLAG_PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_A_WEB_Zone:
       router_id: 192.168.255.9
       rd: 192.168.255.9:11
@@ -1175,6 +1179,7 @@ router_bgp:
           peer_group: MLAG_PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_B_OP_Zone:
       router_id: 192.168.255.9
       rd: 192.168.255.9:20
@@ -1190,6 +1195,7 @@ router_bgp:
           peer_group: MLAG_PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_B_WAN_Zone:
       router_id: 192.168.255.9
       rd: 192.168.255.9:21
@@ -1205,6 +1211,7 @@ router_bgp:
           peer_group: MLAG_PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_C_OP_Zone:
       router_id: 192.168.255.9
       rd: 192.168.255.9:30
@@ -1220,6 +1227,7 @@ router_bgp:
           peer_group: MLAG_PEER
       redistribute_routes:
       - connected
+      address_families: null
     Tenant_C_WAN_Zone:
       router_id: 192.168.255.9
       rd: 192.168.255.9:31
@@ -1235,6 +1243,7 @@ router_bgp:
           peer_group: MLAG_PEER
       redistribute_routes:
       - connected
+      address_families: null
 ip_extcommunity_lists: null
 router_ospf: null
 router_isis: null

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/inventory/group_vars/DC1_TENANTS_NETWORKS.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/inventory/group_vars/DC1_TENANTS_NETWORKS.yml
@@ -110,22 +110,16 @@ tenants:
               always: false
             update_source: Loopback123
             ebgp_multihop: 3
-            address_family:
-              - ipv4
             nodes: [DC1-BL1A, DC1-BL1B]
             set_ipv4_next_hop: 123.1.1.1
             local_as: 123
           fd5a:fe45:8831:06c5::a:
             remote_as: 12345
             send_community:
-            address_family:
-              - ipv6
             nodes: [DC1-BL1A, DC1-BL1B]
             set_ipv6_next_hop: fd5a:fe45:8831:06c5::1
           fd5a:fe45:8831:06c5::b:
             remote_as: 12345
-            address_family:
-              - ipv6
             nodes: [DC1-BL1A, DC1-BL1B]
         svis:
           150:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1807,7 +1807,6 @@ router_bgp:
           route_map: < route_map_name >
         < route_type >:
           route_map: < route_map_name >
-
       aggregate_addresses:
         < aggregate_address_1/mask >:
           advertise_only: < true | false >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1781,6 +1781,8 @@ router_bgp:
       neighbors:
         < neighbor_ip_address >:
           remote_as: < asn >
+          peer_group: < peer_group_name >
+          password: "< encrypted_password >"
           local_as: < asn >
           description: < description >
           ebgp_multihop: < integer >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1805,14 +1805,7 @@ router_bgp:
           route_map: < route_map_name >
         < route_type >:
           route_map: < route_map_name >
-      address_families:
-        < address_family >:
-          neighbors:
-            < neighbor_ip_address >:
-              activate: < true | false >
-        networks:
-          < prefix_address >:
-            route_map: < route_map_name >
+
       aggregate_addresses:
         < aggregate_address_1/mask >:
           advertise_only: < true | false >
@@ -1823,6 +1816,14 @@ router_bgp:
           attribute_map: < route_map_name >
           match_map: < route_map_name >
           advertise_only: < true | false >
+      address_families:
+        < address_family >:
+          neighbors:
+            < neighbor_ip_address >:
+              activate: < true | false >
+        networks:
+          < prefix_address >:
+            route_map: < route_map_name >
     < vrf_name_2 >:
       rd: "<route distinguisher >"
       route_targets:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1794,9 +1794,6 @@ router_bgp:
           update_source: < interface >
           route_map_out: < route-map name >
           route_map_in: < route-map name >
-          address_family:
-            - < address_family_1 >
-            - < address_family_2 >
         < neighbor_ip_address >:
           remote_as: < asn >
           description: < description >
@@ -1808,6 +1805,14 @@ router_bgp:
           route_map: < route_map_name >
         < route_type >:
           route_map: < route_map_name >
+      address_families:
+        < address_family >:
+          neighbors:
+            < neighbor_ip_address >:
+              activate: < true | false >
+        networks:
+          < prefix_address >:
+            route_map: < route_map_name >
       aggregate_addresses:
         < aggregate_address_1/mask >:
           advertise_only: < true | false >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -413,13 +413,6 @@ router bgp {{ router_bgp.as }}
 {%         if router_bgp.vrfs[vrf].timers is arista.avd.defined %}
       timers bgp {{ router_bgp.vrfs[vrf].timers }}
 {%         endif %}
-{%         for network in router_bgp.vrfs[vrf].networks | arista.avd.natural_sort %}
-{%             if router_bgp.vrfs[vrf].networks[network].route_map is arista.avd.defined %}
-      network {{ network }} route-map {{ router_bgp.vrfs[vrf].networks[network].route_map }}
-{%             else %}
-      network {{ network }}
-{%             endif %}
-{%         endfor %}
 {%         for neighbor in router_bgp.vrfs[vrf].neighbors | arista.avd.natural_sort %}
 {%             if router_bgp.vrfs[vrf].neighbors[neighbor].remote_as is arista.avd.defined %}
       neighbor {{ neighbor }} remote-as {{ router_bgp.vrfs[vrf].neighbors[neighbor].remote_as }}
@@ -476,12 +469,6 @@ router bgp {{ router_bgp.as }}
 {%             if router_bgp.vrfs[vrf].neighbors[neighbor].route_map_in is arista.avd.defined %}
       neighbor {{ neighbor }} route-map {{ router_bgp.vrfs[vrf].neighbors[neighbor].route_map_in }} in
 {%             endif %}
-{%             if router_bgp.vrfs[vrf].neighbors[neighbor].address_family is arista.avd.defined %}
-{%                 for family in router_bgp.vrfs[vrf].neighbors[neighbor].address_family %}
-      address-family {{ family }}
-         neighbor {{ neighbor }} activate
-{%                 endfor %}
-{%             endif %}
 {%         endfor %}
 {%         for redistribute_route in router_bgp.vrfs[vrf].redistribute_routes | arista.avd.natural_sort %}
 {%             set redistribute_cli = "redistribute " ~ redistribute_route %}
@@ -508,6 +495,24 @@ router bgp {{ router_bgp.as }}
 {%                 set aggregate_address_cli = aggregate_address_cli ~ " advertise-only" %}
 {%             endif %}
       {{ aggregate_address_cli }}
+{%         endfor %}
+{%         for  address_family in router_bgp.vrfs[vrf].address_families | arista.avd.natural_sort %}
+      !
+      address-family {{ address_family }}
+{%             for neighbor in router_bgp.vrfs[vrf].address_families[address_family].neighbors | arista.avd.natural_sort %}
+{%                 set neighbor_cli = "neighbor " ~ neighbor %}
+{%                 if router_bgp.vrfs[vrf].address_families[address_family].neighbors[neighbor].activate is arista.avd.defined(true) %}
+{%                     set neighbor_cli = neighbor_cli ~ " activate" %}
+{%                 endif %}
+         {{ neighbor_cli }}
+{%             endfor %}
+{%             for network in router_bgp.vrfs[vrf].address_families[address_family].networks | arista.avd.natural_sort %}
+{%                 set network_cli = "network " ~ network %}
+{%                 if router_bgp.vrfs[vrf].address_families[address_family].networks[network].route_map is arista.avd.defined %}
+{%                     set network_cli = network_cli ~ " route-map " ~ router_bgp.vrfs[vrf].address_families[address_family].networks[network].route_map %}
+{%                 endif %}
+         {{ network_cli }}
+{%             endfor %}
 {%         endfor %}
 {%     endfor %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -500,11 +500,9 @@ router bgp {{ router_bgp.as }}
       !
       address-family {{ address_family }}
 {%             for neighbor in router_bgp.vrfs[vrf].address_families[address_family].neighbors | arista.avd.natural_sort %}
-{%                 set neighbor_cli = "neighbor " ~ neighbor %}
 {%                 if router_bgp.vrfs[vrf].address_families[address_family].neighbors[neighbor].activate is arista.avd.defined(true) %}
-{%                     set neighbor_cli = neighbor_cli ~ " activate" %}
+         neighbor {{ neighbor }} activate
 {%                 endif %}
-         {{ neighbor_cli }}
 {%             endfor %}
 {%             for network in router_bgp.vrfs[vrf].address_families[address_family].networks | arista.avd.natural_sort %}
 {%                 set network_cli = "network " ~ network %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -413,6 +413,13 @@ router bgp {{ router_bgp.as }}
 {%         if router_bgp.vrfs[vrf].timers is arista.avd.defined %}
       timers bgp {{ router_bgp.vrfs[vrf].timers }}
 {%         endif %}
+{%         for network in router_bgp.vrfs[vrf].networks | arista.avd.natural_sort %}
+{%             if router_bgp.vrfs[vrf].networks[network].route_map is arista.avd.defined %}
+      network {{ network }} route-map {{ router_bgp.vrfs[vrf].networks[network].route_map }}
+{%             else %}
+      network {{ network }}
+{%             endif %}
+{%         endfor %}
 {%         for neighbor in router_bgp.vrfs[vrf].neighbors | arista.avd.natural_sort %}
 {%             if router_bgp.vrfs[vrf].neighbors[neighbor].remote_as is arista.avd.defined %}
       neighbor {{ neighbor }} remote-as {{ router_bgp.vrfs[vrf].neighbors[neighbor].remote_as }}

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/network-services.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/network-services.md
@@ -196,6 +196,9 @@ tenants:
 
         # Dictionary of BGP peer definitions | Optional.
         # This will configure BGP neighbors inside the tenant VRF for peering with external devices.
+        # The configured peer will automatically be activated for ipv4 or ipv6 address family based on the ip address.
+        # Note, only ipv4 and ipv6 address families are currently supported in eos_designs.
+        # For other address families, use custom_structured configuration with eos_cli_config_gen.
         bgp_peers:
           < IPv4_address or IPv6_address >:
             remote_as: < remote ASN >
@@ -208,8 +211,6 @@ tenants:
               always: < true | false >
             update_source: < interface >
             ebgp_multihop: < 1-255 >
-            address_family:
-              - < ipv4 | ipv6 >
             # Nodes is required to restrict configuration of BGP neighbors to certain nodes in the network.
             nodes: [ < node_1 >, < node_2> ]
             # Next hop settings can be either ipv4 or ipv6 for one neighbor, this will be applied by a uniquely generated route-map per neighbor.

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/network-services.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/network-services.md
@@ -214,6 +214,7 @@ tenants:
             # Nodes is required to restrict configuration of BGP neighbors to certain nodes in the network.
             nodes: [ < node_1 >, < node_2> ]
             # Next hop settings can be either ipv4 or ipv6 for one neighbor, this will be applied by a uniquely generated route-map per neighbor.
+            # Next hop takes precedence over route_map_out.
             set_ipv4_next_hop: < IPv4_address >
             set_ipv6_next_hop: < IPv6_address >
             route_map_out: < route-map name >

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/network-services.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/network-services.md
@@ -216,6 +216,8 @@ tenants:
             # Next hop settings can be either ipv4 or ipv6 for one neighbor, this will be applied by a uniquely generated route-map per neighbor.
             set_ipv4_next_hop: < IPv4_address >
             set_ipv6_next_hop: < IPv6_address >
+            route_map_out: < route-map name >
+            route_map_in: < route-map name >
             local_as: < local BGP ASN >
 
         # Optional configuration of extra route-targets for this VRF. Useful for route-leaking or gateway between address families.

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenant_evpn_vxlan/leaf-tenant-router-bgp-evpn-vrfs.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenant_evpn_vxlan/leaf-tenant-router-bgp-evpn-vrfs.j2
@@ -49,15 +49,11 @@
 {%                     if tenants[tenant].vrfs[vrf].bgp_peers[bgp_peer].nodes is arista.avd.defined %}
 {%                         if inventory_hostname in tenants[tenant].vrfs[vrf].bgp_peers[bgp_peer].nodes %}
 {%                             set neighbor_params = tenants[tenant].vrfs[vrf].bgp_peers[bgp_peer] %}
-{%                             if neighbor_params.address_family is arista.avd.defined %}
-{%                                 if "ipv4" in neighbor_params.address_family %}
-{%                                     do bgp_vrf.address_family_ipv4_neighbors.append( bgp_peer ) %}
-{%                                 endif %}
-{%                                 if "ipv6" in neighbor_params.address_family %}
-{%                                     do bgp_vrf.address_family_ipv6_neighbors.append( bgp_peer ) %}
-{%                                 endif %}
-{%                             else %}{# default address family ipv4 #}
+{%                             if bgp_peer | ipv4 %}
 {%                                 do bgp_vrf.address_family_ipv4_neighbors.append( bgp_peer ) %}
+{%                             endif %}
+{%                             if bgp_peer | ipv6 %}
+{%                                 do bgp_vrf.address_family_ipv6_neighbors.append( bgp_peer ) %}
 {%                             endif %}
 {%                             if neighbor_params.set_ipv4_next_hop is arista.avd.defined or neighbor_params.set_ipv6_next_hop is arista.avd.defined %}
 {%                                 do neighbor_params.update({ 'route_map_out':'RM-' ~ vrf ~ '-' ~ bgp_peer ~ '-SET-NEXT-HOP-OUT' }) %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenant_evpn_vxlan/leaf-tenant-router-bgp-evpn-vrfs.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenant_evpn_vxlan/leaf-tenant-router-bgp-evpn-vrfs.j2
@@ -95,7 +95,7 @@
 {%                 endif %}
 {%             endif %}
       address_families:
-{%             if bgp_vrf.address_family_ipv4_neighbors is arista.avd.defined and bgp_vrf.address_family_ipv4_neighbors | length %}
+{%             if bgp_vrf.address_family_ipv4_neighbors | length > 0 %}
         ipv4:
           neighbors:
 {%                 for ipv4_neighbor in bgp_vrf.address_family_ipv4_neighbors %}
@@ -103,7 +103,7 @@
               activate: true
 {%                 endfor %}
 {%             endif %}
-{%             if bgp_vrf.address_family_ipv6_neighbors is arista.avd.defined and bgp_vrf.address_family_ipv6_neighbors | length %}
+{%             if bgp_vrf.address_family_ipv6_neighbors | length > 0 %}
         ipv6:
           neighbors:
 {%                 for ipv6_neighbor in bgp_vrf.address_family_ipv6_neighbors %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenant_evpn_vxlan/leaf-tenant-router-bgp-evpn-vrfs.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenant_evpn_vxlan/leaf-tenant-router-bgp-evpn-vrfs.j2
@@ -1,8 +1,11 @@
 {# Leaf tenant router bgp evpn VRFs #}
+{% set bgp_vrf = namespace() %}
 {% for tenant in tenants | arista.avd.natural_sort if ( tenant in leaf.filter_tenants or "all" in leaf.filter_tenants ) and leaf.evpn_services_l2_only == false %}
 ## {{ tenant }} ##
 {%     if tenants[tenant].vrfs is defined %}
 {%         for vrf in tenants[tenant].vrfs | arista.avd.natural_sort if leaf.vrfs is not none and vrf in leaf.vrfs %}
+{%             set bgp_vrf.address_family_ipv4_neighbors = [] %}
+{%             set bgp_vrf.address_family_ipv6_neighbors = [] %}
 {%             set leaf_evpn_rt = (leaf.evpn_rt_admin_subfield or tenants[tenant].vrfs[vrf].vrf_vni) ~ ':' ~ tenants[tenant].vrfs[vrf].vrf_vni %}
 {%             set route_targets = namespace(import={'evpn' : [leaf_evpn_rt]},export={'evpn' : [leaf_evpn_rt]}) %}
 {%             for additional_route_target in tenants[tenant].vrfs[vrf].additional_route_targets | arista.avd.natural_sort %}
@@ -46,8 +49,15 @@
 {%                     if tenants[tenant].vrfs[vrf].bgp_peers[bgp_peer].nodes is arista.avd.defined %}
 {%                         if inventory_hostname in tenants[tenant].vrfs[vrf].bgp_peers[bgp_peer].nodes %}
 {%                             set neighbor_params = tenants[tenant].vrfs[vrf].bgp_peers[bgp_peer] %}
-{%                             if neighbor_params.address_family is not arista.avd.defined %}
-{%                                 do neighbor_params.update({'address_family': ['ipv4']}) %}
+{%                             if neighbor_params.address_family is arista.avd.defined %}
+{%                                 if "ipv4" in neighbor_params.address_family %}
+{%                                     do bgp_vrf.address_family_ipv4_neighbors.append( bgp_peer ) %}
+{%                                 endif %}
+{%                                 if "ipv6" in neighbor_params.address_family %}
+{%                                     do bgp_vrf.address_family_ipv6_neighbors.append( bgp_peer ) %}
+{%                                 endif %}
+{%                             else %}{# default address family ipv4 #}
+{%                                 do bgp_vrf.address_family_ipv4_neighbors.append( bgp_peer ) %}
 {%                             endif %}
 {%                             if neighbor_params.set_ipv4_next_hop is arista.avd.defined or neighbor_params.set_ipv6_next_hop is arista.avd.defined %}
 {%                                 do neighbor_params.update({ 'route_map_out':'RM-' ~ vrf ~ '-' ~ bgp_peer ~ '-SET-NEXT-HOP-OUT' }) %}
@@ -64,6 +74,7 @@
 {%                                 endif %}
 {%                             endif%}
 {%                             do neighbor_params.pop('nodes') %}
+{%                             do neighbor_params.pop('address_family') %}
         {{ bgp_peer }}:
           {{ neighbor_params }}
 {%                         endif %}
@@ -86,6 +97,23 @@
 {%                 elif tenants[tenant].vrfs[vrf].redistribute_static == true %}
         - static
 {%                 endif %}
+{%             endif %}
+      address_families:
+{%             if bgp_vrf.address_family_ipv4_neighbors is arista.avd.defined and bgp_vrf.address_family_ipv4_neighbors | length %}
+        ipv4:
+          neighbors:
+{%                 for ipv4_neighbor in bgp_vrf.address_family_ipv4_neighbors %}
+            {{ ipv4_neighbor }}:
+              activate: true
+{%                 endfor %}
+{%             endif %}
+{%             if bgp_vrf.address_family_ipv6_neighbors is arista.avd.defined and bgp_vrf.address_family_ipv6_neighbors | length %}
+        ipv6:
+          neighbors:
+{%                 for ipv6_neighbor in bgp_vrf.address_family_ipv6_neighbors %}
+            {{ ipv6_neighbor }}:
+              activate: true
+{%                 endfor %}
 {%             endif %}
 {%         endfor %}
 {%    endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenant_evpn_vxlan/leaf-tenant-router-bgp-evpn-vrfs.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenant_evpn_vxlan/leaf-tenant-router-bgp-evpn-vrfs.j2
@@ -70,7 +70,6 @@
 {%                                 endif %}
 {%                             endif%}
 {%                             do neighbor_params.pop('nodes') %}
-{%                             do neighbor_params.pop('address_family') %}
         {{ bgp_peer }}:
           {{ neighbor_params }}
 {%                         endif %}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Fixes #696 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

```yaml
## new data model ##
router_bgp:
  vrfs:
    < vrf_name_1 >:
      address_families:
        < address_family >:
          neighbors:
            < neighbor_ip_address >:
              activate: < true | false >
#  + define networks per address family
        networks:
          < prefix_address >:
            route_map: < route_map_name >

## old data model ##
router_bgp:
  vrfs:
    < vrf_name_1 >:
      neighbors:
        < neighbor_ip_address >:
          address_family:
            - < address_family >
````

## How to test
see molecule results eos_cli_config_gen

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
