### PR TITLE
BGP peer group name RFC5549 and for molecule converge to use eos_designs

### DIFF
--- a/.github/workflows/molecule-eos-designs.yml
+++ b/.github/workflows/molecule-eos-designs.yml
@@ -21,6 +21,7 @@ jobs:
           - 'evpn_underlay_isis_overlay_ibgp'
           - 'eos_designs-twodc-5stage-clos'
           - 'eos_l3ls_evpn_deprecation_test'
+          - 'evpn_underlay_rfc5549_overlay_ebgp'
           # - 'upgrade_v1.0_to_v1.1'
     steps:
       - name: 'set environment variables'

--- a/.github/workflows/molecule-new-release.yml
+++ b/.github/workflows/molecule-new-release.yml
@@ -15,6 +15,7 @@ jobs:
           - 'evpn_underlay_ospf_overlay_ebgp'
           - 'evpn_underlay_isis_overlay_ibgp'
           - 'eos_designs-twodc-5stage-clos'
+          - "evpn_underlay_rfc5549_overlay_ebgp"
           - 'eos_cli_config_gen'
     steps:
       - name: 'set environment variables'

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/converge.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/converge.yml
@@ -8,4 +8,4 @@
     - name: generate intented variables
       delegate_to: 127.0.0.1
       import_role:
-         name: arista.avd.eos_l3ls_evpn
+         name: arista.avd.eos_designs

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -555,7 +555,7 @@ router general
 | Send community | all |
 | Maximum routes | 0 (no limit) |
 
-#### IPv4-UNDERLAY-PEERS
+#### UNDERLAY_PEERS
 
 | Settings | Value |
 | -------- | ----- |
@@ -580,10 +580,10 @@ router general
 
 | Neighbor Interface | Peer Group | Remote AS |
 | ------------------ | ---------- | --------- |
-| Ethernet1 | IPv4-UNDERLAY-PEERS | 65001 |
-| Ethernet2 | IPv4-UNDERLAY-PEERS | 65001 |
-| Ethernet3 | IPv4-UNDERLAY-PEERS | 65001 |
-| Ethernet4 | IPv4-UNDERLAY-PEERS | 65001 |
+| Ethernet1 | UNDERLAY_PEERS | 65001 |
+| Ethernet2 | UNDERLAY_PEERS | 65001 |
+| Ethernet3 | UNDERLAY_PEERS | 65001 |
+| Ethernet4 | UNDERLAY_PEERS | 65001 |
 
 ### Router BGP EVPN Address Family
 
@@ -621,15 +621,15 @@ router bgp 65104
    neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
    neighbor EVPN-OVERLAY-PEERS send-community
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
-   neighbor IPv4-UNDERLAY-PEERS peer group
-   neighbor IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
-   neighbor IPv4-UNDERLAY-PEERS send-community
-   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
-   neighbor interface Ethernet1 peer-group IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor interface Ethernet2 peer-group IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor interface Ethernet3 peer-group IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor interface Ethernet4 peer-group IPv4-UNDERLAY-PEERS remote-as 65001
+   neighbor UNDERLAY_PEERS peer group
+   neighbor UNDERLAY_PEERS remote-as 65001
+   neighbor UNDERLAY_PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor UNDERLAY_PEERS send-community
+   neighbor UNDERLAY_PEERS maximum-routes 12000
+   neighbor interface Ethernet1 peer-group UNDERLAY_PEERS remote-as 65001
+   neighbor interface Ethernet2 peer-group UNDERLAY_PEERS remote-as 65001
+   neighbor interface Ethernet3 peer-group UNDERLAY_PEERS remote-as 65001
+   neighbor interface Ethernet4 peer-group UNDERLAY_PEERS remote-as 65001
    neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS
    neighbor 192.168.255.1 remote-as 65001
    neighbor 192.168.255.1 description DC1-SPINE1
@@ -668,8 +668,8 @@ router bgp 65104
    address-family ipv4
       neighbor EVPN-OVERLAY-PEERS next-hop address-family ipv6 originate
       no neighbor EVPN-OVERLAY-PEERS activate
-      neighbor IPv4-UNDERLAY-PEERS next-hop address-family ipv6 originate
-      neighbor IPv4-UNDERLAY-PEERS activate
+      neighbor UNDERLAY_PEERS next-hop address-family ipv6 originate
+      neighbor UNDERLAY_PEERS activate
    !
    vrf Tenant_A_WAN_Zone
       rd 192.168.255.10:14

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -536,7 +536,7 @@ ip route vrf Tenant_A_WAN_Zone 10.3.4.0/24 1.2.3.4
 | Send community | all |
 | Maximum routes | 0 (no limit) |
 
-#### IPv4-UNDERLAY-PEERS
+#### UNDERLAY_PEERS
 
 | Settings | Value |
 | -------- | ----- |
@@ -561,10 +561,10 @@ ip route vrf Tenant_A_WAN_Zone 10.3.4.0/24 1.2.3.4
 
 | Neighbor Interface | Peer Group | Remote AS |
 | ------------------ | ---------- | --------- |
-| Ethernet1 | IPv4-UNDERLAY-PEERS | 65001 |
-| Ethernet2 | IPv4-UNDERLAY-PEERS | 65001 |
-| Ethernet3 | IPv4-UNDERLAY-PEERS | 65001 |
-| Ethernet4 | IPv4-UNDERLAY-PEERS | 65001 |
+| Ethernet1 | UNDERLAY_PEERS | 65001 |
+| Ethernet2 | UNDERLAY_PEERS | 65001 |
+| Ethernet3 | UNDERLAY_PEERS | 65001 |
+| Ethernet4 | UNDERLAY_PEERS | 65001 |
 
 ### Router BGP EVPN Address Family
 
@@ -602,15 +602,15 @@ router bgp 65105
    neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
    neighbor EVPN-OVERLAY-PEERS send-community
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
-   neighbor IPv4-UNDERLAY-PEERS peer group
-   neighbor IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
-   neighbor IPv4-UNDERLAY-PEERS send-community
-   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
-   neighbor interface Ethernet1 peer-group IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor interface Ethernet2 peer-group IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor interface Ethernet3 peer-group IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor interface Ethernet4 peer-group IPv4-UNDERLAY-PEERS remote-as 65001
+   neighbor UNDERLAY_PEERS peer group
+   neighbor UNDERLAY_PEERS remote-as 65001
+   neighbor UNDERLAY_PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor UNDERLAY_PEERS send-community
+   neighbor UNDERLAY_PEERS maximum-routes 12000
+   neighbor interface Ethernet1 peer-group UNDERLAY_PEERS remote-as 65001
+   neighbor interface Ethernet2 peer-group UNDERLAY_PEERS remote-as 65001
+   neighbor interface Ethernet3 peer-group UNDERLAY_PEERS remote-as 65001
+   neighbor interface Ethernet4 peer-group UNDERLAY_PEERS remote-as 65001
    neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS
    neighbor 192.168.255.1 remote-as 65001
    neighbor 192.168.255.1 description DC1-SPINE1
@@ -649,8 +649,8 @@ router bgp 65105
    address-family ipv4
       neighbor EVPN-OVERLAY-PEERS next-hop address-family ipv6 originate
       no neighbor EVPN-OVERLAY-PEERS activate
-      neighbor IPv4-UNDERLAY-PEERS next-hop address-family ipv6 originate
-      neighbor IPv4-UNDERLAY-PEERS activate
+      neighbor UNDERLAY_PEERS next-hop address-family ipv6 originate
+      neighbor UNDERLAY_PEERS activate
    !
    vrf Tenant_A_WAN_Zone
       rd 192.168.255.11:14

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -554,7 +554,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | Send community | all |
 | Maximum routes | 0 (no limit) |
 
-#### IPv4-UNDERLAY-PEERS
+#### UNDERLAY_PEERS
 
 | Settings | Value |
 | -------- | ----- |
@@ -576,10 +576,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | Neighbor Interface | Peer Group | Remote AS |
 | ------------------ | ---------- | --------- |
-| Ethernet1 | IPv4-UNDERLAY-PEERS | 65001 |
-| Ethernet2 | IPv4-UNDERLAY-PEERS | 65001 |
-| Ethernet3 | IPv4-UNDERLAY-PEERS | 65001 |
-| Ethernet4 | IPv4-UNDERLAY-PEERS | 65001 |
+| Ethernet1 | UNDERLAY_PEERS | 65001 |
+| Ethernet2 | UNDERLAY_PEERS | 65001 |
+| Ethernet3 | UNDERLAY_PEERS | 65001 |
+| Ethernet4 | UNDERLAY_PEERS | 65001 |
 
 ### Router BGP EVPN Address Family
 
@@ -615,15 +615,15 @@ router bgp 65101
    neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
    neighbor EVPN-OVERLAY-PEERS send-community
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
-   neighbor IPv4-UNDERLAY-PEERS peer group
-   neighbor IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
-   neighbor IPv4-UNDERLAY-PEERS send-community
-   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
-   neighbor interface Ethernet1 peer-group IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor interface Ethernet2 peer-group IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor interface Ethernet3 peer-group IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor interface Ethernet4 peer-group IPv4-UNDERLAY-PEERS remote-as 65001
+   neighbor UNDERLAY_PEERS peer group
+   neighbor UNDERLAY_PEERS remote-as 65001
+   neighbor UNDERLAY_PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor UNDERLAY_PEERS send-community
+   neighbor UNDERLAY_PEERS maximum-routes 12000
+   neighbor interface Ethernet1 peer-group UNDERLAY_PEERS remote-as 65001
+   neighbor interface Ethernet2 peer-group UNDERLAY_PEERS remote-as 65001
+   neighbor interface Ethernet3 peer-group UNDERLAY_PEERS remote-as 65001
+   neighbor interface Ethernet4 peer-group UNDERLAY_PEERS remote-as 65001
    neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS
    neighbor 192.168.255.1 remote-as 65001
    neighbor 192.168.255.1 description DC1-SPINE1
@@ -656,8 +656,8 @@ router bgp 65101
    address-family ipv4
       neighbor EVPN-OVERLAY-PEERS next-hop address-family ipv6 originate
       no neighbor EVPN-OVERLAY-PEERS activate
-      neighbor IPv4-UNDERLAY-PEERS next-hop address-family ipv6 originate
-      neighbor IPv4-UNDERLAY-PEERS activate
+      neighbor UNDERLAY_PEERS next-hop address-family ipv6 originate
+      neighbor UNDERLAY_PEERS activate
    !
    vrf Tenant_A_APP_Zone
       rd 192.168.255.5:12

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -924,22 +924,22 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | Send community | all |
 | Maximum routes | 0 (no limit) |
 
-#### IPv4-UNDERLAY-PEERS
-
-| Settings | Value |
-| -------- | ----- |
-| Address Family | ipv4 |
-| Remote_as | 65001 |
-| Send community | all |
-| Maximum routes | 12000 |
-
-#### MLAG-IPv4-UNDERLAY-PEER
+#### MLAG_PEER
 
 | Settings | Value |
 | -------- | ----- |
 | Address Family | ipv4 |
 | Remote_as | 65102 |
 | Next-hop self | True |
+| Send community | all |
+| Maximum routes | 12000 |
+
+#### UNDERLAY_PEERS
+
+| Settings | Value |
+| -------- | ----- |
+| Address Family | ipv4 |
+| Remote_as | 65001 |
 | Send community | all |
 | Maximum routes | 12000 |
 
@@ -951,22 +951,22 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | 192.168.255.2 | 65001 | default |
 | 192.168.255.3 | 65001 | default |
 | 192.168.255.4 | 65001 | default |
-| 10.255.251.3 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Tenant_A_APP_Zone |
-| 10.255.251.3 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Tenant_A_DB_Zone |
-| 10.255.251.3 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Tenant_A_OP_Zone |
-| 10.255.251.3 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Tenant_A_WEB_Zone |
-| 10.255.251.3 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Tenant_B_OP_Zone |
-| 10.255.251.3 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Tenant_C_OP_Zone |
+| 10.255.251.3 | Inherited from peer group MLAG_PEER | Tenant_A_APP_Zone |
+| 10.255.251.3 | Inherited from peer group MLAG_PEER | Tenant_A_DB_Zone |
+| 10.255.251.3 | Inherited from peer group MLAG_PEER | Tenant_A_OP_Zone |
+| 10.255.251.3 | Inherited from peer group MLAG_PEER | Tenant_A_WEB_Zone |
+| 10.255.251.3 | Inherited from peer group MLAG_PEER | Tenant_B_OP_Zone |
+| 10.255.251.3 | Inherited from peer group MLAG_PEER | Tenant_C_OP_Zone |
 
 ### BGP Neighbor Interfaces
 
 | Neighbor Interface | Peer Group | Remote AS |
 | ------------------ | ---------- | --------- |
-| Ethernet1 | IPv4-UNDERLAY-PEERS | 65001 |
-| Ethernet2 | IPv4-UNDERLAY-PEERS | 65001 |
-| Ethernet3 | IPv4-UNDERLAY-PEERS | 65001 |
-| Ethernet4 | IPv4-UNDERLAY-PEERS | 65001 |
-| Vlan4093 | MLAG-IPv4-UNDERLAY-PEER | 65102 |
+| Ethernet1 | UNDERLAY_PEERS | 65001 |
+| Ethernet2 | UNDERLAY_PEERS | 65001 |
+| Ethernet3 | UNDERLAY_PEERS | 65001 |
+| Ethernet4 | UNDERLAY_PEERS | 65001 |
+| Vlan4093 | MLAG_PEER | 65102 |
 
 ### Router BGP EVPN Address Family
 
@@ -1012,23 +1012,23 @@ router bgp 65102
    neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
    neighbor EVPN-OVERLAY-PEERS send-community
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
-   neighbor IPv4-UNDERLAY-PEERS peer group
-   neighbor IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
-   neighbor IPv4-UNDERLAY-PEERS send-community
-   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
-   neighbor MLAG-IPv4-UNDERLAY-PEER peer group
-   neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65102
-   neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
-   neighbor MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==
-   neighbor MLAG-IPv4-UNDERLAY-PEER send-community
-   neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000
-   neighbor MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN in
-   neighbor interface Ethernet1 peer-group IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor interface Ethernet2 peer-group IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor interface Ethernet3 peer-group IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor interface Ethernet4 peer-group IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor interface Vlan4093 peer-group MLAG-IPv4-UNDERLAY-PEER remote-as 65102
+   neighbor MLAG_PEER peer group
+   neighbor MLAG_PEER remote-as 65102
+   neighbor MLAG_PEER next-hop-self
+   neighbor MLAG_PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==
+   neighbor MLAG_PEER send-community
+   neighbor MLAG_PEER maximum-routes 12000
+   neighbor MLAG_PEER route-map RM-MLAG-PEER-IN in
+   neighbor UNDERLAY_PEERS peer group
+   neighbor UNDERLAY_PEERS remote-as 65001
+   neighbor UNDERLAY_PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor UNDERLAY_PEERS send-community
+   neighbor UNDERLAY_PEERS maximum-routes 12000
+   neighbor interface Ethernet1 peer-group UNDERLAY_PEERS remote-as 65001
+   neighbor interface Ethernet2 peer-group UNDERLAY_PEERS remote-as 65001
+   neighbor interface Ethernet3 peer-group UNDERLAY_PEERS remote-as 65001
+   neighbor interface Ethernet4 peer-group UNDERLAY_PEERS remote-as 65001
+   neighbor interface Vlan4093 peer-group MLAG_PEER remote-as 65102
    neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS
    neighbor 192.168.255.1 remote-as 65001
    neighbor 192.168.255.1 description DC1-SPINE1
@@ -1097,17 +1097,17 @@ router bgp 65102
    address-family ipv4
       neighbor EVPN-OVERLAY-PEERS next-hop address-family ipv6 originate
       no neighbor EVPN-OVERLAY-PEERS activate
-      neighbor IPv4-UNDERLAY-PEERS next-hop address-family ipv6 originate
-      neighbor IPv4-UNDERLAY-PEERS activate
-      neighbor MLAG-IPv4-UNDERLAY-PEER next-hop address-family ipv6 originate
-      neighbor MLAG-IPv4-UNDERLAY-PEER activate
+      neighbor MLAG_PEER next-hop address-family ipv6 originate
+      neighbor MLAG_PEER activate
+      neighbor UNDERLAY_PEERS next-hop address-family ipv6 originate
+      neighbor UNDERLAY_PEERS activate
    !
    vrf Tenant_A_APP_Zone
       rd 192.168.255.6:12
       route-target import evpn 12:12
       route-target export evpn 12:12
       router-id 192.168.255.6
-      neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.3 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1115,7 +1115,7 @@ router bgp 65102
       route-target import evpn 13:13
       route-target export evpn 13:13
       router-id 192.168.255.6
-      neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.3 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1123,7 +1123,7 @@ router bgp 65102
       route-target import evpn 10:10
       route-target export evpn 10:10
       router-id 192.168.255.6
-      neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.3 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1131,7 +1131,7 @@ router bgp 65102
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.6
-      neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.3 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1139,7 +1139,7 @@ router bgp 65102
       route-target import evpn 20:20
       route-target export evpn 20:20
       router-id 192.168.255.6
-      neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.3 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1147,7 +1147,7 @@ router bgp 65102
       route-target import evpn 30:30
       route-target export evpn 30:30
       router-id 192.168.255.6
-      neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.3 peer group MLAG_PEER
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -924,22 +924,22 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | Send community | all |
 | Maximum routes | 0 (no limit) |
 
-#### IPv4-UNDERLAY-PEERS
-
-| Settings | Value |
-| -------- | ----- |
-| Address Family | ipv4 |
-| Remote_as | 65001 |
-| Send community | all |
-| Maximum routes | 12000 |
-
-#### MLAG-IPv4-UNDERLAY-PEER
+#### MLAG_PEER
 
 | Settings | Value |
 | -------- | ----- |
 | Address Family | ipv4 |
 | Remote_as | 65102 |
 | Next-hop self | True |
+| Send community | all |
+| Maximum routes | 12000 |
+
+#### UNDERLAY_PEERS
+
+| Settings | Value |
+| -------- | ----- |
+| Address Family | ipv4 |
+| Remote_as | 65001 |
 | Send community | all |
 | Maximum routes | 12000 |
 
@@ -951,22 +951,22 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | 192.168.255.2 | 65001 | default |
 | 192.168.255.3 | 65001 | default |
 | 192.168.255.4 | 65001 | default |
-| 10.255.251.2 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Tenant_A_APP_Zone |
-| 10.255.251.2 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Tenant_A_DB_Zone |
-| 10.255.251.2 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Tenant_A_OP_Zone |
-| 10.255.251.2 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Tenant_A_WEB_Zone |
-| 10.255.251.2 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Tenant_B_OP_Zone |
-| 10.255.251.2 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Tenant_C_OP_Zone |
+| 10.255.251.2 | Inherited from peer group MLAG_PEER | Tenant_A_APP_Zone |
+| 10.255.251.2 | Inherited from peer group MLAG_PEER | Tenant_A_DB_Zone |
+| 10.255.251.2 | Inherited from peer group MLAG_PEER | Tenant_A_OP_Zone |
+| 10.255.251.2 | Inherited from peer group MLAG_PEER | Tenant_A_WEB_Zone |
+| 10.255.251.2 | Inherited from peer group MLAG_PEER | Tenant_B_OP_Zone |
+| 10.255.251.2 | Inherited from peer group MLAG_PEER | Tenant_C_OP_Zone |
 
 ### BGP Neighbor Interfaces
 
 | Neighbor Interface | Peer Group | Remote AS |
 | ------------------ | ---------- | --------- |
-| Ethernet1 | IPv4-UNDERLAY-PEERS | 65001 |
-| Ethernet2 | IPv4-UNDERLAY-PEERS | 65001 |
-| Ethernet3 | IPv4-UNDERLAY-PEERS | 65001 |
-| Ethernet4 | IPv4-UNDERLAY-PEERS | 65001 |
-| Vlan4093 | MLAG-IPv4-UNDERLAY-PEER | 65102 |
+| Ethernet1 | UNDERLAY_PEERS | 65001 |
+| Ethernet2 | UNDERLAY_PEERS | 65001 |
+| Ethernet3 | UNDERLAY_PEERS | 65001 |
+| Ethernet4 | UNDERLAY_PEERS | 65001 |
+| Vlan4093 | MLAG_PEER | 65102 |
 
 ### Router BGP EVPN Address Family
 
@@ -1012,23 +1012,23 @@ router bgp 65102
    neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
    neighbor EVPN-OVERLAY-PEERS send-community
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
-   neighbor IPv4-UNDERLAY-PEERS peer group
-   neighbor IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
-   neighbor IPv4-UNDERLAY-PEERS send-community
-   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
-   neighbor MLAG-IPv4-UNDERLAY-PEER peer group
-   neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65102
-   neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
-   neighbor MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==
-   neighbor MLAG-IPv4-UNDERLAY-PEER send-community
-   neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000
-   neighbor MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN in
-   neighbor interface Ethernet1 peer-group IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor interface Ethernet2 peer-group IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor interface Ethernet3 peer-group IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor interface Ethernet4 peer-group IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor interface Vlan4093 peer-group MLAG-IPv4-UNDERLAY-PEER remote-as 65102
+   neighbor MLAG_PEER peer group
+   neighbor MLAG_PEER remote-as 65102
+   neighbor MLAG_PEER next-hop-self
+   neighbor MLAG_PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==
+   neighbor MLAG_PEER send-community
+   neighbor MLAG_PEER maximum-routes 12000
+   neighbor MLAG_PEER route-map RM-MLAG-PEER-IN in
+   neighbor UNDERLAY_PEERS peer group
+   neighbor UNDERLAY_PEERS remote-as 65001
+   neighbor UNDERLAY_PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor UNDERLAY_PEERS send-community
+   neighbor UNDERLAY_PEERS maximum-routes 12000
+   neighbor interface Ethernet1 peer-group UNDERLAY_PEERS remote-as 65001
+   neighbor interface Ethernet2 peer-group UNDERLAY_PEERS remote-as 65001
+   neighbor interface Ethernet3 peer-group UNDERLAY_PEERS remote-as 65001
+   neighbor interface Ethernet4 peer-group UNDERLAY_PEERS remote-as 65001
+   neighbor interface Vlan4093 peer-group MLAG_PEER remote-as 65102
    neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS
    neighbor 192.168.255.1 remote-as 65001
    neighbor 192.168.255.1 description DC1-SPINE1
@@ -1097,17 +1097,17 @@ router bgp 65102
    address-family ipv4
       neighbor EVPN-OVERLAY-PEERS next-hop address-family ipv6 originate
       no neighbor EVPN-OVERLAY-PEERS activate
-      neighbor IPv4-UNDERLAY-PEERS next-hop address-family ipv6 originate
-      neighbor IPv4-UNDERLAY-PEERS activate
-      neighbor MLAG-IPv4-UNDERLAY-PEER next-hop address-family ipv6 originate
-      neighbor MLAG-IPv4-UNDERLAY-PEER activate
+      neighbor MLAG_PEER next-hop address-family ipv6 originate
+      neighbor MLAG_PEER activate
+      neighbor UNDERLAY_PEERS next-hop address-family ipv6 originate
+      neighbor UNDERLAY_PEERS activate
    !
    vrf Tenant_A_APP_Zone
       rd 192.168.255.7:12
       route-target import evpn 12:12
       route-target export evpn 12:12
       router-id 192.168.255.7
-      neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.2 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1115,7 +1115,7 @@ router bgp 65102
       route-target import evpn 13:13
       route-target export evpn 13:13
       router-id 192.168.255.7
-      neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.2 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1123,7 +1123,7 @@ router bgp 65102
       route-target import evpn 10:10
       route-target export evpn 10:10
       router-id 192.168.255.7
-      neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.2 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1131,7 +1131,7 @@ router bgp 65102
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.7
-      neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.2 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1139,7 +1139,7 @@ router bgp 65102
       route-target import evpn 20:20
       route-target export evpn 20:20
       router-id 192.168.255.7
-      neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.2 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1147,7 +1147,7 @@ router bgp 65102
       route-target import evpn 30:30
       route-target export evpn 30:30
       router-id 192.168.255.7
-      neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.2 peer group MLAG_PEER
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE1.md
@@ -383,7 +383,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | Send community | all |
 | Maximum routes | 0 (no limit) |
 
-#### IPv4-UNDERLAY-PEERS
+#### UNDERLAY_PEERS
 
 | Settings | Value |
 | -------- | ----- |
@@ -408,7 +408,7 @@ router bgp 65001
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    bgp listen range 192.168.255.0/24 peer-group EVPN-OVERLAY-PEERS peer-filter LEAF-AS-RANGE
-   bgp listen range fe80::/10 peer-group IPv4-UNDERLAY-PEERS peer-filter LEAF-AS-RANGE
+   bgp listen range fe80::/10 peer-group UNDERLAY_PEERS peer-filter LEAF-AS-RANGE
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
@@ -417,10 +417,10 @@ router bgp 65001
    neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
    neighbor EVPN-OVERLAY-PEERS send-community
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
-   neighbor IPv4-UNDERLAY-PEERS peer group
-   neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
-   neighbor IPv4-UNDERLAY-PEERS send-community
-   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   neighbor UNDERLAY_PEERS peer group
+   neighbor UNDERLAY_PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor UNDERLAY_PEERS send-community
+   neighbor UNDERLAY_PEERS maximum-routes 12000
    redistribute connected route-map RM-CONN-2-BGP
    !
    address-family evpn
@@ -429,8 +429,8 @@ router bgp 65001
    address-family ipv4
       neighbor EVPN-OVERLAY-PEERS next-hop address-family ipv6 originate
       no neighbor EVPN-OVERLAY-PEERS activate
-      neighbor IPv4-UNDERLAY-PEERS next-hop address-family ipv6 originate
-      neighbor IPv4-UNDERLAY-PEERS activate
+      neighbor UNDERLAY_PEERS next-hop address-family ipv6 originate
+      neighbor UNDERLAY_PEERS activate
 ```
 
 # BFD

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE2.md
@@ -383,7 +383,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | Send community | all |
 | Maximum routes | 0 (no limit) |
 
-#### IPv4-UNDERLAY-PEERS
+#### UNDERLAY_PEERS
 
 | Settings | Value |
 | -------- | ----- |
@@ -408,7 +408,7 @@ router bgp 65001
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    bgp listen range 192.168.255.0/24 peer-group EVPN-OVERLAY-PEERS peer-filter LEAF-AS-RANGE
-   bgp listen range fe80::/10 peer-group IPv4-UNDERLAY-PEERS peer-filter LEAF-AS-RANGE
+   bgp listen range fe80::/10 peer-group UNDERLAY_PEERS peer-filter LEAF-AS-RANGE
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
@@ -417,10 +417,10 @@ router bgp 65001
    neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
    neighbor EVPN-OVERLAY-PEERS send-community
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
-   neighbor IPv4-UNDERLAY-PEERS peer group
-   neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
-   neighbor IPv4-UNDERLAY-PEERS send-community
-   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   neighbor UNDERLAY_PEERS peer group
+   neighbor UNDERLAY_PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor UNDERLAY_PEERS send-community
+   neighbor UNDERLAY_PEERS maximum-routes 12000
    redistribute connected route-map RM-CONN-2-BGP
    !
    address-family evpn
@@ -429,8 +429,8 @@ router bgp 65001
    address-family ipv4
       neighbor EVPN-OVERLAY-PEERS next-hop address-family ipv6 originate
       no neighbor EVPN-OVERLAY-PEERS activate
-      neighbor IPv4-UNDERLAY-PEERS next-hop address-family ipv6 originate
-      neighbor IPv4-UNDERLAY-PEERS activate
+      neighbor UNDERLAY_PEERS next-hop address-family ipv6 originate
+      neighbor UNDERLAY_PEERS activate
 ```
 
 # BFD

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE3.md
@@ -383,7 +383,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | Send community | all |
 | Maximum routes | 0 (no limit) |
 
-#### IPv4-UNDERLAY-PEERS
+#### UNDERLAY_PEERS
 
 | Settings | Value |
 | -------- | ----- |
@@ -408,7 +408,7 @@ router bgp 65001
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    bgp listen range 192.168.255.0/24 peer-group EVPN-OVERLAY-PEERS peer-filter LEAF-AS-RANGE
-   bgp listen range fe80::/10 peer-group IPv4-UNDERLAY-PEERS peer-filter LEAF-AS-RANGE
+   bgp listen range fe80::/10 peer-group UNDERLAY_PEERS peer-filter LEAF-AS-RANGE
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
@@ -417,10 +417,10 @@ router bgp 65001
    neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
    neighbor EVPN-OVERLAY-PEERS send-community
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
-   neighbor IPv4-UNDERLAY-PEERS peer group
-   neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
-   neighbor IPv4-UNDERLAY-PEERS send-community
-   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   neighbor UNDERLAY_PEERS peer group
+   neighbor UNDERLAY_PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor UNDERLAY_PEERS send-community
+   neighbor UNDERLAY_PEERS maximum-routes 12000
    redistribute connected route-map RM-CONN-2-BGP
    !
    address-family evpn
@@ -429,8 +429,8 @@ router bgp 65001
    address-family ipv4
       neighbor EVPN-OVERLAY-PEERS next-hop address-family ipv6 originate
       no neighbor EVPN-OVERLAY-PEERS activate
-      neighbor IPv4-UNDERLAY-PEERS next-hop address-family ipv6 originate
-      neighbor IPv4-UNDERLAY-PEERS activate
+      neighbor UNDERLAY_PEERS next-hop address-family ipv6 originate
+      neighbor UNDERLAY_PEERS activate
 ```
 
 # BFD

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE4.md
@@ -383,7 +383,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | Send community | all |
 | Maximum routes | 0 (no limit) |
 
-#### IPv4-UNDERLAY-PEERS
+#### UNDERLAY_PEERS
 
 | Settings | Value |
 | -------- | ----- |
@@ -408,7 +408,7 @@ router bgp 65001
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    bgp listen range 192.168.255.0/24 peer-group EVPN-OVERLAY-PEERS peer-filter LEAF-AS-RANGE
-   bgp listen range fe80::/10 peer-group IPv4-UNDERLAY-PEERS peer-filter LEAF-AS-RANGE
+   bgp listen range fe80::/10 peer-group UNDERLAY_PEERS peer-filter LEAF-AS-RANGE
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
@@ -417,10 +417,10 @@ router bgp 65001
    neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
    neighbor EVPN-OVERLAY-PEERS send-community
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
-   neighbor IPv4-UNDERLAY-PEERS peer group
-   neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
-   neighbor IPv4-UNDERLAY-PEERS send-community
-   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   neighbor UNDERLAY_PEERS peer group
+   neighbor UNDERLAY_PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor UNDERLAY_PEERS send-community
+   neighbor UNDERLAY_PEERS maximum-routes 12000
    redistribute connected route-map RM-CONN-2-BGP
    !
    address-family evpn
@@ -429,8 +429,8 @@ router bgp 65001
    address-family ipv4
       neighbor EVPN-OVERLAY-PEERS next-hop address-family ipv6 originate
       no neighbor EVPN-OVERLAY-PEERS activate
-      neighbor IPv4-UNDERLAY-PEERS next-hop address-family ipv6 originate
-      neighbor IPv4-UNDERLAY-PEERS activate
+      neighbor UNDERLAY_PEERS next-hop address-family ipv6 originate
+      neighbor UNDERLAY_PEERS activate
 ```
 
 # BFD

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -1098,22 +1098,22 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | Send community | all |
 | Maximum routes | 0 (no limit) |
 
-#### IPv4-UNDERLAY-PEERS
-
-| Settings | Value |
-| -------- | ----- |
-| Address Family | ipv4 |
-| Remote_as | 65001 |
-| Send community | all |
-| Maximum routes | 12000 |
-
-#### MLAG-IPv4-UNDERLAY-PEER
+#### MLAG_PEER
 
 | Settings | Value |
 | -------- | ----- |
 | Address Family | ipv4 |
 | Remote_as | 65103 |
 | Next-hop self | True |
+| Send community | all |
+| Maximum routes | 12000 |
+
+#### UNDERLAY_PEERS
+
+| Settings | Value |
+| -------- | ----- |
+| Address Family | ipv4 |
+| Remote_as | 65001 |
 | Send community | all |
 | Maximum routes | 12000 |
 
@@ -1125,25 +1125,25 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | 192.168.255.2 | 65001 | default |
 | 192.168.255.3 | 65001 | default |
 | 192.168.255.4 | 65001 | default |
-| 10.255.251.7 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Tenant_A_APP_Zone |
-| 10.255.251.7 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Tenant_A_DB_Zone |
-| 10.255.251.7 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Tenant_A_OP_Zone |
-| 10.255.251.7 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Tenant_A_WAN_Zone |
-| 10.255.251.7 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Tenant_A_WEB_Zone |
-| 10.255.251.7 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Tenant_B_OP_Zone |
-| 10.255.251.7 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Tenant_B_WAN_Zone |
-| 10.255.251.7 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Tenant_C_OP_Zone |
-| 10.255.251.7 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Tenant_C_WAN_Zone |
+| 10.255.251.7 | Inherited from peer group MLAG_PEER | Tenant_A_APP_Zone |
+| 10.255.251.7 | Inherited from peer group MLAG_PEER | Tenant_A_DB_Zone |
+| 10.255.251.7 | Inherited from peer group MLAG_PEER | Tenant_A_OP_Zone |
+| 10.255.251.7 | Inherited from peer group MLAG_PEER | Tenant_A_WAN_Zone |
+| 10.255.251.7 | Inherited from peer group MLAG_PEER | Tenant_A_WEB_Zone |
+| 10.255.251.7 | Inherited from peer group MLAG_PEER | Tenant_B_OP_Zone |
+| 10.255.251.7 | Inherited from peer group MLAG_PEER | Tenant_B_WAN_Zone |
+| 10.255.251.7 | Inherited from peer group MLAG_PEER | Tenant_C_OP_Zone |
+| 10.255.251.7 | Inherited from peer group MLAG_PEER | Tenant_C_WAN_Zone |
 
 ### BGP Neighbor Interfaces
 
 | Neighbor Interface | Peer Group | Remote AS |
 | ------------------ | ---------- | --------- |
-| Ethernet1 | IPv4-UNDERLAY-PEERS | 65001 |
-| Ethernet2 | IPv4-UNDERLAY-PEERS | 65001 |
-| Ethernet3 | IPv4-UNDERLAY-PEERS | 65001 |
-| Ethernet4 | IPv4-UNDERLAY-PEERS | 65001 |
-| Vlan4093 | MLAG-IPv4-UNDERLAY-PEER | 65103 |
+| Ethernet1 | UNDERLAY_PEERS | 65001 |
+| Ethernet2 | UNDERLAY_PEERS | 65001 |
+| Ethernet3 | UNDERLAY_PEERS | 65001 |
+| Ethernet4 | UNDERLAY_PEERS | 65001 |
+| Vlan4093 | MLAG_PEER | 65103 |
 
 ### Router BGP EVPN Address Family
 
@@ -1195,23 +1195,23 @@ router bgp 65103
    neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
    neighbor EVPN-OVERLAY-PEERS send-community
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
-   neighbor IPv4-UNDERLAY-PEERS peer group
-   neighbor IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
-   neighbor IPv4-UNDERLAY-PEERS send-community
-   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
-   neighbor MLAG-IPv4-UNDERLAY-PEER peer group
-   neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65103
-   neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
-   neighbor MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==
-   neighbor MLAG-IPv4-UNDERLAY-PEER send-community
-   neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000
-   neighbor MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN in
-   neighbor interface Ethernet1 peer-group IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor interface Ethernet2 peer-group IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor interface Ethernet3 peer-group IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor interface Ethernet4 peer-group IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor interface Vlan4093 peer-group MLAG-IPv4-UNDERLAY-PEER remote-as 65103
+   neighbor MLAG_PEER peer group
+   neighbor MLAG_PEER remote-as 65103
+   neighbor MLAG_PEER next-hop-self
+   neighbor MLAG_PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==
+   neighbor MLAG_PEER send-community
+   neighbor MLAG_PEER maximum-routes 12000
+   neighbor MLAG_PEER route-map RM-MLAG-PEER-IN in
+   neighbor UNDERLAY_PEERS peer group
+   neighbor UNDERLAY_PEERS remote-as 65001
+   neighbor UNDERLAY_PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor UNDERLAY_PEERS send-community
+   neighbor UNDERLAY_PEERS maximum-routes 12000
+   neighbor interface Ethernet1 peer-group UNDERLAY_PEERS remote-as 65001
+   neighbor interface Ethernet2 peer-group UNDERLAY_PEERS remote-as 65001
+   neighbor interface Ethernet3 peer-group UNDERLAY_PEERS remote-as 65001
+   neighbor interface Ethernet4 peer-group UNDERLAY_PEERS remote-as 65001
+   neighbor interface Vlan4093 peer-group MLAG_PEER remote-as 65103
    neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS
    neighbor 192.168.255.1 remote-as 65001
    neighbor 192.168.255.1 description DC1-SPINE1
@@ -1298,17 +1298,17 @@ router bgp 65103
    address-family ipv4
       neighbor EVPN-OVERLAY-PEERS next-hop address-family ipv6 originate
       no neighbor EVPN-OVERLAY-PEERS activate
-      neighbor IPv4-UNDERLAY-PEERS next-hop address-family ipv6 originate
-      neighbor IPv4-UNDERLAY-PEERS activate
-      neighbor MLAG-IPv4-UNDERLAY-PEER next-hop address-family ipv6 originate
-      neighbor MLAG-IPv4-UNDERLAY-PEER activate
+      neighbor MLAG_PEER next-hop address-family ipv6 originate
+      neighbor MLAG_PEER activate
+      neighbor UNDERLAY_PEERS next-hop address-family ipv6 originate
+      neighbor UNDERLAY_PEERS activate
    !
    vrf Tenant_A_APP_Zone
       rd 192.168.255.8:12
       route-target import evpn 12:12
       route-target export evpn 12:12
       router-id 192.168.255.8
-      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.7 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1316,7 +1316,7 @@ router bgp 65103
       route-target import evpn 13:13
       route-target export evpn 13:13
       router-id 192.168.255.8
-      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.7 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1324,7 +1324,7 @@ router bgp 65103
       route-target import evpn 10:10
       route-target export evpn 10:10
       router-id 192.168.255.8
-      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.7 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -1332,7 +1332,7 @@ router bgp 65103
       route-target import evpn 14:14
       route-target export evpn 14:14
       router-id 192.168.255.8
-      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.7 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1340,7 +1340,7 @@ router bgp 65103
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.8
-      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.7 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1348,7 +1348,7 @@ router bgp 65103
       route-target import evpn 20:20
       route-target export evpn 20:20
       router-id 192.168.255.8
-      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.7 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -1356,7 +1356,7 @@ router bgp 65103
       route-target import evpn 21:21
       route-target export evpn 21:21
       router-id 192.168.255.8
-      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.7 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1364,7 +1364,7 @@ router bgp 65103
       route-target import evpn 30:30
       route-target export evpn 30:30
       router-id 192.168.255.8
-      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.7 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -1372,7 +1372,7 @@ router bgp 65103
       route-target import evpn 31:31
       route-target export evpn 31:31
       router-id 192.168.255.8
-      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.7 peer group MLAG_PEER
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -1083,22 +1083,22 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | Send community | all |
 | Maximum routes | 0 (no limit) |
 
-#### IPv4-UNDERLAY-PEERS
-
-| Settings | Value |
-| -------- | ----- |
-| Address Family | ipv4 |
-| Remote_as | 65001 |
-| Send community | all |
-| Maximum routes | 12000 |
-
-#### MLAG-IPv4-UNDERLAY-PEER
+#### MLAG_PEER
 
 | Settings | Value |
 | -------- | ----- |
 | Address Family | ipv4 |
 | Remote_as | 65103 |
 | Next-hop self | True |
+| Send community | all |
+| Maximum routes | 12000 |
+
+#### UNDERLAY_PEERS
+
+| Settings | Value |
+| -------- | ----- |
+| Address Family | ipv4 |
+| Remote_as | 65001 |
 | Send community | all |
 | Maximum routes | 12000 |
 
@@ -1110,25 +1110,25 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | 192.168.255.2 | 65001 | default |
 | 192.168.255.3 | 65001 | default |
 | 192.168.255.4 | 65001 | default |
-| 10.255.251.6 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Tenant_A_APP_Zone |
-| 10.255.251.6 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Tenant_A_DB_Zone |
-| 10.255.251.6 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Tenant_A_OP_Zone |
-| 10.255.251.6 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Tenant_A_WAN_Zone |
-| 10.255.251.6 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Tenant_A_WEB_Zone |
-| 10.255.251.6 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Tenant_B_OP_Zone |
-| 10.255.251.6 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Tenant_B_WAN_Zone |
-| 10.255.251.6 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Tenant_C_OP_Zone |
-| 10.255.251.6 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Tenant_C_WAN_Zone |
+| 10.255.251.6 | Inherited from peer group MLAG_PEER | Tenant_A_APP_Zone |
+| 10.255.251.6 | Inherited from peer group MLAG_PEER | Tenant_A_DB_Zone |
+| 10.255.251.6 | Inherited from peer group MLAG_PEER | Tenant_A_OP_Zone |
+| 10.255.251.6 | Inherited from peer group MLAG_PEER | Tenant_A_WAN_Zone |
+| 10.255.251.6 | Inherited from peer group MLAG_PEER | Tenant_A_WEB_Zone |
+| 10.255.251.6 | Inherited from peer group MLAG_PEER | Tenant_B_OP_Zone |
+| 10.255.251.6 | Inherited from peer group MLAG_PEER | Tenant_B_WAN_Zone |
+| 10.255.251.6 | Inherited from peer group MLAG_PEER | Tenant_C_OP_Zone |
+| 10.255.251.6 | Inherited from peer group MLAG_PEER | Tenant_C_WAN_Zone |
 
 ### BGP Neighbor Interfaces
 
 | Neighbor Interface | Peer Group | Remote AS |
 | ------------------ | ---------- | --------- |
-| Ethernet1 | IPv4-UNDERLAY-PEERS | 65001 |
-| Ethernet2 | IPv4-UNDERLAY-PEERS | 65001 |
-| Ethernet3 | IPv4-UNDERLAY-PEERS | 65001 |
-| Ethernet4 | IPv4-UNDERLAY-PEERS | 65001 |
-| Vlan4093 | MLAG-IPv4-UNDERLAY-PEER | 65103 |
+| Ethernet1 | UNDERLAY_PEERS | 65001 |
+| Ethernet2 | UNDERLAY_PEERS | 65001 |
+| Ethernet3 | UNDERLAY_PEERS | 65001 |
+| Ethernet4 | UNDERLAY_PEERS | 65001 |
+| Vlan4093 | MLAG_PEER | 65103 |
 
 ### Router BGP EVPN Address Family
 
@@ -1180,23 +1180,23 @@ router bgp 65103
    neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
    neighbor EVPN-OVERLAY-PEERS send-community
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
-   neighbor IPv4-UNDERLAY-PEERS peer group
-   neighbor IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
-   neighbor IPv4-UNDERLAY-PEERS send-community
-   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
-   neighbor MLAG-IPv4-UNDERLAY-PEER peer group
-   neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65103
-   neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
-   neighbor MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==
-   neighbor MLAG-IPv4-UNDERLAY-PEER send-community
-   neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000
-   neighbor MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN in
-   neighbor interface Ethernet1 peer-group IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor interface Ethernet2 peer-group IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor interface Ethernet3 peer-group IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor interface Ethernet4 peer-group IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor interface Vlan4093 peer-group MLAG-IPv4-UNDERLAY-PEER remote-as 65103
+   neighbor MLAG_PEER peer group
+   neighbor MLAG_PEER remote-as 65103
+   neighbor MLAG_PEER next-hop-self
+   neighbor MLAG_PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==
+   neighbor MLAG_PEER send-community
+   neighbor MLAG_PEER maximum-routes 12000
+   neighbor MLAG_PEER route-map RM-MLAG-PEER-IN in
+   neighbor UNDERLAY_PEERS peer group
+   neighbor UNDERLAY_PEERS remote-as 65001
+   neighbor UNDERLAY_PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor UNDERLAY_PEERS send-community
+   neighbor UNDERLAY_PEERS maximum-routes 12000
+   neighbor interface Ethernet1 peer-group UNDERLAY_PEERS remote-as 65001
+   neighbor interface Ethernet2 peer-group UNDERLAY_PEERS remote-as 65001
+   neighbor interface Ethernet3 peer-group UNDERLAY_PEERS remote-as 65001
+   neighbor interface Ethernet4 peer-group UNDERLAY_PEERS remote-as 65001
+   neighbor interface Vlan4093 peer-group MLAG_PEER remote-as 65103
    neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS
    neighbor 192.168.255.1 remote-as 65001
    neighbor 192.168.255.1 description DC1-SPINE1
@@ -1283,17 +1283,17 @@ router bgp 65103
    address-family ipv4
       neighbor EVPN-OVERLAY-PEERS next-hop address-family ipv6 originate
       no neighbor EVPN-OVERLAY-PEERS activate
-      neighbor IPv4-UNDERLAY-PEERS next-hop address-family ipv6 originate
-      neighbor IPv4-UNDERLAY-PEERS activate
-      neighbor MLAG-IPv4-UNDERLAY-PEER next-hop address-family ipv6 originate
-      neighbor MLAG-IPv4-UNDERLAY-PEER activate
+      neighbor MLAG_PEER next-hop address-family ipv6 originate
+      neighbor MLAG_PEER activate
+      neighbor UNDERLAY_PEERS next-hop address-family ipv6 originate
+      neighbor UNDERLAY_PEERS activate
    !
    vrf Tenant_A_APP_Zone
       rd 192.168.255.9:12
       route-target import evpn 12:12
       route-target export evpn 12:12
       router-id 192.168.255.9
-      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.6 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1301,7 +1301,7 @@ router bgp 65103
       route-target import evpn 13:13
       route-target export evpn 13:13
       router-id 192.168.255.9
-      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.6 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1309,7 +1309,7 @@ router bgp 65103
       route-target import evpn 10:10
       route-target export evpn 10:10
       router-id 192.168.255.9
-      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.6 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -1317,7 +1317,7 @@ router bgp 65103
       route-target import evpn 14:14
       route-target export evpn 14:14
       router-id 192.168.255.9
-      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.6 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1325,7 +1325,7 @@ router bgp 65103
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.9
-      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.6 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1333,7 +1333,7 @@ router bgp 65103
       route-target import evpn 20:20
       route-target export evpn 20:20
       router-id 192.168.255.9
-      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.6 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -1341,7 +1341,7 @@ router bgp 65103
       route-target import evpn 21:21
       route-target export evpn 21:21
       router-id 192.168.255.9
-      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.6 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1349,7 +1349,7 @@ router bgp 65103
       route-target import evpn 30:30
       route-target export evpn 30:30
       router-id 192.168.255.9
-      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.6 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -1357,7 +1357,7 @@ router bgp 65103
       route-target import evpn 31:31
       route-target export evpn 31:31
       router-id 192.168.255.9
-      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.6 peer group MLAG_PEER
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-BL1A.cfg
@@ -169,15 +169,15 @@ router bgp 65104
    neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
    neighbor EVPN-OVERLAY-PEERS send-community
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
-   neighbor IPv4-UNDERLAY-PEERS peer group
-   neighbor IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
-   neighbor IPv4-UNDERLAY-PEERS send-community
-   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
-   neighbor interface Ethernet1 peer-group IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor interface Ethernet2 peer-group IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor interface Ethernet3 peer-group IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor interface Ethernet4 peer-group IPv4-UNDERLAY-PEERS remote-as 65001
+   neighbor UNDERLAY_PEERS peer group
+   neighbor UNDERLAY_PEERS remote-as 65001
+   neighbor UNDERLAY_PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor UNDERLAY_PEERS send-community
+   neighbor UNDERLAY_PEERS maximum-routes 12000
+   neighbor interface Ethernet1 peer-group UNDERLAY_PEERS remote-as 65001
+   neighbor interface Ethernet2 peer-group UNDERLAY_PEERS remote-as 65001
+   neighbor interface Ethernet3 peer-group UNDERLAY_PEERS remote-as 65001
+   neighbor interface Ethernet4 peer-group UNDERLAY_PEERS remote-as 65001
    neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS
    neighbor 192.168.255.1 remote-as 65001
    neighbor 192.168.255.1 description DC1-SPINE1
@@ -216,8 +216,8 @@ router bgp 65104
    address-family ipv4
       neighbor EVPN-OVERLAY-PEERS next-hop address-family ipv6 originate
       no neighbor EVPN-OVERLAY-PEERS activate
-      neighbor IPv4-UNDERLAY-PEERS next-hop address-family ipv6 originate
-      neighbor IPv4-UNDERLAY-PEERS activate
+      neighbor UNDERLAY_PEERS next-hop address-family ipv6 originate
+      neighbor UNDERLAY_PEERS activate
    !
    vrf Tenant_A_WAN_Zone
       rd 192.168.255.10:14

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-BL1B.cfg
@@ -169,15 +169,15 @@ router bgp 65105
    neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
    neighbor EVPN-OVERLAY-PEERS send-community
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
-   neighbor IPv4-UNDERLAY-PEERS peer group
-   neighbor IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
-   neighbor IPv4-UNDERLAY-PEERS send-community
-   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
-   neighbor interface Ethernet1 peer-group IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor interface Ethernet2 peer-group IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor interface Ethernet3 peer-group IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor interface Ethernet4 peer-group IPv4-UNDERLAY-PEERS remote-as 65001
+   neighbor UNDERLAY_PEERS peer group
+   neighbor UNDERLAY_PEERS remote-as 65001
+   neighbor UNDERLAY_PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor UNDERLAY_PEERS send-community
+   neighbor UNDERLAY_PEERS maximum-routes 12000
+   neighbor interface Ethernet1 peer-group UNDERLAY_PEERS remote-as 65001
+   neighbor interface Ethernet2 peer-group UNDERLAY_PEERS remote-as 65001
+   neighbor interface Ethernet3 peer-group UNDERLAY_PEERS remote-as 65001
+   neighbor interface Ethernet4 peer-group UNDERLAY_PEERS remote-as 65001
    neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS
    neighbor 192.168.255.1 remote-as 65001
    neighbor 192.168.255.1 description DC1-SPINE1
@@ -216,8 +216,8 @@ router bgp 65105
    address-family ipv4
       neighbor EVPN-OVERLAY-PEERS next-hop address-family ipv6 originate
       no neighbor EVPN-OVERLAY-PEERS activate
-      neighbor IPv4-UNDERLAY-PEERS next-hop address-family ipv6 originate
-      neighbor IPv4-UNDERLAY-PEERS activate
+      neighbor UNDERLAY_PEERS next-hop address-family ipv6 originate
+      neighbor UNDERLAY_PEERS activate
    !
    vrf Tenant_A_WAN_Zone
       rd 192.168.255.11:14

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
@@ -185,15 +185,15 @@ router bgp 65101
    neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
    neighbor EVPN-OVERLAY-PEERS send-community
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
-   neighbor IPv4-UNDERLAY-PEERS peer group
-   neighbor IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
-   neighbor IPv4-UNDERLAY-PEERS send-community
-   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
-   neighbor interface Ethernet1 peer-group IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor interface Ethernet2 peer-group IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor interface Ethernet3 peer-group IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor interface Ethernet4 peer-group IPv4-UNDERLAY-PEERS remote-as 65001
+   neighbor UNDERLAY_PEERS peer group
+   neighbor UNDERLAY_PEERS remote-as 65001
+   neighbor UNDERLAY_PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor UNDERLAY_PEERS send-community
+   neighbor UNDERLAY_PEERS maximum-routes 12000
+   neighbor interface Ethernet1 peer-group UNDERLAY_PEERS remote-as 65001
+   neighbor interface Ethernet2 peer-group UNDERLAY_PEERS remote-as 65001
+   neighbor interface Ethernet3 peer-group UNDERLAY_PEERS remote-as 65001
+   neighbor interface Ethernet4 peer-group UNDERLAY_PEERS remote-as 65001
    neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS
    neighbor 192.168.255.1 remote-as 65001
    neighbor 192.168.255.1 description DC1-SPINE1
@@ -226,8 +226,8 @@ router bgp 65101
    address-family ipv4
       neighbor EVPN-OVERLAY-PEERS next-hop address-family ipv6 originate
       no neighbor EVPN-OVERLAY-PEERS activate
-      neighbor IPv4-UNDERLAY-PEERS next-hop address-family ipv6 originate
-      neighbor IPv4-UNDERLAY-PEERS activate
+      neighbor UNDERLAY_PEERS next-hop address-family ipv6 originate
+      neighbor UNDERLAY_PEERS activate
    !
    vrf Tenant_A_APP_Zone
       rd 192.168.255.5:12

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
@@ -449,23 +449,23 @@ router bgp 65102
    neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
    neighbor EVPN-OVERLAY-PEERS send-community
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
-   neighbor IPv4-UNDERLAY-PEERS peer group
-   neighbor IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
-   neighbor IPv4-UNDERLAY-PEERS send-community
-   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
-   neighbor MLAG-IPv4-UNDERLAY-PEER peer group
-   neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65102
-   neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
-   neighbor MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==
-   neighbor MLAG-IPv4-UNDERLAY-PEER send-community
-   neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000
-   neighbor MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN in
-   neighbor interface Ethernet1 peer-group IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor interface Ethernet2 peer-group IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor interface Ethernet3 peer-group IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor interface Ethernet4 peer-group IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor interface Vlan4093 peer-group MLAG-IPv4-UNDERLAY-PEER remote-as 65102
+   neighbor MLAG_PEER peer group
+   neighbor MLAG_PEER remote-as 65102
+   neighbor MLAG_PEER next-hop-self
+   neighbor MLAG_PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==
+   neighbor MLAG_PEER send-community
+   neighbor MLAG_PEER maximum-routes 12000
+   neighbor MLAG_PEER route-map RM-MLAG-PEER-IN in
+   neighbor UNDERLAY_PEERS peer group
+   neighbor UNDERLAY_PEERS remote-as 65001
+   neighbor UNDERLAY_PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor UNDERLAY_PEERS send-community
+   neighbor UNDERLAY_PEERS maximum-routes 12000
+   neighbor interface Ethernet1 peer-group UNDERLAY_PEERS remote-as 65001
+   neighbor interface Ethernet2 peer-group UNDERLAY_PEERS remote-as 65001
+   neighbor interface Ethernet3 peer-group UNDERLAY_PEERS remote-as 65001
+   neighbor interface Ethernet4 peer-group UNDERLAY_PEERS remote-as 65001
+   neighbor interface Vlan4093 peer-group MLAG_PEER remote-as 65102
    neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS
    neighbor 192.168.255.1 remote-as 65001
    neighbor 192.168.255.1 description DC1-SPINE1
@@ -534,17 +534,17 @@ router bgp 65102
    address-family ipv4
       neighbor EVPN-OVERLAY-PEERS next-hop address-family ipv6 originate
       no neighbor EVPN-OVERLAY-PEERS activate
-      neighbor IPv4-UNDERLAY-PEERS next-hop address-family ipv6 originate
-      neighbor IPv4-UNDERLAY-PEERS activate
-      neighbor MLAG-IPv4-UNDERLAY-PEER next-hop address-family ipv6 originate
-      neighbor MLAG-IPv4-UNDERLAY-PEER activate
+      neighbor MLAG_PEER next-hop address-family ipv6 originate
+      neighbor MLAG_PEER activate
+      neighbor UNDERLAY_PEERS next-hop address-family ipv6 originate
+      neighbor UNDERLAY_PEERS activate
    !
    vrf Tenant_A_APP_Zone
       rd 192.168.255.6:12
       route-target import evpn 12:12
       route-target export evpn 12:12
       router-id 192.168.255.6
-      neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.3 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -552,7 +552,7 @@ router bgp 65102
       route-target import evpn 13:13
       route-target export evpn 13:13
       router-id 192.168.255.6
-      neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.3 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -560,7 +560,7 @@ router bgp 65102
       route-target import evpn 10:10
       route-target export evpn 10:10
       router-id 192.168.255.6
-      neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.3 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -568,7 +568,7 @@ router bgp 65102
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.6
-      neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.3 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -576,7 +576,7 @@ router bgp 65102
       route-target import evpn 20:20
       route-target export evpn 20:20
       router-id 192.168.255.6
-      neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.3 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -584,7 +584,7 @@ router bgp 65102
       route-target import evpn 30:30
       route-target export evpn 30:30
       router-id 192.168.255.6
-      neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.3 peer group MLAG_PEER
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
@@ -449,23 +449,23 @@ router bgp 65102
    neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
    neighbor EVPN-OVERLAY-PEERS send-community
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
-   neighbor IPv4-UNDERLAY-PEERS peer group
-   neighbor IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
-   neighbor IPv4-UNDERLAY-PEERS send-community
-   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
-   neighbor MLAG-IPv4-UNDERLAY-PEER peer group
-   neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65102
-   neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
-   neighbor MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==
-   neighbor MLAG-IPv4-UNDERLAY-PEER send-community
-   neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000
-   neighbor MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN in
-   neighbor interface Ethernet1 peer-group IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor interface Ethernet2 peer-group IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor interface Ethernet3 peer-group IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor interface Ethernet4 peer-group IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor interface Vlan4093 peer-group MLAG-IPv4-UNDERLAY-PEER remote-as 65102
+   neighbor MLAG_PEER peer group
+   neighbor MLAG_PEER remote-as 65102
+   neighbor MLAG_PEER next-hop-self
+   neighbor MLAG_PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==
+   neighbor MLAG_PEER send-community
+   neighbor MLAG_PEER maximum-routes 12000
+   neighbor MLAG_PEER route-map RM-MLAG-PEER-IN in
+   neighbor UNDERLAY_PEERS peer group
+   neighbor UNDERLAY_PEERS remote-as 65001
+   neighbor UNDERLAY_PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor UNDERLAY_PEERS send-community
+   neighbor UNDERLAY_PEERS maximum-routes 12000
+   neighbor interface Ethernet1 peer-group UNDERLAY_PEERS remote-as 65001
+   neighbor interface Ethernet2 peer-group UNDERLAY_PEERS remote-as 65001
+   neighbor interface Ethernet3 peer-group UNDERLAY_PEERS remote-as 65001
+   neighbor interface Ethernet4 peer-group UNDERLAY_PEERS remote-as 65001
+   neighbor interface Vlan4093 peer-group MLAG_PEER remote-as 65102
    neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS
    neighbor 192.168.255.1 remote-as 65001
    neighbor 192.168.255.1 description DC1-SPINE1
@@ -534,17 +534,17 @@ router bgp 65102
    address-family ipv4
       neighbor EVPN-OVERLAY-PEERS next-hop address-family ipv6 originate
       no neighbor EVPN-OVERLAY-PEERS activate
-      neighbor IPv4-UNDERLAY-PEERS next-hop address-family ipv6 originate
-      neighbor IPv4-UNDERLAY-PEERS activate
-      neighbor MLAG-IPv4-UNDERLAY-PEER next-hop address-family ipv6 originate
-      neighbor MLAG-IPv4-UNDERLAY-PEER activate
+      neighbor MLAG_PEER next-hop address-family ipv6 originate
+      neighbor MLAG_PEER activate
+      neighbor UNDERLAY_PEERS next-hop address-family ipv6 originate
+      neighbor UNDERLAY_PEERS activate
    !
    vrf Tenant_A_APP_Zone
       rd 192.168.255.7:12
       route-target import evpn 12:12
       route-target export evpn 12:12
       router-id 192.168.255.7
-      neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.2 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -552,7 +552,7 @@ router bgp 65102
       route-target import evpn 13:13
       route-target export evpn 13:13
       router-id 192.168.255.7
-      neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.2 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -560,7 +560,7 @@ router bgp 65102
       route-target import evpn 10:10
       route-target export evpn 10:10
       router-id 192.168.255.7
-      neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.2 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -568,7 +568,7 @@ router bgp 65102
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.7
-      neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.2 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -576,7 +576,7 @@ router bgp 65102
       route-target import evpn 20:20
       route-target export evpn 20:20
       router-id 192.168.255.7
-      neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.2 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -584,7 +584,7 @@ router bgp 65102
       route-target import evpn 30:30
       route-target export evpn 30:30
       router-id 192.168.255.7
-      neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.2 peer group MLAG_PEER
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE1.cfg
@@ -113,7 +113,7 @@ router bgp 65001
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    bgp listen range 192.168.255.0/24 peer-group EVPN-OVERLAY-PEERS peer-filter LEAF-AS-RANGE
-   bgp listen range fe80::/10 peer-group IPv4-UNDERLAY-PEERS peer-filter LEAF-AS-RANGE
+   bgp listen range fe80::/10 peer-group UNDERLAY_PEERS peer-filter LEAF-AS-RANGE
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
@@ -122,10 +122,10 @@ router bgp 65001
    neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
    neighbor EVPN-OVERLAY-PEERS send-community
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
-   neighbor IPv4-UNDERLAY-PEERS peer group
-   neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
-   neighbor IPv4-UNDERLAY-PEERS send-community
-   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   neighbor UNDERLAY_PEERS peer group
+   neighbor UNDERLAY_PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor UNDERLAY_PEERS send-community
+   neighbor UNDERLAY_PEERS maximum-routes 12000
    redistribute connected route-map RM-CONN-2-BGP
    !
    address-family evpn
@@ -134,8 +134,8 @@ router bgp 65001
    address-family ipv4
       neighbor EVPN-OVERLAY-PEERS next-hop address-family ipv6 originate
       no neighbor EVPN-OVERLAY-PEERS activate
-      neighbor IPv4-UNDERLAY-PEERS next-hop address-family ipv6 originate
-      neighbor IPv4-UNDERLAY-PEERS activate
+      neighbor UNDERLAY_PEERS next-hop address-family ipv6 originate
+      neighbor UNDERLAY_PEERS activate
 !
 management api http-commands
    protocol https

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE2.cfg
@@ -113,7 +113,7 @@ router bgp 65001
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    bgp listen range 192.168.255.0/24 peer-group EVPN-OVERLAY-PEERS peer-filter LEAF-AS-RANGE
-   bgp listen range fe80::/10 peer-group IPv4-UNDERLAY-PEERS peer-filter LEAF-AS-RANGE
+   bgp listen range fe80::/10 peer-group UNDERLAY_PEERS peer-filter LEAF-AS-RANGE
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
@@ -122,10 +122,10 @@ router bgp 65001
    neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
    neighbor EVPN-OVERLAY-PEERS send-community
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
-   neighbor IPv4-UNDERLAY-PEERS peer group
-   neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
-   neighbor IPv4-UNDERLAY-PEERS send-community
-   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   neighbor UNDERLAY_PEERS peer group
+   neighbor UNDERLAY_PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor UNDERLAY_PEERS send-community
+   neighbor UNDERLAY_PEERS maximum-routes 12000
    redistribute connected route-map RM-CONN-2-BGP
    !
    address-family evpn
@@ -134,8 +134,8 @@ router bgp 65001
    address-family ipv4
       neighbor EVPN-OVERLAY-PEERS next-hop address-family ipv6 originate
       no neighbor EVPN-OVERLAY-PEERS activate
-      neighbor IPv4-UNDERLAY-PEERS next-hop address-family ipv6 originate
-      neighbor IPv4-UNDERLAY-PEERS activate
+      neighbor UNDERLAY_PEERS next-hop address-family ipv6 originate
+      neighbor UNDERLAY_PEERS activate
 !
 management api http-commands
    protocol https

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE3.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE3.cfg
@@ -113,7 +113,7 @@ router bgp 65001
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    bgp listen range 192.168.255.0/24 peer-group EVPN-OVERLAY-PEERS peer-filter LEAF-AS-RANGE
-   bgp listen range fe80::/10 peer-group IPv4-UNDERLAY-PEERS peer-filter LEAF-AS-RANGE
+   bgp listen range fe80::/10 peer-group UNDERLAY_PEERS peer-filter LEAF-AS-RANGE
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
@@ -122,10 +122,10 @@ router bgp 65001
    neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
    neighbor EVPN-OVERLAY-PEERS send-community
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
-   neighbor IPv4-UNDERLAY-PEERS peer group
-   neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
-   neighbor IPv4-UNDERLAY-PEERS send-community
-   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   neighbor UNDERLAY_PEERS peer group
+   neighbor UNDERLAY_PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor UNDERLAY_PEERS send-community
+   neighbor UNDERLAY_PEERS maximum-routes 12000
    redistribute connected route-map RM-CONN-2-BGP
    !
    address-family evpn
@@ -134,8 +134,8 @@ router bgp 65001
    address-family ipv4
       neighbor EVPN-OVERLAY-PEERS next-hop address-family ipv6 originate
       no neighbor EVPN-OVERLAY-PEERS activate
-      neighbor IPv4-UNDERLAY-PEERS next-hop address-family ipv6 originate
-      neighbor IPv4-UNDERLAY-PEERS activate
+      neighbor UNDERLAY_PEERS next-hop address-family ipv6 originate
+      neighbor UNDERLAY_PEERS activate
 !
 management api http-commands
    protocol https

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE4.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE4.cfg
@@ -113,7 +113,7 @@ router bgp 65001
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4
    bgp listen range 192.168.255.0/24 peer-group EVPN-OVERLAY-PEERS peer-filter LEAF-AS-RANGE
-   bgp listen range fe80::/10 peer-group IPv4-UNDERLAY-PEERS peer-filter LEAF-AS-RANGE
+   bgp listen range fe80::/10 peer-group UNDERLAY_PEERS peer-filter LEAF-AS-RANGE
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
@@ -122,10 +122,10 @@ router bgp 65001
    neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
    neighbor EVPN-OVERLAY-PEERS send-community
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
-   neighbor IPv4-UNDERLAY-PEERS peer group
-   neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
-   neighbor IPv4-UNDERLAY-PEERS send-community
-   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   neighbor UNDERLAY_PEERS peer group
+   neighbor UNDERLAY_PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor UNDERLAY_PEERS send-community
+   neighbor UNDERLAY_PEERS maximum-routes 12000
    redistribute connected route-map RM-CONN-2-BGP
    !
    address-family evpn
@@ -134,8 +134,8 @@ router bgp 65001
    address-family ipv4
       neighbor EVPN-OVERLAY-PEERS next-hop address-family ipv6 originate
       no neighbor EVPN-OVERLAY-PEERS activate
-      neighbor IPv4-UNDERLAY-PEERS next-hop address-family ipv6 originate
-      neighbor IPv4-UNDERLAY-PEERS activate
+      neighbor UNDERLAY_PEERS next-hop address-family ipv6 originate
+      neighbor UNDERLAY_PEERS activate
 !
 management api http-commands
    protocol https

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
@@ -594,23 +594,23 @@ router bgp 65103
    neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
    neighbor EVPN-OVERLAY-PEERS send-community
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
-   neighbor IPv4-UNDERLAY-PEERS peer group
-   neighbor IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
-   neighbor IPv4-UNDERLAY-PEERS send-community
-   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
-   neighbor MLAG-IPv4-UNDERLAY-PEER peer group
-   neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65103
-   neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
-   neighbor MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==
-   neighbor MLAG-IPv4-UNDERLAY-PEER send-community
-   neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000
-   neighbor MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN in
-   neighbor interface Ethernet1 peer-group IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor interface Ethernet2 peer-group IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor interface Ethernet3 peer-group IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor interface Ethernet4 peer-group IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor interface Vlan4093 peer-group MLAG-IPv4-UNDERLAY-PEER remote-as 65103
+   neighbor MLAG_PEER peer group
+   neighbor MLAG_PEER remote-as 65103
+   neighbor MLAG_PEER next-hop-self
+   neighbor MLAG_PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==
+   neighbor MLAG_PEER send-community
+   neighbor MLAG_PEER maximum-routes 12000
+   neighbor MLAG_PEER route-map RM-MLAG-PEER-IN in
+   neighbor UNDERLAY_PEERS peer group
+   neighbor UNDERLAY_PEERS remote-as 65001
+   neighbor UNDERLAY_PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor UNDERLAY_PEERS send-community
+   neighbor UNDERLAY_PEERS maximum-routes 12000
+   neighbor interface Ethernet1 peer-group UNDERLAY_PEERS remote-as 65001
+   neighbor interface Ethernet2 peer-group UNDERLAY_PEERS remote-as 65001
+   neighbor interface Ethernet3 peer-group UNDERLAY_PEERS remote-as 65001
+   neighbor interface Ethernet4 peer-group UNDERLAY_PEERS remote-as 65001
+   neighbor interface Vlan4093 peer-group MLAG_PEER remote-as 65103
    neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS
    neighbor 192.168.255.1 remote-as 65001
    neighbor 192.168.255.1 description DC1-SPINE1
@@ -697,17 +697,17 @@ router bgp 65103
    address-family ipv4
       neighbor EVPN-OVERLAY-PEERS next-hop address-family ipv6 originate
       no neighbor EVPN-OVERLAY-PEERS activate
-      neighbor IPv4-UNDERLAY-PEERS next-hop address-family ipv6 originate
-      neighbor IPv4-UNDERLAY-PEERS activate
-      neighbor MLAG-IPv4-UNDERLAY-PEER next-hop address-family ipv6 originate
-      neighbor MLAG-IPv4-UNDERLAY-PEER activate
+      neighbor MLAG_PEER next-hop address-family ipv6 originate
+      neighbor MLAG_PEER activate
+      neighbor UNDERLAY_PEERS next-hop address-family ipv6 originate
+      neighbor UNDERLAY_PEERS activate
    !
    vrf Tenant_A_APP_Zone
       rd 192.168.255.8:12
       route-target import evpn 12:12
       route-target export evpn 12:12
       router-id 192.168.255.8
-      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.7 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -715,7 +715,7 @@ router bgp 65103
       route-target import evpn 13:13
       route-target export evpn 13:13
       router-id 192.168.255.8
-      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.7 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -723,7 +723,7 @@ router bgp 65103
       route-target import evpn 10:10
       route-target export evpn 10:10
       router-id 192.168.255.8
-      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.7 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -731,7 +731,7 @@ router bgp 65103
       route-target import evpn 14:14
       route-target export evpn 14:14
       router-id 192.168.255.8
-      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.7 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -739,7 +739,7 @@ router bgp 65103
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.8
-      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.7 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -747,7 +747,7 @@ router bgp 65103
       route-target import evpn 20:20
       route-target export evpn 20:20
       router-id 192.168.255.8
-      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.7 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -755,7 +755,7 @@ router bgp 65103
       route-target import evpn 21:21
       route-target export evpn 21:21
       router-id 192.168.255.8
-      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.7 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -763,7 +763,7 @@ router bgp 65103
       route-target import evpn 30:30
       route-target export evpn 30:30
       router-id 192.168.255.8
-      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.7 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -771,7 +771,7 @@ router bgp 65103
       route-target import evpn 31:31
       route-target export evpn 31:31
       router-id 192.168.255.8
-      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.7 peer group MLAG_PEER
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
@@ -581,23 +581,23 @@ router bgp 65103
    neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
    neighbor EVPN-OVERLAY-PEERS send-community
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
-   neighbor IPv4-UNDERLAY-PEERS peer group
-   neighbor IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
-   neighbor IPv4-UNDERLAY-PEERS send-community
-   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
-   neighbor MLAG-IPv4-UNDERLAY-PEER peer group
-   neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65103
-   neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
-   neighbor MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==
-   neighbor MLAG-IPv4-UNDERLAY-PEER send-community
-   neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000
-   neighbor MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN in
-   neighbor interface Ethernet1 peer-group IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor interface Ethernet2 peer-group IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor interface Ethernet3 peer-group IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor interface Ethernet4 peer-group IPv4-UNDERLAY-PEERS remote-as 65001
-   neighbor interface Vlan4093 peer-group MLAG-IPv4-UNDERLAY-PEER remote-as 65103
+   neighbor MLAG_PEER peer group
+   neighbor MLAG_PEER remote-as 65103
+   neighbor MLAG_PEER next-hop-self
+   neighbor MLAG_PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==
+   neighbor MLAG_PEER send-community
+   neighbor MLAG_PEER maximum-routes 12000
+   neighbor MLAG_PEER route-map RM-MLAG-PEER-IN in
+   neighbor UNDERLAY_PEERS peer group
+   neighbor UNDERLAY_PEERS remote-as 65001
+   neighbor UNDERLAY_PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor UNDERLAY_PEERS send-community
+   neighbor UNDERLAY_PEERS maximum-routes 12000
+   neighbor interface Ethernet1 peer-group UNDERLAY_PEERS remote-as 65001
+   neighbor interface Ethernet2 peer-group UNDERLAY_PEERS remote-as 65001
+   neighbor interface Ethernet3 peer-group UNDERLAY_PEERS remote-as 65001
+   neighbor interface Ethernet4 peer-group UNDERLAY_PEERS remote-as 65001
+   neighbor interface Vlan4093 peer-group MLAG_PEER remote-as 65103
    neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS
    neighbor 192.168.255.1 remote-as 65001
    neighbor 192.168.255.1 description DC1-SPINE1
@@ -684,17 +684,17 @@ router bgp 65103
    address-family ipv4
       neighbor EVPN-OVERLAY-PEERS next-hop address-family ipv6 originate
       no neighbor EVPN-OVERLAY-PEERS activate
-      neighbor IPv4-UNDERLAY-PEERS next-hop address-family ipv6 originate
-      neighbor IPv4-UNDERLAY-PEERS activate
-      neighbor MLAG-IPv4-UNDERLAY-PEER next-hop address-family ipv6 originate
-      neighbor MLAG-IPv4-UNDERLAY-PEER activate
+      neighbor MLAG_PEER next-hop address-family ipv6 originate
+      neighbor MLAG_PEER activate
+      neighbor UNDERLAY_PEERS next-hop address-family ipv6 originate
+      neighbor UNDERLAY_PEERS activate
    !
    vrf Tenant_A_APP_Zone
       rd 192.168.255.9:12
       route-target import evpn 12:12
       route-target export evpn 12:12
       router-id 192.168.255.9
-      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.6 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -702,7 +702,7 @@ router bgp 65103
       route-target import evpn 13:13
       route-target export evpn 13:13
       router-id 192.168.255.9
-      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.6 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -710,7 +710,7 @@ router bgp 65103
       route-target import evpn 10:10
       route-target export evpn 10:10
       router-id 192.168.255.9
-      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.6 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -718,7 +718,7 @@ router bgp 65103
       route-target import evpn 14:14
       route-target export evpn 14:14
       router-id 192.168.255.9
-      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.6 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -726,7 +726,7 @@ router bgp 65103
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.9
-      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.6 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -734,7 +734,7 @@ router bgp 65103
       route-target import evpn 20:20
       route-target export evpn 20:20
       router-id 192.168.255.9
-      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.6 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -742,7 +742,7 @@ router bgp 65103
       route-target import evpn 21:21
       route-target export evpn 21:21
       router-id 192.168.255.9
-      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.6 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -750,7 +750,7 @@ router bgp 65103
       route-target import evpn 30:30
       route-target export evpn 30:30
       router-id 192.168.255.9
-      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.6 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -758,7 +758,7 @@ router bgp 65103
       route-target import evpn 31:31
       route-target export evpn 31:31
       router-id 192.168.255.9
-      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.6 peer group MLAG_PEER
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
@@ -274,7 +274,7 @@ router_bgp:
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
   peer_groups:
-    IPv4-UNDERLAY-PEERS:
+    UNDERLAY_PEERS:
       type: ipv4
       remote_as: 65001
       password: AQQvKeimxJu+uGQ/yYvv9w==
@@ -290,19 +290,19 @@ router_bgp:
       maximum_routes: 0
   neighbor_interfaces:
     Ethernet1:
-      peer_group: IPv4-UNDERLAY-PEERS
+      peer_group: UNDERLAY_PEERS
       remote_as: 65001
       description: DC1-SPINE1_Ethernet6
     Ethernet2:
-      peer_group: IPv4-UNDERLAY-PEERS
+      peer_group: UNDERLAY_PEERS
       remote_as: 65001
       description: DC1-SPINE2_Ethernet6
     Ethernet3:
-      peer_group: IPv4-UNDERLAY-PEERS
+      peer_group: UNDERLAY_PEERS
       remote_as: 65001
       description: DC1-SPINE3_Ethernet6
     Ethernet4:
-      peer_group: IPv4-UNDERLAY-PEERS
+      peer_group: UNDERLAY_PEERS
       remote_as: 65001
       description: DC1-SPINE4_Ethernet6
   neighbors:
@@ -333,7 +333,7 @@ router_bgp:
     peer_groups:
       EVPN-OVERLAY-PEERS:
         activate: false
-      IPv4-UNDERLAY-PEERS:
+      UNDERLAY_PEERS:
         activate: true
   address_family_rtc: null
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
@@ -274,7 +274,7 @@ router_bgp:
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
   peer_groups:
-    IPv4-UNDERLAY-PEERS:
+    UNDERLAY_PEERS:
       type: ipv4
       remote_as: 65001
       password: AQQvKeimxJu+uGQ/yYvv9w==
@@ -290,19 +290,19 @@ router_bgp:
       maximum_routes: 0
   neighbor_interfaces:
     Ethernet1:
-      peer_group: IPv4-UNDERLAY-PEERS
+      peer_group: UNDERLAY_PEERS
       remote_as: 65001
       description: DC1-SPINE1_Ethernet7
     Ethernet2:
-      peer_group: IPv4-UNDERLAY-PEERS
+      peer_group: UNDERLAY_PEERS
       remote_as: 65001
       description: DC1-SPINE2_Ethernet7
     Ethernet3:
-      peer_group: IPv4-UNDERLAY-PEERS
+      peer_group: UNDERLAY_PEERS
       remote_as: 65001
       description: DC1-SPINE3_Ethernet7
     Ethernet4:
-      peer_group: IPv4-UNDERLAY-PEERS
+      peer_group: UNDERLAY_PEERS
       remote_as: 65001
       description: DC1-SPINE4_Ethernet7
   neighbors:
@@ -333,7 +333,7 @@ router_bgp:
     peer_groups:
       EVPN-OVERLAY-PEERS:
         activate: false
-      IPv4-UNDERLAY-PEERS:
+      UNDERLAY_PEERS:
         activate: true
   address_family_rtc: null
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
@@ -305,7 +305,7 @@ router_bgp:
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
   peer_groups:
-    IPv4-UNDERLAY-PEERS:
+    UNDERLAY_PEERS:
       type: ipv4
       remote_as: 65001
       password: AQQvKeimxJu+uGQ/yYvv9w==
@@ -321,19 +321,19 @@ router_bgp:
       maximum_routes: 0
   neighbor_interfaces:
     Ethernet1:
-      peer_group: IPv4-UNDERLAY-PEERS
+      peer_group: UNDERLAY_PEERS
       remote_as: 65001
       description: DC1-SPINE1_Ethernet1
     Ethernet2:
-      peer_group: IPv4-UNDERLAY-PEERS
+      peer_group: UNDERLAY_PEERS
       remote_as: 65001
       description: DC1-SPINE2_Ethernet1
     Ethernet3:
-      peer_group: IPv4-UNDERLAY-PEERS
+      peer_group: UNDERLAY_PEERS
       remote_as: 65001
       description: DC1-SPINE3_Ethernet1
     Ethernet4:
-      peer_group: IPv4-UNDERLAY-PEERS
+      peer_group: UNDERLAY_PEERS
       remote_as: 65001
       description: DC1-SPINE4_Ethernet1
   neighbors:
@@ -364,7 +364,7 @@ router_bgp:
     peer_groups:
       EVPN-OVERLAY-PEERS:
         activate: false
-      IPv4-UNDERLAY-PEERS:
+      UNDERLAY_PEERS:
         activate: true
   address_family_rtc: null
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -675,13 +675,13 @@ router_bgp:
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
   peer_groups:
-    IPv4-UNDERLAY-PEERS:
+    UNDERLAY_PEERS:
       type: ipv4
       remote_as: 65001
       password: AQQvKeimxJu+uGQ/yYvv9w==
       maximum_routes: 12000
       send_community: all
-    MLAG-IPv4-UNDERLAY-PEER:
+    MLAG_PEER:
       type: ipv4
       remote_as: 65102
       next_hop_self: true
@@ -699,23 +699,23 @@ router_bgp:
       maximum_routes: 0
   neighbor_interfaces:
     Ethernet1:
-      peer_group: IPv4-UNDERLAY-PEERS
+      peer_group: UNDERLAY_PEERS
       remote_as: 65001
       description: DC1-SPINE1_Ethernet2
     Ethernet2:
-      peer_group: IPv4-UNDERLAY-PEERS
+      peer_group: UNDERLAY_PEERS
       remote_as: 65001
       description: DC1-SPINE2_Ethernet2
     Ethernet3:
-      peer_group: IPv4-UNDERLAY-PEERS
+      peer_group: UNDERLAY_PEERS
       remote_as: 65001
       description: DC1-SPINE3_Ethernet2
     Ethernet4:
-      peer_group: IPv4-UNDERLAY-PEERS
+      peer_group: UNDERLAY_PEERS
       remote_as: 65001
       description: DC1-SPINE4_Ethernet2
     Vlan4093:
-      peer_group: MLAG-IPv4-UNDERLAY-PEER
+      peer_group: MLAG_PEER
       remote_as: 65102
       description: DC1-LEAF2B
   neighbors:
@@ -746,9 +746,9 @@ router_bgp:
     peer_groups:
       EVPN-OVERLAY-PEERS:
         activate: false
-      IPv4-UNDERLAY-PEERS:
+      UNDERLAY_PEERS:
         activate: true
-      MLAG-IPv4-UNDERLAY-PEER:
+      MLAG_PEER:
         activate: true
   address_family_rtc: null
   vlan_aware_bundles:
@@ -832,7 +832,7 @@ router_bgp:
           - '12:12'
       neighbors:
         10.255.251.3:
-          peer_group: MLAG-IPv4-UNDERLAY-PEER
+          peer_group: MLAG_PEER
       redistribute_routes:
       - connected
     Tenant_A_DB_Zone:
@@ -847,7 +847,7 @@ router_bgp:
           - '13:13'
       neighbors:
         10.255.251.3:
-          peer_group: MLAG-IPv4-UNDERLAY-PEER
+          peer_group: MLAG_PEER
       redistribute_routes:
       - connected
     Tenant_A_OP_Zone:
@@ -862,7 +862,7 @@ router_bgp:
           - '10:10'
       neighbors:
         10.255.251.3:
-          peer_group: MLAG-IPv4-UNDERLAY-PEER
+          peer_group: MLAG_PEER
       redistribute_routes:
       - connected
     Tenant_A_WEB_Zone:
@@ -877,7 +877,7 @@ router_bgp:
           - '11:11'
       neighbors:
         10.255.251.3:
-          peer_group: MLAG-IPv4-UNDERLAY-PEER
+          peer_group: MLAG_PEER
       redistribute_routes:
       - connected
     Tenant_B_OP_Zone:
@@ -892,7 +892,7 @@ router_bgp:
           - '20:20'
       neighbors:
         10.255.251.3:
-          peer_group: MLAG-IPv4-UNDERLAY-PEER
+          peer_group: MLAG_PEER
       redistribute_routes:
       - connected
     Tenant_C_OP_Zone:
@@ -907,7 +907,7 @@ router_bgp:
           - '30:30'
       neighbors:
         10.255.251.3:
-          peer_group: MLAG-IPv4-UNDERLAY-PEER
+          peer_group: MLAG_PEER
       redistribute_routes:
       - connected
 ip_extcommunity_lists: null

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -675,13 +675,13 @@ router_bgp:
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
   peer_groups:
-    IPv4-UNDERLAY-PEERS:
+    UNDERLAY_PEERS:
       type: ipv4
       remote_as: 65001
       password: AQQvKeimxJu+uGQ/yYvv9w==
       maximum_routes: 12000
       send_community: all
-    MLAG-IPv4-UNDERLAY-PEER:
+    MLAG_PEER:
       type: ipv4
       remote_as: 65102
       next_hop_self: true
@@ -699,23 +699,23 @@ router_bgp:
       maximum_routes: 0
   neighbor_interfaces:
     Ethernet1:
-      peer_group: IPv4-UNDERLAY-PEERS
+      peer_group: UNDERLAY_PEERS
       remote_as: 65001
       description: DC1-SPINE1_Ethernet3
     Ethernet2:
-      peer_group: IPv4-UNDERLAY-PEERS
+      peer_group: UNDERLAY_PEERS
       remote_as: 65001
       description: DC1-SPINE2_Ethernet3
     Ethernet3:
-      peer_group: IPv4-UNDERLAY-PEERS
+      peer_group: UNDERLAY_PEERS
       remote_as: 65001
       description: DC1-SPINE3_Ethernet3
     Ethernet4:
-      peer_group: IPv4-UNDERLAY-PEERS
+      peer_group: UNDERLAY_PEERS
       remote_as: 65001
       description: DC1-SPINE4_Ethernet3
     Vlan4093:
-      peer_group: MLAG-IPv4-UNDERLAY-PEER
+      peer_group: MLAG_PEER
       remote_as: 65102
       description: DC1-LEAF2A
   neighbors:
@@ -746,9 +746,9 @@ router_bgp:
     peer_groups:
       EVPN-OVERLAY-PEERS:
         activate: false
-      IPv4-UNDERLAY-PEERS:
+      UNDERLAY_PEERS:
         activate: true
-      MLAG-IPv4-UNDERLAY-PEER:
+      MLAG_PEER:
         activate: true
   address_family_rtc: null
   vlan_aware_bundles:
@@ -832,7 +832,7 @@ router_bgp:
           - '12:12'
       neighbors:
         10.255.251.2:
-          peer_group: MLAG-IPv4-UNDERLAY-PEER
+          peer_group: MLAG_PEER
       redistribute_routes:
       - connected
     Tenant_A_DB_Zone:
@@ -847,7 +847,7 @@ router_bgp:
           - '13:13'
       neighbors:
         10.255.251.2:
-          peer_group: MLAG-IPv4-UNDERLAY-PEER
+          peer_group: MLAG_PEER
       redistribute_routes:
       - connected
     Tenant_A_OP_Zone:
@@ -862,7 +862,7 @@ router_bgp:
           - '10:10'
       neighbors:
         10.255.251.2:
-          peer_group: MLAG-IPv4-UNDERLAY-PEER
+          peer_group: MLAG_PEER
       redistribute_routes:
       - connected
     Tenant_A_WEB_Zone:
@@ -877,7 +877,7 @@ router_bgp:
           - '11:11'
       neighbors:
         10.255.251.2:
-          peer_group: MLAG-IPv4-UNDERLAY-PEER
+          peer_group: MLAG_PEER
       redistribute_routes:
       - connected
     Tenant_B_OP_Zone:
@@ -892,7 +892,7 @@ router_bgp:
           - '20:20'
       neighbors:
         10.255.251.2:
-          peer_group: MLAG-IPv4-UNDERLAY-PEER
+          peer_group: MLAG_PEER
       redistribute_routes:
       - connected
     Tenant_C_OP_Zone:
@@ -907,7 +907,7 @@ router_bgp:
           - '30:30'
       neighbors:
         10.255.251.2:
-          peer_group: MLAG-IPv4-UNDERLAY-PEER
+          peer_group: MLAG_PEER
       redistribute_routes:
       - connected
 ip_extcommunity_lists: null

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
@@ -182,7 +182,7 @@ router_bgp:
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
   peer_groups:
-    IPv4-UNDERLAY-PEERS:
+    UNDERLAY_PEERS:
       type: ipv4
       peer_filter: LEAF-AS-RANGE
       bgp_listen_range_prefix: fe80::/10
@@ -210,7 +210,7 @@ router_bgp:
         activate: true
   address_family_ipv4:
     peer_groups:
-      IPv4-UNDERLAY-PEERS:
+      UNDERLAY_PEERS:
         activate: true
       EVPN-OVERLAY-PEERS:
         activate: false

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
@@ -182,7 +182,7 @@ router_bgp:
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
   peer_groups:
-    IPv4-UNDERLAY-PEERS:
+    UNDERLAY_PEERS:
       type: ipv4
       peer_filter: LEAF-AS-RANGE
       bgp_listen_range_prefix: fe80::/10
@@ -210,7 +210,7 @@ router_bgp:
         activate: true
   address_family_ipv4:
     peer_groups:
-      IPv4-UNDERLAY-PEERS:
+      UNDERLAY_PEERS:
         activate: true
       EVPN-OVERLAY-PEERS:
         activate: false

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
@@ -182,7 +182,7 @@ router_bgp:
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
   peer_groups:
-    IPv4-UNDERLAY-PEERS:
+    UNDERLAY_PEERS:
       type: ipv4
       peer_filter: LEAF-AS-RANGE
       bgp_listen_range_prefix: fe80::/10
@@ -210,7 +210,7 @@ router_bgp:
         activate: true
   address_family_ipv4:
     peer_groups:
-      IPv4-UNDERLAY-PEERS:
+      UNDERLAY_PEERS:
         activate: true
       EVPN-OVERLAY-PEERS:
         activate: false

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
@@ -182,7 +182,7 @@ router_bgp:
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
   peer_groups:
-    IPv4-UNDERLAY-PEERS:
+    UNDERLAY_PEERS:
       type: ipv4
       peer_filter: LEAF-AS-RANGE
       bgp_listen_range_prefix: fe80::/10
@@ -210,7 +210,7 @@ router_bgp:
         activate: true
   address_family_ipv4:
     peer_groups:
-      IPv4-UNDERLAY-PEERS:
+      UNDERLAY_PEERS:
         activate: true
       EVPN-OVERLAY-PEERS:
         activate: false

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -951,13 +951,13 @@ router_bgp:
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
   peer_groups:
-    IPv4-UNDERLAY-PEERS:
+    UNDERLAY_PEERS:
       type: ipv4
       remote_as: 65001
       password: AQQvKeimxJu+uGQ/yYvv9w==
       maximum_routes: 12000
       send_community: all
-    MLAG-IPv4-UNDERLAY-PEER:
+    MLAG_PEER:
       type: ipv4
       remote_as: 65103
       next_hop_self: true
@@ -975,23 +975,23 @@ router_bgp:
       maximum_routes: 0
   neighbor_interfaces:
     Ethernet1:
-      peer_group: IPv4-UNDERLAY-PEERS
+      peer_group: UNDERLAY_PEERS
       remote_as: 65001
       description: DC1-SPINE1_Ethernet4
     Ethernet2:
-      peer_group: IPv4-UNDERLAY-PEERS
+      peer_group: UNDERLAY_PEERS
       remote_as: 65001
       description: DC1-SPINE2_Ethernet4
     Ethernet3:
-      peer_group: IPv4-UNDERLAY-PEERS
+      peer_group: UNDERLAY_PEERS
       remote_as: 65001
       description: DC1-SPINE3_Ethernet4
     Ethernet4:
-      peer_group: IPv4-UNDERLAY-PEERS
+      peer_group: UNDERLAY_PEERS
       remote_as: 65001
       description: DC1-SPINE4_Ethernet4
     Vlan4093:
-      peer_group: MLAG-IPv4-UNDERLAY-PEER
+      peer_group: MLAG_PEER
       remote_as: 65103
       description: DC1-SVC3B
   neighbors:
@@ -1022,9 +1022,9 @@ router_bgp:
     peer_groups:
       EVPN-OVERLAY-PEERS:
         activate: false
-      IPv4-UNDERLAY-PEERS:
+      UNDERLAY_PEERS:
         activate: true
-      MLAG-IPv4-UNDERLAY-PEER:
+      MLAG_PEER:
         activate: true
   address_family_rtc: null
   vlan_aware_bundles:
@@ -1132,7 +1132,7 @@ router_bgp:
           - '12:12'
       neighbors:
         10.255.251.7:
-          peer_group: MLAG-IPv4-UNDERLAY-PEER
+          peer_group: MLAG_PEER
       redistribute_routes:
       - connected
     Tenant_A_DB_Zone:
@@ -1147,7 +1147,7 @@ router_bgp:
           - '13:13'
       neighbors:
         10.255.251.7:
-          peer_group: MLAG-IPv4-UNDERLAY-PEER
+          peer_group: MLAG_PEER
       redistribute_routes:
       - connected
     Tenant_A_OP_Zone:
@@ -1162,7 +1162,7 @@ router_bgp:
           - '10:10'
       neighbors:
         10.255.251.7:
-          peer_group: MLAG-IPv4-UNDERLAY-PEER
+          peer_group: MLAG_PEER
       redistribute_routes:
       - connected
     Tenant_A_WAN_Zone:
@@ -1177,7 +1177,7 @@ router_bgp:
           - '14:14'
       neighbors:
         10.255.251.7:
-          peer_group: MLAG-IPv4-UNDERLAY-PEER
+          peer_group: MLAG_PEER
       redistribute_routes:
       - connected
     Tenant_A_WEB_Zone:
@@ -1192,7 +1192,7 @@ router_bgp:
           - '11:11'
       neighbors:
         10.255.251.7:
-          peer_group: MLAG-IPv4-UNDERLAY-PEER
+          peer_group: MLAG_PEER
       redistribute_routes:
       - connected
     Tenant_B_OP_Zone:
@@ -1207,7 +1207,7 @@ router_bgp:
           - '20:20'
       neighbors:
         10.255.251.7:
-          peer_group: MLAG-IPv4-UNDERLAY-PEER
+          peer_group: MLAG_PEER
       redistribute_routes:
       - connected
     Tenant_B_WAN_Zone:
@@ -1222,7 +1222,7 @@ router_bgp:
           - '21:21'
       neighbors:
         10.255.251.7:
-          peer_group: MLAG-IPv4-UNDERLAY-PEER
+          peer_group: MLAG_PEER
       redistribute_routes:
       - connected
     Tenant_C_OP_Zone:
@@ -1237,7 +1237,7 @@ router_bgp:
           - '30:30'
       neighbors:
         10.255.251.7:
-          peer_group: MLAG-IPv4-UNDERLAY-PEER
+          peer_group: MLAG_PEER
       redistribute_routes:
       - connected
     Tenant_C_WAN_Zone:
@@ -1252,7 +1252,7 @@ router_bgp:
           - '31:31'
       neighbors:
         10.255.251.7:
-          peer_group: MLAG-IPv4-UNDERLAY-PEER
+          peer_group: MLAG_PEER
       redistribute_routes:
       - connected
 ip_extcommunity_lists: null

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -931,13 +931,13 @@ router_bgp:
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
   peer_groups:
-    IPv4-UNDERLAY-PEERS:
+    UNDERLAY_PEERS:
       type: ipv4
       remote_as: 65001
       password: AQQvKeimxJu+uGQ/yYvv9w==
       maximum_routes: 12000
       send_community: all
-    MLAG-IPv4-UNDERLAY-PEER:
+    MLAG_PEER:
       type: ipv4
       remote_as: 65103
       next_hop_self: true
@@ -955,23 +955,23 @@ router_bgp:
       maximum_routes: 0
   neighbor_interfaces:
     Ethernet1:
-      peer_group: IPv4-UNDERLAY-PEERS
+      peer_group: UNDERLAY_PEERS
       remote_as: 65001
       description: DC1-SPINE1_Ethernet5
     Ethernet2:
-      peer_group: IPv4-UNDERLAY-PEERS
+      peer_group: UNDERLAY_PEERS
       remote_as: 65001
       description: DC1-SPINE2_Ethernet5
     Ethernet3:
-      peer_group: IPv4-UNDERLAY-PEERS
+      peer_group: UNDERLAY_PEERS
       remote_as: 65001
       description: DC1-SPINE3_Ethernet5
     Ethernet4:
-      peer_group: IPv4-UNDERLAY-PEERS
+      peer_group: UNDERLAY_PEERS
       remote_as: 65001
       description: DC1-SPINE4_Ethernet5
     Vlan4093:
-      peer_group: MLAG-IPv4-UNDERLAY-PEER
+      peer_group: MLAG_PEER
       remote_as: 65103
       description: DC1-SVC3A
   neighbors:
@@ -1002,9 +1002,9 @@ router_bgp:
     peer_groups:
       EVPN-OVERLAY-PEERS:
         activate: false
-      IPv4-UNDERLAY-PEERS:
+      UNDERLAY_PEERS:
         activate: true
-      MLAG-IPv4-UNDERLAY-PEER:
+      MLAG_PEER:
         activate: true
   address_family_rtc: null
   vlan_aware_bundles:
@@ -1112,7 +1112,7 @@ router_bgp:
           - '12:12'
       neighbors:
         10.255.251.6:
-          peer_group: MLAG-IPv4-UNDERLAY-PEER
+          peer_group: MLAG_PEER
       redistribute_routes:
       - connected
     Tenant_A_DB_Zone:
@@ -1127,7 +1127,7 @@ router_bgp:
           - '13:13'
       neighbors:
         10.255.251.6:
-          peer_group: MLAG-IPv4-UNDERLAY-PEER
+          peer_group: MLAG_PEER
       redistribute_routes:
       - connected
     Tenant_A_OP_Zone:
@@ -1142,7 +1142,7 @@ router_bgp:
           - '10:10'
       neighbors:
         10.255.251.6:
-          peer_group: MLAG-IPv4-UNDERLAY-PEER
+          peer_group: MLAG_PEER
       redistribute_routes:
       - connected
     Tenant_A_WAN_Zone:
@@ -1157,7 +1157,7 @@ router_bgp:
           - '14:14'
       neighbors:
         10.255.251.6:
-          peer_group: MLAG-IPv4-UNDERLAY-PEER
+          peer_group: MLAG_PEER
       redistribute_routes:
       - connected
     Tenant_A_WEB_Zone:
@@ -1172,7 +1172,7 @@ router_bgp:
           - '11:11'
       neighbors:
         10.255.251.6:
-          peer_group: MLAG-IPv4-UNDERLAY-PEER
+          peer_group: MLAG_PEER
       redistribute_routes:
       - connected
     Tenant_B_OP_Zone:
@@ -1187,7 +1187,7 @@ router_bgp:
           - '20:20'
       neighbors:
         10.255.251.6:
-          peer_group: MLAG-IPv4-UNDERLAY-PEER
+          peer_group: MLAG_PEER
       redistribute_routes:
       - connected
     Tenant_B_WAN_Zone:
@@ -1202,7 +1202,7 @@ router_bgp:
           - '21:21'
       neighbors:
         10.255.251.6:
-          peer_group: MLAG-IPv4-UNDERLAY-PEER
+          peer_group: MLAG_PEER
       redistribute_routes:
       - connected
     Tenant_C_OP_Zone:
@@ -1217,7 +1217,7 @@ router_bgp:
           - '30:30'
       neighbors:
         10.255.251.6:
-          peer_group: MLAG-IPv4-UNDERLAY-PEER
+          peer_group: MLAG_PEER
       redistribute_routes:
       - connected
     Tenant_C_WAN_Zone:
@@ -1232,7 +1232,7 @@ router_bgp:
           - '31:31'
       neighbors:
         10.255.251.6:
-          peer_group: MLAG-IPv4-UNDERLAY-PEER
+          peer_group: MLAG_PEER
       redistribute_routes:
       - connected
 ip_extcommunity_lists: null

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
@@ -31,9 +31,11 @@ vxlan_vlan_aware_bundles: true
 bgp_peer_groups:
   IPv4_UNDERLAY_PEERS:
     password: "AQQvKeimxJu+uGQ/yYvv9w=="
+    name: "UNDERLAY_PEERS"
   EVPN_OVERLAY_PEERS:
       password: "q+VNViP5i4rVjW1cxFv2wA=="
   MLAG_IPv4_UNDERLAY_PEER:
+      name: "MLAG_PEER"
       password: "vnEaG8gMeQf3d3cN6PktXQ=="
 
 # Spine Switches

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/fabric/bgp_base/leaf-router-bgp-rfc5549-neighbors.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/fabric/bgp_base/leaf-router-bgp-rfc5549-neighbors.j2
@@ -2,13 +2,13 @@
 {% if switch.underlay_routing_protocol == "ebgp"  and underlay_rfc5549 is arista.avd.defined(true) %}
 {%     for uplink_to_spine_interface in leaf.uplink_to_spine_interfaces %}
       {{ uplink_to_spine_interface }}:
-        peer_group: IPv4-UNDERLAY-PEERS
+        peer_group: {{ bgp_peer_groups.IPv4_UNDERLAY_PEERS.name | arista.avd.default("IPv4-UNDERLAY-PEERS") }}
         remote_as: {{ spine.bgp_as }}
         description: {{ leaf.spines[loop.index0] }}_{{ leaf.spine_interfaces[loop.index0] }}
 {%     endfor %}
 {%     if leaf.mlag == true %}
       Vlan4093:
-        peer_group: MLAG-IPv4-UNDERLAY-PEER
+        peer_group: {{ bgp_peer_groups.MLAG_IPv4_UNDERLAY_PEER.name | arista.avd.default("MLAG-IPv4-UNDERLAY-PEER") }}
         remote_as: {{ switch.bgp_as }}
         description: {{ leaf.mlag_peer }}
 {%     endif %}


### PR DESCRIPTION
## Change Summary

Seems like a new change introduced in #800 was left out of the RFC5549 PR.
Also the molecule converge seems to use the deprecated eos_l3ls_evpn role for the test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)


## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been rebased from devel before I start
- [X] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [X] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
