### PR TITLE
Support for 2-level inheritance on port-profiles

### DIFF
--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -442,7 +442,8 @@ vlan 4092
 | Ethernet15 | server08_no_profile_port_channel_Eth1 | *trunk | *1-4094 | *- | *- | 15 |
 | Ethernet16 |  server09_override_profile_no_port_channel_Eth1 | access | 210 | - | - | - |
 | Ethernet17 | server10_no_profile_port_channel_lacp_fallback_Eth1 | *trunk | *1-4094 | *- | *- | 17 |
-| Ethernet18 | server10_inherit_profile_port_channel_lacp_fallback_Eth1 | *trunk | *1-4094 | *- | *- | 18 |
+| Ethernet18 | server11_inherit_profile_port_channel_lacp_fallback_Eth1 | *trunk | *1-4094 | *- | *- | 18 |
+| Ethernet19 | server12_inherit_nested_profile_port_channel_lacp_fallback_Eth1 | *trunk | *1-4094 | *- | *- | 19 |
 
 *Inherited from Port-Channel Interface
 
@@ -588,9 +589,15 @@ interface Ethernet17
    lacp port-priority 8192
 !
 interface Ethernet18
-   description server10_inherit_profile_port_channel_lacp_fallback_Eth1
+   description server11_inherit_profile_port_channel_lacp_fallback_Eth1
    no shutdown
    channel-group 18 mode active
+   lacp port-priority 8192
+!
+interface Ethernet19
+   description server12_inherit_nested_profile_port_channel_lacp_fallback_Eth1
+   no shutdown
+   channel-group 19 mode active
    lacp port-priority 8192
 ```
 
@@ -608,7 +615,8 @@ interface Ethernet18
 | Port-Channel14 | server07_inherit_all_from_profile_port_channel_ALL_WITH_SECURITY_PORT_CHANNEL | switched | trunk | 1-4094 | - | - | - | - | 14 | - |
 | Port-Channel15 | server08_no_profile_port_channel_server08_no_profile_port_channel | switched | trunk | 1-4094 | - | - | - | - | 15 | - |
 | Port-Channel17 | server10_no_profile_port_channel_lacp_fallback_server10_no_profile_port_channel_lacp_fallback | switched | trunk | 1-4094 | - | - | 90 | static | 17 | - |
-| Port-Channel18 | server10_inherit_profile_port_channel_lacp_fallback_ALL_WITH_SECURITY_PORT_CHANNEL | switched | trunk | 1-4094 | - | - | 10 | static | 18 | - |
+| Port-Channel18 | server11_inherit_profile_port_channel_lacp_fallback_ALL_WITH_SECURITY_PORT_CHANNEL | switched | trunk | 1-4094 | - | - | 10 | static | 18 | - |
+| Port-Channel19 | server12_inherit_nested_profile_port_channel_lacp_fallback_NESTED_ALL_WITH_SECURITY_PORT_CHANNEL | switched | trunk | 1-4094 | - | - | 10 | static | 19 | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -684,12 +692,28 @@ interface Port-Channel17
    storm-control unknown-unicast level 2
 !
 interface Port-Channel18
-   description server10_inherit_profile_port_channel_lacp_fallback_ALL_WITH_SECURITY_PORT_CHANNEL
+   description server11_inherit_profile_port_channel_lacp_fallback_ALL_WITH_SECURITY_PORT_CHANNEL
    no shutdown
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
    mlag 18
+   port-channel lacp fallback timeout 10
+   port-channel lacp fallback static
+   spanning-tree portfast
+   spanning-tree bpdufilter enable
+   storm-control all level 10
+   storm-control broadcast level pps 100
+   storm-control multicast level 1
+   storm-control unknown-unicast level 2
+!
+interface Port-Channel19
+   description server12_inherit_nested_profile_port_channel_lacp_fallback_NESTED_ALL_WITH_SECURITY_PORT_CHANNEL
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 1-4094
+   switchport mode trunk
+   mlag 19
    port-channel lacp fallback timeout 10
    port-channel lacp fallback static
    spanning-tree portfast

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -441,7 +441,8 @@ vlan 4092
 | Ethernet15 | server08_no_profile_port_channel_Eth2 | *trunk | *1-4094 | *- | *- | 15 |
 | Ethernet16 |  server09_override_profile_no_port_channel_Eth2 | access | 210 | - | - | - |
 | Ethernet17 | server10_no_profile_port_channel_lacp_fallback_Eth2 | *trunk | *1-4094 | *- | *- | 17 |
-| Ethernet18 | server10_inherit_profile_port_channel_lacp_fallback_Eth2 | *trunk | *1-4094 | *- | *- | 18 |
+| Ethernet18 | server11_inherit_profile_port_channel_lacp_fallback_Eth2 | *trunk | *1-4094 | *- | *- | 18 |
+| Ethernet19 | server12_inherit_nested_profile_port_channel_lacp_fallback_Eth2 | *trunk | *1-4094 | *- | *- | 19 |
 
 *Inherited from Port-Channel Interface
 
@@ -582,9 +583,15 @@ interface Ethernet17
    lacp port-priority 32768
 !
 interface Ethernet18
-   description server10_inherit_profile_port_channel_lacp_fallback_Eth2
+   description server11_inherit_profile_port_channel_lacp_fallback_Eth2
    no shutdown
    channel-group 18 mode active
+   lacp port-priority 32768
+!
+interface Ethernet19
+   description server12_inherit_nested_profile_port_channel_lacp_fallback_Eth2
+   no shutdown
+   channel-group 19 mode active
    lacp port-priority 32768
 ```
 
@@ -601,7 +608,8 @@ interface Ethernet18
 | Port-Channel14 | server07_inherit_all_from_profile_port_channel_ALL_WITH_SECURITY_PORT_CHANNEL | switched | trunk | 1-4094 | - | - | - | - | 14 | - |
 | Port-Channel15 | server08_no_profile_port_channel_server08_no_profile_port_channel | switched | trunk | 1-4094 | - | - | - | - | 15 | - |
 | Port-Channel17 | server10_no_profile_port_channel_lacp_fallback_server10_no_profile_port_channel_lacp_fallback | switched | trunk | 1-4094 | - | - | 90 | static | 17 | - |
-| Port-Channel18 | server10_inherit_profile_port_channel_lacp_fallback_ALL_WITH_SECURITY_PORT_CHANNEL | switched | trunk | 1-4094 | - | - | 10 | static | 18 | - |
+| Port-Channel18 | server11_inherit_profile_port_channel_lacp_fallback_ALL_WITH_SECURITY_PORT_CHANNEL | switched | trunk | 1-4094 | - | - | 10 | static | 18 | - |
+| Port-Channel19 | server12_inherit_nested_profile_port_channel_lacp_fallback_NESTED_ALL_WITH_SECURITY_PORT_CHANNEL | switched | trunk | 1-4094 | - | - | 10 | static | 19 | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -669,12 +677,28 @@ interface Port-Channel17
    storm-control unknown-unicast level 2
 !
 interface Port-Channel18
-   description server10_inherit_profile_port_channel_lacp_fallback_ALL_WITH_SECURITY_PORT_CHANNEL
+   description server11_inherit_profile_port_channel_lacp_fallback_ALL_WITH_SECURITY_PORT_CHANNEL
    no shutdown
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
    mlag 18
+   port-channel lacp fallback timeout 10
+   port-channel lacp fallback static
+   spanning-tree portfast
+   spanning-tree bpdufilter enable
+   storm-control all level 10
+   storm-control broadcast level pps 100
+   storm-control multicast level 1
+   storm-control unknown-unicast level 2
+!
+interface Port-Channel19
+   description server12_inherit_nested_profile_port_channel_lacp_fallback_NESTED_ALL_WITH_SECURITY_PORT_CHANNEL
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 1-4094
+   switchport mode trunk
+   mlag 19
    port-channel lacp fallback timeout 10
    port-channel lacp fallback static
    spanning-tree portfast

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/fabric/DC1_FABRIC-topology.csv
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/fabric/DC1_FABRIC-topology.csv
@@ -107,7 +107,8 @@ l3leaf,DC1-SVC3A,Ethernet14,server,server07_inherit_all_from_profile_port_channe
 l3leaf,DC1-SVC3A,Ethernet15,server,server08_no_profile_port_channel,Eth1
 l3leaf,DC1-SVC3A,Ethernet16,server,server09_override_profile_no_port_channel,Eth1
 l3leaf,DC1-SVC3A,Ethernet17,server,server10_no_profile_port_channel_lacp_fallback,Eth1
-l3leaf,DC1-SVC3A,Ethernet18,server,server10_inherit_profile_port_channel_lacp_fallback,Eth1
+l3leaf,DC1-SVC3A,Ethernet18,server,server11_inherit_profile_port_channel_lacp_fallback,Eth1
+l3leaf,DC1-SVC3A,Ethernet19,server,server12_inherit_nested_profile_port_channel_lacp_fallback,Eth1
 l3leaf,DC1-SVC3B,Ethernet1,spine,DC1-SPINE1,Ethernet5
 l3leaf,DC1-SVC3B,Ethernet2,spine,DC1-SPINE2,Ethernet5
 l3leaf,DC1-SVC3B,Ethernet3,spine,DC1-SPINE3,Ethernet5
@@ -123,4 +124,5 @@ l3leaf,DC1-SVC3B,Ethernet14,server,server07_inherit_all_from_profile_port_channe
 l3leaf,DC1-SVC3B,Ethernet15,server,server08_no_profile_port_channel,Eth2
 l3leaf,DC1-SVC3B,Ethernet16,server,server09_override_profile_no_port_channel,Eth2
 l3leaf,DC1-SVC3B,Ethernet17,server,server10_no_profile_port_channel_lacp_fallback,Eth2
-l3leaf,DC1-SVC3B,Ethernet18,server,server10_inherit_profile_port_channel_lacp_fallback,Eth2
+l3leaf,DC1-SVC3B,Ethernet18,server,server11_inherit_profile_port_channel_lacp_fallback,Eth2
+l3leaf,DC1-SVC3B,Ethernet19,server,server12_inherit_nested_profile_port_channel_lacp_fallback,Eth2

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
@@ -218,12 +218,28 @@ interface Port-Channel17
    storm-control unknown-unicast level 2
 !
 interface Port-Channel18
-   description server10_inherit_profile_port_channel_lacp_fallback_ALL_WITH_SECURITY_PORT_CHANNEL
+   description server11_inherit_profile_port_channel_lacp_fallback_ALL_WITH_SECURITY_PORT_CHANNEL
    no shutdown
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
    mlag 18
+   port-channel lacp fallback timeout 10
+   port-channel lacp fallback static
+   spanning-tree portfast
+   spanning-tree bpdufilter enable
+   storm-control all level 10
+   storm-control broadcast level pps 100
+   storm-control multicast level 1
+   storm-control unknown-unicast level 2
+!
+interface Port-Channel19
+   description server12_inherit_nested_profile_port_channel_lacp_fallback_NESTED_ALL_WITH_SECURITY_PORT_CHANNEL
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 1-4094
+   switchport mode trunk
+   mlag 19
    port-channel lacp fallback timeout 10
    port-channel lacp fallback static
    spanning-tree portfast
@@ -362,9 +378,15 @@ interface Ethernet17
    lacp port-priority 8192
 !
 interface Ethernet18
-   description server10_inherit_profile_port_channel_lacp_fallback_Eth1
+   description server11_inherit_profile_port_channel_lacp_fallback_Eth1
    no shutdown
    channel-group 18 mode active
+   lacp port-priority 8192
+!
+interface Ethernet19
+   description server12_inherit_nested_profile_port_channel_lacp_fallback_Eth1
+   no shutdown
+   channel-group 19 mode active
    lacp port-priority 8192
 !
 interface Loopback0

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
@@ -210,12 +210,28 @@ interface Port-Channel17
    storm-control unknown-unicast level 2
 !
 interface Port-Channel18
-   description server10_inherit_profile_port_channel_lacp_fallback_ALL_WITH_SECURITY_PORT_CHANNEL
+   description server11_inherit_profile_port_channel_lacp_fallback_ALL_WITH_SECURITY_PORT_CHANNEL
    no shutdown
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
    mlag 18
+   port-channel lacp fallback timeout 10
+   port-channel lacp fallback static
+   spanning-tree portfast
+   spanning-tree bpdufilter enable
+   storm-control all level 10
+   storm-control broadcast level pps 100
+   storm-control multicast level 1
+   storm-control unknown-unicast level 2
+!
+interface Port-Channel19
+   description server12_inherit_nested_profile_port_channel_lacp_fallback_NESTED_ALL_WITH_SECURITY_PORT_CHANNEL
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 1-4094
+   switchport mode trunk
+   mlag 19
    port-channel lacp fallback timeout 10
    port-channel lacp fallback static
    spanning-tree portfast
@@ -349,9 +365,15 @@ interface Ethernet17
    lacp port-priority 32768
 !
 interface Ethernet18
-   description server10_inherit_profile_port_channel_lacp_fallback_Eth2
+   description server11_inherit_profile_port_channel_lacp_fallback_Eth2
    no shutdown
    channel-group 18 mode active
+   lacp port-priority 32768
+!
+interface Ethernet19
+   description server12_inherit_nested_profile_port_channel_lacp_fallback_Eth2
+   no shutdown
+   channel-group 19 mode active
    lacp port-priority 32768
 !
 interface Loopback0

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -792,32 +792,6 @@ port_channel_interfaces:
         level: 2
         unit: percent
     mlag: 15
-  Port-Channel18:
-    description: server10_inherit_profile_port_channel_lacp_fallback_ALL_WITH_SECURITY_PORT_CHANNEL
-    type: switched
-    shutdown: false
-    mode: trunk
-    l2_mtu: 8000
-    vlans: 1-4094
-    spanning_tree_portfast: edge
-    spanning_tree_bpdufilter: true
-    spanning_tree_bpduguard: false
-    storm_control:
-      all:
-        level: 10
-        unit: percent
-      broadcast:
-        level: 100
-        unit: pps
-      multicast:
-        level: 1
-        unit: percent
-      unknown-unicast:
-        level: 2
-        unit: percent
-    mlag: 18
-    lacp_fallback_mode: static
-    lacp_fallback_timeout: 10
   Port-Channel17:
     description: server10_no_profile_port_channel_lacp_fallback_server10_no_profile_port_channel_lacp_fallback
     type: switched
@@ -843,6 +817,58 @@ port_channel_interfaces:
     mlag: 17
     lacp_fallback_mode: static
     lacp_fallback_timeout: 90
+  Port-Channel18:
+    description: server11_inherit_profile_port_channel_lacp_fallback_ALL_WITH_SECURITY_PORT_CHANNEL
+    type: switched
+    shutdown: false
+    mode: trunk
+    l2_mtu: 8000
+    vlans: 1-4094
+    spanning_tree_portfast: edge
+    spanning_tree_bpdufilter: true
+    spanning_tree_bpduguard: false
+    storm_control:
+      all:
+        level: 10
+        unit: percent
+      broadcast:
+        level: 100
+        unit: pps
+      multicast:
+        level: 1
+        unit: percent
+      unknown-unicast:
+        level: 2
+        unit: percent
+    mlag: 18
+    lacp_fallback_mode: static
+    lacp_fallback_timeout: 10
+  Port-Channel19:
+    description: server12_inherit_nested_profile_port_channel_lacp_fallback_NESTED_ALL_WITH_SECURITY_PORT_CHANNEL
+    type: switched
+    shutdown: false
+    mode: trunk
+    l2_mtu: 8000
+    vlans: 1-4094
+    spanning_tree_portfast: edge
+    spanning_tree_bpdufilter: true
+    spanning_tree_bpduguard: false
+    storm_control:
+      all:
+        level: 10
+        unit: percent
+      broadcast:
+        level: 100
+        unit: pps
+      multicast:
+        level: 1
+        unit: percent
+      unknown-unicast:
+        level: 2
+        unit: percent
+    mlag: 19
+    lacp_fallback_mode: static
+    lacp_fallback_timeout: 10
 ethernet_interfaces:
   Ethernet5:
     peer: DC1-SVC3B
@@ -1101,37 +1127,6 @@ ethernet_interfaces:
         level: 2
         unit: percent
     profile: ALL_WITH_SECURITY_PORT_CHANNEL
-  Ethernet18:
-    peer: server10_inherit_profile_port_channel_lacp_fallback
-    peer_interface: Eth1
-    peer_type: server
-    description: server10_inherit_profile_port_channel_lacp_fallback_Eth1
-    l2_mtu: 8000
-    type: switched
-    shutdown: false
-    mode: trunk
-    vlans: 1-4094
-    spanning_tree_portfast: edge
-    spanning_tree_bpdufilter: true
-    spanning_tree_bpduguard: false
-    storm_control:
-      all:
-        level: 10
-        unit: percent
-      broadcast:
-        level: 100
-        unit: pps
-      multicast:
-        level: 1
-        unit: percent
-      unknown-unicast:
-        level: 2
-        unit: percent
-    channel_group:
-      id: 18
-      mode: active
-    profile: ALL_WITH_SECURITY_PORT_CHANNEL_LACP_FALLBACK
-    lacp_port_priority: 8192
   Ethernet17:
     peer: server10_no_profile_port_channel_lacp_fallback
     peer_interface: Eth1
@@ -1160,6 +1155,68 @@ ethernet_interfaces:
     channel_group:
       id: 17
       mode: active
+    lacp_port_priority: 8192
+  Ethernet18:
+    peer: server11_inherit_profile_port_channel_lacp_fallback
+    peer_interface: Eth1
+    peer_type: server
+    description: server11_inherit_profile_port_channel_lacp_fallback_Eth1
+    l2_mtu: 8000
+    type: switched
+    shutdown: false
+    mode: trunk
+    vlans: 1-4094
+    spanning_tree_portfast: edge
+    spanning_tree_bpdufilter: true
+    spanning_tree_bpduguard: false
+    storm_control:
+      all:
+        level: 10
+        unit: percent
+      broadcast:
+        level: 100
+        unit: pps
+      multicast:
+        level: 1
+        unit: percent
+      unknown-unicast:
+        level: 2
+        unit: percent
+    channel_group:
+      id: 18
+      mode: active
+    profile: ALL_WITH_SECURITY_PORT_CHANNEL_LACP_FALLBACK
+    lacp_port_priority: 8192
+  Ethernet19:
+    peer: server12_inherit_nested_profile_port_channel_lacp_fallback
+    peer_interface: Eth1
+    peer_type: server
+    description: server12_inherit_nested_profile_port_channel_lacp_fallback_Eth1
+    l2_mtu: 8000
+    type: switched
+    shutdown: false
+    mode: trunk
+    vlans: 1-4094
+    spanning_tree_portfast: edge
+    spanning_tree_bpdufilter: true
+    spanning_tree_bpduguard: false
+    storm_control:
+      all:
+        level: 10
+        unit: percent
+      broadcast:
+        level: 100
+        unit: pps
+      multicast:
+        level: 1
+        unit: percent
+      unknown-unicast:
+        level: 2
+        unit: percent
+    channel_group:
+      id: 19
+      mode: active
+    profile: NESTED_PORT_PROFILE
     lacp_port_priority: 8192
 mlag_configuration:
   domain_id: DC1_SVC3

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -785,32 +785,6 @@ port_channel_interfaces:
         level: 2
         unit: percent
     mlag: 15
-  Port-Channel18:
-    description: server10_inherit_profile_port_channel_lacp_fallback_ALL_WITH_SECURITY_PORT_CHANNEL
-    type: switched
-    shutdown: false
-    mode: trunk
-    l2_mtu: 8000
-    vlans: 1-4094
-    spanning_tree_portfast: edge
-    spanning_tree_bpdufilter: true
-    spanning_tree_bpduguard: false
-    storm_control:
-      all:
-        level: 10
-        unit: percent
-      broadcast:
-        level: 100
-        unit: pps
-      multicast:
-        level: 1
-        unit: percent
-      unknown-unicast:
-        level: 2
-        unit: percent
-    mlag: 18
-    lacp_fallback_mode: static
-    lacp_fallback_timeout: 10
   Port-Channel17:
     description: server10_no_profile_port_channel_lacp_fallback_server10_no_profile_port_channel_lacp_fallback
     type: switched
@@ -836,6 +810,58 @@ port_channel_interfaces:
     mlag: 17
     lacp_fallback_mode: static
     lacp_fallback_timeout: 90
+  Port-Channel18:
+    description: server11_inherit_profile_port_channel_lacp_fallback_ALL_WITH_SECURITY_PORT_CHANNEL
+    type: switched
+    shutdown: false
+    mode: trunk
+    l2_mtu: 8000
+    vlans: 1-4094
+    spanning_tree_portfast: edge
+    spanning_tree_bpdufilter: true
+    spanning_tree_bpduguard: false
+    storm_control:
+      all:
+        level: 10
+        unit: percent
+      broadcast:
+        level: 100
+        unit: pps
+      multicast:
+        level: 1
+        unit: percent
+      unknown-unicast:
+        level: 2
+        unit: percent
+    mlag: 18
+    lacp_fallback_mode: static
+    lacp_fallback_timeout: 10
+  Port-Channel19:
+    description: server12_inherit_nested_profile_port_channel_lacp_fallback_NESTED_ALL_WITH_SECURITY_PORT_CHANNEL
+    type: switched
+    shutdown: false
+    mode: trunk
+    l2_mtu: 8000
+    vlans: 1-4094
+    spanning_tree_portfast: edge
+    spanning_tree_bpdufilter: true
+    spanning_tree_bpduguard: false
+    storm_control:
+      all:
+        level: 10
+        unit: percent
+      broadcast:
+        level: 100
+        unit: pps
+      multicast:
+        level: 1
+        unit: percent
+      unknown-unicast:
+        level: 2
+        unit: percent
+    mlag: 19
+    lacp_fallback_mode: static
+    lacp_fallback_timeout: 10
 ethernet_interfaces:
   Ethernet5:
     peer: DC1-SVC3A
@@ -1081,37 +1107,6 @@ ethernet_interfaces:
         level: 2
         unit: percent
     profile: ALL_WITH_SECURITY_PORT_CHANNEL
-  Ethernet18:
-    peer: server10_inherit_profile_port_channel_lacp_fallback
-    peer_interface: Eth2
-    peer_type: server
-    description: server10_inherit_profile_port_channel_lacp_fallback_Eth2
-    l2_mtu: 8000
-    type: switched
-    shutdown: false
-    mode: trunk
-    vlans: 1-4094
-    spanning_tree_portfast: edge
-    spanning_tree_bpdufilter: true
-    spanning_tree_bpduguard: false
-    storm_control:
-      all:
-        level: 10
-        unit: percent
-      broadcast:
-        level: 100
-        unit: pps
-      multicast:
-        level: 1
-        unit: percent
-      unknown-unicast:
-        level: 2
-        unit: percent
-    channel_group:
-      id: 18
-      mode: active
-    profile: ALL_WITH_SECURITY_PORT_CHANNEL_LACP_FALLBACK
-    lacp_port_priority: 32768
   Ethernet17:
     peer: server10_no_profile_port_channel_lacp_fallback
     peer_interface: Eth2
@@ -1140,6 +1135,68 @@ ethernet_interfaces:
     channel_group:
       id: 17
       mode: active
+    lacp_port_priority: 32768
+  Ethernet18:
+    peer: server11_inherit_profile_port_channel_lacp_fallback
+    peer_interface: Eth2
+    peer_type: server
+    description: server11_inherit_profile_port_channel_lacp_fallback_Eth2
+    l2_mtu: 8000
+    type: switched
+    shutdown: false
+    mode: trunk
+    vlans: 1-4094
+    spanning_tree_portfast: edge
+    spanning_tree_bpdufilter: true
+    spanning_tree_bpduguard: false
+    storm_control:
+      all:
+        level: 10
+        unit: percent
+      broadcast:
+        level: 100
+        unit: pps
+      multicast:
+        level: 1
+        unit: percent
+      unknown-unicast:
+        level: 2
+        unit: percent
+    channel_group:
+      id: 18
+      mode: active
+    profile: ALL_WITH_SECURITY_PORT_CHANNEL_LACP_FALLBACK
+    lacp_port_priority: 32768
+  Ethernet19:
+    peer: server12_inherit_nested_profile_port_channel_lacp_fallback
+    peer_interface: Eth2
+    peer_type: server
+    description: server12_inherit_nested_profile_port_channel_lacp_fallback_Eth2
+    l2_mtu: 8000
+    type: switched
+    shutdown: false
+    mode: trunk
+    vlans: 1-4094
+    spanning_tree_portfast: edge
+    spanning_tree_bpdufilter: true
+    spanning_tree_bpduguard: false
+    storm_control:
+      all:
+        level: 10
+        unit: percent
+      broadcast:
+        level: 100
+        unit: pps
+      multicast:
+        level: 1
+        unit: percent
+      unknown-unicast:
+        level: 2
+        unit: percent
+    channel_group:
+      id: 19
+      mode: active
+    profile: NESTED_PORT_PROFILE
     lacp_port_priority: 32768
 mlag_configuration:
   domain_id: DC1_SVC3

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_SERVERS.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_SERVERS.yml
@@ -17,7 +17,7 @@ port_profiles:
     vlans: "210-211"
 
   ALL_WITH_SECURITY:
-    profile: NON_EXISTING_PROFILE #Test that pointing to a nonexisting profile won't break templates.
+    parent_profile: NON_EXISTING_PROFILE #Test that pointing to a nonexisting profile won't break templates.
     mode: trunk
     vlans: "1-4094"
     spanning_tree_bpdufilter: true
@@ -90,7 +90,7 @@ port_profiles:
         timeout: 10
 
   NESTED_PORT_PROFILE:
-    profile: ALL_WITH_SECURITY_PORT_CHANNEL_LACP_FALLBACK
+    parent_profile: ALL_WITH_SECURITY_PORT_CHANNEL_LACP_FALLBACK
     port_channel:
       description: NESTED_ALL_WITH_SECURITY_PORT_CHANNEL
       mode: active

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_SERVERS.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_SERVERS.yml
@@ -17,6 +17,7 @@ port_profiles:
     vlans: "210-211"
 
   ALL_WITH_SECURITY:
+    profile: NON_EXISTING_PROFILE #Test that pointing to a nonexisting profile won't break templates.
     mode: trunk
     vlans: "1-4094"
     spanning_tree_bpdufilter: true
@@ -87,6 +88,12 @@ port_profiles:
       lacp_fallback:
         mode: static
         timeout: 10
+
+  NESTED_PORT_PROFILE:
+    profile: ALL_WITH_SECURITY_PORT_CHANNEL_LACP_FALLBACK
+    port_channel:
+      description: NESTED_ALL_WITH_SECURITY_PORT_CHANNEL
+      mode: active
 
 servers:
   server01_MLAG:
@@ -302,13 +309,21 @@ servers:
           lacp_fallback:
             mode: static
 
-  server10_inherit_profile_port_channel_lacp_fallback:
+  server11_inherit_profile_port_channel_lacp_fallback:
     rack: RackC
     adapters:
       - server_ports: [ Eth1, Eth2 ]
         switch_ports: [ Ethernet18, Ethernet18 ]
         switches: [ DC1-SVC3A, DC1-SVC3B ]
         profile: ALL_WITH_SECURITY_PORT_CHANNEL_LACP_FALLBACK
+
+  server12_inherit_nested_profile_port_channel_lacp_fallback:
+    rack: RackC
+    adapters:
+      - server_ports: [ Eth1, Eth2 ]
+        switch_ports: [ Ethernet19, Ethernet19 ]
+        switches: [ DC1-SVC3A, DC1-SVC3B ]
+        profile: NESTED_PORT_PROFILE
 
 firewalls:
   FIREWALL01:

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/common/connected-endpoints.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/common/connected-endpoints.md
@@ -41,10 +41,11 @@ connected_endpoints_keys:
 ```yaml
 # Optional profiles to apply on endpoints facing interfaces
 # Each profile can support all or some of the following keys according to your own needs.
-# Keys are the same used under  endpoints adapters.
-# Keys defined under endpoints Adapters take precedence.
+# Keys are the same used under endpoints adapters. Keys defined under endpoints adapters take precedence.
+# Port_profiles can refer to another port_profile to inherit settings in up to two levels (adapter->profile->profile).
 port_profiles:
   < port_profile_1 >:
+    profile: < port_profile_name >
     speed: < interface_speed | forced interface_speed | auto interface_speed >
     mode: < access | dot1q-tunnel | trunk >
     l2_mtu: < l2_mtu - if defined this profile should only be used for platforms supporting the "l2 mtu" CLI >

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/common/connected-endpoints.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/common/connected-endpoints.md
@@ -42,10 +42,10 @@ connected_endpoints_keys:
 # Optional profiles to apply on endpoints facing interfaces
 # Each profile can support all or some of the following keys according to your own needs.
 # Keys are the same used under endpoints adapters. Keys defined under endpoints adapters take precedence.
-# Port_profiles can refer to another port_profile to inherit settings in up to two levels (adapter->profile->profile).
+# Port_profiles can refer to another port_profile to inherit settings in up to two levels (adapter->profile->parent_profile).
 port_profiles:
   < port_profile_1 >:
-    profile: < port_profile_name >
+    parent_profile: < port_profile_name >
     speed: < interface_speed | forced interface_speed | auto interface_speed >
     mode: < access | dot1q-tunnel | trunk >
     l2_mtu: < l2_mtu - if defined this profile should only be used for platforms supporting the "l2 mtu" CLI >

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/ethernet-interfaces.j2
@@ -6,24 +6,58 @@ ethernet_interfaces:
 {%             for switch in adapter.switches | arista.avd.natural_sort %}
 {%                 if switch == inventory_hostname %}
 {%                     if adapter.profile is arista.avd.defined %}
-{%                         set adapter_profile = port_profiles[adapter.profile] %}
+{%                         set adapter_profile = port_profiles[adapter.profile] | arista.avd.default({}) %}
 {%                     else %}
 {%                         set adapter_profile = dict() %}
 {%                     endif %}
-{%                     set adapter_speed = adapter.speed | arista.avd.default(adapter_profile.speed) %}
-{%                     set adapter_mode = adapter.mode | arista.avd.default(adapter_profile.mode) %}
-{%                     set adapter_l2_mtu = adapter.l2_mtu | arista.avd.default(adapter_profile.l2_mtu) %}
-{%                     set adapter_vlans = adapter.vlans | arista.avd.default(adapter_profile.vlans) %}
-{%                     set adapter_native_vlan = adapter.native_vlan | arista.avd.default(adapter_profile.native_vlan) %}
-{%                     set adapter_spanning_tree_portfast = adapter.spanning_tree_portfast | arista.avd.default(adapter_profile.spanning_tree_portfast) %}
-{%                     set adapter_spanning_tree_bpdufilter = adapter.spanning_tree_bpdufilter | arista.avd.default(adapter_profile.spanning_tree_bpdufilter) %}
-{%                     set adapter_spanning_tree_bpduguard = adapter.spanning_tree_bpduguard | arista.avd.default(adapter_profile.spanning_tree_bpduguard) %}
-{%                     set adapter_storm_control = adapter.storm_control | arista.avd.default(adapter_profile.storm_control) %}
-{%                     set adapter_port_channel = adapter.port_channel | arista.avd.default(adapter_profile.port_channel) %}
-{%                     set adapter_flowcontrol = adapter.flowcontrol | arista.avd.default(adapter_profile.flowcontrol) %}
-{%                     set adapter_qos_profile = adapter.qos_profile | arista.avd.default(adapter_profile.qos_profile) %}
-{%                     set adapter_ptp = adapter.ptp | arista.avd.default(adapter_profile.ptp) %}
-{%                     set adapter_mtu = adapter.mtu | arista.avd.default(adapter_profile.mtu) %}
+{%                     if adapter_profile.profile is arista.avd.defined %}
+{%                         set base_profile = port_profiles[adapter_profile.profile] | arista.avd.default({}) %}
+{%                     endif %}
+{%                     set adapter_speed = adapter.speed | arista.avd.default(
+                           adapter_profile.speed,
+                           base_profile.speed) %}
+{%                     set adapter_mode = adapter.mode | arista.avd.default(
+                           adapter_profile.mode,
+                           base_profile.mode) %}
+{%                     set adapter_l2_mtu = adapter.l2_mtu | arista.avd.default(
+                           adapter_profile.l2_mtu,
+                           base_profile.l2_mtu) %}
+{%                     set adapter_vlans = adapter.vlans | arista.avd.default(
+                           adapter_profile.vlans,
+                           base_profile.vlans) %}
+{%                     set adapter_native_vlan = adapter.native_vlan | arista.avd.default(
+                           adapter_profile.native_vlan,
+                           base_profile.native_vlan) %}
+{%                     set adapter_spanning_tree_portfast = adapter.spanning_tree_portfast | arista.avd.default(
+                           adapter_profile.spanning_tree_portfast,
+                           base_profile.spanning_tree_portfast) %}
+{%                     set adapter_spanning_tree_bpdufilter = adapter.spanning_tree_bpdufilter | arista.avd.default(
+                           adapter_profile.spanning_tree_bpdufilter,
+                           base_profile.spanning_tree_bpdufilter) %}
+{%                     set adapter_spanning_tree_bpduguard = adapter.spanning_tree_bpduguard | arista.avd.default(
+                           adapter_profile.spanning_tree_bpduguard,
+                           base_profile.spanning_tree_bpduguard) %}
+{%                     set adapter_storm_control = adapter.storm_control | arista.avd.default(
+                           adapter_profile.storm_control,
+                           base_profile.storm_control) %}
+{%                     set adapter_port_channel = adapter.port_channel | arista.avd.default(
+                           adapter_profile.port_channel,
+                           base_profile.port_channel) %}
+{%                     set adapter_flowcontrol = adapter.flowcontrol | arista.avd.default(
+                           adapter_profile.flowcontrol,
+                           base_profile.flowcontrol) %}
+{%                     set adapter_qos_profile = adapter.qos_profile | arista.avd.default(
+                           adapter_profile.qos_profile,
+                           base_profile.qos_profile) %}
+{%                     set adapter_ptp = adapter.ptp | arista.avd.default(
+                           adapter_profile.ptp,
+                           base_profile.ptp) %}
+{%                     set adapter_mtu = adapter.mtu | arista.avd.default(
+                           adapter_profile.mtu,
+                           base_profile.mtu) %}
+{%                     set lacp_fallback_mode = adapter.port_channel.lacp_fallback.mode | arista.avd.default(
+                                                adapter_profile.port_channel.lacp_fallback.mode,
+                                                base_profile.port_channel.lacp_fallback.mode) %}
 {%                     set channel_group_id = (adapter.switch_ports[0] | regex_findall("\d") | join) %}
 {%                     set endpoint_ports = adapter.server_ports | arista.avd.default(adapter.endpoint_ports) %}
 {%                     set peer_type = connected_endpoints_keys[endpoint_key].type %}
@@ -90,7 +124,7 @@ ethernet_interfaces:
       enable: {{ adapter_ptp.enable }}
 {%                         endif %}
 {%                     endif %}
-{%                     if adapter_port_channel.lacp_fallback.mode is arista.avd.defined('static') %}
+{%                     if lacp_fallback_mode is arista.avd.defined('static') %}
 {%                         if loop.first %}
     lacp_port_priority: 8192
 {%                         else %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/ethernet-interfaces.j2
@@ -10,54 +10,54 @@ ethernet_interfaces:
 {%                     else %}
 {%                         set adapter_profile = dict() %}
 {%                     endif %}
-{%                     if adapter_profile.profile is arista.avd.defined %}
-{%                         set base_profile = port_profiles[adapter_profile.profile] | arista.avd.default({}) %}
+{%                     if adapter_profile.parent_profile is arista.avd.defined %}
+{%                         set parent_profile = port_profiles[adapter_profile.parent_profile] | arista.avd.default({}) %}
 {%                     endif %}
 {%                     set adapter_speed = adapter.speed | arista.avd.default(
-                           adapter_profile.speed,
-                           base_profile.speed) %}
+                                           adapter_profile.speed,
+                                           parent_profile.speed) %}
 {%                     set adapter_mode = adapter.mode | arista.avd.default(
-                           adapter_profile.mode,
-                           base_profile.mode) %}
+                                          adapter_profile.mode,
+                                          parent_profile.mode) %}
 {%                     set adapter_l2_mtu = adapter.l2_mtu | arista.avd.default(
-                           adapter_profile.l2_mtu,
-                           base_profile.l2_mtu) %}
+                                            adapter_profile.l2_mtu,
+                                            parent_profile.l2_mtu) %}
 {%                     set adapter_vlans = adapter.vlans | arista.avd.default(
-                           adapter_profile.vlans,
-                           base_profile.vlans) %}
+                                           adapter_profile.vlans,
+                                           parent_profile.vlans) %}
 {%                     set adapter_native_vlan = adapter.native_vlan | arista.avd.default(
-                           adapter_profile.native_vlan,
-                           base_profile.native_vlan) %}
+                                                 adapter_profile.native_vlan,
+                                                 parent_profile.native_vlan) %}
 {%                     set adapter_spanning_tree_portfast = adapter.spanning_tree_portfast | arista.avd.default(
-                           adapter_profile.spanning_tree_portfast,
-                           base_profile.spanning_tree_portfast) %}
+                                                            adapter_profile.spanning_tree_portfast,
+                                                            parent_profile.spanning_tree_portfast) %}
 {%                     set adapter_spanning_tree_bpdufilter = adapter.spanning_tree_bpdufilter | arista.avd.default(
-                           adapter_profile.spanning_tree_bpdufilter,
-                           base_profile.spanning_tree_bpdufilter) %}
+                                                              adapter_profile.spanning_tree_bpdufilter,
+                                                              parent_profile.spanning_tree_bpdufilter) %}
 {%                     set adapter_spanning_tree_bpduguard = adapter.spanning_tree_bpduguard | arista.avd.default(
-                           adapter_profile.spanning_tree_bpduguard,
-                           base_profile.spanning_tree_bpduguard) %}
+                                                             adapter_profile.spanning_tree_bpduguard,
+                                                             parent_profile.spanning_tree_bpduguard) %}
 {%                     set adapter_storm_control = adapter.storm_control | arista.avd.default(
-                           adapter_profile.storm_control,
-                           base_profile.storm_control) %}
+                                                   adapter_profile.storm_control,
+                                                   parent_profile.storm_control) %}
 {%                     set adapter_port_channel = adapter.port_channel | arista.avd.default(
-                           adapter_profile.port_channel,
-                           base_profile.port_channel) %}
+                                                  adapter_profile.port_channel,
+                                                  parent_profile.port_channel) %}
 {%                     set adapter_flowcontrol = adapter.flowcontrol | arista.avd.default(
-                           adapter_profile.flowcontrol,
-                           base_profile.flowcontrol) %}
+                                                 adapter_profile.flowcontrol,
+                                                 parent_profile.flowcontrol) %}
 {%                     set adapter_qos_profile = adapter.qos_profile | arista.avd.default(
-                           adapter_profile.qos_profile,
-                           base_profile.qos_profile) %}
+                                                 adapter_profile.qos_profile,
+                                                 parent_profile.qos_profile) %}
 {%                     set adapter_ptp = adapter.ptp | arista.avd.default(
-                           adapter_profile.ptp,
-                           base_profile.ptp) %}
+                                         adapter_profile.ptp,
+                                         parent_profile.ptp) %}
 {%                     set adapter_mtu = adapter.mtu | arista.avd.default(
-                           adapter_profile.mtu,
-                           base_profile.mtu) %}
+                                         adapter_profile.mtu,
+                                         parent_profile.mtu) %}
 {%                     set lacp_fallback_mode = adapter.port_channel.lacp_fallback.mode | arista.avd.default(
                                                 adapter_profile.port_channel.lacp_fallback.mode,
-                                                base_profile.port_channel.lacp_fallback.mode) %}
+                                                parent_profile.port_channel.lacp_fallback.mode) %}
 {%                     set channel_group_id = (adapter.switch_ports[0] | regex_findall("\d") | join) %}
 {%                     set endpoint_ports = adapter.server_ports | arista.avd.default(adapter.endpoint_ports) %}
 {%                     set peer_type = connected_endpoints_keys[endpoint_key].type %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/port-channel-interfaces.j2
@@ -4,30 +4,64 @@ port_channel_interfaces:
 {%     for connected_endpoint in connected_endpoints[endpoint_key] | arista.avd.natural_sort %}
 {%         for adapter in connected_endpoints[endpoint_key][connected_endpoint].adapters | arista.avd.natural_sort %}
 {%             if adapter.profile is arista.avd.defined %}
-{%                 set adapter_profile = port_profiles[adapter.profile] %}
+{%                 set adapter_profile = port_profiles[adapter.profile] | arista.avd.default({}) %}
 {%             else %}
 {%                 set adapter_profile = dict() %}
 {%             endif %}
-{%             set adapter_port_channel = adapter.port_channel | arista.avd.default(adapter_profile.port_channel) %}
+{%             if adapter_profile.profile is arista.avd.defined %}
+{%                 set base_profile = port_profiles[adapter_profile.profile] | arista.avd.default({}) %}
+{%             endif %}
+{%             set adapter_port_channel = adapter.port_channel | arista.avd.default(
+                                          adapter_profile.port_channel,
+                                          base_profile.port_channel) %}
 {%             if adapter_port_channel is arista.avd.defined and adapter_port_channel.mode is arista.avd.defined %}
+{%                 set adapter_port_channel_description = adapter.port_channel.description | arista.avd.default(
+                                                          adapter_profile.port_channel.description,
+                                                          base_profile.port_channel.description) %}
 {%                 for switch in adapter.switches | arista.avd.natural_sort %}
 {%                     if switch == inventory_hostname %}
-{%                         set adapter_mode = adapter.mode | arista.avd.default(adapter_profile.mode) %}
-{%                         set adapter_l2_mtu = adapter.l2_mtu | arista.avd.default(adapter_profile.l2_mtu) %}
-{%                         set adapter_vlans = adapter.vlans | arista.avd.default(adapter_profile.vlans) %}
-{%                         set adapter_native_vlan = adapter.native_vlan | arista.avd.default(adapter_profile.native_vlan) %}
-{%                         set adapter_spanning_tree_portfast = adapter.spanning_tree_portfast | arista.avd.default(adapter_profile.spanning_tree_portfast) %}
-{%                         set adapter_spanning_tree_bpdufilter = adapter.spanning_tree_bpdufilter | arista.avd.default(adapter_profile.spanning_tree_bpdufilter) %}
-{%                         set adapter_spanning_tree_bpduguard = adapter.spanning_tree_bpduguard | arista.avd.default(adapter_profile.spanning_tree_bpduguard) %}
-{%                         set adapter_storm_control = adapter.storm_control | arista.avd.default(adapter_profile.storm_control) %}
-{%                         set adapter_flowcontrol = adapter.flowcontrol | arista.avd.default(adapter_profile.flowcontrol) %}
-{%                         set adapter_qos_profile = adapter.qos_profile | arista.avd.default(adapter_profile.qos_profile) %}
-{%                         set adapter_mtu = adapter.mtu | arista.avd.default(adapter_profile.mtu) %}
+{%                         set adapter_mode = adapter.mode | arista.avd.default(
+                                              adapter_profile.mode,
+                                              base_profile.mode) %}
+{%                         set adapter_l2_mtu = adapter.l2_mtu | arista.avd.default(
+                                                adapter_profile.l2_mtu,
+                                                base_profile.l2_mtu) %}
+{%                         set adapter_vlans = adapter.vlans | arista.avd.default(
+                                               adapter_profile.vlans,
+                                               base_profile.vlans) %}
+{%                         set adapter_native_vlan = adapter.native_vlan | arista.avd.default(
+                                                     adapter_profile.native_vlan,
+                                                     base_profile.native_vlan) %}
+{%                         set adapter_spanning_tree_portfast = adapter.spanning_tree_portfast | arista.avd.default(
+                                                                adapter_profile.spanning_tree_portfast,
+                                                                base_profile.spanning_tree_portfast) %}
+{%                         set adapter_spanning_tree_bpdufilter = adapter.spanning_tree_bpdufilter | arista.avd.default(
+                                                                  adapter_profile.spanning_tree_bpdufilter,
+                                                                  base_profile.spanning_tree_bpdufilter) %}
+{%                         set adapter_spanning_tree_bpduguard = adapter.spanning_tree_bpduguard | arista.avd.default(
+                                                                 adapter_profile.spanning_tree_bpduguard,
+                                                                 base_profile.spanning_tree_bpduguard) %}
+{%                         set adapter_storm_control = adapter.storm_control | arista.avd.default(
+                                                       adapter_profile.storm_control,
+                                                       base_profile.storm_control) %}
+{%                         set adapter_flowcontrol = adapter.flowcontrol | arista.avd.default(
+                                                     adapter_profile.flowcontrol,
+                                                     base_profile.flowcontrol) %}
+{%                         set adapter_qos_profile = adapter.qos_profile | arista.avd.default(
+                                                     adapter_profile.qos_profile,
+                                                     base_profile.qos_profile) %}
+{%                         set adapter_mtu = adapter.mtu | arista.avd.default(
+                                             adapter_profile.mtu,
+                                             base_profile.mtu) %}
+{%                         set lacp_fallback_mode = adapter.port_channel.lacp_fallback.mode | arista.avd.default(
+                                                    adapter_profile.port_channel.lacp_fallback.mode,
+                                                    base_profile.port_channel.lacp_fallback.mode) %}
+{%                         set lacp_fallback_timeout = adapter.port_channel.lacp_fallback.timeout | arista.avd.default(
+                                                       adapter_profile.port_channel.lacp_fallback.timeout,
+                                                       base_profile.port_channel.lacp_fallback.timeout) %}
 {%                         set channel_group_id = (adapter.switch_ports[0] | regex_findall("\d") | join) %}
-{%                         set lacp_fallback_mode = adapter_port_channel.lacp_fallback.mode | arista.avd.default(adapter_profile.lacp_fallback.mode) %}
-{%                         set lacp_fallback_timeout = adapter_port_channel.lacp_fallback.timeout | arista.avd.default(adapter_profile.lacp_fallback.timeout) %}
   Port-Channel{{ channel_group_id }}:
-    description: {{ connected_endpoint }}_{{ adapter_port_channel.description }}
+    description: {{ connected_endpoint }}_{{ adapter_port_channel_description }}
     type: switched
     shutdown: false
     mode: {{ adapter_mode }}
@@ -61,12 +95,12 @@ port_channel_interfaces:
 {%                             endfor %}
 {%                         endif %}
 {%                         if adapter.switches | unique | list | length > 1 %}
-{%                             if adapter_port_channel.short_esi is arista.avd.defined %}
-{%                                 if adapter_port_channel.short_esi.split(':') | length == 3 %}
-    esi: {{ adapter_port_channel.short_esi | arista.avd.generate_esi }}
-    rt: {{ adapter_port_channel.short_esi | arista.avd.generate_route_target }}
-{%                                     if adapter_port_channel.mode == 'active' %}
-    lacp_id: {{ adapter_port_channel.short_esi | arista.avd.generate_lacp_id }}
+{%                             if adapter.port_channel.short_esi is arista.avd.defined %}
+{%                                 if adapter.port_channel.short_esi.split(':') | length == 3 %}
+    esi: {{ adapter.port_channel.short_esi | arista.avd.generate_esi }}
+    rt: {{ adapter.port_channel.short_esi | arista.avd.generate_route_target }}
+{%                                     if adapter_port_channel_mode == 'active' %}
+    lacp_id: {{ adapter.port_channel.short_esi | arista.avd.generate_lacp_id }}
 {%                                     endif %}
 {%                                 endif %}
 {%                             else %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/port-channel-interfaces.j2
@@ -8,57 +8,57 @@ port_channel_interfaces:
 {%             else %}
 {%                 set adapter_profile = dict() %}
 {%             endif %}
-{%             if adapter_profile.profile is arista.avd.defined %}
-{%                 set base_profile = port_profiles[adapter_profile.profile] | arista.avd.default({}) %}
+{%             if adapter_profile.parent_profile is arista.avd.defined %}
+{%                 set parent_profile = port_profiles[adapter_profile.parent_profile] | arista.avd.default({}) %}
 {%             endif %}
 {%             set adapter_port_channel = adapter.port_channel | arista.avd.default(
                                           adapter_profile.port_channel,
-                                          base_profile.port_channel) %}
+                                          parent_profile.port_channel) %}
 {%             if adapter_port_channel is arista.avd.defined and adapter_port_channel.mode is arista.avd.defined %}
 {%                 set adapter_port_channel_description = adapter.port_channel.description | arista.avd.default(
                                                           adapter_profile.port_channel.description,
-                                                          base_profile.port_channel.description) %}
+                                                          parent_profile.port_channel.description) %}
 {%                 for switch in adapter.switches | arista.avd.natural_sort %}
 {%                     if switch == inventory_hostname %}
 {%                         set adapter_mode = adapter.mode | arista.avd.default(
                                               adapter_profile.mode,
-                                              base_profile.mode) %}
+                                              parent_profile.mode) %}
 {%                         set adapter_l2_mtu = adapter.l2_mtu | arista.avd.default(
                                                 adapter_profile.l2_mtu,
-                                                base_profile.l2_mtu) %}
+                                                parent_profile.l2_mtu) %}
 {%                         set adapter_vlans = adapter.vlans | arista.avd.default(
                                                adapter_profile.vlans,
-                                               base_profile.vlans) %}
+                                               parent_profile.vlans) %}
 {%                         set adapter_native_vlan = adapter.native_vlan | arista.avd.default(
                                                      adapter_profile.native_vlan,
-                                                     base_profile.native_vlan) %}
+                                                     parent_profile.native_vlan) %}
 {%                         set adapter_spanning_tree_portfast = adapter.spanning_tree_portfast | arista.avd.default(
                                                                 adapter_profile.spanning_tree_portfast,
-                                                                base_profile.spanning_tree_portfast) %}
+                                                                parent_profile.spanning_tree_portfast) %}
 {%                         set adapter_spanning_tree_bpdufilter = adapter.spanning_tree_bpdufilter | arista.avd.default(
                                                                   adapter_profile.spanning_tree_bpdufilter,
-                                                                  base_profile.spanning_tree_bpdufilter) %}
+                                                                  parent_profile.spanning_tree_bpdufilter) %}
 {%                         set adapter_spanning_tree_bpduguard = adapter.spanning_tree_bpduguard | arista.avd.default(
                                                                  adapter_profile.spanning_tree_bpduguard,
-                                                                 base_profile.spanning_tree_bpduguard) %}
+                                                                 parent_profile.spanning_tree_bpduguard) %}
 {%                         set adapter_storm_control = adapter.storm_control | arista.avd.default(
                                                        adapter_profile.storm_control,
-                                                       base_profile.storm_control) %}
+                                                       parent_profile.storm_control) %}
 {%                         set adapter_flowcontrol = adapter.flowcontrol | arista.avd.default(
                                                      adapter_profile.flowcontrol,
-                                                     base_profile.flowcontrol) %}
+                                                     parent_profile.flowcontrol) %}
 {%                         set adapter_qos_profile = adapter.qos_profile | arista.avd.default(
                                                      adapter_profile.qos_profile,
-                                                     base_profile.qos_profile) %}
+                                                     parent_profile.qos_profile) %}
 {%                         set adapter_mtu = adapter.mtu | arista.avd.default(
                                              adapter_profile.mtu,
-                                             base_profile.mtu) %}
+                                             parent_profile.mtu) %}
 {%                         set lacp_fallback_mode = adapter.port_channel.lacp_fallback.mode | arista.avd.default(
                                                     adapter_profile.port_channel.lacp_fallback.mode,
-                                                    base_profile.port_channel.lacp_fallback.mode) %}
+                                                    parent_profile.port_channel.lacp_fallback.mode) %}
 {%                         set lacp_fallback_timeout = adapter.port_channel.lacp_fallback.timeout | arista.avd.default(
                                                        adapter_profile.port_channel.lacp_fallback.timeout,
-                                                       base_profile.port_channel.lacp_fallback.timeout) %}
+                                                       parent_profile.port_channel.lacp_fallback.timeout) %}
 {%                         set channel_group_id = (adapter.switch_ports[0] | regex_findall("\d") | join) %}
   Port-Channel{{ channel_group_id }}:
     description: {{ connected_endpoint }}_{{ adapter_port_channel_description }}


### PR DESCRIPTION
## Change Summary

Support for 2-level inheritance on port-profiles

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Fixes #875 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->
Adding `profile` keyword to port-profiles so they can inherit settings.

```yaml
# Port_profiles can refer to another port_profile to inherit settings in up to two levels (adapter->profile->profile).
port_profiles:
  < port_profile_1 >:
    parent_profile: < port_profile_name >
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Added molecule test cases and also verified that none of the existing cases broke.
Also added negative test by pointing at non-existing nested profile.
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
