### PR TITLE
Feature:(eos_designs) lacp fallback

### DIFF
--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -441,6 +441,8 @@ vlan 4094
 | Ethernet14 | server07_inherit_all_from_profile_port_channel_Eth1 | *trunk | *1-4094 | *- | *- | 14 |
 | Ethernet15 | server08_no_profile_port_channel_Eth1 | *trunk | *1-4094 | *- | *- | 15 |
 | Ethernet16 |  server09_override_profile_no_port_channel_Eth1 | access | 210 | - | - | - |
+| Ethernet17 | server10_no_profile_port_channel_lacp_fallback_Eth1 | *trunk | *1-4094 | *- | *- | 17 |
+| Ethernet18 | server10_inherit_profile_port_channel_lacp_fallback_Eth1 | *trunk | *1-4094 | *- | *- | 18 |
 
 *Inherited from Port-Channel Interface
 
@@ -574,6 +576,16 @@ interface Ethernet16
    storm-control broadcast level 200
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+!
+interface Ethernet17
+   description server10_no_profile_port_channel_lacp_fallback_Eth1
+   no shutdown
+   channel-group 17 mode active
+!
+interface Ethernet18
+   description server10_inherit_profile_port_channel_lacp_fallback_Eth1
+   no shutdown
+   channel-group 18 mode active
 ```
 
 ## Port-Channel Interfaces
@@ -589,6 +601,8 @@ interface Ethernet16
 | Port-Channel10 | server03_ESI_PortChanne1 | switched | trunk | 110-111,210-211 | - | - | - | - | 10 | - |
 | Port-Channel14 | server07_inherit_all_from_profile_port_channel_ALL_WITH_SECURITY_PORT_CHANNEL | switched | trunk | 1-4094 | - | - | - | - | 14 | - |
 | Port-Channel15 | server08_no_profile_port_channel_server08_no_profile_port_channel | switched | trunk | 1-4094 | - | - | - | - | 15 | - |
+| Port-Channel17 | server10_no_profile_port_channel_lacp_fallback_server10_no_profile_port_channel_lacp_fallback | switched | trunk | 1-4094 | - | - | 90 | static | 17 | - |
+| Port-Channel18 | server10_inherit_profile_port_channel_lacp_fallback_ALL_WITH_SECURITY_PORT_CHANNEL | switched | trunk | 1-4094 | - | - | 10 | static | 18 | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -640,6 +654,38 @@ interface Port-Channel15
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
    mlag 15
+   spanning-tree portfast
+   spanning-tree bpdufilter enable
+   storm-control all level 10
+   storm-control broadcast level pps 100
+   storm-control multicast level 1
+   storm-control unknown-unicast level 2
+!
+interface Port-Channel17
+   description server10_no_profile_port_channel_lacp_fallback_server10_no_profile_port_channel_lacp_fallback
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 1-4094
+   switchport mode trunk
+   mlag 17
+   port-channel lacp fallback timeout 90
+   port-channel lacp fallback static
+   spanning-tree portfast
+   spanning-tree bpdufilter enable
+   storm-control all level 10
+   storm-control broadcast level pps 100
+   storm-control multicast level 1
+   storm-control unknown-unicast level 2
+!
+interface Port-Channel18
+   description server10_inherit_profile_port_channel_lacp_fallback_ALL_WITH_SECURITY_PORT_CHANNEL
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 1-4094
+   switchport mode trunk
+   mlag 18
+   port-channel lacp fallback timeout 10
+   port-channel lacp fallback static
    spanning-tree portfast
    spanning-tree bpdufilter enable
    storm-control all level 10

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -581,11 +581,13 @@ interface Ethernet17
    description server10_no_profile_port_channel_lacp_fallback_Eth1
    no shutdown
    channel-group 17 mode active
+   lacp port-priority 8192
 !
 interface Ethernet18
    description server10_inherit_profile_port_channel_lacp_fallback_Eth1
    no shutdown
    channel-group 18 mode active
+   lacp port-priority 8192
 ```
 
 ## Port-Channel Interfaces

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -575,11 +575,13 @@ interface Ethernet17
    description server10_no_profile_port_channel_lacp_fallback_Eth2
    no shutdown
    channel-group 17 mode active
+   lacp port-priority 32768
 !
 interface Ethernet18
    description server10_inherit_profile_port_channel_lacp_fallback_Eth2
    no shutdown
    channel-group 18 mode active
+   lacp port-priority 32768
 ```
 
 ## Port-Channel Interfaces

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -440,6 +440,8 @@ vlan 4094
 | Ethernet14 | server07_inherit_all_from_profile_port_channel_Eth2 | *trunk | *1-4094 | *- | *- | 14 |
 | Ethernet15 | server08_no_profile_port_channel_Eth2 | *trunk | *1-4094 | *- | *- | 15 |
 | Ethernet16 |  server09_override_profile_no_port_channel_Eth2 | access | 210 | - | - | - |
+| Ethernet17 | server10_no_profile_port_channel_lacp_fallback_Eth2 | *trunk | *1-4094 | *- | *- | 17 |
+| Ethernet18 | server10_inherit_profile_port_channel_lacp_fallback_Eth2 | *trunk | *1-4094 | *- | *- | 18 |
 
 *Inherited from Port-Channel Interface
 
@@ -568,6 +570,16 @@ interface Ethernet16
    storm-control broadcast level 200
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+!
+interface Ethernet17
+   description server10_no_profile_port_channel_lacp_fallback_Eth2
+   no shutdown
+   channel-group 17 mode active
+!
+interface Ethernet18
+   description server10_inherit_profile_port_channel_lacp_fallback_Eth2
+   no shutdown
+   channel-group 18 mode active
 ```
 
 ## Port-Channel Interfaces
@@ -582,6 +594,8 @@ interface Ethernet16
 | Port-Channel7 | DC1_L2LEAF2_Po1 | switched | trunk | 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350 | - | - | - | - | 7 | - |
 | Port-Channel14 | server07_inherit_all_from_profile_port_channel_ALL_WITH_SECURITY_PORT_CHANNEL | switched | trunk | 1-4094 | - | - | - | - | 14 | - |
 | Port-Channel15 | server08_no_profile_port_channel_server08_no_profile_port_channel | switched | trunk | 1-4094 | - | - | - | - | 15 | - |
+| Port-Channel17 | server10_no_profile_port_channel_lacp_fallback_server10_no_profile_port_channel_lacp_fallback | switched | trunk | 1-4094 | - | - | 90 | static | 17 | - |
+| Port-Channel18 | server10_inherit_profile_port_channel_lacp_fallback_ALL_WITH_SECURITY_PORT_CHANNEL | switched | trunk | 1-4094 | - | - | 10 | static | 18 | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -625,6 +639,38 @@ interface Port-Channel15
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
    mlag 15
+   spanning-tree portfast
+   spanning-tree bpdufilter enable
+   storm-control all level 10
+   storm-control broadcast level pps 100
+   storm-control multicast level 1
+   storm-control unknown-unicast level 2
+!
+interface Port-Channel17
+   description server10_no_profile_port_channel_lacp_fallback_server10_no_profile_port_channel_lacp_fallback
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 1-4094
+   switchport mode trunk
+   mlag 17
+   port-channel lacp fallback timeout 90
+   port-channel lacp fallback static
+   spanning-tree portfast
+   spanning-tree bpdufilter enable
+   storm-control all level 10
+   storm-control broadcast level pps 100
+   storm-control multicast level 1
+   storm-control unknown-unicast level 2
+!
+interface Port-Channel18
+   description server10_inherit_profile_port_channel_lacp_fallback_ALL_WITH_SECURITY_PORT_CHANNEL
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 1-4094
+   switchport mode trunk
+   mlag 18
+   port-channel lacp fallback timeout 10
+   port-channel lacp fallback static
    spanning-tree portfast
    spanning-tree bpdufilter enable
    storm-control all level 10

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/fabric/DC1_FABRIC-topology.csv
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/fabric/DC1_FABRIC-topology.csv
@@ -88,6 +88,8 @@ l3leaf,DC1-SVC3A,Ethernet13,server,server06_override_profile,Eth1
 l3leaf,DC1-SVC3A,Ethernet14,server,server07_inherit_all_from_profile_port_channel,Eth1
 l3leaf,DC1-SVC3A,Ethernet15,server,server08_no_profile_port_channel,Eth1
 l3leaf,DC1-SVC3A,Ethernet16,server,server09_override_profile_no_port_channel,Eth1
+l3leaf,DC1-SVC3A,Ethernet17,server,server10_no_profile_port_channel_lacp_fallback,Eth1
+l3leaf,DC1-SVC3A,Ethernet18,server,server10_inherit_profile_port_channel_lacp_fallback,Eth1
 l3leaf,DC1-SVC3B,Ethernet1,spine,DC1-SPINE1,Ethernet5
 l3leaf,DC1-SVC3B,Ethernet2,spine,DC1-SPINE2,Ethernet5
 l3leaf,DC1-SVC3B,Ethernet3,spine,DC1-SPINE3,Ethernet5
@@ -102,3 +104,5 @@ l3leaf,DC1-SVC3B,Ethernet13,server,server06_override_profile,Eth2
 l3leaf,DC1-SVC3B,Ethernet14,server,server07_inherit_all_from_profile_port_channel,Eth2
 l3leaf,DC1-SVC3B,Ethernet15,server,server08_no_profile_port_channel,Eth2
 l3leaf,DC1-SVC3B,Ethernet16,server,server09_override_profile_no_port_channel,Eth2
+l3leaf,DC1-SVC3B,Ethernet17,server,server10_no_profile_port_channel_lacp_fallback,Eth2
+l3leaf,DC1-SVC3B,Ethernet18,server,server10_inherit_profile_port_channel_lacp_fallback,Eth2

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
@@ -355,11 +355,13 @@ interface Ethernet17
    description server10_no_profile_port_channel_lacp_fallback_Eth1
    no shutdown
    channel-group 17 mode active
+   lacp port-priority 8192
 !
 interface Ethernet18
    description server10_inherit_profile_port_channel_lacp_fallback_Eth1
    no shutdown
    channel-group 18 mode active
+   lacp port-priority 8192
 !
 interface Loopback0
    description EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
@@ -201,6 +201,38 @@ interface Port-Channel15
    storm-control multicast level 1
    storm-control unknown-unicast level 2
 !
+interface Port-Channel17
+   description server10_no_profile_port_channel_lacp_fallback_server10_no_profile_port_channel_lacp_fallback
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 1-4094
+   switchport mode trunk
+   mlag 17
+   port-channel lacp fallback timeout 90
+   port-channel lacp fallback static
+   spanning-tree portfast
+   spanning-tree bpdufilter enable
+   storm-control all level 10
+   storm-control broadcast level pps 100
+   storm-control multicast level 1
+   storm-control unknown-unicast level 2
+!
+interface Port-Channel18
+   description server10_inherit_profile_port_channel_lacp_fallback_ALL_WITH_SECURITY_PORT_CHANNEL
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 1-4094
+   switchport mode trunk
+   mlag 18
+   port-channel lacp fallback timeout 10
+   port-channel lacp fallback static
+   spanning-tree portfast
+   spanning-tree bpdufilter enable
+   storm-control all level 10
+   storm-control broadcast level pps 100
+   storm-control multicast level 1
+   storm-control unknown-unicast level 2
+!
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet4
    no shutdown
@@ -318,6 +350,16 @@ interface Ethernet16
    storm-control broadcast level 200
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+!
+interface Ethernet17
+   description server10_no_profile_port_channel_lacp_fallback_Eth1
+   no shutdown
+   channel-group 17 mode active
+!
+interface Ethernet18
+   description server10_inherit_profile_port_channel_lacp_fallback_Eth1
+   no shutdown
+   channel-group 18 mode active
 !
 interface Loopback0
    description EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
@@ -342,11 +342,13 @@ interface Ethernet17
    description server10_no_profile_port_channel_lacp_fallback_Eth2
    no shutdown
    channel-group 17 mode active
+   lacp port-priority 32768
 !
 interface Ethernet18
    description server10_inherit_profile_port_channel_lacp_fallback_Eth2
    no shutdown
    channel-group 18 mode active
+   lacp port-priority 32768
 !
 interface Loopback0
    description EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
@@ -193,6 +193,38 @@ interface Port-Channel15
    storm-control multicast level 1
    storm-control unknown-unicast level 2
 !
+interface Port-Channel17
+   description server10_no_profile_port_channel_lacp_fallback_server10_no_profile_port_channel_lacp_fallback
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 1-4094
+   switchport mode trunk
+   mlag 17
+   port-channel lacp fallback timeout 90
+   port-channel lacp fallback static
+   spanning-tree portfast
+   spanning-tree bpdufilter enable
+   storm-control all level 10
+   storm-control broadcast level pps 100
+   storm-control multicast level 1
+   storm-control unknown-unicast level 2
+!
+interface Port-Channel18
+   description server10_inherit_profile_port_channel_lacp_fallback_ALL_WITH_SECURITY_PORT_CHANNEL
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 1-4094
+   switchport mode trunk
+   mlag 18
+   port-channel lacp fallback timeout 10
+   port-channel lacp fallback static
+   spanning-tree portfast
+   spanning-tree bpdufilter enable
+   storm-control all level 10
+   storm-control broadcast level pps 100
+   storm-control multicast level 1
+   storm-control unknown-unicast level 2
+!
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet5
    no shutdown
@@ -305,6 +337,16 @@ interface Ethernet16
    storm-control broadcast level 200
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+!
+interface Ethernet17
+   description server10_no_profile_port_channel_lacp_fallback_Eth2
+   no shutdown
+   channel-group 17 mode active
+!
+interface Ethernet18
+   description server10_inherit_profile_port_channel_lacp_fallback_Eth2
+   no shutdown
+   channel-group 18 mode active
 !
 interface Loopback0
    description EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -676,6 +676,7 @@ ethernet_interfaces:
       id: 18
       mode: active
     profile: ALL_WITH_SECURITY_PORT_CHANNEL_LACP_FALLBACK
+    lacp_port_priority: 8192
   Ethernet17:
     peer: server10_no_profile_port_channel_lacp_fallback
     peer_interface: Eth1
@@ -704,6 +705,7 @@ ethernet_interfaces:
     channel_group:
       id: 17
       mode: active
+    lacp_port_priority: 8192
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -341,6 +341,57 @@ port_channel_interfaces:
         level: 2
         unit: percent
     mlag: 15
+  Port-Channel18:
+    description: server10_inherit_profile_port_channel_lacp_fallback_ALL_WITH_SECURITY_PORT_CHANNEL
+    type: switched
+    shutdown: false
+    mode: trunk
+    l2_mtu: 8000
+    vlans: 1-4094
+    spanning_tree_portfast: edge
+    spanning_tree_bpdufilter: true
+    spanning_tree_bpduguard: false
+    storm_control:
+      all:
+        level: 10
+        unit: percent
+      broadcast:
+        level: 100
+        unit: pps
+      multicast:
+        level: 1
+        unit: percent
+      unknown-unicast:
+        level: 2
+        unit: percent
+    mlag: 18
+    lacp_fallback_mode: static
+    lacp_fallback_timeout: 10
+  Port-Channel17:
+    description: server10_no_profile_port_channel_lacp_fallback_server10_no_profile_port_channel_lacp_fallback
+    type: switched
+    shutdown: false
+    mode: trunk
+    vlans: 1-4094
+    spanning_tree_portfast: edge
+    spanning_tree_bpdufilter: true
+    spanning_tree_bpduguard: false
+    storm_control:
+      all:
+        level: 10
+        unit: percent
+      broadcast:
+        level: 100
+        unit: pps
+      multicast:
+        level: 1
+        unit: percent
+      unknown-unicast:
+        level: 2
+        unit: percent
+    mlag: 17
+    lacp_fallback_mode: static
+    lacp_fallback_timeout: 90
 ethernet_interfaces:
   Ethernet1:
     peer: DC1-SPINE1
@@ -595,6 +646,64 @@ ethernet_interfaces:
         level: 2
         unit: percent
     profile: ALL_WITH_SECURITY_PORT_CHANNEL
+  Ethernet18:
+    peer: server10_inherit_profile_port_channel_lacp_fallback
+    peer_interface: Eth1
+    peer_type: server
+    description: server10_inherit_profile_port_channel_lacp_fallback_Eth1
+    l2_mtu: 8000
+    type: switched
+    shutdown: false
+    mode: trunk
+    vlans: 1-4094
+    spanning_tree_portfast: edge
+    spanning_tree_bpdufilter: true
+    spanning_tree_bpduguard: false
+    storm_control:
+      all:
+        level: 10
+        unit: percent
+      broadcast:
+        level: 100
+        unit: pps
+      multicast:
+        level: 1
+        unit: percent
+      unknown-unicast:
+        level: 2
+        unit: percent
+    channel_group:
+      id: 18
+      mode: active
+    profile: ALL_WITH_SECURITY_PORT_CHANNEL_LACP_FALLBACK
+  Ethernet17:
+    peer: server10_no_profile_port_channel_lacp_fallback
+    peer_interface: Eth1
+    peer_type: server
+    description: server10_no_profile_port_channel_lacp_fallback_Eth1
+    type: switched
+    shutdown: false
+    mode: trunk
+    vlans: 1-4094
+    spanning_tree_portfast: edge
+    spanning_tree_bpdufilter: true
+    spanning_tree_bpduguard: false
+    storm_control:
+      all:
+        level: 10
+        unit: percent
+      broadcast:
+        level: 100
+        unit: pps
+      multicast:
+        level: 1
+        unit: percent
+      unknown-unicast:
+        level: 2
+        unit: percent
+    channel_group:
+      id: 17
+      mode: active
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -334,6 +334,57 @@ port_channel_interfaces:
         level: 2
         unit: percent
     mlag: 15
+  Port-Channel18:
+    description: server10_inherit_profile_port_channel_lacp_fallback_ALL_WITH_SECURITY_PORT_CHANNEL
+    type: switched
+    shutdown: false
+    mode: trunk
+    l2_mtu: 8000
+    vlans: 1-4094
+    spanning_tree_portfast: edge
+    spanning_tree_bpdufilter: true
+    spanning_tree_bpduguard: false
+    storm_control:
+      all:
+        level: 10
+        unit: percent
+      broadcast:
+        level: 100
+        unit: pps
+      multicast:
+        level: 1
+        unit: percent
+      unknown-unicast:
+        level: 2
+        unit: percent
+    mlag: 18
+    lacp_fallback_mode: static
+    lacp_fallback_timeout: 10
+  Port-Channel17:
+    description: server10_no_profile_port_channel_lacp_fallback_server10_no_profile_port_channel_lacp_fallback
+    type: switched
+    shutdown: false
+    mode: trunk
+    vlans: 1-4094
+    spanning_tree_portfast: edge
+    spanning_tree_bpdufilter: true
+    spanning_tree_bpduguard: false
+    storm_control:
+      all:
+        level: 10
+        unit: percent
+      broadcast:
+        level: 100
+        unit: pps
+      multicast:
+        level: 1
+        unit: percent
+      unknown-unicast:
+        level: 2
+        unit: percent
+    mlag: 17
+    lacp_fallback_mode: static
+    lacp_fallback_timeout: 90
 ethernet_interfaces:
   Ethernet1:
     peer: DC1-SPINE1
@@ -575,6 +626,64 @@ ethernet_interfaces:
         level: 2
         unit: percent
     profile: ALL_WITH_SECURITY_PORT_CHANNEL
+  Ethernet18:
+    peer: server10_inherit_profile_port_channel_lacp_fallback
+    peer_interface: Eth2
+    peer_type: server
+    description: server10_inherit_profile_port_channel_lacp_fallback_Eth2
+    l2_mtu: 8000
+    type: switched
+    shutdown: false
+    mode: trunk
+    vlans: 1-4094
+    spanning_tree_portfast: edge
+    spanning_tree_bpdufilter: true
+    spanning_tree_bpduguard: false
+    storm_control:
+      all:
+        level: 10
+        unit: percent
+      broadcast:
+        level: 100
+        unit: pps
+      multicast:
+        level: 1
+        unit: percent
+      unknown-unicast:
+        level: 2
+        unit: percent
+    channel_group:
+      id: 18
+      mode: active
+    profile: ALL_WITH_SECURITY_PORT_CHANNEL_LACP_FALLBACK
+  Ethernet17:
+    peer: server10_no_profile_port_channel_lacp_fallback
+    peer_interface: Eth2
+    peer_type: server
+    description: server10_no_profile_port_channel_lacp_fallback_Eth2
+    type: switched
+    shutdown: false
+    mode: trunk
+    vlans: 1-4094
+    spanning_tree_portfast: edge
+    spanning_tree_bpdufilter: true
+    spanning_tree_bpduguard: false
+    storm_control:
+      all:
+        level: 10
+        unit: percent
+      broadcast:
+        level: 100
+        unit: pps
+      multicast:
+        level: 1
+        unit: percent
+      unknown-unicast:
+        level: 2
+        unit: percent
+    channel_group:
+      id: 17
+      mode: active
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -656,6 +656,7 @@ ethernet_interfaces:
       id: 18
       mode: active
     profile: ALL_WITH_SECURITY_PORT_CHANNEL_LACP_FALLBACK
+    lacp_port_priority: 32768
   Ethernet17:
     peer: server10_no_profile_port_channel_lacp_fallback
     peer_interface: Eth2
@@ -684,6 +685,7 @@ ethernet_interfaces:
     channel_group:
       id: 17
       mode: active
+    lacp_port_priority: 32768
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_SERVERS.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_SERVERS.yml
@@ -61,6 +61,33 @@ port_profiles:
       description: ALL_WITH_SECURITY_PORT_CHANNEL
       mode: active
 
+  ALL_WITH_SECURITY_PORT_CHANNEL_LACP_FALLBACK:
+    mode: trunk
+    vlans: "1-4094"
+    spanning_tree_bpdufilter: true
+    spanning_tree_bpduguard: false
+    spanning_tree_portfast: edge
+    l2_mtu: 8000
+    storm_control:
+      all:
+        level: 10
+        unit: percent
+      broadcast:
+        level: 100
+        unit: pps
+      multicast:
+        level: 1
+        unit: percent
+      'unknown-unicast':
+        level: 2
+        unit: percent
+    port_channel:
+      description: ALL_WITH_SECURITY_PORT_CHANNEL
+      mode: active
+      lacp_fallback:
+        mode: static
+        timeout: 10
+
 servers:
   server01_MLAG:
     rack: RackB
@@ -244,3 +271,42 @@ servers:
             level: 2
             unit: percent
         port_channel: {}   #Setting to empty dict, to override port-channel inherited from profile
+
+  server10_no_profile_port_channel_lacp_fallback:
+    rack: RackC
+    adapters:
+      - server_ports: [ Eth1, Eth2 ]
+        switch_ports: [ Ethernet17, Ethernet17 ]
+        switches: [ DC1-SVC3A, DC1-SVC3B ]
+        mode: trunk
+        vlans: "1-4094"
+        spanning_tree_bpdufilter: true
+        spanning_tree_bpduguard: false
+        spanning_tree_portfast: edge
+        storm_control:
+          all:
+            level: 10
+            unit: percent
+          broadcast:
+            level: 100
+            unit: pps
+          multicast:
+            level: 1
+            unit: percent
+          'unknown-unicast':
+            level: 2
+            unit: percent
+        port_channel:
+          description: server10_no_profile_port_channel_lacp_fallback
+          mode: active
+          lacp_fallback:
+            mode: static
+
+  server10_inherit_profile_port_channel_lacp_fallback:
+    rack: RackC
+    adapters:
+      - server_ports: [ Eth1, Eth2 ]
+        switch_ports: [ Ethernet18, Ethernet18 ]
+        switches: [ DC1-SVC3A, DC1-SVC3B ]
+        profile: ALL_WITH_SECURITY_PORT_CHANNEL_LACP_FALLBACK
+

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -21,6 +21,9 @@ interface {{ ethernet_interface }}
 {%     endif %}
 {%     if ethernet_interfaces[ethernet_interface].channel_group.id is arista.avd.defined and ethernet_interfaces[ethernet_interface].channel_group.mode is arista.avd.defined %}
    channel-group {{ ethernet_interfaces[ethernet_interface].channel_group.id }} mode {{ ethernet_interfaces[ethernet_interface].channel_group.mode }}
+{%         if ethernet_interfaces[ethernet_interface].lacp_port_priority is arista.avd.defined %}
+   lacp port-priority {{ ethernet_interfaces[ethernet_interface].lacp_port_priority }}
+{%         endif %}
 {%     else %}
 {%         if ethernet_interfaces[ethernet_interface].mtu is arista.avd.defined %}
    mtu {{ ethernet_interfaces[ethernet_interface].mtu }}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
@@ -54,10 +54,10 @@ interface {{ port_channel_interface }}
    lacp system-id {{ port_channel_interfaces[port_channel_interface].lacp_id }}
 {%     endif %}
 {%     if port_channel_interfaces[port_channel_interface].lacp_fallback_timeout is arista.avd.defined %}
-   port-channel lacp fallback timeout {{ lacp_fallback_timeout }}
+   port-channel lacp fallback timeout {{ port_channel_interfaces[port_channel_interface].lacp_fallback_timeout }}
 {%     endif %}
 {%     if port_channel_interfaces[port_channel_interface].lacp_fallback_mode is arista.avd.defined %}
-   port-channel lacp fallback {{ lacp_fallback_mode }}
+   port-channel lacp fallback {{ port_channel_interfaces[port_channel_interface].lacp_fallback_mode }}
 {%     endif %}
 {%     if port_channel_interfaces[port_channel_interface].qos.trust is arista.avd.defined %}
    qos trust {{ port_channel_interfaces[port_channel_interface].qos.trust }}

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/servers.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/servers.md
@@ -41,6 +41,9 @@ port_profiles:
     port_channel:
       description: < port_channel_description >
       mode: < active | passive | on >
+      lacp_fallback:
+        mode: < static > | Currently only static mode is supported
+        timeout: < timeout in seconds > | Optional - default is 90 seconds
 
 # Dictionary of servers, a device attaching to a L2 switched port(s)
 servers:
@@ -130,6 +133,11 @@ servers:
 
           # Port-Channel Mode.
           mode: < active | passive | on >
+
+          # LACP Fallback configuration | Optional
+          lacp_fallback:
+            mode: < static > Currently only static mode is supported
+            timeout: < timeout in seconds > | Optional - default is 90 seconds
 
   < server_2 >:
     rack: RackC

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/edge_ports/leaf-server-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/edge_ports/leaf-server-interfaces.j2
@@ -86,7 +86,7 @@
       enable: {{ adapter_ptp.enable }}
 {%                     endif %}
 {%                 endif %}
-{%                 if adapter_port_channel.lacp_fallback is arista.avd.defined %}
+{%                 if adapter_port_channel.lacp_fallback.mode is arista.avd.defined('static') %}
 {%                     if loop.first %}
     lacp_port_priority: 8192
 {%                     else %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/edge_ports/leaf-server-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/edge_ports/leaf-server-interfaces.j2
@@ -86,6 +86,13 @@
       enable: {{ adapter_ptp.enable }}
 {%                     endif %}
 {%                 endif %}
+{%                 if adapter_port_channel.lacp_fallback is arista.avd.defined %}
+{%                     if loop.first %}
+    lacp_port_priority: 8192
+{%                     else %}
+    lacp_port_priority: 32768
+{%                     endif %}
+{%                 endif %}
 {%             endif %}
 {%         endfor %}
 {%     endfor %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/edge_ports/leaf-server-port-channels.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/edge_ports/leaf-server-port-channels.j2
@@ -6,22 +6,24 @@
 {%         else %}
 {%             set adapter_profile = dict() %}
 {%         endif %}
-{%         set adapter_port_channel = adapter.port_channel | arista.avd.default( adapter_profile.port_channel ) %}
+{%         set adapter_port_channel = adapter.port_channel | arista.avd.default(adapter_profile.port_channel) %}
 {%         if adapter_port_channel is arista.avd.defined and adapter_port_channel.mode is arista.avd.defined %}
 {%             for switch in adapter.switches | arista.avd.natural_sort %}
 {%                 if switch == inventory_hostname %}
-{%                     set adapter_mode = adapter.mode | arista.avd.default( adapter_profile.mode ) %}
-{%                     set adapter_l2_mtu = adapter.l2_mtu | arista.avd.default( adapter_profile.l2_mtu ) %}
-{%                     set adapter_vlans = adapter.vlans | arista.avd.default( adapter_profile.vlans ) %}
-{%                     set adapter_native_vlan = adapter.native_vlan | arista.avd.default( adapter_profile.native_vlan ) %}
-{%                     set adapter_spanning_tree_portfast = adapter.spanning_tree_portfast | arista.avd.default( adapter_profile.spanning_tree_portfast ) %}
-{%                     set adapter_spanning_tree_bpdufilter = adapter.spanning_tree_bpdufilter | arista.avd.default( adapter_profile.spanning_tree_bpdufilter ) %}
-{%                     set adapter_spanning_tree_bpduguard = adapter.spanning_tree_bpduguard | arista.avd.default( adapter_profile.spanning_tree_bpduguard ) %}
-{%                     set adapter_storm_control = adapter.storm_control | arista.avd.default( adapter_profile.storm_control ) %}
-{%                     set adapter_flowcontrol = adapter.flowcontrol | arista.avd.default( adapter_profile.flowcontrol ) %}
-{%                     set adapter_qos_profile = adapter.qos_profile | arista.avd.default( adapter_profile.qos_profile ) %}
-{%                     set adapter_mtu = adapter.mtu | arista.avd.default( adapter_profile.mtu ) %}
+{%                     set adapter_mode = adapter.mode | arista.avd.default(adapter_profile.mode) %}
+{%                     set adapter_l2_mtu = adapter.l2_mtu | arista.avd.default(adapter_profile.l2_mtu) %}
+{%                     set adapter_vlans = adapter.vlans | arista.avd.default(adapter_profile.vlans) %}
+{%                     set adapter_native_vlan = adapter.native_vlan | arista.avd.default(adapter_profile.native_vlan) %}
+{%                     set adapter_spanning_tree_portfast = adapter.spanning_tree_portfast | arista.avd.default(adapter_profile.spanning_tree_portfast) %}
+{%                     set adapter_spanning_tree_bpdufilter = adapter.spanning_tree_bpdufilter | arista.avd.default(adapter_profile.spanning_tree_bpdufilter) %}
+{%                     set adapter_spanning_tree_bpduguard = adapter.spanning_tree_bpduguard | arista.avd.default(adapter_profile.spanning_tree_bpduguard) %}
+{%                     set adapter_storm_control = adapter.storm_control | arista.avd.default(adapter_profile.storm_control) %}
+{%                     set adapter_flowcontrol = adapter.flowcontrol | arista.avd.default(adapter_profile.flowcontrol) %}
+{%                     set adapter_qos_profile = adapter.qos_profile | arista.avd.default(adapter_profile.qos_profile) %}
+{%                     set adapter_mtu = adapter.mtu | arista.avd.default(adapter_profile.mtu) %}
 {%                     set channel_group_id = (adapter.switch_ports[0] | regex_findall("\d") | join ) %}
+{%                     set lacp_fallback_mode = adapter_port_channel.lacp_fallback.mode | arista.avd.default(adapter_profile.lacp_fallback.mode) %}
+{%                     set lacp_fallback_timeout = adapter_port_channel.lacp_fallback.timeout | arista.avd.default(adapter_profile.lacp_fallback.timeout) %}
   Port-Channel{{ channel_group_id }}:
     description: {{ server }}_{{ adapter_port_channel.description }}
     type: switched
@@ -68,6 +70,10 @@
 {%                         else %}
     mlag: {{ channel_group_id }}
 {%                         endif %}
+{%                     endif %}
+{%                     if lacp_fallback_mode is arista.avd.defined %}
+    lacp_fallback_mode: {{ lacp_fallback_mode }}
+    lacp_fallback_timeout: {{ lacp_fallback_timeout | arista.avd.default('90') }}
 {%                     endif %}
 {%                     if adapter_qos_profile is arista.avd.defined %}
     service_profile: {{ adapter_qos_profile }}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/edge_ports/leaf-server-port-channels.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/edge_ports/leaf-server-port-channels.j2
@@ -71,7 +71,7 @@
     mlag: {{ channel_group_id }}
 {%                         endif %}
 {%                     endif %}
-{%                     if lacp_fallback_mode is arista.avd.defined %}
+{%                     if lacp_fallback_mode is arista.avd.defined('static') %}
     lacp_fallback_mode: {{ lacp_fallback_mode }}
     lacp_fallback_timeout: {{ lacp_fallback_timeout | arista.avd.default('90') }}
 {%                     endif %}


### PR DESCRIPTION
## Change Summary

Small changes to server interfaces data model to allow for lacp fallback functionality. Also removed wrapping spaces in eos_designs leaf-server-port-channels.j2 template on request from Carl.

Added lacp fallback to eos_cli_config_gen as well as LACP port priority to make the active fallback interface selection deterministic.

Also fixed a bug in eos_cli_config_gen port-channel-interfaces.j2 template that called the lacp fallback variable in an incorrect way.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [x] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Fixes #211
Loosely related to #542 and #37

## Component(s) name

arista.avd.eos_designs
arista.avd.eos_cli_config_gen

## Proposed changes
In eos_designs I've implemented a data model under server interfaces port_channel dict to enable LACP fallback on port-channels. This is available on profiles as well. The only mode implemented is static, if something else is configured it will be ignored. The timeout is optional and can be omitted, this will make eos_designs set the value to EOS default = 90 seconds.

    port_channel:
      ...
      lacp_fallback:
        mode: static
        timeout: 10

The templates leaf-server-port-channels.j2 and leaf-server-interfaces.j2 have been modified to accommodate this new functionality. eos_designs now also implicitly configures lacp port-priority on interfaces that are members of port-channels with lacp fallback enabled. The first switch/port in the adapter loop gets the lower priority and will be selected to keep its interface active.

## How to test
Added port channels with LACP fallback to molecule evpn_underlay_ebgp_overlay_ebgp and ran it + verified only intended changes produced.

## Checklist:
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
