### PR TITLE
Add support for not setting mgmt_ip on devices

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF1A.md
@@ -45,25 +45,17 @@
 
 | Management Interface | description | Type | VRF | IP Address | Gateway |
 | -------------------- | ----------- | ---- | --- | ---------- | ------- |
-| Management1 | oob_management | oob | MGMT | 192.168.1.10/24 | 192.168.1.254 |
 | Vlan4085 | L2LEAF_INBAND_MGMT | inband | default | 172.21.110.4/24 | 172.21.110.1 |
 
 #### IPv6
 
 | Management Interface | description | Type | VRF | IPv6 Address | IPv6 Gateway |
 | -------------------- | ----------- | ---- | --- | ------------ | ------------ |
-| Management1 | oob_management | oob | MGMT | -  | - |
 | Vlan4085 | L2LEAF_INBAND_MGMT | inband | default | -  | - |
 
 ### Management Interfaces Device Configuration
 
 ```eos
-!
-interface Management1
-   description oob_management
-   no shutdown
-   vrf MGMT
-   ip address 192.168.1.10/24
 !
 interface Vlan4085
    description L2LEAF_INBAND_MGMT

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF2A.md
@@ -49,25 +49,17 @@
 
 | Management Interface | description | Type | VRF | IP Address | Gateway |
 | -------------------- | ----------- | ---- | --- | ---------- | ------- |
-| Management1 | oob_management | oob | MGMT | 192.168.1.11/24 | 192.168.1.254 |
 | Vlan4085 | L2LEAF_INBAND_MGMT | inband | default | 172.21.110.5/24 | 172.21.110.1 |
 
 #### IPv6
 
 | Management Interface | description | Type | VRF | IPv6 Address | IPv6 Gateway |
 | -------------------- | ----------- | ---- | --- | ------------ | ------------ |
-| Management1 | oob_management | oob | MGMT | -  | - |
 | Vlan4085 | L2LEAF_INBAND_MGMT | inband | default | -  | - |
 
 ### Management Interfaces Device Configuration
 
 ```eos
-!
-interface Management1
-   description oob_management
-   no shutdown
-   vrf MGMT
-   ip address 192.168.1.11/24
 !
 interface Vlan4085
    description L2LEAF_INBAND_MGMT

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF1A.md
@@ -3,7 +3,6 @@
 <!-- toc -->
 
 - [Management](#management)
-  - [Management Interfaces](#management-interfaces)
   - [Management API HTTP](#management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
@@ -45,33 +44,6 @@
 
 <!-- toc -->
 # Management
-
-## Management Interfaces
-
-### Management Interfaces Summary
-
-#### IPv4
-
-| Management Interface | description | Type | VRF | IP Address | Gateway |
-| -------------------- | ----------- | ---- | --- | ---------- | ------- |
-| Management1 | oob_management | oob | MGMT | 192.168.1.7/24 | 192.168.1.254 |
-
-#### IPv6
-
-| Management Interface | description | Type | VRF | IPv6 Address | IPv6 Gateway |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ |
-| Management1 | oob_management | oob | MGMT | -  | - |
-
-### Management Interfaces Device Configuration
-
-```eos
-!
-interface Management1
-   description oob_management
-   no shutdown
-   vrf MGMT
-   ip address 192.168.1.7/24
-```
 
 ## Management API HTTP
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2A.md
@@ -3,7 +3,6 @@
 <!-- toc -->
 
 - [Management](#management)
-  - [Management Interfaces](#management-interfaces)
   - [Management API HTTP](#management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
@@ -48,33 +47,6 @@
 
 <!-- toc -->
 # Management
-
-## Management Interfaces
-
-### Management Interfaces Summary
-
-#### IPv4
-
-| Management Interface | description | Type | VRF | IP Address | Gateway |
-| -------------------- | ----------- | ---- | --- | ---------- | ------- |
-| Management1 | oob_management | oob | MGMT | 192.168.1.8/16 | 192.168.1.254 |
-
-#### IPv6
-
-| Management Interface | description | Type | VRF | IPv6 Address | IPv6 Gateway |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ |
-| Management1 | oob_management | oob | MGMT | -  | - |
-
-### Management Interfaces Device Configuration
-
-```eos
-!
-interface Management1
-   description oob_management
-   no shutdown
-   vrf MGMT
-   ip address 192.168.1.8/16
-```
 
 ## Management API HTTP
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
@@ -165,7 +165,7 @@ snmp-server location TWODC_5STAGE_CLOS DC1 DC1_POD1 DC1-POD1-LEAF2B
 | --------- | --------------- | ------------ | --------- |
 | RACK2_MLAG | Vlan4094 | 172.19.110.2 | Port-Channel5 |
 
-Dual primary detection is enabled. The detection delay is 5 seconds.
+Dual primary detection is disabled.
 
 ## MLAG Device Configuration
 
@@ -175,9 +175,7 @@ mlag configuration
    domain-id RACK2_MLAG
    local-interface Vlan4094
    peer-address 172.19.110.2
-   peer-address heartbeat 192.168.1.8 vrf MGMT
    peer-link Port-Channel5
-   dual-primary detection delay 5 action errdisable all-interfaces
    reload-delay mlag 300
    reload-delay non-mlag 330
 ```

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-SPINE1.md
@@ -3,7 +3,6 @@
 <!-- toc -->
 
 - [Management](#management)
-  - [Management Interfaces](#management-interfaces)
   - [Management API HTTP](#management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
@@ -37,33 +36,6 @@
 
 <!-- toc -->
 # Management
-
-## Management Interfaces
-
-### Management Interfaces Summary
-
-#### IPv4
-
-| Management Interface | description | Type | VRF | IP Address | Gateway |
-| -------------------- | ----------- | ---- | --- | ---------- | ------- |
-| Management1 | oob_management | oob | MGMT | 192.168.1.5/24 | 192.168.1.254 |
-
-#### IPv6
-
-| Management Interface | description | Type | VRF | IPv6 Address | IPv6 Gateway |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ |
-| Management1 | oob_management | oob | MGMT | -  | - |
-
-### Management Interfaces Device Configuration
-
-```eos
-!
-interface Management1
-   description oob_management
-   no shutdown
-   vrf MGMT
-   ip address 192.168.1.5/24
-```
 
 ## Management API HTTP
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-RS1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-RS1.md
@@ -3,7 +3,6 @@
 <!-- toc -->
 
 - [Management](#management)
-  - [Management Interfaces](#management-interfaces)
   - [Management API HTTP](#management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
@@ -37,33 +36,6 @@
 
 <!-- toc -->
 # Management
-
-## Management Interfaces
-
-### Management Interfaces Summary
-
-#### IPv4
-
-| Management Interface | description | Type | VRF | IP Address | Gateway |
-| -------------------- | ----------- | ---- | --- | ---------- | ------- |
-| Management1 | oob_management | oob | MGMT | 192.168.1.3/24 | 192.168.1.254 |
-
-#### IPv6
-
-| Management Interface | description | Type | VRF | IPv6 Address | IPv6 Gateway |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ |
-| Management1 | oob_management | oob | MGMT | -  | - |
-
-### Management Interfaces Device Configuration
-
-```eos
-!
-interface Management1
-   description oob_management
-   no shutdown
-   vrf MGMT
-   ip address 192.168.1.3/24
-```
 
 ## Management API HTTP
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-SUPER-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-SUPER-SPINE1.md
@@ -3,7 +3,6 @@
 <!-- toc -->
 
 - [Management](#management)
-  - [Management Interfaces](#management-interfaces)
   - [Management API HTTP](#management-api-http)
 - [Authentication](#authentication)
   - [Local Users](#local-users)
@@ -35,33 +34,6 @@
 
 <!-- toc -->
 # Management
-
-## Management Interfaces
-
-### Management Interfaces Summary
-
-#### IPv4
-
-| Management Interface | description | Type | VRF | IP Address | Gateway |
-| -------------------- | ----------- | ---- | --- | ---------- | ------- |
-| Management1 | oob_management | oob | MGMT | 192.168.1.1/24 | 192.168.1.254 |
-
-#### IPv6
-
-| Management Interface | description | Type | VRF | IPv6 Address | IPv6 Gateway |
-| -------------------- | ----------- | ---- | --- | ------------ | ------------ |
-| Management1 | oob_management | oob | MGMT | -  | - |
-
-### Management Interfaces Device Configuration
-
-```eos
-!
-interface Management1
-   description oob_management
-   no shutdown
-   vrf MGMT
-   ip address 192.168.1.1/24
-```
 
 ## Management API HTTP
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/fabric/TWODC_5STAGE_CLOS-documentation.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/fabric/TWODC_5STAGE_CLOS-documentation.md
@@ -19,20 +19,20 @@
 
 | POD | Type | Node | Management IP | Platform | Provisioned in CloudVision |
 | --- | ---- | ---- | ------------- | -------- | -------------------------- |
-| DC1_POD1 | l2leaf | DC1-POD1-L2LEAF1A | 192.168.1.10/24 | vEOS-LAB | Provisioned |
-| DC1_POD1 | l2leaf | DC1-POD1-L2LEAF2A | 192.168.1.11/24 | vEOS-LAB | Provisioned |
+| DC1_POD1 | l2leaf | DC1-POD1-L2LEAF1A | - | vEOS-LAB | Provisioned |
+| DC1_POD1 | l2leaf | DC1-POD1-L2LEAF2A | - | vEOS-LAB | Provisioned |
 | DC1_POD1 | l2leaf | DC1-POD1-L2LEAF2B | 192.168.1.12/24 | vEOS-LAB | Provisioned |
-| DC1_POD1 | l3leaf | DC1-POD1-LEAF1A | 192.168.1.7/24 | vEOS-LAB | Provisioned |
-| DC1_POD1 | l3leaf | DC1-POD1-LEAF2A | 192.168.1.8/16 | vEOS-LAB | Provisioned |
+| DC1_POD1 | l3leaf | DC1-POD1-LEAF1A | - | vEOS-LAB | Provisioned |
+| DC1_POD1 | l3leaf | DC1-POD1-LEAF2A | - | vEOS-LAB | Provisioned |
 | DC1_POD1 | l3leaf | DC1-POD1-LEAF2B | 192.168.1.9/16 | vEOS-LAB | Provisioned |
-| DC1_POD1 | spine | DC1-POD1-SPINE1 | 192.168.1.5/24 | vEOS-LAB | Provisioned |
+| DC1_POD1 | spine | DC1-POD1-SPINE1 | - | vEOS-LAB | Provisioned |
 | DC1_POD1 | spine | DC1-POD1-SPINE2 | 192.168.1.6/24 | vEOS-LAB | Provisioned |
 | DC1_POD2 | l3leaf | DC1-POD2-LEAF1A | 192.168.1.15/24 | vEOS-LAB | Provisioned |
 | DC1_POD2 | spine | DC1-POD2-SPINE1 | 192.168.1.13/24 | vEOS-LAB | Provisioned |
 | DC1_POD2 | spine | DC1-POD2-SPINE2 | 192.168.1.14/24 | vEOS-LAB | Provisioned |
-| DC1 | overlay-controller | DC1-RS1 | 192.168.1.3/24 | vEOS-LAB | Provisioned |
+| DC1 | overlay-controller | DC1-RS1 | - | vEOS-LAB | Provisioned |
 | DC1 | overlay-controller | DC1-RS2 | 192.168.1.4/24 | vEOS-LAB | Provisioned |
-| DC1 | super-spine | DC1-SUPER-SPINE1 | 192.168.1.1/24 | vEOS-LAB | Provisioned |
+| DC1 | super-spine | DC1-SUPER-SPINE1 | - | vEOS-LAB | Provisioned |
 | DC1 | super-spine | DC1-SUPER-SPINE2 | 192.168.1.2/24 | vEOS-LAB | Provisioned |
 | DC2_POD1 | l2leaf | DC2-POD1-L2LEAF1A | 192.168.1.23/24 | vEOS-LAB | Provisioned |
 | DC2_POD1 | l3leaf | DC2-POD1-LEAF1A | 192.168.1.22/24 | vEOS-LAB | Provisioned |

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-L2LEAF1A.cfg
@@ -36,12 +36,6 @@ interface Ethernet1
    no shutdown
    channel-group 1 mode active
 !
-interface Management1
-   description oob_management
-   no shutdown
-   vrf MGMT
-   ip address 192.168.1.10/24
-!
 interface Vlan4085
    description L2LEAF_INBAND_MGMT
    no shutdown

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-L2LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-L2LEAF2A.cfg
@@ -81,12 +81,6 @@ interface Ethernet4
    no shutdown
    channel-group 3 mode active
 !
-interface Management1
-   description oob_management
-   no shutdown
-   vrf MGMT
-   ip address 192.168.1.11/24
-!
 interface Vlan4085
    description L2LEAF_INBAND_MGMT
    no shutdown

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF1A.cfg
@@ -71,12 +71,6 @@ interface Loopback1
    no shutdown
    ip address 172.18.110.3/32
 !
-interface Management1
-   description oob_management
-   no shutdown
-   vrf MGMT
-   ip address 192.168.1.7/24
-!
 interface Vlan4085
    description L2LEAF_INBAND_MGMT
    no shutdown

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2A.cfg
@@ -123,12 +123,6 @@ interface Loopback1
    no shutdown
    ip address 172.18.110.4/32
 !
-interface Management1
-   description oob_management
-   no shutdown
-   vrf MGMT
-   ip address 192.168.1.8/16
-!
 interface Vlan110
    description Tenant_A_OP_Zone_1
    no shutdown

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2B.cfg
@@ -197,9 +197,7 @@ mlag configuration
    domain-id RACK2_MLAG
    local-interface Vlan4094
    peer-address 172.19.110.2
-   peer-address heartbeat 192.168.1.8 vrf MGMT
    peer-link Port-Channel5
-   dual-primary detection delay 5 action errdisable all-interfaces
    reload-delay mlag 300
    reload-delay non-mlag 330
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-SPINE1.cfg
@@ -77,12 +77,6 @@ interface Loopback0
    no shutdown
    ip address 172.16.110.1/32
 !
-interface Management1
-   description oob_management
-   no shutdown
-   vrf MGMT
-   ip address 192.168.1.5/24
-!
 ip routing
 no ip routing vrf MGMT
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-RS1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-RS1.cfg
@@ -48,12 +48,6 @@ interface Loopback0
    no shutdown
    ip address 172.16.10.1/32
 !
-interface Management1
-   description oob_management
-   no shutdown
-   vrf MGMT
-   ip address 192.168.1.3/24
-!
 ip routing
 no ip routing vrf MGMT
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-SUPER-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-SUPER-SPINE1.cfg
@@ -77,12 +77,6 @@ interface Loopback0
    no shutdown
    ip address 172.16.100.1/32
 !
-interface Management1
-   description oob_management
-   no shutdown
-   vrf MGMT
-   ip address 192.168.1.1/24
-!
 ip routing
 no ip routing vrf MGMT
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF1A.yml
@@ -26,21 +26,6 @@ local_users:
 vrfs:
   MGMT:
     ip_routing: false
-management_interfaces:
-  Management1:
-    description: oob_management
-    shutdown: false
-    vrf: MGMT
-    ip_address: 192.168.1.10/24
-    gateway: 192.168.1.254
-    type: oob
-  Vlan4085:
-    description: L2LEAF_INBAND_MGMT
-    shutdown: false
-    mtu: 1500
-    ip_address: 172.21.110.4/24
-    gateway: 172.21.110.1
-    type: inband
 management_api_http:
   enable_vrfs:
     MGMT: {}
@@ -68,5 +53,13 @@ vlans:
   4085:
     tenant: system
     name: L2LEAF_INBAND_MGMT
+management_interfaces:
+  Vlan4085:
+    description: L2LEAF_INBAND_MGMT
+    shutdown: false
+    mtu: 1500
+    ip_address: 172.21.110.4/24
+    gateway: 172.21.110.1
+    type: inband
 ip_igmp_snooping:
   globally_enabled: true

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF2A.yml
@@ -27,21 +27,6 @@ local_users:
 vrfs:
   MGMT:
     ip_routing: false
-management_interfaces:
-  Management1:
-    description: oob_management
-    shutdown: false
-    vrf: MGMT
-    ip_address: 192.168.1.11/24
-    gateway: 192.168.1.254
-    type: oob
-  Vlan4085:
-    description: L2LEAF_INBAND_MGMT
-    shutdown: false
-    mtu: 1500
-    ip_address: 172.21.110.5/24
-    gateway: 172.21.110.1
-    type: inband
 management_api_http:
   enable_vrfs:
     MGMT: {}
@@ -143,5 +128,13 @@ mlag_configuration:
   peer_link: Port-Channel3
   reload_delay_mlag: 300
   reload_delay_non_mlag: 330
+management_interfaces:
+  Vlan4085:
+    description: L2LEAF_INBAND_MGMT
+    shutdown: false
+    mtu: 1500
+    ip_address: 172.21.110.5/24
+    gateway: 172.21.110.1
+    type: inband
 ip_igmp_snooping:
   globally_enabled: true

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF1A.yml
@@ -106,14 +106,6 @@ local_users:
 vrfs:
   MGMT:
     ip_routing: false
-management_interfaces:
-  Management1:
-    description: oob_management
-    shutdown: false
-    vrf: MGMT
-    ip_address: 192.168.1.7/24
-    gateway: 192.168.1.254
-    type: oob
 management_api_http:
   enable_vrfs:
     MGMT: {}

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2A.yml
@@ -163,14 +163,6 @@ vrfs:
   Common_VRF:
     tenant: Tenant_A
     ip_routing: true
-management_interfaces:
-  Management1:
-    description: oob_management
-    shutdown: false
-    vrf: MGMT
-    ip_address: 192.168.1.8/16
-    gateway: 192.168.1.254
-    type: oob
 management_api_http:
   enable_vrfs:
     MGMT: {}

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
@@ -349,10 +349,6 @@ mlag_configuration:
   domain_id: RACK2_MLAG
   local_interface: Vlan4094
   peer_address: 172.19.110.2
-  peer_address_heartbeat:
-    peer_ip: 192.168.1.8
-    vrf: MGMT
-  dual_primary_detection_delay: 5
   peer_link: Port-Channel5
   reload_delay_mlag: 300
   reload_delay_non_mlag: 330

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-SPINE1.yml
@@ -118,14 +118,6 @@ local_users:
 vrfs:
   MGMT:
     ip_routing: false
-management_interfaces:
-  Management1:
-    description: oob_management
-    shutdown: false
-    vrf: MGMT
-    ip_address: 192.168.1.5/24
-    gateway: 192.168.1.254
-    type: oob
 management_api_http:
   enable_vrfs:
     MGMT: {}

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-RS1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-RS1.yml
@@ -108,14 +108,6 @@ local_users:
 vrfs:
   MGMT:
     ip_routing: false
-management_interfaces:
-  Management1:
-    description: oob_management
-    shutdown: false
-    vrf: MGMT
-    ip_address: 192.168.1.3/24
-    gateway: 192.168.1.254
-    type: oob
 management_api_http:
   enable_vrfs:
     MGMT: {}

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-SUPER-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-SUPER-SPINE1.yml
@@ -69,14 +69,6 @@ local_users:
 vrfs:
   MGMT:
     ip_routing: false
-management_interfaces:
-  Management1:
-    description: oob_management
-    shutdown: false
-    vrf: MGMT
-    ip_address: 192.168.1.1/24
-    gateway: 192.168.1.254
-    type: oob
 management_api_http:
   enable_vrfs:
     MGMT: {}

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/DC1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/DC1.yml
@@ -11,7 +11,7 @@ super_spine:
   nodes:
     DC1-SUPER-SPINE1:
       id: 1
-      mgmt_ip: 192.168.1.1/24
+      # mgmt_ip: 192.168.1.1/24 Test without management IP
       # evpn_role: none
       # evpn_route_servers: []
     DC1-SUPER-SPINE2:
@@ -32,7 +32,7 @@ overlay_controller:
   nodes:
     DC1-RS1:
       id: 1
-      mgmt_ip: 192.168.1.3/24
+      # mgmt_ip: 192.168.1.3/24 Test without management IP
       bgp_as: 65101
       evpn_role: server
       evpn_route_servers: [ DC2-RS1, DC2-SUPER-SPINE1, DC2-POD1-SPINE1, DC2-POD1-LEAF1A ]

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/DC1_POD1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/DC1_POD1.yml
@@ -24,7 +24,7 @@ spine:
     # Spine also working as EVPN RS
     DC1-POD1-SPINE1:
       id: 1
-      mgmt_ip: 192.168.1.5/24
+      # mgmt_ip: 192.168.1.5/24 Test without management IP
       evpn_role: server
       super_spine_interfaces: [ Ethernet1, Ethernet1 ]
       evpn_route_servers: [ DC2-RS1, DC2-SUPER-SPINE1, DC2-POD1-SPINE1, DC2-POD1-LEAF1A ]
@@ -57,7 +57,7 @@ l3leaf:
       nodes:
         DC1-POD1-LEAF1A:
           id: 1
-          mgmt_ip: 192.168.1.7/24
+          # mgmt_ip: 192.168.1.7/24 Test without management IP
           spine_interfaces: [ Ethernet3, Ethernet3 ]
     # Regular MLAG pair
     RACK2_MLAG:
@@ -73,7 +73,7 @@ l3leaf:
       nodes:
         DC1-POD1-LEAF2A:
           id: 2
-          mgmt_ip: 192.168.1.8/16
+          # mgmt_ip: 192.168.1.8/16 Test without management IP
           spine_interfaces: [ Ethernet4, Ethernet4 ]
         DC1-POD1-LEAF2B:
           id: 3
@@ -94,7 +94,7 @@ l2leaf:
       nodes:
         DC1-POD1-L2LEAF1A:
           id: 1
-          mgmt_ip: 192.168.1.10/24
+          # mgmt_ip: 192.168.1.10/24 Test without management IP
           l3leaf_interfaces: [ Ethernet3 ]
     RACK2_MLAG:
       platform: vEOS-LAB
@@ -106,7 +106,7 @@ l2leaf:
       nodes:
         DC1-POD1-L2LEAF2A:
           id: 2
-          mgmt_ip: 192.168.1.11/24
+          # mgmt_ip: 192.168.1.11/24 Test without management IP
           l3leaf_interfaces: [ Ethernet3, Ethernet3 ]
         DC1-POD1-L2LEAF2B:
           id: 3

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/fabric-topology.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/fabric-topology.md
@@ -124,7 +124,7 @@ spine:
       # Peer with these EVPN Route Servers / Route Reflectors | Optional
       evpn_route_servers: [ < route_server_inventory_hostname >, < route_server_inventory_hostname >]
 
-      # Node management IP address | Required.
+      # Node management IP address | Optional.
       mgmt_ip: < IPv4_address/Mask >
     < inventory_hostname >:
       id: < integer >
@@ -252,7 +252,7 @@ l3leaf:
           # Unique identifier | Required.
           id: < integer >
 
-          # Node management IP address | Required.
+          # Node management IP address | Optional.
           mgmt_ip: < IPv4_address/Mask >
 
           # Uplink to spine interfaces (list), interface located on L3 Leaf,
@@ -429,7 +429,7 @@ l2leaf:
           # Unique identifier | Required.
           id: < integer >
 
-          # Node management IP address | Required.
+          # Node management IP address | Optional.
           mgmt_ip: < IPv4_address/Mask >
 
           # l3leaf interfaces (list), interface located on l3leaf,

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/base/management-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/base/management-interfaces.j2
@@ -1,5 +1,8 @@
 {# Management interface #}
-{% if mgmt_interface is defined %}
+{% if mgmt_interface is arista.avd.defined and 
+      mgmt_interface_vrf is arista.avd.defined and
+      mgmt_gateway is arista.avd.defined and
+      switch.mgmt_ip is arista.avd.defined %}
 management_interfaces:
   {{ mgmt_interface }}:
     description: oob_management

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/base/management-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/base/management-interfaces.j2
@@ -1,5 +1,5 @@
 {# Management interface #}
-{% if mgmt_interface is arista.avd.defined and 
+{% if mgmt_interface is arista.avd.defined and
       mgmt_interface_vrf is arista.avd.defined and
       mgmt_gateway is arista.avd.defined and
       switch.mgmt_ip is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/facts/switch/l2leaf.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/facts/switch/l2leaf.j2
@@ -12,7 +12,7 @@ switch:
   id: {{ switch_id }}
 
 {# switch.mgmt_ip #}
-  mgmt_ip: {{ l2leaf.node_groups[l2leaf_node_group].nodes[node].mgmt_ip }}
+  mgmt_ip: {{ l2leaf.node_groups[l2leaf_node_group].nodes[node].mgmt_ip | arista.avd.default() }}
 
 {# switch.spanning_tree_mode #}
   spanning_tree_mode: {{ l2leaf.node_groups[l2leaf_node_group].spanning_tree_mode | arista.avd.default(
@@ -107,7 +107,9 @@ switch:
 
   mlag_peer_ip: {% include templates[design.type].ip_addressing[type].mlag_ip_secondary %}
 
+{%                     if l2leaf.node_groups[l2leaf_node_group].nodes[loop.nextitem].mgmt_ip | arista.avd.default() is truthy %}
   mlag_peer_mgmt_ip: {{ l2leaf.node_groups[l2leaf_node_group].nodes[loop.nextitem].mgmt_ip | ansible.netcommon.ipaddr('address') }}
+{%                     endif %}
 {%                 elif loop.index == 2 %}
 {%                     set mlag_primary_id = l2leaf.node_groups[l2leaf_node_group].nodes[loop.previtem].id %}
 {%                     set mlag_secondary_id = switch_id %}
@@ -117,7 +119,9 @@ switch:
 
   mlag_peer_ip: {% include templates[design.type].ip_addressing[type].mlag_ip_primary %}
 
+{%                     if l2leaf.node_groups[l2leaf_node_group].nodes[loop.previtem].mgmt_ip | arista.avd.default() is truthy %}
   mlag_peer_mgmt_ip: {{ l2leaf.node_groups[l2leaf_node_group].nodes[loop.previtem].mgmt_ip | ansible.netcommon.ipaddr('address') }}
+{%                     endif %}
 {%                 endif %}
 {%             else %}
   mlag: false

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/facts/switch/l3leaf.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/facts/switch/l3leaf.j2
@@ -11,7 +11,7 @@ switch:
   id: {{ switch_id }}
 
 {# switch.mgmt_ip #}
-  mgmt_ip: {{ l3leaf.node_groups[l3leaf_node_group].nodes[node].mgmt_ip }}
+  mgmt_ip: {{ l3leaf.node_groups[l3leaf_node_group].nodes[node].mgmt_ip | arista.avd.default() }}
 
 {# switch.platform #}
 {%             set switch_platform = l3leaf.node_groups[l3leaf_node_group].platform | arista.avd.default(
@@ -143,7 +143,9 @@ switch:
 {%                     set mlag_secondary_id = l3leaf.node_groups[l3leaf_node_group].nodes[loop.nextitem].id %}
   mlag_role: "primary"
   mlag_peer: {{ loop.nextitem }}
+{%                     if l3leaf.node_groups[l3leaf_node_group].nodes[loop.nextitem].mgmt_ip | arista.avd.default() is truthy %}
   mlag_peer_mgmt_ip: {{ l3leaf.node_groups[l3leaf_node_group].nodes[loop.nextitem].mgmt_ip | ansible.netcommon.ipaddr('address') }}
+{%                     endif %}
   mlag_ip: {% include templates[design.type].ip_addressing[type].mlag_ip_primary %}
 
   mlag_peer_ip: {% include templates[design.type].ip_addressing[type].mlag_ip_secondary %}
@@ -157,7 +159,9 @@ switch:
 {%                     set mlag_secondary_id = switch_id %}
   mlag_role: "secondary"
   mlag_peer: {{ loop.previtem }}
+{%                     if l3leaf.node_groups[l3leaf_node_group].nodes[loop.previtem].mgmt_ip | arista.avd.default() is truthy %}
   mlag_peer_mgmt_ip: {{ l3leaf.node_groups[l3leaf_node_group].nodes[loop.previtem].mgmt_ip | ansible.netcommon.ipaddr('address') }}
+{%                     endif %}
   mlag_ip: {% include templates[design.type].ip_addressing[type].mlag_ip_secondary %}
 
   mlag_peer_ip: {% include templates[design.type].ip_addressing[type].mlag_ip_primary %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/facts/switch/overlay-controller.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/facts/switch/overlay-controller.j2
@@ -7,7 +7,7 @@ switch:
   id: {{ switch_id }}
 
 {# switch.mgmt_ip #}
-  mgmt_ip: {{ overlay_controller.nodes[node].mgmt_ip }}
+  mgmt_ip: {{ overlay_controller.nodes[node].mgmt_ip | arista.avd.default() }}
 
 {# switch.spanning_tree_mode #}
   spanning_tree_mode: "none"

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/facts/switch/spine.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/facts/switch/spine.j2
@@ -7,7 +7,7 @@ switch:
   id: {{ switch_id }}
 
 {# switch.mgmt_ip #}
-  mgmt_ip: {{ spine.nodes[node].mgmt_ip }}
+  mgmt_ip: {{ spine.nodes[node].mgmt_ip | arista.avd.default() }}
 
 {# switch.spanning_tree_mode #}
   spanning_tree_mode: "none"

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/facts/switch/super-spine.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/facts/switch/super-spine.j2
@@ -7,7 +7,7 @@ switch:
   id: {{ switch_id }}
 
 {# switch.mgmt_ip #}
-  mgmt_ip: {{ super_spine.nodes[node].mgmt_ip }}
+  mgmt_ip: {{ super_spine.nodes[node].mgmt_ip | arista.avd.default() }}
 
 {# switch.spanning_tree_mode #}
   spanning_tree_mode: "none"

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/mlag/mlag-configuration.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/mlag/mlag-configuration.j2
@@ -3,7 +3,9 @@ mlag_configuration:
   domain_id: {{ switch.mlag_group }}
   local_interface: Vlan{{ switch.mlag_peer_vlan }}
   peer_address: {{ switch.mlag_peer_ip }}
-{% if switch.mlag_dual_primary_detection == true %}
+{% if switch.mlag_dual_primary_detection == true and 
+      switch.mlag_peer_mgmt_ip is arista.avd.defined and 
+      mgmt_interface_vrf is arista.avd.defined %}
   peer_address_heartbeat:
     peer_ip: {{ switch.mlag_peer_mgmt_ip }}
     vrf: {{ mgmt_interface_vrf }}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/mlag/mlag-configuration.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/mlag/mlag-configuration.j2
@@ -3,8 +3,8 @@ mlag_configuration:
   domain_id: {{ switch.mlag_group }}
   local_interface: Vlan{{ switch.mlag_peer_vlan }}
   peer_address: {{ switch.mlag_peer_ip }}
-{% if switch.mlag_dual_primary_detection == true and 
-      switch.mlag_peer_mgmt_ip is arista.avd.defined and 
+{% if switch.mlag_dual_primary_detection == true and
+      switch.mlag_peer_mgmt_ip is arista.avd.defined and
       mgmt_interface_vrf is arista.avd.defined %}
   peer_address_heartbeat:
     peer_ip: {{ switch.mlag_peer_mgmt_ip }}


### PR DESCRIPTION
## Change Summary

Add support for not setting `mgmt_ip` on devices.

<!-- Enter short PR description -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Fixes #682 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->
- Fix various templates to not require `mgmt_ip` to be set.
- Update molecule to test for this on all device types.
- Update readme to show that `mgmt_ip` is now optional.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Tested with `none`, `undefined` and `''`(empty string)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been rebased from devel before I start
- [ ] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
