### PR TITLE
eos_cli_config_gen(feature): switchport default mode trunk phone

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/switchport-mode.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/switchport-mode.yml
@@ -2,3 +2,7 @@
 
 switchport_default:
     mode: access
+    #phone:
+        #cos: < 0-7 >
+        #trunk: < untagged >
+        #vlan: < 1-4094 >

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/switchport-mode.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/switchport-mode.yml
@@ -4,5 +4,5 @@ switchport_default:
     mode: access
     #phone:
         #cos: < 0-7 >
-        #trunk: < untagged >
+        #trunk: < tagged | untagged >
         #vlan: < 1-4094 >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -755,7 +755,7 @@ switchport_default:
   mode: < routed | access >
   phone:
     cos: < 0-7 >
-    trunk: < untagged >
+    trunk: < tagged | untagged >
     vlan: < 1-4094 >
 ```
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -686,7 +686,7 @@ ethernet_interfaces:
     l2_mtu: < l2-mtu - if defined this profile should only be used for platforms supporting the "l2 mtu" CLI >
     vlans: "< list of vlans as string >"
     native_vlan: <native vlan number>
-    mode: < access | dot1q-tunnel | trunk | trunk-phone >
+    mode: < access | dot1q-tunnel | trunk | "trunk phone" >
     phone:
       trunk: < tagged | untagged >
       vlan: < 1-4094 >
@@ -799,7 +799,7 @@ port_channel_interfaces:
     vlans: "< list of vlans as string >"
     type: < routed | switched | l3dot1q >
     encapsulation_dot1q_vlan: < vlan tag to configure on sub-interface >
-    mode: < access | dot1q-tunnel | trunk | trunk-phone >
+    mode: < access | dot1q-tunnel | trunk | "trunk phone" >
     phone:
       trunk: < tagged | untagged >
       vlan: < 1-4094 >
@@ -823,7 +823,7 @@ port_channel_interfaces:
   < Port-Channel_interface_2 >:
     description: < description >
     vlans: "< list of vlans as string >"
-    mode: < access | dot1q-tunnel | trunk | trunk-phone >
+    mode: < access | dot1q-tunnel | trunk | "trunk phone" >
     esi: < EVPN Ethernet Segment Identifier (Type 1 format) >
     rt: < EVPN Route Target for ESI with format xx:xx:xx:xx:xx:xx >
     lacp_id: < LACP ID with format xxxx.xxxx.xxxx >
@@ -831,7 +831,7 @@ port_channel_interfaces:
     description: < description >
     vlans: "< list of vlans as string >"
     type: < routed | switched | l3dot1q >
-    mode: < access | dot1q-tunnel | trunk | trunk-phone >
+    mode: < access | dot1q-tunnel | trunk | "trunk phone" >
     spanning_tree_bpdufilter: < true | false >
     spanning_tree_bpduguard: < true | false >
     spanning_tree_portfast: < edge | network >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -753,6 +753,10 @@ interface_defaults:
 ```yaml
 switchport_default:
   mode: < routed | access >
+  phone:
+    cos: < 0-7 >
+    trunk: < untagged >
+    vlan: < 1-4094 >
 ```
 
 #### Loopback Interfaces

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -686,7 +686,10 @@ ethernet_interfaces:
     l2_mtu: < l2-mtu - if defined this profile should only be used for platforms supporting the "l2 mtu" CLI >
     vlans: "< list of vlans as string >"
     native_vlan: <native vlan number>
-    mode: < access | dot1q-tunnel | trunk >
+    mode: < access | dot1q-tunnel | trunk | trunk-phone >
+    phone:
+      trunk: < tagged | untagged >
+      vlan: < 1-4094 >
     l2_protocol:
       encapsulation_dot1q_vlan: < vlan number >
     flowcontrol:
@@ -796,7 +799,10 @@ port_channel_interfaces:
     vlans: "< list of vlans as string >"
     type: < routed | switched | l3dot1q >
     encapsulation_dot1q_vlan: < vlan tag to configure on sub-interface >
-    mode: < access | dot1q-tunnel | trunk >
+    mode: < access | dot1q-tunnel | trunk | trunk-phone >
+    phone:
+      trunk: < tagged | untagged >
+      vlan: < 1-4094 >
     l2_protocol:
       encapsulation_dot1q_vlan: < vlan number >
     mtu: < mtu >
@@ -817,7 +823,7 @@ port_channel_interfaces:
   < Port-Channel_interface_2 >:
     description: < description >
     vlans: "< list of vlans as string >"
-    mode: < access | trunk >
+    mode: < access | dot1q-tunnel | trunk | trunk-phone >
     esi: < EVPN Ethernet Segment Identifier (Type 1 format) >
     rt: < EVPN Route Target for ESI with format xx:xx:xx:xx:xx:xx >
     lacp_id: < LACP ID with format xxxx.xxxx.xxxx >
@@ -825,7 +831,7 @@ port_channel_interfaces:
     description: < description >
     vlans: "< list of vlans as string >"
     type: < routed | switched | l3dot1q >
-    mode: < access | dot1q-tunnel | trunk >
+    mode: < access | dot1q-tunnel | trunk | trunk-phone >
     spanning_tree_bpdufilter: < true | false >
     spanning_tree_bpduguard: < true | false >
     spanning_tree_portfast: < edge | network >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/switchport-default.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/switchport-default.j2
@@ -5,6 +5,9 @@
 ### Switchport Defaults Summary
 
 - Default Switchport Mode: {{ switchport_default.mode }}
+- Default Switchport Phone COS: {{ switchport_default.phone.cos }}
+- Default Switchport Phone Trunk: {{ switchport_default.phone.trunk }}
+- Default Switchport Phone VLAN: {{ switchport_default.phone.vlan }}
 
 ### Switchport Default Configuration
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/switchport-default.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/switchport-default.j2
@@ -1,13 +1,21 @@
-{% if switchport_default.mode is arista.avd.defined %}
+{% if switchport_default is arista.avd.defined %}
 
 ## Switchport Default
 
 ### Switchport Defaults Summary
 
+{%     if switchport_default.mode is arista.avd.defined %}
 - Default Switchport Mode: {{ switchport_default.mode }}
+{%     endif %}
+{%     if switchport_default.phone.cos is arista.avd.defined %}
 - Default Switchport Phone COS: {{ switchport_default.phone.cos }}
+{%     endif %}
+{%     if switchport_default.phone.trunk is arista.avd.defined %}
 - Default Switchport Phone Trunk: {{ switchport_default.phone.trunk }}
+{%     endif %}
+{%     if switchport_default.phone.vlan is arista.avd.defined %}
 - Default Switchport Phone VLAN: {{ switchport_default.phone.vlan }}
+{%     endif %}
 
 ### Switchport Default Configuration
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -60,6 +60,12 @@ interface {{ ethernet_interface }}
    switchport trunk native vlan {{ ethernet_interfaces[ethernet_interface].native_vlan }}
 {%             endif %}
 {%         endif %}
+{%         if ethernet_interfaces[ethernet_interface].phone.vlan is defined and ethernet_interfaces[ethernet_interface].phone.vlan %}
+   switchport phone vlan {{ ethernet_interfaces[ethernet_interface].phone.vlan }}
+{%         endif %}
+{%         if ethernet_interfaces[ethernet_interface].phone.trunk is defined and ethernet_interfaces[ethernet_interface].phone.trunk %}
+   switchport phone vlan {{ ethernet_interfaces[ethernet_interface].phone.trunk }}
+{%         endif %}
 {%         if ethernet_interfaces[ethernet_interface].mode is arista.avd.defined %}
    switchport mode {{ ethernet_interfaces[ethernet_interface].mode }}
 {%         endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -60,11 +60,11 @@ interface {{ ethernet_interface }}
    switchport trunk native vlan {{ ethernet_interfaces[ethernet_interface].native_vlan }}
 {%             endif %}
 {%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].phone.vlan is defined and ethernet_interfaces[ethernet_interface].phone.vlan %}
+{%         if ethernet_interfaces[ethernet_interface].phone.vlan is arista.avd.defined %}
    switchport phone vlan {{ ethernet_interfaces[ethernet_interface].phone.vlan }}
 {%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].phone.trunk is defined and ethernet_interfaces[ethernet_interface].phone.trunk %}
-   switchport phone vlan {{ ethernet_interfaces[ethernet_interface].phone.trunk }}
+{%         if ethernet_interfaces[ethernet_interface].phone.trunk is arista.avd.defined %}
+   switchport phone trunk {{ ethernet_interfaces[ethernet_interface].phone.trunk }}
 {%         endif %}
 {%         if ethernet_interfaces[ethernet_interface].mode is arista.avd.defined %}
    switchport mode {{ ethernet_interfaces[ethernet_interface].mode }}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
@@ -32,11 +32,11 @@ interface {{ port_channel_interface }}
 {%     if port_channel_interfaces[port_channel_interface].native_vlan is arista.avd.defined and port_channel_interfaces[port_channel_interface].mode is arista.avd.defined("trunk") %}
    switchport trunk native vlan {{ port_channel_interfaces[port_channel_interface].native_vlan }}
 {%     endif %}
-{%     if port_channel_interfaces[port_channel_interface].phone.vlan is defined and port_channel_interfaces[port_channel_interface].phone.vlan %}
+{%     if port_channel_interfaces[port_channel_interface].phone.vlan is arista.avd.defined %}
    switchport phone vlan {{ port_channel_interfaces[port_channel_interface].phone.vlan }}
 {%     endif %}
-{%     if port_channel_interfaces[port_channel_interface].phone.trunk is defined and port_channel_interfaces[port_channel_interface].phone.trunk %}
-   switchport phone vlan {{ port_channel_interfaces[port_channel_interface].phone.trunk }}
+{%     if port_channel_interfaces[port_channel_interface].phone.trunk is arista.avd.defined%}
+   switchport phone trunk {{ port_channel_interfaces[port_channel_interface].phone.trunk }}
 {%     endif %}
 {%     if port_channel_interfaces[port_channel_interface].mode is arista.avd.defined("trunk") %}
    switchport mode {{ port_channel_interfaces[port_channel_interface].mode }}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
@@ -32,6 +32,12 @@ interface {{ port_channel_interface }}
 {%     if port_channel_interfaces[port_channel_interface].native_vlan is arista.avd.defined and port_channel_interfaces[port_channel_interface].mode is arista.avd.defined("trunk") %}
    switchport trunk native vlan {{ port_channel_interfaces[port_channel_interface].native_vlan }}
 {%     endif %}
+{%     if port_channel_interfaces[port_channel_interface].phone.vlan is defined and port_channel_interfaces[port_channel_interface].phone.vlan %}
+   switchport phone vlan {{ port_channel_interfaces[port_channel_interface].phone.vlan }}
+{%     endif %}
+{%     if port_channel_interfaces[port_channel_interface].phone.trunk is defined and port_channel_interfaces[port_channel_interface].phone.trunk %}
+   switchport phone vlan {{ port_channel_interfaces[port_channel_interface].phone.trunk }}
+{%     endif %}
 {%     if port_channel_interfaces[port_channel_interface].mode is arista.avd.defined("trunk") %}
    switchport mode {{ port_channel_interfaces[port_channel_interface].mode }}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/switchport-default.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/switchport-default.j2
@@ -11,7 +11,7 @@ switchport default mode access
 switchport default phone cos {{ switchport_default.phone.cos }}
 !
 {% endif %}
-{% if switchport_default.phone.trunk is is arista.avd.defined and switchport_default.phone.trunk %}
+{% if switchport_default.phone.trunk is is arista.avd.defined and switchport_default.phone.trunk == 'untagged' %}
 switchport default phone trunk untagged
 !
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/switchport-default.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/switchport-default.j2
@@ -1,8 +1,21 @@
-{# switchport default #}
+{# switchport default mode #}
 {% if switchport_default.mode is arista.avd.defined('routed') %}
 !
 switchport default mode routed
 {% elif switchport_default.mode is arista.avd.defined('access') %}
 !
 switchport default mode access
+{% endif %}
+{# switchport default phone #}
+{% if switchport_default.phone.cos is is arista.avd.defined %}
+switchport default phone cos {{ switchport_default.phone.cos }}
+!
+{% endif %}
+{% if switchport_default.phone.trunk is is arista.avd.defined and switchport_default.phone.trunk %}
+switchport default phone trunk untagged
+!
+{% endif %}
+{% if switchport_default.phone.vlan is is arista.avd.defined and switchport_default.phone.vlan %}
+switchport default phone vlan {{ switchport_default.phone.vlan }}
+!
 {% endif %}


### PR DESCRIPTION
## Change Summary

Add support for Arista Campus Phone configuration

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [x] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Fixes #218

## Component(s) name

`arista.avd.eos_cli_config_gen `

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been rebased from devel before I start
- [X] I have read the [**CONTRIBUTING**](https://www.avd.sh/docs/contributing/) document.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
