### PR TITLE
Define all BGP peers on spines for RFC5549 explicitly

### DIFF
--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE1.md
@@ -375,7 +375,6 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | Settings | Value |
 | -------- | ----- |
 | Address Family | evpn |
-| Listen range prefix | 192.168.255.0/24 |
 | Next-hop unchanged | True |
 | Source | Loopback0 |
 | Bfd | true |
@@ -388,9 +387,32 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | Settings | Value |
 | -------- | ----- |
 | Address Family | ipv4 |
-| Listen range prefix | fe80::/10 |
 | Send community | all |
 | Maximum routes | 12000 |
+
+### BGP Neighbors
+
+| Neighbor | Remote AS | VRF |
+| -------- | --------- | --- |
+| 192.168.255.5 | 65101 | default |
+| 192.168.255.6 | 65102 | default |
+| 192.168.255.7 | 65102 | default |
+| 192.168.255.8 | 65103 | default |
+| 192.168.255.9 | 65103 | default |
+| 192.168.255.10 | 65104 | default |
+| 192.168.255.11 | 65105 | default |
+
+### BGP Neighbor Interfaces
+
+| Neighbor Interface | Peer Group | Remote AS |
+| ------------------ | ---------- | --------- |
+| Ethernet1 | UNDERLAY_PEERS | 65101 |
+| Ethernet2 | UNDERLAY_PEERS | 65102 |
+| Ethernet3 | UNDERLAY_PEERS | 65102 |
+| Ethernet4 | UNDERLAY_PEERS | 65103 |
+| Ethernet5 | UNDERLAY_PEERS | 65103 |
+| Ethernet6 | UNDERLAY_PEERS | 65104 |
+| Ethernet7 | UNDERLAY_PEERS | 65105 |
 
 ### Router BGP EVPN Address Family
 
@@ -407,8 +429,6 @@ router bgp 65001
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4
-   bgp listen range 192.168.255.0/24 peer-group EVPN-OVERLAY-PEERS peer-filter LEAF-AS-RANGE
-   bgp listen range fe80::/10 peer-group UNDERLAY_PEERS peer-filter LEAF-AS-RANGE
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
@@ -421,6 +441,34 @@ router bgp 65001
    neighbor UNDERLAY_PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
    neighbor UNDERLAY_PEERS send-community
    neighbor UNDERLAY_PEERS maximum-routes 12000
+   neighbor interface Ethernet1 peer-group UNDERLAY_PEERS remote-as 65101
+   neighbor interface Ethernet2 peer-group UNDERLAY_PEERS remote-as 65102
+   neighbor interface Ethernet3 peer-group UNDERLAY_PEERS remote-as 65102
+   neighbor interface Ethernet4 peer-group UNDERLAY_PEERS remote-as 65103
+   neighbor interface Ethernet5 peer-group UNDERLAY_PEERS remote-as 65103
+   neighbor interface Ethernet6 peer-group UNDERLAY_PEERS remote-as 65104
+   neighbor interface Ethernet7 peer-group UNDERLAY_PEERS remote-as 65105
+   neighbor 192.168.255.5 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.5 remote-as 65101
+   neighbor 192.168.255.5 description DC1-LEAF1A
+   neighbor 192.168.255.6 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.6 remote-as 65102
+   neighbor 192.168.255.6 description DC1-LEAF2A
+   neighbor 192.168.255.7 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.7 remote-as 65102
+   neighbor 192.168.255.7 description DC1-LEAF2B
+   neighbor 192.168.255.8 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.8 remote-as 65103
+   neighbor 192.168.255.8 description DC1-SVC3A
+   neighbor 192.168.255.9 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.9 remote-as 65103
+   neighbor 192.168.255.9 description DC1-SVC3B
+   neighbor 192.168.255.10 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.10 remote-as 65104
+   neighbor 192.168.255.10 description DC1-BL1A
+   neighbor 192.168.255.11 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.11 remote-as 65105
+   neighbor 192.168.255.11 description DC1-BL1B
    redistribute connected route-map RM-CONN-2-BGP
    !
    address-family evpn

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE2.md
@@ -375,7 +375,6 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | Settings | Value |
 | -------- | ----- |
 | Address Family | evpn |
-| Listen range prefix | 192.168.255.0/24 |
 | Next-hop unchanged | True |
 | Source | Loopback0 |
 | Bfd | true |
@@ -388,9 +387,32 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | Settings | Value |
 | -------- | ----- |
 | Address Family | ipv4 |
-| Listen range prefix | fe80::/10 |
 | Send community | all |
 | Maximum routes | 12000 |
+
+### BGP Neighbors
+
+| Neighbor | Remote AS | VRF |
+| -------- | --------- | --- |
+| 192.168.255.5 | 65101 | default |
+| 192.168.255.6 | 65102 | default |
+| 192.168.255.7 | 65102 | default |
+| 192.168.255.8 | 65103 | default |
+| 192.168.255.9 | 65103 | default |
+| 192.168.255.10 | 65104 | default |
+| 192.168.255.11 | 65105 | default |
+
+### BGP Neighbor Interfaces
+
+| Neighbor Interface | Peer Group | Remote AS |
+| ------------------ | ---------- | --------- |
+| Ethernet1 | UNDERLAY_PEERS | 65101 |
+| Ethernet2 | UNDERLAY_PEERS | 65102 |
+| Ethernet3 | UNDERLAY_PEERS | 65102 |
+| Ethernet4 | UNDERLAY_PEERS | 65103 |
+| Ethernet5 | UNDERLAY_PEERS | 65103 |
+| Ethernet6 | UNDERLAY_PEERS | 65104 |
+| Ethernet7 | UNDERLAY_PEERS | 65105 |
 
 ### Router BGP EVPN Address Family
 
@@ -407,8 +429,6 @@ router bgp 65001
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4
-   bgp listen range 192.168.255.0/24 peer-group EVPN-OVERLAY-PEERS peer-filter LEAF-AS-RANGE
-   bgp listen range fe80::/10 peer-group UNDERLAY_PEERS peer-filter LEAF-AS-RANGE
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
@@ -421,6 +441,34 @@ router bgp 65001
    neighbor UNDERLAY_PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
    neighbor UNDERLAY_PEERS send-community
    neighbor UNDERLAY_PEERS maximum-routes 12000
+   neighbor interface Ethernet1 peer-group UNDERLAY_PEERS remote-as 65101
+   neighbor interface Ethernet2 peer-group UNDERLAY_PEERS remote-as 65102
+   neighbor interface Ethernet3 peer-group UNDERLAY_PEERS remote-as 65102
+   neighbor interface Ethernet4 peer-group UNDERLAY_PEERS remote-as 65103
+   neighbor interface Ethernet5 peer-group UNDERLAY_PEERS remote-as 65103
+   neighbor interface Ethernet6 peer-group UNDERLAY_PEERS remote-as 65104
+   neighbor interface Ethernet7 peer-group UNDERLAY_PEERS remote-as 65105
+   neighbor 192.168.255.5 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.5 remote-as 65101
+   neighbor 192.168.255.5 description DC1-LEAF1A
+   neighbor 192.168.255.6 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.6 remote-as 65102
+   neighbor 192.168.255.6 description DC1-LEAF2A
+   neighbor 192.168.255.7 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.7 remote-as 65102
+   neighbor 192.168.255.7 description DC1-LEAF2B
+   neighbor 192.168.255.8 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.8 remote-as 65103
+   neighbor 192.168.255.8 description DC1-SVC3A
+   neighbor 192.168.255.9 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.9 remote-as 65103
+   neighbor 192.168.255.9 description DC1-SVC3B
+   neighbor 192.168.255.10 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.10 remote-as 65104
+   neighbor 192.168.255.10 description DC1-BL1A
+   neighbor 192.168.255.11 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.11 remote-as 65105
+   neighbor 192.168.255.11 description DC1-BL1B
    redistribute connected route-map RM-CONN-2-BGP
    !
    address-family evpn

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE3.md
@@ -375,7 +375,6 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | Settings | Value |
 | -------- | ----- |
 | Address Family | evpn |
-| Listen range prefix | 192.168.255.0/24 |
 | Next-hop unchanged | True |
 | Source | Loopback0 |
 | Bfd | true |
@@ -388,9 +387,32 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | Settings | Value |
 | -------- | ----- |
 | Address Family | ipv4 |
-| Listen range prefix | fe80::/10 |
 | Send community | all |
 | Maximum routes | 12000 |
+
+### BGP Neighbors
+
+| Neighbor | Remote AS | VRF |
+| -------- | --------- | --- |
+| 192.168.255.5 | 65101 | default |
+| 192.168.255.6 | 65102 | default |
+| 192.168.255.7 | 65102 | default |
+| 192.168.255.8 | 65103 | default |
+| 192.168.255.9 | 65103 | default |
+| 192.168.255.10 | 65104 | default |
+| 192.168.255.11 | 65105 | default |
+
+### BGP Neighbor Interfaces
+
+| Neighbor Interface | Peer Group | Remote AS |
+| ------------------ | ---------- | --------- |
+| Ethernet1 | UNDERLAY_PEERS | 65101 |
+| Ethernet2 | UNDERLAY_PEERS | 65102 |
+| Ethernet3 | UNDERLAY_PEERS | 65102 |
+| Ethernet4 | UNDERLAY_PEERS | 65103 |
+| Ethernet5 | UNDERLAY_PEERS | 65103 |
+| Ethernet6 | UNDERLAY_PEERS | 65104 |
+| Ethernet7 | UNDERLAY_PEERS | 65105 |
 
 ### Router BGP EVPN Address Family
 
@@ -407,8 +429,6 @@ router bgp 65001
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4
-   bgp listen range 192.168.255.0/24 peer-group EVPN-OVERLAY-PEERS peer-filter LEAF-AS-RANGE
-   bgp listen range fe80::/10 peer-group UNDERLAY_PEERS peer-filter LEAF-AS-RANGE
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
@@ -421,6 +441,34 @@ router bgp 65001
    neighbor UNDERLAY_PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
    neighbor UNDERLAY_PEERS send-community
    neighbor UNDERLAY_PEERS maximum-routes 12000
+   neighbor interface Ethernet1 peer-group UNDERLAY_PEERS remote-as 65101
+   neighbor interface Ethernet2 peer-group UNDERLAY_PEERS remote-as 65102
+   neighbor interface Ethernet3 peer-group UNDERLAY_PEERS remote-as 65102
+   neighbor interface Ethernet4 peer-group UNDERLAY_PEERS remote-as 65103
+   neighbor interface Ethernet5 peer-group UNDERLAY_PEERS remote-as 65103
+   neighbor interface Ethernet6 peer-group UNDERLAY_PEERS remote-as 65104
+   neighbor interface Ethernet7 peer-group UNDERLAY_PEERS remote-as 65105
+   neighbor 192.168.255.5 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.5 remote-as 65101
+   neighbor 192.168.255.5 description DC1-LEAF1A
+   neighbor 192.168.255.6 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.6 remote-as 65102
+   neighbor 192.168.255.6 description DC1-LEAF2A
+   neighbor 192.168.255.7 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.7 remote-as 65102
+   neighbor 192.168.255.7 description DC1-LEAF2B
+   neighbor 192.168.255.8 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.8 remote-as 65103
+   neighbor 192.168.255.8 description DC1-SVC3A
+   neighbor 192.168.255.9 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.9 remote-as 65103
+   neighbor 192.168.255.9 description DC1-SVC3B
+   neighbor 192.168.255.10 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.10 remote-as 65104
+   neighbor 192.168.255.10 description DC1-BL1A
+   neighbor 192.168.255.11 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.11 remote-as 65105
+   neighbor 192.168.255.11 description DC1-BL1B
    redistribute connected route-map RM-CONN-2-BGP
    !
    address-family evpn

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE4.md
@@ -375,7 +375,6 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | Settings | Value |
 | -------- | ----- |
 | Address Family | evpn |
-| Listen range prefix | 192.168.255.0/24 |
 | Next-hop unchanged | True |
 | Source | Loopback0 |
 | Bfd | true |
@@ -388,9 +387,32 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | Settings | Value |
 | -------- | ----- |
 | Address Family | ipv4 |
-| Listen range prefix | fe80::/10 |
 | Send community | all |
 | Maximum routes | 12000 |
+
+### BGP Neighbors
+
+| Neighbor | Remote AS | VRF |
+| -------- | --------- | --- |
+| 192.168.255.5 | 65101 | default |
+| 192.168.255.6 | 65102 | default |
+| 192.168.255.7 | 65102 | default |
+| 192.168.255.8 | 65103 | default |
+| 192.168.255.9 | 65103 | default |
+| 192.168.255.10 | 65104 | default |
+| 192.168.255.11 | 65105 | default |
+
+### BGP Neighbor Interfaces
+
+| Neighbor Interface | Peer Group | Remote AS |
+| ------------------ | ---------- | --------- |
+| Ethernet1 | UNDERLAY_PEERS | 65101 |
+| Ethernet2 | UNDERLAY_PEERS | 65102 |
+| Ethernet3 | UNDERLAY_PEERS | 65102 |
+| Ethernet4 | UNDERLAY_PEERS | 65103 |
+| Ethernet5 | UNDERLAY_PEERS | 65103 |
+| Ethernet6 | UNDERLAY_PEERS | 65104 |
+| Ethernet7 | UNDERLAY_PEERS | 65105 |
 
 ### Router BGP EVPN Address Family
 
@@ -407,8 +429,6 @@ router bgp 65001
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4
-   bgp listen range 192.168.255.0/24 peer-group EVPN-OVERLAY-PEERS peer-filter LEAF-AS-RANGE
-   bgp listen range fe80::/10 peer-group UNDERLAY_PEERS peer-filter LEAF-AS-RANGE
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
@@ -421,6 +441,34 @@ router bgp 65001
    neighbor UNDERLAY_PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
    neighbor UNDERLAY_PEERS send-community
    neighbor UNDERLAY_PEERS maximum-routes 12000
+   neighbor interface Ethernet1 peer-group UNDERLAY_PEERS remote-as 65101
+   neighbor interface Ethernet2 peer-group UNDERLAY_PEERS remote-as 65102
+   neighbor interface Ethernet3 peer-group UNDERLAY_PEERS remote-as 65102
+   neighbor interface Ethernet4 peer-group UNDERLAY_PEERS remote-as 65103
+   neighbor interface Ethernet5 peer-group UNDERLAY_PEERS remote-as 65103
+   neighbor interface Ethernet6 peer-group UNDERLAY_PEERS remote-as 65104
+   neighbor interface Ethernet7 peer-group UNDERLAY_PEERS remote-as 65105
+   neighbor 192.168.255.5 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.5 remote-as 65101
+   neighbor 192.168.255.5 description DC1-LEAF1A
+   neighbor 192.168.255.6 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.6 remote-as 65102
+   neighbor 192.168.255.6 description DC1-LEAF2A
+   neighbor 192.168.255.7 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.7 remote-as 65102
+   neighbor 192.168.255.7 description DC1-LEAF2B
+   neighbor 192.168.255.8 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.8 remote-as 65103
+   neighbor 192.168.255.8 description DC1-SVC3A
+   neighbor 192.168.255.9 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.9 remote-as 65103
+   neighbor 192.168.255.9 description DC1-SVC3B
+   neighbor 192.168.255.10 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.10 remote-as 65104
+   neighbor 192.168.255.10 description DC1-BL1A
+   neighbor 192.168.255.11 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.11 remote-as 65105
+   neighbor 192.168.255.11 description DC1-BL1B
    redistribute connected route-map RM-CONN-2-BGP
    !
    address-family evpn

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE1.cfg
@@ -112,8 +112,6 @@ router bgp 65001
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4
-   bgp listen range 192.168.255.0/24 peer-group EVPN-OVERLAY-PEERS peer-filter LEAF-AS-RANGE
-   bgp listen range fe80::/10 peer-group UNDERLAY_PEERS peer-filter LEAF-AS-RANGE
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
@@ -126,6 +124,34 @@ router bgp 65001
    neighbor UNDERLAY_PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
    neighbor UNDERLAY_PEERS send-community
    neighbor UNDERLAY_PEERS maximum-routes 12000
+   neighbor interface Ethernet1 peer-group UNDERLAY_PEERS remote-as 65101
+   neighbor interface Ethernet2 peer-group UNDERLAY_PEERS remote-as 65102
+   neighbor interface Ethernet3 peer-group UNDERLAY_PEERS remote-as 65102
+   neighbor interface Ethernet4 peer-group UNDERLAY_PEERS remote-as 65103
+   neighbor interface Ethernet5 peer-group UNDERLAY_PEERS remote-as 65103
+   neighbor interface Ethernet6 peer-group UNDERLAY_PEERS remote-as 65104
+   neighbor interface Ethernet7 peer-group UNDERLAY_PEERS remote-as 65105
+   neighbor 192.168.255.5 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.5 remote-as 65101
+   neighbor 192.168.255.5 description DC1-LEAF1A
+   neighbor 192.168.255.6 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.6 remote-as 65102
+   neighbor 192.168.255.6 description DC1-LEAF2A
+   neighbor 192.168.255.7 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.7 remote-as 65102
+   neighbor 192.168.255.7 description DC1-LEAF2B
+   neighbor 192.168.255.8 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.8 remote-as 65103
+   neighbor 192.168.255.8 description DC1-SVC3A
+   neighbor 192.168.255.9 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.9 remote-as 65103
+   neighbor 192.168.255.9 description DC1-SVC3B
+   neighbor 192.168.255.10 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.10 remote-as 65104
+   neighbor 192.168.255.10 description DC1-BL1A
+   neighbor 192.168.255.11 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.11 remote-as 65105
+   neighbor 192.168.255.11 description DC1-BL1B
    redistribute connected route-map RM-CONN-2-BGP
    !
    address-family evpn

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE2.cfg
@@ -112,8 +112,6 @@ router bgp 65001
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4
-   bgp listen range 192.168.255.0/24 peer-group EVPN-OVERLAY-PEERS peer-filter LEAF-AS-RANGE
-   bgp listen range fe80::/10 peer-group UNDERLAY_PEERS peer-filter LEAF-AS-RANGE
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
@@ -126,6 +124,34 @@ router bgp 65001
    neighbor UNDERLAY_PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
    neighbor UNDERLAY_PEERS send-community
    neighbor UNDERLAY_PEERS maximum-routes 12000
+   neighbor interface Ethernet1 peer-group UNDERLAY_PEERS remote-as 65101
+   neighbor interface Ethernet2 peer-group UNDERLAY_PEERS remote-as 65102
+   neighbor interface Ethernet3 peer-group UNDERLAY_PEERS remote-as 65102
+   neighbor interface Ethernet4 peer-group UNDERLAY_PEERS remote-as 65103
+   neighbor interface Ethernet5 peer-group UNDERLAY_PEERS remote-as 65103
+   neighbor interface Ethernet6 peer-group UNDERLAY_PEERS remote-as 65104
+   neighbor interface Ethernet7 peer-group UNDERLAY_PEERS remote-as 65105
+   neighbor 192.168.255.5 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.5 remote-as 65101
+   neighbor 192.168.255.5 description DC1-LEAF1A
+   neighbor 192.168.255.6 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.6 remote-as 65102
+   neighbor 192.168.255.6 description DC1-LEAF2A
+   neighbor 192.168.255.7 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.7 remote-as 65102
+   neighbor 192.168.255.7 description DC1-LEAF2B
+   neighbor 192.168.255.8 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.8 remote-as 65103
+   neighbor 192.168.255.8 description DC1-SVC3A
+   neighbor 192.168.255.9 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.9 remote-as 65103
+   neighbor 192.168.255.9 description DC1-SVC3B
+   neighbor 192.168.255.10 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.10 remote-as 65104
+   neighbor 192.168.255.10 description DC1-BL1A
+   neighbor 192.168.255.11 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.11 remote-as 65105
+   neighbor 192.168.255.11 description DC1-BL1B
    redistribute connected route-map RM-CONN-2-BGP
    !
    address-family evpn

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE3.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE3.cfg
@@ -112,8 +112,6 @@ router bgp 65001
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4
-   bgp listen range 192.168.255.0/24 peer-group EVPN-OVERLAY-PEERS peer-filter LEAF-AS-RANGE
-   bgp listen range fe80::/10 peer-group UNDERLAY_PEERS peer-filter LEAF-AS-RANGE
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
@@ -126,6 +124,34 @@ router bgp 65001
    neighbor UNDERLAY_PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
    neighbor UNDERLAY_PEERS send-community
    neighbor UNDERLAY_PEERS maximum-routes 12000
+   neighbor interface Ethernet1 peer-group UNDERLAY_PEERS remote-as 65101
+   neighbor interface Ethernet2 peer-group UNDERLAY_PEERS remote-as 65102
+   neighbor interface Ethernet3 peer-group UNDERLAY_PEERS remote-as 65102
+   neighbor interface Ethernet4 peer-group UNDERLAY_PEERS remote-as 65103
+   neighbor interface Ethernet5 peer-group UNDERLAY_PEERS remote-as 65103
+   neighbor interface Ethernet6 peer-group UNDERLAY_PEERS remote-as 65104
+   neighbor interface Ethernet7 peer-group UNDERLAY_PEERS remote-as 65105
+   neighbor 192.168.255.5 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.5 remote-as 65101
+   neighbor 192.168.255.5 description DC1-LEAF1A
+   neighbor 192.168.255.6 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.6 remote-as 65102
+   neighbor 192.168.255.6 description DC1-LEAF2A
+   neighbor 192.168.255.7 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.7 remote-as 65102
+   neighbor 192.168.255.7 description DC1-LEAF2B
+   neighbor 192.168.255.8 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.8 remote-as 65103
+   neighbor 192.168.255.8 description DC1-SVC3A
+   neighbor 192.168.255.9 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.9 remote-as 65103
+   neighbor 192.168.255.9 description DC1-SVC3B
+   neighbor 192.168.255.10 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.10 remote-as 65104
+   neighbor 192.168.255.10 description DC1-BL1A
+   neighbor 192.168.255.11 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.11 remote-as 65105
+   neighbor 192.168.255.11 description DC1-BL1B
    redistribute connected route-map RM-CONN-2-BGP
    !
    address-family evpn

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE4.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE4.cfg
@@ -112,8 +112,6 @@ router bgp 65001
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    maximum-paths 4 ecmp 4
-   bgp listen range 192.168.255.0/24 peer-group EVPN-OVERLAY-PEERS peer-filter LEAF-AS-RANGE
-   bgp listen range fe80::/10 peer-group UNDERLAY_PEERS peer-filter LEAF-AS-RANGE
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
@@ -126,6 +124,34 @@ router bgp 65001
    neighbor UNDERLAY_PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
    neighbor UNDERLAY_PEERS send-community
    neighbor UNDERLAY_PEERS maximum-routes 12000
+   neighbor interface Ethernet1 peer-group UNDERLAY_PEERS remote-as 65101
+   neighbor interface Ethernet2 peer-group UNDERLAY_PEERS remote-as 65102
+   neighbor interface Ethernet3 peer-group UNDERLAY_PEERS remote-as 65102
+   neighbor interface Ethernet4 peer-group UNDERLAY_PEERS remote-as 65103
+   neighbor interface Ethernet5 peer-group UNDERLAY_PEERS remote-as 65103
+   neighbor interface Ethernet6 peer-group UNDERLAY_PEERS remote-as 65104
+   neighbor interface Ethernet7 peer-group UNDERLAY_PEERS remote-as 65105
+   neighbor 192.168.255.5 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.5 remote-as 65101
+   neighbor 192.168.255.5 description DC1-LEAF1A
+   neighbor 192.168.255.6 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.6 remote-as 65102
+   neighbor 192.168.255.6 description DC1-LEAF2A
+   neighbor 192.168.255.7 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.7 remote-as 65102
+   neighbor 192.168.255.7 description DC1-LEAF2B
+   neighbor 192.168.255.8 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.8 remote-as 65103
+   neighbor 192.168.255.8 description DC1-SVC3A
+   neighbor 192.168.255.9 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.9 remote-as 65103
+   neighbor 192.168.255.9 description DC1-SVC3B
+   neighbor 192.168.255.10 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.10 remote-as 65104
+   neighbor 192.168.255.10 description DC1-BL1A
+   neighbor 192.168.255.11 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.11 remote-as 65105
+   neighbor 192.168.255.11 description DC1-BL1B
    redistribute connected route-map RM-CONN-2-BGP
    !
    address-family evpn

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
@@ -8,8 +8,6 @@ router_bgp:
   peer_groups:
     UNDERLAY_PEERS:
       type: ipv4
-      peer_filter: LEAF-AS-RANGE
-      bgp_listen_range_prefix: fe80::/10
       password: AQQvKeimxJu+uGQ/yYvv9w==
       maximum_routes: 12000
       send_community: all
@@ -22,8 +20,6 @@ router_bgp:
       send_community: all
       maximum_routes: 0
       next_hop_unchanged: true
-      bgp_listen_range_prefix: 192.168.255.0/24
-      peer_filter: LEAF-AS-RANGE
   address_family_ipv4:
     peer_groups:
       UNDERLAY_PEERS:
@@ -33,10 +29,68 @@ router_bgp:
   redistribute_routes:
     connected:
       route_map: RM-CONN-2-BGP
+  neighbor_interfaces:
+    Ethernet6:
+      peer_group: UNDERLAY_PEERS
+      remote_as: 65104
+      description: DC1-BL1A_Ethernet6
+    Ethernet7:
+      peer_group: UNDERLAY_PEERS
+      remote_as: 65105
+      description: DC1-BL1B_Ethernet7
+    Ethernet1:
+      peer_group: UNDERLAY_PEERS
+      remote_as: 65101
+      description: DC1-LEAF1A_Ethernet1
+    Ethernet2:
+      peer_group: UNDERLAY_PEERS
+      remote_as: 65102
+      description: DC1-LEAF2A_Ethernet2
+    Ethernet3:
+      peer_group: UNDERLAY_PEERS
+      remote_as: 65102
+      description: DC1-LEAF2B_Ethernet3
+    Ethernet4:
+      peer_group: UNDERLAY_PEERS
+      remote_as: 65103
+      description: DC1-SVC3A_Ethernet4
+    Ethernet5:
+      peer_group: UNDERLAY_PEERS
+      remote_as: 65103
+      description: DC1-SVC3B_Ethernet5
   address_family_evpn:
     peer_groups:
       EVPN-OVERLAY-PEERS:
         activate: true
+  neighbors:
+    192.168.255.10:
+      peer_group: EVPN-OVERLAY-PEERS
+      description: DC1-BL1A
+      remote_as: 65104
+    192.168.255.11:
+      peer_group: EVPN-OVERLAY-PEERS
+      description: DC1-BL1B
+      remote_as: 65105
+    192.168.255.5:
+      peer_group: EVPN-OVERLAY-PEERS
+      description: DC1-LEAF1A
+      remote_as: 65101
+    192.168.255.6:
+      peer_group: EVPN-OVERLAY-PEERS
+      description: DC1-LEAF2A
+      remote_as: 65102
+    192.168.255.7:
+      peer_group: EVPN-OVERLAY-PEERS
+      description: DC1-LEAF2B
+      remote_as: 65102
+    192.168.255.8:
+      peer_group: EVPN-OVERLAY-PEERS
+      description: DC1-SVC3A
+      remote_as: 65103
+    192.168.255.9:
+      peer_group: EVPN-OVERLAY-PEERS
+      description: DC1-SVC3B
+      remote_as: 65103
 static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
@@ -8,8 +8,6 @@ router_bgp:
   peer_groups:
     UNDERLAY_PEERS:
       type: ipv4
-      peer_filter: LEAF-AS-RANGE
-      bgp_listen_range_prefix: fe80::/10
       password: AQQvKeimxJu+uGQ/yYvv9w==
       maximum_routes: 12000
       send_community: all
@@ -22,8 +20,6 @@ router_bgp:
       send_community: all
       maximum_routes: 0
       next_hop_unchanged: true
-      bgp_listen_range_prefix: 192.168.255.0/24
-      peer_filter: LEAF-AS-RANGE
   address_family_ipv4:
     peer_groups:
       UNDERLAY_PEERS:
@@ -33,10 +29,68 @@ router_bgp:
   redistribute_routes:
     connected:
       route_map: RM-CONN-2-BGP
+  neighbor_interfaces:
+    Ethernet6:
+      peer_group: UNDERLAY_PEERS
+      remote_as: 65104
+      description: DC1-BL1A_Ethernet6
+    Ethernet7:
+      peer_group: UNDERLAY_PEERS
+      remote_as: 65105
+      description: DC1-BL1B_Ethernet7
+    Ethernet1:
+      peer_group: UNDERLAY_PEERS
+      remote_as: 65101
+      description: DC1-LEAF1A_Ethernet1
+    Ethernet2:
+      peer_group: UNDERLAY_PEERS
+      remote_as: 65102
+      description: DC1-LEAF2A_Ethernet2
+    Ethernet3:
+      peer_group: UNDERLAY_PEERS
+      remote_as: 65102
+      description: DC1-LEAF2B_Ethernet3
+    Ethernet4:
+      peer_group: UNDERLAY_PEERS
+      remote_as: 65103
+      description: DC1-SVC3A_Ethernet4
+    Ethernet5:
+      peer_group: UNDERLAY_PEERS
+      remote_as: 65103
+      description: DC1-SVC3B_Ethernet5
   address_family_evpn:
     peer_groups:
       EVPN-OVERLAY-PEERS:
         activate: true
+  neighbors:
+    192.168.255.10:
+      peer_group: EVPN-OVERLAY-PEERS
+      description: DC1-BL1A
+      remote_as: 65104
+    192.168.255.11:
+      peer_group: EVPN-OVERLAY-PEERS
+      description: DC1-BL1B
+      remote_as: 65105
+    192.168.255.5:
+      peer_group: EVPN-OVERLAY-PEERS
+      description: DC1-LEAF1A
+      remote_as: 65101
+    192.168.255.6:
+      peer_group: EVPN-OVERLAY-PEERS
+      description: DC1-LEAF2A
+      remote_as: 65102
+    192.168.255.7:
+      peer_group: EVPN-OVERLAY-PEERS
+      description: DC1-LEAF2B
+      remote_as: 65102
+    192.168.255.8:
+      peer_group: EVPN-OVERLAY-PEERS
+      description: DC1-SVC3A
+      remote_as: 65103
+    192.168.255.9:
+      peer_group: EVPN-OVERLAY-PEERS
+      description: DC1-SVC3B
+      remote_as: 65103
 static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
@@ -8,8 +8,6 @@ router_bgp:
   peer_groups:
     UNDERLAY_PEERS:
       type: ipv4
-      peer_filter: LEAF-AS-RANGE
-      bgp_listen_range_prefix: fe80::/10
       password: AQQvKeimxJu+uGQ/yYvv9w==
       maximum_routes: 12000
       send_community: all
@@ -22,8 +20,6 @@ router_bgp:
       send_community: all
       maximum_routes: 0
       next_hop_unchanged: true
-      bgp_listen_range_prefix: 192.168.255.0/24
-      peer_filter: LEAF-AS-RANGE
   address_family_ipv4:
     peer_groups:
       UNDERLAY_PEERS:
@@ -33,10 +29,68 @@ router_bgp:
   redistribute_routes:
     connected:
       route_map: RM-CONN-2-BGP
+  neighbor_interfaces:
+    Ethernet6:
+      peer_group: UNDERLAY_PEERS
+      remote_as: 65104
+      description: DC1-BL1A_Ethernet6
+    Ethernet7:
+      peer_group: UNDERLAY_PEERS
+      remote_as: 65105
+      description: DC1-BL1B_Ethernet7
+    Ethernet1:
+      peer_group: UNDERLAY_PEERS
+      remote_as: 65101
+      description: DC1-LEAF1A_Ethernet1
+    Ethernet2:
+      peer_group: UNDERLAY_PEERS
+      remote_as: 65102
+      description: DC1-LEAF2A_Ethernet2
+    Ethernet3:
+      peer_group: UNDERLAY_PEERS
+      remote_as: 65102
+      description: DC1-LEAF2B_Ethernet3
+    Ethernet4:
+      peer_group: UNDERLAY_PEERS
+      remote_as: 65103
+      description: DC1-SVC3A_Ethernet4
+    Ethernet5:
+      peer_group: UNDERLAY_PEERS
+      remote_as: 65103
+      description: DC1-SVC3B_Ethernet5
   address_family_evpn:
     peer_groups:
       EVPN-OVERLAY-PEERS:
         activate: true
+  neighbors:
+    192.168.255.10:
+      peer_group: EVPN-OVERLAY-PEERS
+      description: DC1-BL1A
+      remote_as: 65104
+    192.168.255.11:
+      peer_group: EVPN-OVERLAY-PEERS
+      description: DC1-BL1B
+      remote_as: 65105
+    192.168.255.5:
+      peer_group: EVPN-OVERLAY-PEERS
+      description: DC1-LEAF1A
+      remote_as: 65101
+    192.168.255.6:
+      peer_group: EVPN-OVERLAY-PEERS
+      description: DC1-LEAF2A
+      remote_as: 65102
+    192.168.255.7:
+      peer_group: EVPN-OVERLAY-PEERS
+      description: DC1-LEAF2B
+      remote_as: 65102
+    192.168.255.8:
+      peer_group: EVPN-OVERLAY-PEERS
+      description: DC1-SVC3A
+      remote_as: 65103
+    192.168.255.9:
+      peer_group: EVPN-OVERLAY-PEERS
+      description: DC1-SVC3B
+      remote_as: 65103
 static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
@@ -8,8 +8,6 @@ router_bgp:
   peer_groups:
     UNDERLAY_PEERS:
       type: ipv4
-      peer_filter: LEAF-AS-RANGE
-      bgp_listen_range_prefix: fe80::/10
       password: AQQvKeimxJu+uGQ/yYvv9w==
       maximum_routes: 12000
       send_community: all
@@ -22,8 +20,6 @@ router_bgp:
       send_community: all
       maximum_routes: 0
       next_hop_unchanged: true
-      bgp_listen_range_prefix: 192.168.255.0/24
-      peer_filter: LEAF-AS-RANGE
   address_family_ipv4:
     peer_groups:
       UNDERLAY_PEERS:
@@ -33,10 +29,68 @@ router_bgp:
   redistribute_routes:
     connected:
       route_map: RM-CONN-2-BGP
+  neighbor_interfaces:
+    Ethernet6:
+      peer_group: UNDERLAY_PEERS
+      remote_as: 65104
+      description: DC1-BL1A_Ethernet6
+    Ethernet7:
+      peer_group: UNDERLAY_PEERS
+      remote_as: 65105
+      description: DC1-BL1B_Ethernet7
+    Ethernet1:
+      peer_group: UNDERLAY_PEERS
+      remote_as: 65101
+      description: DC1-LEAF1A_Ethernet1
+    Ethernet2:
+      peer_group: UNDERLAY_PEERS
+      remote_as: 65102
+      description: DC1-LEAF2A_Ethernet2
+    Ethernet3:
+      peer_group: UNDERLAY_PEERS
+      remote_as: 65102
+      description: DC1-LEAF2B_Ethernet3
+    Ethernet4:
+      peer_group: UNDERLAY_PEERS
+      remote_as: 65103
+      description: DC1-SVC3A_Ethernet4
+    Ethernet5:
+      peer_group: UNDERLAY_PEERS
+      remote_as: 65103
+      description: DC1-SVC3B_Ethernet5
   address_family_evpn:
     peer_groups:
       EVPN-OVERLAY-PEERS:
         activate: true
+  neighbors:
+    192.168.255.10:
+      peer_group: EVPN-OVERLAY-PEERS
+      description: DC1-BL1A
+      remote_as: 65104
+    192.168.255.11:
+      peer_group: EVPN-OVERLAY-PEERS
+      description: DC1-BL1B
+      remote_as: 65105
+    192.168.255.5:
+      peer_group: EVPN-OVERLAY-PEERS
+      description: DC1-LEAF1A
+      remote_as: 65101
+    192.168.255.6:
+      peer_group: EVPN-OVERLAY-PEERS
+      description: DC1-LEAF2A
+      remote_as: 65102
+    192.168.255.7:
+      peer_group: EVPN-OVERLAY-PEERS
+      description: DC1-LEAF2B
+      remote_as: 65102
+    192.168.255.8:
+      peer_group: EVPN-OVERLAY-PEERS
+      description: DC1-SVC3A
+      remote_as: 65103
+    192.168.255.9:
+      peer_group: EVPN-OVERLAY-PEERS
+      description: DC1-SVC3B
+      remote_as: 65103
 static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/overlay/ebgp/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/overlay/ebgp/router-bgp.j2
@@ -52,25 +52,3 @@ router_bgp:
       description: {{ evpn_route_client }}
       remote_as: {{ overlay_data.evpn_route_clients[evpn_route_client].bgp_as }}
 {% endfor %}
-{% if switch.evpn_role == "sndbfasjf" and underlay_rfc5549 is arista.avd.defined(true)%}
-{%     for l3leaf_node_group in l3leaf.node_groups | arista.avd.natural_sort %}
-{%         if l3leaf.node_groups[l3leaf_node_group].spines is defined %}
-{%             set leaf_spines = l3leaf.node_groups[l3leaf_node_group].spines %}
-{%         else %}
-{%             set leaf_spines = l3leaf.defaults.spines %}
-{%         endif %}
-{%         for node in l3leaf.node_groups[l3leaf_node_group].nodes | arista.avd.natural_sort %}
-{#    erlay network peering #}
-{%             for leaf_spine in leaf_spines %}
-{%                 if leaf_spine == inventory_hostname %}
-    {{ l3leaf.node_groups[l3leaf_node_group].nodes[node].spine_interfaces[loop.index0] }}:
-      peer_group: {{ bgp_peer_groups.EVPN_OVERLAY_PEERS.name | arista.avd.default("EVPN-OVERLAY-PEERS") }}
-      remote_as: {{ l3leaf.node_groups[l3leaf_node_group].nodes[node].bgp_as | arista.avd.default(
-                    l3leaf.node_groups[l3leaf_node_group].bgp_as,
-                    l3leaf.defaults.bgp_as) }}
-      description: {{ node }}_{{ l3leaf.node_groups[l3leaf_node_group].nodes[node].spine_interfaces[loop.index0] }}
-{%                endif %}
-{%            endfor %}
-{%        endfor %}
-{%    endfor %}
-{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/overlay/ebgp/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/overlay/ebgp/router-bgp.j2
@@ -12,10 +12,6 @@ router_bgp:
 {%     if switch.evpn_role == "server" %}
       next_hop_unchanged: true
 {%     endif %}
-{%     if switch.evpn_role == "server" and underlay_rfc5549 is arista.avd.defined(true)%}
-      bgp_listen_range_prefix: {{ overlay_loopback_network_summary }}
-      peer_filter: LEAF-AS-RANGE
-{%     endif %}
 
   address_family_ipv4:
     peer_groups:
@@ -50,11 +46,31 @@ router_bgp:
       route_map_out: RM-EVPN-FILTER-AS{{ overlay_data.evpn_route_servers[evpn_route_server].bgp_as }}
 {%     endif %}
 {% endfor %}
-{% if underlay_rfc5549 is not arista.avd.defined(true) %}
-{%     for evpn_route_client in overlay_data.evpn_route_clients | arista.avd.natural_sort %}
+{% for evpn_route_client in overlay_data.evpn_route_clients | arista.avd.natural_sort %}
     {{ overlay_data.evpn_route_clients[evpn_route_client].ip_address }}:
       peer_group: {{ bgp_peer_groups.EVPN_OVERLAY_PEERS.name | arista.avd.default("EVPN-OVERLAY-PEERS") }}
       description: {{ evpn_route_client }}
       remote_as: {{ overlay_data.evpn_route_clients[evpn_route_client].bgp_as }}
-{%     endfor %}
+{% endfor %}
+{% if switch.evpn_role == "sndbfasjf" and underlay_rfc5549 is arista.avd.defined(true)%}
+{%     for l3leaf_node_group in l3leaf.node_groups | arista.avd.natural_sort %}
+{%         if l3leaf.node_groups[l3leaf_node_group].spines is defined %}
+{%             set leaf_spines = l3leaf.node_groups[l3leaf_node_group].spines %}
+{%         else %}
+{%             set leaf_spines = l3leaf.defaults.spines %}
+{%         endif %}
+{%         for node in l3leaf.node_groups[l3leaf_node_group].nodes | arista.avd.natural_sort %}
+{#    erlay network peering #}
+{%             for leaf_spine in leaf_spines %}
+{%                 if leaf_spine == inventory_hostname %}
+    {{ l3leaf.node_groups[l3leaf_node_group].nodes[node].spine_interfaces[loop.index0] }}:
+      peer_group: {{ bgp_peer_groups.EVPN_OVERLAY_PEERS.name | arista.avd.default("EVPN-OVERLAY-PEERS") }}
+      remote_as: {{ l3leaf.node_groups[l3leaf_node_group].nodes[node].bgp_as | arista.avd.default(
+                    l3leaf.node_groups[l3leaf_node_group].bgp_as,
+                    l3leaf.defaults.bgp_as) }}
+      description: {{ node }}_{{ l3leaf.node_groups[l3leaf_node_group].nodes[node].spine_interfaces[loop.index0] }}
+{%                endif %}
+{%            endfor %}
+{%        endfor %}
+{%    endfor %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/underlay/ebgp/spine-router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/underlay/ebgp/spine-router-bgp.j2
@@ -4,10 +4,6 @@ router_bgp:
   peer_groups:
     {{ bgp_peer_groups.IPv4_UNDERLAY_PEERS.name | arista.avd.default("IPv4-UNDERLAY-PEERS") }}:
       type: ipv4
-{% if underlay_rfc5549 is arista.avd.defined(true) %}
-      peer_filter: LEAF-AS-RANGE
-      bgp_listen_range_prefix: "fe80::/10"
-{% endif %}
       password: "{{ bgp_peer_groups.IPv4_UNDERLAY_PEERS.password }}"
       maximum_routes: 12000
       send_community: all
@@ -19,44 +15,48 @@ router_bgp:
     connected:
       route_map: RM-CONN-2-BGP
 
-{% if underlay_rfc5549 is arista.avd.defined(true) %}
-{# future place to add RFC5549 EBGP peerings #}
-
-{% else %}
 {# Regular EBGP peerings #}
 {# Spine router bgp neighbors configuration #}
+{% if underlay_rfc5549 is arista.avd.defined(true) %}
+  neighbor_interfaces:
+{% else %}
   neighbors:
-{%     for l3leaf_node_group in l3leaf.node_groups | arista.avd.natural_sort %}
-{%         if l3leaf.node_groups[l3leaf_node_group].spines is defined %}
-{%             set leaf_spines = l3leaf.node_groups[l3leaf_node_group].spines %}
-{%         else %}
-{%             set leaf_spines = l3leaf.defaults.spines %}
-{%         endif %}
-{%         for node in l3leaf.node_groups[l3leaf_node_group].nodes | arista.avd.natural_sort %}
-{# Underlay network peering #}
-{%             for leaf_spine in leaf_spines %}
-{%                 if leaf_spine == inventory_hostname %}
+{% endif %}
+{% for l3leaf_node_group in l3leaf.node_groups | arista.avd.natural_sort %}
+{%     if l3leaf.node_groups[l3leaf_node_group].spines is defined %}
+{%         set leaf_spines = l3leaf.node_groups[l3leaf_node_group].spines %}
+{%     else %}
+{%         set leaf_spines = l3leaf.defaults.spines %}
+{%     endif %}
+{%     for node in l3leaf.node_groups[l3leaf_node_group].nodes | arista.avd.natural_sort %}
+{#erlay network peering #}
+{%         for leaf_spine in leaf_spines %}
+{%             if leaf_spine == inventory_hostname %}
+{%                 if underlay_rfc5549 is arista.avd.defined(true) %}
+    {{ l3leaf.node_groups[l3leaf_node_group].nodes[node].spine_interfaces[loop.index0] }}:
+{%                 else %}
     {{ underlay_p2p_network_summary | ipaddr('network') | ipmath(((l3leaf.node_groups[l3leaf_node_group].nodes[node].id -1) * 2 * switch.max_spines * max_l3leaf_to_spine_links) + loop.index0 * 2 + 1) }}:
+{%                 endif %}
       peer_group: {{ bgp_peer_groups.IPv4_UNDERLAY_PEERS.name | arista.avd.default("IPv4-UNDERLAY-PEERS") }}
       remote_as: {{ l3leaf.node_groups[l3leaf_node_group].nodes[node].bgp_as | arista.avd.default(
                     l3leaf.node_groups[l3leaf_node_group].bgp_as,
                     l3leaf.defaults.bgp_as) }}
       description: {{ node }}_{{ l3leaf.node_groups[l3leaf_node_group].nodes[node].spine_interfaces[loop.index0] }}
-{%                 endif %}
-{%             endfor %}
+{%             endif %}
 {%         endfor %}
 {%     endfor %}
+{% endfor %}
 
 {# Underlay network peering to super spines #}
-{%     set spine_uplink_list = spine.nodes[inventory_hostname]['uplinks_to_super_spine_interfaces'] | arista.avd.default(
-                                   spine.uplinks_to_super_spine_interfaces,
-                                   []) %}
-{%     for spine_uplink in spine_uplink_list %}
-{%         set s_spine_id = loop.index0 // max_spine_to_super_spine_links + 1 %}
-{%         set ip_pool = super_spine_underlay_p2p_network_summary %}
-{#     max number of hosts in subnet will be divided by max super-spine number to avoid address changes when provisioning new spines #}
-{%         set ip_pool_max_hosts_in_subnet = ip_pool | ipaddr('size') %}
-{%         set offset = loop.index0 % max_spine_to_super_spine_links %}
+{% set spine_uplink_list = spine.nodes[inventory_hostname]['uplinks_to_super_spine_interfaces'] | arista.avd.default(
+                               spine.uplinks_to_super_spine_interfaces,
+                               []) %}
+{% for spine_uplink in spine_uplink_list %}
+{%     set s_spine_id = loop.index0 // max_spine_to_super_spine_links + 1 %}
+{%     set ip_pool = super_spine_underlay_p2p_network_summary %}
+{# max number of hosts in subnet will be divided by max super-spine number to avoid address changes when provisioning new spines #}
+{%     set ip_pool_max_hosts_in_subnet = ip_pool | ipaddr('size') %}
+{%     set offset = loop.index0 % max_spine_to_super_spine_links %}
     {{
       ip_pool | ipaddr('network') | ipmath(
             (ip_pool_max_hosts_in_subnet / max_super_spines) | int * (s_spine_id - 1) + ((switch.id - 1) * max_spine_to_super_spine_links + offset) * 2
@@ -64,23 +64,22 @@ router_bgp:
     }}:
       peer_group: {{ bgp_peer_groups.IPv4_UNDERLAY_PEERS.name | arista.avd.default("IPv4-UNDERLAY-PEERS") }}
       remote_as: {{ super_spine.bgp_as }}
-{%     endfor %}
+{% endfor %}
 
 {## Underlay network peering to Overlay Controllers #}
-{%     if overlay_controller is defined %}
-{%         for overlay_controller_node in overlay_controller.nodes | arista.avd.natural_sort %}
-{%             set overlay_controller_remote_switches = overlay_controller.nodes[overlay_controller_node].remote_switches | arista.avd.default(overlay_controller.defaults.remote_switches) %}
-{%             for overlay_controller_remote_switch in overlay_controller_remote_switches %}
-{%                 if overlay_controller_remote_switch == inventory_hostname %}
+{% if overlay_controller is defined %}
+{%     for overlay_controller_node in overlay_controller.nodes | arista.avd.natural_sort %}
+{%         set overlay_controller_remote_switches = overlay_controller.nodes[overlay_controller_node].remote_switches | arista.avd.default(overlay_controller.defaults.remote_switches) %}
+{%         for overlay_controller_remote_switch in overlay_controller_remote_switches %}
+{%             if overlay_controller_remote_switch == inventory_hostname %}
     {{ overlay_controller_p2p_network_summary | ipaddr('network') | ipmath(((overlay_controller.nodes[overlay_controller_node].id -1) * 2 * max_overlay_controller_to_switch_links) + loop.index0 * 2 + 1) }}:
       peer_group: {{ bgp_peer_groups.IPv4_UNDERLAY_PEERS.name | arista.avd.default("IPv4-UNDERLAY-PEERS") }}
       description: {{ overlay_controller_node }}
       remote_as: {{ overlay_controller.nodes[overlay_controller_node].bgp_as | arista.avd.default(overlay_controller.defaults.bgp_as) }}
-{%                     if overlay_controller_p2p_bfd is arista.avd.defined(true) %}
+{%                 if overlay_controller_p2p_bfd is arista.avd.defined(true) %}
       bfd: true
-{%                     endif %}
 {%                 endif %}
-{%             endfor %}
+{%             endif %}
 {%         endfor %}
-{%     endif %}
+{%     endfor %}
 {% endif %}


### PR DESCRIPTION
## Change Summary

Define all BGP peers on spines for RFC5549 explicitly. This change would cause BGP flap.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [x] Other (please describe):

## Related Issue(s)


## Component(s) name

`arista.avd.eos_designs`

## How to test
Tested on ATD topology

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
