### PR TITLE
Add support for A/A model to connect L2LEAF (new)

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
@@ -176,22 +176,18 @@ interface Port-Channel10
    switchport
    switchport trunk allowed vlan 2-3000
    switchport mode trunk
-   !
    evpn ethernet-segment
       identifier 0000:0000:0404:0404:0303
       route-target import 04:04:03:03:02:02
-   !
 !
 interface Port-Channel50
    description SRV-POD03_PortChanne1
    switchport
    switchport trunk allowed vlan 1-4000
    switchport mode trunk
-   !
    evpn ethernet-segment
       identifier 0000:0000:0303:0202:0101
       route-target import 03:03:02:02:01:01
-   !
    lacp system-id 0303.0202.0101
 !
 interface Port-Channel51

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
@@ -44,22 +44,18 @@ interface Port-Channel10
    switchport
    switchport trunk allowed vlan 2-3000
    switchport mode trunk
-   !
    evpn ethernet-segment
       identifier 0000:0000:0404:0404:0303
       route-target import 04:04:03:03:02:02
-   !
 !
 interface Port-Channel50
    description SRV-POD03_PortChanne1
    switchport
    switchport trunk allowed vlan 1-4000
    switchport mode trunk
-   !
    evpn ethernet-segment
       identifier 0000:0000:0303:0202:0101
       route-target import 03:03:02:02:01:01
-   !
    lacp system-id 0303.0202.0101
 !
 interface Port-Channel51

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF1A.md
@@ -267,7 +267,7 @@ interface Ethernet4
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel3 | RACK2_SINGLE_Po1 | switched | trunk | 4085 | - | - | - | - | 3 | - |
+| Port-Channel3 | RACK2_SINGLE_Po1 | switched | trunk | 4085 | - | - | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -279,7 +279,6 @@ interface Port-Channel3
    switchport
    switchport trunk allowed vlan 4085
    switchport mode trunk
-   mlag 3
    service-profile QOS-PROFILE
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-LEAF1A.md
@@ -277,7 +277,7 @@ interface Ethernet7
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel3 | RACK1_SINGLE_Po1 | switched | trunk | 4092 | - | - | - | - | 3 | - |
+| Port-Channel3 | RACK1_SINGLE_Po1 | switched | trunk | 4092 | - | - | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -289,7 +289,6 @@ interface Port-Channel3
    switchport
    switchport trunk allowed vlan 4092
    switchport mode trunk
-   mlag 3
    service-profile QOS-PROFILE
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF1A.cfg
@@ -28,7 +28,6 @@ interface Port-Channel3
    switchport
    switchport trunk allowed vlan 4085
    switchport mode trunk
-   mlag 3
    service-profile QOS-PROFILE
 !
 interface Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-LEAF1A.cfg
@@ -31,7 +31,6 @@ interface Port-Channel3
    switchport
    switchport trunk allowed vlan 4092
    switchport mode trunk
-   mlag 3
    service-profile QOS-PROFILE
 !
 interface Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF1A.yml
@@ -180,7 +180,6 @@ port_channel_interfaces:
     vlans: 4085
     mode: trunk
     service_profile: QOS-PROFILE
-    mlag: 3
 vlans:
   4085:
     tenant: system

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF1A.yml
@@ -199,7 +199,6 @@ port_channel_interfaces:
     vlans: 4092
     mode: trunk
     service_profile: QOS-PROFILE
-    mlag: 3
 vlans:
   4092:
     tenant: system

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF1B.md
@@ -1,4 +1,4 @@
-# DC1-L2LEAF1A
+# DC1-L2LEAF1B
 # Table of Contents
 <!-- toc -->
 
@@ -52,7 +52,7 @@
 
 | Management Interface | description | Type | VRF | IP Address | Gateway |
 | -------------------- | ----------- | ---- | --- | ---------- | ------- |
-| Management1 | oob_management | oob | MGMT | 192.168.200.112/24 | 192.168.200.5 |
+| Management1 | oob_management | oob | MGMT | 192.168.200.115/24 | 192.168.200.5 |
 
 #### IPv6
 
@@ -68,7 +68,7 @@ interface Management1
    description oob_management
    no shutdown
    vrf MGMT
-   ip address 192.168.200.112/24
+   ip address 192.168.200.115/24
 ```
 
 ## Name Servers
@@ -178,7 +178,7 @@ daemon TerminAttr
 
 | Contact | Location | SNMP Traps |
 | ------- | -------- | ---------- |
-| example@example.com | DC1_FABRIC rackE DC1-L2LEAF1A |  Disabled  |
+| example@example.com | DC1_FABRIC rackE DC1-L2LEAF1B |  Disabled  |
 
 ### SNMP ACLs
 | IP | ACL | VRF |
@@ -205,7 +205,7 @@ daemon TerminAttr
 ```eos
 !
 snmp-server contact example@example.com
-snmp-server location DC1_FABRIC rackE DC1-L2LEAF1A
+snmp-server location DC1_FABRIC rackE DC1-L2LEAF1B
 ```
 
 # MLAG
@@ -214,7 +214,7 @@ snmp-server location DC1_FABRIC rackE DC1-L2LEAF1A
 
 | Domain-id | Local-interface | Peer-address | Peer-link |
 | --------- | --------------- | ------------ | --------- |
-| DC1_L2LEAF1 | Vlan4094 | 10.255.252.15 | Port-Channel3 |
+| DC1_L2LEAF1 | Vlan4094 | 10.255.252.14 | Port-Channel3 |
 
 Dual primary detection is disabled.
 
@@ -225,7 +225,7 @@ Dual primary detection is disabled.
 mlag configuration
    domain-id DC1_L2LEAF1
    local-interface Vlan4094
-   peer-address 10.255.252.15
+   peer-address 10.255.252.14
    peer-link Port-Channel3
    reload-delay mlag 300
    reload-delay non-mlag 330
@@ -330,10 +330,10 @@ vlan 4094
 
 | Interface | Description | Mode | VLANs | Native VLAN | Trunk Group | Channel-Group |
 | --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
-| Ethernet1 | DC1-LEAF2A_Ethernet7 | *trunk | *110-111,120-121,130-131,160-161 | *- | *- | 1 |
-| Ethernet2 | DC1-LEAF2B_Ethernet7 | *trunk | *110-111,120-121,130-131,160-161 | *- | *- | 1 |
-| Ethernet3 | MLAG_PEER_DC1-L2LEAF1B_Ethernet3 | *trunk | *2-4094 | *- | *['MLAG'] | 3 |
-| Ethernet4 | MLAG_PEER_DC1-L2LEAF1B_Ethernet4 | *trunk | *2-4094 | *- | *['MLAG'] | 3 |
+| Ethernet1 | DC1-LEAF2A_Ethernet8 | *trunk | *110-111,120-121,130-131,160-161 | *- | *- | 1 |
+| Ethernet2 | DC1-LEAF2B_Ethernet8 | *trunk | *110-111,120-121,130-131,160-161 | *- | *- | 1 |
+| Ethernet3 | MLAG_PEER_DC1-L2LEAF1A_Ethernet3 | *trunk | *2-4094 | *- | *['MLAG'] | 3 |
+| Ethernet4 | MLAG_PEER_DC1-L2LEAF1A_Ethernet4 | *trunk | *2-4094 | *- | *['MLAG'] | 3 |
 
 *Inherited from Port-Channel Interface
 
@@ -342,22 +342,22 @@ vlan 4094
 ```eos
 !
 interface Ethernet1
-   description DC1-LEAF2A_Ethernet7
+   description DC1-LEAF2A_Ethernet8
    no shutdown
    channel-group 1 mode active
 !
 interface Ethernet2
-   description DC1-LEAF2B_Ethernet7
+   description DC1-LEAF2B_Ethernet8
    no shutdown
    channel-group 1 mode active
 !
 interface Ethernet3
-   description MLAG_PEER_DC1-L2LEAF1B_Ethernet3
+   description MLAG_PEER_DC1-L2LEAF1A_Ethernet3
    no shutdown
    channel-group 3 mode active
 !
 interface Ethernet4
-   description MLAG_PEER_DC1-L2LEAF1B_Ethernet4
+   description MLAG_PEER_DC1-L2LEAF1A_Ethernet4
    no shutdown
    channel-group 3 mode active
 ```
@@ -370,15 +370,15 @@ interface Ethernet4
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel1 | DC1-LEAF2A_Po7 | switched | trunk | 110-111,120-121,130-131,160-161 | - | - | - | - | 1 | - |
-| Port-Channel3 | MLAG_PEER_DC1-L2LEAF1B_Po3 | switched | trunk | 2-4094 | - | ['MLAG'] | - | - | - | - |
+| Port-Channel1 | DC1-LEAF2B_Po7 | switched | trunk | 110-111,120-121,130-131,160-161 | - | - | - | - | 1 | - |
+| Port-Channel3 | MLAG_PEER_DC1-L2LEAF1A_Po3 | switched | trunk | 2-4094 | - | ['MLAG'] | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
 
 ```eos
 !
 interface Port-Channel1
-   description DC1-LEAF2A_Po7
+   description DC1-LEAF2B_Po7
    no shutdown
    switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,160-161
@@ -386,7 +386,7 @@ interface Port-Channel1
    mlag 1
 !
 interface Port-Channel3
-   description MLAG_PEER_DC1-L2LEAF1B_Po3
+   description MLAG_PEER_DC1-L2LEAF1A_Po3
    no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
@@ -406,7 +406,7 @@ interface Port-Channel3
 
 | Interface | VRF | IP Address | IP Address Virtual | IP Router Virtual Address | VRRP | ACL In | ACL Out |
 | --------- | --- | ---------- | ------------------ | ------------------------- | ---- | ------ | ------- |
-| Vlan4094 |  default  |  10.255.252.14/31  |  -  |  -  |  -  |  -  |  -  |
+| Vlan4094 |  default  |  10.255.252.15/31  |  -  |  -  |  -  |  -  |  -  |
 
 
 ### VLAN Interfaces Device Configuration
@@ -418,7 +418,7 @@ interface Vlan4094
    no shutdown
    mtu 1500
    no autostate
-   ip address 10.255.252.14/31
+   ip address 10.255.252.15/31
 ```
 
 # Routing

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF3A.md
@@ -1,4 +1,4 @@
-# DC1-L2LEAF1A
+# DC1-L2LEAF3A
 # Table of Contents
 <!-- toc -->
 
@@ -12,9 +12,6 @@
 - [Monitoring](#monitoring)
   - [TerminAttr Daemon](#terminattr-daemon)
   - [SNMP](#snmp)
-- [MLAG](#mlag)
-  - [MLAG Summary](#mlag-summary)
-  - [MLAG Device Configuration](#mlag-device-configuration)
 - [Spanning Tree](#spanning-tree)
   - [Spanning Tree Summary](#spanning-tree-summary)
   - [Spanning Tree Device Configuration](#spanning-tree-device-configuration)
@@ -27,7 +24,6 @@
 - [Interfaces](#interfaces)
   - [Ethernet Interfaces](#ethernet-interfaces)
   - [Port-Channel Interfaces](#port-channel-interfaces)
-  - [VLAN Interfaces](#vlan-interfaces)
 - [Routing](#routing)
   - [IP Routing](#ip-routing)
   - [IPv6 Routing](#ipv6-routing)
@@ -52,7 +48,7 @@
 
 | Management Interface | description | Type | VRF | IP Address | Gateway |
 | -------------------- | ----------- | ---- | --- | ---------- | ------- |
-| Management1 | oob_management | oob | MGMT | 192.168.200.112/24 | 192.168.200.5 |
+| Management1 | oob_management | oob | MGMT | 192.168.200.116/24 | 192.168.200.5 |
 
 #### IPv6
 
@@ -68,7 +64,7 @@ interface Management1
    description oob_management
    no shutdown
    vrf MGMT
-   ip address 192.168.200.112/24
+   ip address 192.168.200.116/24
 ```
 
 ## Name Servers
@@ -178,7 +174,7 @@ daemon TerminAttr
 
 | Contact | Location | SNMP Traps |
 | ------- | -------- | ---------- |
-| example@example.com | DC1_FABRIC rackE DC1-L2LEAF1A |  Disabled  |
+| example@example.com | DC1_FABRIC rackE DC1-L2LEAF3A |  Disabled  |
 
 ### SNMP ACLs
 | IP | ACL | VRF |
@@ -205,30 +201,7 @@ daemon TerminAttr
 ```eos
 !
 snmp-server contact example@example.com
-snmp-server location DC1_FABRIC rackE DC1-L2LEAF1A
-```
-
-# MLAG
-
-## MLAG Summary
-
-| Domain-id | Local-interface | Peer-address | Peer-link |
-| --------- | --------------- | ------------ | --------- |
-| DC1_L2LEAF1 | Vlan4094 | 10.255.252.15 | Port-Channel3 |
-
-Dual primary detection is disabled.
-
-## MLAG Device Configuration
-
-```eos
-!
-mlag configuration
-   domain-id DC1_L2LEAF1
-   local-interface Vlan4094
-   peer-address 10.255.252.15
-   peer-link Port-Channel3
-   reload-delay mlag 300
-   reload-delay non-mlag 330
+snmp-server location DC1_FABRIC rackE DC1-L2LEAF3A
 ```
 
 # Spanning Tree
@@ -245,14 +218,12 @@ STP mode: **mstp**
 
 ### Global Spanning-Tree Settings
 
-Spanning Tree disabled for VLANs: **4094**
 
 ## Spanning Tree Device Configuration
 
 ```eos
 !
 spanning-tree mode mstp
-no spanning-tree vlan-id 4094
 spanning-tree mst 0 priority 16384
 ```
 
@@ -285,7 +256,6 @@ vlan internal order ascending range 1006 1199
 | 131 | Tenant_A_APP_Zone_2 | none  |
 | 160 | Tenant_A_VMOTION | none  |
 | 161 | Tenant_A_NFS | none  |
-| 4094 | MLAG_PEER | MLAG  |
 
 ## VLANs Device Configuration
 
@@ -314,10 +284,6 @@ vlan 160
 !
 vlan 161
    name Tenant_A_NFS
-!
-vlan 4094
-   name MLAG_PEER
-   trunk group MLAG
 ```
 
 # Interfaces
@@ -330,10 +296,8 @@ vlan 4094
 
 | Interface | Description | Mode | VLANs | Native VLAN | Trunk Group | Channel-Group |
 | --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
-| Ethernet1 | DC1-LEAF2A_Ethernet7 | *trunk | *110-111,120-121,130-131,160-161 | *- | *- | 1 |
-| Ethernet2 | DC1-LEAF2B_Ethernet7 | *trunk | *110-111,120-121,130-131,160-161 | *- | *- | 1 |
-| Ethernet3 | MLAG_PEER_DC1-L2LEAF1B_Ethernet3 | *trunk | *2-4094 | *- | *['MLAG'] | 3 |
-| Ethernet4 | MLAG_PEER_DC1-L2LEAF1B_Ethernet4 | *trunk | *2-4094 | *- | *['MLAG'] | 3 |
+| Ethernet1 | DC1-LEAF2A_Ethernet9 | *trunk | *110-111,120-121,130-131,160-161 | *- | *- | 1 |
+| Ethernet2 | DC1-LEAF2B_Ethernet9 | *trunk | *110-111,120-121,130-131,160-161 | *- | *- | 1 |
 
 *Inherited from Port-Channel Interface
 
@@ -342,24 +306,14 @@ vlan 4094
 ```eos
 !
 interface Ethernet1
-   description DC1-LEAF2A_Ethernet7
+   description DC1-LEAF2A_Ethernet9
    no shutdown
    channel-group 1 mode active
 !
 interface Ethernet2
-   description DC1-LEAF2B_Ethernet7
+   description DC1-LEAF2B_Ethernet9
    no shutdown
    channel-group 1 mode active
-!
-interface Ethernet3
-   description MLAG_PEER_DC1-L2LEAF1B_Ethernet3
-   no shutdown
-   channel-group 3 mode active
-!
-interface Ethernet4
-   description MLAG_PEER_DC1-L2LEAF1B_Ethernet4
-   no shutdown
-   channel-group 3 mode active
 ```
 
 ## Port-Channel Interfaces
@@ -370,55 +324,18 @@ interface Ethernet4
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel1 | DC1-LEAF2A_Po7 | switched | trunk | 110-111,120-121,130-131,160-161 | - | - | - | - | 1 | - |
-| Port-Channel3 | MLAG_PEER_DC1-L2LEAF1B_Po3 | switched | trunk | 2-4094 | - | ['MLAG'] | - | - | - | - |
+| Port-Channel1 | DC1-LEAF2A_Po9 | switched | trunk | 110-111,120-121,130-131,160-161 | - | - | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
 
 ```eos
 !
 interface Port-Channel1
-   description DC1-LEAF2A_Po7
+   description DC1-LEAF2A_Po9
    no shutdown
    switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,160-161
    switchport mode trunk
-   mlag 1
-!
-interface Port-Channel3
-   description MLAG_PEER_DC1-L2LEAF1B_Po3
-   no shutdown
-   switchport
-   switchport trunk allowed vlan 2-4094
-   switchport mode trunk
-   switchport trunk group MLAG
-```
-
-## VLAN Interfaces
-
-### VLAN Interfaces Summary
-
-| Interface | Description | VRF |  MTU | Shutdown |
-| --------- | ----------- | --- | ---- | -------- |
-| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  false  |
-
-#### IPv4
-
-| Interface | VRF | IP Address | IP Address Virtual | IP Router Virtual Address | VRRP | ACL In | ACL Out |
-| --------- | --- | ---------- | ------------------ | ------------------------- | ---- | ------ | ------- |
-| Vlan4094 |  default  |  10.255.252.14/31  |  -  |  -  |  -  |  -  |  -  |
-
-
-### VLAN Interfaces Device Configuration
-
-```eos
-!
-interface Vlan4094
-   description MLAG_PEER
-   no shutdown
-   mtu 1500
-   no autostate
-   ip address 10.255.252.14/31
 ```
 
 # Routing

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -14,9 +14,6 @@
   - [SNMP](#snmp)
 - [Hardware TCAM Profile](#hardware-tcam-profile)
   - [Hardware TCAM configuration](#hardware-tcam-configuration)
-- [MLAG](#mlag)
-  - [MLAG Summary](#mlag-summary)
-  - [MLAG Device Configuration](#mlag-device-configuration)
 - [Spanning Tree](#spanning-tree)
   - [Spanning Tree Summary](#spanning-tree-summary)
   - [Spanning Tree Device Configuration](#spanning-tree-device-configuration)
@@ -236,29 +233,6 @@ hardware tcam
    system profile vxlan-routing
 ```
 
-# MLAG
-
-## MLAG Summary
-
-| Domain-id | Local-interface | Peer-address | Peer-link |
-| --------- | --------------- | ------------ | --------- |
-| DC1_LEAF2 | Vlan4094 | 10.255.252.3 | Port-Channel5 |
-
-Dual primary detection is disabled.
-
-## MLAG Device Configuration
-
-```eos
-!
-mlag configuration
-   domain-id DC1_LEAF2
-   local-interface Vlan4094
-   peer-address 10.255.252.3
-   peer-link Port-Channel5
-   reload-delay mlag 780
-   reload-delay non-mlag 1020
-```
-
 # Spanning Tree
 
 ## Spanning Tree Summary
@@ -275,7 +249,6 @@ STP Root Super: **True**
 
 ### Global Spanning-Tree Settings
 
-Spanning Tree disabled for VLANs: **4093-4094**
 
 ## Spanning Tree Device Configuration
 
@@ -283,7 +256,6 @@ Spanning Tree disabled for VLANs: **4093-4094**
 !
 spanning-tree root super
 spanning-tree mode mstp
-no spanning-tree vlan-id 4093-4094
 spanning-tree mst 0 priority 4096
 ```
 
@@ -308,7 +280,6 @@ vlan internal order ascending range 1006 1199
 
 | VLAN ID | Name | Trunk Groups |
 | ------- | ---- | ------------ |
-| 2 | MLAG_iBGP_Tenant_C_OP_Zone | LEAF_PEER_L3  |
 | 110 | Tenant_A_OP_Zone_1 | none  |
 | 111 | Tenant_A_OP_Zone_2 | none  |
 | 120 | Tenant_A_WEB_Zone_1 | none  |
@@ -323,21 +294,10 @@ vlan internal order ascending range 1006 1199
 | 211 | Tenant_B_OP_Zone_2 | none  |
 | 310 | Tenant_C_OP_Zone_1 | none  |
 | 311 | Tenant_C_OP_Zone_2 | none  |
-| 3009 | MLAG_iBGP_Tenant_A_OP_Zone | LEAF_PEER_L3  |
-| 3010 | MLAG_iBGP_Tenant_A_WEB_Zone | LEAF_PEER_L3  |
-| 3011 | MLAG_iBGP_Tenant_A_APP_Zone | LEAF_PEER_L3  |
-| 3012 | MLAG_iBGP_Tenant_A_DB_Zone | LEAF_PEER_L3  |
-| 3019 | MLAG_iBGP_Tenant_B_OP_Zone | LEAF_PEER_L3  |
-| 4093 | LEAF_PEER_L3 | LEAF_PEER_L3  |
-| 4094 | MLAG_PEER | MLAG  |
 
 ## VLANs Device Configuration
 
 ```eos
-!
-vlan 2
-   name MLAG_iBGP_Tenant_C_OP_Zone
-   trunk group LEAF_PEER_L3
 !
 vlan 110
    name Tenant_A_OP_Zone_1
@@ -380,34 +340,6 @@ vlan 310
 !
 vlan 311
    name Tenant_C_OP_Zone_2
-!
-vlan 3009
-   name MLAG_iBGP_Tenant_A_OP_Zone
-   trunk group LEAF_PEER_L3
-!
-vlan 3010
-   name MLAG_iBGP_Tenant_A_WEB_Zone
-   trunk group LEAF_PEER_L3
-!
-vlan 3011
-   name MLAG_iBGP_Tenant_A_APP_Zone
-   trunk group LEAF_PEER_L3
-!
-vlan 3012
-   name MLAG_iBGP_Tenant_A_DB_Zone
-   trunk group LEAF_PEER_L3
-!
-vlan 3019
-   name MLAG_iBGP_Tenant_B_OP_Zone
-   trunk group LEAF_PEER_L3
-!
-vlan 4093
-   name LEAF_PEER_L3
-   trunk group LEAF_PEER_L3
-!
-vlan 4094
-   name MLAG_PEER
-   trunk group MLAG
 ```
 
 # Interfaces
@@ -420,9 +352,9 @@ vlan 4094
 
 | Interface | Description | Mode | VLANs | Native VLAN | Trunk Group | Channel-Group |
 | --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
-| Ethernet5 | MLAG_PEER_DC1-LEAF2B_Ethernet5 | *trunk | *2-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 5 |
-| Ethernet6 | MLAG_PEER_DC1-LEAF2B_Ethernet6 | *trunk | *2-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 5 |
 | Ethernet7 | DC1-L2LEAF1A_Ethernet1 | *trunk | *110-111,120-121,130-131,160-161 | *- | *- | 7 |
+| Ethernet8 | DC1-L2LEAF1B_Ethernet1 | *trunk | *110-111,120-121,130-131,160-161 | *- | *- | 7 |
+| Ethernet9 | DC1-L2LEAF3A_Ethernet1 | *trunk | *110-111,120-121,130-131,160-161 | *- | *- | 9 |
 | Ethernet10 | server01_MLAG_Eth2 | *trunk | *210-211 | *- | *- | 10 |
 | Ethernet11 | server01_MTU_PROFILE_MLAG_Eth4 | *access | *110 | *- | *- | 11 |
 | Ethernet12 | server01_MTU_ADAPTOR_MLAG_Eth6 | *access | *- | *- | *- | 12 |
@@ -476,20 +408,20 @@ interface Ethernet4
    no switchport
    ip address 172.31.255.23/31
 !
-interface Ethernet5
-   description MLAG_PEER_DC1-LEAF2B_Ethernet5
-   no shutdown
-   channel-group 5 mode active
-!
-interface Ethernet6
-   description MLAG_PEER_DC1-LEAF2B_Ethernet6
-   no shutdown
-   channel-group 5 mode active
-!
 interface Ethernet7
    description DC1-L2LEAF1A_Ethernet1
    no shutdown
    channel-group 7 mode active
+!
+interface Ethernet8
+   description DC1-L2LEAF1B_Ethernet1
+   no shutdown
+   channel-group 7 mode active
+!
+interface Ethernet9
+   description DC1-L2LEAF3A_Ethernet1
+   no shutdown
+   channel-group 9 mode active
 !
 interface Ethernet10
    description server01_MLAG_Eth2
@@ -527,8 +459,8 @@ interface Ethernet21
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel5 | MLAG_PEER_DC1-LEAF2B_Po5 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
-| Port-Channel7 | DC1_L2LEAF1_Po1 | switched | trunk | 110-111,120-121,130-131,160-161 | - | - | - | - | 7 | - |
+| Port-Channel7 | DC1_L2LEAF1_Po1 | switched | trunk | 110-111,120-121,130-131,160-161 | - | - | - | - | - | 0000:0000:0808:0707:0606 |
+| Port-Channel9 | DC1_L2LEAF3_Po1 | switched | trunk | 110-111,120-121,130-131,160-161 | - | - | - | - | - | 0000:0000:0606:0707:0808 |
 | Port-Channel10 | server01_MLAG_PortChanne1 | switched | trunk | 210-211 | - | - | - | - | 10 | - |
 | Port-Channel11 | server01_MTU_PROFILE_MLAG_PortChanne1 | switched | access | 110 | - | - | - | - | 11 | - |
 | Port-Channel12 | server01_MTU_ADAPTOR_MLAG_PortChanne1 | switched | access | - | - | - | - | - | 12 | - |
@@ -538,22 +470,27 @@ interface Ethernet21
 
 ```eos
 !
-interface Port-Channel5
-   description MLAG_PEER_DC1-LEAF2B_Po5
-   no shutdown
-   switchport
-   switchport trunk allowed vlan 2-4094
-   switchport mode trunk
-   switchport trunk group LEAF_PEER_L3
-   switchport trunk group MLAG
-!
 interface Port-Channel7
    description DC1_L2LEAF1_Po1
    no shutdown
    switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,160-161
    switchport mode trunk
-   mlag 7
+   evpn ethernet-segment
+      identifier 0000:0000:0808:0707:0606
+      route-target import 08:08:07:07:06:06
+   lacp system-id 0808.0707.0606
+!
+interface Port-Channel9
+   description DC1_L2LEAF3_Po1
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 110-111,120-121,130-131,160-161
+   switchport mode trunk
+   evpn ethernet-segment
+      identifier 0000:0000:0606:0707:0808
+      route-target import 06:06:07:07:08:08
+   lacp system-id 0606.0707.0808
 !
 interface Port-Channel10
    description server01_MLAG_PortChanne1
@@ -635,7 +572,6 @@ interface Loopback100
 
 | Interface | Description | VRF |  MTU | Shutdown |
 | --------- | ----------- | --- | ---- | -------- |
-| Vlan2 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone  |  Tenant_C_OP_Zone  |  1500  |  false  |
 | Vlan110 |  Tenant_A_OP_Zone_1  |  Tenant_A_OP_Zone  |  -  |  false  |
 | Vlan111 |  Tenant_A_OP_Zone_2  |  Tenant_A_OP_Zone  |  -  |  false  |
 | Vlan120 |  Tenant_A_WEB_Zone_1  |  Tenant_A_WEB_Zone  |  -  |  false  |
@@ -648,19 +584,11 @@ interface Loopback100
 | Vlan211 |  Tenant_B_OP_Zone_2  |  Tenant_B_OP_Zone  |  -  |  false  |
 | Vlan310 |  Tenant_C_OP_Zone_1  |  Tenant_C_OP_Zone  |  -  |  false  |
 | Vlan311 |  Tenant_C_OP_Zone_2  |  Tenant_C_OP_Zone  |  -  |  false  |
-| Vlan3009 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone  |  Tenant_A_OP_Zone  |  1500  |  false  |
-| Vlan3010 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone  |  Tenant_A_WEB_Zone  |  1500  |  false  |
-| Vlan3011 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone  |  Tenant_A_APP_Zone  |  1500  |  false  |
-| Vlan3012 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone  |  Tenant_A_DB_Zone  |  1500  |  false  |
-| Vlan3019 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone  |  Tenant_B_OP_Zone  |  1500  |  false  |
-| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  false  |
-| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  false  |
 
 #### IPv4
 
 | Interface | VRF | IP Address | IP Address Virtual | IP Router Virtual Address | VRRP | ACL In | ACL Out |
 | --------- | --- | ---------- | ------------------ | ------------------------- | ---- | ------ | ------- |
-| Vlan2 |  Tenant_C_OP_Zone  |  10.255.251.2/31  |  -  |  -  |  -  |  -  |  -  |
 | Vlan110 |  Tenant_A_OP_Zone  |  -  |  10.1.10.1/24  |  -  |  -  |  -  |  -  |
 | Vlan111 |  Tenant_A_OP_Zone  |  -  |  10.1.11.1/24  |  -  |  -  |  -  |  -  |
 | Vlan120 |  Tenant_A_WEB_Zone  |  -  |  10.1.20.1/24  |  -  |  -  |  -  |  -  |
@@ -673,25 +601,11 @@ interface Loopback100
 | Vlan211 |  Tenant_B_OP_Zone  |  -  |  10.2.11.1/24  |  -  |  -  |  -  |  -  |
 | Vlan310 |  Tenant_C_OP_Zone  |  -  |  10.3.10.1/24  |  -  |  -  |  -  |  -  |
 | Vlan311 |  Tenant_C_OP_Zone  |  -  |  10.3.11.1/24  |  -  |  -  |  -  |  -  |
-| Vlan3009 |  Tenant_A_OP_Zone  |  10.255.251.2/31  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3010 |  Tenant_A_WEB_Zone  |  10.255.251.2/31  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3011 |  Tenant_A_APP_Zone  |  10.255.251.2/31  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3012 |  Tenant_A_DB_Zone  |  10.255.251.2/31  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3019 |  Tenant_B_OP_Zone  |  10.255.251.2/31  |  -  |  -  |  -  |  -  |  -  |
-| Vlan4093 |  default  |  10.255.251.2/31  |  -  |  -  |  -  |  -  |  -  |
-| Vlan4094 |  default  |  10.255.252.2/31  |  -  |  -  |  -  |  -  |  -  |
 
 
 ### VLAN Interfaces Device Configuration
 
 ```eos
-!
-interface Vlan2
-   description MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone
-   no shutdown
-   mtu 1500
-   vrf Tenant_C_OP_Zone
-   ip address 10.255.251.2/31
 !
 interface Vlan110
    description Tenant_A_OP_Zone_1
@@ -767,54 +681,6 @@ interface Vlan311
    no shutdown
    vrf Tenant_C_OP_Zone
    ip address virtual 10.3.11.1/24
-!
-interface Vlan3009
-   description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone
-   no shutdown
-   mtu 1500
-   vrf Tenant_A_OP_Zone
-   ip address 10.255.251.2/31
-!
-interface Vlan3010
-   description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone
-   no shutdown
-   mtu 1500
-   vrf Tenant_A_WEB_Zone
-   ip address 10.255.251.2/31
-!
-interface Vlan3011
-   description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
-   no shutdown
-   mtu 1500
-   vrf Tenant_A_APP_Zone
-   ip address 10.255.251.2/31
-!
-interface Vlan3012
-   description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone
-   no shutdown
-   mtu 1500
-   vrf Tenant_A_DB_Zone
-   ip address 10.255.251.2/31
-!
-interface Vlan3019
-   description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone
-   no shutdown
-   mtu 1500
-   vrf Tenant_B_OP_Zone
-   ip address 10.255.251.2/31
-!
-interface Vlan4093
-   description MLAG_PEER_L3_PEERING
-   no shutdown
-   mtu 1500
-   ip address 10.255.251.2/31
-!
-interface Vlan4094
-   description MLAG_PEER
-   no shutdown
-   mtu 1500
-   no autostate
-   ip address 10.255.252.2/31
 ```
 
 ## VXLAN Interface
@@ -861,7 +727,6 @@ interface Vlan4094
 !
 interface Vxlan1
    vxlan source-interface Loopback1
-   vxlan virtual-router encapsulation mac-address mlag-system-id
    vxlan udp-port 4789
    vxlan vlan 110 vni 10110
    vxlan vlan 111 vni 50111
@@ -984,16 +849,6 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | Send community | all |
 | Maximum routes | 0 (no limit) |
 
-#### MLAG-PEERS
-
-| Settings | Value |
-| -------- | ----- |
-| Address Family | ipv4 |
-| Remote AS | 65102 |
-| Next-hop self | True |
-| Send community | all |
-| Maximum routes | 12000 |
-
 #### UNDERLAY-PEERS
 
 | Settings | Value |
@@ -1007,7 +862,6 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | Neighbor | Remote AS | VRF |
 | -------- | --------- | --- |
-| 10.255.251.3 | Inherited from peer group MLAG-PEERS | default |
 | 172.31.255.16 | Inherited from peer group UNDERLAY-PEERS | default |
 | 172.31.255.18 | Inherited from peer group UNDERLAY-PEERS | default |
 | 172.31.255.20 | Inherited from peer group UNDERLAY-PEERS | default |
@@ -1016,12 +870,6 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | 192.168.255.2 | 65001 | default |
 | 192.168.255.3 | 65001 | default |
 | 192.168.255.4 | 65001 | default |
-| 10.255.251.3 | Inherited from peer group MLAG-PEERS | Tenant_A_APP_Zone |
-| 10.255.251.3 | Inherited from peer group MLAG-PEERS | Tenant_A_DB_Zone |
-| 10.255.251.3 | Inherited from peer group MLAG-PEERS | Tenant_A_OP_Zone |
-| 10.255.251.3 | Inherited from peer group MLAG-PEERS | Tenant_A_WEB_Zone |
-| 10.255.251.3 | Inherited from peer group MLAG-PEERS | Tenant_B_OP_Zone |
-| 10.255.251.3 | Inherited from peer group MLAG-PEERS | Tenant_C_OP_Zone |
 
 ### Router BGP EVPN Address Family
 
@@ -1067,20 +915,11 @@ router bgp 65102
    neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
    neighbor EVPN-OVERLAY-PEERS send-community
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
-   neighbor MLAG-PEERS peer group
-   neighbor MLAG-PEERS remote-as 65102
-   neighbor MLAG-PEERS next-hop-self
-   neighbor MLAG-PEERS password 7 vnEaG8gMeQf3d3cN6PktXQ==
-   neighbor MLAG-PEERS send-community
-   neighbor MLAG-PEERS maximum-routes 12000
-   neighbor MLAG-PEERS route-map RM-MLAG-PEER-IN in
    neighbor UNDERLAY-PEERS peer group
    neighbor UNDERLAY-PEERS remote-as 65001
    neighbor UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
    neighbor UNDERLAY-PEERS send-community
    neighbor UNDERLAY-PEERS maximum-routes 12000
-   neighbor 10.255.251.3 peer group MLAG-PEERS
-   neighbor 10.255.251.3 description DC1-LEAF2B
    neighbor 172.31.255.16 peer group UNDERLAY-PEERS
    neighbor 172.31.255.16 description DC1-SPINE1_Ethernet2
    neighbor 172.31.255.18 peer group UNDERLAY-PEERS
@@ -1156,7 +995,6 @@ router bgp 65102
    !
    address-family ipv4
       no neighbor EVPN-OVERLAY-PEERS activate
-      neighbor MLAG-PEERS activate
       neighbor UNDERLAY-PEERS activate
    !
    vrf Tenant_A_APP_Zone
@@ -1164,7 +1002,6 @@ router bgp 65102
       route-target import evpn 12:12
       route-target export evpn 12:12
       router-id 192.168.255.10
-      neighbor 10.255.251.3 peer group MLAG-PEERS
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1172,7 +1009,6 @@ router bgp 65102
       route-target import evpn 13:13
       route-target export evpn 13:13
       router-id 192.168.255.10
-      neighbor 10.255.251.3 peer group MLAG-PEERS
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1180,7 +1016,6 @@ router bgp 65102
       route-target import evpn 10:10
       route-target export evpn 10:10
       router-id 192.168.255.10
-      neighbor 10.255.251.3 peer group MLAG-PEERS
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1188,7 +1023,6 @@ router bgp 65102
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.10
-      neighbor 10.255.251.3 peer group MLAG-PEERS
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1196,7 +1030,6 @@ router bgp 65102
       route-target import evpn 20:20
       route-target export evpn 20:20
       router-id 192.168.255.10
-      neighbor 10.255.251.3 peer group MLAG-PEERS
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1204,7 +1037,6 @@ router bgp 65102
       route-target import evpn 30:30
       route-target export evpn 30:30
       router-id 192.168.255.10
-      neighbor 10.255.251.3 peer group MLAG-PEERS
       redistribute connected
 ```
 
@@ -1278,22 +1110,12 @@ ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
 | -------- | ---- | ---------------- |
 | 10 | permit | match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY |
 
-#### RM-MLAG-PEER-IN
-
-| Sequence | Type | Match and/or Set |
-| -------- | ---- | ---------------- |
-| 10 | permit | set origin incomplete |
-
 ### Route-maps Device Configuration
 
 ```eos
 !
 route-map RM-CONN-2-BGP permit 10
    match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
-!
-route-map RM-MLAG-PEER-IN permit 10
-   description Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing
-   set origin incomplete
 ```
 
 # ACL

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -14,9 +14,6 @@
   - [SNMP](#snmp)
 - [Hardware TCAM Profile](#hardware-tcam-profile)
   - [Hardware TCAM configuration](#hardware-tcam-configuration)
-- [MLAG](#mlag)
-  - [MLAG Summary](#mlag-summary)
-  - [MLAG Device Configuration](#mlag-device-configuration)
 - [Spanning Tree](#spanning-tree)
   - [Spanning Tree Summary](#spanning-tree-summary)
   - [Spanning Tree Device Configuration](#spanning-tree-device-configuration)
@@ -236,29 +233,6 @@ hardware tcam
    system profile vxlan-routing
 ```
 
-# MLAG
-
-## MLAG Summary
-
-| Domain-id | Local-interface | Peer-address | Peer-link |
-| --------- | --------------- | ------------ | --------- |
-| DC1_LEAF2 | Vlan4094 | 10.255.252.2 | Port-Channel5 |
-
-Dual primary detection is disabled.
-
-## MLAG Device Configuration
-
-```eos
-!
-mlag configuration
-   domain-id DC1_LEAF2
-   local-interface Vlan4094
-   peer-address 10.255.252.2
-   peer-link Port-Channel5
-   reload-delay mlag 780
-   reload-delay non-mlag 1020
-```
-
 # Spanning Tree
 
 ## Spanning Tree Summary
@@ -275,7 +249,6 @@ STP Root Super: **True**
 
 ### Global Spanning-Tree Settings
 
-Spanning Tree disabled for VLANs: **4093-4094**
 
 ## Spanning Tree Device Configuration
 
@@ -283,7 +256,6 @@ Spanning Tree disabled for VLANs: **4093-4094**
 !
 spanning-tree root super
 spanning-tree mode mstp
-no spanning-tree vlan-id 4093-4094
 spanning-tree mst 0 priority 4096
 ```
 
@@ -308,7 +280,6 @@ vlan internal order ascending range 1006 1199
 
 | VLAN ID | Name | Trunk Groups |
 | ------- | ---- | ------------ |
-| 2 | MLAG_iBGP_Tenant_C_OP_Zone | LEAF_PEER_L3  |
 | 110 | Tenant_A_OP_Zone_1 | none  |
 | 111 | Tenant_A_OP_Zone_2 | none  |
 | 120 | Tenant_A_WEB_Zone_1 | none  |
@@ -323,21 +294,10 @@ vlan internal order ascending range 1006 1199
 | 211 | Tenant_B_OP_Zone_2 | none  |
 | 310 | Tenant_C_OP_Zone_1 | none  |
 | 311 | Tenant_C_OP_Zone_2 | none  |
-| 3009 | MLAG_iBGP_Tenant_A_OP_Zone | LEAF_PEER_L3  |
-| 3010 | MLAG_iBGP_Tenant_A_WEB_Zone | LEAF_PEER_L3  |
-| 3011 | MLAG_iBGP_Tenant_A_APP_Zone | LEAF_PEER_L3  |
-| 3012 | MLAG_iBGP_Tenant_A_DB_Zone | LEAF_PEER_L3  |
-| 3019 | MLAG_iBGP_Tenant_B_OP_Zone | LEAF_PEER_L3  |
-| 4093 | LEAF_PEER_L3 | LEAF_PEER_L3  |
-| 4094 | MLAG_PEER | MLAG  |
 
 ## VLANs Device Configuration
 
 ```eos
-!
-vlan 2
-   name MLAG_iBGP_Tenant_C_OP_Zone
-   trunk group LEAF_PEER_L3
 !
 vlan 110
    name Tenant_A_OP_Zone_1
@@ -380,34 +340,6 @@ vlan 310
 !
 vlan 311
    name Tenant_C_OP_Zone_2
-!
-vlan 3009
-   name MLAG_iBGP_Tenant_A_OP_Zone
-   trunk group LEAF_PEER_L3
-!
-vlan 3010
-   name MLAG_iBGP_Tenant_A_WEB_Zone
-   trunk group LEAF_PEER_L3
-!
-vlan 3011
-   name MLAG_iBGP_Tenant_A_APP_Zone
-   trunk group LEAF_PEER_L3
-!
-vlan 3012
-   name MLAG_iBGP_Tenant_A_DB_Zone
-   trunk group LEAF_PEER_L3
-!
-vlan 3019
-   name MLAG_iBGP_Tenant_B_OP_Zone
-   trunk group LEAF_PEER_L3
-!
-vlan 4093
-   name LEAF_PEER_L3
-   trunk group LEAF_PEER_L3
-!
-vlan 4094
-   name MLAG_PEER
-   trunk group MLAG
 ```
 
 # Interfaces
@@ -420,9 +352,9 @@ vlan 4094
 
 | Interface | Description | Mode | VLANs | Native VLAN | Trunk Group | Channel-Group |
 | --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
-| Ethernet5 | MLAG_PEER_DC1-LEAF2A_Ethernet5 | *trunk | *2-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 5 |
-| Ethernet6 | MLAG_PEER_DC1-LEAF2A_Ethernet6 | *trunk | *2-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 5 |
 | Ethernet7 | DC1-L2LEAF1A_Ethernet2 | *trunk | *110-111,120-121,130-131,160-161 | *- | *- | 7 |
+| Ethernet8 | DC1-L2LEAF1B_Ethernet2 | *trunk | *110-111,120-121,130-131,160-161 | *- | *- | 7 |
+| Ethernet9 | DC1-L2LEAF3A_Ethernet2 | *trunk | *110-111,120-121,130-131,160-161 | *- | *- | 9 |
 | Ethernet10 | server01_MLAG_Eth3 | *trunk | *210-211 | *- | *- | 10 |
 | Ethernet11 | server01_MTU_PROFILE_MLAG_Eth5 | *access | *110 | *- | *- | 11 |
 | Ethernet12 | server01_MTU_ADAPTOR_MLAG_Eth7 | *access | *- | *- | *- | 12 |
@@ -476,20 +408,20 @@ interface Ethernet4
    no switchport
    ip address 172.31.255.39/31
 !
-interface Ethernet5
-   description MLAG_PEER_DC1-LEAF2A_Ethernet5
-   no shutdown
-   channel-group 5 mode active
-!
-interface Ethernet6
-   description MLAG_PEER_DC1-LEAF2A_Ethernet6
-   no shutdown
-   channel-group 5 mode active
-!
 interface Ethernet7
    description DC1-L2LEAF1A_Ethernet2
    no shutdown
    channel-group 7 mode active
+!
+interface Ethernet8
+   description DC1-L2LEAF1B_Ethernet2
+   no shutdown
+   channel-group 7 mode active
+!
+interface Ethernet9
+   description DC1-L2LEAF3A_Ethernet2
+   no shutdown
+   channel-group 9 mode active
 !
 interface Ethernet10
    description server01_MLAG_Eth3
@@ -527,8 +459,8 @@ interface Ethernet21
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel5 | MLAG_PEER_DC1-LEAF2A_Po5 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
-| Port-Channel7 | DC1_L2LEAF1_Po1 | switched | trunk | 110-111,120-121,130-131,160-161 | - | - | - | - | 7 | - |
+| Port-Channel7 | DC1_L2LEAF1_Po1 | switched | trunk | 110-111,120-121,130-131,160-161 | - | - | - | - | - | 0000:0000:0808:0707:0606 |
+| Port-Channel9 | DC1_L2LEAF3_Po1 | switched | trunk | 110-111,120-121,130-131,160-161 | - | - | - | - | - | 0000:0000:0606:0707:0808 |
 | Port-Channel10 | server01_MLAG_PortChanne1 | switched | trunk | 210-211 | - | - | - | - | 10 | - |
 | Port-Channel11 | server01_MTU_PROFILE_MLAG_PortChanne1 | switched | access | 110 | - | - | - | - | 11 | - |
 | Port-Channel12 | server01_MTU_ADAPTOR_MLAG_PortChanne1 | switched | access | - | - | - | - | - | 12 | - |
@@ -538,22 +470,27 @@ interface Ethernet21
 
 ```eos
 !
-interface Port-Channel5
-   description MLAG_PEER_DC1-LEAF2A_Po5
-   no shutdown
-   switchport
-   switchport trunk allowed vlan 2-4094
-   switchport mode trunk
-   switchport trunk group LEAF_PEER_L3
-   switchport trunk group MLAG
-!
 interface Port-Channel7
    description DC1_L2LEAF1_Po1
    no shutdown
    switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,160-161
    switchport mode trunk
-   mlag 7
+   evpn ethernet-segment
+      identifier 0000:0000:0808:0707:0606
+      route-target import 08:08:07:07:06:06
+   lacp system-id 0808.0707.0606
+!
+interface Port-Channel9
+   description DC1_L2LEAF3_Po1
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 110-111,120-121,130-131,160-161
+   switchport mode trunk
+   evpn ethernet-segment
+      identifier 0000:0000:0606:0707:0808
+      route-target import 06:06:07:07:08:08
+   lacp system-id 0606.0707.0808
 !
 interface Port-Channel10
    description server01_MLAG_PortChanne1
@@ -596,7 +533,7 @@ interface Port-Channel20
 | Interface | Description | VRF | IP Address |
 | --------- | ----------- | --- | ---------- |
 | Loopback0 | EVPN_Overlay_Peering | default | 192.168.255.11/32 |
-| Loopback1 | VTEP_VXLAN_Tunnel_Source | default | 192.168.254.10/32 |
+| Loopback1 | VTEP_VXLAN_Tunnel_Source | default | 192.168.254.11/32 |
 | Loopback100 | Tenant_A_OP_Zone_VTEP_DIAGNOSTICS | Tenant_A_OP_Zone | 10.255.1.11/32 |
 
 #### IPv6
@@ -620,7 +557,7 @@ interface Loopback0
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
    no shutdown
-   ip address 192.168.254.10/32
+   ip address 192.168.254.11/32
 !
 interface Loopback100
    description Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
@@ -635,7 +572,6 @@ interface Loopback100
 
 | Interface | Description | VRF |  MTU | Shutdown |
 | --------- | ----------- | --- | ---- | -------- |
-| Vlan2 |  MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone  |  Tenant_C_OP_Zone  |  1500  |  false  |
 | Vlan110 |  Tenant_A_OP_Zone_1  |  Tenant_A_OP_Zone  |  -  |  false  |
 | Vlan111 |  Tenant_A_OP_Zone_2  |  Tenant_A_OP_Zone  |  -  |  false  |
 | Vlan120 |  Tenant_A_WEB_Zone_1  |  Tenant_A_WEB_Zone  |  -  |  false  |
@@ -648,19 +584,11 @@ interface Loopback100
 | Vlan211 |  Tenant_B_OP_Zone_2  |  Tenant_B_OP_Zone  |  -  |  false  |
 | Vlan310 |  Tenant_C_OP_Zone_1  |  Tenant_C_OP_Zone  |  -  |  false  |
 | Vlan311 |  Tenant_C_OP_Zone_2  |  Tenant_C_OP_Zone  |  -  |  false  |
-| Vlan3009 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone  |  Tenant_A_OP_Zone  |  1500  |  false  |
-| Vlan3010 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone  |  Tenant_A_WEB_Zone  |  1500  |  false  |
-| Vlan3011 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone  |  Tenant_A_APP_Zone  |  1500  |  false  |
-| Vlan3012 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone  |  Tenant_A_DB_Zone  |  1500  |  false  |
-| Vlan3019 |  MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone  |  Tenant_B_OP_Zone  |  1500  |  false  |
-| Vlan4093 |  MLAG_PEER_L3_PEERING  |  default  |  1500  |  false  |
-| Vlan4094 |  MLAG_PEER  |  default  |  1500  |  false  |
 
 #### IPv4
 
 | Interface | VRF | IP Address | IP Address Virtual | IP Router Virtual Address | VRRP | ACL In | ACL Out |
 | --------- | --- | ---------- | ------------------ | ------------------------- | ---- | ------ | ------- |
-| Vlan2 |  Tenant_C_OP_Zone  |  10.255.251.3/31  |  -  |  -  |  -  |  -  |  -  |
 | Vlan110 |  Tenant_A_OP_Zone  |  -  |  10.1.10.1/24  |  -  |  -  |  -  |  -  |
 | Vlan111 |  Tenant_A_OP_Zone  |  -  |  10.1.11.1/24  |  -  |  -  |  -  |  -  |
 | Vlan120 |  Tenant_A_WEB_Zone  |  -  |  10.1.20.1/24  |  -  |  -  |  -  |  -  |
@@ -673,25 +601,11 @@ interface Loopback100
 | Vlan211 |  Tenant_B_OP_Zone  |  -  |  10.2.11.1/24  |  -  |  -  |  -  |  -  |
 | Vlan310 |  Tenant_C_OP_Zone  |  -  |  10.3.10.1/24  |  -  |  -  |  -  |  -  |
 | Vlan311 |  Tenant_C_OP_Zone  |  -  |  10.3.11.1/24  |  -  |  -  |  -  |  -  |
-| Vlan3009 |  Tenant_A_OP_Zone  |  10.255.251.3/31  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3010 |  Tenant_A_WEB_Zone  |  10.255.251.3/31  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3011 |  Tenant_A_APP_Zone  |  10.255.251.3/31  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3012 |  Tenant_A_DB_Zone  |  10.255.251.3/31  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3019 |  Tenant_B_OP_Zone  |  10.255.251.3/31  |  -  |  -  |  -  |  -  |  -  |
-| Vlan4093 |  default  |  10.255.251.3/31  |  -  |  -  |  -  |  -  |  -  |
-| Vlan4094 |  default  |  10.255.252.3/31  |  -  |  -  |  -  |  -  |  -  |
 
 
 ### VLAN Interfaces Device Configuration
 
 ```eos
-!
-interface Vlan2
-   description MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone
-   no shutdown
-   mtu 1500
-   vrf Tenant_C_OP_Zone
-   ip address 10.255.251.3/31
 !
 interface Vlan110
    description Tenant_A_OP_Zone_1
@@ -767,54 +681,6 @@ interface Vlan311
    no shutdown
    vrf Tenant_C_OP_Zone
    ip address virtual 10.3.11.1/24
-!
-interface Vlan3009
-   description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone
-   no shutdown
-   mtu 1500
-   vrf Tenant_A_OP_Zone
-   ip address 10.255.251.3/31
-!
-interface Vlan3010
-   description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone
-   no shutdown
-   mtu 1500
-   vrf Tenant_A_WEB_Zone
-   ip address 10.255.251.3/31
-!
-interface Vlan3011
-   description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
-   no shutdown
-   mtu 1500
-   vrf Tenant_A_APP_Zone
-   ip address 10.255.251.3/31
-!
-interface Vlan3012
-   description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone
-   no shutdown
-   mtu 1500
-   vrf Tenant_A_DB_Zone
-   ip address 10.255.251.3/31
-!
-interface Vlan3019
-   description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone
-   no shutdown
-   mtu 1500
-   vrf Tenant_B_OP_Zone
-   ip address 10.255.251.3/31
-!
-interface Vlan4093
-   description MLAG_PEER_L3_PEERING
-   no shutdown
-   mtu 1500
-   ip address 10.255.251.3/31
-!
-interface Vlan4094
-   description MLAG_PEER
-   no shutdown
-   mtu 1500
-   no autostate
-   ip address 10.255.252.3/31
 ```
 
 ## VXLAN Interface
@@ -861,7 +727,6 @@ interface Vlan4094
 !
 interface Vxlan1
    vxlan source-interface Loopback1
-   vxlan virtual-router encapsulation mac-address mlag-system-id
    vxlan udp-port 4789
    vxlan vlan 110 vni 10110
    vxlan vlan 111 vni 50111
@@ -984,16 +849,6 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | Send community | all |
 | Maximum routes | 0 (no limit) |
 
-#### MLAG-PEERS
-
-| Settings | Value |
-| -------- | ----- |
-| Address Family | ipv4 |
-| Remote AS | 65102 |
-| Next-hop self | True |
-| Send community | all |
-| Maximum routes | 12000 |
-
 #### UNDERLAY-PEERS
 
 | Settings | Value |
@@ -1007,7 +862,6 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | Neighbor | Remote AS | VRF |
 | -------- | --------- | --- |
-| 10.255.251.2 | Inherited from peer group MLAG-PEERS | default |
 | 172.31.255.32 | Inherited from peer group UNDERLAY-PEERS | default |
 | 172.31.255.34 | Inherited from peer group UNDERLAY-PEERS | default |
 | 172.31.255.36 | Inherited from peer group UNDERLAY-PEERS | default |
@@ -1016,12 +870,6 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | 192.168.255.2 | 65001 | default |
 | 192.168.255.3 | 65001 | default |
 | 192.168.255.4 | 65001 | default |
-| 10.255.251.2 | Inherited from peer group MLAG-PEERS | Tenant_A_APP_Zone |
-| 10.255.251.2 | Inherited from peer group MLAG-PEERS | Tenant_A_DB_Zone |
-| 10.255.251.2 | Inherited from peer group MLAG-PEERS | Tenant_A_OP_Zone |
-| 10.255.251.2 | Inherited from peer group MLAG-PEERS | Tenant_A_WEB_Zone |
-| 10.255.251.2 | Inherited from peer group MLAG-PEERS | Tenant_B_OP_Zone |
-| 10.255.251.2 | Inherited from peer group MLAG-PEERS | Tenant_C_OP_Zone |
 
 ### Router BGP EVPN Address Family
 
@@ -1067,20 +915,11 @@ router bgp 65102
    neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
    neighbor EVPN-OVERLAY-PEERS send-community
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
-   neighbor MLAG-PEERS peer group
-   neighbor MLAG-PEERS remote-as 65102
-   neighbor MLAG-PEERS next-hop-self
-   neighbor MLAG-PEERS password 7 vnEaG8gMeQf3d3cN6PktXQ==
-   neighbor MLAG-PEERS send-community
-   neighbor MLAG-PEERS maximum-routes 12000
-   neighbor MLAG-PEERS route-map RM-MLAG-PEER-IN in
    neighbor UNDERLAY-PEERS peer group
    neighbor UNDERLAY-PEERS remote-as 65001
    neighbor UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
    neighbor UNDERLAY-PEERS send-community
    neighbor UNDERLAY-PEERS maximum-routes 12000
-   neighbor 10.255.251.2 peer group MLAG-PEERS
-   neighbor 10.255.251.2 description DC1-LEAF2A
    neighbor 172.31.255.32 peer group UNDERLAY-PEERS
    neighbor 172.31.255.32 description DC1-SPINE1_Ethernet3
    neighbor 172.31.255.34 peer group UNDERLAY-PEERS
@@ -1156,7 +995,6 @@ router bgp 65102
    !
    address-family ipv4
       no neighbor EVPN-OVERLAY-PEERS activate
-      neighbor MLAG-PEERS activate
       neighbor UNDERLAY-PEERS activate
    !
    vrf Tenant_A_APP_Zone
@@ -1164,7 +1002,6 @@ router bgp 65102
       route-target import evpn 12:12
       route-target export evpn 12:12
       router-id 192.168.255.11
-      neighbor 10.255.251.2 peer group MLAG-PEERS
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1172,7 +1009,6 @@ router bgp 65102
       route-target import evpn 13:13
       route-target export evpn 13:13
       router-id 192.168.255.11
-      neighbor 10.255.251.2 peer group MLAG-PEERS
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1180,7 +1016,6 @@ router bgp 65102
       route-target import evpn 10:10
       route-target export evpn 10:10
       router-id 192.168.255.11
-      neighbor 10.255.251.2 peer group MLAG-PEERS
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1188,7 +1023,6 @@ router bgp 65102
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.11
-      neighbor 10.255.251.2 peer group MLAG-PEERS
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1196,7 +1030,6 @@ router bgp 65102
       route-target import evpn 20:20
       route-target export evpn 20:20
       router-id 192.168.255.11
-      neighbor 10.255.251.2 peer group MLAG-PEERS
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1204,7 +1037,6 @@ router bgp 65102
       route-target import evpn 30:30
       route-target export evpn 30:30
       router-id 192.168.255.11
-      neighbor 10.255.251.2 peer group MLAG-PEERS
       redistribute connected
 ```
 
@@ -1278,22 +1110,12 @@ ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
 | -------- | ---- | ---------------- |
 | 10 | permit | match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY |
 
-#### RM-MLAG-PEER-IN
-
-| Sequence | Type | Match and/or Set |
-| -------- | ---- | ---------------- |
-| 10 | permit | set origin incomplete |
-
 ### Route-maps Device Configuration
 
 ```eos
 !
 route-map RM-CONN-2-BGP permit 10
    match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
-!
-route-map RM-MLAG-PEER-IN permit 10
-   description Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing
-   set origin incomplete
 ```
 
 # ACL

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/fabric/DC1_FABRIC-documentation.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/fabric/DC1_FABRIC-documentation.md
@@ -22,8 +22,10 @@
 | DC1_FABRIC | l3leaf | DC1-BL1A | 192.168.200.110/24 | 7280R | Provisioned |
 | DC1_FABRIC | l3leaf | DC1-BL1B | 192.168.200.111/24 | 7280R | Provisioned |
 | DC1_FABRIC | l2leaf | DC1-L2LEAF1A | 192.168.200.112/24 | vEOS-LAB | Provisioned |
+| DC1_FABRIC | l2leaf | DC1-L2LEAF1B | 192.168.200.115/24 | vEOS-LAB | Provisioned |
 | DC1_FABRIC | l2leaf | DC1-L2LEAF2A | 192.168.200.113/24 | vEOS-LAB | Provisioned |
 | DC1_FABRIC | l2leaf | DC1-L2LEAF2B | 192.168.200.114/24 | vEOS-LAB | Provisioned |
+| DC1_FABRIC | l2leaf | DC1-L2LEAF3A | 192.168.200.116/24 | vEOS-LAB | Provisioned |
 | DC1_FABRIC | l3leaf | DC1-LEAF1A | 192.168.200.105/24 | 7050SX3 | Provisioned |
 | DC1_FABRIC | l3leaf | DC1-LEAF2A | 192.168.200.106/24 | 7280R | Provisioned |
 | DC1_FABRIC | l3leaf | DC1-LEAF2B | 192.168.200.107/24 | 7280R | Provisioned |
@@ -54,12 +56,18 @@
 | l3leaf | DC1-BL1B | Ethernet4 | spine | DC1-SPINE4 | Ethernet7 |
 | l2leaf | DC1-L2LEAF1A | Ethernet1 | l3leaf | DC1-LEAF2A | Ethernet7 |
 | l2leaf | DC1-L2LEAF1A | Ethernet2 | l3leaf | DC1-LEAF2B | Ethernet7 |
+| l2leaf | DC1-L2LEAF1A | Ethernet3 | mlag_peer | DC1-L2LEAF1B | Ethernet3 |
+| l2leaf | DC1-L2LEAF1A | Ethernet4 | mlag_peer | DC1-L2LEAF1B | Ethernet4 |
+| l2leaf | DC1-L2LEAF1B | Ethernet1 | l3leaf | DC1-LEAF2A | Ethernet8 |
+| l2leaf | DC1-L2LEAF1B | Ethernet2 | l3leaf | DC1-LEAF2B | Ethernet8 |
 | l2leaf | DC1-L2LEAF2A | Ethernet1 | l3leaf | DC1-SVC3A | Ethernet7 |
 | l2leaf | DC1-L2LEAF2A | Ethernet2 | l3leaf | DC1-SVC3B | Ethernet7 |
 | l2leaf | DC1-L2LEAF2A | Ethernet3 | mlag_peer | DC1-L2LEAF2B | Ethernet3 |
 | l2leaf | DC1-L2LEAF2A | Ethernet4 | mlag_peer | DC1-L2LEAF2B | Ethernet4 |
 | l2leaf | DC1-L2LEAF2B | Ethernet1 | l3leaf | DC1-SVC3A | Ethernet8 |
 | l2leaf | DC1-L2LEAF2B | Ethernet2 | l3leaf | DC1-SVC3B | Ethernet8 |
+| l2leaf | DC1-L2LEAF3A | Ethernet1 | l3leaf | DC1-LEAF2A | Ethernet9 |
+| l2leaf | DC1-L2LEAF3A | Ethernet2 | l3leaf | DC1-LEAF2B | Ethernet9 |
 | l3leaf | DC1-LEAF1A | Ethernet1 | spine | DC1-SPINE1 | Ethernet1 |
 | l3leaf | DC1-LEAF1A | Ethernet2 | spine | DC1-SPINE2 | Ethernet1 |
 | l3leaf | DC1-LEAF1A | Ethernet3 | spine | DC1-SPINE3 | Ethernet1 |
@@ -68,8 +76,6 @@
 | l3leaf | DC1-LEAF2A | Ethernet2 | spine | DC1-SPINE2 | Ethernet2 |
 | l3leaf | DC1-LEAF2A | Ethernet3 | spine | DC1-SPINE3 | Ethernet2 |
 | l3leaf | DC1-LEAF2A | Ethernet4 | spine | DC1-SPINE4 | Ethernet2 |
-| l3leaf | DC1-LEAF2A | Ethernet5 | mlag_peer | DC1-LEAF2B | Ethernet5 |
-| l3leaf | DC1-LEAF2A | Ethernet6 | mlag_peer | DC1-LEAF2B | Ethernet6 |
 | l3leaf | DC1-LEAF2B | Ethernet1 | spine | DC1-SPINE1 | Ethernet3 |
 | l3leaf | DC1-LEAF2B | Ethernet2 | spine | DC1-SPINE2 | Ethernet3 |
 | l3leaf | DC1-LEAF2B | Ethernet3 | spine | DC1-SPINE3 | Ethernet3 |
@@ -162,6 +168,6 @@
 | DC1_FABRIC | DC1-BL1B | 192.168.254.15/32 |
 | DC1_FABRIC | DC1-LEAF1A | 192.168.254.9/32 |
 | DC1_FABRIC | DC1-LEAF2A | 192.168.254.10/32 |
-| DC1_FABRIC | DC1-LEAF2B | 192.168.254.10/32 |
+| DC1_FABRIC | DC1-LEAF2B | 192.168.254.11/32 |
 | DC1_FABRIC | DC1-SVC3A | 192.168.254.12/32 |
 | DC1_FABRIC | DC1-SVC3B | 192.168.254.12/32 |

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/fabric/DC1_FABRIC-topology.csv
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/fabric/DC1_FABRIC-topology.csv
@@ -17,6 +17,12 @@ l3leaf,DC1-BL1B,Ethernet9,l3_interface,,
 l3leaf,DC1-BL1B,Ethernet4000,my_precious,MY-own-peer,Ethernet123
 l2leaf,DC1-L2LEAF1A,Ethernet1,l3leaf,DC1-LEAF2A,Ethernet7
 l2leaf,DC1-L2LEAF1A,Ethernet2,l3leaf,DC1-LEAF2B,Ethernet7
+l2leaf,DC1-L2LEAF1A,Ethernet3,mlag_peer,DC1-L2LEAF1B,Ethernet3
+l2leaf,DC1-L2LEAF1A,Ethernet4,mlag_peer,DC1-L2LEAF1B,Ethernet4
+l2leaf,DC1-L2LEAF1B,Ethernet1,l3leaf,DC1-LEAF2A,Ethernet8
+l2leaf,DC1-L2LEAF1B,Ethernet2,l3leaf,DC1-LEAF2B,Ethernet8
+l2leaf,DC1-L2LEAF1B,Ethernet3,mlag_peer,DC1-L2LEAF1A,Ethernet3
+l2leaf,DC1-L2LEAF1B,Ethernet4,mlag_peer,DC1-L2LEAF1A,Ethernet4
 l2leaf,DC1-L2LEAF2A,Ethernet1,l3leaf,DC1-SVC3A,Ethernet7
 l2leaf,DC1-L2LEAF2A,Ethernet2,l3leaf,DC1-SVC3B,Ethernet7
 l2leaf,DC1-L2LEAF2A,Ethernet3,mlag_peer,DC1-L2LEAF2B,Ethernet3
@@ -25,6 +31,8 @@ l2leaf,DC1-L2LEAF2B,Ethernet1,l3leaf,DC1-SVC3A,Ethernet8
 l2leaf,DC1-L2LEAF2B,Ethernet2,l3leaf,DC1-SVC3B,Ethernet8
 l2leaf,DC1-L2LEAF2B,Ethernet3,mlag_peer,DC1-L2LEAF2A,Ethernet3
 l2leaf,DC1-L2LEAF2B,Ethernet4,mlag_peer,DC1-L2LEAF2A,Ethernet4
+l2leaf,DC1-L2LEAF3A,Ethernet1,l3leaf,DC1-LEAF2A,Ethernet9
+l2leaf,DC1-L2LEAF3A,Ethernet2,l3leaf,DC1-LEAF2B,Ethernet9
 l3leaf,DC1-LEAF1A,Ethernet1,spine,DC1-SPINE1,Ethernet1
 l3leaf,DC1-LEAF1A,Ethernet2,spine,DC1-SPINE2,Ethernet1
 l3leaf,DC1-LEAF1A,Ethernet3,spine,DC1-SPINE3,Ethernet1
@@ -35,9 +43,9 @@ l3leaf,DC1-LEAF2A,Ethernet1,spine,DC1-SPINE1,Ethernet2
 l3leaf,DC1-LEAF2A,Ethernet2,spine,DC1-SPINE2,Ethernet2
 l3leaf,DC1-LEAF2A,Ethernet3,spine,DC1-SPINE3,Ethernet2
 l3leaf,DC1-LEAF2A,Ethernet4,spine,DC1-SPINE4,Ethernet2
-l3leaf,DC1-LEAF2A,Ethernet5,mlag_peer,DC1-LEAF2B,Ethernet5
-l3leaf,DC1-LEAF2A,Ethernet6,mlag_peer,DC1-LEAF2B,Ethernet6
 l3leaf,DC1-LEAF2A,Ethernet7,l2leaf,DC1-L2LEAF1A,Ethernet1
+l3leaf,DC1-LEAF2A,Ethernet8,l2leaf,DC1-L2LEAF1B,Ethernet1
+l3leaf,DC1-LEAF2A,Ethernet9,l2leaf,DC1-L2LEAF3A,Ethernet1
 l3leaf,DC1-LEAF2A,Ethernet10,server,server01_MLAG,Eth2
 l3leaf,DC1-LEAF2A,Ethernet11,server,server01_MTU_PROFILE_MLAG,Eth4
 l3leaf,DC1-LEAF2A,Ethernet12,server,server01_MTU_ADAPTOR_MLAG,Eth6
@@ -47,9 +55,9 @@ l3leaf,DC1-LEAF2B,Ethernet1,spine,DC1-SPINE1,Ethernet3
 l3leaf,DC1-LEAF2B,Ethernet2,spine,DC1-SPINE2,Ethernet3
 l3leaf,DC1-LEAF2B,Ethernet3,spine,DC1-SPINE3,Ethernet3
 l3leaf,DC1-LEAF2B,Ethernet4,spine,DC1-SPINE4,Ethernet3
-l3leaf,DC1-LEAF2B,Ethernet5,mlag_peer,DC1-LEAF2A,Ethernet5
-l3leaf,DC1-LEAF2B,Ethernet6,mlag_peer,DC1-LEAF2A,Ethernet6
 l3leaf,DC1-LEAF2B,Ethernet7,l2leaf,DC1-L2LEAF1A,Ethernet2
+l3leaf,DC1-LEAF2B,Ethernet8,l2leaf,DC1-L2LEAF1B,Ethernet2
+l3leaf,DC1-LEAF2B,Ethernet9,l2leaf,DC1-L2LEAF3A,Ethernet2
 l3leaf,DC1-LEAF2B,Ethernet10,server,server01_MLAG,Eth3
 l3leaf,DC1-LEAF2B,Ethernet11,server,server01_MTU_PROFILE_MLAG,Eth5
 l3leaf,DC1-LEAF2B,Ethernet12,server,server01_MTU_ADAPTOR_MLAG,Eth7

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF1B.cfg
@@ -12,7 +12,7 @@ transceiver qsfp default-mode 4x10G
 !
 service routing protocols model multi-agent
 !
-hostname DC1-L2LEAF1A
+hostname DC1-L2LEAF1B
 ip name-server vrf MGMT 8.8.8.8
 ip name-server vrf MGMT 192.168.200.5
 !
@@ -20,7 +20,7 @@ ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 !
 snmp-server contact example@example.com
-snmp-server location DC1_FABRIC rackE DC1-L2LEAF1A
+snmp-server location DC1_FABRIC rackE DC1-L2LEAF1B
 !
 spanning-tree mode mstp
 no spanning-tree vlan-id 4094
@@ -63,7 +63,7 @@ vlan 4094
 vrf instance MGMT
 !
 interface Port-Channel1
-   description DC1-LEAF2A_Po7
+   description DC1-LEAF2B_Po7
    no shutdown
    switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,160-161
@@ -71,7 +71,7 @@ interface Port-Channel1
    mlag 1
 !
 interface Port-Channel3
-   description MLAG_PEER_DC1-L2LEAF1B_Po3
+   description MLAG_PEER_DC1-L2LEAF1A_Po3
    no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
@@ -79,22 +79,22 @@ interface Port-Channel3
    switchport trunk group MLAG
 !
 interface Ethernet1
-   description DC1-LEAF2A_Ethernet7
+   description DC1-LEAF2A_Ethernet8
    no shutdown
    channel-group 1 mode active
 !
 interface Ethernet2
-   description DC1-LEAF2B_Ethernet7
+   description DC1-LEAF2B_Ethernet8
    no shutdown
    channel-group 1 mode active
 !
 interface Ethernet3
-   description MLAG_PEER_DC1-L2LEAF1B_Ethernet3
+   description MLAG_PEER_DC1-L2LEAF1A_Ethernet3
    no shutdown
    channel-group 3 mode active
 !
 interface Ethernet4
-   description MLAG_PEER_DC1-L2LEAF1B_Ethernet4
+   description MLAG_PEER_DC1-L2LEAF1A_Ethernet4
    no shutdown
    channel-group 3 mode active
 !
@@ -102,14 +102,14 @@ interface Management1
    description oob_management
    no shutdown
    vrf MGMT
-   ip address 192.168.200.112/24
+   ip address 192.168.200.115/24
 !
 interface Vlan4094
    description MLAG_PEER
    no shutdown
    mtu 1500
    no autostate
-   ip address 10.255.252.14/31
+   ip address 10.255.252.15/31
 !
 ip routing
 no ip routing vrf MGMT
@@ -117,7 +117,7 @@ no ip routing vrf MGMT
 mlag configuration
    domain-id DC1_L2LEAF1
    local-interface Vlan4094
-   peer-address 10.255.252.15
+   peer-address 10.255.252.14
    peer-link Port-Channel3
    reload-delay mlag 300
    reload-delay non-mlag 330

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF3A.cfg
@@ -12,7 +12,7 @@ transceiver qsfp default-mode 4x10G
 !
 service routing protocols model multi-agent
 !
-hostname DC1-L2LEAF1A
+hostname DC1-L2LEAF3A
 ip name-server vrf MGMT 8.8.8.8
 ip name-server vrf MGMT 192.168.200.5
 !
@@ -20,10 +20,9 @@ ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 !
 snmp-server contact example@example.com
-snmp-server location DC1_FABRIC rackE DC1-L2LEAF1A
+snmp-server location DC1_FABRIC rackE DC1-L2LEAF3A
 !
 spanning-tree mode mstp
-no spanning-tree vlan-id 4094
 spanning-tree mst 0 priority 16384
 !
 no aaa root
@@ -56,71 +55,33 @@ vlan 160
 vlan 161
    name Tenant_A_NFS
 !
-vlan 4094
-   name MLAG_PEER
-   trunk group MLAG
-!
 vrf instance MGMT
 !
 interface Port-Channel1
-   description DC1-LEAF2A_Po7
+   description DC1-LEAF2A_Po9
    no shutdown
    switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,160-161
    switchport mode trunk
-   mlag 1
-!
-interface Port-Channel3
-   description MLAG_PEER_DC1-L2LEAF1B_Po3
-   no shutdown
-   switchport
-   switchport trunk allowed vlan 2-4094
-   switchport mode trunk
-   switchport trunk group MLAG
 !
 interface Ethernet1
-   description DC1-LEAF2A_Ethernet7
+   description DC1-LEAF2A_Ethernet9
    no shutdown
    channel-group 1 mode active
 !
 interface Ethernet2
-   description DC1-LEAF2B_Ethernet7
+   description DC1-LEAF2B_Ethernet9
    no shutdown
    channel-group 1 mode active
-!
-interface Ethernet3
-   description MLAG_PEER_DC1-L2LEAF1B_Ethernet3
-   no shutdown
-   channel-group 3 mode active
-!
-interface Ethernet4
-   description MLAG_PEER_DC1-L2LEAF1B_Ethernet4
-   no shutdown
-   channel-group 3 mode active
 !
 interface Management1
    description oob_management
    no shutdown
    vrf MGMT
-   ip address 192.168.200.112/24
-!
-interface Vlan4094
-   description MLAG_PEER
-   no shutdown
-   mtu 1500
-   no autostate
-   ip address 10.255.252.14/31
+   ip address 192.168.200.116/24
 !
 ip routing
 no ip routing vrf MGMT
-!
-mlag configuration
-   domain-id DC1_L2LEAF1
-   local-interface Vlan4094
-   peer-address 10.255.252.15
-   peer-link Port-Channel3
-   reload-delay mlag 300
-   reload-delay non-mlag 330
 !
 ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
@@ -29,7 +29,6 @@ hardware speed-group 4 serdes 10G
 !
 spanning-tree root super
 spanning-tree mode mstp
-no spanning-tree vlan-id 4093-4094
 spanning-tree mst 0 priority 4096
 !
 platform sand lag hardware-only
@@ -39,10 +38,6 @@ no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
-!
-vlan 2
-   name MLAG_iBGP_Tenant_C_OP_Zone
-   trunk group LEAF_PEER_L3
 !
 vlan 110
    name Tenant_A_OP_Zone_1
@@ -86,34 +81,6 @@ vlan 310
 vlan 311
    name Tenant_C_OP_Zone_2
 !
-vlan 3009
-   name MLAG_iBGP_Tenant_A_OP_Zone
-   trunk group LEAF_PEER_L3
-!
-vlan 3010
-   name MLAG_iBGP_Tenant_A_WEB_Zone
-   trunk group LEAF_PEER_L3
-!
-vlan 3011
-   name MLAG_iBGP_Tenant_A_APP_Zone
-   trunk group LEAF_PEER_L3
-!
-vlan 3012
-   name MLAG_iBGP_Tenant_A_DB_Zone
-   trunk group LEAF_PEER_L3
-!
-vlan 3019
-   name MLAG_iBGP_Tenant_B_OP_Zone
-   trunk group LEAF_PEER_L3
-!
-vlan 4093
-   name LEAF_PEER_L3
-   trunk group LEAF_PEER_L3
-!
-vlan 4094
-   name MLAG_PEER
-   trunk group MLAG
-!
 vrf instance MGMT
 !
 vrf instance Tenant_A_APP_Zone
@@ -128,22 +95,27 @@ vrf instance Tenant_B_OP_Zone
 !
 vrf instance Tenant_C_OP_Zone
 !
-interface Port-Channel5
-   description MLAG_PEER_DC1-LEAF2B_Po5
-   no shutdown
-   switchport
-   switchport trunk allowed vlan 2-4094
-   switchport mode trunk
-   switchport trunk group LEAF_PEER_L3
-   switchport trunk group MLAG
-!
 interface Port-Channel7
    description DC1_L2LEAF1_Po1
    no shutdown
    switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,160-161
    switchport mode trunk
-   mlag 7
+   evpn ethernet-segment
+      identifier 0000:0000:0808:0707:0606
+      route-target import 08:08:07:07:06:06
+   lacp system-id 0808.0707.0606
+!
+interface Port-Channel9
+   description DC1_L2LEAF3_Po1
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 110-111,120-121,130-131,160-161
+   switchport mode trunk
+   evpn ethernet-segment
+      identifier 0000:0000:0606:0707:0808
+      route-target import 06:06:07:07:08:08
+   lacp system-id 0606.0707.0808
 !
 interface Port-Channel10
    description server01_MLAG_PortChanne1
@@ -208,20 +180,20 @@ interface Ethernet4
    no switchport
    ip address 172.31.255.23/31
 !
-interface Ethernet5
-   description MLAG_PEER_DC1-LEAF2B_Ethernet5
-   no shutdown
-   channel-group 5 mode active
-!
-interface Ethernet6
-   description MLAG_PEER_DC1-LEAF2B_Ethernet6
-   no shutdown
-   channel-group 5 mode active
-!
 interface Ethernet7
    description DC1-L2LEAF1A_Ethernet1
    no shutdown
    channel-group 7 mode active
+!
+interface Ethernet8
+   description DC1-L2LEAF1B_Ethernet1
+   no shutdown
+   channel-group 7 mode active
+!
+interface Ethernet9
+   description DC1-L2LEAF3A_Ethernet1
+   no shutdown
+   channel-group 9 mode active
 !
 interface Ethernet10
    description server01_MLAG_Eth2
@@ -271,13 +243,6 @@ interface Management1
    no shutdown
    vrf MGMT
    ip address 192.168.200.106/24
-!
-interface Vlan2
-   description MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone
-   no shutdown
-   mtu 1500
-   vrf Tenant_C_OP_Zone
-   ip address 10.255.251.2/31
 !
 interface Vlan110
    description Tenant_A_OP_Zone_1
@@ -354,57 +319,8 @@ interface Vlan311
    vrf Tenant_C_OP_Zone
    ip address virtual 10.3.11.1/24
 !
-interface Vlan3009
-   description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone
-   no shutdown
-   mtu 1500
-   vrf Tenant_A_OP_Zone
-   ip address 10.255.251.2/31
-!
-interface Vlan3010
-   description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone
-   no shutdown
-   mtu 1500
-   vrf Tenant_A_WEB_Zone
-   ip address 10.255.251.2/31
-!
-interface Vlan3011
-   description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
-   no shutdown
-   mtu 1500
-   vrf Tenant_A_APP_Zone
-   ip address 10.255.251.2/31
-!
-interface Vlan3012
-   description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone
-   no shutdown
-   mtu 1500
-   vrf Tenant_A_DB_Zone
-   ip address 10.255.251.2/31
-!
-interface Vlan3019
-   description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone
-   no shutdown
-   mtu 1500
-   vrf Tenant_B_OP_Zone
-   ip address 10.255.251.2/31
-!
-interface Vlan4093
-   description MLAG_PEER_L3_PEERING
-   no shutdown
-   mtu 1500
-   ip address 10.255.251.2/31
-!
-interface Vlan4094
-   description MLAG_PEER
-   no shutdown
-   mtu 1500
-   no autostate
-   ip address 10.255.252.2/31
-!
 interface Vxlan1
    vxlan source-interface Loopback1
-   vxlan virtual-router encapsulation mac-address mlag-system-id
    vxlan udp-port 4789
    vxlan vlan 110 vni 10110
    vxlan vlan 111 vni 50111
@@ -447,22 +363,10 @@ ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.255.0/24 eq 32
    seq 20 permit 192.168.254.0/24 eq 32
 !
-mlag configuration
-   domain-id DC1_LEAF2
-   local-interface Vlan4094
-   peer-address 10.255.252.3
-   peer-link Port-Channel5
-   reload-delay mlag 780
-   reload-delay non-mlag 1020
-!
 ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
 route-map RM-CONN-2-BGP permit 10
    match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
-!
-route-map RM-MLAG-PEER-IN permit 10
-   description Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing
-   set origin incomplete
 !
 router bfd
    multihop interval 1200 min-rx 1200 multiplier 3
@@ -479,20 +383,11 @@ router bgp 65102
    neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
    neighbor EVPN-OVERLAY-PEERS send-community
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
-   neighbor MLAG-PEERS peer group
-   neighbor MLAG-PEERS remote-as 65102
-   neighbor MLAG-PEERS next-hop-self
-   neighbor MLAG-PEERS password 7 vnEaG8gMeQf3d3cN6PktXQ==
-   neighbor MLAG-PEERS send-community
-   neighbor MLAG-PEERS maximum-routes 12000
-   neighbor MLAG-PEERS route-map RM-MLAG-PEER-IN in
    neighbor UNDERLAY-PEERS peer group
    neighbor UNDERLAY-PEERS remote-as 65001
    neighbor UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
    neighbor UNDERLAY-PEERS send-community
    neighbor UNDERLAY-PEERS maximum-routes 12000
-   neighbor 10.255.251.3 peer group MLAG-PEERS
-   neighbor 10.255.251.3 description DC1-LEAF2B
    neighbor 172.31.255.16 peer group UNDERLAY-PEERS
    neighbor 172.31.255.16 description DC1-SPINE1_Ethernet2
    neighbor 172.31.255.18 peer group UNDERLAY-PEERS
@@ -568,7 +463,6 @@ router bgp 65102
    !
    address-family ipv4
       no neighbor EVPN-OVERLAY-PEERS activate
-      neighbor MLAG-PEERS activate
       neighbor UNDERLAY-PEERS activate
    !
    vrf Tenant_A_APP_Zone
@@ -576,7 +470,6 @@ router bgp 65102
       route-target import evpn 12:12
       route-target export evpn 12:12
       router-id 192.168.255.10
-      neighbor 10.255.251.3 peer group MLAG-PEERS
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -584,7 +477,6 @@ router bgp 65102
       route-target import evpn 13:13
       route-target export evpn 13:13
       router-id 192.168.255.10
-      neighbor 10.255.251.3 peer group MLAG-PEERS
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -592,7 +484,6 @@ router bgp 65102
       route-target import evpn 10:10
       route-target export evpn 10:10
       router-id 192.168.255.10
-      neighbor 10.255.251.3 peer group MLAG-PEERS
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -600,7 +491,6 @@ router bgp 65102
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.10
-      neighbor 10.255.251.3 peer group MLAG-PEERS
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -608,7 +498,6 @@ router bgp 65102
       route-target import evpn 20:20
       route-target export evpn 20:20
       router-id 192.168.255.10
-      neighbor 10.255.251.3 peer group MLAG-PEERS
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -616,7 +505,6 @@ router bgp 65102
       route-target import evpn 30:30
       route-target export evpn 30:30
       router-id 192.168.255.10
-      neighbor 10.255.251.3 peer group MLAG-PEERS
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
@@ -29,7 +29,6 @@ hardware speed-group 4 serdes 10G
 !
 spanning-tree root super
 spanning-tree mode mstp
-no spanning-tree vlan-id 4093-4094
 spanning-tree mst 0 priority 4096
 !
 platform sand lag hardware-only
@@ -39,10 +38,6 @@ no enable password
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
-!
-vlan 2
-   name MLAG_iBGP_Tenant_C_OP_Zone
-   trunk group LEAF_PEER_L3
 !
 vlan 110
    name Tenant_A_OP_Zone_1
@@ -86,34 +81,6 @@ vlan 310
 vlan 311
    name Tenant_C_OP_Zone_2
 !
-vlan 3009
-   name MLAG_iBGP_Tenant_A_OP_Zone
-   trunk group LEAF_PEER_L3
-!
-vlan 3010
-   name MLAG_iBGP_Tenant_A_WEB_Zone
-   trunk group LEAF_PEER_L3
-!
-vlan 3011
-   name MLAG_iBGP_Tenant_A_APP_Zone
-   trunk group LEAF_PEER_L3
-!
-vlan 3012
-   name MLAG_iBGP_Tenant_A_DB_Zone
-   trunk group LEAF_PEER_L3
-!
-vlan 3019
-   name MLAG_iBGP_Tenant_B_OP_Zone
-   trunk group LEAF_PEER_L3
-!
-vlan 4093
-   name LEAF_PEER_L3
-   trunk group LEAF_PEER_L3
-!
-vlan 4094
-   name MLAG_PEER
-   trunk group MLAG
-!
 vrf instance MGMT
 !
 vrf instance Tenant_A_APP_Zone
@@ -128,22 +95,27 @@ vrf instance Tenant_B_OP_Zone
 !
 vrf instance Tenant_C_OP_Zone
 !
-interface Port-Channel5
-   description MLAG_PEER_DC1-LEAF2A_Po5
-   no shutdown
-   switchport
-   switchport trunk allowed vlan 2-4094
-   switchport mode trunk
-   switchport trunk group LEAF_PEER_L3
-   switchport trunk group MLAG
-!
 interface Port-Channel7
    description DC1_L2LEAF1_Po1
    no shutdown
    switchport
    switchport trunk allowed vlan 110-111,120-121,130-131,160-161
    switchport mode trunk
-   mlag 7
+   evpn ethernet-segment
+      identifier 0000:0000:0808:0707:0606
+      route-target import 08:08:07:07:06:06
+   lacp system-id 0808.0707.0606
+!
+interface Port-Channel9
+   description DC1_L2LEAF3_Po1
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 110-111,120-121,130-131,160-161
+   switchport mode trunk
+   evpn ethernet-segment
+      identifier 0000:0000:0606:0707:0808
+      route-target import 06:06:07:07:08:08
+   lacp system-id 0606.0707.0808
 !
 interface Port-Channel10
    description server01_MLAG_PortChanne1
@@ -208,20 +180,20 @@ interface Ethernet4
    no switchport
    ip address 172.31.255.39/31
 !
-interface Ethernet5
-   description MLAG_PEER_DC1-LEAF2A_Ethernet5
-   no shutdown
-   channel-group 5 mode active
-!
-interface Ethernet6
-   description MLAG_PEER_DC1-LEAF2A_Ethernet6
-   no shutdown
-   channel-group 5 mode active
-!
 interface Ethernet7
    description DC1-L2LEAF1A_Ethernet2
    no shutdown
    channel-group 7 mode active
+!
+interface Ethernet8
+   description DC1-L2LEAF1B_Ethernet2
+   no shutdown
+   channel-group 7 mode active
+!
+interface Ethernet9
+   description DC1-L2LEAF3A_Ethernet2
+   no shutdown
+   channel-group 9 mode active
 !
 interface Ethernet10
    description server01_MLAG_Eth3
@@ -258,7 +230,7 @@ interface Loopback0
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
    no shutdown
-   ip address 192.168.254.10/32
+   ip address 192.168.254.11/32
 !
 interface Loopback100
    description Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
@@ -271,13 +243,6 @@ interface Management1
    no shutdown
    vrf MGMT
    ip address 192.168.200.107/24
-!
-interface Vlan2
-   description MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone
-   no shutdown
-   mtu 1500
-   vrf Tenant_C_OP_Zone
-   ip address 10.255.251.3/31
 !
 interface Vlan110
    description Tenant_A_OP_Zone_1
@@ -354,57 +319,8 @@ interface Vlan311
    vrf Tenant_C_OP_Zone
    ip address virtual 10.3.11.1/24
 !
-interface Vlan3009
-   description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone
-   no shutdown
-   mtu 1500
-   vrf Tenant_A_OP_Zone
-   ip address 10.255.251.3/31
-!
-interface Vlan3010
-   description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone
-   no shutdown
-   mtu 1500
-   vrf Tenant_A_WEB_Zone
-   ip address 10.255.251.3/31
-!
-interface Vlan3011
-   description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
-   no shutdown
-   mtu 1500
-   vrf Tenant_A_APP_Zone
-   ip address 10.255.251.3/31
-!
-interface Vlan3012
-   description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone
-   no shutdown
-   mtu 1500
-   vrf Tenant_A_DB_Zone
-   ip address 10.255.251.3/31
-!
-interface Vlan3019
-   description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone
-   no shutdown
-   mtu 1500
-   vrf Tenant_B_OP_Zone
-   ip address 10.255.251.3/31
-!
-interface Vlan4093
-   description MLAG_PEER_L3_PEERING
-   no shutdown
-   mtu 1500
-   ip address 10.255.251.3/31
-!
-interface Vlan4094
-   description MLAG_PEER
-   no shutdown
-   mtu 1500
-   no autostate
-   ip address 10.255.252.3/31
-!
 interface Vxlan1
    vxlan source-interface Loopback1
-   vxlan virtual-router encapsulation mac-address mlag-system-id
    vxlan udp-port 4789
    vxlan vlan 110 vni 10110
    vxlan vlan 111 vni 50111
@@ -447,22 +363,10 @@ ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.255.0/24 eq 32
    seq 20 permit 192.168.254.0/24 eq 32
 !
-mlag configuration
-   domain-id DC1_LEAF2
-   local-interface Vlan4094
-   peer-address 10.255.252.2
-   peer-link Port-Channel5
-   reload-delay mlag 780
-   reload-delay non-mlag 1020
-!
 ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
 route-map RM-CONN-2-BGP permit 10
    match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
-!
-route-map RM-MLAG-PEER-IN permit 10
-   description Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing
-   set origin incomplete
 !
 router bfd
    multihop interval 1200 min-rx 1200 multiplier 3
@@ -479,20 +383,11 @@ router bgp 65102
    neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
    neighbor EVPN-OVERLAY-PEERS send-community
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
-   neighbor MLAG-PEERS peer group
-   neighbor MLAG-PEERS remote-as 65102
-   neighbor MLAG-PEERS next-hop-self
-   neighbor MLAG-PEERS password 7 vnEaG8gMeQf3d3cN6PktXQ==
-   neighbor MLAG-PEERS send-community
-   neighbor MLAG-PEERS maximum-routes 12000
-   neighbor MLAG-PEERS route-map RM-MLAG-PEER-IN in
    neighbor UNDERLAY-PEERS peer group
    neighbor UNDERLAY-PEERS remote-as 65001
    neighbor UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
    neighbor UNDERLAY-PEERS send-community
    neighbor UNDERLAY-PEERS maximum-routes 12000
-   neighbor 10.255.251.2 peer group MLAG-PEERS
-   neighbor 10.255.251.2 description DC1-LEAF2A
    neighbor 172.31.255.32 peer group UNDERLAY-PEERS
    neighbor 172.31.255.32 description DC1-SPINE1_Ethernet3
    neighbor 172.31.255.34 peer group UNDERLAY-PEERS
@@ -568,7 +463,6 @@ router bgp 65102
    !
    address-family ipv4
       no neighbor EVPN-OVERLAY-PEERS activate
-      neighbor MLAG-PEERS activate
       neighbor UNDERLAY-PEERS activate
    !
    vrf Tenant_A_APP_Zone
@@ -576,7 +470,6 @@ router bgp 65102
       route-target import evpn 12:12
       route-target export evpn 12:12
       router-id 192.168.255.11
-      neighbor 10.255.251.2 peer group MLAG-PEERS
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -584,7 +477,6 @@ router bgp 65102
       route-target import evpn 13:13
       route-target export evpn 13:13
       router-id 192.168.255.11
-      neighbor 10.255.251.2 peer group MLAG-PEERS
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -592,7 +484,6 @@ router bgp 65102
       route-target import evpn 10:10
       route-target export evpn 10:10
       router-id 192.168.255.11
-      neighbor 10.255.251.2 peer group MLAG-PEERS
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -600,7 +491,6 @@ router bgp 65102
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.11
-      neighbor 10.255.251.2 peer group MLAG-PEERS
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -608,7 +498,6 @@ router bgp 65102
       route-target import evpn 20:20
       route-target export evpn 20:20
       router-id 192.168.255.11
-      neighbor 10.255.251.2 peer group MLAG-PEERS
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -616,7 +505,6 @@ router bgp 65102
       route-target import evpn 30:30
       route-target export evpn 30:30
       router-id 192.168.255.11
-      neighbor 10.255.251.2 peer group MLAG-PEERS
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1B.yml
@@ -33,7 +33,7 @@ ntp_server:
   - 192.168.200.5
 snmp_server:
   contact: example@example.com
-  location: DC1_FABRIC rackE DC1-L2LEAF1A
+  location: DC1_FABRIC rackE DC1-L2LEAF1B
 spanning_tree:
   mode: mstp
   mst_instances:
@@ -57,7 +57,7 @@ management_interfaces:
     description: oob_management
     shutdown: false
     vrf: MGMT
-    ip_address: 192.168.200.112/24
+    ip_address: 192.168.200.115/24
     gateway: 192.168.200.5
     type: oob
 management_api_http:
@@ -98,12 +98,12 @@ vlan_interfaces:
   Vlan4094:
     description: MLAG_PEER
     shutdown: false
-    ip_address: 10.255.252.14/31
+    ip_address: 10.255.252.15/31
     no_autostate: true
     mtu: 1500
 port_channel_interfaces:
   Port-Channel3:
-    description: MLAG_PEER_DC1-L2LEAF1B_Po3
+    description: MLAG_PEER_DC1-L2LEAF1A_Po3
     type: switched
     shutdown: false
     vlans: 2-4094
@@ -111,7 +111,7 @@ port_channel_interfaces:
     trunk_groups:
     - MLAG
   Port-Channel1:
-    description: DC1-LEAF2A_Po7
+    description: DC1-LEAF2B_Po7
     type: switched
     shutdown: false
     vlans: 110-111,120-121,130-131,160-161
@@ -119,20 +119,20 @@ port_channel_interfaces:
     mlag: 1
 ethernet_interfaces:
   Ethernet3:
-    peer: DC1-L2LEAF1B
+    peer: DC1-L2LEAF1A
     peer_interface: Ethernet3
     peer_type: mlag_peer
-    description: MLAG_PEER_DC1-L2LEAF1B_Ethernet3
+    description: MLAG_PEER_DC1-L2LEAF1A_Ethernet3
     type: switched
     shutdown: false
     channel_group:
       id: 3
       mode: active
   Ethernet4:
-    peer: DC1-L2LEAF1B
+    peer: DC1-L2LEAF1A
     peer_interface: Ethernet4
     peer_type: mlag_peer
-    description: MLAG_PEER_DC1-L2LEAF1B_Ethernet4
+    description: MLAG_PEER_DC1-L2LEAF1A_Ethernet4
     type: switched
     shutdown: false
     channel_group:
@@ -140,9 +140,9 @@ ethernet_interfaces:
       mode: active
   Ethernet1:
     peer: DC1-LEAF2A
-    peer_interface: Ethernet7
+    peer_interface: Ethernet8
     peer_type: l3leaf
-    description: DC1-LEAF2A_Ethernet7
+    description: DC1-LEAF2A_Ethernet8
     type: switched
     shutdown: false
     channel_group:
@@ -150,9 +150,9 @@ ethernet_interfaces:
       mode: active
   Ethernet2:
     peer: DC1-LEAF2B
-    peer_interface: Ethernet7
+    peer_interface: Ethernet8
     peer_type: l3leaf
-    description: DC1-LEAF2B_Ethernet7
+    description: DC1-LEAF2B_Ethernet8
     type: switched
     shutdown: false
     channel_group:
@@ -161,7 +161,7 @@ ethernet_interfaces:
 mlag_configuration:
   domain_id: DC1_L2LEAF1
   local_interface: Vlan4094
-  peer_address: 10.255.252.15
+  peer_address: 10.255.252.14
   peer_link: Port-Channel3
   reload_delay_mlag: 300
   reload_delay_non_mlag: 330

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF3A.yml
@@ -1,0 +1,123 @@
+static_routes:
+- vrf: MGMT
+  destination_address_prefix: 0.0.0.0/0
+  gateway: 192.168.200.5
+service_routing_protocols_model: multi-agent
+ip_routing: true
+daemon_terminattr:
+  ingestgrpcurl:
+    ips:
+    - 192.168.200.11
+    port: 9910
+  ingestauth_key: telarista
+  ingestvrf: MGMT
+  smashexcludes: ale,flexCounter,hardware,kni,pulse,strata
+  ingestexclude: /Sysdb/cell/1/agent,/Sysdb/cell/2/agent
+  disable_aaa: false
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+name_server:
+  source:
+    vrf: MGMT
+  nodes:
+  - 192.168.200.5
+  - 8.8.8.8
+ntp_server:
+  local_interface:
+    vrf: MGMT
+    interface: Management1
+  nodes:
+  - 192.168.200.5
+snmp_server:
+  contact: example@example.com
+  location: DC1_FABRIC rackE DC1-L2LEAF3A
+spanning_tree:
+  mode: mstp
+  mst_instances:
+    '0':
+      priority: 16384
+local_users:
+  admin:
+    privilege: 15
+    role: network-admin
+    no_password: true
+  cvpadmin:
+    privilege: 15
+    role: network-admin
+    sha512_password: $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
+vrfs:
+  MGMT:
+    ip_routing: false
+management_interfaces:
+  Management1:
+    description: oob_management
+    shutdown: false
+    vrf: MGMT
+    ip_address: 192.168.200.116/24
+    gateway: 192.168.200.5
+    type: oob
+management_api_http:
+  enable_vrfs:
+    MGMT: {}
+  enable_https: true
+ethernet_interfaces:
+  Ethernet1:
+    peer: DC1-LEAF2A
+    peer_interface: Ethernet9
+    peer_type: l3leaf
+    description: DC1-LEAF2A_Ethernet9
+    type: switched
+    shutdown: false
+    channel_group:
+      id: 1
+      mode: active
+  Ethernet2:
+    peer: DC1-LEAF2B
+    peer_interface: Ethernet9
+    peer_type: l3leaf
+    description: DC1-LEAF2B_Ethernet9
+    type: switched
+    shutdown: false
+    channel_group:
+      id: 1
+      mode: active
+port_channel_interfaces:
+  Port-Channel1:
+    description: DC1-LEAF2A_Po9
+    type: switched
+    shutdown: false
+    vlans: 110-111,120-121,130-131,160-161
+    mode: trunk
+ip_igmp_snooping:
+  globally_enabled: true
+  vlans:
+    120:
+      enabled: false
+vlans:
+  130:
+    tenant: Tenant_A
+    name: Tenant_A_APP_Zone_1
+  131:
+    tenant: Tenant_A
+    name: Tenant_A_APP_Zone_2
+  110:
+    tenant: Tenant_A
+    name: Tenant_A_OP_Zone_1
+  111:
+    tenant: Tenant_A
+    name: Tenant_A_OP_Zone_2
+  120:
+    tenant: Tenant_A
+    name: Tenant_A_WEB_Zone_1
+  121:
+    tenant: Tenant_A
+    name: Tenant_A_WEBZone_2
+  160:
+    tenant: Tenant_A
+    name: Tenant_A_VMOTION
+  161:
+    tenant: Tenant_A
+    name: Tenant_A_NFS

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -6,14 +6,6 @@ router_bgp:
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
   peer_groups:
-    MLAG-PEERS:
-      type: ipv4
-      remote_as: 65102
-      next_hop_self: true
-      password: vnEaG8gMeQf3d3cN6PktXQ==
-      maximum_routes: 12000
-      send_community: all
-      route_map_in: RM-MLAG-PEER-IN
     UNDERLAY-PEERS:
       type: ipv4
       remote_as: 65001
@@ -30,16 +22,14 @@ router_bgp:
       maximum_routes: 0
   address_family_ipv4:
     peer_groups:
-      MLAG-PEERS:
-        activate: true
       UNDERLAY-PEERS:
         activate: true
       EVPN-OVERLAY-PEERS:
         activate: false
+  redistribute_routes:
+    connected:
+      route_map: RM-CONN-2-BGP
   neighbors:
-    10.255.251.3:
-      peer_group: MLAG-PEERS
-      description: DC1-LEAF2B
     172.31.255.16:
       peer_group: UNDERLAY-PEERS
       description: DC1-SPINE1_Ethernet2
@@ -68,9 +58,6 @@ router_bgp:
       peer_group: EVPN-OVERLAY-PEERS
       description: DC1-SPINE4
       remote_as: 65001
-  redistribute_routes:
-    connected:
-      route_map: RM-CONN-2-BGP
   address_family_evpn:
     peer_groups:
       EVPN-OVERLAY-PEERS:
@@ -86,9 +73,6 @@ router_bgp:
         export:
           evpn:
           - '12:12'
-      neighbors:
-        10.255.251.3:
-          peer_group: MLAG-PEERS
       redistribute_routes:
       - connected
     Tenant_A_DB_Zone:
@@ -101,9 +85,6 @@ router_bgp:
         export:
           evpn:
           - '13:13'
-      neighbors:
-        10.255.251.3:
-          peer_group: MLAG-PEERS
       redistribute_routes:
       - connected
     Tenant_A_OP_Zone:
@@ -116,9 +97,6 @@ router_bgp:
         export:
           evpn:
           - '10:10'
-      neighbors:
-        10.255.251.3:
-          peer_group: MLAG-PEERS
       redistribute_routes:
       - connected
     Tenant_A_WEB_Zone:
@@ -131,9 +109,6 @@ router_bgp:
         export:
           evpn:
           - '11:11'
-      neighbors:
-        10.255.251.3:
-          peer_group: MLAG-PEERS
       redistribute_routes:
       - connected
     Tenant_B_OP_Zone:
@@ -146,9 +121,6 @@ router_bgp:
         export:
           evpn:
           - '20:20'
-      neighbors:
-        10.255.251.3:
-          peer_group: MLAG-PEERS
       redistribute_routes:
       - connected
     Tenant_C_OP_Zone:
@@ -161,9 +133,6 @@ router_bgp:
         export:
           evpn:
           - '30:30'
-      neighbors:
-        10.255.251.3:
-          peer_group: MLAG-PEERS
       redistribute_routes:
       - connected
   vlan_aware_bundles:
@@ -285,7 +254,6 @@ spanning_tree:
   mst_instances:
     '0':
       priority: 4096
-  no_spanning_tree_vlan: 4093-4094
 local_users:
   admin:
     privilege: 15
@@ -334,323 +302,21 @@ management_api_http:
   enable_vrfs:
     MGMT: {}
   enable_https: true
-vlans:
-  4093:
-    tenant: system
-    name: LEAF_PEER_L3
-    trunk_groups:
-    - LEAF_PEER_L3
-  4094:
-    tenant: system
-    name: MLAG_PEER
-    trunk_groups:
-    - MLAG
-  130:
-    tenant: Tenant_A
-    name: Tenant_A_APP_Zone_1
-  131:
-    tenant: Tenant_A
-    name: Tenant_A_APP_Zone_2
-  3011:
-    tenant: Tenant_A
-    name: MLAG_iBGP_Tenant_A_APP_Zone
-    trunk_groups:
-    - LEAF_PEER_L3
-  140:
-    tenant: Tenant_A
-    name: Tenant_A_DB_BZone_1
-  141:
-    tenant: Tenant_A
-    name: Tenant_A_DB_Zone_2
-  3012:
-    tenant: Tenant_A
-    name: MLAG_iBGP_Tenant_A_DB_Zone
-    trunk_groups:
-    - LEAF_PEER_L3
-  110:
-    tenant: Tenant_A
-    name: Tenant_A_OP_Zone_1
-  111:
-    tenant: Tenant_A
-    name: Tenant_A_OP_Zone_2
-  3009:
-    tenant: Tenant_A
-    name: MLAG_iBGP_Tenant_A_OP_Zone
-    trunk_groups:
-    - LEAF_PEER_L3
-  120:
-    tenant: Tenant_A
-    name: Tenant_A_WEB_Zone_1
-  121:
-    tenant: Tenant_A
-    name: Tenant_A_WEBZone_2
-  3010:
-    tenant: Tenant_A
-    name: MLAG_iBGP_Tenant_A_WEB_Zone
-    trunk_groups:
-    - LEAF_PEER_L3
-  160:
-    tenant: Tenant_A
-    name: Tenant_A_VMOTION
-  161:
-    tenant: Tenant_A
-    name: Tenant_A_NFS
-  210:
-    tenant: Tenant_B
-    name: Tenant_B_OP_Zone_1
-  211:
-    tenant: Tenant_B
-    name: Tenant_B_OP_Zone_2
-  3019:
-    tenant: Tenant_B
-    name: MLAG_iBGP_Tenant_B_OP_Zone
-    trunk_groups:
-    - LEAF_PEER_L3
-  310:
-    tenant: Tenant_C
-    name: Tenant_C_OP_Zone_1
-  311:
-    tenant: Tenant_C
-    name: Tenant_C_OP_Zone_2
-  2:
-    tenant: Tenant_C
-    name: MLAG_iBGP_Tenant_C_OP_Zone
-    trunk_groups:
-    - LEAF_PEER_L3
-vlan_interfaces:
-  Vlan4093:
-    description: MLAG_PEER_L3_PEERING
+loopback_interfaces:
+  Loopback0:
+    description: EVPN_Overlay_Peering
     shutdown: false
-    ip_address: 10.255.251.2/31
-    mtu: 1500
-  Vlan4094:
-    description: MLAG_PEER
+    ip_address: 192.168.255.10/32
+  Loopback1:
+    description: VTEP_VXLAN_Tunnel_Source
     shutdown: false
-    ip_address: 10.255.252.2/31
-    no_autostate: true
-    mtu: 1500
-  Vlan130:
-    tenant: Tenant_A
-    tags:
-    - app
-    - erp1
-    description: Tenant_A_APP_Zone_1
-    shutdown: false
-    vrf: Tenant_A_APP_Zone
-    ip_address_virtual: 10.1.30.1/24
-  Vlan131:
-    tenant: Tenant_A
-    tags:
-    - app
-    description: Tenant_A_APP_Zone_2
-    shutdown: false
-    vrf: Tenant_A_APP_Zone
-    ip_address_virtual: 10.1.31.1/24
-  Vlan3011:
-    tenant: Tenant_A
-    type: underlay_peering
-    shutdown: false
-    description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone'
-    vrf: Tenant_A_APP_Zone
-    ip_address: 10.255.251.2/31
-    mtu: 1500
-  Vlan140:
-    tenant: Tenant_A
-    tags:
-    - db
-    - erp1
-    description: Tenant_A_DB_BZone_1
-    shutdown: false
-    vrf: Tenant_A_DB_Zone
-    ip_address_virtual: 10.1.40.1/24
-  Vlan141:
-    tenant: Tenant_A
-    tags:
-    - db
-    description: Tenant_A_DB_Zone_2
-    shutdown: false
-    vrf: Tenant_A_DB_Zone
-    ip_address_virtual: 10.1.41.1/24
-  Vlan3012:
-    tenant: Tenant_A
-    type: underlay_peering
-    shutdown: false
-    description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone'
-    vrf: Tenant_A_DB_Zone
-    ip_address: 10.255.251.2/31
-    mtu: 1500
-  Vlan110:
-    tenant: Tenant_A
-    tags:
-    - opzone
-    description: Tenant_A_OP_Zone_1
+    ip_address: 192.168.254.10/32
+  Loopback100:
+    description: Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
     shutdown: false
     vrf: Tenant_A_OP_Zone
-    ip_address_virtual: 10.1.10.1/24
-  Vlan111:
-    tenant: Tenant_A
-    tags:
-    - opzone
-    description: Tenant_A_OP_Zone_2
-    shutdown: false
-    vrf: Tenant_A_OP_Zone
-    ip_address_virtual: 10.1.11.1/24
-    ip_helpers:
-      1.1.1.1:
-        source_interface: lo100
-        vrf: MGMT
-  Vlan3009:
-    tenant: Tenant_A
-    type: underlay_peering
-    shutdown: false
-    description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone'
-    vrf: Tenant_A_OP_Zone
-    ip_address: 10.255.251.2/31
-    mtu: 1500
-  Vlan120:
-    tenant: Tenant_A
-    tags:
-    - web
-    - erp1
-    description: Tenant_A_WEB_Zone_1
-    shutdown: false
-    vrf: Tenant_A_WEB_Zone
-    ip_address_virtual: 10.1.20.1/24
-    ip_helpers:
-      1.1.1.1:
-        source_interface: lo100
-        vrf: TEST
-  Vlan121:
-    tenant: Tenant_A
-    tags:
-    - web
-    description: Tenant_A_WEBZone_2
-    shutdown: true
-    vrf: Tenant_A_WEB_Zone
-    ip_address_virtual: 10.1.10.254/24
-    mtu: 1560
-  Vlan3010:
-    tenant: Tenant_A
-    type: underlay_peering
-    shutdown: false
-    description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone'
-    vrf: Tenant_A_WEB_Zone
-    ip_address: 10.255.251.2/31
-    mtu: 1500
-  Vlan210:
-    tenant: Tenant_B
-    tags:
-    - opzone
-    description: Tenant_B_OP_Zone_1
-    shutdown: false
-    vrf: Tenant_B_OP_Zone
-    ip_address_virtual: 10.2.10.1/24
-  Vlan211:
-    tenant: Tenant_B
-    tags:
-    - opzone
-    description: Tenant_B_OP_Zone_2
-    shutdown: false
-    vrf: Tenant_B_OP_Zone
-    ip_address_virtual: 10.2.11.1/24
-  Vlan3019:
-    tenant: Tenant_B
-    type: underlay_peering
-    shutdown: false
-    description: 'MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone'
-    vrf: Tenant_B_OP_Zone
-    ip_address: 10.255.251.2/31
-    mtu: 1500
-  Vlan310:
-    tenant: Tenant_C
-    tags:
-    - opzone
-    description: Tenant_C_OP_Zone_1
-    shutdown: false
-    vrf: Tenant_C_OP_Zone
-    ip_address_virtual: 10.3.10.1/24
-  Vlan311:
-    tenant: Tenant_C
-    tags:
-    - opzone
-    description: Tenant_C_OP_Zone_2
-    shutdown: false
-    vrf: Tenant_C_OP_Zone
-    ip_address_virtual: 10.3.11.1/24
-  Vlan2:
-    tenant: Tenant_C
-    type: underlay_peering
-    shutdown: false
-    description: 'MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone'
-    vrf: Tenant_C_OP_Zone
-    ip_address: 10.255.251.2/31
-    mtu: 1500
-port_channel_interfaces:
-  Port-Channel5:
-    description: MLAG_PEER_DC1-LEAF2B_Po5
-    type: switched
-    shutdown: false
-    vlans: 2-4094
-    mode: trunk
-    trunk_groups:
-    - LEAF_PEER_L3
-    - MLAG
-  Port-Channel7:
-    description: DC1_L2LEAF1_Po1
-    type: switched
-    shutdown: false
-    vlans: 110-111,120-121,130-131,160-161
-    mode: trunk
-    mlag: 7
-  Port-Channel20:
-    description: FIREWALL01_PortChanne1
-    type: switched
-    shutdown: false
-    mode: trunk
-    vlans: 110-111,210-211
-    mlag: 20
-  Port-Channel10:
-    description: server01_MLAG_PortChanne1
-    type: switched
-    shutdown: false
-    mode: trunk
-    vlans: 210-211
-    mlag: 10
-  Port-Channel12:
-    description: server01_MTU_ADAPTOR_MLAG_PortChanne1
-    type: switched
-    shutdown: false
-    mtu: 1601
-    mlag: 12
-  Port-Channel11:
-    description: server01_MTU_PROFILE_MLAG_PortChanne1
-    type: switched
-    shutdown: false
-    mode: access
-    mtu: 1600
-    vlans: 110
-    mlag: 11
+    ip_address: 10.255.1.10/32
 ethernet_interfaces:
-  Ethernet5:
-    peer: DC1-LEAF2B
-    peer_interface: Ethernet5
-    peer_type: mlag_peer
-    description: MLAG_PEER_DC1-LEAF2B_Ethernet5
-    type: switched
-    shutdown: false
-    channel_group:
-      id: 5
-      mode: active
-  Ethernet6:
-    peer: DC1-LEAF2B
-    peer_interface: Ethernet6
-    peer_type: mlag_peer
-    description: MLAG_PEER_DC1-LEAF2B_Ethernet6
-    type: switched
-    shutdown: false
-    channel_group:
-      id: 5
-      mode: active
   Ethernet1:
     peer: DC1-SPINE1
     peer_interface: Ethernet2
@@ -700,6 +366,26 @@ ethernet_interfaces:
     shutdown: false
     channel_group:
       id: 7
+      mode: active
+  Ethernet8:
+    peer: DC1-L2LEAF1B
+    peer_interface: Ethernet1
+    peer_type: l2leaf
+    description: DC1-L2LEAF1B_Ethernet1
+    type: switched
+    shutdown: false
+    channel_group:
+      id: 7
+      mode: active
+  Ethernet9:
+    peer: DC1-L2LEAF3A
+    peer_interface: Ethernet1
+    peer_type: l2leaf
+    description: DC1-L2LEAF3A_Ethernet1
+    type: switched
+    shutdown: false
+    channel_group:
+      id: 9
       mode: active
   Ethernet20:
     peer: FIREWALL01
@@ -762,42 +448,53 @@ ethernet_interfaces:
       id: 11
       mode: active
     profile: TENANT_A_MTU
-mlag_configuration:
-  domain_id: DC1_LEAF2
-  local_interface: Vlan4094
-  peer_address: 10.255.252.3
-  peer_link: Port-Channel5
-  reload_delay_mlag: 780
-  reload_delay_non_mlag: 1020
-route_maps:
-  RM-MLAG-PEER-IN:
-    sequence_numbers:
-      10:
-        type: permit
-        set:
-        - origin incomplete
-        description: Make routes learned over MLAG Peer-link less preferred on spines
-          to ensure optimal routing
-  RM-CONN-2-BGP:
-    sequence_numbers:
-      10:
-        type: permit
-        match:
-        - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
-loopback_interfaces:
-  Loopback0:
-    description: EVPN_Overlay_Peering
+port_channel_interfaces:
+  Port-Channel7:
+    description: DC1_L2LEAF1_Po1
+    type: switched
     shutdown: false
-    ip_address: 192.168.255.10/32
-  Loopback1:
-    description: VTEP_VXLAN_Tunnel_Source
+    vlans: 110-111,120-121,130-131,160-161
+    mode: trunk
+    esi: 0000:0000:0808:0707:0606
+    rt: 08:08:07:07:06:06
+    lacp_id: 0808.0707.0606
+  Port-Channel9:
+    description: DC1_L2LEAF3_Po1
+    type: switched
     shutdown: false
-    ip_address: 192.168.254.10/32
-  Loopback100:
-    description: Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
+    vlans: 110-111,120-121,130-131,160-161
+    mode: trunk
+    esi: 0000:0000:0606:0707:0808
+    rt: 06:06:07:07:08:08
+    lacp_id: 0606.0707.0808
+  Port-Channel20:
+    description: FIREWALL01_PortChanne1
+    type: switched
     shutdown: false
-    vrf: Tenant_A_OP_Zone
-    ip_address: 10.255.1.10/32
+    mode: trunk
+    vlans: 110-111,210-211
+    mlag: 20
+  Port-Channel10:
+    description: server01_MLAG_PortChanne1
+    type: switched
+    shutdown: false
+    mode: trunk
+    vlans: 210-211
+    mlag: 10
+  Port-Channel12:
+    description: server01_MTU_ADAPTOR_MLAG_PortChanne1
+    type: switched
+    shutdown: false
+    mtu: 1601
+    mlag: 12
+  Port-Channel11:
+    description: server01_MTU_PROFILE_MLAG_PortChanne1
+    type: switched
+    shutdown: false
+    mode: access
+    mtu: 1600
+    vlans: 110
+    mlag: 11
 prefix_lists:
   PL-LOOPBACKS-EVPN-OVERLAY:
     sequence_numbers:
@@ -805,6 +502,13 @@ prefix_lists:
         action: permit 192.168.255.0/24 eq 32
       20:
         action: permit 192.168.254.0/24 eq 32
+route_maps:
+  RM-CONN-2-BGP:
+    sequence_numbers:
+      10:
+        type: permit
+        match:
+        - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
 router_bfd:
   multihop:
     interval: 1200
@@ -815,12 +519,53 @@ ip_igmp_snooping:
   vlans:
     120:
       enabled: false
+vlans:
+  130:
+    tenant: Tenant_A
+    name: Tenant_A_APP_Zone_1
+  131:
+    tenant: Tenant_A
+    name: Tenant_A_APP_Zone_2
+  140:
+    tenant: Tenant_A
+    name: Tenant_A_DB_BZone_1
+  141:
+    tenant: Tenant_A
+    name: Tenant_A_DB_Zone_2
+  110:
+    tenant: Tenant_A
+    name: Tenant_A_OP_Zone_1
+  111:
+    tenant: Tenant_A
+    name: Tenant_A_OP_Zone_2
+  120:
+    tenant: Tenant_A
+    name: Tenant_A_WEB_Zone_1
+  121:
+    tenant: Tenant_A
+    name: Tenant_A_WEBZone_2
+  160:
+    tenant: Tenant_A
+    name: Tenant_A_VMOTION
+  161:
+    tenant: Tenant_A
+    name: Tenant_A_NFS
+  210:
+    tenant: Tenant_B
+    name: Tenant_B_OP_Zone_1
+  211:
+    tenant: Tenant_B
+    name: Tenant_B_OP_Zone_2
+  310:
+    tenant: Tenant_C
+    name: Tenant_C_OP_Zone_1
+  311:
+    tenant: Tenant_C
+    name: Tenant_C_OP_Zone_2
 vxlan_tunnel_interface:
   Vxlan1:
     description: DC1-LEAF2A_VTEP
     source_interface: Loopback1
-    virtual_router:
-      encapsulation_mac_address: mlag-system-id
     vxlan_udp_port: 4789
     vxlan_vni_mappings:
       vlans:
@@ -865,6 +610,115 @@ vxlan_tunnel_interface:
           vni: 20
         Tenant_C_OP_Zone:
           vni: 30
+vlan_interfaces:
+  Vlan130:
+    tenant: Tenant_A
+    tags:
+    - app
+    - erp1
+    description: Tenant_A_APP_Zone_1
+    shutdown: false
+    vrf: Tenant_A_APP_Zone
+    ip_address_virtual: 10.1.30.1/24
+  Vlan131:
+    tenant: Tenant_A
+    tags:
+    - app
+    description: Tenant_A_APP_Zone_2
+    shutdown: false
+    vrf: Tenant_A_APP_Zone
+    ip_address_virtual: 10.1.31.1/24
+  Vlan140:
+    tenant: Tenant_A
+    tags:
+    - db
+    - erp1
+    description: Tenant_A_DB_BZone_1
+    shutdown: false
+    vrf: Tenant_A_DB_Zone
+    ip_address_virtual: 10.1.40.1/24
+  Vlan141:
+    tenant: Tenant_A
+    tags:
+    - db
+    description: Tenant_A_DB_Zone_2
+    shutdown: false
+    vrf: Tenant_A_DB_Zone
+    ip_address_virtual: 10.1.41.1/24
+  Vlan110:
+    tenant: Tenant_A
+    tags:
+    - opzone
+    description: Tenant_A_OP_Zone_1
+    shutdown: false
+    vrf: Tenant_A_OP_Zone
+    ip_address_virtual: 10.1.10.1/24
+  Vlan111:
+    tenant: Tenant_A
+    tags:
+    - opzone
+    description: Tenant_A_OP_Zone_2
+    shutdown: false
+    vrf: Tenant_A_OP_Zone
+    ip_address_virtual: 10.1.11.1/24
+    ip_helpers:
+      1.1.1.1:
+        source_interface: lo100
+        vrf: MGMT
+  Vlan120:
+    tenant: Tenant_A
+    tags:
+    - web
+    - erp1
+    description: Tenant_A_WEB_Zone_1
+    shutdown: false
+    vrf: Tenant_A_WEB_Zone
+    ip_address_virtual: 10.1.20.1/24
+    ip_helpers:
+      1.1.1.1:
+        source_interface: lo100
+        vrf: TEST
+  Vlan121:
+    tenant: Tenant_A
+    tags:
+    - web
+    description: Tenant_A_WEBZone_2
+    shutdown: true
+    vrf: Tenant_A_WEB_Zone
+    ip_address_virtual: 10.1.10.254/24
+    mtu: 1560
+  Vlan210:
+    tenant: Tenant_B
+    tags:
+    - opzone
+    description: Tenant_B_OP_Zone_1
+    shutdown: false
+    vrf: Tenant_B_OP_Zone
+    ip_address_virtual: 10.2.10.1/24
+  Vlan211:
+    tenant: Tenant_B
+    tags:
+    - opzone
+    description: Tenant_B_OP_Zone_2
+    shutdown: false
+    vrf: Tenant_B_OP_Zone
+    ip_address_virtual: 10.2.11.1/24
+  Vlan310:
+    tenant: Tenant_C
+    tags:
+    - opzone
+    description: Tenant_C_OP_Zone_1
+    shutdown: false
+    vrf: Tenant_C_OP_Zone
+    ip_address_virtual: 10.3.10.1/24
+  Vlan311:
+    tenant: Tenant_C
+    tags:
+    - opzone
+    description: Tenant_C_OP_Zone_2
+    shutdown: false
+    vrf: Tenant_C_OP_Zone
+    ip_address_virtual: 10.3.11.1/24
 virtual_source_nat_vrfs:
   Tenant_A_OP_Zone:
     ip_address: 10.255.1.10

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -6,14 +6,6 @@ router_bgp:
   - distance bgp 20 200 200
   - maximum-paths 4 ecmp 4
   peer_groups:
-    MLAG-PEERS:
-      type: ipv4
-      remote_as: 65102
-      next_hop_self: true
-      password: vnEaG8gMeQf3d3cN6PktXQ==
-      maximum_routes: 12000
-      send_community: all
-      route_map_in: RM-MLAG-PEER-IN
     UNDERLAY-PEERS:
       type: ipv4
       remote_as: 65001
@@ -30,16 +22,14 @@ router_bgp:
       maximum_routes: 0
   address_family_ipv4:
     peer_groups:
-      MLAG-PEERS:
-        activate: true
       UNDERLAY-PEERS:
         activate: true
       EVPN-OVERLAY-PEERS:
         activate: false
+  redistribute_routes:
+    connected:
+      route_map: RM-CONN-2-BGP
   neighbors:
-    10.255.251.2:
-      peer_group: MLAG-PEERS
-      description: DC1-LEAF2A
     172.31.255.32:
       peer_group: UNDERLAY-PEERS
       description: DC1-SPINE1_Ethernet3
@@ -68,9 +58,6 @@ router_bgp:
       peer_group: EVPN-OVERLAY-PEERS
       description: DC1-SPINE4
       remote_as: 65001
-  redistribute_routes:
-    connected:
-      route_map: RM-CONN-2-BGP
   address_family_evpn:
     peer_groups:
       EVPN-OVERLAY-PEERS:
@@ -86,9 +73,6 @@ router_bgp:
         export:
           evpn:
           - '12:12'
-      neighbors:
-        10.255.251.2:
-          peer_group: MLAG-PEERS
       redistribute_routes:
       - connected
     Tenant_A_DB_Zone:
@@ -101,9 +85,6 @@ router_bgp:
         export:
           evpn:
           - '13:13'
-      neighbors:
-        10.255.251.2:
-          peer_group: MLAG-PEERS
       redistribute_routes:
       - connected
     Tenant_A_OP_Zone:
@@ -116,9 +97,6 @@ router_bgp:
         export:
           evpn:
           - '10:10'
-      neighbors:
-        10.255.251.2:
-          peer_group: MLAG-PEERS
       redistribute_routes:
       - connected
     Tenant_A_WEB_Zone:
@@ -131,9 +109,6 @@ router_bgp:
         export:
           evpn:
           - '11:11'
-      neighbors:
-        10.255.251.2:
-          peer_group: MLAG-PEERS
       redistribute_routes:
       - connected
     Tenant_B_OP_Zone:
@@ -146,9 +121,6 @@ router_bgp:
         export:
           evpn:
           - '20:20'
-      neighbors:
-        10.255.251.2:
-          peer_group: MLAG-PEERS
       redistribute_routes:
       - connected
     Tenant_C_OP_Zone:
@@ -161,9 +133,6 @@ router_bgp:
         export:
           evpn:
           - '30:30'
-      neighbors:
-        10.255.251.2:
-          peer_group: MLAG-PEERS
       redistribute_routes:
       - connected
   vlan_aware_bundles:
@@ -285,7 +254,6 @@ spanning_tree:
   mst_instances:
     '0':
       priority: 4096
-  no_spanning_tree_vlan: 4093-4094
 local_users:
   admin:
     privilege: 15
@@ -334,323 +302,21 @@ management_api_http:
   enable_vrfs:
     MGMT: {}
   enable_https: true
-vlans:
-  4093:
-    tenant: system
-    name: LEAF_PEER_L3
-    trunk_groups:
-    - LEAF_PEER_L3
-  4094:
-    tenant: system
-    name: MLAG_PEER
-    trunk_groups:
-    - MLAG
-  130:
-    tenant: Tenant_A
-    name: Tenant_A_APP_Zone_1
-  131:
-    tenant: Tenant_A
-    name: Tenant_A_APP_Zone_2
-  3011:
-    tenant: Tenant_A
-    name: MLAG_iBGP_Tenant_A_APP_Zone
-    trunk_groups:
-    - LEAF_PEER_L3
-  140:
-    tenant: Tenant_A
-    name: Tenant_A_DB_BZone_1
-  141:
-    tenant: Tenant_A
-    name: Tenant_A_DB_Zone_2
-  3012:
-    tenant: Tenant_A
-    name: MLAG_iBGP_Tenant_A_DB_Zone
-    trunk_groups:
-    - LEAF_PEER_L3
-  110:
-    tenant: Tenant_A
-    name: Tenant_A_OP_Zone_1
-  111:
-    tenant: Tenant_A
-    name: Tenant_A_OP_Zone_2
-  3009:
-    tenant: Tenant_A
-    name: MLAG_iBGP_Tenant_A_OP_Zone
-    trunk_groups:
-    - LEAF_PEER_L3
-  120:
-    tenant: Tenant_A
-    name: Tenant_A_WEB_Zone_1
-  121:
-    tenant: Tenant_A
-    name: Tenant_A_WEBZone_2
-  3010:
-    tenant: Tenant_A
-    name: MLAG_iBGP_Tenant_A_WEB_Zone
-    trunk_groups:
-    - LEAF_PEER_L3
-  160:
-    tenant: Tenant_A
-    name: Tenant_A_VMOTION
-  161:
-    tenant: Tenant_A
-    name: Tenant_A_NFS
-  210:
-    tenant: Tenant_B
-    name: Tenant_B_OP_Zone_1
-  211:
-    tenant: Tenant_B
-    name: Tenant_B_OP_Zone_2
-  3019:
-    tenant: Tenant_B
-    name: MLAG_iBGP_Tenant_B_OP_Zone
-    trunk_groups:
-    - LEAF_PEER_L3
-  310:
-    tenant: Tenant_C
-    name: Tenant_C_OP_Zone_1
-  311:
-    tenant: Tenant_C
-    name: Tenant_C_OP_Zone_2
-  2:
-    tenant: Tenant_C
-    name: MLAG_iBGP_Tenant_C_OP_Zone
-    trunk_groups:
-    - LEAF_PEER_L3
-vlan_interfaces:
-  Vlan4093:
-    description: MLAG_PEER_L3_PEERING
+loopback_interfaces:
+  Loopback0:
+    description: EVPN_Overlay_Peering
     shutdown: false
-    ip_address: 10.255.251.3/31
-    mtu: 1500
-  Vlan4094:
-    description: MLAG_PEER
+    ip_address: 192.168.255.11/32
+  Loopback1:
+    description: VTEP_VXLAN_Tunnel_Source
     shutdown: false
-    ip_address: 10.255.252.3/31
-    no_autostate: true
-    mtu: 1500
-  Vlan130:
-    tenant: Tenant_A
-    tags:
-    - app
-    - erp1
-    description: Tenant_A_APP_Zone_1
-    shutdown: false
-    vrf: Tenant_A_APP_Zone
-    ip_address_virtual: 10.1.30.1/24
-  Vlan131:
-    tenant: Tenant_A
-    tags:
-    - app
-    description: Tenant_A_APP_Zone_2
-    shutdown: false
-    vrf: Tenant_A_APP_Zone
-    ip_address_virtual: 10.1.31.1/24
-  Vlan3011:
-    tenant: Tenant_A
-    type: underlay_peering
-    shutdown: false
-    description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone'
-    vrf: Tenant_A_APP_Zone
-    ip_address: 10.255.251.3/31
-    mtu: 1500
-  Vlan140:
-    tenant: Tenant_A
-    tags:
-    - db
-    - erp1
-    description: Tenant_A_DB_BZone_1
-    shutdown: false
-    vrf: Tenant_A_DB_Zone
-    ip_address_virtual: 10.1.40.1/24
-  Vlan141:
-    tenant: Tenant_A
-    tags:
-    - db
-    description: Tenant_A_DB_Zone_2
-    shutdown: false
-    vrf: Tenant_A_DB_Zone
-    ip_address_virtual: 10.1.41.1/24
-  Vlan3012:
-    tenant: Tenant_A
-    type: underlay_peering
-    shutdown: false
-    description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone'
-    vrf: Tenant_A_DB_Zone
-    ip_address: 10.255.251.3/31
-    mtu: 1500
-  Vlan110:
-    tenant: Tenant_A
-    tags:
-    - opzone
-    description: Tenant_A_OP_Zone_1
+    ip_address: 192.168.254.11/32
+  Loopback100:
+    description: Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
     shutdown: false
     vrf: Tenant_A_OP_Zone
-    ip_address_virtual: 10.1.10.1/24
-  Vlan111:
-    tenant: Tenant_A
-    tags:
-    - opzone
-    description: Tenant_A_OP_Zone_2
-    shutdown: false
-    vrf: Tenant_A_OP_Zone
-    ip_address_virtual: 10.1.11.1/24
-    ip_helpers:
-      1.1.1.1:
-        source_interface: lo100
-        vrf: MGMT
-  Vlan3009:
-    tenant: Tenant_A
-    type: underlay_peering
-    shutdown: false
-    description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone'
-    vrf: Tenant_A_OP_Zone
-    ip_address: 10.255.251.3/31
-    mtu: 1500
-  Vlan120:
-    tenant: Tenant_A
-    tags:
-    - web
-    - erp1
-    description: Tenant_A_WEB_Zone_1
-    shutdown: false
-    vrf: Tenant_A_WEB_Zone
-    ip_address_virtual: 10.1.20.1/24
-    ip_helpers:
-      1.1.1.1:
-        source_interface: lo100
-        vrf: TEST
-  Vlan121:
-    tenant: Tenant_A
-    tags:
-    - web
-    description: Tenant_A_WEBZone_2
-    shutdown: true
-    vrf: Tenant_A_WEB_Zone
-    ip_address_virtual: 10.1.10.254/24
-    mtu: 1560
-  Vlan3010:
-    tenant: Tenant_A
-    type: underlay_peering
-    shutdown: false
-    description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone'
-    vrf: Tenant_A_WEB_Zone
-    ip_address: 10.255.251.3/31
-    mtu: 1500
-  Vlan210:
-    tenant: Tenant_B
-    tags:
-    - opzone
-    description: Tenant_B_OP_Zone_1
-    shutdown: false
-    vrf: Tenant_B_OP_Zone
-    ip_address_virtual: 10.2.10.1/24
-  Vlan211:
-    tenant: Tenant_B
-    tags:
-    - opzone
-    description: Tenant_B_OP_Zone_2
-    shutdown: false
-    vrf: Tenant_B_OP_Zone
-    ip_address_virtual: 10.2.11.1/24
-  Vlan3019:
-    tenant: Tenant_B
-    type: underlay_peering
-    shutdown: false
-    description: 'MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone'
-    vrf: Tenant_B_OP_Zone
-    ip_address: 10.255.251.3/31
-    mtu: 1500
-  Vlan310:
-    tenant: Tenant_C
-    tags:
-    - opzone
-    description: Tenant_C_OP_Zone_1
-    shutdown: false
-    vrf: Tenant_C_OP_Zone
-    ip_address_virtual: 10.3.10.1/24
-  Vlan311:
-    tenant: Tenant_C
-    tags:
-    - opzone
-    description: Tenant_C_OP_Zone_2
-    shutdown: false
-    vrf: Tenant_C_OP_Zone
-    ip_address_virtual: 10.3.11.1/24
-  Vlan2:
-    tenant: Tenant_C
-    type: underlay_peering
-    shutdown: false
-    description: 'MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone'
-    vrf: Tenant_C_OP_Zone
-    ip_address: 10.255.251.3/31
-    mtu: 1500
-port_channel_interfaces:
-  Port-Channel5:
-    description: MLAG_PEER_DC1-LEAF2A_Po5
-    type: switched
-    shutdown: false
-    vlans: 2-4094
-    mode: trunk
-    trunk_groups:
-    - LEAF_PEER_L3
-    - MLAG
-  Port-Channel7:
-    description: DC1_L2LEAF1_Po1
-    type: switched
-    shutdown: false
-    vlans: 110-111,120-121,130-131,160-161
-    mode: trunk
-    mlag: 7
-  Port-Channel20:
-    description: FIREWALL01_PortChanne1
-    type: switched
-    shutdown: false
-    mode: trunk
-    vlans: 110-111,210-211
-    mlag: 20
-  Port-Channel10:
-    description: server01_MLAG_PortChanne1
-    type: switched
-    shutdown: false
-    mode: trunk
-    vlans: 210-211
-    mlag: 10
-  Port-Channel12:
-    description: server01_MTU_ADAPTOR_MLAG_PortChanne1
-    type: switched
-    shutdown: false
-    mtu: 1601
-    mlag: 12
-  Port-Channel11:
-    description: server01_MTU_PROFILE_MLAG_PortChanne1
-    type: switched
-    shutdown: false
-    mode: access
-    mtu: 1600
-    vlans: 110
-    mlag: 11
+    ip_address: 10.255.1.11/32
 ethernet_interfaces:
-  Ethernet5:
-    peer: DC1-LEAF2A
-    peer_interface: Ethernet5
-    peer_type: mlag_peer
-    description: MLAG_PEER_DC1-LEAF2A_Ethernet5
-    type: switched
-    shutdown: false
-    channel_group:
-      id: 5
-      mode: active
-  Ethernet6:
-    peer: DC1-LEAF2A
-    peer_interface: Ethernet6
-    peer_type: mlag_peer
-    description: MLAG_PEER_DC1-LEAF2A_Ethernet6
-    type: switched
-    shutdown: false
-    channel_group:
-      id: 5
-      mode: active
   Ethernet1:
     peer: DC1-SPINE1
     peer_interface: Ethernet3
@@ -700,6 +366,26 @@ ethernet_interfaces:
     shutdown: false
     channel_group:
       id: 7
+      mode: active
+  Ethernet8:
+    peer: DC1-L2LEAF1B
+    peer_interface: Ethernet2
+    peer_type: l2leaf
+    description: DC1-L2LEAF1B_Ethernet2
+    type: switched
+    shutdown: false
+    channel_group:
+      id: 7
+      mode: active
+  Ethernet9:
+    peer: DC1-L2LEAF3A
+    peer_interface: Ethernet2
+    peer_type: l2leaf
+    description: DC1-L2LEAF3A_Ethernet2
+    type: switched
+    shutdown: false
+    channel_group:
+      id: 9
       mode: active
   Ethernet20:
     peer: FIREWALL01
@@ -762,42 +448,53 @@ ethernet_interfaces:
       id: 11
       mode: active
     profile: TENANT_A_MTU
-mlag_configuration:
-  domain_id: DC1_LEAF2
-  local_interface: Vlan4094
-  peer_address: 10.255.252.2
-  peer_link: Port-Channel5
-  reload_delay_mlag: 780
-  reload_delay_non_mlag: 1020
-route_maps:
-  RM-MLAG-PEER-IN:
-    sequence_numbers:
-      10:
-        type: permit
-        set:
-        - origin incomplete
-        description: Make routes learned over MLAG Peer-link less preferred on spines
-          to ensure optimal routing
-  RM-CONN-2-BGP:
-    sequence_numbers:
-      10:
-        type: permit
-        match:
-        - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
-loopback_interfaces:
-  Loopback0:
-    description: EVPN_Overlay_Peering
+port_channel_interfaces:
+  Port-Channel7:
+    description: DC1_L2LEAF1_Po1
+    type: switched
     shutdown: false
-    ip_address: 192.168.255.11/32
-  Loopback1:
-    description: VTEP_VXLAN_Tunnel_Source
+    vlans: 110-111,120-121,130-131,160-161
+    mode: trunk
+    esi: 0000:0000:0808:0707:0606
+    rt: 08:08:07:07:06:06
+    lacp_id: 0808.0707.0606
+  Port-Channel9:
+    description: DC1_L2LEAF3_Po1
+    type: switched
     shutdown: false
-    ip_address: 192.168.254.10/32
-  Loopback100:
-    description: Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
+    vlans: 110-111,120-121,130-131,160-161
+    mode: trunk
+    esi: 0000:0000:0606:0707:0808
+    rt: 06:06:07:07:08:08
+    lacp_id: 0606.0707.0808
+  Port-Channel20:
+    description: FIREWALL01_PortChanne1
+    type: switched
     shutdown: false
-    vrf: Tenant_A_OP_Zone
-    ip_address: 10.255.1.11/32
+    mode: trunk
+    vlans: 110-111,210-211
+    mlag: 20
+  Port-Channel10:
+    description: server01_MLAG_PortChanne1
+    type: switched
+    shutdown: false
+    mode: trunk
+    vlans: 210-211
+    mlag: 10
+  Port-Channel12:
+    description: server01_MTU_ADAPTOR_MLAG_PortChanne1
+    type: switched
+    shutdown: false
+    mtu: 1601
+    mlag: 12
+  Port-Channel11:
+    description: server01_MTU_PROFILE_MLAG_PortChanne1
+    type: switched
+    shutdown: false
+    mode: access
+    mtu: 1600
+    vlans: 110
+    mlag: 11
 prefix_lists:
   PL-LOOPBACKS-EVPN-OVERLAY:
     sequence_numbers:
@@ -805,6 +502,13 @@ prefix_lists:
         action: permit 192.168.255.0/24 eq 32
       20:
         action: permit 192.168.254.0/24 eq 32
+route_maps:
+  RM-CONN-2-BGP:
+    sequence_numbers:
+      10:
+        type: permit
+        match:
+        - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
 router_bfd:
   multihop:
     interval: 1200
@@ -815,12 +519,53 @@ ip_igmp_snooping:
   vlans:
     120:
       enabled: false
+vlans:
+  130:
+    tenant: Tenant_A
+    name: Tenant_A_APP_Zone_1
+  131:
+    tenant: Tenant_A
+    name: Tenant_A_APP_Zone_2
+  140:
+    tenant: Tenant_A
+    name: Tenant_A_DB_BZone_1
+  141:
+    tenant: Tenant_A
+    name: Tenant_A_DB_Zone_2
+  110:
+    tenant: Tenant_A
+    name: Tenant_A_OP_Zone_1
+  111:
+    tenant: Tenant_A
+    name: Tenant_A_OP_Zone_2
+  120:
+    tenant: Tenant_A
+    name: Tenant_A_WEB_Zone_1
+  121:
+    tenant: Tenant_A
+    name: Tenant_A_WEBZone_2
+  160:
+    tenant: Tenant_A
+    name: Tenant_A_VMOTION
+  161:
+    tenant: Tenant_A
+    name: Tenant_A_NFS
+  210:
+    tenant: Tenant_B
+    name: Tenant_B_OP_Zone_1
+  211:
+    tenant: Tenant_B
+    name: Tenant_B_OP_Zone_2
+  310:
+    tenant: Tenant_C
+    name: Tenant_C_OP_Zone_1
+  311:
+    tenant: Tenant_C
+    name: Tenant_C_OP_Zone_2
 vxlan_tunnel_interface:
   Vxlan1:
     description: DC1-LEAF2B_VTEP
     source_interface: Loopback1
-    virtual_router:
-      encapsulation_mac_address: mlag-system-id
     vxlan_udp_port: 4789
     vxlan_vni_mappings:
       vlans:
@@ -865,6 +610,115 @@ vxlan_tunnel_interface:
           vni: 20
         Tenant_C_OP_Zone:
           vni: 30
+vlan_interfaces:
+  Vlan130:
+    tenant: Tenant_A
+    tags:
+    - app
+    - erp1
+    description: Tenant_A_APP_Zone_1
+    shutdown: false
+    vrf: Tenant_A_APP_Zone
+    ip_address_virtual: 10.1.30.1/24
+  Vlan131:
+    tenant: Tenant_A
+    tags:
+    - app
+    description: Tenant_A_APP_Zone_2
+    shutdown: false
+    vrf: Tenant_A_APP_Zone
+    ip_address_virtual: 10.1.31.1/24
+  Vlan140:
+    tenant: Tenant_A
+    tags:
+    - db
+    - erp1
+    description: Tenant_A_DB_BZone_1
+    shutdown: false
+    vrf: Tenant_A_DB_Zone
+    ip_address_virtual: 10.1.40.1/24
+  Vlan141:
+    tenant: Tenant_A
+    tags:
+    - db
+    description: Tenant_A_DB_Zone_2
+    shutdown: false
+    vrf: Tenant_A_DB_Zone
+    ip_address_virtual: 10.1.41.1/24
+  Vlan110:
+    tenant: Tenant_A
+    tags:
+    - opzone
+    description: Tenant_A_OP_Zone_1
+    shutdown: false
+    vrf: Tenant_A_OP_Zone
+    ip_address_virtual: 10.1.10.1/24
+  Vlan111:
+    tenant: Tenant_A
+    tags:
+    - opzone
+    description: Tenant_A_OP_Zone_2
+    shutdown: false
+    vrf: Tenant_A_OP_Zone
+    ip_address_virtual: 10.1.11.1/24
+    ip_helpers:
+      1.1.1.1:
+        source_interface: lo100
+        vrf: MGMT
+  Vlan120:
+    tenant: Tenant_A
+    tags:
+    - web
+    - erp1
+    description: Tenant_A_WEB_Zone_1
+    shutdown: false
+    vrf: Tenant_A_WEB_Zone
+    ip_address_virtual: 10.1.20.1/24
+    ip_helpers:
+      1.1.1.1:
+        source_interface: lo100
+        vrf: TEST
+  Vlan121:
+    tenant: Tenant_A
+    tags:
+    - web
+    description: Tenant_A_WEBZone_2
+    shutdown: true
+    vrf: Tenant_A_WEB_Zone
+    ip_address_virtual: 10.1.10.254/24
+    mtu: 1560
+  Vlan210:
+    tenant: Tenant_B
+    tags:
+    - opzone
+    description: Tenant_B_OP_Zone_1
+    shutdown: false
+    vrf: Tenant_B_OP_Zone
+    ip_address_virtual: 10.2.10.1/24
+  Vlan211:
+    tenant: Tenant_B
+    tags:
+    - opzone
+    description: Tenant_B_OP_Zone_2
+    shutdown: false
+    vrf: Tenant_B_OP_Zone
+    ip_address_virtual: 10.2.11.1/24
+  Vlan310:
+    tenant: Tenant_C
+    tags:
+    - opzone
+    description: Tenant_C_OP_Zone_1
+    shutdown: false
+    vrf: Tenant_C_OP_Zone
+    ip_address_virtual: 10.3.10.1/24
+  Vlan311:
+    tenant: Tenant_C
+    tags:
+    - opzone
+    description: Tenant_C_OP_Zone_2
+    shutdown: false
+    vrf: Tenant_C_OP_Zone
+    ip_address_virtual: 10.3.11.1/24
 virtual_source_nat_vrfs:
   Tenant_A_OP_Zone:
     ip_address: 10.255.1.11

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
@@ -96,6 +96,7 @@ l3leaf:
     DC1_LEAF2:
       bgp_as: 65102
       rack: "rackD"
+      mlag: false
       nodes:
         DC1-LEAF2A:
           id: 2
@@ -155,8 +156,8 @@ l2leaf:
     rack: "rackE"
   node_groups:
     DC1_L2LEAF1:
-      mlag: false
       parent_l3leafs: [ DC1-LEAF2A, DC1-LEAF2B ]
+      short_esi: 0808:0707:0606
       filter:
         tenants: [ Tenant_A ]
         tags: [ opzone, web, app ]
@@ -166,6 +167,11 @@ l2leaf:
           mgmt_ip: 192.168.200.112/24
           mac_address: '0c:1d:c0:1d:62:01'
           l3leaf_interfaces: [ Ethernet7, Ethernet7 ]
+        DC1-L2LEAF1B:
+          id: 11
+          mgmt_ip: 192.168.200.115/24
+          mac_address: '0c:1d:c0:1d:62:02'
+          l3leaf_interfaces: [ Ethernet8, Ethernet8 ]
     DC1_L2LEAF2:
       mlag_dual_primary_detection: true
       nodes:
@@ -179,6 +185,18 @@ l2leaf:
           mgmt_ip: 192.168.200.114/24
           mac_address: '0c:1d:c0:1d:62:01'
           l3leaf_interfaces: [ Ethernet8, Ethernet8 ]
+    DC1_L2LEAF3:
+      parent_l3leafs: [ DC1-LEAF2A, DC1-LEAF2B ]
+      short_esi: 0606:0707:0808
+      filter:
+        tenants: [ Tenant_A ]
+        tags: [ opzone, web, app ]
+      nodes:
+        DC1-L2LEAF3A:
+          id: 12
+          mgmt_ip: 192.168.200.116/24
+          mac_address: '0c:1d:c0:1d:62:01'
+          l3leaf_interfaces: [ Ethernet9, Ethernet9 ]
 
 #### Override for vEOS Lab Caveats ####
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/hosts
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/hosts
@@ -44,12 +44,18 @@ all:
                   hosts:
                     DC1-L2LEAF1A:
                       ansible_host: 192.168.200.112
+                    DC1-L2LEAF1B:
+                      ansible_host: 192.168.200.115
                 DC1_L2LEAF2:
                   hosts:
                     DC1-L2LEAF2A:
                       ansible_host: 192.168.200.113
                     DC1-L2LEAF2B:
                       ansible_host: 192.168.200.114
+                DC1_L2LEAF3:
+                  hosts:
+                    DC1-L2LEAF3A:
+                      ansible_host: 192.168.200.116
         DC1_TENANTS_NETWORKS:
           children:
             DC1_LEAFS:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
@@ -42,13 +42,11 @@ interface {{ port_channel_interface }}
    mlag {{ port_channel_interfaces[port_channel_interface].mlag }}
 {%     endif %}
 {%     if port_channel_interfaces[port_channel_interface].esi is arista.avd.defined %}
-   !
    evpn ethernet-segment
       identifier {{ port_channel_interfaces[port_channel_interface].esi }}
 {%         if port_channel_interfaces[port_channel_interface].rt is arista.avd.defined %}
       route-target import {{ port_channel_interfaces[port_channel_interface].rt }}
 {%         endif %}
-   !
 {%     endif %}
 {%     if port_channel_interfaces[port_channel_interface].lacp_id is arista.avd.defined %}
    lacp system-id {{ port_channel_interfaces[port_channel_interface].lacp_id }}

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/fabric-topology.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/fabric-topology.md
@@ -423,7 +423,7 @@ l2leaf:
           l3leaf_interfaces: [ < ethernet_interface_6 >, < ethernet_interface_6 > ]
 
     # node_group_2, will result in MLAG pair.
-    < node_group_1 >:
+    < node_group_2 >:
       parent_l3leafs: [ DC1-SVC3A, DC1-SVC3B ]
       nodes:
 
@@ -438,7 +438,39 @@ l2leaf:
           id: < integer >
           mgmt_ip: < IPv4_address/Mask >
           l3leaf_interfaces: [ < ethernet_interface_8 >, < ethernet_interface_8 > ]
+
+    # node_group_3, will result in Active/Active connection to L3LEAFs.
+    # Can be applied on sigle L2LEAF or MLAG nodes.
+    < node_group_3 >:
+      parent_l3leafs: [ DC1-SVC3A, DC1-SVC3B ]
+      short_esi: < short esi value >
+      nodes:
+
+        # First node.
+        < l2_leaf_inventory_hostname_2 >:
+          id: < integer >
+          mgmt_ip: < IPv4_address/Mask >
+          l3leaf_interfaces: [ < ethernet_interface_7 >, < ethernet_interface_7 > ]
 ```
+
+???+ note "Short ESI description"
+    To help provide consistency when configuring EVPN A/A ESI values, arista.avd provides an abstraction in the form of a `short_esi` key.
+    `short_esi` is an abbreviated 3 octets value to encode [Ethernet Segment ID](https://tools.ietf.org/html/rfc7432#section-8.3.1) and LACP ID.
+    Transformation from abstraction to network values is managed by a [filter_plugin](../../../../plugins/README.md) and provides following result:
+
+    - _EVPN ESI_: 0000:0000:0808:0707:0606
+    - _LACP ID_: 0808.0707.0606
+    - _Route Target_: 08:08:07:07:06:06
+
+    ```yaml
+    # Short ESI setting:
+    short_esi: 0808:0707:0606
+
+    # Short ESI transformation result:
+    esi: 0000:0000:0808:0707:0606
+    rt: 08:08:07:07:06:06
+    lacp_id: 0808.0707.0606
+    ```
 
 **Example:**
 
@@ -475,6 +507,14 @@ l2leaf:
           id: 11
           mgmt_ip: 192.168.2.114/24
           l3leaf_interfaces: [ Ethernet6, Ethernet6 ]
+    DC1_L2LEAF6:
+      parent_l3leafs: [ DC1-LEAF6A, DC1-LEAF6B ]
+      short_esi: 0808:0707:0606
+      nodes:
+        DC1-L2LEAF6A:
+          id: 12
+          mgmt_ip: 192.168.200.116/24
+          l3leaf_interfaces: [ Ethernet7, Ethernet7 ]
 ```
 
 ## Super Spine Variables

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/underlay/interfaces/l3leaf-port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/underlay/interfaces/l3leaf-port-channel-interfaces.j2
@@ -77,7 +77,13 @@ port_channel_interfaces:
 {%                 if p2p_uplinks_qos_profile is arista.avd.defined %}
     service_profile: {{ p2p_uplinks_qos_profile }}
 {%                 endif %}
+{%                 if switch.mlag is arista.avd.defined(true) %}
     mlag: {{ l3_leaf.channel_group_id }}
+{%                 elif l2leaf.node_groups[l2leaf_node_group].short_esi is arista.avd.defined %}
+    esi: {{ l2leaf.node_groups[l2leaf_node_group].short_esi | arista.avd.generate_esi }}
+    rt: {{ l2leaf.node_groups[l2leaf_node_group].short_esi | arista.avd.generate_route_target }}
+    lacp_id: {{ l2leaf.node_groups[l2leaf_node_group].short_esi | arista.avd.generate_lacp_id }}
+{%                 endif %}
 {%             break %}
 {%             endfor %}
 {%         endif %}


### PR DESCRIPTION
## Change Summary
EVPN A/A to connect L2LEAF to L3LEAF

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Dependant on #876 
Fixes #807

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

Add support of EVPN A/A to attach L2LEAF to L3LEAF nodes.

On L2LEAF nodes, the minimum data model is:

```yaml
l2leaf:
  node_groups:
    DC1_L2LEAF1:
      short_esi: 0808:0707:0606
      parent_l3leafs: [ DC1-LEAF2A, DC1-LEAF2B ]
      nodes:
        DC1-L2LEAF1A:
          l3leaf_interfaces: [ Ethernet7, Ethernet7 ]
```

> The scenario is limited to dual attachment of an L2LEAF to 2 L3LEAFs in the same node groups. Does not support connectivity redundancy from a SERVER standpoint.


## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Check molecule configuration: https://github.com/titom73/ansible-avd/blob/1591872bca2b4bc74339130dc36c403ea68469cc/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
