### PR TITLE
Fix(devcontainer): Resolve issue with devcontainer and windows support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,8 @@
+ARG VARIANT="3.6"
+FROM avdteam/base:${VARIANT}
+
+WORKDIR /workspace
+VOLUME ["/workspace"]
+
+USER avd
+RUN rm -f /home/avd/.gitconfig

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,11 +1,14 @@
 {
-    "dockerComposeFile": [
-        "../development/docker-compose.yml",
-    ],
-    "postStartCommand": ["sudo", "chmod", "666", "/var/run/docker.sock"],
+    "name": "AVD Development",
+    "build": {
+        "dockerfile": "Dockerfile",
+        // Update 'VARIANT' to pick Python version of AVD runner: 3.6, 3.7, 3.8
+        "args": { "VARIANT": "3.6" },
+    },
     "remoteUser": "avd",
-    "service": "ansible",
-    "workspaceFolder": "/projects/",
+    "updateRemoteUserUID": true,
+    "workspaceMount": "source=${localWorkspaceFolder}/..,target=/workspace,type=bind,consistency=delegated",
+    "workspaceFolder": "/workspace",
     "extensions": [
         "christian-kohler.path-intellisense",
         "codezombiech.gitignore",
@@ -36,7 +39,7 @@
     "settings": {
         "python.pythonPath": "/usr/local/bin/python",
         "python.analysis.extraPaths": [
-            "/projects/"
+            "/workspace/"
         ],
         "python.linting.pylintEnabled": true,
         "python.linting.enabled": true,


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [x] Other (please describe): devcontainer

## Proposed changes

- Use configuration that support windows environment
- Add support for codespace
- Require to update a VScode setting on windows for docker driver

```json
"remote.containers.workspaceMountConsistency": "delegated"
```

_Known limitations_

- Mounts can be slow on macos (https://github.com/docker/for-mac/issues/3677)

## How to test

Use VScode devcontainer option.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
