### PR TITLE
Fix(eos_cli_config_gen): Update template to support dst_fields for traffic-policy

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/traffic-policies.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/traffic-policies.md
@@ -150,7 +150,7 @@ traffic-policies
       match BLUE-C1-POLICY-01 ipv4
          source prefix 10.0.0.0/8 192.168.0.0/16
          destination prefix field-set DEMO-01
-         protocol tcp
+         protocol tcp source port 1,10-20
          ttl 10, 20-30
          actions
             set traffic class 5
@@ -158,7 +158,7 @@ traffic-policies
       !
       match BLUE-C1-POLICY-02 ipv4
          source prefix field-set DEMO-01 DEMO-02
-         protocol tcp
+         protocol tcp flags established destination port field-set SERVICE-DEMO
          protocol icmp
          actions
             count DEMO-TRAFFIC
@@ -178,7 +178,7 @@ traffic-policies
       match BLUE-C1-POLICY-04 ipv4
          source prefix field-set DEMO-02
          destination prefix field-set DEMO-01
-         protocol tcp
+         protocol tcp flags established source port 22
          protocol icmp
          actions
             set traffic class 5
@@ -198,7 +198,7 @@ traffic-policies
       counter DEMO-TRAFFIC
       match BLUE-C2-POLICY-01 ipv4
          source prefix 10.0.0.0/8 192.168.0.0/16
-         protocol tcp
+         protocol tcp source port 1,10-20
          protocol icmp
          actions
             set traffic class 5

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/traffic-policies.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/traffic-policies.cfg
@@ -28,7 +28,7 @@ traffic-policies
       match BLUE-C1-POLICY-01 ipv4
          source prefix 10.0.0.0/8 192.168.0.0/16
          destination prefix field-set DEMO-01
-         protocol tcp
+         protocol tcp source port 1,10-20
          ttl 10, 20-30
          actions
             set traffic class 5
@@ -36,7 +36,7 @@ traffic-policies
       !
       match BLUE-C1-POLICY-02 ipv4
          source prefix field-set DEMO-01 DEMO-02
-         protocol tcp
+         protocol tcp flags established destination port field-set SERVICE-DEMO
          protocol icmp
          actions
             count DEMO-TRAFFIC
@@ -56,7 +56,7 @@ traffic-policies
       match BLUE-C1-POLICY-04 ipv4
          source prefix field-set DEMO-02
          destination prefix field-set DEMO-01
-         protocol tcp
+         protocol tcp flags established source port 22
          protocol icmp
          actions
             set traffic class 5
@@ -76,7 +76,7 @@ traffic-policies
       counter DEMO-TRAFFIC
       match BLUE-C2-POLICY-01 ipv4
          source prefix 10.0.0.0/8 192.168.0.0/16
-         protocol tcp
+         protocol tcp source port 1,10-20
          protocol icmp
          actions
             set traffic class 5

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/traffic-policies.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/traffic-policies.j2
@@ -71,13 +71,13 @@ traffic-policies
 {%                     if traffic_policies.policies[policy].matches[match].protocols is arista.avd.defined %}
 {%                         for protocol in traffic_policies.policies[policy].matches[match].protocols %}
 {#                             -- destination port-list -- #}
-{%                             if traffic_policies.policies[policy].matches[match].protocols[protocol].dst_port is arista.avd.defined protocol | lower in ['tcp','udp'] %}
+{%                             if traffic_policies.policies[policy].matches[match].protocols[protocol].dst_port is arista.avd.defined and protocol | lower in ['tcp','udp'] %}
          protocol {{ protocol }}{% if traffic_policies.policies[policy].matches[match].protocols[protocol].flags is arista.avd.defined %} flags {{ traffic_policies.policies[policy].matches[match].protocols[protocol].flags  | join(' ') }}{% endif %} destination port {{ traffic_policies.policies[policy].matches[match].protocols[protocol].dst_port }}
 {#                             -- source port-list -- #}
-{%                             elif traffic_policies.policies[policy].matches[match].protocols[protocol].src_port is arista.avd.defined protocol | lower in ['tcp','udp'] %}
+{%                             elif traffic_policies.policies[policy].matches[match].protocols[protocol].src_port is arista.avd.defined and protocol | lower in ['tcp','udp'] %}
          protocol {{ protocol }}{% if traffic_policies.policies[policy].matches[match].protocols[protocol].flags is arista.avd.defined %} flags {{ traffic_policies.policies[policy].matches[match].protocols[protocol].flags  | join(' ') }}{% endif %} source port {{ traffic_policies.policies[policy].matches[match].protocols[protocol].src_port }}
 {#                             -- destination field-set -- #}
-{%                             elif traffic_policies.policies[policy].matches[match].protocols[protocol].dst_field is arista.avd.defined protocol | lower in ['tcp','udp'] %}
+{%                             elif traffic_policies.policies[policy].matches[match].protocols[protocol].dst_field is arista.avd.defined and protocol | lower in ['tcp','udp'] %}
          protocol {{ protocol }}{% if traffic_policies.policies[policy].matches[match].protocols[protocol].flags is arista.avd.defined %} flags {{ traffic_policies.policies[policy].matches[match].protocols[protocol].flags  | join(' ') }}{% endif %} destination port field-set {{ traffic_policies.policies[policy].matches[match].protocols[protocol].dst_field }}
 {#                             -- source field-set -- #}
 {%                             elif traffic_policies.policies[policy].matches[match].protocols[protocol].src_field is arista.avd.defined and protocol | lower in ['tcp','udp'] %}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Fixes #886

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Fix an error in template syntax

## How to test

Check Molecule scenario for `eos_cli_config_gen`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
