### PR TITLE
BGP: add support for address-family IPv6 prefix-lists

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
@@ -135,10 +135,18 @@ router bgp 65101
       network 10.0.0.0/8
       network 172.16.0.0/12
       network 192.168.0.0/16 route-map RM-FOO-MATCH
+      neighbor foo prefix-list PL-BAR-v4-IN in
+      neighbor foo prefix-list PL-BAR-v4-OUT out
+      neighbor 192.0.2.1 prefix-list PL-FOO-v4-IN in
+      neighbor 192.0.2.1 prefix-list PL-FOO-v4-OUT out
    !
    address-family ipv6
       network 2001:db8:100::/40
       network 2001:db8:200::/40 route-map RM-BAR-MATCH
+      neighbor baz prefix-list PL-BAR-v6-IN in
+      neighbor baz prefix-list PL-BAR-v6-OUT out
+      neighbor 2001:db8::1 prefix-list PL-FOO-v6-IN in
+      neighbor 2001:db8::1 prefix-list PL-FOO-v6-OUT out
 ```
 
 # Multicast

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-base.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-base.cfg
@@ -28,9 +28,17 @@ router bgp 65101
       network 10.0.0.0/8
       network 172.16.0.0/12
       network 192.168.0.0/16 route-map RM-FOO-MATCH
+      neighbor foo prefix-list PL-BAR-v4-IN in
+      neighbor foo prefix-list PL-BAR-v4-OUT out
+      neighbor 192.0.2.1 prefix-list PL-FOO-v4-IN in
+      neighbor 192.0.2.1 prefix-list PL-FOO-v4-OUT out
    !
    address-family ipv6
       network 2001:db8:100::/40
       network 2001:db8:200::/40 route-map RM-BAR-MATCH
+      neighbor baz prefix-list PL-BAR-v6-IN in
+      neighbor baz prefix-list PL-BAR-v6-OUT out
+      neighbor 2001:db8::1 prefix-list PL-FOO-v6-IN in
+      neighbor 2001:db8::1 prefix-list PL-FOO-v6-OUT out
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-base.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-base.yml
@@ -26,8 +26,26 @@ router_bgp:
       172.16.0.0/12:
       192.168.0.0/16:
         route_map: RM-FOO-MATCH
+    peer_groups:
+      foo:
+        prefix_list_in: PL-BAR-v4-IN
+        prefix_list_out: PL-BAR-v4-OUT
+    neighbors:
+      192.0.2.1:
+        prefix_list_in: PL-FOO-v4-IN
+        prefix_list_out: PL-FOO-v4-OUT
+
   address_family_ipv6:
     networks:
       2001:db8:100::/40:
       2001:db8:200::/40:
         route_map: RM-BAR-MATCH
+    peer_groups:
+      baz:
+        prefix_list_in: PL-BAR-v6-IN
+        prefix_list_out: PL-BAR-v6-OUT
+    neighbors:
+      2001:db8::1:
+        prefix_list_in: PL-FOO-v6-IN
+        prefix_list_out: PL-FOO-v6-OUT
+

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1789,12 +1789,16 @@ router_bgp:
         activate: < true | false >
         route_map_in: < route_map_name >
         route_map_out: < route_map_name >
+        prefix_list_in: < prefix_list_name >
+        prefix_list_out: < prefix_list_name >
       < peer_group_name >:
         activate: true
     neighbors:
       < neighbor_ip_address>:
         route_map_in: < route_map_name >
         route_map_out: < route_map_name >
+        prefix_list_in: < prefix_list_name >
+        prefix_list_out: < prefix_list_name >
         activate: < true | false >
     redistribute_routes:
       < route_type >:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -368,6 +368,12 @@ router bgp {{ router_bgp.as }}
 {%             if router_bgp.address_family_ipv6.peer_groups[peer_group].route_map_out is arista.avd.defined %}
       neighbor {{ peer_group }} route-map {{ router_bgp.address_family_ipv6.peer_groups[peer_group].route_map_out }} out
 {%             endif %}
+{%             if router_bgp.address_family_ipv6.peer_groups[peer_group].prefix_list_in is arista.avd.defined %}
+      neighbor {{ peer_group }} prefix-list {{ router_bgp.address_family_ipv6.peer_groups[peer_group].prefix_list_in }} in
+{%             endif %}
+{%             if router_bgp.address_family_ipv6.peer_groups[peer_group].prefix_list_out is arista.avd.defined %}
+      neighbor {{ peer_group }} prefix-list {{ router_bgp.address_family_ipv6.peer_groups[peer_group].prefix_list_out }} out
+{%             endif %}
 {%             if router_bgp.address_family_ipv6.peer_groups[peer_group].activate is arista.avd.defined(true) %}
       neighbor {{ peer_group }} activate
 {%             elif router_bgp.address_family_ipv6.peer_groups[peer_group].activate is arista.avd.defined(false) %}
@@ -380,6 +386,12 @@ router bgp {{ router_bgp.as }}
 {%             endif %}
 {%             if router_bgp.address_family_ipv6.neighbors[neighbor].route_map_out is arista.avd.defined %}
       neighbor {{ neighbor }} route-map {{ router_bgp.address_family_ipv6.neighbors[neighbor].route_map_out }} out
+{%             endif %}
+{%             if router_bgp.address_family_ipv6.neighbors[neighbor].prefix_list_in is arista.avd.defined %}
+      neighbor {{ neighbor }} prefix-list {{ router_bgp.address_family_ipv6.neighbors[neighbor].prefix_list_in }} in
+{%             endif %}
+{%             if router_bgp.address_family_ipv6.neighbors[neighbor].prefix_list_out is arista.avd.defined %}
+      neighbor {{ neighbor }} prefix-list {{ router_bgp.address_family_ipv6.neighbors[neighbor].prefix_list_out }} out
 {%             endif %}
 {%             if router_bgp.address_family_ipv6.neighbors[neighbor].activate is arista.avd.defined(true) %}
       neighbor {{ neighbor }} activate


### PR DESCRIPTION
## Change Summary

Add support for declaring IPv6 prefix-list in/out for an IPv6 BGP neighbor/peer-group in `eos_cli_config_gen`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [x] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Fixes #923 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Extend YML definition

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Molecule

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
