### PR TITLE
Add support for subinterfaces as tenant l3_interfaces

### DIFF
--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -295,6 +295,8 @@ vlan 350
 | Ethernet7 | test | routed | - | 10.10.10.10/24 | Tenant_A_WAN_Zone | 9000 | false | - | - |
 | Ethernet8 | test | routed | - | 10.10.10.10/24 | Tenant_L3_VRF_Zone | 9000 | false | - | - |
 | Ethernet9 | test | routed | - | 10.10.20.20/24 | Tenant_L3_VRF_Zone | 9000 | false | - | - |
+| Ethernet10.100 | subinterface test | l3dot1q | - | 10.10.11.10/24 | Tenant_L3_VRF_Zone | 9000 | false | - | - |
+| Ethernet10.200 | subinterface test with vlan override | l3dot1q | - | 10.10.21.10/24 | Tenant_L3_VRF_Zone | 9000 | false | - | - |
 | Ethernet41 | P2P_LINK_TO_DC1-SPINE1_Ethernet6 | routed | - | 172.31.255.81/31 | default | 1500 | false | - | - |
 | Ethernet42 | P2P_LINK_TO_DC1-SPINE2_Ethernet6 | routed | - | 172.31.255.83/31 | default | 1500 | false | - | - |
 | Ethernet43 | P2P_LINK_TO_DC1-SPINE3_Ethernet6 | routed | - | 172.31.255.85/31 | default | 1500 | false | - | - |
@@ -328,6 +330,26 @@ interface Ethernet9
    no switchport
    vrf Tenant_L3_VRF_Zone
    ip address 10.10.20.20/24
+!
+interface Ethernet10
+   no shutdown
+   no switchport
+!
+interface Ethernet10.100
+   description subinterface test
+   no shutdown
+   mtu 9000
+   encapsulation dot1q vlan 100
+   vrf Tenant_L3_VRF_Zone
+   ip address 10.10.11.10/24
+!
+interface Ethernet10.200
+   description subinterface test with vlan override
+   no shutdown
+   mtu 9000
+   encapsulation dot1q vlan 121
+   vrf Tenant_L3_VRF_Zone
+   ip address 10.10.21.10/24
 !
 interface Ethernet41
    description P2P_LINK_TO_DC1-SPINE1_Ethernet6

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -293,6 +293,8 @@ vlan 350
 | Ethernet7 | test | routed | - | 10.10.20.20/24 | Tenant_A_WAN_Zone | 9000 | false | - | - |
 | Ethernet8 | test | routed | - | 10.10.30.10/24 | Tenant_L3_VRF_Zone | 9000 | false | - | - |
 | Ethernet9 | test | routed | - | 10.10.40.20/24 | Tenant_L3_VRF_Zone | 9000 | false | - | - |
+| Ethernet10.100 | subinterface test | l3dot1q | - | 10.10.31.10/24 | Tenant_L3_VRF_Zone | 9000 | false | - | - |
+| Ethernet10.200 | subinterface test with vlan override | l3dot1q | - | 10.10.41.10/24 | Tenant_L3_VRF_Zone | 9000 | false | - | - |
 | Ethernet45 | P2P_LINK_TO_DC1-SPINE1_Ethernet7 | routed | - | 172.31.255.97/31 | default | 1500 | false | - | - |
 | Ethernet46 | P2P_LINK_TO_DC1-SPINE2_Ethernet7 | routed | - | 172.31.255.99/31 | default | 1500 | false | - | - |
 | Ethernet47 | P2P_LINK_TO_DC1-SPINE3_Ethernet7 | routed | - | 172.31.255.101/31 | default | 1500 | false | - | - |
@@ -326,6 +328,26 @@ interface Ethernet9
    no switchport
    vrf Tenant_L3_VRF_Zone
    ip address 10.10.40.20/24
+!
+interface Ethernet10
+   no shutdown
+   no switchport
+!
+interface Ethernet10.100
+   description subinterface test
+   no shutdown
+   mtu 9000
+   encapsulation dot1q vlan 100
+   vrf Tenant_L3_VRF_Zone
+   ip address 10.10.31.10/24
+!
+interface Ethernet10.200
+   description subinterface test with vlan override
+   no shutdown
+   mtu 9000
+   encapsulation dot1q vlan 141
+   vrf Tenant_L3_VRF_Zone
+   ip address 10.10.41.10/24
 !
 interface Ethernet45
    description P2P_LINK_TO_DC1-SPINE1_Ethernet7

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/fabric/DC1_FABRIC-topology.csv
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/fabric/DC1_FABRIC-topology.csv
@@ -2,6 +2,9 @@ Node Type,Node,Node Interface,Peer Type,Peer,Peer Interface
 l3leaf,DC1-BL1A,Ethernet7,l3_interface,,
 l3leaf,DC1-BL1A,Ethernet8,l3_interface,,
 l3leaf,DC1-BL1A,Ethernet9,l3_interface,,
+l3leaf,DC1-BL1A,Ethernet10,l3_interface,,
+l3leaf,DC1-BL1A,Ethernet10.100,l3_interface,,
+l3leaf,DC1-BL1A,Ethernet10.200,l3_interface,,
 l3leaf,DC1-BL1A,Ethernet41,spine,DC1-SPINE1,Ethernet6
 l3leaf,DC1-BL1A,Ethernet42,spine,DC1-SPINE2,Ethernet6
 l3leaf,DC1-BL1A,Ethernet43,spine,DC1-SPINE3,Ethernet6
@@ -10,6 +13,9 @@ l3leaf,DC1-BL1A,Ethernet4000,my_precious,MY-own-peer,Ethernet123
 l3leaf,DC1-BL1B,Ethernet7,l3_interface,,
 l3leaf,DC1-BL1B,Ethernet8,l3_interface,,
 l3leaf,DC1-BL1B,Ethernet9,l3_interface,,
+l3leaf,DC1-BL1B,Ethernet10,l3_interface,,
+l3leaf,DC1-BL1B,Ethernet10.100,l3_interface,,
+l3leaf,DC1-BL1B,Ethernet10.200,l3_interface,,
 l3leaf,DC1-BL1B,Ethernet45,spine,DC1-SPINE1,Ethernet7
 l3leaf,DC1-BL1B,Ethernet46,spine,DC1-SPINE2,Ethernet7
 l3leaf,DC1-BL1B,Ethernet47,spine,DC1-SPINE3,Ethernet7

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1A.cfg
@@ -80,6 +80,26 @@ interface Ethernet9
    vrf Tenant_L3_VRF_Zone
    ip address 10.10.20.20/24
 !
+interface Ethernet10
+   no shutdown
+   no switchport
+!
+interface Ethernet10.100
+   description subinterface test
+   no shutdown
+   mtu 9000
+   encapsulation dot1q vlan 100
+   vrf Tenant_L3_VRF_Zone
+   ip address 10.10.11.10/24
+!
+interface Ethernet10.200
+   description subinterface test with vlan override
+   no shutdown
+   mtu 9000
+   encapsulation dot1q vlan 121
+   vrf Tenant_L3_VRF_Zone
+   ip address 10.10.21.10/24
+!
 interface Ethernet41
    description P2P_LINK_TO_DC1-SPINE1_Ethernet6
    no shutdown

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1B.cfg
@@ -79,6 +79,26 @@ interface Ethernet9
    vrf Tenant_L3_VRF_Zone
    ip address 10.10.40.20/24
 !
+interface Ethernet10
+   no shutdown
+   no switchport
+!
+interface Ethernet10.100
+   description subinterface test
+   no shutdown
+   mtu 9000
+   encapsulation dot1q vlan 100
+   vrf Tenant_L3_VRF_Zone
+   ip address 10.10.31.10/24
+!
+interface Ethernet10.200
+   description subinterface test with vlan override
+   no shutdown
+   mtu 9000
+   encapsulation dot1q vlan 141
+   vrf Tenant_L3_VRF_Zone
+   ip address 10.10.41.10/24
+!
 interface Ethernet45
    description P2P_LINK_TO_DC1-SPINE1_Ethernet7
    no shutdown

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
@@ -376,6 +376,28 @@ ethernet_interfaces:
     mtu: 9000
     shutdown: false
     description: test
+  Ethernet10.100:
+    type: l3dot1q
+    encapsulation_dot1q_vlan: 100
+    peer_type: l3_interface
+    vrf: Tenant_L3_VRF_Zone
+    ip_address: 10.10.11.10/24
+    mtu: 9000
+    shutdown: false
+    description: subinterface test
+  Ethernet10.200:
+    type: l3dot1q
+    encapsulation_dot1q_vlan: 121
+    peer_type: l3_interface
+    vrf: Tenant_L3_VRF_Zone
+    ip_address: 10.10.21.10/24
+    mtu: 9000
+    shutdown: false
+    description: subinterface test with vlan override
+  Ethernet10:
+    type: routed
+    peer_type: l3_interface
+    shutdown: false
   Ethernet4000:
     description: My test
     ip_address: 10.3.2.1/21

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
@@ -375,6 +375,28 @@ ethernet_interfaces:
     mtu: 9000
     shutdown: false
     description: test
+  Ethernet10.100:
+    type: l3dot1q
+    encapsulation_dot1q_vlan: 100
+    peer_type: l3_interface
+    vrf: Tenant_L3_VRF_Zone
+    ip_address: 10.10.31.10/24
+    mtu: 9000
+    shutdown: false
+    description: subinterface test
+  Ethernet10.200:
+    type: l3dot1q
+    encapsulation_dot1q_vlan: 141
+    peer_type: l3_interface
+    vrf: Tenant_L3_VRF_Zone
+    ip_address: 10.10.41.10/24
+    mtu: 9000
+    shutdown: false
+    description: subinterface test with vlan override
+  Ethernet10:
+    type: routed
+    peer_type: l3_interface
+    shutdown: false
   Ethernet4000:
     description: My second test
     ip_address: 10.1.2.3/12

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_TENANTS_NETWORKS.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_TENANTS_NETWORKS.yml
@@ -184,6 +184,19 @@ tenants:
             mtu: 9000
             enabled: True
             description: "test"
+          - interfaces: [ Ethernet10.100, Ethernet10.100 ]
+            ip_addresses: [10.10.11.10/24, 10.10.31.10/24]
+            nodes: [DC1-BL1A, DC1-BL1B]
+            mtu: 9000
+            enabled: True
+            description: "subinterface test"
+          - interfaces: [ Ethernet10.200, Ethernet10.200 ]
+            encapsulation_dot1q_vlan: [ 121, 141 ]
+            ip_addresses: [10.10.21.10/24, 10.10.41.10/24]
+            nodes: [DC1-BL1A, DC1-BL1B]
+            mtu: 9000
+            enabled: True
+            description: "subinterface test with vlan override"
     l2vlans:
       # L2 vlan as string
       '160':

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/network-services.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/network-services.md
@@ -182,6 +182,15 @@ tenants:
             enabled: < true | false >
             mtu: <mtu >
 
+          # For sub-interfaces the dot1q vlan is derived from the interface name by default, but can also be specified.
+          - interfaces: [ <interface_name1.sub-if-id>, <interface_name2.sub-if-id> ]
+            encapsulation_dot1q_vlan: [ <vlan id>, <vlan id> ]
+            ip_addresses: [ <IPv4_address/Mask>, <IPv4_address/Mask> ]
+            nodes: [ < node_1 >, < node_2 > ]
+            description: < description >
+            enabled: < true | false >
+            mtu: <mtu >
+
         # Dictionary of static routes | Optional.
         # This will create static routes inside the tenant VRF, if none specified, all l3leafs that carry the VRF also get the static routes.
         # If a node has a static route in the VRF, redistribute static will be automatically enabled in that VRF. This automatic behaviour can be

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenants/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenants/ethernet-interfaces.j2
@@ -1,13 +1,24 @@
 {# Leaf Tenant l3 interfaces #}
+{% set l3_interface_subif_parents = [] %}
 ethernet_interfaces:
 {% for tenant in switch.tenants | arista.avd.natural_sort %}
 {%     for vrf in switch.tenants[tenant].vrfs | arista.avd.natural_sort %}
 {%         for l3_interface in tenants[tenant].vrfs[vrf].l3_interfaces | arista.avd.default([]) %}
-{%             if l3_interface.nodes is arista.avd.defined and l3_interface.ip_addresses is arista.avd.defined and l3_interface.interfaces is arista.avd.defined and inventory_hostname in l3_interface.nodes %}
+{%             if l3_interface.nodes is arista.avd.defined and inventory_hostname in l3_interface.nodes and l3_interface.ip_addresses is arista.avd.defined and l3_interface.interfaces is arista.avd.defined %}
 {%                 for node in l3_interface.nodes %}
 {%                     if node == inventory_hostname %}
+{%                         if '.' in l3_interface.interfaces[loop.index0] %}
+{%                             set l3_interface_subif_id = l3_interface.encapsulation_dot1q_vlan[loop.index0] | arista.avd.default(
+                                                           l3_interface.interfaces[loop.index0].split('.') | last) %}
+{%                             do l3_interface_subif_parents.append(l3_interface.interfaces[loop.index0].split('.') | first) %}
+{%                         endif %}
   {{ l3_interface.interfaces[loop.index0] }}:
+{%                         if l3_interface_subif_id is arista.avd.defined %}
+    type: l3dot1q
+    encapsulation_dot1q_vlan: {{ l3_interface_subif_id }}
+{%                         else %}
     type: routed
+{%                         endif %}
     peer_type: l3_interface
     vrf: {{ vrf }}
     ip_address: {{ l3_interface.ip_addresses[loop.index0] }}
@@ -27,4 +38,12 @@ ethernet_interfaces:
 {%             endif %}
 {%         endfor %}
 {%     endfor %}
+{% endfor %}
+{# Create parent / base interfaces as routed. Will be merged onto structured config, #}
+{# so even if the same interfaces are created elsewhere, it will still work. #}
+{% for l3_interface_subif_parent in l3_interface_subif_parents | arista.avd.natural_sort | unique %}
+  {{ l3_interface_subif_parent }}:
+    type: routed
+    peer_type: l3_interface
+    shutdown: false
 {% endfor %}


### PR DESCRIPTION
## Change Summary

Add support for subinterfaces as tenant l3_interfaces

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Fixes #857 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

```yaml
        # List of L3 interfaces | Optional.
        # This will create IP routed interface inside VRF. Length of interfaces, nodes and ip_addresses must match.
        l3_interfaces:
          - interfaces: [ <interface_name1>, <interface_name2>, <interface_name3> ]
            ip_addresses: [ <IPv4_address/Mask>, <IPv4_address/Mask>, <IPv4_address/Mask> ]
            nodes: [ < node_1 >, < node_2 >, < node_1 > ]
            description: < description >
            enabled: < true | false >
            mtu: <mtu >

          # For sub-interfaces the dot1q vlan is derived from the interface name by default, but can also be specified.
          - interfaces: [ <interface_name1.sub-if-id>, <interface_name2.sub-if-id> ]
            encapsulation_dot1q_vlan: [ <vlan id>, <vlan id> ]
            ip_addresses: [ <IPv4_address/Mask>, <IPv4_address/Mask> ]
            nodes: [ < node_1 >, < node_2 > ]
            description: < description >
            enabled: < true | false >
            mtu: <mtu >
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Added test of subinterfaces to molecule both with auto-derived vlan as well as manually specified vlan.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contributing/) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
