### PR TITLE
fix(ansible2rst): Remove pylint test disabled

### DIFF
--- a/ansible_collections/arista/avd/docs/_build/ansible2rst.py
+++ b/ansible_collections/arista/avd/docs/_build/ansible2rst.py
@@ -94,9 +94,8 @@ def rst_ify(text):
         t = _URL_W_TEXT.sub(r'`' + r"\1" + r" <" + r"\2" + r">`_", t)
         t = _URL.sub(r'`' + r"\1" + r" <" + r"\1" + r">`_", t)
         t = _CONST.sub(r'``' + r"\1" + r"``", t)
-    except Exception as e:
-        raise AnsibleError("Could not process (%s) : %s" % (str(text), str(e)))  # noqa # pylint: disable=raise-missing-from
-
+    except Exception as error_caught:
+        raise AnsibleError("Could not process (%s) : %s" % (str(text), str(error_caught)))
     return t
 
 #####################################################################################


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Component(s) name

ansible2rst script

## Proposed changes

Remove comment to disable `raise-missing-from`

## How to test

```bash
$ make sanity-lint
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
