### PR TITLE
Fixing templates with wrong indentation

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
@@ -122,6 +122,7 @@ interface Ethernet50
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
 | Port-Channel3 | MLAG_PEER_DC1-LEAF1B_Po3 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
 | Port-Channel5 | DC1_L2LEAF1_Po1 | switched | trunk | 110,201 | - | - | - | - | 5 | - |
+| Port-Channel10 | SRV01_bond0 | switched | trunk | 2-3000 | - | - | - | - | - | 0000:0000:0404:0404:0303 |
 | Port-Channel50 | SRV-POD03_PortChanne1 | switched | trunk | 1-4000 | - | - | - | - | - | 0000:0000:0303:0202:0101 |
 | Port-Channel51 | ipv6_prefix | switched | trunk | 1-500 | - | - | - | - | - | - |
 | Port-Channel100.101 | IFL for TENANT01 | switched | access | - | - | - | - | - | - | - |
@@ -170,15 +171,26 @@ interface Port-Channel9
    ip address 10.9.2.3/31
    bfd interval 500 min-rx 500 multiplier 5
 !
+interface Port-Channel10
+   description SRV01_bond0
+   switchport
+   switchport trunk allowed vlan 2-3000
+   switchport mode trunk
+   !
+   evpn ethernet-segment
+      identifier 0000:0000:0404:0404:0303
+      route-target import 04:04:03:03:02:02
+   !
+!
 interface Port-Channel50
    description SRV-POD03_PortChanne1
    switchport
    switchport trunk allowed vlan 1-4000
    switchport mode trunk
    !
-    evpn ethernet-segment
-       identifier 0000:0000:0303:0202:0101
-       route-target import 03:03:02:02:01:01
+   evpn ethernet-segment
+      identifier 0000:0000:0303:0202:0101
+      route-target import 03:03:02:02:01:01
    !
    lacp system-id 0303.0202.0101
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
@@ -39,15 +39,26 @@ interface Port-Channel9
    ip address 10.9.2.3/31
    bfd interval 500 min-rx 500 multiplier 5
 !
+interface Port-Channel10
+   description SRV01_bond0
+   switchport
+   switchport trunk allowed vlan 2-3000
+   switchport mode trunk
+   !
+   evpn ethernet-segment
+      identifier 0000:0000:0404:0404:0303
+      route-target import 04:04:03:03:02:02
+   !
+!
 interface Port-Channel50
    description SRV-POD03_PortChanne1
    switchport
    switchport trunk allowed vlan 1-4000
    switchport mode trunk
    !
-    evpn ethernet-segment
-       identifier 0000:0000:0303:0202:0101
-       route-target import 03:03:02:02:01:01
+   evpn ethernet-segment
+      identifier 0000:0000:0303:0202:0101
+      route-target import 03:03:02:02:01:01
    !
    lacp system-id 0303.0202.0101
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
@@ -26,6 +26,13 @@ port_channel_interfaces:
       - LEAF_PEER_L3
       - MLAG
 
+  Port-Channel10:
+    description: SRV01_bond0
+    vlans: 2-3000
+    mode: trunk
+    esi: 0000:0000:0404:0404:0303
+    rt: 04:04:03:03:02:02
+
   Port-Channel50:
     description: SRV-POD03_PortChanne1
     vlans: 1-4000

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
@@ -43,10 +43,10 @@ interface {{ port_channel_interface }}
 {%     endif %}
 {%     if port_channel_interfaces[port_channel_interface].esi is arista.avd.defined %}
    !
-    evpn ethernet-segment
-       identifier {{ port_channel_interfaces[port_channel_interface].esi }}
+   evpn ethernet-segment
+      identifier {{ port_channel_interfaces[port_channel_interface].esi }}
 {%         if port_channel_interfaces[port_channel_interface].rt is arista.avd.defined %}
-       route-target import {{ port_channel_interfaces[port_channel_interface].rt }}
+      route-target import {{ port_channel_interfaces[port_channel_interface].rt }}
 {%         endif %}
    !
 {%     endif %}


### PR DESCRIPTION
## Change Summary

Fixing wrong indentation and remnants of hardcoded peer names.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Component(s) name
`arista.avd.eos_cli_config_gen`

## Proposed changes
This patch fixes an cosmetic intendention in a template and leftovers from hardcoded peerlink values. The diff should be descriptive enough. Since it only fixes minor bugs.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
