### PR TITLE
eos_cli_config_gen(feature): vrf neighbor bgp weight

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -80,6 +80,7 @@ interface Management1
 | Ethernet6 |  SRV-POD02_Eth1 | trunk | 110-111,210-211 | - | - | - |
 | Ethernet7 |  Molecule L2 | access | - | - | - | - |
 | Ethernet11 |  interface_in_mode_access_accepting_tagged_LACP | access | 200 | - | - | - |
+| Ethernet12 |  interface_with_dot1q_tunnel | dot1q-tunnel | 300 | - | - | - |
 
 *Inherited from Port-Channel Interface
 
@@ -231,6 +232,12 @@ interface Ethernet11
    switchport access vlan 200
    switchport mode access
    l2-protocol encapsulation dot1q vlan 200
+!
+interface Ethernet12
+   description interface_with_dot1q_tunnel
+   switchport
+   switchport access vlan 300
+   switchport mode dot1q-tunnel
 ```
 
 # Routing

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vrf-lite.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vrf-lite.md
@@ -197,7 +197,9 @@ router bgp 65001
       rd 1.0.1.1:101
       neighbor 10.1.1.0 peer group OBS_WAN
       neighbor 10.255.1.1 peer group WELCOME_ROUTERS
+      neighbor 10.255.1.1 weight 65535
       neighbor 101.0.3.1 peer group SEDI
+      neighbor 101.0.3.1 weight 100
       redistribute static
       aggregate-address 0.0.0.0/0 as-set summary-only attribute-map RM-BGP-AGG-APPLY-SET
       aggregate-address 193.1.0.0/16 as-set summary-only attribute-map RM-BGP-AGG-APPLY-SET

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-vrf-lite.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-vrf-lite.cfg
@@ -56,7 +56,9 @@ router bgp 65001
       rd 1.0.1.1:101
       neighbor 10.1.1.0 peer group OBS_WAN
       neighbor 10.255.1.1 peer group WELCOME_ROUTERS
+      neighbor 10.255.1.1 weight 65535
       neighbor 101.0.3.1 peer group SEDI
+      neighbor 101.0.3.1 weight 100
       redistribute static
       aggregate-address 0.0.0.0/0 as-set summary-only attribute-map RM-BGP-AGG-APPLY-SET
       aggregate-address 193.1.0.0/16 as-set summary-only attribute-map RM-BGP-AGG-APPLY-SET

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-vrf-lite.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-vrf-lite.yml
@@ -63,8 +63,10 @@ router_bgp:
           peer_group: OBS_WAN
         10.255.1.1:
           peer_group: WELCOME_ROUTERS
+          weight: 65535
         101.0.3.1:
           peer_group: SEDI
+          weight: 100
       redistribute_routes:
         - static
       aggregate_addresses:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -486,8 +486,8 @@ router bgp {{ router_bgp.as }}
 {%         if router_bgp.vrfs[vrf].neighbors[neighbor].password is arista.avd.defined %}
       neighbor {{ neighbor }} password 7 {{ router_bgp.vrfs[vrf].neighbors[neighbor].password }}
 {%         endif %}
-{%             if router_bgp.neighbors[neighbor].weight is arista.avd.defined %}
-      neighbor {{ neighbor }} weight {{ router_bgp.neighbors[neighbor].weight }}
+{%             if router_bgp.vrfs[vrf].neighbors[neighbor].weight is arista.avd.defined %}
+      neighbor {{ neighbor }} weight {{ router_bgp.vrfs[vrf].neighbors[neighbor].weight }}
 {%             endif %}
 {%             if router_bgp.vrfs[vrf].neighbors[neighbor].local_as is arista.avd.defined %}
       neighbor {{ neighbor }} local-as {{ router_bgp.vrfs[vrf].neighbors[neighbor].local_as }} no-prepend replace-as

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -486,6 +486,9 @@ router bgp {{ router_bgp.as }}
 {%         if router_bgp.vrfs[vrf].neighbors[neighbor].password is arista.avd.defined %}
       neighbor {{ neighbor }} password 7 {{ router_bgp.vrfs[vrf].neighbors[neighbor].password }}
 {%         endif %}
+{%             if router_bgp.neighbors[neighbor].weight is arista.avd.defined %}
+      neighbor {{ neighbor }} weight {{ router_bgp.neighbors[neighbor].weight }}
+{%             endif %}
 {%             if router_bgp.vrfs[vrf].neighbors[neighbor].local_as is arista.avd.defined %}
       neighbor {{ neighbor }} local-as {{ router_bgp.vrfs[vrf].neighbors[neighbor].local_as }} no-prepend replace-as
 {%             endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/network-services.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/network-services.md
@@ -229,6 +229,7 @@ tenants:
             route_map_out: < route-map name >
             route_map_in: < route-map name >
             local_as: < local BGP ASN >
+            weight: < 0-65535>
 
         # Optional configuration of extra route-targets for this VRF. Useful for route-leaking or gateway between address families.
         additional_route_targets:


### PR DESCRIPTION
## Change Summary

Enable support for setting BGP neighbor weight within VRF.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [x] Documentation content changes
- [ ] Other (please describe):

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contributing/) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
