### PR TITLE
Fix(inventory_to_container): Add return guard if no children in inven…

### DIFF
--- a/ansible_collections/arista/avd/plugins/modules/inventory_to_container.py
+++ b/ansible_collections/arista/avd/plugins/modules/inventory_to_container.py
@@ -328,6 +328,8 @@ def get_devices(dict_inventory, search_container=None, devices=None, device_filt
     # W102 Workaround to avoid list as default value.
     if device_filter is None:
         device_filter = ["all"]
+    if dict_inventory is None:
+        return devices
 
     for k1, v1 in dict_inventory.items():
         # Read a leaf


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Fixes #939

## Component(s) name

`arista.avd.eos_config_deploy_cvp`

## Proposed changes
Add a return guard in `avd/plugins/modules/inventory_to_container.py` in the `get_devices()` function in order to avoid the cast issue.

## How to test
Playbook:
```
- hosts: cv_server
  tasks:
    - name: deploy configuration via CVP
      import_role:
         name: arista.avd.eos_config_deploy_cvp
      vars:
        container_root: 'DC1_FABRIC'
        configlets_prefix: 'DC1-AVD'
        device_filter: 'DC1'
        state: present
        execute_tasks: false
```
Inventory:
```
    # DC1_Fabric - EVPN Fabric running in home lab
    DC1:
      children:
        DC1_FABRIC:
          children:
            DC1_SPINES:
              hosts:
                DC1-SPINE1:
                  ansible_host: 10.0.0.1
                DC1-SPINE2:
                  ansible_host: 10.0.0.2
            DC1_L3LEAFS:
              children:
                DC1_LEAF1:
                  hosts:
                    DC1-LEAF1A:
                      ansible_host: 10.0.0.3
                    DC1-LEAF1B:
                      ansible_host: 10.0.0.4
            DC1_L2LEAFS:
              children:
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
