### PR TITLE
eos_validate_state(fix): provide protection when description is not defined

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_validate_state/templates/validate_state_report-csv.j2
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/templates/validate_state_report-csv.j2
@@ -62,7 +62,7 @@ test_id,node,test_category,test_description,test,result,failure_reason
 {%     if hostvars[node].ethernet_interface_state_results is defined and hostvars[node].ethernet_interface_state_results.results is defined %}
 {%         for result in hostvars[node].ethernet_interface_state_results.results %}
 {%             set test_id.value = test_id.value + 1 %}
-{{ test_id.value }},{{ node }},Interface State,Ethernet Interface Status & Line Protocol == "up",{{ result.ethernet_interface.key }} - {{ result.ethernet_interface.value.description }},{% if result.failed == false %}PASS{% else %}FAIL,{{ result.msg }}{% endif %}
+{{ test_id.value }},{{ node }},Interface State,Ethernet Interface Status & Line Protocol == "up",{{ result.ethernet_interface.key }} - {{ result.ethernet_interface.value.description | arista.avd.default('') }},{% if result.failed == false %}PASS{% else %}FAIL,{{ result.msg }}{% endif %}
 
 {%         endfor %}
 {%    endif %}
@@ -72,7 +72,7 @@ test_id,node,test_category,test_description,test,result,failure_reason
 {%     if hostvars[node].port_channel_interface_state_results is defined and hostvars[node].port_channel_interface_state_results.results is defined %}
 {%         for result in hostvars[node].port_channel_interface_state_results.results %}
 {%             set test_id.value = test_id.value + 1 %}
-{{ test_id.value }},{{ node }},Interface State,Port-Channel Interface Status & Line Protocol == "up",{{ result.port_channel_interface.key }} - {{ result.port_channel_interface.value.description }},{% if result.failed == false %}PASS{% else %}FAIL,{{ result.msg }}{% endif %}
+{{ test_id.value }},{{ node }},Interface State,Port-Channel Interface Status & Line Protocol == "up",{{ result.port_channel_interface.key }} - {{ result.port_channel_interface.value.description | arista.avd.default('') }},{% if result.failed == false %}PASS{% else %}FAIL,{{ result.msg }}{% endif %}
 
 {%         endfor %}
 {%    endif %}
@@ -82,7 +82,7 @@ test_id,node,test_category,test_description,test,result,failure_reason
 {%     if hostvars[node].vlan_interface_state_results is defined and hostvars[node].vlan_interface_state_results.results is defined %}
 {%         for result in hostvars[node].vlan_interface_state_results.results %}
 {%             set test_id.value = test_id.value + 1 %}
-{{ test_id.value }},{{ node }},Interface State,Vlan Interface Status & Line Protocol == "up",{{ result.vlan_interface.key }} - {{ result.vlan_interface.value.description }},{% if result.failed == false %}PASS{% else %}FAIL,{{ result.msg }}{% endif %}
+{{ test_id.value }},{{ node }},Interface State,Vlan Interface Status & Line Protocol == "up",{{ result.vlan_interface.key }} - {{ result.vlan_interface.value.description | arista.avd.default('') }},{% if result.failed == false %}PASS{% else %}FAIL,{{ result.msg }}{% endif %}
 
 {%         endfor %}
 {%    endif %}
@@ -100,7 +100,7 @@ test_id,node,test_category,test_description,test,result,failure_reason
 {%     if hostvars[node].loopback_interface_state_results is defined and hostvars[node].loopback_interface_state_results.results is defined %}
 {%         for result in hostvars[node].loopback_interface_state_results.results %}
 {%             set test_id.value = test_id.value + 1 %}
-{{ test_id.value }},{{ node }},Interface State,Loopback Interface Status & Line Protocol == "up",{{ result.loopback_interface.key }} - {{ result.loopback_interface.value.description }},{% if result.failed == false %}PASS{% else %}FAIL,{{ result.msg }}{% endif %}
+{{ test_id.value }},{{ node }},Interface State,Loopback Interface Status & Line Protocol == "up",{{ result.loopback_interface.key }} - {{ result.loopback_interface.value.description | arista.avd.default('') }},{% if result.failed == false %}PASS{% else %}FAIL,{{ result.msg }}{% endif %}
 
 {%         endfor %}
 {%    endif %}


### PR DESCRIPTION
## Change Summary

Fix issue with CSV reports fails to generate when the description is not defined on an interface.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):


## Component(s) name

`arista.avd.eos_validate_state`

## Proposed changes

Use `arista.avd.default` to test and provide protection for all decription vars.

## How to test

Run eos_validate_state, with interfaces containing no description.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
