### PR TITLE
eos_cli_config_gen(fix) ethernet-interfaces dot1q-tunnel

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
@@ -128,6 +128,12 @@ interface Ethernet11
    switchport mode access
    l2-protocol encapsulation dot1q vlan 200
 !
+interface Ethernet12
+   description interface_with_dot1q_tunnel
+   switchport
+   switchport access vlan 300
+   switchport mode dot1q-tunnel
+!
 interface Management1
    description oob_management
    vrf MGMT

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
@@ -188,3 +188,9 @@ ethernet_interfaces:
     vlans: 200
     l2_protocol:
       encapsulation_dot1q_vlan: 200
+
+  Ethernet12:
+    description: interface_with_dot1q_tunnel
+    type: switched
+    mode: dot1q-tunnel
+    vlans: 300

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -47,7 +47,7 @@ interface {{ ethernet_interface }}
 {%         if ethernet_interfaces[ethernet_interface].flowcontrol.received is arista.avd.defined %}
    flowcontrol receive {{ ethernet_interfaces[ethernet_interface].flowcontrol.received }}
 {%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].mode is arista.avd.defined('access') %}
+{%         if ethernet_interfaces[ethernet_interface].mode is arista.avd.defined('access') or ethernet_interfaces[ethernet_interface].mode is arista.avd.defined('dot1q-tunnel') %}
 {%             if ethernet_interfaces[ethernet_interface].vlans is arista.avd.defined %}
    switchport access vlan {{ ethernet_interfaces[ethernet_interface].vlans }}
 {%             endif %}


### PR DESCRIPTION
Fixes aristanetworks/ansible-avd#968

## Change Summary

When the switchport mode is dot1q tunnel, we should also render the access vlan. Currently we only render this config (access vlan) if the switchport is in access mode.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Fixes #968 

## Component(s) name

`eos_cli_config_gen/templates/eos/ethernet-interfaces.j2`

## Proposed changes
We now render the `switchport access vlan #` when the port is in either `access` or `dot1q-tunnel` mode


## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
