### PR TITLE
Add support for configurable "short_esi" prefix

### DIFF
--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -459,8 +459,8 @@ interface Ethernet21
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel7 | DC1_L2LEAF1_Po1 | switched | trunk | 110-111,120-121,130-131,160-161 | - | - | - | - | - | 0000:0000:0808:0707:0606 |
-| Port-Channel9 | DC1-L2LEAF3A_Po1 | switched | trunk | 110-111,120-121,130-131,160-161 | - | - | - | - | - | 0000:0000:0606:0707:0808 |
+| Port-Channel7 | DC1_L2LEAF1_Po1 | switched | trunk | 110-111,120-121,130-131,160-161 | - | - | - | - | - | 0000:1234:0808:0707:0606 |
+| Port-Channel9 | DC1-L2LEAF3A_Po1 | switched | trunk | 110-111,120-121,130-131,160-161 | - | - | - | - | - | 0000:1234:0606:0707:0808 |
 | Port-Channel10 | server01_MLAG_PortChanne1 | switched | trunk | 210-211 | - | - | - | - | 10 | - |
 | Port-Channel11 | server01_MTU_PROFILE_MLAG_PortChanne1 | switched | access | 110 | - | - | - | - | 11 | - |
 | Port-Channel12 | server01_MTU_ADAPTOR_MLAG_PortChanne1 | switched | access | - | - | - | - | - | 12 | - |
@@ -477,7 +477,7 @@ interface Port-Channel7
    switchport trunk allowed vlan 110-111,120-121,130-131,160-161
    switchport mode trunk
    evpn ethernet-segment
-      identifier 0000:0000:0808:0707:0606
+      identifier 0000:1234:0808:0707:0606
       route-target import 08:08:07:07:06:06
    lacp system-id 0808.0707.0606
 !
@@ -488,7 +488,7 @@ interface Port-Channel9
    switchport trunk allowed vlan 110-111,120-121,130-131,160-161
    switchport mode trunk
    evpn ethernet-segment
-      identifier 0000:0000:0606:0707:0808
+      identifier 0000:1234:0606:0707:0808
       route-target import 06:06:07:07:08:08
    lacp system-id 0606.0707.0808
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -459,8 +459,8 @@ interface Ethernet21
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel7 | DC1_L2LEAF1_Po1 | switched | trunk | 110-111,120-121,130-131,160-161 | - | - | - | - | - | 0000:0000:0808:0707:0606 |
-| Port-Channel9 | DC1-L2LEAF3A_Po1 | switched | trunk | 110-111,120-121,130-131,160-161 | - | - | - | - | - | 0000:0000:0606:0707:0808 |
+| Port-Channel7 | DC1_L2LEAF1_Po1 | switched | trunk | 110-111,120-121,130-131,160-161 | - | - | - | - | - | 0000:1234:0808:0707:0606 |
+| Port-Channel9 | DC1-L2LEAF3A_Po1 | switched | trunk | 110-111,120-121,130-131,160-161 | - | - | - | - | - | 0000:1234:0606:0707:0808 |
 | Port-Channel10 | server01_MLAG_PortChanne1 | switched | trunk | 210-211 | - | - | - | - | 10 | - |
 | Port-Channel11 | server01_MTU_PROFILE_MLAG_PortChanne1 | switched | access | 110 | - | - | - | - | 11 | - |
 | Port-Channel12 | server01_MTU_ADAPTOR_MLAG_PortChanne1 | switched | access | - | - | - | - | - | 12 | - |
@@ -477,7 +477,7 @@ interface Port-Channel7
    switchport trunk allowed vlan 110-111,120-121,130-131,160-161
    switchport mode trunk
    evpn ethernet-segment
-      identifier 0000:0000:0808:0707:0606
+      identifier 0000:1234:0808:0707:0606
       route-target import 08:08:07:07:06:06
    lacp system-id 0808.0707.0606
 !
@@ -488,7 +488,7 @@ interface Port-Channel9
    switchport trunk allowed vlan 110-111,120-121,130-131,160-161
    switchport mode trunk
    evpn ethernet-segment
-      identifier 0000:0000:0606:0707:0808
+      identifier 0000:1234:0606:0707:0808
       route-target import 06:06:07:07:08:08
    lacp system-id 0606.0707.0808
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -611,7 +611,7 @@ interface Ethernet44
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
 | Port-Channel5 | MLAG_PEER_DC1-SVC3B_Po5 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
 | Port-Channel7 | DC1_L2LEAF2_Po1 | switched | trunk | 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350 | - | - | - | - | 7 | - |
-| Port-Channel10 | server03_ESI_PortChanne1 | switched | trunk | 110-111,210-211 | - | - | - | - | - | 0000:0000:0303:0202:0101 |
+| Port-Channel10 | server03_ESI_PortChanne1 | switched | trunk | 110-111,210-211 | - | - | - | - | - | 0000:1234:0303:0202:0101 |
 | Port-Channel14 | server07_inherit_all_from_profile_port_channel_ALL_WITH_SECURITY_PORT_CHANNEL | switched | trunk | 1-4094 | - | - | - | - | 14 | - |
 | Port-Channel15 | server08_no_profile_port_channel_server08_no_profile_port_channel | switched | trunk | 1-4094 | - | - | - | - | 15 | - |
 | Port-Channel17 | server10_no_profile_port_channel_lacp_fallback_server10_no_profile_port_channel_lacp_fallback | switched | trunk | 1-4094 | - | - | 90 | static | 17 | - |
@@ -646,7 +646,7 @@ interface Port-Channel10
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
    evpn ethernet-segment
-      identifier 0000:0000:0303:0202:0101
+      identifier 0000:1234:0303:0202:0101
       route-target import 03:03:02:02:01:01
    lacp system-id 0303.0202.0101
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -611,7 +611,7 @@ interface Ethernet44
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
 | Port-Channel5 | MLAG_PEER_DC1-SVC3A_Po5 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
 | Port-Channel7 | DC1_L2LEAF2_Po1 | switched | trunk | 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350 | - | - | - | - | 7 | - |
-| Port-Channel10 | server03_ESI_PortChanne1 | switched | trunk | 110-111,210-211 | - | - | - | - | - | 0000:0000:0303:0202:0101 |
+| Port-Channel10 | server03_ESI_PortChanne1 | switched | trunk | 110-111,210-211 | - | - | - | - | - | 0000:1234:0303:0202:0101 |
 | Port-Channel14 | server07_inherit_all_from_profile_port_channel_ALL_WITH_SECURITY_PORT_CHANNEL | switched | trunk | 1-4094 | - | - | - | - | 14 | - |
 | Port-Channel15 | server08_no_profile_port_channel_server08_no_profile_port_channel | switched | trunk | 1-4094 | - | - | - | - | 15 | - |
 | Port-Channel17 | server10_no_profile_port_channel_lacp_fallback_server10_no_profile_port_channel_lacp_fallback | switched | trunk | 1-4094 | - | - | 90 | static | 17 | - |
@@ -646,7 +646,7 @@ interface Port-Channel10
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
    evpn ethernet-segment
-      identifier 0000:0000:0303:0202:0101
+      identifier 0000:1234:0303:0202:0101
       route-target import 03:03:02:02:01:01
    lacp system-id 0303.0202.0101
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
@@ -102,7 +102,7 @@ interface Port-Channel7
    switchport trunk allowed vlan 110-111,120-121,130-131,160-161
    switchport mode trunk
    evpn ethernet-segment
-      identifier 0000:0000:0808:0707:0606
+      identifier 0000:1234:0808:0707:0606
       route-target import 08:08:07:07:06:06
    lacp system-id 0808.0707.0606
 !
@@ -113,7 +113,7 @@ interface Port-Channel9
    switchport trunk allowed vlan 110-111,120-121,130-131,160-161
    switchport mode trunk
    evpn ethernet-segment
-      identifier 0000:0000:0606:0707:0808
+      identifier 0000:1234:0606:0707:0808
       route-target import 06:06:07:07:08:08
    lacp system-id 0606.0707.0808
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
@@ -102,7 +102,7 @@ interface Port-Channel7
    switchport trunk allowed vlan 110-111,120-121,130-131,160-161
    switchport mode trunk
    evpn ethernet-segment
-      identifier 0000:0000:0808:0707:0606
+      identifier 0000:1234:0808:0707:0606
       route-target import 08:08:07:07:06:06
    lacp system-id 0808.0707.0606
 !
@@ -113,7 +113,7 @@ interface Port-Channel9
    switchport trunk allowed vlan 110-111,120-121,130-131,160-161
    switchport mode trunk
    evpn ethernet-segment
-      identifier 0000:0000:0606:0707:0808
+      identifier 0000:1234:0606:0707:0808
       route-target import 06:06:07:07:08:08
    lacp system-id 0606.0707.0808
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
@@ -172,7 +172,7 @@ interface Port-Channel10
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
    evpn ethernet-segment
-      identifier 0000:0000:0303:0202:0101
+      identifier 0000:1234:0303:0202:0101
       route-target import 03:03:02:02:01:01
    lacp system-id 0303.0202.0101
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
@@ -172,7 +172,7 @@ interface Port-Channel10
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
    evpn ethernet-segment
-      identifier 0000:0000:0303:0202:0101
+      identifier 0000:1234:0303:0202:0101
       route-target import 03:03:02:02:01:01
    lacp system-id 0303.0202.0101
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -459,7 +459,7 @@ port_channel_interfaces:
     shutdown: false
     vlans: 110-111,120-121,130-131,160-161
     mode: trunk
-    esi: 0000:0000:0808:0707:0606
+    esi: 0000:1234:0808:0707:0606
     rt: 08:08:07:07:06:06
     lacp_id: 0808.0707.0606
   Port-Channel9:
@@ -468,7 +468,7 @@ port_channel_interfaces:
     shutdown: false
     vlans: 110-111,120-121,130-131,160-161
     mode: trunk
-    esi: 0000:0000:0606:0707:0808
+    esi: 0000:1234:0606:0707:0808
     rt: 06:06:07:07:08:08
     lacp_id: 0606.0707.0808
   Port-Channel20:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -459,7 +459,7 @@ port_channel_interfaces:
     shutdown: false
     vlans: 110-111,120-121,130-131,160-161
     mode: trunk
-    esi: 0000:0000:0808:0707:0606
+    esi: 0000:1234:0808:0707:0606
     rt: 08:08:07:07:06:06
     lacp_id: 0808.0707.0606
   Port-Channel9:
@@ -468,7 +468,7 @@ port_channel_interfaces:
     shutdown: false
     vlans: 110-111,120-121,130-131,160-161
     mode: trunk
-    esi: 0000:0000:0606:0707:0808
+    esi: 0000:1234:0606:0707:0808
     rt: 06:06:07:07:08:08
     lacp_id: 0606.0707.0808
   Port-Channel20:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -748,7 +748,7 @@ port_channel_interfaces:
     shutdown: false
     mode: trunk
     vlans: 110-111,210-211
-    esi: 0000:0000:0303:0202:0101
+    esi: 0000:1234:0303:0202:0101
     rt: 03:03:02:02:01:01
     lacp_id: 0303.0202.0101
   Port-Channel14:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -748,7 +748,7 @@ port_channel_interfaces:
     shutdown: false
     mode: trunk
     vlans: 110-111,210-211
-    esi: 0000:0000:0303:0202:0101
+    esi: 0000:1234:0303:0202:0101
     rt: 03:03:02:02:01:01
     lacp_id: 0303.0202.0101
   Port-Channel14:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
@@ -32,6 +32,9 @@ evpn_hostflap_detection:
   enabled: false
   threshold: 30
 
+# Set short_esi prefix to non-default value
+evpn_short_esi_prefix: "0000:1234:"
+
 # bgp peer groups passwords
 bgp_peer_groups:
   IPv4_UNDERLAY_PEERS:

--- a/ansible_collections/arista/avd/roles/eos_designs/defaults/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/defaults/main.yml
@@ -95,6 +95,8 @@ overlay_routing_protocol: BGP
 
 evpn_ebgp_multihop: 3
 
+evpn_short_esi_prefix: "0000:0000:"
+
 # Underlay OSPF Defaults
 underlay_ospf_process_id: 100
 underlay_ospf_area: 0.0.0.0

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/fabric-variables.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/fabric-variables.md
@@ -144,6 +144,9 @@ evpn_overlay_bgp_rtc: < true | false , default -> false >
 # from Route-server-1 to Router-server-2 just for Route-server-2 to throw them away because of AS Path loop detection.
 evpn_prevent_readvertise_to_server : < true | false , default -> false >
 
+# Configure prefix for "short_esi" values | Optional
+evpn_short_esi_prefix: < string, default -> "0000:0000:" >
+
 # Optional IP subnet assigned to Inband Management SVI on l2leafs in default VRF.
 # Parent l3leafs will have SVI with "ip virtual-router" and host-route injection based on ARP. This allows all l3leafs to reuse the same subnet
 # SVI IP address will be assigned as follows:

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/port-channel-interfaces.j2
@@ -97,7 +97,7 @@ port_channel_interfaces:
 {%                         if adapter.switches | unique | list | length > 1 %}
 {%                             if adapter.port_channel.short_esi is arista.avd.defined %}
 {%                                 if adapter.port_channel.short_esi.split(':') | length == 3 %}
-    esi: {{ adapter.port_channel.short_esi | arista.avd.generate_esi }}
+    esi: {{ adapter.port_channel.short_esi | arista.avd.generate_esi(evpn_short_esi_prefix) }}
     rt: {{ adapter.port_channel.short_esi | arista.avd.generate_route_target }}
 {%                                     if adapter_port_channel.mode == 'active' %}
     lacp_id: {{ adapter.port_channel.short_esi | arista.avd.generate_lacp_id }}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/underlay/interfaces/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/underlay/interfaces/port-channel-interfaces.j2
@@ -22,7 +22,7 @@ port_channel_interfaces:
 {%         if switch.mlag == true %}
     mlag: {{ link.channel_group_id }}
 {%         elif link.short_esi is arista.avd.defined %}
-    esi: {{ link.short_esi | arista.avd.generate_esi }}
+    esi: {{ link.short_esi | arista.avd.generate_esi(evpn_short_esi_prefix) }}
     rt: {{ link.short_esi | arista.avd.generate_route_target }}
     lacp_id: {{ link.short_esi | arista.avd.generate_lacp_id }}
 {%         endif %}


### PR DESCRIPTION
## Change Summary

Add support for configurable `short_esi` prefix by setting `evpn_short_esi_prefix`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [x] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Based of branch of #932. Must be rebased from devel when #932 merges. This PR only has 1 commit.

Fixes #746 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->
```
# Configure prefix for "short_esi" values | Optional
evpn_short_esi_prefix: < string, default -> "0000:0000:" >
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Updated molecule `evpn_underlay_ebgp_overlay_ebgp` to use this knob. All changes are as expected.
Other molecule scenarios using `short_esi` are not affected.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
