### PR TITLE
Add support for `raw_eos_cli`

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/base.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/base.md
@@ -21,6 +21,7 @@
 - [Filters](#filters)
 - [ACL](#acl)
 - [Quality Of Service](#quality-of-service)
+- [EOS CLI](#eos-cli)
 
 <!-- toc -->
 # Management
@@ -188,3 +189,11 @@ management security
 # ACL
 
 # Quality Of Service
+
+# EOS CLI
+
+```eos
+!
+interface Loopback1000
+  description Interface created with eos_cli on device level
+```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -118,6 +118,10 @@ interface Ethernet1
    no switchport
    ip address 172.31.255.1/31
    bfd interval 500 min-rx 500 multiplier 5
+   comment
+   Comment created from eos_cli under ethernet_interfaces.Ethernet1
+   EOF
+
 !
 interface Ethernet2
    description SRV-POD02_Eth1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
@@ -172,6 +172,10 @@ interface Port-Channel5
    storm-control broadcast level 1
    storm-control multicast level 1
    storm-control unknown-unicast level 1
+   comment
+   Comment created from eos_cli under port_channel_interfaces.Port-Channel5
+   EOF
+
 !
 interface Port-Channel8
    description to Dev02 Port-channel 8

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vrf-lite.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vrf-lite.md
@@ -203,6 +203,11 @@ router bgp 65001
       redistribute static
       aggregate-address 0.0.0.0/0 as-set summary-only attribute-map RM-BGP-AGG-APPLY-SET
       aggregate-address 193.1.0.0/16 as-set summary-only attribute-map RM-BGP-AGG-APPLY-SET
+      !
+      comment
+      Comment created from eos_cli under router_bgp.vrfs.BLUE-C1
+      EOF
+
 ```
 
 # Multicast

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
@@ -246,6 +246,10 @@ interface Vlan2001
    description SVI Description
    vrf Tenant_B
    ip address virtual 10.2.1.1/24
+   comment
+   Comment created from eos_cli under vlan_interfaces.Vlan2001
+   EOF
+
 !
 interface Vlan2002
    description SVI Description

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/base.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/base.cfg
@@ -52,4 +52,7 @@ management ssh
    vrf mgt
       no shutdown
 !
+interface Loopback1000
+  description Interface created with eos_cli on device level
+!
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
@@ -13,6 +13,10 @@ interface Ethernet1
    no switchport
    ip address 172.31.255.1/31
    bfd interval 500 min-rx 500 multiplier 5
+   comment
+   Comment created from eos_cli under ethernet_interfaces.Ethernet1
+   EOF
+
 !
 interface Ethernet2
    description SRV-POD02_Eth1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
@@ -24,6 +24,10 @@ interface Port-Channel5
    storm-control broadcast level 1
    storm-control multicast level 1
    storm-control unknown-unicast level 1
+   comment
+   Comment created from eos_cli under port_channel_interfaces.Port-Channel5
+   EOF
+
 !
 interface Port-Channel8
    description to Dev02 Port-channel 8

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-vrf-lite.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-vrf-lite.cfg
@@ -62,5 +62,10 @@ router bgp 65001
       redistribute static
       aggregate-address 0.0.0.0/0 as-set summary-only attribute-map RM-BGP-AGG-APPLY-SET
       aggregate-address 193.1.0.0/16 as-set summary-only attribute-map RM-BGP-AGG-APPLY-SET
+      !
+      comment
+      Comment created from eos_cli under router_bgp.vrfs.BLUE-C1
+      EOF
+
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
@@ -127,6 +127,10 @@ interface Vlan2001
    description SVI Description
    vrf Tenant_B
    ip address virtual 10.2.1.1/24
+   comment
+   Comment created from eos_cli under vlan_interfaces.Vlan2001
+   EOF
+
 !
 interface Vlan2002
    description SVI Description

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/base.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/base.yml
@@ -42,3 +42,7 @@ management_ssh:
   vrfs:
     mgt:
       enable: true
+
+eos_cli: |
+  interface Loopback1000
+    description Interface created with eos_cli on device level

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
@@ -13,6 +13,10 @@ ethernet_interfaces:
       interval: 500
       min_rx: 500
       multiplier: 5
+    eos_cli: |
+      comment
+      Comment created from eos_cli under ethernet_interfaces.Ethernet1
+      EOF
 
   Ethernet6:
     logging:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
@@ -16,6 +16,10 @@ port_channel_interfaces:
       unknown_unicast:
         level: 1
         unit: percent
+    eos_cli: |
+      comment
+      Comment created from eos_cli under port_channel_interfaces.Port-Channel5
+      EOF
 
   Port-Channel15:
     description: DC1_L2LEAF3_Po1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-vrf-lite.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-vrf-lite.yml
@@ -80,6 +80,10 @@ router_bgp:
           summary_only: true
           attribute_map: RM-BGP-AGG-APPLY-SET
           advertise_only: false
+      eos_cli: |
+        comment
+        Comment created from eos_cli under router_bgp.vrfs.BLUE-C1
+        EOF
 
 static_routes:
   - vrf: BLUE-C1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
@@ -5,6 +5,10 @@ vlan_interfaces:
     description: SVI Description
     vrf: Tenant_B
     ip_address_virtual: 10.2.1.1/24
+    eos_cli: |
+      comment
+      Comment created from eos_cli under vlan_interfaces.Vlan2001
+      EOF
 
   Vlan2002:
     description: SVI Description

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF1A.md
@@ -33,6 +33,7 @@
   - [VRF Instances Summary](#vrf-instances-summary)
   - [VRF Instances Device Configuration](#vrf-instances-device-configuration)
 - [Quality Of Service](#quality-of-service)
+- [EOS CLI](#eos-cli)
 
 <!-- toc -->
 # Management
@@ -322,3 +323,12 @@ vrf instance MGMT
 ```
 
 # Quality Of Service
+
+# EOS CLI
+
+```eos
+!
+interface Loopback1111
+  description Loopback created from raw_eos_cli under platform_settings vEOS-LAB
+
+```

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF2A.md
@@ -37,6 +37,7 @@
   - [VRF Instances Summary](#vrf-instances-summary)
   - [VRF Instances Device Configuration](#vrf-instances-device-configuration)
 - [Quality Of Service](#quality-of-service)
+- [EOS CLI](#eos-cli)
 
 <!-- toc -->
 # Management
@@ -432,3 +433,15 @@ vrf instance MGMT
 ```
 
 # Quality Of Service
+
+# EOS CLI
+
+```eos
+!
+interface Loopback1002
+  description Loopback created from raw_eos_cli under l2leaf node-group RACK2_MLAG
+
+interface Loopback1000
+  description Loopback created from raw_eos_cli under VRF Common_VRF
+
+```

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF2A.md
@@ -441,6 +441,9 @@ vrf instance MGMT
 interface Loopback1002
   description Loopback created from raw_eos_cli under l2leaf node-group RACK2_MLAG
 
+interface Loopback1111
+  description Loopback created from raw_eos_cli under platform_settings vEOS-LAB
+
 interface Loopback1000
   description Loopback created from raw_eos_cli under VRF Common_VRF
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF2B.md
@@ -449,6 +449,9 @@ vrf instance MGMT
 interface Loopback1003
   description Loopback created from raw_eos_cli under l2leaf node DC1-POD1-L2LEAF2B
 
+interface Loopback1111
+  description Loopback created from raw_eos_cli under platform_settings vEOS-LAB
+
 interface Loopback1000
   description Loopback created from raw_eos_cli under VRF Common_VRF
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF2B.md
@@ -37,6 +37,7 @@
   - [VRF Instances Summary](#vrf-instances-summary)
   - [VRF Instances Device Configuration](#vrf-instances-device-configuration)
 - [Quality Of Service](#quality-of-service)
+- [EOS CLI](#eos-cli)
 
 <!-- toc -->
 # Management
@@ -440,3 +441,15 @@ vrf instance MGMT
 ```
 
 # Quality Of Service
+
+# EOS CLI
+
+```eos
+!
+interface Loopback1003
+  description Loopback created from raw_eos_cli under l2leaf node DC1-POD1-L2LEAF2B
+
+interface Loopback1000
+  description Loopback created from raw_eos_cli under VRF Common_VRF
+
+```

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF1A.md
@@ -41,6 +41,7 @@
   - [VRF Instances Summary](#vrf-instances-summary)
   - [VRF Instances Device Configuration](#vrf-instances-device-configuration)
 - [Quality Of Service](#quality-of-service)
+- [EOS CLI](#eos-cli)
 
 <!-- toc -->
 # Management
@@ -668,3 +669,12 @@ vrf instance MGMT
 ```
 
 # Quality Of Service
+
+# EOS CLI
+
+```eos
+!
+interface Loopback1002
+  description Loopback created from raw_eos_cli under node DC1-POD1-LEAF1A
+
+```

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF1A.md
@@ -677,4 +677,7 @@ vrf instance MGMT
 interface Loopback1002
   description Loopback created from raw_eos_cli under node DC1-POD1-LEAF1A
 
+interface Loopback1111
+  description Loopback created from raw_eos_cli under platform_settings vEOS-LAB
+
 ```

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2A.md
@@ -979,6 +979,9 @@ vrf instance MGMT
 interface Loopback1002
   description Loopback created from raw_eos_cli under l3leaf node-group RACK2_MLAG
 
+interface Loopback1111
+  description Loopback created from raw_eos_cli under platform_settings vEOS-LAB
+
 interface Loopback1000
   description Loopback created from raw_eos_cli under VRF Common_VRF
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2A.md
@@ -44,6 +44,7 @@
   - [VRF Instances Summary](#vrf-instances-summary)
   - [VRF Instances Device Configuration](#vrf-instances-device-configuration)
 - [Quality Of Service](#quality-of-service)
+- [EOS CLI](#eos-cli)
 
 <!-- toc -->
 # Management
@@ -254,6 +255,10 @@ vlan 4094
 | Ethernet4 | DC1-POD1-L2LEAF2B_Ethernet1 | *trunk | *110-112,2500,2600,4085 | *- | *- | 3 |
 | Ethernet5 | MLAG_PEER_DC1-POD1-LEAF2B_Ethernet5 | *trunk | *2-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 5 |
 | Ethernet6 | MLAG_PEER_DC1-POD1-LEAF2B_Ethernet6 | *trunk | *2-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 5 |
+| Ethernet16 | server-1_Eth1 | *access | *110 | *- | *- | 16 |
+| Ethernet17 | server-1_Eth3 | *access | *110 | *- | *- | 17 |
+| Ethernet18 | server-1_Eth5 | *access | *110 | *- | *- | 18 |
+| Ethernet19 | server-1_Eth7 | *access | *110 | *- | *- | 19 |
 
 *Inherited from Port-Channel Interface
 
@@ -313,6 +318,42 @@ interface Ethernet7
    mtu 1500
    no switchport
    ip address 100.100.100.101/24
+!
+interface Ethernet16
+   description server-1_Eth1
+   no shutdown
+   channel-group 16 mode active
+   comment
+   Comment created from raw_eos_cli under profile TENANT_A
+   EOF
+
+!
+interface Ethernet17
+   description server-1_Eth3
+   no shutdown
+   channel-group 17 mode active
+   comment
+   Comment created from raw_eos_cli under adapter for switch Eth17
+   EOF
+
+!
+interface Ethernet18
+   description server-1_Eth5
+   no shutdown
+   channel-group 18 mode active
+   comment
+   Comment created from raw_eos_cli under profile NESTED_TENANT_A
+   EOF
+
+!
+interface Ethernet19
+   description server-1_Eth7
+   no shutdown
+   channel-group 19 mode active
+   comment
+   Comment created from raw_eos_cli under profile NESTED_TENANT_A
+   EOF
+
 ```
 
 ## Port-Channel Interfaces
@@ -325,6 +366,10 @@ interface Ethernet7
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
 | Port-Channel3 | RACK2_MLAG_Po1 | switched | trunk | 110-112,2500,2600,4085 | - | - | - | - | 3 | - |
 | Port-Channel5 | MLAG_PEER_DC1-POD1-LEAF2B_Po5 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
+| Port-Channel16 | server-1_PortChannel | switched | access | 110 | - | - | - | - | 16 | - |
+| Port-Channel17 | server-1_PortChannel | switched | access | 110 | - | - | - | - | 17 | - |
+| Port-Channel18 | server-1_PortChannel | switched | access | 110 | - | - | - | - | 18 | - |
+| Port-Channel19 | server-1_PortChannel | switched | access | 110 | - | - | - | - | 19 | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -348,6 +393,46 @@ interface Port-Channel5
    switchport trunk group LEAF_PEER_L3
    switchport trunk group MLAG
    service-profile QOS-PROFILE
+!
+interface Port-Channel16
+   description server-1_PortChannel
+   no shutdown
+   switchport
+   switchport access vlan 110
+   mlag 16
+   service-profile bar
+!
+interface Port-Channel17
+   description server-1_PortChannel
+   no shutdown
+   switchport
+   switchport access vlan 110
+   mlag 17
+   service-profile foo
+!
+interface Port-Channel18
+   description server-1_PortChannel
+   no shutdown
+   switchport
+   switchport access vlan 110
+   mlag 18
+   service-profile foo
+   comment
+   Comment created from raw_eos_cli under port_channel on profile NESTED_TENANT_A
+   EOF
+
+!
+interface Port-Channel19
+   description server-1_PortChannel
+   no shutdown
+   switchport
+   switchport access vlan 110
+   mlag 19
+   service-profile foo
+   comment
+   Comment created from raw_eos_cli under adapter port_channel for switch Po19
+   EOF
+
 ```
 
 ## Loopback Interfaces
@@ -430,6 +515,10 @@ interface Vlan112
    no shutdown
    vrf Common_VRF
    ip address virtual 10.1.12.1/24
+   comment
+   Comment created from raw_eos_cli under SVI 112 in VRF Common_VRF
+   EOF
+
 !
 interface Vlan4085
    description L2LEAF_INBAND_MGMT
@@ -726,6 +815,11 @@ router bgp 65112
       route-target export evpn 1025:1025
       router-id 172.16.110.4
       redistribute connected
+      !
+      comment
+      Comment created from raw_eos_cli under BGP for VRF Common_VRF
+      EOF
+
 ```
 
 # BFD
@@ -877,3 +971,15 @@ vrf instance MGMT
 ```
 
 # Quality Of Service
+
+# EOS CLI
+
+```eos
+!
+interface Loopback1002
+  description Loopback created from raw_eos_cli under l3leaf node-group RACK2_MLAG
+
+interface Loopback1000
+  description Loopback created from raw_eos_cli under VRF Common_VRF
+
+```

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
@@ -1008,6 +1008,9 @@ vrf instance MGMT
 interface Loopback1002
   description Loopback created from raw_eos_cli under l3leaf node-group RACK2_MLAG
 
+interface Loopback1111
+  description Loopback created from raw_eos_cli under platform_settings vEOS-LAB
+
 interface Loopback1000
   description Loopback created from raw_eos_cli under VRF Common_VRF
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
@@ -45,6 +45,7 @@
   - [VRF Instances Summary](#vrf-instances-summary)
   - [VRF Instances Device Configuration](#vrf-instances-device-configuration)
 - [Quality Of Service](#quality-of-service)
+- [EOS CLI](#eos-cli)
 
 <!-- toc -->
 # Management
@@ -280,6 +281,10 @@ vlan 4094
 | Ethernet4 | DC1-POD1-L2LEAF2B_Ethernet2 | *trunk | *110-112,2500,2600,4085 | *- | *- | 3 |
 | Ethernet5 | MLAG_PEER_DC1-POD1-LEAF2A_Ethernet5 | *trunk | *2-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 5 |
 | Ethernet6 | MLAG_PEER_DC1-POD1-LEAF2A_Ethernet6 | *trunk | *2-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 5 |
+| Ethernet16 | server-1_Eth2 | *access | *110 | *- | *- | 16 |
+| Ethernet17 | server-1_Eth4 | *access | *110 | *- | *- | 17 |
+| Ethernet18 | server-1_Eth6 | *access | *110 | *- | *- | 18 |
+| Ethernet19 | server-1_Eth8 | *access | *110 | *- | *- | 19 |
 
 *Inherited from Port-Channel Interface
 
@@ -340,6 +345,42 @@ interface Ethernet7
    no switchport
    ip address 11.1.0.38/31
    ptp enable
+!
+interface Ethernet16
+   description server-1_Eth2
+   no shutdown
+   channel-group 16 mode active
+   comment
+   Comment created from raw_eos_cli under profile TENANT_A
+   EOF
+
+!
+interface Ethernet17
+   description server-1_Eth4
+   no shutdown
+   channel-group 17 mode active
+   comment
+   Comment created from raw_eos_cli under adapter for switch Eth17
+   EOF
+
+!
+interface Ethernet18
+   description server-1_Eth6
+   no shutdown
+   channel-group 18 mode active
+   comment
+   Comment created from raw_eos_cli under profile NESTED_TENANT_A
+   EOF
+
+!
+interface Ethernet19
+   description server-1_Eth8
+   no shutdown
+   channel-group 19 mode active
+   comment
+   Comment created from raw_eos_cli under profile NESTED_TENANT_A
+   EOF
+
 ```
 
 ## Port-Channel Interfaces
@@ -352,6 +393,10 @@ interface Ethernet7
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
 | Port-Channel3 | RACK2_MLAG_Po1 | switched | trunk | 110-112,2500,2600,4085 | - | - | - | - | 3 | - |
 | Port-Channel5 | MLAG_PEER_DC1-POD1-LEAF2A_Po5 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
+| Port-Channel16 | server-1_PortChannel | switched | access | 110 | - | - | - | - | 16 | - |
+| Port-Channel17 | server-1_PortChannel | switched | access | 110 | - | - | - | - | 17 | - |
+| Port-Channel18 | server-1_PortChannel | switched | access | 110 | - | - | - | - | 18 | - |
+| Port-Channel19 | server-1_PortChannel | switched | access | 110 | - | - | - | - | 19 | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -375,6 +420,46 @@ interface Port-Channel5
    switchport trunk group LEAF_PEER_L3
    switchport trunk group MLAG
    service-profile QOS-PROFILE
+!
+interface Port-Channel16
+   description server-1_PortChannel
+   no shutdown
+   switchport
+   switchport access vlan 110
+   mlag 16
+   service-profile bar
+!
+interface Port-Channel17
+   description server-1_PortChannel
+   no shutdown
+   switchport
+   switchport access vlan 110
+   mlag 17
+   service-profile foo
+!
+interface Port-Channel18
+   description server-1_PortChannel
+   no shutdown
+   switchport
+   switchport access vlan 110
+   mlag 18
+   service-profile foo
+   comment
+   Comment created from raw_eos_cli under port_channel on profile NESTED_TENANT_A
+   EOF
+
+!
+interface Port-Channel19
+   description server-1_PortChannel
+   no shutdown
+   switchport
+   switchport access vlan 110
+   mlag 19
+   service-profile foo
+   comment
+   Comment created from raw_eos_cli under adapter port_channel for switch Po19
+   EOF
+
 ```
 
 ## Loopback Interfaces
@@ -457,6 +542,10 @@ interface Vlan112
    no shutdown
    vrf Common_VRF
    ip address virtual 10.1.12.1/24
+   comment
+   Comment created from raw_eos_cli under SVI 112 in VRF Common_VRF
+   EOF
+
 !
 interface Vlan4085
    description L2LEAF_INBAND_MGMT
@@ -755,6 +844,11 @@ router bgp 65112
       route-target export evpn 1025:1025
       router-id 172.16.110.5
       redistribute connected
+      !
+      comment
+      Comment created from raw_eos_cli under BGP for VRF Common_VRF
+      EOF
+
 ```
 
 # BFD
@@ -906,3 +1000,15 @@ vrf instance MGMT
 ```
 
 # Quality Of Service
+
+# EOS CLI
+
+```eos
+!
+interface Loopback1002
+  description Loopback created from raw_eos_cli under l3leaf node-group RACK2_MLAG
+
+interface Loopback1000
+  description Loopback created from raw_eos_cli under VRF Common_VRF
+
+```

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-SPINE1.md
@@ -33,6 +33,7 @@
   - [VRF Instances Summary](#vrf-instances-summary)
   - [VRF Instances Device Configuration](#vrf-instances-device-configuration)
 - [Quality Of Service](#quality-of-service)
+- [EOS CLI](#eos-cli)
 
 <!-- toc -->
 # Management
@@ -558,3 +559,12 @@ vrf instance MGMT
 ```
 
 # Quality Of Service
+
+# EOS CLI
+
+```eos
+!
+interface Loopback1111
+  description Loopback created from raw_eos_cli under platform_settings vEOS-LAB
+
+```

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-SPINE2.md
@@ -32,6 +32,7 @@
   - [VRF Instances Summary](#vrf-instances-summary)
   - [VRF Instances Device Configuration](#vrf-instances-device-configuration)
 - [Quality Of Service](#quality-of-service)
+- [EOS CLI](#eos-cli)
 
 <!-- toc -->
 # Management
@@ -452,3 +453,12 @@ vrf instance MGMT
 ```
 
 # Quality Of Service
+
+# EOS CLI
+
+```eos
+!
+interface Loopback1111
+  description Loopback created from raw_eos_cli under platform_settings vEOS-LAB
+
+```

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-LEAF1A.md
@@ -41,6 +41,7 @@
   - [VRF Instances Summary](#vrf-instances-summary)
   - [VRF Instances Device Configuration](#vrf-instances-device-configuration)
 - [Quality Of Service](#quality-of-service)
+- [EOS CLI](#eos-cli)
 
 <!-- toc -->
 # Management
@@ -348,6 +349,10 @@ interface Vlan112
    no shutdown
    vrf Common_VRF
    ip address virtual 10.1.12.1/24
+   comment
+   Comment created from raw_eos_cli under SVI 112 in VRF Common_VRF
+   EOF
+
 !
 interface Vlan4092
    description L2LEAF_INBAND_MGMT
@@ -605,6 +610,11 @@ router bgp 65121
       route-target export evpn 1025:1025
       router-id 172.16.120.3
       redistribute connected
+      !
+      comment
+      Comment created from raw_eos_cli under BGP for VRF Common_VRF
+      EOF
+
 ```
 
 # BFD
@@ -724,3 +734,12 @@ vrf instance MGMT
 ```
 
 # Quality Of Service
+
+# EOS CLI
+
+```eos
+!
+interface Loopback1000
+  description Loopback created from raw_eos_cli under VRF Common_VRF
+
+```

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-LEAF1A.md
@@ -739,6 +739,9 @@ vrf instance MGMT
 
 ```eos
 !
+interface Loopback1111
+  description Loopback created from raw_eos_cli under platform_settings vEOS-LAB
+
 interface Loopback1000
   description Loopback created from raw_eos_cli under VRF Common_VRF
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-SPINE1.md
@@ -34,6 +34,7 @@
   - [VRF Instances Summary](#vrf-instances-summary)
   - [VRF Instances Device Configuration](#vrf-instances-device-configuration)
 - [Quality Of Service](#quality-of-service)
+- [EOS CLI](#eos-cli)
 
 <!-- toc -->
 # Management
@@ -502,3 +503,12 @@ vrf instance MGMT
 ```
 
 # Quality Of Service
+
+# EOS CLI
+
+```eos
+!
+interface Loopback1111
+  description Loopback created from raw_eos_cli under platform_settings vEOS-LAB
+
+```

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-SPINE2.md
@@ -34,6 +34,7 @@
   - [VRF Instances Summary](#vrf-instances-summary)
   - [VRF Instances Device Configuration](#vrf-instances-device-configuration)
 - [Quality Of Service](#quality-of-service)
+- [EOS CLI](#eos-cli)
 
 <!-- toc -->
 # Management
@@ -490,3 +491,12 @@ vrf instance MGMT
 ```
 
 # Quality Of Service
+
+# EOS CLI
+
+```eos
+!
+interface Loopback1111
+  description Loopback created from raw_eos_cli under platform_settings vEOS-LAB
+
+```

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-RS1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-RS1.md
@@ -33,6 +33,7 @@
   - [VRF Instances Summary](#vrf-instances-summary)
   - [VRF Instances Device Configuration](#vrf-instances-device-configuration)
 - [Quality Of Service](#quality-of-service)
+- [EOS CLI](#eos-cli)
 
 <!-- toc -->
 # Management
@@ -516,3 +517,12 @@ vrf instance MGMT
 ```
 
 # Quality Of Service
+
+# EOS CLI
+
+```eos
+!
+interface Loopback1111
+  description Loopback created from raw_eos_cli under platform_settings vEOS-LAB
+
+```

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-RS2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-RS2.md
@@ -34,6 +34,7 @@
   - [VRF Instances Summary](#vrf-instances-summary)
   - [VRF Instances Device Configuration](#vrf-instances-device-configuration)
 - [Quality Of Service](#quality-of-service)
+- [EOS CLI](#eos-cli)
 
 <!-- toc -->
 # Management
@@ -536,3 +537,12 @@ vrf instance MGMT
 ```
 
 # Quality Of Service
+
+# EOS CLI
+
+```eos
+!
+interface Loopback1111
+  description Loopback created from raw_eos_cli under platform_settings vEOS-LAB
+
+```

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-SUPER-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-SUPER-SPINE1.md
@@ -31,6 +31,7 @@
   - [VRF Instances Summary](#vrf-instances-summary)
   - [VRF Instances Device Configuration](#vrf-instances-device-configuration)
 - [Quality Of Service](#quality-of-service)
+- [EOS CLI](#eos-cli)
 
 <!-- toc -->
 # Management
@@ -438,3 +439,12 @@ vrf instance MGMT
 ```
 
 # Quality Of Service
+
+# EOS CLI
+
+```eos
+!
+interface Loopback1111
+  description Loopback created from raw_eos_cli under platform_settings vEOS-LAB
+
+```

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-SUPER-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-SUPER-SPINE2.md
@@ -32,6 +32,7 @@
   - [VRF Instances Summary](#vrf-instances-summary)
   - [VRF Instances Device Configuration](#vrf-instances-device-configuration)
 - [Quality Of Service](#quality-of-service)
+- [EOS CLI](#eos-cli)
 
 <!-- toc -->
 # Management
@@ -464,3 +465,12 @@ vrf instance MGMT
 ```
 
 # Quality Of Service
+
+# EOS CLI
+
+```eos
+!
+interface Loopback1111
+  description Loopback created from raw_eos_cli under platform_settings vEOS-LAB
+
+```

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-L2LEAF1A.md
@@ -33,6 +33,7 @@
   - [VRF Instances Summary](#vrf-instances-summary)
   - [VRF Instances Device Configuration](#vrf-instances-device-configuration)
 - [Quality Of Service](#quality-of-service)
+- [EOS CLI](#eos-cli)
 
 <!-- toc -->
 # Management
@@ -330,3 +331,12 @@ vrf instance MGMT
 ```
 
 # Quality Of Service
+
+# EOS CLI
+
+```eos
+!
+interface Loopback1011
+  description Loopback created from raw_eos_cli under l2leaf defaults in DC2 POD1
+
+```

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-L2LEAF1A.md
@@ -339,4 +339,7 @@ vrf instance MGMT
 interface Loopback1011
   description Loopback created from raw_eos_cli under l2leaf defaults in DC2 POD1
 
+interface Loopback1111
+  description Loopback created from raw_eos_cli under platform_settings vEOS-LAB
+
 ```

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-LEAF1A.md
@@ -692,6 +692,9 @@ vrf instance MGMT
 interface Loopback1010
   description Loopback created from raw_eos_cli under l3leaf defaults in DC2 POD1
 
+interface Loopback1111
+  description Loopback created from raw_eos_cli under platform_settings vEOS-LAB
+
 interface Loopback1000
   description Loopback created from raw_eos_cli under VRF Common_VRF
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-LEAF1A.md
@@ -42,6 +42,7 @@
   - [VRF Instances Summary](#vrf-instances-summary)
   - [VRF Instances Device Configuration](#vrf-instances-device-configuration)
 - [Quality Of Service](#quality-of-service)
+- [EOS CLI](#eos-cli)
 
 <!-- toc -->
 # Management
@@ -570,6 +571,11 @@ router bgp 65211
       route-target export evpn 1025:1025
       router-id 172.16.210.3
       redistribute connected
+      !
+      comment
+      Comment created from raw_eos_cli under BGP for VRF Common_VRF
+      EOF
+
 ```
 
 # BFD
@@ -678,3 +684,15 @@ vrf instance MGMT
 ```
 
 # Quality Of Service
+
+# EOS CLI
+
+```eos
+!
+interface Loopback1010
+  description Loopback created from raw_eos_cli under l3leaf defaults in DC2 POD1
+
+interface Loopback1000
+  description Loopback created from raw_eos_cli under VRF Common_VRF
+
+```

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-SPINE1.md
@@ -34,6 +34,7 @@
   - [VRF Instances Summary](#vrf-instances-summary)
   - [VRF Instances Device Configuration](#vrf-instances-device-configuration)
 - [Quality Of Service](#quality-of-service)
+- [EOS CLI](#eos-cli)
 
 <!-- toc -->
 # Management
@@ -500,3 +501,12 @@ vrf instance MGMT
 ```
 
 # Quality Of Service
+
+# EOS CLI
+
+```eos
+!
+interface Loopback1009
+  description Loopback created from raw_eos_cli under spine defaults in DC2 POD1
+
+```

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-SPINE1.md
@@ -509,4 +509,7 @@ vrf instance MGMT
 interface Loopback1009
   description Loopback created from raw_eos_cli under spine defaults in DC2 POD1
 
+interface Loopback1111
+  description Loopback created from raw_eos_cli under platform_settings vEOS-LAB
+
 ```

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-SPINE2.md
@@ -446,4 +446,7 @@ vrf instance MGMT
 interface Loopback1009
   description Loopback created from raw_eos_cli under spine defaults in DC2 POD1
 
+interface Loopback1111
+  description Loopback created from raw_eos_cli under platform_settings vEOS-LAB
+
 ```

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-SPINE2.md
@@ -32,6 +32,7 @@
   - [VRF Instances Summary](#vrf-instances-summary)
   - [VRF Instances Device Configuration](#vrf-instances-device-configuration)
 - [Quality Of Service](#quality-of-service)
+- [EOS CLI](#eos-cli)
 
 <!-- toc -->
 # Management
@@ -437,3 +438,12 @@ vrf instance MGMT
 ```
 
 # Quality Of Service
+
+# EOS CLI
+
+```eos
+!
+interface Loopback1009
+  description Loopback created from raw_eos_cli under spine defaults in DC2 POD1
+
+```

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-RS1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-RS1.md
@@ -34,6 +34,7 @@
   - [VRF Instances Summary](#vrf-instances-summary)
   - [VRF Instances Device Configuration](#vrf-instances-device-configuration)
 - [Quality Of Service](#quality-of-service)
+- [EOS CLI](#eos-cli)
 
 <!-- toc -->
 # Management
@@ -472,3 +473,12 @@ vrf instance MGMT
 ```
 
 # Quality Of Service
+
+# EOS CLI
+
+```eos
+!
+interface Loopback1111
+  description Loopback created from raw_eos_cli under platform_settings vEOS-LAB
+
+```

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-RS2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-RS2.md
@@ -32,6 +32,7 @@
   - [VRF Instances Summary](#vrf-instances-summary)
   - [VRF Instances Device Configuration](#vrf-instances-device-configuration)
 - [Quality Of Service](#quality-of-service)
+- [EOS CLI](#eos-cli)
 
 <!-- toc -->
 # Management
@@ -408,3 +409,12 @@ vrf instance MGMT
 ```
 
 # Quality Of Service
+
+# EOS CLI
+
+```eos
+!
+interface Loopback1111
+  description Loopback created from raw_eos_cli under platform_settings vEOS-LAB
+
+```

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-SUPER-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-SUPER-SPINE1.md
@@ -34,6 +34,7 @@
   - [VRF Instances Summary](#vrf-instances-summary)
   - [VRF Instances Device Configuration](#vrf-instances-device-configuration)
 - [Quality Of Service](#quality-of-service)
+- [EOS CLI](#eos-cli)
 
 <!-- toc -->
 # Management
@@ -540,3 +541,12 @@ vrf instance MGMT
 ```
 
 # Quality Of Service
+
+# EOS CLI
+
+```eos
+!
+interface Loopback1111
+  description Loopback created from raw_eos_cli under platform_settings vEOS-LAB
+
+```

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-SUPER-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-SUPER-SPINE2.md
@@ -32,6 +32,7 @@
   - [VRF Instances Summary](#vrf-instances-summary)
   - [VRF Instances Device Configuration](#vrf-instances-device-configuration)
 - [Quality Of Service](#quality-of-service)
+- [EOS CLI](#eos-cli)
 
 <!-- toc -->
 # Management
@@ -422,3 +423,12 @@ vrf instance MGMT
 ```
 
 # Quality Of Service
+
+# EOS CLI
+
+```eos
+!
+interface Loopback1111
+  description Loopback created from raw_eos_cli under platform_settings vEOS-LAB
+
+```

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/fabric/TWODC_5STAGE_CLOS-topology.csv
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/fabric/TWODC_5STAGE_CLOS-topology.csv
@@ -19,6 +19,10 @@ l3leaf,DC1-POD1-LEAF2A,Ethernet4,l2leaf,DC1-POD1-L2LEAF2B,Ethernet1
 l3leaf,DC1-POD1-LEAF2A,Ethernet5,mlag_peer,DC1-POD1-LEAF2B,Ethernet5
 l3leaf,DC1-POD1-LEAF2A,Ethernet6,mlag_peer,DC1-POD1-LEAF2B,Ethernet6
 l3leaf,DC1-POD1-LEAF2A,Ethernet7,l3leaf,DC2-POD1-LEAF1A,Ethernet6
+l3leaf,DC1-POD1-LEAF2A,Ethernet16,server,server-1,Eth1
+l3leaf,DC1-POD1-LEAF2A,Ethernet17,server,server-1,Eth3
+l3leaf,DC1-POD1-LEAF2A,Ethernet18,server,server-1,Eth5
+l3leaf,DC1-POD1-LEAF2A,Ethernet19,server,server-1,Eth7
 l3leaf,DC1-POD1-LEAF2B,Ethernet1,spine,DC1-POD1-SPINE1,Ethernet5
 l3leaf,DC1-POD1-LEAF2B,Ethernet2,spine,DC1-POD1-SPINE2,Ethernet5
 l3leaf,DC1-POD1-LEAF2B,Ethernet3,l2leaf,DC1-POD1-L2LEAF2A,Ethernet2
@@ -26,6 +30,10 @@ l3leaf,DC1-POD1-LEAF2B,Ethernet4,l2leaf,DC1-POD1-L2LEAF2B,Ethernet2
 l3leaf,DC1-POD1-LEAF2B,Ethernet5,mlag_peer,DC1-POD1-LEAF2A,Ethernet5
 l3leaf,DC1-POD1-LEAF2B,Ethernet6,mlag_peer,DC1-POD1-LEAF2A,Ethernet6
 l3leaf,DC1-POD1-LEAF2B,Ethernet7,l3leaf,DC2-POD1-LEAF1A,Ethernet7
+l3leaf,DC1-POD1-LEAF2B,Ethernet16,server,server-1,Eth2
+l3leaf,DC1-POD1-LEAF2B,Ethernet17,server,server-1,Eth4
+l3leaf,DC1-POD1-LEAF2B,Ethernet18,server,server-1,Eth6
+l3leaf,DC1-POD1-LEAF2B,Ethernet19,server,server-1,Eth8
 spine,DC1-POD1-SPINE1,Ethernet1,super-spine,DC1-SUPER-SPINE1,Ethernet1
 spine,DC1-POD1-SPINE1,Ethernet2,super-spine,DC1-SUPER-SPINE2,Ethernet1
 spine,DC1-POD1-SPINE1,Ethernet3,l3leaf,DC1-POD1-LEAF1A,Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-L2LEAF1A.cfg
@@ -54,4 +54,8 @@ management api http-commands
    vrf MGMT
       no shutdown
 !
+interface Loopback1111
+  description Loopback created from raw_eos_cli under platform_settings vEOS-LAB
+
+!
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-L2LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-L2LEAF2A.cfg
@@ -114,4 +114,11 @@ management api http-commands
    vrf MGMT
       no shutdown
 !
+interface Loopback1002
+  description Loopback created from raw_eos_cli under l2leaf node-group RACK2_MLAG
+
+interface Loopback1000
+  description Loopback created from raw_eos_cli under VRF Common_VRF
+
+!
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-L2LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-L2LEAF2A.cfg
@@ -117,6 +117,9 @@ management api http-commands
 interface Loopback1002
   description Loopback created from raw_eos_cli under l2leaf node-group RACK2_MLAG
 
+interface Loopback1111
+  description Loopback created from raw_eos_cli under platform_settings vEOS-LAB
+
 interface Loopback1000
   description Loopback created from raw_eos_cli under VRF Common_VRF
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-L2LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-L2LEAF2B.cfg
@@ -120,4 +120,11 @@ management api http-commands
    vrf MGMT
       no shutdown
 !
+interface Loopback1003
+  description Loopback created from raw_eos_cli under l2leaf node DC1-POD1-L2LEAF2B
+
+interface Loopback1000
+  description Loopback created from raw_eos_cli under VRF Common_VRF
+
+!
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-L2LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-L2LEAF2B.cfg
@@ -123,6 +123,9 @@ management api http-commands
 interface Loopback1003
   description Loopback created from raw_eos_cli under l2leaf node DC1-POD1-L2LEAF2B
 
+interface Loopback1111
+  description Loopback created from raw_eos_cli under platform_settings vEOS-LAB
+
 interface Loopback1000
   description Loopback created from raw_eos_cli under VRF Common_VRF
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF1A.cfg
@@ -200,5 +200,8 @@ management api http-commands
 interface Loopback1002
   description Loopback created from raw_eos_cli under node DC1-POD1-LEAF1A
 
+interface Loopback1111
+  description Loopback created from raw_eos_cli under platform_settings vEOS-LAB
+
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF1A.cfg
@@ -197,4 +197,8 @@ management api http-commands
    vrf MGMT
       no shutdown
 !
+interface Loopback1002
+  description Loopback created from raw_eos_cli under node DC1-POD1-LEAF1A
+
+!
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2A.cfg
@@ -414,6 +414,9 @@ management api http-commands
 interface Loopback1002
   description Loopback created from raw_eos_cli under l3leaf node-group RACK2_MLAG
 
+interface Loopback1111
+  description Loopback created from raw_eos_cli under platform_settings vEOS-LAB
+
 interface Loopback1000
   description Loopback created from raw_eos_cli under VRF Common_VRF
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2A.cfg
@@ -68,6 +68,46 @@ interface Port-Channel5
    switchport trunk group MLAG
    service-profile QOS-PROFILE
 !
+interface Port-Channel16
+   description server-1_PortChannel
+   no shutdown
+   switchport
+   switchport access vlan 110
+   mlag 16
+   service-profile bar
+!
+interface Port-Channel17
+   description server-1_PortChannel
+   no shutdown
+   switchport
+   switchport access vlan 110
+   mlag 17
+   service-profile foo
+!
+interface Port-Channel18
+   description server-1_PortChannel
+   no shutdown
+   switchport
+   switchport access vlan 110
+   mlag 18
+   service-profile foo
+   comment
+   Comment created from raw_eos_cli under port_channel on profile NESTED_TENANT_A
+   EOF
+
+!
+interface Port-Channel19
+   description server-1_PortChannel
+   no shutdown
+   switchport
+   switchport access vlan 110
+   mlag 19
+   service-profile foo
+   comment
+   Comment created from raw_eos_cli under adapter port_channel for switch Po19
+   EOF
+
+!
 interface Ethernet1
    description P2P_LINK_TO_DC1-POD1-SPINE1_Ethernet4
    no shutdown
@@ -113,6 +153,42 @@ interface Ethernet7
    no switchport
    ip address 100.100.100.101/24
 !
+interface Ethernet16
+   description server-1_Eth1
+   no shutdown
+   channel-group 16 mode active
+   comment
+   Comment created from raw_eos_cli under profile TENANT_A
+   EOF
+
+!
+interface Ethernet17
+   description server-1_Eth3
+   no shutdown
+   channel-group 17 mode active
+   comment
+   Comment created from raw_eos_cli under adapter for switch Eth17
+   EOF
+
+!
+interface Ethernet18
+   description server-1_Eth5
+   no shutdown
+   channel-group 18 mode active
+   comment
+   Comment created from raw_eos_cli under profile NESTED_TENANT_A
+   EOF
+
+!
+interface Ethernet19
+   description server-1_Eth7
+   no shutdown
+   channel-group 19 mode active
+   comment
+   Comment created from raw_eos_cli under profile NESTED_TENANT_A
+   EOF
+
+!
 interface Loopback0
    description EVPN_Overlay_Peering
    no shutdown
@@ -140,6 +216,10 @@ interface Vlan112
    no shutdown
    vrf Common_VRF
    ip address virtual 10.1.12.1/24
+   comment
+   Comment created from raw_eos_cli under SVI 112 in VRF Common_VRF
+   EOF
+
 !
 interface Vlan4085
    description L2LEAF_INBAND_MGMT
@@ -318,6 +398,11 @@ router bgp 65112
       route-target export evpn 1025:1025
       router-id 172.16.110.4
       redistribute connected
+      !
+      comment
+      Comment created from raw_eos_cli under BGP for VRF Common_VRF
+      EOF
+
 !
 management api http-commands
    protocol https
@@ -325,5 +410,12 @@ management api http-commands
    !
    vrf MGMT
       no shutdown
+!
+interface Loopback1002
+  description Loopback created from raw_eos_cli under l3leaf node-group RACK2_MLAG
+
+interface Loopback1000
+  description Loopback created from raw_eos_cli under VRF Common_VRF
+
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2B.cfg
@@ -68,6 +68,46 @@ interface Port-Channel5
    switchport trunk group MLAG
    service-profile QOS-PROFILE
 !
+interface Port-Channel16
+   description server-1_PortChannel
+   no shutdown
+   switchport
+   switchport access vlan 110
+   mlag 16
+   service-profile bar
+!
+interface Port-Channel17
+   description server-1_PortChannel
+   no shutdown
+   switchport
+   switchport access vlan 110
+   mlag 17
+   service-profile foo
+!
+interface Port-Channel18
+   description server-1_PortChannel
+   no shutdown
+   switchport
+   switchport access vlan 110
+   mlag 18
+   service-profile foo
+   comment
+   Comment created from raw_eos_cli under port_channel on profile NESTED_TENANT_A
+   EOF
+
+!
+interface Port-Channel19
+   description server-1_PortChannel
+   no shutdown
+   switchport
+   switchport access vlan 110
+   mlag 19
+   service-profile foo
+   comment
+   Comment created from raw_eos_cli under adapter port_channel for switch Po19
+   EOF
+
+!
 interface Ethernet1
    description P2P_LINK_TO_DC1-POD1-SPINE1_Ethernet5
    no shutdown
@@ -114,6 +154,42 @@ interface Ethernet7
    ip address 11.1.0.38/31
    ptp enable
 !
+interface Ethernet16
+   description server-1_Eth2
+   no shutdown
+   channel-group 16 mode active
+   comment
+   Comment created from raw_eos_cli under profile TENANT_A
+   EOF
+
+!
+interface Ethernet17
+   description server-1_Eth4
+   no shutdown
+   channel-group 17 mode active
+   comment
+   Comment created from raw_eos_cli under adapter for switch Eth17
+   EOF
+
+!
+interface Ethernet18
+   description server-1_Eth6
+   no shutdown
+   channel-group 18 mode active
+   comment
+   Comment created from raw_eos_cli under profile NESTED_TENANT_A
+   EOF
+
+!
+interface Ethernet19
+   description server-1_Eth8
+   no shutdown
+   channel-group 19 mode active
+   comment
+   Comment created from raw_eos_cli under profile NESTED_TENANT_A
+   EOF
+
+!
 interface Loopback0
    description EVPN_Overlay_Peering
    no shutdown
@@ -147,6 +223,10 @@ interface Vlan112
    no shutdown
    vrf Common_VRF
    ip address virtual 10.1.12.1/24
+   comment
+   Comment created from raw_eos_cli under SVI 112 in VRF Common_VRF
+   EOF
+
 !
 interface Vlan4085
    description L2LEAF_INBAND_MGMT
@@ -325,6 +405,11 @@ router bgp 65112
       route-target export evpn 1025:1025
       router-id 172.16.110.5
       redistribute connected
+      !
+      comment
+      Comment created from raw_eos_cli under BGP for VRF Common_VRF
+      EOF
+
 !
 management api http-commands
    protocol https
@@ -332,5 +417,12 @@ management api http-commands
    !
    vrf MGMT
       no shutdown
+!
+interface Loopback1002
+  description Loopback created from raw_eos_cli under l3leaf node-group RACK2_MLAG
+
+interface Loopback1000
+  description Loopback created from raw_eos_cli under VRF Common_VRF
+
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2B.cfg
@@ -421,6 +421,9 @@ management api http-commands
 interface Loopback1002
   description Loopback created from raw_eos_cli under l3leaf node-group RACK2_MLAG
 
+interface Loopback1111
+  description Loopback created from raw_eos_cli under platform_settings vEOS-LAB
+
 interface Loopback1000
   description Loopback created from raw_eos_cli under VRF Common_VRF
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-SPINE1.cfg
@@ -191,4 +191,8 @@ management api http-commands
    vrf MGMT
       no shutdown
 !
+interface Loopback1111
+  description Loopback created from raw_eos_cli under platform_settings vEOS-LAB
+
+!
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-SPINE2.cfg
@@ -124,4 +124,8 @@ management api http-commands
    vrf MGMT
       no shutdown
 !
+interface Loopback1111
+  description Loopback created from raw_eos_cli under platform_settings vEOS-LAB
+
+!
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD2-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD2-LEAF1A.cfg
@@ -242,6 +242,9 @@ management api http-commands
    vrf MGMT
       no shutdown
 !
+interface Loopback1111
+  description Loopback created from raw_eos_cli under platform_settings vEOS-LAB
+
 interface Loopback1000
   description Loopback created from raw_eos_cli under VRF Common_VRF
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD2-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD2-LEAF1A.cfg
@@ -98,6 +98,10 @@ interface Vlan112
    no shutdown
    vrf Common_VRF
    ip address virtual 10.1.12.1/24
+   comment
+   Comment created from raw_eos_cli under SVI 112 in VRF Common_VRF
+   EOF
+
 !
 interface Vlan4092
    description L2LEAF_INBAND_MGMT
@@ -225,6 +229,11 @@ router bgp 65121
       route-target export evpn 1025:1025
       router-id 172.16.120.3
       redistribute connected
+      !
+      comment
+      Comment created from raw_eos_cli under BGP for VRF Common_VRF
+      EOF
+
 !
 management api http-commands
    protocol https
@@ -232,5 +241,9 @@ management api http-commands
    !
    vrf MGMT
       no shutdown
+!
+interface Loopback1000
+  description Loopback created from raw_eos_cli under VRF Common_VRF
+
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD2-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD2-SPINE1.cfg
@@ -144,4 +144,8 @@ management api http-commands
    vrf MGMT
       no shutdown
 !
+interface Loopback1111
+  description Loopback created from raw_eos_cli under platform_settings vEOS-LAB
+
+!
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD2-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD2-SPINE2.cfg
@@ -134,4 +134,8 @@ management api http-commands
    vrf MGMT
       no shutdown
 !
+interface Loopback1111
+  description Loopback created from raw_eos_cli under platform_settings vEOS-LAB
+
+!
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-RS1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-RS1.cfg
@@ -155,4 +155,8 @@ management api http-commands
    vrf MGMT
       no shutdown
 !
+interface Loopback1111
+  description Loopback created from raw_eos_cli under platform_settings vEOS-LAB
+
+!
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-RS2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-RS2.cfg
@@ -155,4 +155,8 @@ management api http-commands
    vrf MGMT
       no shutdown
 !
+interface Loopback1111
+  description Loopback created from raw_eos_cli under platform_settings vEOS-LAB
+
+!
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-SUPER-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-SUPER-SPINE1.cfg
@@ -130,4 +130,8 @@ management api http-commands
    vrf MGMT
       no shutdown
 !
+interface Loopback1111
+  description Loopback created from raw_eos_cli under platform_settings vEOS-LAB
+
+!
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-SUPER-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-SUPER-SPINE2.cfg
@@ -134,4 +134,8 @@ management api http-commands
    vrf MGMT
       no shutdown
 !
+interface Loopback1111
+  description Loopback created from raw_eos_cli under platform_settings vEOS-LAB
+
+!
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-L2LEAF1A.cfg
@@ -63,5 +63,8 @@ management api http-commands
 interface Loopback1011
   description Loopback created from raw_eos_cli under l2leaf defaults in DC2 POD1
 
+interface Loopback1111
+  description Loopback created from raw_eos_cli under platform_settings vEOS-LAB
+
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-L2LEAF1A.cfg
@@ -60,4 +60,8 @@ management api http-commands
    vrf MGMT
       no shutdown
 !
+interface Loopback1011
+  description Loopback created from raw_eos_cli under l2leaf defaults in DC2 POD1
+
+!
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-LEAF1A.cfg
@@ -187,6 +187,11 @@ router bgp 65211
       route-target export evpn 1025:1025
       router-id 172.16.210.3
       redistribute connected
+      !
+      comment
+      Comment created from raw_eos_cli under BGP for VRF Common_VRF
+      EOF
+
 !
 management api http-commands
    protocol https
@@ -194,5 +199,12 @@ management api http-commands
    !
    vrf MGMT
       no shutdown
+!
+interface Loopback1010
+  description Loopback created from raw_eos_cli under l3leaf defaults in DC2 POD1
+
+interface Loopback1000
+  description Loopback created from raw_eos_cli under VRF Common_VRF
+
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-LEAF1A.cfg
@@ -203,6 +203,9 @@ management api http-commands
 interface Loopback1010
   description Loopback created from raw_eos_cli under l3leaf defaults in DC2 POD1
 
+interface Loopback1111
+  description Loopback created from raw_eos_cli under platform_settings vEOS-LAB
+
 interface Loopback1000
   description Loopback created from raw_eos_cli under VRF Common_VRF
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-SPINE1.cfg
@@ -141,4 +141,8 @@ management api http-commands
    vrf MGMT
       no shutdown
 !
+interface Loopback1009
+  description Loopback created from raw_eos_cli under spine defaults in DC2 POD1
+
+!
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-SPINE1.cfg
@@ -144,5 +144,8 @@ management api http-commands
 interface Loopback1009
   description Loopback created from raw_eos_cli under spine defaults in DC2 POD1
 
+interface Loopback1111
+  description Loopback created from raw_eos_cli under platform_settings vEOS-LAB
+
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-SPINE2.cfg
@@ -111,4 +111,8 @@ management api http-commands
    vrf MGMT
       no shutdown
 !
+interface Loopback1009
+  description Loopback created from raw_eos_cli under spine defaults in DC2 POD1
+
+!
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-SPINE2.cfg
@@ -114,5 +114,8 @@ management api http-commands
 interface Loopback1009
   description Loopback created from raw_eos_cli under spine defaults in DC2 POD1
 
+interface Loopback1111
+  description Loopback created from raw_eos_cli under platform_settings vEOS-LAB
+
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-RS1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-RS1.cfg
@@ -117,4 +117,8 @@ management api http-commands
    vrf MGMT
       no shutdown
 !
+interface Loopback1111
+  description Loopback created from raw_eos_cli under platform_settings vEOS-LAB
+
+!
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-RS2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-RS2.cfg
@@ -86,4 +86,8 @@ management api http-commands
    vrf MGMT
       no shutdown
 !
+interface Loopback1111
+  description Loopback created from raw_eos_cli under platform_settings vEOS-LAB
+
+!
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-SUPER-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-SUPER-SPINE1.cfg
@@ -175,4 +175,8 @@ management api http-commands
    vrf MGMT
       no shutdown
 !
+interface Loopback1111
+  description Loopback created from raw_eos_cli under platform_settings vEOS-LAB
+
+!
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-SUPER-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-SUPER-SPINE2.cfg
@@ -98,4 +98,8 @@ management api http-commands
    vrf MGMT
       no shutdown
 !
+interface Loopback1111
+  description Loopback created from raw_eos_cli under platform_settings vEOS-LAB
+
+!
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF1A.yml
@@ -30,6 +30,8 @@ management_api_http:
   enable_vrfs:
     MGMT: {}
   enable_https: true
+eos_cli: "interface Loopback1111\n  description Loopback created from raw_eos_cli\
+  \ under platform_settings vEOS-LAB\n"
 ethernet_interfaces:
   Ethernet1:
     peer: DC1-POD1-LEAF1A

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF2A.yml
@@ -31,6 +31,9 @@ management_api_http:
   enable_vrfs:
     MGMT: {}
   enable_https: true
+eos_cli: "interface Loopback1002\n  description Loopback created from raw_eos_cli\
+  \ under l2leaf node-group RACK2_MLAG\n\ninterface Loopback1000\n  description Loopback\
+  \ created from raw_eos_cli under VRF Common_VRF\n"
 vlans:
   4094:
     tenant: system

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF2A.yml
@@ -32,8 +32,9 @@ management_api_http:
     MGMT: {}
   enable_https: true
 eos_cli: "interface Loopback1002\n  description Loopback created from raw_eos_cli\
-  \ under l2leaf node-group RACK2_MLAG\n\ninterface Loopback1000\n  description Loopback\
-  \ created from raw_eos_cli under VRF Common_VRF\n"
+  \ under l2leaf node-group RACK2_MLAG\n\ninterface Loopback1111\n  description Loopback\
+  \ created from raw_eos_cli under platform_settings vEOS-LAB\n\ninterface Loopback1000\n\
+  \  description Loopback created from raw_eos_cli under VRF Common_VRF\n"
 vlans:
   4094:
     tenant: system

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF2B.yml
@@ -46,6 +46,9 @@ management_api_http:
   enable_vrfs:
     MGMT: {}
   enable_https: true
+eos_cli: "interface Loopback1003\n  description Loopback created from raw_eos_cli\
+  \ under l2leaf node DC1-POD1-L2LEAF2B\n\ninterface Loopback1000\n  description Loopback\
+  \ created from raw_eos_cli under VRF Common_VRF\n"
 vlans:
   4094:
     tenant: system

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF2B.yml
@@ -47,8 +47,9 @@ management_api_http:
     MGMT: {}
   enable_https: true
 eos_cli: "interface Loopback1003\n  description Loopback created from raw_eos_cli\
-  \ under l2leaf node DC1-POD1-L2LEAF2B\n\ninterface Loopback1000\n  description Loopback\
-  \ created from raw_eos_cli under VRF Common_VRF\n"
+  \ under l2leaf node DC1-POD1-L2LEAF2B\n\ninterface Loopback1111\n  description Loopback\
+  \ created from raw_eos_cli under platform_settings vEOS-LAB\n\ninterface Loopback1000\n\
+  \  description Loopback created from raw_eos_cli under VRF Common_VRF\n"
 vlans:
   4094:
     tenant: system

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF1A.yml
@@ -111,7 +111,8 @@ management_api_http:
     MGMT: {}
   enable_https: true
 eos_cli: "interface Loopback1002\n  description Loopback created from raw_eos_cli\
-  \ under node DC1-POD1-LEAF1A\n"
+  \ under node DC1-POD1-LEAF1A\n\ninterface Loopback1111\n  description Loopback created\
+  \ from raw_eos_cli under platform_settings vEOS-LAB\n"
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF1A.yml
@@ -110,6 +110,8 @@ management_api_http:
   enable_vrfs:
     MGMT: {}
   enable_https: true
+eos_cli: "interface Loopback1002\n  description Loopback created from raw_eos_cli\
+  \ under node DC1-POD1-LEAF1A\n"
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2A.yml
@@ -175,8 +175,9 @@ management_api_http:
     MGMT: {}
   enable_https: true
 eos_cli: "interface Loopback1002\n  description Loopback created from raw_eos_cli\
-  \ under l3leaf node-group RACK2_MLAG\n\ninterface Loopback1000\n  description Loopback\
-  \ created from raw_eos_cli under VRF Common_VRF\n"
+  \ under l3leaf node-group RACK2_MLAG\n\ninterface Loopback1111\n  description Loopback\
+  \ created from raw_eos_cli under platform_settings vEOS-LAB\n\ninterface Loopback1000\n\
+  \  description Loopback created from raw_eos_cli under VRF Common_VRF\n"
 vlans:
   4093:
     tenant: system

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2A.yml
@@ -92,6 +92,13 @@ router_bgp:
           - 1025:1025
       redistribute_routes:
       - connected
+      eos_cli: 'comment
+
+        Comment created from raw_eos_cli under BGP for VRF Common_VRF
+
+        EOF
+
+        '
   vlans:
     110:
       tenant: Tenant_A
@@ -167,6 +174,9 @@ management_api_http:
   enable_vrfs:
     MGMT: {}
   enable_https: true
+eos_cli: "interface Loopback1002\n  description Loopback created from raw_eos_cli\
+  \ under l3leaf node-group RACK2_MLAG\n\ninterface Loopback1000\n  description Loopback\
+  \ created from raw_eos_cli under VRF Common_VRF\n"
 vlans:
   4093:
     tenant: system
@@ -240,6 +250,13 @@ vlan_interfaces:
     shutdown: false
     vrf: Common_VRF
     ip_address_virtual: 10.1.12.1/24
+    eos_cli: 'comment
+
+      Comment created from raw_eos_cli under SVI 112 in VRF Common_VRF
+
+      EOF
+
+      '
 port_channel_interfaces:
   Port-Channel5:
     description: MLAG_PEER_DC1-POD1-LEAF2B_Po5
@@ -259,6 +276,52 @@ port_channel_interfaces:
     mode: trunk
     service_profile: QOS-PROFILE
     mlag: 3
+  Port-Channel16:
+    description: server-1_PortChannel
+    type: switched
+    shutdown: false
+    mode: access
+    vlans: 110
+    mlag: 16
+    service_profile: bar
+  Port-Channel17:
+    description: server-1_PortChannel
+    type: switched
+    shutdown: false
+    mode: access
+    vlans: 110
+    mlag: 17
+    service_profile: foo
+  Port-Channel18:
+    description: server-1_PortChannel
+    type: switched
+    shutdown: false
+    mode: access
+    vlans: 110
+    mlag: 18
+    service_profile: foo
+    eos_cli: 'comment
+
+      Comment created from raw_eos_cli under port_channel on profile NESTED_TENANT_A
+
+      EOF
+
+      '
+  Port-Channel19:
+    description: server-1_PortChannel
+    type: switched
+    shutdown: false
+    mode: access
+    vlans: 110
+    mlag: 19
+    service_profile: foo
+    eos_cli: 'comment
+
+      Comment created from raw_eos_cli under adapter port_channel for switch Po19
+
+      EOF
+
+      '
 ethernet_interfaces:
   Ethernet5:
     peer: DC1-POD1-LEAF2B
@@ -333,6 +396,90 @@ ethernet_interfaces:
     shutdown: false
     mtu: 1500
     ip_address: 100.100.100.101/24
+  Ethernet16:
+    peer: server-1
+    peer_interface: Eth1
+    peer_type: server
+    description: server-1_Eth1
+    type: switched
+    shutdown: false
+    mode: access
+    vlans: 110
+    channel_group:
+      id: 16
+      mode: active
+    profile: TENANT_A
+    service_profile: bar
+    eos_cli: 'comment
+
+      Comment created from raw_eos_cli under profile TENANT_A
+
+      EOF
+
+      '
+  Ethernet17:
+    peer: server-1
+    peer_interface: Eth3
+    peer_type: server
+    description: server-1_Eth3
+    type: switched
+    shutdown: false
+    mode: access
+    vlans: 110
+    channel_group:
+      id: 17
+      mode: active
+    profile: TENANT_A
+    service_profile: foo
+    eos_cli: 'comment
+
+      Comment created from raw_eos_cli under adapter for switch Eth17
+
+      EOF
+
+      '
+  Ethernet18:
+    peer: server-1
+    peer_interface: Eth5
+    peer_type: server
+    description: server-1_Eth5
+    type: switched
+    shutdown: false
+    mode: access
+    vlans: 110
+    channel_group:
+      id: 18
+      mode: active
+    profile: NESTED_TENANT_A
+    service_profile: foo
+    eos_cli: 'comment
+
+      Comment created from raw_eos_cli under profile NESTED_TENANT_A
+
+      EOF
+
+      '
+  Ethernet19:
+    peer: server-1
+    peer_interface: Eth7
+    peer_type: server
+    description: server-1_Eth7
+    type: switched
+    shutdown: false
+    mode: access
+    vlans: 110
+    channel_group:
+      id: 19
+      mode: active
+    profile: NESTED_TENANT_A
+    service_profile: foo
+    eos_cli: 'comment
+
+      Comment created from raw_eos_cli under profile NESTED_TENANT_A
+
+      EOF
+
+      '
 mlag_configuration:
   domain_id: RACK2_MLAG
   local_interface: Vlan4094

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
@@ -185,8 +185,9 @@ management_api_http:
     MGMT: {}
   enable_https: true
 eos_cli: "interface Loopback1002\n  description Loopback created from raw_eos_cli\
-  \ under l3leaf node-group RACK2_MLAG\n\ninterface Loopback1000\n  description Loopback\
-  \ created from raw_eos_cli under VRF Common_VRF\n"
+  \ under l3leaf node-group RACK2_MLAG\n\ninterface Loopback1111\n  description Loopback\
+  \ created from raw_eos_cli under platform_settings vEOS-LAB\n\ninterface Loopback1000\n\
+  \  description Loopback created from raw_eos_cli under VRF Common_VRF\n"
 vlans:
   4093:
     tenant: system

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
@@ -94,6 +94,13 @@ router_bgp:
           - 1025:1025
       redistribute_routes:
       - connected
+      eos_cli: 'comment
+
+        Comment created from raw_eos_cli under BGP for VRF Common_VRF
+
+        EOF
+
+        '
   vlans:
     110:
       tenant: Tenant_A
@@ -177,6 +184,9 @@ management_api_http:
   enable_vrfs:
     MGMT: {}
   enable_https: true
+eos_cli: "interface Loopback1002\n  description Loopback created from raw_eos_cli\
+  \ under l3leaf node-group RACK2_MLAG\n\ninterface Loopback1000\n  description Loopback\
+  \ created from raw_eos_cli under VRF Common_VRF\n"
 vlans:
   4093:
     tenant: system
@@ -250,6 +260,13 @@ vlan_interfaces:
     shutdown: false
     vrf: Common_VRF
     ip_address_virtual: 10.1.12.1/24
+    eos_cli: 'comment
+
+      Comment created from raw_eos_cli under SVI 112 in VRF Common_VRF
+
+      EOF
+
+      '
 port_channel_interfaces:
   Port-Channel5:
     description: MLAG_PEER_DC1-POD1-LEAF2A_Po5
@@ -269,6 +286,52 @@ port_channel_interfaces:
     mode: trunk
     service_profile: QOS-PROFILE
     mlag: 3
+  Port-Channel16:
+    description: server-1_PortChannel
+    type: switched
+    shutdown: false
+    mode: access
+    vlans: 110
+    mlag: 16
+    service_profile: bar
+  Port-Channel17:
+    description: server-1_PortChannel
+    type: switched
+    shutdown: false
+    mode: access
+    vlans: 110
+    mlag: 17
+    service_profile: foo
+  Port-Channel18:
+    description: server-1_PortChannel
+    type: switched
+    shutdown: false
+    mode: access
+    vlans: 110
+    mlag: 18
+    service_profile: foo
+    eos_cli: 'comment
+
+      Comment created from raw_eos_cli under port_channel on profile NESTED_TENANT_A
+
+      EOF
+
+      '
+  Port-Channel19:
+    description: server-1_PortChannel
+    type: switched
+    shutdown: false
+    mode: access
+    vlans: 110
+    mlag: 19
+    service_profile: foo
+    eos_cli: 'comment
+
+      Comment created from raw_eos_cli under adapter port_channel for switch Po19
+
+      EOF
+
+      '
 ethernet_interfaces:
   Ethernet5:
     peer: DC1-POD1-LEAF2A
@@ -345,6 +408,90 @@ ethernet_interfaces:
     ip_address: 11.1.0.38/31
     ptp:
       enable: true
+  Ethernet16:
+    peer: server-1
+    peer_interface: Eth2
+    peer_type: server
+    description: server-1_Eth2
+    type: switched
+    shutdown: false
+    mode: access
+    vlans: 110
+    channel_group:
+      id: 16
+      mode: active
+    profile: TENANT_A
+    service_profile: bar
+    eos_cli: 'comment
+
+      Comment created from raw_eos_cli under profile TENANT_A
+
+      EOF
+
+      '
+  Ethernet17:
+    peer: server-1
+    peer_interface: Eth4
+    peer_type: server
+    description: server-1_Eth4
+    type: switched
+    shutdown: false
+    mode: access
+    vlans: 110
+    channel_group:
+      id: 17
+      mode: active
+    profile: TENANT_A
+    service_profile: foo
+    eos_cli: 'comment
+
+      Comment created from raw_eos_cli under adapter for switch Eth17
+
+      EOF
+
+      '
+  Ethernet18:
+    peer: server-1
+    peer_interface: Eth6
+    peer_type: server
+    description: server-1_Eth6
+    type: switched
+    shutdown: false
+    mode: access
+    vlans: 110
+    channel_group:
+      id: 18
+      mode: active
+    profile: NESTED_TENANT_A
+    service_profile: foo
+    eos_cli: 'comment
+
+      Comment created from raw_eos_cli under profile NESTED_TENANT_A
+
+      EOF
+
+      '
+  Ethernet19:
+    peer: server-1
+    peer_interface: Eth8
+    peer_type: server
+    description: server-1_Eth8
+    type: switched
+    shutdown: false
+    mode: access
+    vlans: 110
+    channel_group:
+      id: 19
+      mode: active
+    profile: NESTED_TENANT_A
+    service_profile: foo
+    eos_cli: 'comment
+
+      Comment created from raw_eos_cli under profile NESTED_TENANT_A
+
+      EOF
+
+      '
 mlag_configuration:
   domain_id: RACK2_MLAG
   local_interface: Vlan4094

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-SPINE1.yml
@@ -122,6 +122,8 @@ management_api_http:
   enable_vrfs:
     MGMT: {}
   enable_https: true
+eos_cli: "interface Loopback1111\n  description Loopback created from raw_eos_cli\
+  \ under platform_settings vEOS-LAB\n"
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-SPINE2.yml
@@ -76,6 +76,8 @@ management_api_http:
   enable_vrfs:
     MGMT: {}
   enable_https: true
+eos_cli: "interface Loopback1111\n  description Loopback created from raw_eos_cli\
+  \ under platform_settings vEOS-LAB\n"
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-LEAF1A.yml
@@ -161,6 +161,9 @@ management_api_http:
   enable_vrfs:
     MGMT: {}
   enable_https: true
+eos_cli: "interface Loopback1111\n  description Loopback created from raw_eos_cli\
+  \ under platform_settings vEOS-LAB\n\ninterface Loopback1000\n  description Loopback\
+  \ created from raw_eos_cli under VRF Common_VRF\n"
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
@@ -301,8 +304,6 @@ router_bfd:
     multiplier: 3
 ip_igmp_snooping:
   globally_enabled: true
-eos_cli: "interface Loopback1000\n  description Loopback created from raw_eos_cli\
-  \ under VRF Common_VRF\n"
 vxlan_tunnel_interface:
   Vxlan1:
     description: DC1-POD2-LEAF1A_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-LEAF1A.yml
@@ -75,6 +75,13 @@ router_bgp:
           - 1025:1025
       redistribute_routes:
       - connected
+      eos_cli: 'comment
+
+        Comment created from raw_eos_cli under BGP for VRF Common_VRF
+
+        EOF
+
+        '
   vlans:
     110:
       tenant: Tenant_A
@@ -250,6 +257,13 @@ vlan_interfaces:
     shutdown: false
     vrf: Common_VRF
     ip_address_virtual: 10.1.12.1/24
+    eos_cli: 'comment
+
+      Comment created from raw_eos_cli under SVI 112 in VRF Common_VRF
+
+      EOF
+
+      '
 prefix_lists:
   PL-LOOPBACKS-EVPN-OVERLAY:
     sequence_numbers:
@@ -287,6 +301,8 @@ router_bfd:
     multiplier: 3
 ip_igmp_snooping:
   globally_enabled: true
+eos_cli: "interface Loopback1000\n  description Loopback created from raw_eos_cli\
+  \ under VRF Common_VRF\n"
 vxlan_tunnel_interface:
   Vxlan1:
     description: DC1-POD2-LEAF1A_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-SPINE1.yml
@@ -102,6 +102,8 @@ management_api_http:
   enable_vrfs:
     MGMT: {}
   enable_https: true
+eos_cli: "interface Loopback1111\n  description Loopback created from raw_eos_cli\
+  \ under platform_settings vEOS-LAB\n"
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-SPINE2.yml
@@ -98,6 +98,8 @@ management_api_http:
   enable_vrfs:
     MGMT: {}
   enable_https: true
+eos_cli: "interface Loopback1111\n  description Loopback created from raw_eos_cli\
+  \ under platform_settings vEOS-LAB\n"
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-RS1-debug-vars.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-RS1-debug-vars.yml
@@ -1,0 +1,657 @@
+molecule_ephemeral_directory: /home/holbech/.cache/molecule/avd/eos_designs-twodc-5stage-clos
+molecule_file: /home/holbech/.cache/molecule/avd/eos_designs-twodc-5stage-clos/molecule.yml
+molecule_instance_config: /home/holbech/.cache/molecule/avd/eos_designs-twodc-5stage-clos/instance_config.yml
+molecule_no_log: true
+molecule_scenario_directory: /home/holbech/ansible-avd/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos
+molecule_yml:
+  dependency:
+    command: null
+    enabled: true
+    env: {}
+    name: galaxy
+    options: {}
+  driver:
+    name: delegated
+    options:
+      managed: true
+    provider:
+      name: null
+    safe_files: []
+    ssh_connection_options: []
+  platforms:
+  - groups:
+    - DC1_POD1_LEAFS
+    - DC1
+    - TWODC_5STAGE_CLOS
+    image: avdteam/base:3.6
+    managed: false
+    name: DC1-POD1-LEAF1A
+    pre_build_image: true
+  provisioner:
+    ansible_args:
+    - --inventory=inventory/hosts
+    children: {}
+    config_options:
+      defaults:
+        command_warnings: false
+        gathering: explicit
+        jinja2_extensions: jinja2.ext.loopcontrols,jinja2.ext.do,jinja2.ext.i18n
+    connection_options: {}
+    env: {}
+    inventory:
+      group_vars: {}
+      host_vars: {}
+      hosts: {}
+      links:
+        group_vars: inventory/group_vars/
+        host_vars: inventory/host_vars/
+        hosts: inventory/inventory.yml
+    name: ansible
+    options: {}
+    playbooks:
+      cleanup: cleanup.yml
+      converge: converge.yml
+      create: create.yml
+      destroy: destroy.yml
+      prepare: prepare.yml
+      side_effect: side_effect.yml
+      verify: verify.yml
+  scenario:
+    check_sequence:
+    - dependency
+    - cleanup
+    - destroy
+    - create
+    - prepare
+    - converge
+    - check
+    - cleanup
+    - destroy
+    cleanup_sequence:
+    - destroy
+    converge_sequence:
+    - syntax
+    - create
+    - converge
+    - verify
+    create_sequence:
+    - dependency
+    - create
+    - prepare
+    destroy_sequence:
+    - dependency
+    - cleanup
+    - destroy
+    name: eos_designs-twodc-5stage-clos
+    test_sequence:
+    - syntax
+    - create
+    - converge
+    - idempotence
+    - verify
+  verifier:
+    additional_files_or_dirs: []
+    ansible_args:
+    - --inventory=inventory/inventory.yml
+    config_options:
+      defaults:
+        command_warnings: false
+        gathering: explicit
+        jinja2_extensions: jinja2.ext.loopcontrols,jinja2.ext.do,jinja2.ext.i18n
+    enabled: true
+    env: {}
+    inventory:
+      links:
+        group_vars: inventory/group_vars/
+        host_vars: inventory/host_vars/
+        hosts: inventory/inventory.yml
+    name: ansible
+    options: {}
+ansible_host: 10.83.28.157
+ansible_connection: httpapi
+ansible_httpapi_port: 8003
+ansible_httpapi_host: 10.83.28.157
+ansible_httpapi_use_ssl: true
+ansible_httpapi_validate_certs: false
+ansible_network_os: eos
+ansible_user: admin
+ansible_ssh_pass: arista
+ansible_become: true
+ansible_become_method: enable
+root_dir: /home/holbech/ansible-avd/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos
+snmp_settings:
+  location: true
+fabric_name: TWODC_5STAGE_CLOS
+evpn_ebgp_multihop: 5
+evpn_overlay_bgp_rtc: true
+bgp_peer_groups:
+  IPv4_UNDERLAY_PEERS:
+    password: AQQvKeimxJu+uGQ/yYvv9w==
+  EVPN_OVERLAY_PEERS:
+    password: q+VNViP5i4rVjW1cxFv2wA==
+  MLAG_IPv4_UNDERLAY_PEER:
+    password: vnEaG8gMeQf3d3cN6PktXQ==
+mgmt_gateway: 192.168.1.254
+mgmt_destination_networks:
+- 0.0.0.0/0
+p2p_uplinks_qos_profile: QOS-PROFILE
+p2p_uplinks_ptp:
+  enable: true
+local_users:
+  admin:
+    privilege: 15
+    role: network-admin
+    no_password: true
+    sha512_password: $6$eJ5TvI8oru5i9e8G$R1X/SbtGTk9xoEHEBQASc7SC2nHYmi.crVgp2pXuCXwxsXEA81e4E0cXgQ6kX08fIeQzauqhv2kS.RGJFCon5/
+l3_edge:
+  p2p_links_ip_pools:
+    pool-leaf: 11.1.0.0/24
+    pool-spine: 11.1.1.0/24
+    pool-super-spine: 11.1.2.0/24
+  p2p_links_profiles:
+    generic-profile:
+      mtu: 1499
+      bfd: false
+      ptp_enable: true
+  p2p_links:
+  - nodes:
+    - DC1-SUPER-SPINE1
+    - DC2-SUPER-SPINE1
+    id: 1
+    interfaces:
+    - Ethernet6
+    - Ethernet4
+    as:
+    - 65100
+    - 65200
+    ip_pool: pool-super-spine
+    profile: generic-profile
+    include_in_underlay_protocol: true
+    macsec_profile: MACSEC_PROFILE
+  - nodes:
+    - DC1-SUPER-SPINE2
+    - DC2-SUPER-SPINE2
+    id: 2
+    interfaces:
+    - Ethernet6
+    - Ethernet4
+    as:
+    - 65100
+    - 65200
+    ip_pool: pool-super-spine
+    mtu: 1500
+    include_in_underlay_protocol: true
+  - nodes:
+    - DC1-POD2-SPINE1
+    - DC2-POD1-SPINE1
+    id: 10
+    interfaces:
+    - Ethernet5
+    - Ethernet5
+    as:
+    - 65120
+    - 65210
+    ip_pool: pool-spine
+    mtu: 1500
+    include_in_underlay_protocol: true
+  - nodes:
+    - DC1-POD2-SPINE2
+    - DC2-POD1-SPINE2
+    interfaces:
+    - Ethernet4
+    - Ethernet5
+    as:
+    - 65112
+    - 65210
+    ip:
+    - 200.200.200.101/24
+    - 200.200.200.201/24
+    mtu: 1498
+    profile: generic-profile
+    include_in_underlay_protocol: true
+  - nodes:
+    - DC1-POD1-LEAF2A
+    - DC2-POD1-LEAF1A
+    interfaces:
+    - Ethernet7
+    - Ethernet6
+    as:
+    - 65112
+    - 65211
+    ip:
+    - 100.100.100.101/24
+    - 100.100.100.201/24
+    mtu: 1500
+    include_in_underlay_protocol: true
+  - nodes:
+    - DC1-POD1-LEAF2B
+    - DC2-POD1-LEAF1A
+    id: 20
+    interfaces:
+    - Ethernet7
+    - Ethernet7
+    as:
+    - 65120
+    - 65211
+    ip_pool: pool-leaf
+    profile: generic-profile
+    bfd: true
+    include_in_underlay_protocol: true
+p2p_uplinks_mtu: 1500
+spine_bgp_defaults:
+- no bgp default ipv4-unicast
+- distance bgp 20 200 200
+- graceful-restart restart-time 300
+- graceful-restart
+super_spine_bgp_defaults:
+- no bgp default ipv4-unicast
+- distance bgp 20 200 200
+- graceful-restart restart-time 300
+- graceful-restart
+leaf_bgp_defaults:
+- no bgp default ipv4-unicast
+- distance bgp 20 200 200
+- graceful-restart restart-time 300
+- graceful-restart
+platform_settings:
+- platforms:
+  - default
+  reload_delay:
+    mlag: 300
+    non_mlag: 330
+- platforms:
+  - vEOS-LAB
+  raw_eos_cli: "interface Loopback1111\n  description Loopback created from raw_eos_cli\
+    \ under platform_settings vEOS-LAB\n"
+  reload_delay:
+    mlag: 300
+    non_mlag: 330
+dc_name: DC1
+super_spine_loopback_network_summary: 172.16.100.0/24
+max_super_spines: 4
+super_spine:
+  platform: vEOS-LAB
+  bgp_as: 65100
+  nodes:
+    DC1-SUPER-SPINE1:
+      id: 1
+    DC1-SUPER-SPINE2:
+      id: 2
+      mgmt_ip: 192.168.1.2/24
+overlay_controller_loopback_network_summary: 172.16.10.0/24
+overlay_controller_p2p_network_summary: 172.17.10.0/24
+overlay_controller_p2p_bfd: true
+max_overlay_controller_to_switch_links: 4
+overlay_controller:
+  platform: vEOS-LAB
+  nodes:
+    DC1-RS1:
+      id: 1
+      bgp_as: 65101
+      evpn_role: server
+      evpn_route_servers:
+      - DC2-RS1
+      - DC2-SUPER-SPINE1
+      - DC2-POD1-SPINE1
+      - DC2-POD1-LEAF1A
+      remote_switches_interfaces:
+      - Ethernet5
+      - Ethernet6
+      - Ethernet4
+      remote_switches:
+      - DC1-SUPER-SPINE1
+      - DC1-POD1-SPINE1
+      - DC1-POD1-LEAF1A
+      uplink_to_remote_switches:
+      - Ethernet1
+      - Ethernet2
+      - Ethernet3
+    DC1-RS2:
+      id: 2
+      mgmt_ip: 192.168.1.4/24
+      bgp_as: 65102
+      evpn_role: server
+      evpn_route_servers:
+      - DC2-RS1
+      - DC2-SUPER-SPINE1
+      - DC2-POD1-SPINE1
+      - DC2-POD1-LEAF1A
+      remote_switches_interfaces:
+      - Ethernet5
+      - Ethernet4
+      - Ethernet3
+      remote_switches:
+      - DC1-SUPER-SPINE2
+      - DC1-POD2-SPINE1
+      - DC1-POD2-LEAF1A
+      uplink_to_remote_switches:
+      - Ethernet1
+      - Ethernet2
+      - Ethernet3
+evpn_prevent_readvertise_to_server: true
+inventory_file: /home/holbech/.cache/molecule/avd/eos_designs-twodc-5stage-clos/inventory/hosts
+inventory_dir: /home/holbech/.cache/molecule/avd/eos_designs-twodc-5stage-clos/inventory
+type: overlay-controller
+ansible_port: 8003
+inventory_hostname: DC1-RS1
+inventory_hostname_short: DC1-RS1
+group_names:
+- DC1
+- DC1_ROUTE_SERVERS
+- TWODC_5STAGE_CLOS
+ansible_facts:
+  switch:
+    underlay_routing_protocol: ebgp
+    overlay_routing_protocol: ebgp
+    id: 1
+    spanning_tree_mode: none
+    platform: vEOS-LAB
+    platform_settings:
+      platforms:
+      - vEOS-LAB
+      raw_eos_cli: "interface Loopback1111\n  description Loopback created from raw_eos_cli\
+        \ under platform_settings vEOS-LAB\n"
+      reload_delay:
+        mlag: 300
+        non_mlag: 330
+    router_id: 172.16.10.1
+    loopback_network_summary: 172.16.10.0/24
+    bgp_defaults:
+    - no bgp default ipv4-unicast
+    - distance bgp 20 200 200
+    - graceful-restart restart-time 300
+    - graceful-restart
+    bgp_as: 65101
+    uplink_interfaces:
+    - Ethernet1
+    - Ethernet2
+    - Ethernet3
+    uplink_switch_interfaces:
+    - Ethernet5
+    - Ethernet6
+    - Ethernet4
+    uplink_switches:
+    - DC1-SUPER-SPINE1
+    - DC1-POD1-SPINE1
+    - DC1-POD1-LEAF1A
+    evpn_role: server
+    evpn_route_servers:
+    - DC2-RS1
+    - DC2-SUPER-SPINE1
+    - DC2-POD1-SPINE1
+    - DC2-POD1-LEAF1A
+  topology:
+    links:
+      Ethernet1:
+        peer: DC1-SUPER-SPINE1
+        peer_interface: Ethernet5
+        peer_type: super-spine
+        peer_bgp_as: 65100
+        type: underlay_p2p
+        bfd: true
+        ip_address: 172.17.10.1
+        peer_ip_address: 172.17.10.0
+      Ethernet2:
+        peer: DC1-POD1-SPINE1
+        peer_interface: Ethernet6
+        peer_type: spine
+        peer_bgp_as: 65110
+        type: underlay_p2p
+        bfd: true
+        ip_address: 172.17.10.3
+        peer_ip_address: 172.17.10.2
+      Ethernet3:
+        peer: DC1-POD1-LEAF1A
+        peer_interface: Ethernet4
+        peer_type: l3leaf
+        peer_bgp_as: 65111
+        type: underlay_p2p
+        bfd: true
+        ip_address: 172.17.10.5
+        peer_ip_address: 172.17.10.4
+    peers:
+    - DC1-SUPER-SPINE1
+    - DC1-POD1-SPINE1
+    - DC1-POD1-LEAF1A
+switch:
+  underlay_routing_protocol: ebgp
+  overlay_routing_protocol: ebgp
+  id: 1
+  spanning_tree_mode: none
+  platform: vEOS-LAB
+  platform_settings:
+    platforms:
+    - vEOS-LAB
+    raw_eos_cli: "interface Loopback1111\n  description Loopback created from raw_eos_cli\
+      \ under platform_settings vEOS-LAB\n"
+    reload_delay:
+      mlag: 300
+      non_mlag: 330
+  router_id: 172.16.10.1
+  loopback_network_summary: 172.16.10.0/24
+  bgp_defaults:
+  - no bgp default ipv4-unicast
+  - distance bgp 20 200 200
+  - graceful-restart restart-time 300
+  - graceful-restart
+  bgp_as: 65101
+  uplink_interfaces:
+  - Ethernet1
+  - Ethernet2
+  - Ethernet3
+  uplink_switch_interfaces:
+  - Ethernet5
+  - Ethernet6
+  - Ethernet4
+  uplink_switches:
+  - DC1-SUPER-SPINE1
+  - DC1-POD1-SPINE1
+  - DC1-POD1-LEAF1A
+  evpn_role: server
+  evpn_route_servers:
+  - DC2-RS1
+  - DC2-SUPER-SPINE1
+  - DC2-POD1-SPINE1
+  - DC2-POD1-LEAF1A
+topology:
+  links:
+    Ethernet1:
+      peer: DC1-SUPER-SPINE1
+      peer_interface: Ethernet5
+      peer_type: super-spine
+      peer_bgp_as: 65100
+      type: underlay_p2p
+      bfd: true
+      ip_address: 172.17.10.1
+      peer_ip_address: 172.17.10.0
+    Ethernet2:
+      peer: DC1-POD1-SPINE1
+      peer_interface: Ethernet6
+      peer_type: spine
+      peer_bgp_as: 65110
+      type: underlay_p2p
+      bfd: true
+      ip_address: 172.17.10.3
+      peer_ip_address: 172.17.10.2
+    Ethernet3:
+      peer: DC1-POD1-LEAF1A
+      peer_interface: Ethernet4
+      peer_type: l3leaf
+      peer_bgp_as: 65111
+      type: underlay_p2p
+      bfd: true
+      ip_address: 172.17.10.5
+      peer_ip_address: 172.17.10.4
+  peers:
+  - DC1-SUPER-SPINE1
+  - DC1-POD1-SPINE1
+  - DC1-POD1-LEAF1A
+playbook_dir: /home/holbech/ansible-avd/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos
+ansible_playbook_python: /usr/bin/python3
+ansible_config_file: /home/holbech/.cache/molecule/avd/eos_designs-twodc-5stage-clos/ansible.cfg
+groups:
+  all:
+  - DC1-POD1-LEAF1A
+  - DC1-POD1-LEAF2A
+  - DC1-POD1-LEAF2B
+  - DC1-POD1-L2LEAF1A
+  - DC1-POD1-L2LEAF2A
+  - DC1-POD1-L2LEAF2B
+  - DC1-POD2-LEAF1A
+  - DC2-POD1-LEAF1A
+  - DC2-POD1-L2LEAF1A
+  - DC1-SUPER-SPINE1
+  - DC1-SUPER-SPINE2
+  - DC1-RS1
+  - DC1-RS2
+  - DC2-SUPER-SPINE1
+  - DC2-SUPER-SPINE2
+  - DC2-RS1
+  - DC2-RS2
+  - DC1-POD1-SPINE1
+  - DC1-POD1-SPINE2
+  - DC1-POD2-SPINE1
+  - DC1-POD2-SPINE2
+  - DC2-POD1-SPINE1
+  - DC2-POD1-SPINE2
+  ungrouped: []
+  DC1:
+  - DC1-POD1-LEAF1A
+  - DC1-SUPER-SPINE1
+  - DC1-SUPER-SPINE2
+  - DC1-RS1
+  - DC1-RS2
+  - DC1-POD1-SPINE1
+  - DC1-POD1-SPINE2
+  - DC1-POD1-LEAF2A
+  - DC1-POD1-LEAF2B
+  - DC1-POD1-L2LEAF1A
+  - DC1-POD1-L2LEAF2A
+  - DC1-POD1-L2LEAF2B
+  - DC1-POD2-SPINE1
+  - DC1-POD2-SPINE2
+  - DC1-POD2-LEAF1A
+  DC1_POD1_LEAFS:
+  - DC1-POD1-LEAF1A
+  - DC1-POD1-LEAF2A
+  - DC1-POD1-LEAF2B
+  - DC1-POD1-L2LEAF1A
+  - DC1-POD1-L2LEAF2A
+  - DC1-POD1-L2LEAF2B
+  TWODC_5STAGE_CLOS:
+  - DC1-POD1-LEAF1A
+  - DC1-SUPER-SPINE1
+  - DC1-SUPER-SPINE2
+  - DC1-RS1
+  - DC1-RS2
+  - DC2-SUPER-SPINE1
+  - DC2-SUPER-SPINE2
+  - DC2-RS1
+  - DC2-RS2
+  - DC1-POD1-SPINE1
+  - DC1-POD1-SPINE2
+  - DC1-POD1-LEAF2A
+  - DC1-POD1-LEAF2B
+  - DC1-POD1-L2LEAF1A
+  - DC1-POD1-L2LEAF2A
+  - DC1-POD1-L2LEAF2B
+  - DC1-POD2-SPINE1
+  - DC1-POD2-SPINE2
+  - DC1-POD2-LEAF1A
+  - DC2-POD1-SPINE1
+  - DC2-POD1-SPINE2
+  - DC2-POD1-LEAF1A
+  - DC2-POD1-L2LEAF1A
+  DC1_SUPER_SPINES:
+  - DC1-SUPER-SPINE1
+  - DC1-SUPER-SPINE2
+  DC1_ROUTE_SERVERS:
+  - DC1-RS1
+  - DC1-RS2
+  DC1_POD1:
+  - DC1-POD1-SPINE1
+  - DC1-POD1-SPINE2
+  - DC1-POD1-LEAF1A
+  - DC1-POD1-LEAF2A
+  - DC1-POD1-LEAF2B
+  - DC1-POD1-L2LEAF1A
+  - DC1-POD1-L2LEAF2A
+  - DC1-POD1-L2LEAF2B
+  DC1_POD1_SPINES:
+  - DC1-POD1-SPINE1
+  - DC1-POD1-SPINE2
+  DC1_POD2:
+  - DC1-POD2-SPINE1
+  - DC1-POD2-SPINE2
+  - DC1-POD2-LEAF1A
+  DC1_POD2_SPINES:
+  - DC1-POD2-SPINE1
+  - DC1-POD2-SPINE2
+  DC1_POD2_LEAFS:
+  - DC1-POD2-LEAF1A
+  DC2:
+  - DC2-SUPER-SPINE1
+  - DC2-SUPER-SPINE2
+  - DC2-RS1
+  - DC2-RS2
+  - DC2-POD1-SPINE1
+  - DC2-POD1-SPINE2
+  - DC2-POD1-LEAF1A
+  - DC2-POD1-L2LEAF1A
+  DC2_SUPER_SPINES:
+  - DC2-SUPER-SPINE1
+  - DC2-SUPER-SPINE2
+  DC2_ROUTE_SERVERS:
+  - DC2-RS1
+  - DC2-RS2
+  DC2_POD1:
+  - DC2-POD1-SPINE1
+  - DC2-POD1-SPINE2
+  - DC2-POD1-LEAF1A
+  - DC2-POD1-L2LEAF1A
+  DC2_POD1_SPINES:
+  - DC2-POD1-SPINE1
+  - DC2-POD1-SPINE2
+  DC2_POD1_LEAFS:
+  - DC2-POD1-LEAF1A
+  - DC2-POD1-L2LEAF1A
+  TENANTS_NETWORKS:
+  - DC1-POD1-LEAF1A
+  - DC1-POD1-LEAF2A
+  - DC1-POD1-LEAF2B
+  - DC1-POD1-L2LEAF1A
+  - DC1-POD1-L2LEAF2A
+  - DC1-POD1-L2LEAF2B
+  - DC1-POD2-LEAF1A
+  - DC2-POD1-LEAF1A
+  - DC2-POD1-L2LEAF1A
+  SERVERS:
+  - DC1-POD1-LEAF1A
+  - DC1-POD1-LEAF2A
+  - DC1-POD1-LEAF2B
+  - DC1-POD1-L2LEAF1A
+  - DC1-POD1-L2LEAF2A
+  - DC1-POD1-L2LEAF2B
+  - DC1-POD2-LEAF1A
+  - DC2-POD1-LEAF1A
+  - DC2-POD1-L2LEAF1A
+omit: __omit_place_holder__005f001b9c786e314ba348bfbae1783d8001e012
+ansible_version:
+  string: 2.10.8
+  full: 2.10.8
+  major: 2
+  minor: 10
+  revision: 8
+ansible_check_mode: false
+ansible_diff_mode: false
+ansible_forks: 50
+ansible_inventory_sources:
+- /home/holbech/.cache/molecule/avd/eos_designs-twodc-5stage-clos/inventory
+- /home/holbech/ansible-avd/ansible_collections/arista/avd/inventory/hosts
+ansible_skip_tags:
+- molecule-notest
+- notest
+ansible_run_tags:
+- debug
+- build
+ansible_verbosity: 0

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-RS1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-RS1.yml
@@ -112,6 +112,8 @@ management_api_http:
   enable_vrfs:
     MGMT: {}
   enable_https: true
+eos_cli: "interface Loopback1111\n  description Loopback created from raw_eos_cli\
+  \ under platform_settings vEOS-LAB\n"
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-RS2-debug-vars.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-RS2-debug-vars.yml
@@ -1,0 +1,659 @@
+molecule_ephemeral_directory: /home/holbech/.cache/molecule/avd/eos_designs-twodc-5stage-clos
+molecule_file: /home/holbech/.cache/molecule/avd/eos_designs-twodc-5stage-clos/molecule.yml
+molecule_instance_config: /home/holbech/.cache/molecule/avd/eos_designs-twodc-5stage-clos/instance_config.yml
+molecule_no_log: true
+molecule_scenario_directory: /home/holbech/ansible-avd/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos
+molecule_yml:
+  dependency:
+    command: null
+    enabled: true
+    env: {}
+    name: galaxy
+    options: {}
+  driver:
+    name: delegated
+    options:
+      managed: true
+    provider:
+      name: null
+    safe_files: []
+    ssh_connection_options: []
+  platforms:
+  - groups:
+    - DC1_POD1_LEAFS
+    - DC1
+    - TWODC_5STAGE_CLOS
+    image: avdteam/base:3.6
+    managed: false
+    name: DC1-POD1-LEAF1A
+    pre_build_image: true
+  provisioner:
+    ansible_args:
+    - --inventory=inventory/hosts
+    children: {}
+    config_options:
+      defaults:
+        command_warnings: false
+        gathering: explicit
+        jinja2_extensions: jinja2.ext.loopcontrols,jinja2.ext.do,jinja2.ext.i18n
+    connection_options: {}
+    env: {}
+    inventory:
+      group_vars: {}
+      host_vars: {}
+      hosts: {}
+      links:
+        group_vars: inventory/group_vars/
+        host_vars: inventory/host_vars/
+        hosts: inventory/inventory.yml
+    name: ansible
+    options: {}
+    playbooks:
+      cleanup: cleanup.yml
+      converge: converge.yml
+      create: create.yml
+      destroy: destroy.yml
+      prepare: prepare.yml
+      side_effect: side_effect.yml
+      verify: verify.yml
+  scenario:
+    check_sequence:
+    - dependency
+    - cleanup
+    - destroy
+    - create
+    - prepare
+    - converge
+    - check
+    - cleanup
+    - destroy
+    cleanup_sequence:
+    - destroy
+    converge_sequence:
+    - syntax
+    - create
+    - converge
+    - verify
+    create_sequence:
+    - dependency
+    - create
+    - prepare
+    destroy_sequence:
+    - dependency
+    - cleanup
+    - destroy
+    name: eos_designs-twodc-5stage-clos
+    test_sequence:
+    - syntax
+    - create
+    - converge
+    - idempotence
+    - verify
+  verifier:
+    additional_files_or_dirs: []
+    ansible_args:
+    - --inventory=inventory/inventory.yml
+    config_options:
+      defaults:
+        command_warnings: false
+        gathering: explicit
+        jinja2_extensions: jinja2.ext.loopcontrols,jinja2.ext.do,jinja2.ext.i18n
+    enabled: true
+    env: {}
+    inventory:
+      links:
+        group_vars: inventory/group_vars/
+        host_vars: inventory/host_vars/
+        hosts: inventory/inventory.yml
+    name: ansible
+    options: {}
+ansible_host: 10.83.28.157
+ansible_connection: httpapi
+ansible_httpapi_port: 8004
+ansible_httpapi_host: 10.83.28.157
+ansible_httpapi_use_ssl: true
+ansible_httpapi_validate_certs: false
+ansible_network_os: eos
+ansible_user: admin
+ansible_ssh_pass: arista
+ansible_become: true
+ansible_become_method: enable
+root_dir: /home/holbech/ansible-avd/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos
+snmp_settings:
+  location: true
+fabric_name: TWODC_5STAGE_CLOS
+evpn_ebgp_multihop: 5
+evpn_overlay_bgp_rtc: true
+bgp_peer_groups:
+  IPv4_UNDERLAY_PEERS:
+    password: AQQvKeimxJu+uGQ/yYvv9w==
+  EVPN_OVERLAY_PEERS:
+    password: q+VNViP5i4rVjW1cxFv2wA==
+  MLAG_IPv4_UNDERLAY_PEER:
+    password: vnEaG8gMeQf3d3cN6PktXQ==
+mgmt_gateway: 192.168.1.254
+mgmt_destination_networks:
+- 0.0.0.0/0
+p2p_uplinks_qos_profile: QOS-PROFILE
+p2p_uplinks_ptp:
+  enable: true
+local_users:
+  admin:
+    privilege: 15
+    role: network-admin
+    no_password: true
+    sha512_password: $6$eJ5TvI8oru5i9e8G$R1X/SbtGTk9xoEHEBQASc7SC2nHYmi.crVgp2pXuCXwxsXEA81e4E0cXgQ6kX08fIeQzauqhv2kS.RGJFCon5/
+l3_edge:
+  p2p_links_ip_pools:
+    pool-leaf: 11.1.0.0/24
+    pool-spine: 11.1.1.0/24
+    pool-super-spine: 11.1.2.0/24
+  p2p_links_profiles:
+    generic-profile:
+      mtu: 1499
+      bfd: false
+      ptp_enable: true
+  p2p_links:
+  - nodes:
+    - DC1-SUPER-SPINE1
+    - DC2-SUPER-SPINE1
+    id: 1
+    interfaces:
+    - Ethernet6
+    - Ethernet4
+    as:
+    - 65100
+    - 65200
+    ip_pool: pool-super-spine
+    profile: generic-profile
+    include_in_underlay_protocol: true
+    macsec_profile: MACSEC_PROFILE
+  - nodes:
+    - DC1-SUPER-SPINE2
+    - DC2-SUPER-SPINE2
+    id: 2
+    interfaces:
+    - Ethernet6
+    - Ethernet4
+    as:
+    - 65100
+    - 65200
+    ip_pool: pool-super-spine
+    mtu: 1500
+    include_in_underlay_protocol: true
+  - nodes:
+    - DC1-POD2-SPINE1
+    - DC2-POD1-SPINE1
+    id: 10
+    interfaces:
+    - Ethernet5
+    - Ethernet5
+    as:
+    - 65120
+    - 65210
+    ip_pool: pool-spine
+    mtu: 1500
+    include_in_underlay_protocol: true
+  - nodes:
+    - DC1-POD2-SPINE2
+    - DC2-POD1-SPINE2
+    interfaces:
+    - Ethernet4
+    - Ethernet5
+    as:
+    - 65112
+    - 65210
+    ip:
+    - 200.200.200.101/24
+    - 200.200.200.201/24
+    mtu: 1498
+    profile: generic-profile
+    include_in_underlay_protocol: true
+  - nodes:
+    - DC1-POD1-LEAF2A
+    - DC2-POD1-LEAF1A
+    interfaces:
+    - Ethernet7
+    - Ethernet6
+    as:
+    - 65112
+    - 65211
+    ip:
+    - 100.100.100.101/24
+    - 100.100.100.201/24
+    mtu: 1500
+    include_in_underlay_protocol: true
+  - nodes:
+    - DC1-POD1-LEAF2B
+    - DC2-POD1-LEAF1A
+    id: 20
+    interfaces:
+    - Ethernet7
+    - Ethernet7
+    as:
+    - 65120
+    - 65211
+    ip_pool: pool-leaf
+    profile: generic-profile
+    bfd: true
+    include_in_underlay_protocol: true
+p2p_uplinks_mtu: 1500
+spine_bgp_defaults:
+- no bgp default ipv4-unicast
+- distance bgp 20 200 200
+- graceful-restart restart-time 300
+- graceful-restart
+super_spine_bgp_defaults:
+- no bgp default ipv4-unicast
+- distance bgp 20 200 200
+- graceful-restart restart-time 300
+- graceful-restart
+leaf_bgp_defaults:
+- no bgp default ipv4-unicast
+- distance bgp 20 200 200
+- graceful-restart restart-time 300
+- graceful-restart
+platform_settings:
+- platforms:
+  - default
+  reload_delay:
+    mlag: 300
+    non_mlag: 330
+- platforms:
+  - vEOS-LAB
+  raw_eos_cli: "interface Loopback1111\n  description Loopback created from raw_eos_cli\
+    \ under platform_settings vEOS-LAB\n"
+  reload_delay:
+    mlag: 300
+    non_mlag: 330
+dc_name: DC1
+super_spine_loopback_network_summary: 172.16.100.0/24
+max_super_spines: 4
+super_spine:
+  platform: vEOS-LAB
+  bgp_as: 65100
+  nodes:
+    DC1-SUPER-SPINE1:
+      id: 1
+    DC1-SUPER-SPINE2:
+      id: 2
+      mgmt_ip: 192.168.1.2/24
+overlay_controller_loopback_network_summary: 172.16.10.0/24
+overlay_controller_p2p_network_summary: 172.17.10.0/24
+overlay_controller_p2p_bfd: true
+max_overlay_controller_to_switch_links: 4
+overlay_controller:
+  platform: vEOS-LAB
+  nodes:
+    DC1-RS1:
+      id: 1
+      bgp_as: 65101
+      evpn_role: server
+      evpn_route_servers:
+      - DC2-RS1
+      - DC2-SUPER-SPINE1
+      - DC2-POD1-SPINE1
+      - DC2-POD1-LEAF1A
+      remote_switches_interfaces:
+      - Ethernet5
+      - Ethernet6
+      - Ethernet4
+      remote_switches:
+      - DC1-SUPER-SPINE1
+      - DC1-POD1-SPINE1
+      - DC1-POD1-LEAF1A
+      uplink_to_remote_switches:
+      - Ethernet1
+      - Ethernet2
+      - Ethernet3
+    DC1-RS2:
+      id: 2
+      mgmt_ip: 192.168.1.4/24
+      bgp_as: 65102
+      evpn_role: server
+      evpn_route_servers:
+      - DC2-RS1
+      - DC2-SUPER-SPINE1
+      - DC2-POD1-SPINE1
+      - DC2-POD1-LEAF1A
+      remote_switches_interfaces:
+      - Ethernet5
+      - Ethernet4
+      - Ethernet3
+      remote_switches:
+      - DC1-SUPER-SPINE2
+      - DC1-POD2-SPINE1
+      - DC1-POD2-LEAF1A
+      uplink_to_remote_switches:
+      - Ethernet1
+      - Ethernet2
+      - Ethernet3
+evpn_prevent_readvertise_to_server: true
+inventory_file: /home/holbech/.cache/molecule/avd/eos_designs-twodc-5stage-clos/inventory/hosts
+inventory_dir: /home/holbech/.cache/molecule/avd/eos_designs-twodc-5stage-clos/inventory
+type: overlay-controller
+ansible_port: 8004
+inventory_hostname: DC1-RS2
+inventory_hostname_short: DC1-RS2
+group_names:
+- DC1
+- DC1_ROUTE_SERVERS
+- TWODC_5STAGE_CLOS
+ansible_facts:
+  switch:
+    underlay_routing_protocol: ebgp
+    overlay_routing_protocol: ebgp
+    id: 2
+    mgmt_ip: 192.168.1.4/24
+    spanning_tree_mode: none
+    platform: vEOS-LAB
+    platform_settings:
+      platforms:
+      - vEOS-LAB
+      raw_eos_cli: "interface Loopback1111\n  description Loopback created from raw_eos_cli\
+        \ under platform_settings vEOS-LAB\n"
+      reload_delay:
+        mlag: 300
+        non_mlag: 330
+    router_id: 172.16.10.2
+    loopback_network_summary: 172.16.10.0/24
+    bgp_defaults:
+    - no bgp default ipv4-unicast
+    - distance bgp 20 200 200
+    - graceful-restart restart-time 300
+    - graceful-restart
+    bgp_as: 65102
+    uplink_interfaces:
+    - Ethernet1
+    - Ethernet2
+    - Ethernet3
+    uplink_switch_interfaces:
+    - Ethernet5
+    - Ethernet4
+    - Ethernet3
+    uplink_switches:
+    - DC1-SUPER-SPINE2
+    - DC1-POD2-SPINE1
+    - DC1-POD2-LEAF1A
+    evpn_role: server
+    evpn_route_servers:
+    - DC2-RS1
+    - DC2-SUPER-SPINE1
+    - DC2-POD1-SPINE1
+    - DC2-POD1-LEAF1A
+  topology:
+    links:
+      Ethernet1:
+        peer: DC1-SUPER-SPINE2
+        peer_interface: Ethernet5
+        peer_type: super-spine
+        peer_bgp_as: 65100
+        type: underlay_p2p
+        bfd: true
+        ip_address: 172.17.10.9
+        peer_ip_address: 172.17.10.8
+      Ethernet2:
+        peer: DC1-POD2-SPINE1
+        peer_interface: Ethernet4
+        peer_type: spine
+        peer_bgp_as: 65120
+        type: underlay_p2p
+        bfd: true
+        ip_address: 172.17.10.11
+        peer_ip_address: 172.17.10.10
+      Ethernet3:
+        peer: DC1-POD2-LEAF1A
+        peer_interface: Ethernet3
+        peer_type: l3leaf
+        peer_bgp_as: 65121
+        type: underlay_p2p
+        bfd: true
+        ip_address: 172.17.10.13
+        peer_ip_address: 172.17.10.12
+    peers:
+    - DC1-SUPER-SPINE2
+    - DC1-POD2-SPINE1
+    - DC1-POD2-LEAF1A
+switch:
+  underlay_routing_protocol: ebgp
+  overlay_routing_protocol: ebgp
+  id: 2
+  mgmt_ip: 192.168.1.4/24
+  spanning_tree_mode: none
+  platform: vEOS-LAB
+  platform_settings:
+    platforms:
+    - vEOS-LAB
+    raw_eos_cli: "interface Loopback1111\n  description Loopback created from raw_eos_cli\
+      \ under platform_settings vEOS-LAB\n"
+    reload_delay:
+      mlag: 300
+      non_mlag: 330
+  router_id: 172.16.10.2
+  loopback_network_summary: 172.16.10.0/24
+  bgp_defaults:
+  - no bgp default ipv4-unicast
+  - distance bgp 20 200 200
+  - graceful-restart restart-time 300
+  - graceful-restart
+  bgp_as: 65102
+  uplink_interfaces:
+  - Ethernet1
+  - Ethernet2
+  - Ethernet3
+  uplink_switch_interfaces:
+  - Ethernet5
+  - Ethernet4
+  - Ethernet3
+  uplink_switches:
+  - DC1-SUPER-SPINE2
+  - DC1-POD2-SPINE1
+  - DC1-POD2-LEAF1A
+  evpn_role: server
+  evpn_route_servers:
+  - DC2-RS1
+  - DC2-SUPER-SPINE1
+  - DC2-POD1-SPINE1
+  - DC2-POD1-LEAF1A
+topology:
+  links:
+    Ethernet1:
+      peer: DC1-SUPER-SPINE2
+      peer_interface: Ethernet5
+      peer_type: super-spine
+      peer_bgp_as: 65100
+      type: underlay_p2p
+      bfd: true
+      ip_address: 172.17.10.9
+      peer_ip_address: 172.17.10.8
+    Ethernet2:
+      peer: DC1-POD2-SPINE1
+      peer_interface: Ethernet4
+      peer_type: spine
+      peer_bgp_as: 65120
+      type: underlay_p2p
+      bfd: true
+      ip_address: 172.17.10.11
+      peer_ip_address: 172.17.10.10
+    Ethernet3:
+      peer: DC1-POD2-LEAF1A
+      peer_interface: Ethernet3
+      peer_type: l3leaf
+      peer_bgp_as: 65121
+      type: underlay_p2p
+      bfd: true
+      ip_address: 172.17.10.13
+      peer_ip_address: 172.17.10.12
+  peers:
+  - DC1-SUPER-SPINE2
+  - DC1-POD2-SPINE1
+  - DC1-POD2-LEAF1A
+playbook_dir: /home/holbech/ansible-avd/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos
+ansible_playbook_python: /usr/bin/python3
+ansible_config_file: /home/holbech/.cache/molecule/avd/eos_designs-twodc-5stage-clos/ansible.cfg
+groups:
+  all:
+  - DC1-POD1-LEAF1A
+  - DC1-POD1-LEAF2A
+  - DC1-POD1-LEAF2B
+  - DC1-POD1-L2LEAF1A
+  - DC1-POD1-L2LEAF2A
+  - DC1-POD1-L2LEAF2B
+  - DC1-POD2-LEAF1A
+  - DC2-POD1-LEAF1A
+  - DC2-POD1-L2LEAF1A
+  - DC1-SUPER-SPINE1
+  - DC1-SUPER-SPINE2
+  - DC1-RS1
+  - DC1-RS2
+  - DC2-SUPER-SPINE1
+  - DC2-SUPER-SPINE2
+  - DC2-RS1
+  - DC2-RS2
+  - DC1-POD1-SPINE1
+  - DC1-POD1-SPINE2
+  - DC1-POD2-SPINE1
+  - DC1-POD2-SPINE2
+  - DC2-POD1-SPINE1
+  - DC2-POD1-SPINE2
+  ungrouped: []
+  DC1:
+  - DC1-POD1-LEAF1A
+  - DC1-SUPER-SPINE1
+  - DC1-SUPER-SPINE2
+  - DC1-RS1
+  - DC1-RS2
+  - DC1-POD1-SPINE1
+  - DC1-POD1-SPINE2
+  - DC1-POD1-LEAF2A
+  - DC1-POD1-LEAF2B
+  - DC1-POD1-L2LEAF1A
+  - DC1-POD1-L2LEAF2A
+  - DC1-POD1-L2LEAF2B
+  - DC1-POD2-SPINE1
+  - DC1-POD2-SPINE2
+  - DC1-POD2-LEAF1A
+  DC1_POD1_LEAFS:
+  - DC1-POD1-LEAF1A
+  - DC1-POD1-LEAF2A
+  - DC1-POD1-LEAF2B
+  - DC1-POD1-L2LEAF1A
+  - DC1-POD1-L2LEAF2A
+  - DC1-POD1-L2LEAF2B
+  TWODC_5STAGE_CLOS:
+  - DC1-POD1-LEAF1A
+  - DC1-SUPER-SPINE1
+  - DC1-SUPER-SPINE2
+  - DC1-RS1
+  - DC1-RS2
+  - DC2-SUPER-SPINE1
+  - DC2-SUPER-SPINE2
+  - DC2-RS1
+  - DC2-RS2
+  - DC1-POD1-SPINE1
+  - DC1-POD1-SPINE2
+  - DC1-POD1-LEAF2A
+  - DC1-POD1-LEAF2B
+  - DC1-POD1-L2LEAF1A
+  - DC1-POD1-L2LEAF2A
+  - DC1-POD1-L2LEAF2B
+  - DC1-POD2-SPINE1
+  - DC1-POD2-SPINE2
+  - DC1-POD2-LEAF1A
+  - DC2-POD1-SPINE1
+  - DC2-POD1-SPINE2
+  - DC2-POD1-LEAF1A
+  - DC2-POD1-L2LEAF1A
+  DC1_SUPER_SPINES:
+  - DC1-SUPER-SPINE1
+  - DC1-SUPER-SPINE2
+  DC1_ROUTE_SERVERS:
+  - DC1-RS1
+  - DC1-RS2
+  DC1_POD1:
+  - DC1-POD1-SPINE1
+  - DC1-POD1-SPINE2
+  - DC1-POD1-LEAF1A
+  - DC1-POD1-LEAF2A
+  - DC1-POD1-LEAF2B
+  - DC1-POD1-L2LEAF1A
+  - DC1-POD1-L2LEAF2A
+  - DC1-POD1-L2LEAF2B
+  DC1_POD1_SPINES:
+  - DC1-POD1-SPINE1
+  - DC1-POD1-SPINE2
+  DC1_POD2:
+  - DC1-POD2-SPINE1
+  - DC1-POD2-SPINE2
+  - DC1-POD2-LEAF1A
+  DC1_POD2_SPINES:
+  - DC1-POD2-SPINE1
+  - DC1-POD2-SPINE2
+  DC1_POD2_LEAFS:
+  - DC1-POD2-LEAF1A
+  DC2:
+  - DC2-SUPER-SPINE1
+  - DC2-SUPER-SPINE2
+  - DC2-RS1
+  - DC2-RS2
+  - DC2-POD1-SPINE1
+  - DC2-POD1-SPINE2
+  - DC2-POD1-LEAF1A
+  - DC2-POD1-L2LEAF1A
+  DC2_SUPER_SPINES:
+  - DC2-SUPER-SPINE1
+  - DC2-SUPER-SPINE2
+  DC2_ROUTE_SERVERS:
+  - DC2-RS1
+  - DC2-RS2
+  DC2_POD1:
+  - DC2-POD1-SPINE1
+  - DC2-POD1-SPINE2
+  - DC2-POD1-LEAF1A
+  - DC2-POD1-L2LEAF1A
+  DC2_POD1_SPINES:
+  - DC2-POD1-SPINE1
+  - DC2-POD1-SPINE2
+  DC2_POD1_LEAFS:
+  - DC2-POD1-LEAF1A
+  - DC2-POD1-L2LEAF1A
+  TENANTS_NETWORKS:
+  - DC1-POD1-LEAF1A
+  - DC1-POD1-LEAF2A
+  - DC1-POD1-LEAF2B
+  - DC1-POD1-L2LEAF1A
+  - DC1-POD1-L2LEAF2A
+  - DC1-POD1-L2LEAF2B
+  - DC1-POD2-LEAF1A
+  - DC2-POD1-LEAF1A
+  - DC2-POD1-L2LEAF1A
+  SERVERS:
+  - DC1-POD1-LEAF1A
+  - DC1-POD1-LEAF2A
+  - DC1-POD1-LEAF2B
+  - DC1-POD1-L2LEAF1A
+  - DC1-POD1-L2LEAF2A
+  - DC1-POD1-L2LEAF2B
+  - DC1-POD2-LEAF1A
+  - DC2-POD1-LEAF1A
+  - DC2-POD1-L2LEAF1A
+omit: __omit_place_holder__005f001b9c786e314ba348bfbae1783d8001e012
+ansible_version:
+  string: 2.10.8
+  full: 2.10.8
+  major: 2
+  minor: 10
+  revision: 8
+ansible_check_mode: false
+ansible_diff_mode: false
+ansible_forks: 50
+ansible_inventory_sources:
+- /home/holbech/.cache/molecule/avd/eos_designs-twodc-5stage-clos/inventory
+- /home/holbech/ansible-avd/ansible_collections/arista/avd/inventory/hosts
+ansible_skip_tags:
+- molecule-notest
+- notest
+ansible_run_tags:
+- debug
+- build
+ansible_verbosity: 0

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-RS2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-RS2.yml
@@ -112,6 +112,8 @@ management_api_http:
   enable_vrfs:
     MGMT: {}
   enable_https: true
+eos_cli: "interface Loopback1111\n  description Loopback created from raw_eos_cli\
+  \ under platform_settings vEOS-LAB\n"
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-SUPER-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-SUPER-SPINE1.yml
@@ -73,6 +73,8 @@ management_api_http:
   enable_vrfs:
     MGMT: {}
   enable_https: true
+eos_cli: "interface Loopback1111\n  description Loopback created from raw_eos_cli\
+  \ under platform_settings vEOS-LAB\n"
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-SUPER-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-SUPER-SPINE2.yml
@@ -81,6 +81,8 @@ management_api_http:
   enable_vrfs:
     MGMT: {}
   enable_https: true
+eos_cli: "interface Loopback1111\n  description Loopback created from raw_eos_cli\
+  \ under platform_settings vEOS-LAB\n"
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-L2LEAF1A.yml
@@ -46,7 +46,8 @@ management_api_http:
     MGMT: {}
   enable_https: true
 eos_cli: "interface Loopback1011\n  description Loopback created from raw_eos_cli\
-  \ under l2leaf defaults in DC2 POD1\n"
+  \ under l2leaf defaults in DC2 POD1\n\ninterface Loopback1111\n  description Loopback\
+  \ created from raw_eos_cli under platform_settings vEOS-LAB\n"
 ethernet_interfaces:
   Ethernet1:
     peer: DC2-POD1-LEAF1A

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-L2LEAF1A.yml
@@ -45,6 +45,8 @@ management_api_http:
   enable_vrfs:
     MGMT: {}
   enable_https: true
+eos_cli: "interface Loopback1011\n  description Loopback created from raw_eos_cli\
+  \ under l2leaf defaults in DC2 POD1\n"
 ethernet_interfaces:
   Ethernet1:
     peer: DC2-POD1-LEAF1A

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF1A.yml
@@ -135,8 +135,9 @@ management_api_http:
     MGMT: {}
   enable_https: true
 eos_cli: "interface Loopback1010\n  description Loopback created from raw_eos_cli\
-  \ under l3leaf defaults in DC2 POD1\n\ninterface Loopback1000\n  description Loopback\
-  \ created from raw_eos_cli under VRF Common_VRF\n"
+  \ under l3leaf defaults in DC2 POD1\n\ninterface Loopback1111\n  description Loopback\
+  \ created from raw_eos_cli under platform_settings vEOS-LAB\n\ninterface Loopback1000\n\
+  \  description Loopback created from raw_eos_cli under VRF Common_VRF\n"
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF1A.yml
@@ -88,6 +88,13 @@ router_bgp:
           - 1025:1025
       redistribute_routes:
       - connected
+      eos_cli: 'comment
+
+        Comment created from raw_eos_cli under BGP for VRF Common_VRF
+
+        EOF
+
+        '
 static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0
@@ -127,6 +134,9 @@ management_api_http:
   enable_vrfs:
     MGMT: {}
   enable_https: true
+eos_cli: "interface Loopback1010\n  description Loopback created from raw_eos_cli\
+  \ under l3leaf defaults in DC2 POD1\n\ninterface Loopback1000\n  description Loopback\
+  \ created from raw_eos_cli under VRF Common_VRF\n"
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-SPINE1.yml
@@ -109,6 +109,8 @@ management_api_http:
   enable_vrfs:
     MGMT: {}
   enable_https: true
+eos_cli: "interface Loopback1009\n  description Loopback created from raw_eos_cli\
+  \ under spine defaults in DC2 POD1\n"
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-SPINE1.yml
@@ -110,7 +110,8 @@ management_api_http:
     MGMT: {}
   enable_https: true
 eos_cli: "interface Loopback1009\n  description Loopback created from raw_eos_cli\
-  \ under spine defaults in DC2 POD1\n"
+  \ under spine defaults in DC2 POD1\n\ninterface Loopback1111\n  description Loopback\
+  \ created from raw_eos_cli under platform_settings vEOS-LAB\n"
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-SPINE2.yml
@@ -73,7 +73,8 @@ management_api_http:
     MGMT: {}
   enable_https: true
 eos_cli: "interface Loopback1009\n  description Loopback created from raw_eos_cli\
-  \ under spine defaults in DC2 POD1\n"
+  \ under spine defaults in DC2 POD1\n\ninterface Loopback1111\n  description Loopback\
+  \ created from raw_eos_cli under platform_settings vEOS-LAB\n"
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-SPINE2.yml
@@ -72,6 +72,8 @@ management_api_http:
   enable_vrfs:
     MGMT: {}
   enable_https: true
+eos_cli: "interface Loopback1009\n  description Loopback created from raw_eos_cli\
+  \ under spine defaults in DC2 POD1\n"
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-RS1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-RS1.yml
@@ -101,6 +101,8 @@ management_api_http:
   enable_vrfs:
     MGMT: {}
   enable_https: true
+eos_cli: "interface Loopback1111\n  description Loopback created from raw_eos_cli\
+  \ under platform_settings vEOS-LAB\n"
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-RS2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-RS2.yml
@@ -64,6 +64,8 @@ management_api_http:
   enable_vrfs:
     MGMT: {}
   enable_https: true
+eos_cli: "interface Loopback1111\n  description Loopback created from raw_eos_cli\
+  \ under platform_settings vEOS-LAB\n"
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-SUPER-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-SUPER-SPINE1.yml
@@ -121,6 +121,8 @@ management_api_http:
   enable_vrfs:
     MGMT: {}
   enable_https: true
+eos_cli: "interface Loopback1111\n  description Loopback created from raw_eos_cli\
+  \ under platform_settings vEOS-LAB\n"
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-SUPER-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-SUPER-SPINE2.yml
@@ -68,6 +68,8 @@ management_api_http:
   enable_vrfs:
     MGMT: {}
   enable_https: true
+eos_cli: "interface Loopback1111\n  description Loopback created from raw_eos_cli\
+  \ under platform_settings vEOS-LAB\n"
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/DC1_POD1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/DC1_POD1.yml
@@ -54,11 +54,19 @@ l3leaf:
         tenants: []
         tags: []
         always_include_vrfs_in_tenants: [ 'all' ] #Testing that we respect the empty tenants list, so no VRFs will be configured.
+      # Below will not have any effect since it is overridden on the node level. So just a negative test.
+      raw_eos_cli: |
+        interface Loopback1001
+          description Loopback created from raw_eos_cli under node-group RACK1_SINGLE
       nodes:
         DC1-POD1-LEAF1A:
           id: 1
           # mgmt_ip: 192.168.1.7/24 Test without management IP
           spine_interfaces: [ Ethernet3, Ethernet3 ]
+          raw_eos_cli: |
+            interface Loopback1002
+              description Loopback created from raw_eos_cli under node DC1-POD1-LEAF1A
+
     # Regular MLAG pair
     RACK2_MLAG:
       platform: vEOS-LAB
@@ -70,6 +78,9 @@ l3leaf:
       mlag_dual_primary_detection: true
       spanning_tree_mode: mstp
       spanning_tree_priority: 4096
+      raw_eos_cli: |
+        interface Loopback1002
+          description Loopback created from raw_eos_cli under l3leaf node-group RACK2_MLAG
       nodes:
         DC1-POD1-LEAF2A:
           id: 2
@@ -103,6 +114,9 @@ l2leaf:
       mlag_interfaces: [ Ethernet3, Ethernet4 ]
       spanning_tree_mode: mstp
       spanning_tree_priority: 8192
+      raw_eos_cli: |
+        interface Loopback1002
+          description Loopback created from raw_eos_cli under l2leaf node-group RACK2_MLAG
       nodes:
         DC1-POD1-L2LEAF2A:
           id: 2
@@ -112,3 +126,6 @@ l2leaf:
           id: 3
           mgmt_ip: 192.168.1.12/24
           l3leaf_interfaces: [ Ethernet4, Ethernet4 ]
+          raw_eos_cli: |
+            interface Loopback1003
+              description Loopback created from raw_eos_cli under l2leaf node DC1-POD1-L2LEAF2B

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/DC2_POD1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/DC2_POD1.yml
@@ -19,6 +19,10 @@ spine:
   platform: vEOS-LAB
   bgp_as: 65210
   uplinks_to_super_spine_interfaces: [ Ethernet1, Ethernet2 ]
+  defaults:
+    raw_eos_cli: |
+      interface Loopback1009
+        description Loopback created from raw_eos_cli under spine defaults in DC2 POD1
   nodes:
     # Spine also working as EVPN RS
     DC2-POD1-SPINE1:
@@ -49,6 +53,10 @@ l3leaf:
     filter:
       always_include_vrfs_in_tenants: [ 'all' ] #Testing that we configure all VRFs even with no VLANs.
       tags: []
+    raw_eos_cli: |
+      interface Loopback1010
+        description Loopback created from raw_eos_cli under l3leaf defaults in DC2 POD1
+
   node_groups:
     # Single switch working as underlay L3 router and EVPN RS
     RACK1_SINGLE:
@@ -67,6 +75,9 @@ l2leaf:
     spanning_tree_mode: mstp
     spanning_tree_priority: 8192
     mlag: false
+    raw_eos_cli: |
+      interface Loopback1011
+        description Loopback created from raw_eos_cli under l2leaf defaults in DC2 POD1
   node_groups:
     RACK1_SINGLE:
       parent_l3leafs: [ DC2-POD1-LEAF1A ]

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/SERVERS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/SERVERS.yml
@@ -1,10 +1,26 @@
 ---
 port_profiles:
+  NESTED_TENANT_A:
+    parent_profile: TENANT_A
+    raw_eos_cli: |
+      comment
+      Comment created from raw_eos_cli under profile NESTED_TENANT_A
+      EOF
+    port_channel:
+      raw_eos_cli: |
+        comment
+        Comment created from raw_eos_cli under port_channel on profile NESTED_TENANT_A
+        EOF
 
   TENANT_A:
     mode: access
     vlans: "110"
     qos_profile: "foo"
+    raw_eos_cli: |
+      comment
+      Comment created from raw_eos_cli under profile TENANT_A
+      EOF
+
 
 servers:
 
@@ -12,11 +28,45 @@ servers:
     rack: RackB
     adapters:
       - server_ports: [ Eth1, Eth2 ]
-        switch_ports: [ Ethernet6, Ethernet6 ]
-        switches: [ DC1-POD01-LEAF2A, DC1-POD01-LEAF02B ]
+        switch_ports: [ Ethernet16, Ethernet16 ]
+        switches: [ DC1-POD1-LEAF2A, DC1-POD1-LEAF2B ]
         profile: TENANT_A
         qos_profile: "bar"
         port_channel:
+          state: present
+          description: PortChannel
+          mode: active
+      - server_ports: [ Eth3, Eth4 ]
+        switch_ports: [ Ethernet17, Ethernet17 ]
+        switches: [ DC1-POD1-LEAF2A, DC1-POD1-LEAF2B ]
+        profile: TENANT_A
+        port_channel:
+          state: present
+          description: PortChannel
+          mode: active
+        raw_eos_cli: |
+          comment
+          Comment created from raw_eos_cli under adapter for switch Eth17
+          EOF
+
+      - server_ports: [ Eth5, Eth6 ]
+        switch_ports: [ Ethernet18, Ethernet18 ]
+        switches: [ DC1-POD1-LEAF2A, DC1-POD1-LEAF2B ]
+        profile: NESTED_TENANT_A
+        port_channel:
+          state: present
+          description: PortChannel
+          mode: active
+
+      - server_ports: [ Eth7, Eth8 ]
+        switch_ports: [ Ethernet19, Ethernet19 ]
+        switches: [ DC1-POD1-LEAF2A, DC1-POD1-LEAF2B ]
+        profile: NESTED_TENANT_A
+        port_channel:
+          raw_eos_cli: |
+            comment
+            Comment created from raw_eos_cli under adapter port_channel for switch Po19
+            EOF
           state: present
           description: PortChannel
           mode: active

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/TENANTS_NETWORKS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/TENANTS_NETWORKS.yml
@@ -26,6 +26,25 @@ tenants:
             tags: [opzone]
             enabled: true
             ip_address_virtual: 10.1.12.1/24
+            nodes:
+              DC1-POD1-LEAF1A:
+                raw_eos_cli: |
+                  comment
+                  Comment created from raw_eos_cli under SVI 112 in VRF Common_VRF overridden on DC1-POD1-LEAF1A
+                  EOF
+            raw_eos_cli: |
+              comment
+              Comment created from raw_eos_cli under SVI 112 in VRF Common_VRF
+              EOF
+        raw_eos_cli: |
+          interface Loopback1000
+            description Loopback created from raw_eos_cli under VRF Common_VRF
+        bgp:
+          raw_eos_cli: |
+            comment
+            Comment created from raw_eos_cli under BGP for VRF Common_VRF
+            EOF
+
     # These are pure L2 vlans - so no SVI on l3leafs
     l2vlans:
       "2500":

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/TWODC_5STAGE_CLOS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/TWODC_5STAGE_CLOS.yml
@@ -111,3 +111,16 @@ leaf_bgp_defaults:
   - distance bgp 20 200 200
   - graceful-restart restart-time 300
   - graceful-restart
+
+platform_settings:
+  - platforms: [default]
+    reload_delay:
+      mlag: 300
+      non_mlag: 330
+  - platforms: [vEOS-LAB]
+    raw_eos_cli: |
+      interface Loopback1111
+        description Loopback created from raw_eos_cli under platform_settings vEOS-LAB
+    reload_delay:
+      mlag: 300
+      non_mlag: 330

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -27,6 +27,7 @@
     - [Banners](#banners)
     - [Router BFD](#router-bfd)
     - [Custom Templates](#custom-templates)
+    - [EOS CLI](#eos-cli)
     - [Errdisable](#errdisable)
     - [Filters](#filters)
       - [Prefix Lists](#prefix-lists)
@@ -391,6 +392,14 @@ custom_templates:
   - < template 2 relative path below playbook directory >
 ```
 
+### EOS CLI
+
+```yaml
+# EOS CLI rendered directly on the root level of the final EOS configuration
+eos_cli: |
+  < multiline eos cli >
+```
+
 ### Errdisable
 
 ```yaml
@@ -673,6 +682,9 @@ ethernet_interfaces:
     lacp_timer:
       mode: < fast | normal >
       multiplier: < 3 - 3000 >
+    # EOS CLI rendered directly on the ethernet interface in the final EOS configuration
+    eos_cli: |
+      < multiline eos cli >
 ```
 
 ##### Switched Ethernet Interfaces
@@ -738,6 +750,9 @@ ethernet_interfaces:
     lacp_timer:
       mode: < fast | normal >
       multiplier: < 3 - 3000 >
+    # EOS CLI rendered directly on the ethernet interface in the final EOS configuration
+    eos_cli: |
+      < multiline eos cli >
 ```
 
 #### Interface Defaults
@@ -811,6 +826,9 @@ port_channel_interfaces:
       interval: < rate in milliseconds >
       min_rx: < rate in milliseconds >
       multiplier: < 3-50 >
+    # EOS CLI rendered directly on the port-channel interface in the final EOS configuration
+    eos_cli: |
+      < multiline eos cli >
   < Port-Channel_interface_2 >:
     description: < description >
     vlans: "< list of vlans as string >"
@@ -950,6 +968,9 @@ vlan_interfaces:
     service_policy:
       pbr:
         input: < policy-map name >
+    # EOS CLI rendered directly on the VLAN interface in the final EOS configuration
+    eos_cli: |
+      < multiline eos cli >
 < Vlan_id_2 >:
     description: < description >
     ip_address: < IPv4_address/Mask >
@@ -1911,6 +1932,9 @@ router_bgp:
         networks:
           < prefix_address >:
             route_map: < route_map_name >
+      # EOS CLI rendered directly on the Router BGP, VRF definition in the final EOS configuration
+      eos_cli: |
+        < multiline eos cli >
     < vrf_name_2 >:
       rd: "<route distinguisher >"
       route_targets:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/eos-cli.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/eos-cli.j2
@@ -1,0 +1,8 @@
+{% if eos_cli is arista.avd.defined %}
+
+# EOS CLI
+
+```eos
+{% include 'eos/eos-cli.j2' %}
+```
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-device-documentation.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-device-documentation.j2
@@ -177,5 +177,7 @@
 {% include 'documentation/policy-maps-qos.j2' %}
 {## QOS Profiles #}
 {% include 'documentation/qos-profiles.j2' %}
+{# EOS CLI #}
+{% include 'documentation/eos-cli.j2' %}
 {# Custom Templates #}
 {% include 'documentation/custom-templates.j2' %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
@@ -194,6 +194,8 @@ hostname {{ inventory_hostname }}
 {% include 'eos/management-security.j2' %}
 {# management ssh #}
 {% include 'eos/management-ssh.j2' %}
+{# EOS CLI #}
+{% include 'eos/eos-cli.j2' %}
 {# custom templates #}
 {% include 'eos/custom-templates.j2' %}
 !

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/eos-cli.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/eos-cli.j2
@@ -1,0 +1,4 @@
+{% if eos_cli is arista.avd.defined %}
+!
+{{ eos_cli }}
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -240,4 +240,7 @@ interface {{ ethernet_interface }}
    no mpls ldp interface
 {%         endif %}
 {%     endif %}
+{%     if ethernet_interfaces[ethernet_interface].eos_cli is arista.avd.defined %}
+   {{ ethernet_interfaces[ethernet_interface].eos_cli | indent(3, false) }}
+{%     endif %}
 {% endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
@@ -201,4 +201,7 @@ interface {{ port_channel_interface }}
           port_channel_interfaces[port_channel_interface].bfd.multiplier is arista.avd.defined %}
    bfd interval {{ port_channel_interfaces[port_channel_interface].bfd.interval }} min-rx {{ port_channel_interfaces[port_channel_interface].bfd.min_rx }} multiplier {{ port_channel_interfaces[port_channel_interface].bfd.multiplier }}
 {%     endif %}
+{%     if port_channel_interfaces[port_channel_interface].eos_cli is arista.avd.defined %}
+   {{ port_channel_interfaces[port_channel_interface].eos_cli | indent(3, false) }}
+{%     endif %}
 {% endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -588,5 +588,9 @@ router bgp {{ router_bgp.as }}
          {{ network_cli }}
 {%             endfor %}
 {%         endfor %}
+{%         if router_bgp.vrfs[vrf].eos_cli is arista.avd.defined %}
+      !
+      {{ router_bgp.vrfs[vrf].eos_cli | indent(6, false) }}
+{%         endif %}
 {%     endfor %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
@@ -174,4 +174,7 @@ interface {{ vlan_interface }}
 {%     if vlan_interfaces[vlan_interface].service_policy.pbr.input is arista.avd.defined %}
    service-policy type pbr input {{ vlan_interfaces[vlan_interface].service_policy.pbr.input }}
 {%     endif %}
+{%     if vlan_interfaces[vlan_interface].eos_cli is arista.avd.defined %}
+   {{ vlan_interfaces[vlan_interface].eos_cli | indent(3, false) }}
+{%     endif %}
 {% endfor %}

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/common/connected-endpoints.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/common/connected-endpoints.md
@@ -134,6 +134,10 @@ port_profiles:
         ptp:
           enable: < true | false >
 
+        # EOS CLI rendered directly on the ethernet interface in the final EOS configuration
+        raw_eos_cli: |
+          < multiline eos cli >
+
       < port_profile_2 >:
         mode: < access | dot1q-tunnel | trunk >
         vlans: < vlans as string >
@@ -173,6 +177,10 @@ port_profiles:
           lacp_fallback:
             mode: < static > Currently only static mode is supported
             timeout: < timeout in seconds > | Optional - default is 90 seconds
+
+          # EOS CLI rendered directly on the port-channel interface in the final EOS configuration
+          raw_eos_cli: |
+            < multiline eos cli >
 
   < endpoint_2 >:
     rack: RackC

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/common-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/common-settings.md
@@ -222,7 +222,9 @@ platform_settings:
     reload_delay:
       mlag: < seconds >
       non_mlag: < seconds >
-
+    # EOS CLI rendered directly on the root level of the final EOS configuration
+    raw_eos_cli: |
+      < multiline eos cli >
 ```
 
 note: Recommended default values for Jericho based platform, and all other platforms `default` tag.

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/fabric-topology.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/fabric-topology.md
@@ -110,6 +110,11 @@ spine:
   # Spine BGP AS | Required.
   bgp_as: < bgp_as >
 
+  defaults:
+    # EOS CLI rendered directly on the root level of the final EOS configuration
+    raw_eos_cli: |
+      < multiline eos cli >
+
   # Specify dictionary of Spine nodes | Required.
   nodes:
     < inventory_hostname >:
@@ -126,6 +131,11 @@ spine:
 
       # Node management IP address | Optional.
       mgmt_ip: < IPv4_address/Mask >
+
+      # EOS CLI rendered directly on the root level of the final EOS configuration
+      raw_eos_cli: |
+        < multiline eos cli >
+
     < inventory_hostname >:
       id: < integer >
       mgmt_ip: < IPv4_address/Mask >
@@ -241,6 +251,10 @@ l3leaf:
       # This allows support for centralized routing.
       evpn_services_l2_only: < false | true >
 
+      # EOS CLI rendered directly on the root level of the final EOS configuration
+      raw_eos_cli: |
+        < multiline eos cli >
+
       # The node name must be the same name as inventory_hostname | Required
       # When two nodes are defined, this will automatically configure the nodes as an MLAG pair,
       # unless the "l3leaf.defaults.mlag:" key is set to false.
@@ -267,6 +281,11 @@ l3leaf:
           # L3 Leaf BGP AS. | Required.
           # Inheritance: node > node_group > defaults
           bgp_as: < bgp_as >
+
+          # EOS CLI rendered directly on the root level of the final EOS configuration
+          # Overrides the setting on node_group level.
+          raw_eos_cli: |
+            < multiline eos cli >
 
     # node_group_2, will result in MLAG pair.
     < node_group_2 >:
@@ -418,6 +437,10 @@ l2leaf:
       # Activate or deactivate IGMP snooping for node groups devices
       igmp_snooping_enabled: < true | false >
 
+      # EOS CLI rendered directly on the root level of the final EOS configuration
+      raw_eos_cli: |
+        < multiline eos cli >
+
       # The node name must be the same name as inventory_hostname | Required
       # When two nodes are defined, this will automatically configure the nodes as an MLAG pair,
       # unless the "l2leaf.defaults.mlag:" key is set to false.
@@ -435,6 +458,11 @@ l2leaf:
           # l3leaf interfaces (list), interface located on l3leaf,
           # corresponding to parent_l3leafs and uplink_interfaces | Required.
           l3leaf_interfaces: [ < ethernet_interface_6 >, < ethernet_interface_6 > ]
+
+          # EOS CLI rendered directly on the root level of the final EOS configuration
+          # Overrides the setting on node_group level.
+          raw_eos_cli: |
+            < multiline eos cli >
 
     # node_group_2, will result in MLAG pair.
     < node_group_2 >:
@@ -553,6 +581,11 @@ super_spine:
   platform: vEOS-LAB  # super-spine platform
   bgp_as: <super-spine BGP AS>
 
+  defaults:
+    # EOS CLI rendered directly on the root level of the final EOS configuration
+    raw_eos_cli: |
+      < multiline eos cli >
+
   nodes:
     SU-01:  # super-spine name
       id: 1
@@ -562,7 +595,9 @@ super_spine:
       evpn_role: < client | server | none | default -> none  >
       # Peer with these EVPN Route Servers / Route Reflectors | Optional
       evpn_route_servers: [ < route_server_inventory_hostname >, < route_server_inventory_hostname >]
-    <-- etc. -->
+      # EOS CLI rendered directly on the root level of the final EOS configuration
+      raw_eos_cli: |
+        < multiline eos cli >
 
 # IP address range for loopbacks for all super-spines in the DC,
 # assigned as /32s
@@ -654,6 +689,10 @@ overlay_controller:
 
       # Peer with these EVPN Route Servers / Route Reflectors | Optional
       evpn_route_servers: [ < route_server_inventory_hostname >, < route_server_inventory_hostname > ]
+
+      # EOS CLI rendered directly on the root level of the final EOS configuration
+      raw_eos_cli: |
+        < multiline eos cli >
 
 # Point to Point Network Summary range, assigned as /31 for each uplink interfaces
 # Assign range larger than [ total overlay_controllers * max_overlay_controller_to_switch_links * 2]

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/network-services.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/network-services.md
@@ -160,11 +160,20 @@ tenants:
                 # device unique IP address for node.
                 ip_address: < IPv4_address/Mask >
 
+                # EOS CLI rendered directly on the VLAN interface in the final EOS configuration
+                # Overrides the setting on SVI level.
+                raw_eos_cli: |
+                  < multiline eos cli >
+
               < l3_leaf_inventory_hostname_2 >:
                 ip_address: < IPv4_address/Mask >
 
             # Defined interface MTU
             mtu: < mtu >
+
+            # EOS CLI rendered directly on the VLAN interface in the final EOS configuration
+            raw_eos_cli: |
+              < multiline eos cli >
 
           < 1-4096 >:
             name: < description >
@@ -181,6 +190,9 @@ tenants:
             description: < description >
             enabled: < true | false >
             mtu: <mtu >
+            # EOS CLI rendered directly on the Ethernet interface in the final EOS configuration
+            raw_eos_cli: |
+              < multiline eos cli >
 
           # For sub-interfaces the dot1q vlan is derived from the interface name by default, but can also be specified.
           - interfaces: [ <interface_name1.sub-if-id>, <interface_name2.sub-if-id> ]
@@ -231,6 +243,11 @@ tenants:
             local_as: < local BGP ASN >
             weight: < 0-65535>
 
+        bgp:
+          # EOS CLI rendered directly on the Router BGP, VRF definition in the final EOS configuration
+          raw_eos_cli: |
+            < multiline eos cli >
+
         # Optional configuration of extra route-targets for this VRF. Useful for route-leaking or gateway between address families.
         additional_route_targets:
           - type: < import | export >
@@ -238,6 +255,10 @@ tenants:
             route_target: "< route_target >"
             # Nodes is optional. Default is all nodes where the VRF is defined.
             nodes: [ < node_1 >, < node_2> ]
+
+        # EOS CLI rendered directly on the root level of the final EOS configuration
+        raw_eos_cli: |
+          < multiline eos cli >
 
       < tenant_a_vrf_2 >:
         vrf_vni: < 1-1024 >

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/base/eos-cli.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/base/eos-cli.j2
@@ -1,0 +1,3 @@
+{% if switch.raw_eos_cli is arista.avd.defined %}
+eos_cli: {{ switch.raw_eos_cli | to_json }}
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/base/eos-cli.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/base/eos-cli.j2
@@ -1,3 +1,10 @@
+{% set tmp_eos_clis = [] %}
 {% if switch.raw_eos_cli is arista.avd.defined %}
-eos_cli: {{ switch.raw_eos_cli | to_json }}
+{%     do tmp_eos_clis.append(switch.raw_eos_cli) %}
+{% endif %}
+{% if switch.platform_settings.raw_eos_cli is arista.avd.defined %}
+{%     do tmp_eos_clis.append(switch.platform_settings.raw_eos_cli) %}
+{% endif %}
+{% if tmp_eos_clis | length > 0 %}
+eos_cli: {{ tmp_eos_clis | join('\n') | to_json }}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/base/main.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/base/main.j2
@@ -53,3 +53,5 @@
 
 {% include 'base/management-api-http.j2' %}
 
+{% include 'base/eos-cli.j2' %}
+

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/base/platform.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/base/platform.j2
@@ -1,5 +1,5 @@
 {# platform #}
-{% if switch.platform_settings.lag_hardware_only is arista.avd.defined %} #}
+{% if switch.platform_settings.lag_hardware_only is arista.avd.defined %}
 platform:
   sand:
     lag:

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/ethernet-interfaces.j2
@@ -55,9 +55,12 @@ ethernet_interfaces:
 {%                     set adapter_mtu = adapter.mtu | arista.avd.default(
                                          adapter_profile.mtu,
                                          parent_profile.mtu) %}
-{%                     set lacp_fallback_mode = adapter.port_channel.lacp_fallback.mode | arista.avd.default(
-                                                adapter_profile.port_channel.lacp_fallback.mode,
-                                                parent_profile.port_channel.lacp_fallback.mode) %}
+{%                     set adapter_lacp_fallback_mode = adapter.port_channel.lacp_fallback.mode | arista.avd.default(
+                                                        adapter_profile.port_channel.lacp_fallback.mode,
+                                                        parent_profile.port_channel.lacp_fallback.mode) %}
+{%                     set adapter_raw_eos_cli = adapter.raw_eos_cli | arista.avd.default(
+                                                 adapter_profile.raw_eos_cli,
+                                                 parent_profile.raw_eos_cli) %}
 {%                     set channel_group_id = (adapter.switch_ports[0] | regex_findall("\d") | join) %}
 {%                     set endpoint_ports = adapter.server_ports | arista.avd.default(adapter.endpoint_ports) %}
 {%                     set peer_type = connected_endpoints_keys[endpoint_key].type %}
@@ -124,12 +127,15 @@ ethernet_interfaces:
       enable: {{ adapter_ptp.enable }}
 {%                         endif %}
 {%                     endif %}
-{%                     if lacp_fallback_mode is arista.avd.defined('static') %}
+{%                     if adapter_lacp_fallback_mode is arista.avd.defined('static') %}
 {%                         if loop.first %}
     lacp_port_priority: 8192
 {%                         else %}
     lacp_port_priority: 32768
 {%                         endif %}
+{%                     endif %}
+{%                     if adapter_raw_eos_cli is arista.avd.defined %}
+    eos_cli: {{ adapter_raw_eos_cli | to_json }}
 {%                     endif %}
 {%                 endif %}
 {%             endfor %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/port-channel-interfaces.j2
@@ -53,12 +53,15 @@ port_channel_interfaces:
 {%                         set adapter_mtu = adapter.mtu | arista.avd.default(
                                              adapter_profile.mtu,
                                              parent_profile.mtu) %}
-{%                         set lacp_fallback_mode = adapter.port_channel.lacp_fallback.mode | arista.avd.default(
-                                                    adapter_profile.port_channel.lacp_fallback.mode,
-                                                    parent_profile.port_channel.lacp_fallback.mode) %}
-{%                         set lacp_fallback_timeout = adapter.port_channel.lacp_fallback.timeout | arista.avd.default(
-                                                       adapter_profile.port_channel.lacp_fallback.timeout,
-                                                       parent_profile.port_channel.lacp_fallback.timeout) %}
+{%                         set adapter_lacp_fallback_mode = adapter.port_channel.lacp_fallback.mode | arista.avd.default(
+                                                            adapter_profile.port_channel.lacp_fallback.mode,
+                                                            parent_profile.port_channel.lacp_fallback.mode) %}
+{%                         set adapter_lacp_fallback_timeout = adapter.port_channel.lacp_fallback.timeout | arista.avd.default(
+                                                               adapter_profile.port_channel.lacp_fallback.timeout,
+                                                               parent_profile.port_channel.lacp_fallback.timeout) %}
+{%                         set adapter_raw_eos_cli = adapter.port_channel.raw_eos_cli | arista.avd.default(
+                                                     adapter_profile.port_channel.raw_eos_cli,
+                                                     parent_profile.port_channel.raw_eos_cli) %}
 {%                         set channel_group_id = (adapter.switch_ports[0] | regex_findall("\d") | join) %}
   Port-Channel{{ channel_group_id }}:
     description: {{ connected_endpoint }}_{{ adapter_port_channel_description }}
@@ -107,14 +110,17 @@ port_channel_interfaces:
     mlag: {{ channel_group_id }}
 {%                             endif %}
 {%                         endif %}
-{%                         if lacp_fallback_mode is arista.avd.defined('static') %}
-    lacp_fallback_mode: {{ lacp_fallback_mode }}
-    lacp_fallback_timeout: {{ lacp_fallback_timeout | arista.avd.default('90') }}
+{%                         if adapter_lacp_fallback_mode is arista.avd.defined('static') %}
+    lacp_fallback_mode: {{ adapter_lacp_fallback_mode }}
+    lacp_fallback_timeout: {{ adapter_lacp_fallback_timeout | arista.avd.default('90') }}
 {%                         endif %}
 {%                         if adapter_qos_profile is arista.avd.defined %}
     service_profile: {{ adapter_qos_profile }}
 {%                         endif %}
-{%                     break %}
+{%                         if adapter_raw_eos_cli is arista.avd.defined %}
+    eos_cli: {{ adapter_raw_eos_cli | to_json }}
+{%                         endif %}
+{%                         break %}
 {%                     endif %}
 {%                 endfor %}
 {%             endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/facts/switch/l2leaf.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/facts/switch/l2leaf.j2
@@ -41,6 +41,11 @@ switch:
            l2leaf.node_groups[l2leaf_node_group].rack,
            l2leaf.defaults.rack) }}
 
+{# switch.raw_eos_cli #}
+  raw_eos_cli: {{ l2leaf.node_groups[l2leaf_node_group].nodes[node].raw_eos_cli | arista.avd.default(
+                  l2leaf.node_groups[l2leaf_node_group].raw_eos_cli,
+                  l2leaf.defaults.raw_eos_cli) | to_json() }}
+
 {# switch.configure_tenants #}
   configure_tenants: true
 

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/facts/switch/l2leaf.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/facts/switch/l2leaf.j2
@@ -34,7 +34,7 @@ switch:
 
 {# switch.platform_settings #}
   platform_settings: {{ platform_settings | selectattr("platforms", "arista.avd.contains", switch_platform) | first | arista.avd.default(
-                        platform_settings | selectattr("platforms", "arista.avd.contains", "default") | first) }}
+                        platform_settings | selectattr("platforms", "arista.avd.contains", "default") | first) | to_json() }}
 
 {# switch.rack #}
   rack: {{ l2leaf.node_groups[l2leaf_node_group].nodes[node].rack | arista.avd.default(

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/facts/switch/l3leaf.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/facts/switch/l3leaf.j2
@@ -20,7 +20,7 @@ switch:
 
 {# switch.platform_settings #}
   platform_settings: {{ platform_settings | selectattr("platforms", "arista.avd.contains", switch_platform) | first | arista.avd.default(
-                        platform_settings | selectattr("platforms", "arista.avd.contains", "default") | first) }}
+                        platform_settings | selectattr("platforms", "arista.avd.contains", "default") | first) | to_json() }}
 
 {# switch.configure_tenants #}
   configure_tenants: true

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/facts/switch/l3leaf.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/facts/switch/l3leaf.j2
@@ -75,6 +75,11 @@ switch:
            l3leaf.node_groups[l3leaf_node_group].rack,
            l3leaf.defaults.rack) }}
 
+{# switch.raw_eos_cli #}
+  raw_eos_cli: {{ l3leaf.node_groups[l3leaf_node_group].nodes[node].raw_eos_cli | arista.avd.default(
+                  l3leaf.node_groups[l3leaf_node_group].raw_eos_cli,
+                  l3leaf.defaults.raw_eos_cli) | to_json() }}
+
 {# switch.router_id #}
   router_id: {% include templates[design.type].ip_addressing[type].router_id %}
 

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/facts/switch/overlay-controller.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/facts/switch/overlay-controller.j2
@@ -20,7 +20,7 @@ switch:
 
 {# switch.platform_settings #}
   platform_settings: {{ platform_settings | selectattr("platforms", "arista.avd.contains", switch_platform) | first | arista.avd.default(
-                        platform_settings | selectattr("platforms", "arista.avd.contains", "default") | first) }}
+                        platform_settings | selectattr("platforms", "arista.avd.contains", "default") | first) | to_json() }}
 
 {# switch.router_id #}
   router_id: {% include templates[design.type].ip_addressing[type].router_id %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/facts/switch/overlay-controller.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/facts/switch/overlay-controller.j2
@@ -32,6 +32,10 @@ switch:
   rack: {{ overlay_controller.nodes[node].rack | arista.avd.default(
            overlay_controller.defaults.rack) }}
 
+{# switch.raw_eos_cli #}
+  raw_eos_cli: {{ overlay_controller.nodes[node].raw_eos_cli | arista.avd.default(
+                  overlay_controller.defaults.raw_eos_cli) | to_json() }}
+
 {# switch.bgp_defaults #}
   bgp_defaults: {{ overlay_controller_bgp_defaults | arista.avd.default([]) }}
 

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/facts/switch/spine.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/facts/switch/spine.j2
@@ -34,7 +34,7 @@ switch:
 
 {# switch.platform_settings #}
   platform_settings: {{ platform_settings | selectattr("platforms", "arista.avd.contains", switch_platform) | first | arista.avd.default(
-                        platform_settings | selectattr("platforms", "arista.avd.contains", "default") | first) }}
+                        platform_settings | selectattr("platforms", "arista.avd.contains", "default") | first) | to_json() }}
 
 {# switch.router_id #}
   router_id: {% include templates[design.type].ip_addressing[type].router_id %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/facts/switch/spine.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/facts/switch/spine.j2
@@ -15,6 +15,10 @@ switch:
 {# switch.rack #}
   rack: {{ spine.nodes[node].rack | arista.avd.default() }}
 
+{# switch.raw_eos_cli #}
+  raw_eos_cli: {{ spine.nodes[node].raw_eos_cli | arista.avd.default(
+                  spine.defaults.raw_eos_cli) | to_json }}
+
 {# switch.bgp_defaults #}
   bgp_defaults: {{ spine_bgp_defaults | arista.avd.default([]) }}
 

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/facts/switch/super-spine.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/facts/switch/super-spine.j2
@@ -15,6 +15,10 @@ switch:
 {# switch.rack #}
   rack: {{ super_spine.nodes[inventory_hostname].rack | arista.avd.default() }}
 
+{# switch.raw_eos_cli #}
+  raw_eos_cli: {{ super_spine.nodes[node].raw_eos_cli | arista.avd.default(
+                  super_spine.defaults.raw_eos_cli) | to_json() }}
+
 {# switch.bgp_defaults #}
   bgp_defaults: {{ super_spine_bgp_defaults | arista.avd.default([]) }}
 

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/facts/switch/super-spine.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/facts/switch/super-spine.j2
@@ -30,7 +30,7 @@ switch:
 
 {# switch.platform_settings #}
   platform_settings: {{ platform_settings | selectattr("platforms", "arista.avd.contains", switch_platform) | first | arista.avd.default(
-                        platform_settings | selectattr("platforms", "arista.avd.contains", "default") | first) }}
+                        platform_settings | selectattr("platforms", "arista.avd.contains", "default") | first) | to_json() }}
 
 {# switch.router_id #}
   router_id: {% include templates[design.type].ip_addressing[type].router_id %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenants/eos-cli.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenants/eos-cli.j2
@@ -1,0 +1,15 @@
+{# Read any global set eos_cli and add per tenant-vrf eos_cli #}
+{% set tmp_eos_clis = [] %}
+{% if switch.raw_eos_cli is arista.avd.defined %}
+{%     do tmp_eos_clis.append(switch.raw_eos_cli ) %}
+{% endif %}
+{% for tenant in switch.tenants | arista.avd.natural_sort %}
+{%     for vrf in switch.tenants[tenant].vrfs | arista.avd.natural_sort %}
+{%         if tenants[tenant].vrfs[vrf].raw_eos_cli is arista.avd.defined %}
+{%             do tmp_eos_clis.append(tenants[tenant].vrfs[vrf].raw_eos_cli) %}
+{%         endif %}
+{%     endfor %}
+{% endfor %}
+{% if tmp_eos_clis | length > 0 %}
+eos_cli: {{ tmp_eos_clis | join('\n') | to_json }}
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenants/eos-cli.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenants/eos-cli.j2
@@ -1,7 +1,7 @@
 {# Read any global set eos_cli and add per tenant-vrf eos_cli #}
 {% set tmp_eos_clis = [] %}
-{% if switch.raw_eos_cli is arista.avd.defined %}
-{%     do tmp_eos_clis.append(switch.raw_eos_cli ) %}
+{% if structured_config.eos_cli is arista.avd.defined %}
+{%     do tmp_eos_clis.append(structured_config.eos_cli) %}
 {% endif %}
 {% for tenant in switch.tenants | arista.avd.natural_sort %}
 {%     for vrf in switch.tenants[tenant].vrfs | arista.avd.natural_sort %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenants/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenants/ethernet-interfaces.j2
@@ -33,6 +33,9 @@ ethernet_interfaces:
 {%                         if l3_interface.description is arista.avd.defined %}
     description: {{ l3_interface.description }}
 {%                         endif %}
+{%                         if l3_interface.raw_eos_cli is arista.avd.defined %}
+    eos_cli: {{ l3_interface.raw_eos_cli }}
+{%                         endif %}
 {%                     endif %}
 {%                 endfor %}
 {%             endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenants/main.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenants/main.j2
@@ -8,6 +8,8 @@
 
 {%         include 'designs/l3ls-evpn/tenants/vlans.j2' %}
 
+{%         include 'designs/l3ls-evpn/tenants/eos-cli.j2' %}
+
 {# Only run EVPN/VXLAN templates for VTEPs #}
 {%     if switch.vtep_ip is arista.avd.defined %}
 {%         include 'designs/l3ls-evpn/tenants/vxlan-tunnel-interface.j2' %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenants/router-bgp-vrfs.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenants/router-bgp-vrfs.j2
@@ -103,6 +103,9 @@
               activate: true
 {%                 endfor %}
 {%             endif %}
+{%             if tenants[tenant].vrfs[vrf].bgp.raw_eos_cli is arista.avd.defined %}
+      eos_cli: {{ tenants[tenant].vrfs[vrf].bgp.raw_eos_cli | to_json }}
+{%             endif %}
 {%         endfor %}
 {%     endfor %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenants/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenants/vlan-interfaces.j2
@@ -26,7 +26,10 @@ vlan_interfaces:
 {%             set svi_ip_helpers = svi_config.ip_helpers | arista.avd.default(
                                     tenants[tenant].vrfs[vrf].ip_helpers,
                                     svi_profile.ip_helpers) %}
-
+{%             set svi_raw_eos_cli = svi_config.nodes[inventory_hostname].raw_eos_cli | arista.avd.default(
+                                     svi_profile.nodes[inventory_hostname].raw_eos_cli,
+                                     svi_config.raw_eos_cli,
+                                     svi_profile.raw_eos_cli) %}
   Vlan{{ svi | int }}:
     tenant: {{ tenant }}
     tags: {{ svi_tags }}
@@ -69,6 +72,9 @@ vlan_interfaces:
         vrf: {{ vrf }}
 {%                     endif %}
 {%                 endfor %}
+{%             endif %}
+{%             if svi_raw_eos_cli is arista.avd.defined %}
+    eos_cli: {{ svi_raw_eos_cli | to_json }}
 {%             endif %}
 {%         endfor %}
 {# VLAN interface for iBGP peering in overlay VRFs #}


### PR DESCRIPTION
## Change Summary

Add support for `raw_eos_cli` in `eos_designs` and `eos_cli` in `eos_cli_config_gen`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [x] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

## Component(s) name

`arista.avd.eos_designs`
`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

### `eos_cli_config_gen`
Data model updated with:
```yaml
# EOS CLI rendered directly on the root level of the final EOS configuration
eos_cli: |
  < multiline eos cli >

ethernet_interfaces:
  < interface >:
    # EOS CLI rendered directly on the ethernet interface in the final EOS configuration
    eos_cli: |
      < multiline eos cli >

port_channel_interfaces:
  < interface >:
# EOS CLI rendered directly on the port-channel interface in the final EOS configuration
    eos_cli: |
      < multiline eos cli >

vlan_interfaces:
  < interface >:
# EOS CLI rendered directly on the vlan interface in the final EOS configuration
    eos_cli: |
      < multiline eos cli >

router_bgp:
  vrfs:
    < vrf >:
      # EOS CLI rendered directly on the Router BGP, VRF definition in the final EOS configuration
      eos_cli: |
        < multiline eos cli >
```

### `eos_designs`
Connected Endpoints data model updated with:
```yaml
< connected_endpoints_keys.key >:
  < endpoint_1 >:
    adapters:
      - <...>
        # EOS CLI rendered directly on the ethernet interface in the final EOS configuration
        raw_eos_cli: |
          < multiline eos cli >
        port_channel:
          # EOS CLI rendered directly on the port-channel interface in the final EOS configuration
          raw_eos_cli: |
            < multiline eos cli >
```
Fabric-Topology data models updated with:
```yaml
< spine | l3leaf | l2leaf | overlay_controller | super_spine >:
  defaults:
    # EOS CLI rendered directly on the root level of the final EOS configuration
    raw_eos_cli: |
      < multiline eos cli >
  nodes:
    <node>:
      # EOS CLI rendered directly on the root level of the final EOS configuration
      raw_eos_cli: |
        < multiline eos cli >
```
Network Services data models updated with:
```yaml
tenants:
  <tenant>:
    vrfs:
      <vrf>:
        # EOS CLI rendered directly on the root level of the final EOS configuration
        raw_eos_cli: |
          < multiline eos cli >

        svis:
          <svi>:
            # EOS CLI rendered directly on the VLAN interface in the final EOS configuration
            raw_eos_cli: |
              < multiline eos cli >

            nodes:
              <node>:
                # EOS CLI rendered directly on the VLAN interface in the final EOS configuration
                # Overrides the setting on SVI level.
                raw_eos_cli: |
                  < multiline eos cli >

        l3_interface:
          - <...>
             # EOS CLI rendered directly on the Ethernet interface in the final EOS configuration
            raw_eos_cli: |
              < multiline eos cli >

        bgp:
          # EOS CLI rendered directly on the Router BGP, VRF definition in the final EOS configuration
          raw_eos_cli: |
            < multiline eos cli >
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Added tests to molecule for all supported areas.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contributing/) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
