### PR TITLE
Fix(eos_cli_config_gen): Add missing GATEWAY  v4 and v6 for management interface

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1078,6 +1078,9 @@ management_interfaces:
     ipv6_enable: < true | false >
     ipv6_address: < IPv6_address/Mask >
     type: < oob | inband | default -> oob >
+    # For documentation purpose only
+    gateway: < IPv4 address of default gateway in management VRF >
+    ipv6_gateway: < IPv6 address of default gateway in management VRF >
 ```
 
 #### Management HTTP


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [x] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Fixes #952

## Component(s) name

`arista.avd.cli_config_gen`

## Proposed changes

Add missing field in documentation for management interfaces:

- Gateway for IPv4
- Gateway for IPv6

```yaml
management_interfaces:
  < Management_interface_1 >:
    description: < description >
    shutdown: < true | false >
    vrf: < vrf_name >
    ip_address: < IPv4_address/Mask >
    ipv6_enable: < true | false >
    ipv6_address: < IPv6_address/Mask >
    type: < oob | inband | default -> oob >
    gateway: < IPv4 address of default gateway in management VRF >
    ipv6_gateway: < IPv6 address of default gateway in management VRF >
```

## How to test

Run mkdocs with local stack

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contributing/) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
