### PR TITLE
Lacp timer fast option

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
@@ -77,6 +77,8 @@ interface Management1
 | Ethernet3 | MLAG_PEER_DC1-LEAF1B_Ethernet3 | *trunk | *2-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 3 |
 | Ethernet4 | MLAG_PEER_DC1-LEAF1B_Ethernet4 | *trunk | *2-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 3 |
 | Ethernet5 | DC1-AGG01_Ethernet1 | *trunk | *110,201 | *- | *- | 5 |
+| Ethernet15 | DC1-AGG03_Ethernet1 | *trunk | *110,201 | *- | *- | 15 |
+| Ethernet16 | DC1-AGG04_Ethernet1 | *trunk | *110,201 | *- | *- | 16 |
 | Ethernet50 | SRV-POD03_Eth1 | *trunk | *110,201 | *- | *- | 5 |
 
 *Inherited from Port-Channel Interface
@@ -107,6 +109,17 @@ interface Ethernet8
    description MLAG_PEER_DC1-LEAF1B_Ethernet8
    channel-group 8 mode active
 !
+interface Ethernet15
+   description DC1-AGG03_Ethernet1
+   channel-group 15 mode active
+   lacp timer fast
+   lacp timer multiplier 30
+!
+interface Ethernet16
+   description DC1-AGG04_Ethernet1
+   channel-group 16 mode active
+   lacp timer normal
+!
 interface Ethernet50
    description SRV-POD03_Eth1
    channel-group 5 mode active
@@ -123,6 +136,8 @@ interface Ethernet50
 | Port-Channel3 | MLAG_PEER_DC1-LEAF1B_Po3 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
 | Port-Channel5 | DC1_L2LEAF1_Po1 | switched | trunk | 110,201 | - | - | - | - | 5 | - |
 | Port-Channel10 | SRV01_bond0 | switched | trunk | 2-3000 | - | - | - | - | - | 0000:0000:0404:0404:0303 |
+| Port-Channel15 | DC1_L2LEAF3_Po1 | switched | trunk | 110,201 | - | - | - | - | 15 | - |
+| Port-Channel16 | DC1_L2LEAF4_Po1 | switched | trunk | 110,201 | - | - | - | - | 16 | - |
 | Port-Channel50 | SRV-POD03_PortChanne1 | switched | trunk | 1-4000 | - | - | - | - | - | 0000:0000:0303:0202:0101 |
 | Port-Channel51 | ipv6_prefix | switched | trunk | 1-500 | - | - | - | - | - | - |
 | Port-Channel100.101 | IFL for TENANT01 | switched | access | - | - | - | - | - | - | - |
@@ -179,6 +194,20 @@ interface Port-Channel10
    evpn ethernet-segment
       identifier 0000:0000:0404:0404:0303
       route-target import 04:04:03:03:02:02
+!
+interface Port-Channel15
+   description DC1_L2LEAF3_Po1
+   switchport
+   switchport trunk allowed vlan 110,201
+   switchport mode trunk
+   mlag 15
+!
+interface Port-Channel16
+   description DC1_L2LEAF4_Po1
+   switchport
+   switchport trunk allowed vlan 110,201
+   switchport mode trunk
+   mlag 16
 !
 interface Port-Channel50
    description SRV-POD03_PortChanne1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
@@ -48,6 +48,20 @@ interface Port-Channel10
       identifier 0000:0000:0404:0404:0303
       route-target import 04:04:03:03:02:02
 !
+interface Port-Channel15
+   description DC1_L2LEAF3_Po1
+   switchport
+   switchport trunk allowed vlan 110,201
+   switchport mode trunk
+   mlag 15
+!
+interface Port-Channel16
+   description DC1_L2LEAF4_Po1
+   switchport
+   switchport trunk allowed vlan 110,201
+   switchport mode trunk
+   mlag 16
+!
 interface Port-Channel50
    description SRV-POD03_PortChanne1
    switchport
@@ -98,6 +112,17 @@ interface Ethernet5
 interface Ethernet8
    description MLAG_PEER_DC1-LEAF1B_Ethernet8
    channel-group 8 mode active
+!
+interface Ethernet15
+   description DC1-AGG03_Ethernet1
+   channel-group 15 mode active
+   lacp timer fast
+   lacp timer multiplier 30
+!
+interface Ethernet16
+   description DC1-AGG04_Ethernet1
+   channel-group 16 mode active
+   lacp timer normal
 !
 interface Ethernet50
    description SRV-POD03_Eth1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
@@ -17,6 +17,17 @@ port_channel_interfaces:
         level: 1
         unit: percent
 
+  Port-Channel15:
+    description: DC1_L2LEAF3_Po1
+    vlans: 110,201
+    mode: trunk
+    mlag: 15
+
+  Port-Channel16:
+    description: DC1_L2LEAF4_Po1
+    vlans: 110,201
+    mode: trunk
+    mlag: 16
 
   Port-Channel3:
     description: MLAG_PEER_DC1-LEAF1B_Po3
@@ -143,3 +154,27 @@ ethernet_interfaces:
     channel_group:
       id: 8
       mode: active
+
+  Ethernet15:
+    peer: DC1-AGG03
+    peer_interface: Ethernet1
+    peer_type: l2leaf
+    description: DC1-AGG03_Ethernet1
+    channel_group:
+      id: 15
+      mode: active
+    lacp_timer:
+      mode: fast
+      multiplier: 30
+
+  Ethernet16:
+    peer: DC1-AGG04
+    peer_interface: Ethernet1
+    peer_type: l2leaf
+    description: DC1-AGG04_Ethernet1
+    channel_group:
+      id: 16
+      mode: active
+    lacp_timer:
+      mode: normal
+

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -671,6 +671,9 @@ ethernet_interfaces:
       ip: < true | false >
       ldp:
         interface: < true | false >
+    lacp_timer:
+      mode: < fast | normal >
+      multiplier: < 3 - 3000 >
 ```
 
 ##### Switched Ethernet Interfaces
@@ -731,6 +734,9 @@ ethernet_interfaces:
       interval: < rate in milliseconds >
       min_rx: < rate in milliseconds >
       multiplier: < 3-50 >
+    lacp_timer:
+      mode: < fast | normal >
+      multiplier: < 3 - 3000 >
 ```
 
 #### Interface Defaults

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -24,6 +24,12 @@ interface {{ ethernet_interface }}
 {%         if ethernet_interfaces[ethernet_interface].lacp_port_priority is arista.avd.defined %}
    lacp port-priority {{ ethernet_interfaces[ethernet_interface].lacp_port_priority }}
 {%         endif %}
+{%         if ethernet_interfaces[ethernet_interface].lacp_timer.mode is arista.avd.defined %}
+   lacp timer {{ ethernet_interfaces[ethernet_interface].lacp_timer.mode }}
+{%         endif %}
+{%         if ethernet_interfaces[ethernet_interface].lacp_timer.multiplier is arista.avd.defined %}
+   lacp timer multiplier {{ ethernet_interfaces[ethernet_interface].lacp_timer.multiplier }}
+{%         endif %}
 {%     else %}
 {%         if ethernet_interfaces[ethernet_interface].mtu is arista.avd.defined %}
    mtu {{ ethernet_interfaces[ethernet_interface].mtu }}


### PR DESCRIPTION
## Change Summary

Adding LACP timers mode (fast and normal) also the option to specify a multiplier rate of missed LACP PDUs time out a member.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Fixes #811 

## Component(s) name

`arista.avd.eos_cli_config_gen`

ethernet_interfaces.j2

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

```
    lacp_timer:
      mode: < fast | normal >
      multiplier: < 3 - 3000 >
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Molecule test

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
