### PR TITLE
fix(eos_validate_state): lldp tests

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/lldp_topology_fqdn.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/lldp_topology_fqdn.yml
@@ -15,7 +15,7 @@
     that:
       - lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0] is defined
       - lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0].systemName == ethernet_interface.value.peer + '.' + hostvars[ethernet_interface.value.peer]['dns_domain']
-      - lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0].neighborInterfaceInfo.interfaceId == '\'' + ethernet_interface.value.peer_interface + '\''
+      - lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0].neighborInterfaceInfo.interfaceId == "\"" + ethernet_interface.value.peer_interface + "\""
     fail_msg: "{{ lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0].systemName | default('Interface Down') }} - {{ lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0].neighborInterfaceInfo.interfaceId | default('N/A') }}"
     quiet: true
   loop: "{{ ethernet_interfaces | default({}, true) | dict2items }}"

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/lldp_topology_no_fqdn.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/lldp_topology_no_fqdn.yml
@@ -15,7 +15,7 @@
     that:
       - lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0] is defined
       - lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0].systemName == ethernet_interface.value.peer
-      - lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0].neighborInterfaceInfo.interfaceId == '\'' + ethernet_interface.value.peer_interface + '\''
+      - lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0].neighborInterfaceInfo.interfaceId == "\"" + ethernet_interface.value.peer_interface + "\""
     fail_msg: "{{ lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0].systemName | default('Interface Down') }} - {{ lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0].neighborInterfaceInfo.interfaceId | default('N/A') }}"
     quiet: true
   loop: "{{ ethernet_interfaces | default({}, true) | dict2items }}"


### PR DESCRIPTION
## Change Summary

Fix issue with lldp topology tests reporting false error.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.eos_validate_state`

## Proposed changes

Fix syntax issue in lldp test replace `'` with `"`

## How to test

run `eos_validate_state` with --tags lldp_topology
Configuration with and without domain name.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
