### PR TITLE
Remove extra spaces from rendering of ntp with default VRF

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ntp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ntp.md
@@ -53,7 +53,7 @@ interface Management1
 
 - Local Interface: lo1
 
-- VRF: test
+- VRF: default
 
 | Node | Primary |
 | ---- | ------- |
@@ -64,9 +64,9 @@ interface Management1
 
 ```eos
 !
-ntp local-interface vrf test lo1
-ntp server vrf test 10.1.1.1 prefer
-ntp server vrf test 10.1.1.2
+ntp local-interface lo1
+ntp server 10.1.1.1 prefer
+ntp server 10.1.1.2
 ```
 
 # Authentication

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ntp.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ntp.cfg
@@ -4,9 +4,9 @@ transceiver qsfp default-mode 4x10G
 !
 hostname ntp
 !
-ntp local-interface vrf test lo1
-ntp server vrf test 10.1.1.1 prefer
-ntp server vrf test 10.1.1.2
+ntp local-interface lo1
+ntp server 10.1.1.1 prefer
+ntp server 10.1.1.2
 !
 no aaa root
 no enable password

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ntp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ntp.yml
@@ -1,7 +1,7 @@
-### NTP tests
+### NTP tests (Tested with default VRF here. Tested with Management VRF in "dns-ntp")
 ntp_server:
   local_interface:
-    vrf: test
+    vrf: default
     interface: lo1
   nodes:
     - 10.1.1.1

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ntp-servers.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ntp-servers.j2
@@ -2,17 +2,17 @@
 {% if ntp_server is arista.avd.defined %}
 !
 {%     if ntp_server.local_interface.interface is arista.avd.defined %}
-{%         set ntp_int_cli = "ntp local-interface " %}
+{%         set ntp_int_cli = "ntp local-interface" %}
 {%         if ntp_server.local_interface.vrf is arista.avd.defined and ntp_server.local_interface.vrf != 'default' %}
-{%             set ntp_int_cli = ntp_int_cli ~ "vrf " ~ ntp_server.local_interface.vrf %}
+{%             set ntp_int_cli = ntp_int_cli ~ " vrf " ~ ntp_server.local_interface.vrf %}
 {%         endif %}
 {%         set ntp_int_cli = ntp_int_cli ~ " " ~ ntp_server.local_interface.interface %}
 {{ ntp_int_cli }}
 {%     endif %}
 {%     for node in ntp_server.nodes %}
-{%         set node_cli = "ntp server " %}
+{%         set node_cli = "ntp server" %}
 {%         if ntp_server.local_interface.vrf is arista.avd.defined and ntp_server.local_interface.vrf != 'default' %}
-{%             set node_cli = node_cli ~ "vrf " ~ ntp_server.local_interface.vrf %}
+{%             set node_cli = node_cli ~ " vrf " ~ ntp_server.local_interface.vrf %}
 {%         endif %}
 {%         set node_cli = node_cli ~ " " ~ node %}
 {%         if loop.first %}


### PR DESCRIPTION
## Change Summary

Remove extra spaces from rendering of ntp with default VRF

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Fixes #949 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
