### PR TITLE
include device structured config conditionally + playbook code style

### DIFF
--- a/ansible_collections/arista/avd/roles/build_output_folders/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/build_output_folders/tasks/main.yml
@@ -1,89 +1,89 @@
 ---
 # tasks file for build_directories
 
-- name: 'Cleanup existing folders in {{ output_dir }}'
+- name: "Cleanup existing folders in {{ output_dir }}"
   file:
-    path: '{{ output_dir }}'
+    path: "{{ output_dir }}"
     state: absent
     mode: 0755
   delegate_to: localhost
   run_once: True
 
-- name: 'Create folder {{ output_dir }}'
+- name: "Create folder {{ output_dir }}"
   file:
-    path: '{{ output_dir }}'
+    path: "{{ output_dir }}"
     state: directory
     mode: 0755
   delegate_to: localhost
   run_once: True
 
-- name: 'Create folder {{ structured_dir_name }} for structured YAML files'
+- name: "Create folder {{ structured_dir_name }} for structured YAML files"
   file:
-    path: '{{ structured_dir }}'
+    path: "{{ structured_dir }}"
     state: directory
     mode: 0755
   delegate_to: localhost
   run_once: True
 
-- name: 'Create folder {{ eos_config_dir_name }} for EOS Configuration files'
+- name: "Create folder {{ eos_config_dir_name }} for EOS Configuration files"
   file:
-    path: '{{ eos_config_dir }}'
+    path: "{{ eos_config_dir }}"
     state: directory
     mode: 0755
   delegate_to: localhost
   run_once: True
 
-- name: 'Create folder {{ structured_cvp_name }} for CVP structured YAML files'
+- name: "Create folder {{ structured_cvp_name }} for CVP structured YAML files"
   file:
-    path: '{{ structured_cvp }}'
+    path: "{{ structured_cvp }}"
     state: directory
     mode: 0755
   delegate_to: localhost
   run_once: True
 
-- name: 'Create documentation folder: {{ documentation_dir_name }}'
+- name: "Create documentation folder: {{ documentation_dir_name }}"
   file:
-    path: '{{ documentation_dir }}'
+    path: "{{ documentation_dir }}"
     state: directory
     mode: 0755
   delegate_to: localhost
   run_once: True
 
-- name: 'Create folder {{ fabric_dir_name }} for Fabric documentation'
+- name: "Create folder {{ fabric_dir_name }} for Fabric documentation"
   file:
-    path: '{{ fabric_dir }}'
+    path: "{{ fabric_dir }}"
     state: directory
     mode: 0755
   delegate_to: localhost
   run_once: True
 
-- name: 'Create folder {{ devices_dir_name }} for EOS documentation'
+- name: "Create folder {{ devices_dir_name }} for EOS documentation"
   file:
-    path: '{{ devices_dir }}'
+    path: "{{ devices_dir }}"
     state: directory
     mode: 0755
   delegate_to: localhost
   run_once: True
 
-- name: 'Create folder {{ post_running_config_backup_dir }} for EOS post backup dir'
+- name: "Create folder {{ post_running_config_backup_dir }} for EOS post backup dir"
   file:
-    path: '{{ post_running_config_backup_dir }}'
+    path: "{{ post_running_config_backup_dir }}"
     state: directory
     mode: 0755
   delegate_to: localhost
   run_once: True
 
-- name: 'Create folder {{ pre_running_config_backup_dir }} for EOS pre backup dir'
+- name: "Create folder {{ pre_running_config_backup_dir }} for EOS pre backup dir"
   file:
-    path: '{{ pre_running_config_backup_dir }}'
+    path: "{{ pre_running_config_backup_dir }}"
     state: directory
     mode: 0755
   delegate_to: localhost
   run_once: True
 
-- name: 'Create folder {{ eos_validate_state_name }} for EOS state report dir'
+- name: "Create folder {{ eos_validate_state_name }} for EOS state report dir"
   file:
-    path: '{{ eos_validate_state_dir }}'
+    path: "{{ eos_validate_state_dir }}"
     state: directory
     mode: 0755
   delegate_to: localhost

--- a/ansible_collections/arista/avd/roles/cvp_configlet_upload/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/cvp_configlet_upload/tasks/main.yml
@@ -3,17 +3,17 @@
 - name: generate intented variables
   tags: [build, provision, apply]
   arista.avd.configlet_build_config:
-    configlet_dir: '{{ configlet_directory }}'
-    configlet_prefix: '{{ configlets_cvp_prefix }}'
-    configlet_extension: '{{ file_extension }}'
+    configlet_dir: "{{ configlet_directory }}"
+    configlet_prefix: "{{ configlets_cvp_prefix }}"
+    configlet_extension: "{{ file_extension }}"
   register: CVP_VARS
 
-- name: 'collecting facts from CVP {{ inventory_hostname }}.'
+- name: "collecting facts from CVP {{ inventory_hostname }}."
   tags: [provision, apply]
   arista.cvp.cv_facts:
   register: CVP_FACTS
 
-- name: 'create configlets on CVP {{ inventory_hostname }}.'
+- name: "create configlets on CVP {{ inventory_hostname }}."
   tags: [provision, apply]
   arista.cvp.cv_configlet:
     cvp_facts: "{{ CVP_FACTS.ansible_facts }}"

--- a/ansible_collections/arista/avd/roles/dhcp_provisioner/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/dhcp_provisioner/tasks/main.yml
@@ -1,14 +1,14 @@
 ---
 # tasks file for dhcp_provisioner
-- name: 'build DHCP intended variables'
+- name: Build DHCP intended variables
   template:
     src: ztp_configuration.j2
-    dest: '{{ root_dir }}/intended/structured_configs/cvp/ztp_configuration.yml'
+    dest: "{{ root_dir }}/intended/structured_configs/cvp/ztp_configuration.yml"
   delegate_to: localhost
   run_once: true
 
-- name: 'include DHCP variables to build dhcpd.conf file'
-  include_vars: '{{ root_dir }}/intended/structured_configs/cvp/ztp_configuration.yml'
+- name: include DHCP variables to build dhcpd.conf file
+  include_vars: "{{ root_dir }}/intended/structured_configs/cvp/ztp_configuration.yml"
   run_once: true
 
 - name: start creation/update process.

--- a/ansible_collections/arista/avd/roles/dhcp_provisioner/tasks/offline.yml
+++ b/ansible_collections/arista/avd/roles/dhcp_provisioner/tasks/offline.yml
@@ -1,11 +1,11 @@
 ---
 # Tasks to build offline dhcpd.conf file
 
-- name: 'Execute DHCP configuration role'
+- name: Execute DHCP configuration role
   import_role:
     name: arista.cvp.dhcp_configuration
   vars:
     mode: offline
-    output_dir: '{{ root_dir }}/intended/configs/'
+    output_dir: "{{ root_dir }}/intended/configs/"
   delegate_to: localhost
   run_once: true

--- a/ansible_collections/arista/avd/roles/dhcp_provisioner/tasks/online.yml
+++ b/ansible_collections/arista/avd/roles/dhcp_provisioner/tasks/online.yml
@@ -1,9 +1,9 @@
 ---
 # Tasks to build online dhcpd.conf to specified server
 
-- name: 'Execute DHCP configuration role'
+- name: Execute DHCP configuration role
   import_role:
     name: arista.cvp.dhcp_configuration
   vars:
     mode: online
-    output_dir: '{{ root_dir }}/intended/configs/'
+    output_dir: "{{ root_dir }}/intended/configs/"

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/tasks/main.yml
@@ -2,13 +2,13 @@
 - name: Check if structure configuration file exists
   tags: [build, provision]
   stat:
-    path: '{{ root_dir }}/intended/structured_configs//{{ inventory_hostname }}.yml'
+    path: "{{ root_dir }}/intended/structured_configs//{{ inventory_hostname }}.yml"
   register: stat_result
   delegate_to: localhost
   when: structured_config is not defined
 
 - name: Include device intended structure configuration variables
-  include_vars: '{{ root_dir }}/intended/structured_configs//{{ inventory_hostname }}.yml'
+  include_vars: "{{ root_dir }}/intended/structured_configs//{{ inventory_hostname }}.yml"
   delegate_to: localhost
   tags: [build, provision]
   when: structured_config is not defined and stat_result.stat.exists
@@ -16,7 +16,7 @@
 - name: Generate eos intended configuration
   template:
     src: eos-intended-config.j2
-    dest: '{{ root_dir }}/intended/configs/{{ inventory_hostname }}.cfg'
+    dest: "{{ root_dir }}/intended/configs/{{ inventory_hostname }}.cfg"
   delegate_to: localhost
   register: eosconfig
   tags: [build, provision]
@@ -27,7 +27,7 @@
   block:
     - name: Store checksum of existing device documentation
       ansible.builtin.stat:
-        path: '{{ root_dir }}/documentation/devices/{{ inventory_hostname }}.md'
+        path: "{{ root_dir }}/documentation/devices/{{ inventory_hostname }}.md"
         checksum_algorithm: sha224
         get_attributes: no
         get_checksum: yes
@@ -36,11 +36,11 @@
     - name: Generate content of device documentation
       template:
         src: eos-device-documentation.j2
-        dest: '{{ root_dir }}/documentation/devices/{{ inventory_hostname }}.md'
+        dest: "{{ root_dir }}/documentation/devices/{{ inventory_hostname }}.md"
       changed_when: false
     - name: Generate TOC for device documentation
       add_toc:
-        md_file: '{{ root_dir }}/documentation/devices/{{ inventory_hostname }}.md'
+        md_file: "{{ root_dir }}/documentation/devices/{{ inventory_hostname }}.md"
         skip_lines: 3
       register: toc_result
       changed_when: toc_result.checksum | default('1') != doc_stat_result.stat.checksum | default('0')

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/tasks/main.yml
@@ -5,12 +5,13 @@
     path: '{{ root_dir }}/intended/structured_configs//{{ inventory_hostname }}.yml'
   register: stat_result
   delegate_to: localhost
+  when: structured_config is not defined
 
 - name: Include device intended structure configuration variables
   include_vars: '{{ root_dir }}/intended/structured_configs//{{ inventory_hostname }}.yml'
   delegate_to: localhost
   tags: [build, provision]
-  when: stat_result.stat.exists
+  when: structured_config is not defined and stat_result.stat.exists
 
 - name: Generate eos intended configuration
   template:

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/absent.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/absent.yml
@@ -1,6 +1,6 @@
 ---
 # tasks file for eos-config-deploy-cvp - state=absent
-- name: 'Collecting facts from CVP {{ inventory_hostname }}.'
+- name: "Collecting facts from CVP {{ inventory_hostname }}."
   tags: [reset]
   arista.cvp.cv_facts:
   register: CVP_FACTS
@@ -23,7 +23,7 @@
     tasks: "{{ CVP_DEVICES_RESULTS.data.tasks }}"
     wait: 720
 
-- name: 'Refreshing facts from CVP {{ inventory_hostname }}.'
+- name: "Refreshing facts from CVP {{ inventory_hostname }}."
   tags: [reset]
   arista.cvp.cv_facts:
   register: CVP_FACTS
@@ -31,11 +31,11 @@
 - name: "Deleting Containers topology on {{ inventory_hostname }}"
   tags: [reset]
   arista.cvp.cv_container:
-    topology: '{{ CVP_CONTAINERS }}'
-    cvp_facts: '{{ CVP_FACTS.ansible_facts }}'
+    topology: "{{ CVP_CONTAINERS }}"
+    cvp_facts: "{{ CVP_FACTS.ansible_facts }}"
     mode: delete
 
-- name: 'Delete configlets from CVP {{ inventory_hostname }}.'
+- name: "Delete configlets from CVP {{ inventory_hostname }}."
   tags: [reset]
   arista.cvp.cv_configlet:
     cvp_facts: "{{ CVP_FACTS.ansible_facts }}"

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/cv-device-filter-list.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/cv-device-filter-list.yml
@@ -3,7 +3,7 @@
   tags: [provision, apply]
   arista.cvp.cv_device:
     devices: "{{ CVP_DEVICES }}"
-    cvp_facts: '{{ CVP_FACTS.ansible_facts }}'
-    device_filter: '{{ device_filter }}'
+    cvp_facts: "{{ CVP_FACTS.ansible_facts }}"
+    device_filter: "{{ device_filter }}"
     state: "{{ state }}"
   register: CVP_DEVICES_RESULTS

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/cv-device-filter-string.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/cv-device-filter-string.yml
@@ -3,7 +3,7 @@
   tags: [provision, apply]
   arista.cvp.cv_device:
     devices: "{{ CVP_DEVICES }}"
-    cvp_facts: '{{ CVP_FACTS.ansible_facts }}'
-    device_filter: ['{{ device_filter }}']
+    cvp_facts: "{{ CVP_FACTS.ansible_facts }}"
+    device_filter: ["{{ device_filter }}"]
     state: "{{ state }}"
   register: CVP_DEVICES_RESULTS

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/main-filter-list.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/main-filter-list.yml
@@ -2,10 +2,10 @@
 - name: generate intented variables
   tags: [always]
   arista.avd.inventory_to_container:
-    inventory: '{{ inventory_file }}'
-    container_root: '{{ container_root }}'
-    configlet_dir: '{{ root_dir }}/intended/configs'
-    configlet_prefix: '{{ configlets_prefix }}'
-    destination: '{{ root_dir }}/intended/structured_configs/cvp/{{ inventory_hostname }}_configlets.yml'
+    inventory: "{{ inventory_file }}"
+    container_root: "{{ container_root }}"
+    configlet_dir: "{{ root_dir }}/intended/configs"
+    configlet_prefix: "{{ configlets_prefix }}"
+    destination: "{{ root_dir }}/intended/structured_configs/cvp/{{ inventory_hostname }}_configlets.yml"
     device_filter: "{{ device_filter }}"
   register: CVP_VARS

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/main-filter-string.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/main-filter-string.yml
@@ -2,10 +2,10 @@
 - name: generate intented variables
   tags: [always]
   arista.avd.inventory_to_container:
-    inventory: '{{ inventory_file }}'
-    container_root: '{{ container_root }}'
-    configlet_dir: '{{ root_dir }}/intended/configs'
-    configlet_prefix: '{{ configlets_prefix }}'
-    destination: '{{ root_dir }}/intended/structured_configs/cvp/{{ inventory_hostname }}_configlets.yml'
+    inventory: "{{ inventory_file }}"
+    container_root: "{{ container_root }}"
+    configlet_dir: "{{ root_dir }}/intended/configs"
+    configlet_prefix: "{{ configlets_prefix }}"
+    destination: "{{ root_dir }}/intended/structured_configs/cvp/{{ inventory_hostname }}_configlets.yml"
     device_filter: ['{{ device_filter }}']
   register: CVP_VARS

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/main.yml
@@ -13,17 +13,17 @@
   include_tasks: "./main-filter-list.yml"
   when: "device_filter is not string"
 
-- name: 'Build DEVICES and CONTAINER definition for {{ inventory_hostname }}'
+- name: "Build DEVICES and CONTAINER definition for {{ inventory_hostname }}"
   tags: [generate, build, provision]
   template:
     src: "cvp-devices.j2"
-    dest: '{{ root_dir }}/intended/structured_configs/cvp/{{ inventory_hostname }}.yml'
+    dest: "{{ root_dir }}/intended/structured_configs/cvp/{{ inventory_hostname }}.yml"
   delegate_to: localhost
   run_once: true
 
 - name: "Load CVP device information for {{ inventory_hostname }}"
   tags: [build, provision, online]
-  include_vars: '{{ root_dir }}/intended/structured_configs/cvp/{{ inventory_hostname }}.yml'
+  include_vars: "{{ root_dir }}/intended/structured_configs/cvp/{{ inventory_hostname }}.yml"
   # delegate_to: localhost
 
 #################################################

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/present.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/present.yml
@@ -1,6 +1,6 @@
 ---
 # tasks file for eos-config-deploy-cvp - state=present
-- name: 'Collecting facts from CVP {{ inventory_hostname }}.'
+- name: "Collecting facts from CVP {{ inventory_hostname }}."
   tags: [always]
   arista.cvp.cv_facts:
   register: CVP_FACTS
@@ -11,7 +11,7 @@
     tasks: "{{ CVP_FACTS.ansible_facts.tasks }}"
   when: execute_tasks|bool
 
-- name: 'Create configlets on CVP {{ inventory_hostname }}.'
+- name: "Create configlets on CVP {{ inventory_hostname }}."
   tags: [provision]
   arista.cvp.cv_configlet:
     cvp_facts: "{{ CVP_FACTS.ansible_facts }}"
@@ -19,7 +19,7 @@
     configlet_filter: ["{{ configlets_prefix }}"]
   register: CVP_CONFIGLETS_STATUS
 
-- name: 'Execute any configlet generated tasks to update configuration on {{ inventory_hostname }}'
+- name: "Execute any configlet generated tasks to update configuration on {{ inventory_hostname }}"
   tags: [apply]
   arista.cvp.cv_task:
     tasks: "{{ CVP_CONFIGLETS_STATUS.data.tasks }}"
@@ -31,8 +31,8 @@
 - name: "Building Containers topology on {{ inventory_hostname }}"
   tags: [provision]
   arista.cvp.cv_container:
-    topology: '{{ CVP_CONTAINERS }}'
-    cvp_facts: '{{ CVP_FACTS.ansible_facts }}'
+    topology: "{{ CVP_CONTAINERS }}"
+    cvp_facts: "{{ CVP_FACTS.ansible_facts }}"
   register: CVP_CONTAINER_RESULTS
 
 - name: "Execute pending tasks on {{ inventory_hostname }}"
@@ -43,7 +43,7 @@
   when:
     - execute_tasks|bool
 
-- name: 'Refreshing facts from CVP {{ inventory_hostname }}.'
+- name: "Refreshing facts from CVP {{ inventory_hostname }}."
   tags: [always]
   arista.cvp.cv_facts:
   register: CVP_FACTS

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_eapi/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_eapi/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: replace configuration with intended configuration
   eos_config:
-    src: '{{ root_dir }}/intended/configs/{{ inventory_hostname }}.cfg'
+    src: "{{ root_dir }}/intended/configs/{{ inventory_hostname }}.cfg"
     replace: config
     save_when: modified
     backup: "{{ eos_config_deploy_eapi_pre_running_config_backup }}"

--- a/ansible_collections/arista/avd/roles/eos_designs/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/tasks/main.yml
@@ -10,7 +10,7 @@
 - name: Generate YAML file with hostvars (only for debugging)
   template:
     src: debug/generate-debug-vars.j2
-    dest: '{{ root_dir }}/intended/structured_configs/{{ inventory_hostname }}-debug-vars.yml'
+    dest: "{{ root_dir }}/intended/structured_configs/{{ inventory_hostname }}-debug-vars.yml"
   delegate_to: localhost
   changed_when: False
   tags: [debug, never]
@@ -26,13 +26,13 @@
 - name: Write device structured configuration to YAML file
   template:
     src: generate-structured-config.j2
-    dest: '{{ root_dir }}/intended/structured_configs/{{ inventory_hostname }}.yml'
+    dest: "{{ root_dir }}/intended/structured_configs/{{ inventory_hostname }}.yml"
   delegate_to: localhost
   changed_when: False
   tags: [build, provision]
 
 - name: Include device structured configuration, that was previously generated.
-  include_vars: '{{ root_dir }}/intended/structured_configs/{{ inventory_hostname }}.yml'
+  include_vars: "{{ root_dir }}/intended/structured_configs/{{ inventory_hostname }}.yml"
   delegate_to: localhost
   tags: [build, provision]
 
@@ -44,7 +44,7 @@
   block:
     - name: Store checksum of existing fabric documentation
       ansible.builtin.stat:
-        path: '{{ root_dir }}/documentation/fabric/{{ fabric_name }}-documentation.md'
+        path: "{{ root_dir }}/documentation/fabric/{{ fabric_name }}-documentation.md"
         checksum_algorithm: sha224
         get_attributes: no
         get_checksum: yes
@@ -53,11 +53,11 @@
     - name: Generate fabric documentation in Markdown Format.
       template:
         src: fabric-documentation.j2
-        dest: '{{ root_dir }}/documentation/fabric/{{ fabric_name }}-documentation.md'
+        dest: "{{ root_dir }}/documentation/fabric/{{ fabric_name }}-documentation.md"
       changed_when: false
     - name: Generate TOC for fabric documentation
       add_toc:
-        md_file: '{{ root_dir }}/documentation/fabric/{{ fabric_name }}-documentation.md'
+        md_file: "{{ root_dir }}/documentation/fabric/{{ fabric_name }}-documentation.md"
         skip_lines: 3
       register: toc_result
       changed_when: toc_result.checksum | default('1') != doc_stat_result.stat.checksum | default('0')
@@ -65,7 +65,7 @@
 - name: Generate fabric point-to-point links summary in csv format.
   template:
     src: documentation/fabric-p2p-links.j2
-    dest: '{{ root_dir }}/documentation/fabric/{{ fabric_name }}-p2p-links.csv'
+    dest: "{{ root_dir }}/documentation/fabric/{{ fabric_name }}-p2p-links.csv"
   delegate_to: localhost
   run_once: true
   check_mode: no
@@ -74,7 +74,7 @@
 - name: Generate fabric topology in csv format.
   template:
     src: documentation/fabric-topology.j2
-    dest: '{{ root_dir }}/documentation/fabric/{{ fabric_name }}-topology.csv'
+    dest: "{{ root_dir }}/documentation/fabric/{{ fabric_name }}-topology.csv"
   delegate_to: localhost
   run_once: true
   check_mode: no

--- a/ansible_collections/arista/avd/roles/eos_snapshot/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_snapshot/tasks/main.yml
@@ -19,7 +19,7 @@
     src: device_text_command.j2
     dest: "{{ snapshots_backup_dir }}/{{ inventory_hostname }}/{{ item.item }}.txt"
   loop: "{{ cli_output.results }}"
-  when: '"text" in output_format'
+  when: "'text' in output_format"
 
 - name: Generate json report for fabric
   template:
@@ -27,7 +27,7 @@
     dest: "{{ snapshots_backup_dir }}/report.json"
   delegate_to: localhost
   run_once: true
-  when: '"json" in output_format'
+  when: "'json' in output_format"
 
 - name: Generate yaml report for fabric
   template:
@@ -35,9 +35,8 @@
     dest: "{{ snapshots_backup_dir }}/report.yaml"
   delegate_to: localhost
   run_once: true
-  when: '"yaml" in output_format'
+  when: "'yaml' in output_format"
 
 - name: Generate markdown report for fabric
   include_tasks: "markdown.yml"
-  when:
-    - '"markdown" in output_format'
+  when: "'markdown' in output_format"

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/bgp_check.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/bgp_check.yml
@@ -12,11 +12,11 @@
 - name: Validate ArBGP is configured and operating
   assert:
     that:
-      - ip_route_summary.stdout_lines[0][0] | regex_search("multi-agent")
-      - ip_route_summary.stdout_lines[0][1] | regex_search("multi-agent")
+      - ip_route_summary.stdout_lines[0][0] | regex_search('multi-agent')
+      - ip_route_summary.stdout_lines[0][1] | regex_search('multi-agent')
     fail_msg: "{{ ip_route_summary.stdout_lines[0][0] }}, {{ ip_route_summary.stdout_lines[0][1] }}"
     quiet: yes
-  when: (service_routing_protocols_model is defined and service_routing_protocols_model == "multi-agent")
+  when: (service_routing_protocols_model is defined and service_routing_protocols_model == 'multi-agent')
   ignore_errors: "{{ eos_validate_state_validation_mode_loose }}"
   register: arbgp_state_results
   tags:
@@ -36,14 +36,14 @@
 - name: Validate ip bgp neighbors peer state
   assert:
     that:
-      - bgp_summary.stdout[0].vrfs.default.peers[bgp_neighbor.key].peerState == "Established"
+      - bgp_summary.stdout[0].vrfs.default.peers[bgp_neighbor.key].peerState == 'Established'
     fail_msg: Session state "{{ bgp_summary.stdout[0].vrfs.default.peers[bgp_neighbor.key].peerState }}"
     quiet: yes
   loop: "{{ router_bgp.neighbors | default({}, true) | dict2items }}"
   loop_control:
     loop_var: bgp_neighbor
   when: |
-    (router_bgp.peer_groups[bgp_neighbor.value.peer_group].type == "ipv4" and arbgp_state_results)
+    (router_bgp.peer_groups[bgp_neighbor.value.peer_group].type == 'ipv4' and arbgp_state_results)
   ignore_errors: "{{ eos_validate_state_validation_mode_loose }}"
   register: ip_bgp_peer_state_results
   tags:
@@ -52,14 +52,14 @@
 - name: Validate bgp evpn neighbors peer state
   assert:
     that:
-      - bgp_summary.stdout[1].vrfs.default.peers[bgp_neighbor.key].peerState == "Established"
+      - bgp_summary.stdout[1].vrfs.default.peers[bgp_neighbor.key].peerState == 'Established'
     fail_msg: Session state "{{ bgp_summary.stdout[1].vrfs.default.peers[bgp_neighbor.key].peerState }}"
     quiet: yes
   loop: "{{ router_bgp.neighbors | default({}, true) | dict2items }}"
   loop_control:
     loop_var: bgp_neighbor
   when: |
-    (router_bgp.peer_groups[bgp_neighbor.value.peer_group].type == "evpn"  and arbgp_state_results)
+    (router_bgp.peer_groups[bgp_neighbor.value.peer_group].type == 'evpn'  and arbgp_state_results)
   ignore_errors: "{{ eos_validate_state_validation_mode_loose }}"
   register: bgp_evpn_peer_state_results
   tags:

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/hardware.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/hardware.yml
@@ -69,7 +69,7 @@
 - name: Validate system temperature
   assert:
     that:
-      - environment_temperature.stdout[0].systemStatus == "temperatureOk"
+      - environment_temperature.stdout[0].systemStatus == 'temperatureOk'
     fail_msg: system temperature is "{{ environment_temperature.stdout[0].systemStatus }}"
     quiet: true
   ignore_errors: "{{ eos_validate_state_validation_mode_loose }}"

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/interface_state.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/interface_state.yml
@@ -13,8 +13,8 @@
 - name: Validate Ethernet interfaces state
   assert:
     that:
-      - interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.key].interfaceStatus == "up"
-      - interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.key].lineProtocolStatus == "up"
+      - interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.key].interfaceStatus == 'up'
+      - interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.key].lineProtocolStatus == 'up'
     fail_msg: "interface status: {{ interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.key].interfaceStatus }} - line protocol status: {{ interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.key].lineProtocolStatus }}"
     quiet: true
   loop: "{{ ethernet_interfaces | default({}, true) | dict2items }}"
@@ -28,8 +28,8 @@
 - name: Validate Port-Channel interfaces state
   assert:
     that:
-      - interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.key].interfaceStatus == "up"
-      - interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.key].lineProtocolStatus == "up"
+      - interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.key].interfaceStatus == 'up'
+      - interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.key].lineProtocolStatus == 'up'
     fail_msg: "interface status: {{ interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.key].interfaceStatus }} - line protocol status: {{ interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.key].lineProtocolStatus }}"
     quiet: true
   loop: "{{ port_channel_interfaces | default({}, true) | dict2items }}"
@@ -43,8 +43,8 @@
 - name: Validate Vlan interfaces state
   assert:
     that:
-      - interfaces_state.stdout[0].interfaceDescriptions[vlan_interface.key].interfaceStatus == "up"
-      - interfaces_state.stdout[0].interfaceDescriptions[vlan_interface.key].lineProtocolStatus == "up"
+      - interfaces_state.stdout[0].interfaceDescriptions[vlan_interface.key].interfaceStatus == 'up'
+      - interfaces_state.stdout[0].interfaceDescriptions[vlan_interface.key].lineProtocolStatus == 'up'
     fail_msg: "interface status: {{ interfaces_state.stdout[0].interfaceDescriptions[vlan_interface.key].interfaceStatus }} - line protocol status: {{ interfaces_state.stdout[0].interfaceDescriptions[vlan_interface.key].lineProtocolStatus }}"
     quiet: true
   loop: "{{ vlan_interfaces | default({}, true) | dict2items }}"
@@ -58,8 +58,8 @@
 - name: Validate Vxlan interfaces state
   assert:
     that:
-      - interfaces_state.stdout[0].interfaceDescriptions.Vxlan1.interfaceStatus == "up"
-      - interfaces_state.stdout[0].interfaceDescriptions.Vxlan1.lineProtocolStatus == "up"
+      - interfaces_state.stdout[0].interfaceDescriptions.Vxlan1.interfaceStatus == 'up'
+      - interfaces_state.stdout[0].interfaceDescriptions.Vxlan1.lineProtocolStatus == 'up'
     fail_msg: "interface status: {{ interfaces_state.stdout[0].interfaceDescriptions.Vxlan1.interfaceStatus }} - line protocol status: {{ interfaces_state.stdout[0].interfaceDescriptions.Vxlan1.lineProtocolStatus }}"
     quiet: true
   ignore_errors: "{{ eos_validate_state_validation_mode_loose }}"
@@ -71,8 +71,8 @@
 - name: Validate Loopback interfaces state
   assert:
     that:
-      - interfaces_state.stdout[0].interfaceDescriptions[loopback_interface.key].interfaceStatus == "up"
-      - interfaces_state.stdout[0].interfaceDescriptions[loopback_interface.key].lineProtocolStatus == "up"
+      - interfaces_state.stdout[0].interfaceDescriptions[loopback_interface.key].interfaceStatus == 'up'
+      - interfaces_state.stdout[0].interfaceDescriptions[loopback_interface.key].lineProtocolStatus == 'up'
     fail_msg: "interface status: {{ interfaces_state.stdout[0].interfaceDescriptions[loopback_interface.key].interfaceStatus }} - line protocol status: {{ interfaces_state.stdout[0].interfaceDescriptions[loopback_interface.key].lineProtocolStatus }}"
     quiet: true
   loop: "{{ loopback_interfaces | default({}, true) | dict2items }}"

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/ip_reachability.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/ip_reachability.yml
@@ -24,7 +24,7 @@
 - name: Validate ip reachability (directly connected interfaces)
   assert:
     that:
-      - ip_reachability_test.stdout[0] | regex_search("1 received")
+      - ip_reachability_test.stdout[0] | regex_search('1 received')
     fail_msg: "100% packet loss"
     quiet: true
   loop: "{{ ip_reachability_state.results }}"

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/lldp_topology_fqdn.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/lldp_topology_fqdn.yml
@@ -14,8 +14,8 @@
   assert:
     that:
       - lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0] is defined
-      - lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0].systemName == ethernet_interface.value.peer + "." + hostvars[ethernet_interface.value.peer]['dns_domain']
-      - lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0].neighborInterfaceInfo.interfaceId == "\"" + ethernet_interface.value.peer_interface + "\""
+      - lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0].systemName == ethernet_interface.value.peer + '.' + hostvars[ethernet_interface.value.peer]['dns_domain']
+      - lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0].neighborInterfaceInfo.interfaceId == '\'' + ethernet_interface.value.peer_interface + '\''
     fail_msg: "{{ lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0].systemName | default('Interface Down') }} - {{ lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0].neighborInterfaceInfo.interfaceId | default('N/A') }}"
     quiet: true
   loop: "{{ ethernet_interfaces | default({}, true) | dict2items }}"

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/lldp_topology_no_fqdn.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/lldp_topology_no_fqdn.yml
@@ -15,7 +15,7 @@
     that:
       - lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0] is defined
       - lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0].systemName == ethernet_interface.value.peer
-      - lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0].neighborInterfaceInfo.interfaceId == "\"" + ethernet_interface.value.peer_interface + "\""
+      - lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0].neighborInterfaceInfo.interfaceId == '\'' + ethernet_interface.value.peer_interface + '\''
     fail_msg: "{{ lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0].systemName | default('Interface Down') }} - {{ lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0].neighborInterfaceInfo.interfaceId | default('N/A') }}"
     quiet: true
   loop: "{{ ethernet_interfaces | default({}, true) | dict2items }}"

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/loopback0_reachability.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/loopback0_reachability.yml
@@ -10,7 +10,7 @@
   when: |
     (loopback0_reachability.loopback0_range is defined and loopback0_reachability.loopback0_range is not none) and
     (loopback_interfaces.Loopback0.ip_address is defined and loopback_interfaces.Loopback0.ip_address is not none) and
-    (type is defined and type != "l2leaf")
+    (type is defined and type != 'l2leaf')
   register: loopback0_reachability_state
   tags:
     - loopback0_reachability
@@ -43,7 +43,7 @@
 - name: Validate ip reachability from Inband Management to loopback0 in fabric
   assert:
     that:
-      - inb_mgmt_loopback0_reachability_test.stdout[0] | regex_search("1 received")
+      - inb_mgmt_loopback0_reachability_test.stdout[0] | regex_search('1 received')
     fail_msg: "100% packet loss"
     quiet: true
   loop: "{{ inb_mgmt_loopback0_reachability_state.results }}"

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/main.yml
@@ -4,13 +4,13 @@
   tags:
     - always
   stat:
-    path: '{{ inventory_dir }}/intended/structured_configs//{{ inventory_hostname }}.yml'
+    path: "{{ inventory_dir }}/intended/structured_configs//{{ inventory_hostname }}.yml"
   register: stat_result
   delegate_to: localhost
   when: structured_config is not defined
 
 - name: Include device intended structure configuration variables
-  include_vars: '{{ inventory_dir }}/intended/structured_configs//{{ inventory_hostname }}.yml'
+  include_vars: "{{ inventory_dir }}/intended/structured_configs//{{ inventory_hostname }}.yml"
   delegate_to: localhost
   tags:
     - always

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/main.yml
@@ -1,10 +1,20 @@
 ---
 
+- name: Check if structure configuration file exists
+  tags:
+    - always
+  stat:
+    path: '{{ inventory_dir }}/intended/structured_configs//{{ inventory_hostname }}.yml'
+  register: stat_result
+  delegate_to: localhost
+  when: structured_config is not defined
+
 - name: Include device intended structure configuration variables
   include_vars: '{{ inventory_dir }}/intended/structured_configs//{{ inventory_hostname }}.yml'
   delegate_to: localhost
   tags:
     - always
+  when: structured_config is not defined and stat_result.stat.exists
 
 - name: Generate variables for testing
   template:

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/mlag.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/mlag.yml
@@ -12,8 +12,8 @@
 - name: Validate mlag status
   assert:
     that:
-      - mlag_state.stdout[0].state == "active"
-      - mlag_state.stdout[0].negStatus == "connected"
+      - mlag_state.stdout[0].state == 'active'
+      - mlag_state.stdout[0].negStatus == 'connected'
     fail_msg: "state: {{ mlag_state.stdout[0].state }} - negotiation_status: {{ mlag_state.stdout[0].negStatus }}"
     quiet: true
   ignore_errors: "{{ eos_validate_state_validation_mode_loose }}"

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/ntp.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/ntp.yml
@@ -12,7 +12,7 @@
 - name: Validate ntp status
   assert:
     that:
-      - ntp_status.stdout[0] | regex_search("synchronised to NTP server")
+      - ntp_status.stdout[0] | regex_search('synchronised to NTP server')
     fail_msg: not synchronised to NTP server
     quiet: true
   ignore_errors: "{{ eos_validate_state_validation_mode_loose }}"

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/ping_inband.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/ping_inband.yml
@@ -9,7 +9,7 @@
   ignore_errors: "{{ eos_validate_state_validation_mode_loose }}"
   when: |
     (loopback0_reachability.loopback0_range is arista.avd.defined) and
-    (management_interface.value.type is arista.avd.defined("inband"))
+    (management_interface.value.type is arista.avd.defined('inband'))
   register: inb_mgmt_loopback0_reachability_state
   tags:
     - loopback0_reachability

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/reload_cause.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/reload_cause.yml
@@ -13,7 +13,7 @@
 
 - name: validate reload cause
   assert:
-    that: reload_cause.stdout_lines[0][2] == "Reload requested by the user."
+    that: reload_cause.stdout_lines[0][2] == 'Reload requested by the user.'
     fail_msg: "{{ reload_cause.stdout_lines[0][2] }}"
     quiet: true
   ignore_errors: "{{ eos_validate_state_validation_mode_loose }}"

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/routing_table.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/routing_table.yml
@@ -9,7 +9,7 @@
   ignore_errors: "{{ eos_validate_state_validation_mode_loose }}"
   when: |
     (loopback1_reachability.loopback1_range is defined and loopback1_reachability.loopback1_range is not none) and
-    (type is defined and type == "l3leaf")
+    (type is defined and type == 'l3leaf')
   register: routing_table_loopback1_state
   tags:
     - routing_table_check
@@ -38,7 +38,7 @@
   ignore_errors: "{{ eos_validate_state_validation_mode_loose }}"
   when: |
     (loopback0_reachability.loopback0_range is defined and loopback0_reachability.loopback0_range is not none) and
-    (type is defined and type != "l2leaf")
+    (type is defined and type != 'l2leaf')
   register: routing_table_loopback0_state
   tags:
     - routing_table_check

--- a/ansible_collections/arista/avd/roles/upgrade_tools/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/upgrade_tools/tasks/main.yml
@@ -1,3 +1,3 @@
 ---
-- name: 'Start Upgrade process for subset {{ subset }}.'
+- name: "Start Upgrade process for subset {{ subset }}."
   include_tasks: "./{{ subset }}.yml"

--- a/ansible_collections/arista/avd/roles/upgrade_tools/tasks/v1.0_to_v1.1.yml
+++ b/ansible_collections/arista/avd/roles/upgrade_tools/tasks/v1.0_to_v1.1.yml
@@ -1,8 +1,8 @@
 ---
 # create required directories
-- name: 'Create directory for updated data model'
+- name: Create directory for updated data model
   file:
-    path: '{{ inventory_dir }}/upgrade_1.0_to_1.1/group_vars'
+    path: "{{ inventory_dir }}/upgrade_1.0_to_1.1/group_vars"
     state: directory
     mode: 0755
   delegate_to: localhost
@@ -11,14 +11,14 @@
 # convert DC1_TENANTS_NETWORKS.yml from 1.0 to 1.1 version
 - name: load vars
   include_vars:
-    file: '{{ inventory_dir }}/group_vars/{{ item }}'
+    file: "{{ inventory_dir }}/group_vars/{{ item }}"
     name: tenants_and_networks
   run_once: true
 
 - name: convert DC1_TENANTS_NETWORKS.yml from 1.0 to 1.1 version
   template:
     src: "DC1_TENANTS_NETWORKS.j2"
-    dest: '{{ inventory_dir }}/upgrade_1.0_to_1.1/group_vars/{{ item }}'
+    dest: "{{ inventory_dir }}/upgrade_1.0_to_1.1/group_vars/{{ item }}"
   delegate_to: localhost
   run_once: true
   check_mode: no


### PR DESCRIPTION
## Change Summary

Optimize playbooks to only include structure configuration when not previously loaded.

Refactor playbook style to use `"` instead of `'` when referring to jinja2 blocks. Example

```yaml
# New Style
with_items: "{{ commands_list }}" 

# Replaces this style
with_items: '{{ commands_list }}'
```

Within jinja syntax use `'` instead of `"` when referring to a string

```yaml
# New Style
  assert:
    that:
      - mlag_state.stdout[0].state == 'active'

# Replaces this style
  assert:
    that:
      - mlag_state.stdout[0].state == "active"
```



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Component(s) name

`arista.avd.eos_cli_config_gen`
`arista.avd.eos_validate_state`

## Proposed changes

Add modify the following tasks in `tasks/main.yml`

```yaml
- name: Check if structure configuration file exists
  tags: [build, provision]
  stat:
    path: '{{ root_dir }}/intended/structured_configs//{{ inventory_hostname }}.yml'
  register: stat_result
  delegate_to: localhost
  when: structured_config is not defined

- name: Include device intended structure configuration variables
  include_vars: '{{ root_dir }}/intended/structured_configs//{{ inventory_hostname }}.yml'
  delegate_to: localhost
  tags: [build, provision]
  when: structured_config is not defined and stat_result.stat.exists
```


## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
