### PR TITLE
eos_designs(fix): endpoint adapters with unsorted `switches` variable

### DIFF
--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -358,6 +358,7 @@ vlan 311
 | Ethernet10 | server01_MLAG_Eth2 | *trunk | *210-211 | *- | *- | 10 |
 | Ethernet11 | server01_MTU_PROFILE_MLAG_Eth4 | *access | *110 | *- | *- | 11 |
 | Ethernet12 | server01_MTU_ADAPTOR_MLAG_Eth6 | *access | *- | *- | *- | 12 |
+| Ethernet13 | server01_MTU_ADAPTOR_MLAG_Eth8 | *access | *- | *- | *- | 12 |
 | Ethernet20 | FIREWALL01_E0 | *trunk | *110-111,210-211 | *- | *- | 20 |
 | Ethernet21 |  ROUTER01_Eth0 | access | 110 | - | - | - |
 
@@ -435,6 +436,11 @@ interface Ethernet11
 !
 interface Ethernet12
    description server01_MTU_ADAPTOR_MLAG_Eth6
+   no shutdown
+   channel-group 12 mode active
+!
+interface Ethernet13
+   description server01_MTU_ADAPTOR_MLAG_Eth8
    no shutdown
    channel-group 12 mode active
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -358,6 +358,7 @@ vlan 311
 | Ethernet10 | server01_MLAG_Eth3 | *trunk | *210-211 | *- | *- | 10 |
 | Ethernet11 | server01_MTU_PROFILE_MLAG_Eth5 | *access | *110 | *- | *- | 11 |
 | Ethernet12 | server01_MTU_ADAPTOR_MLAG_Eth7 | *access | *- | *- | *- | 12 |
+| Ethernet13 | server01_MTU_ADAPTOR_MLAG_Eth9 | *access | *- | *- | *- | 12 |
 | Ethernet20 | FIREWALL01_E1 | *trunk | *110-111,210-211 | *- | *- | 20 |
 | Ethernet21 |  ROUTER01_Eth1 | access | 110 | - | - | - |
 
@@ -435,6 +436,11 @@ interface Ethernet11
 !
 interface Ethernet12
    description server01_MTU_ADAPTOR_MLAG_Eth7
+   no shutdown
+   channel-group 12 mode active
+!
+interface Ethernet13
+   description server01_MTU_ADAPTOR_MLAG_Eth9
    no shutdown
    channel-group 12 mode active
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/fabric/DC1_FABRIC-topology.csv
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/fabric/DC1_FABRIC-topology.csv
@@ -49,6 +49,7 @@ l3leaf,DC1-LEAF2A,Ethernet9,l2leaf,DC1-L2LEAF3A,Ethernet1
 l3leaf,DC1-LEAF2A,Ethernet10,server,server01_MLAG,Eth2
 l3leaf,DC1-LEAF2A,Ethernet11,server,server01_MTU_PROFILE_MLAG,Eth4
 l3leaf,DC1-LEAF2A,Ethernet12,server,server01_MTU_ADAPTOR_MLAG,Eth6
+l3leaf,DC1-LEAF2A,Ethernet13,server,server01_MTU_ADAPTOR_MLAG,Eth8
 l3leaf,DC1-LEAF2A,Ethernet20,firewall,FIREWALL01,E0
 l3leaf,DC1-LEAF2A,Ethernet21,router,ROUTER01,Eth0
 l3leaf,DC1-LEAF2B,Ethernet1,spine,DC1-SPINE1,Ethernet3
@@ -61,6 +62,7 @@ l3leaf,DC1-LEAF2B,Ethernet9,l2leaf,DC1-L2LEAF3A,Ethernet2
 l3leaf,DC1-LEAF2B,Ethernet10,server,server01_MLAG,Eth3
 l3leaf,DC1-LEAF2B,Ethernet11,server,server01_MTU_PROFILE_MLAG,Eth5
 l3leaf,DC1-LEAF2B,Ethernet12,server,server01_MTU_ADAPTOR_MLAG,Eth7
+l3leaf,DC1-LEAF2B,Ethernet13,server,server01_MTU_ADAPTOR_MLAG,Eth9
 l3leaf,DC1-LEAF2B,Ethernet20,firewall,FIREWALL01,E1
 l3leaf,DC1-LEAF2B,Ethernet21,router,ROUTER01,Eth1
 spine,DC1-SPINE1,Ethernet1,l3leaf,DC1-LEAF1A,Ethernet1

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
@@ -210,6 +210,11 @@ interface Ethernet12
    no shutdown
    channel-group 12 mode active
 !
+interface Ethernet13
+   description server01_MTU_ADAPTOR_MLAG_Eth8
+   no shutdown
+   channel-group 12 mode active
+!
 interface Ethernet20
    description FIREWALL01_E0
    no shutdown

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
@@ -210,6 +210,11 @@ interface Ethernet12
    no shutdown
    channel-group 12 mode active
 !
+interface Ethernet13
+   description server01_MTU_ADAPTOR_MLAG_Eth9
+   no shutdown
+   channel-group 12 mode active
+!
 interface Ethernet20
    description FIREWALL01_E1
    no shutdown

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -438,6 +438,17 @@ ethernet_interfaces:
     channel_group:
       id: 12
       mode: active
+  Ethernet13:
+    peer: server01_MTU_ADAPTOR_MLAG
+    peer_interface: Eth8
+    peer_type: server
+    description: server01_MTU_ADAPTOR_MLAG_Eth8
+    mtu: 1601
+    type: switched
+    shutdown: false
+    channel_group:
+      id: 12
+      mode: active
   Ethernet11:
     peer: server01_MTU_PROFILE_MLAG
     peer_interface: Eth4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -438,6 +438,17 @@ ethernet_interfaces:
     channel_group:
       id: 12
       mode: active
+  Ethernet13:
+    peer: server01_MTU_ADAPTOR_MLAG
+    peer_interface: Eth9
+    peer_type: server
+    description: server01_MTU_ADAPTOR_MLAG_Eth9
+    mtu: 1601
+    type: switched
+    shutdown: false
+    channel_group:
+      id: 12
+      mode: active
   Ethernet11:
     peer: server01_MTU_PROFILE_MLAG
     peer_interface: Eth5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_SERVERS.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_SERVERS.yml
@@ -121,9 +121,9 @@ servers:
   server01_MTU_ADAPTOR_MLAG:
     rack: RackB
     adapters:
-      - server_ports: [ Eth6, Eth7 ]
-        switch_ports: [ Ethernet12, Ethernet12 ]
-        switches: [ DC1-LEAF2A, DC1-LEAF2B ]
+      - server_ports: [ Eth6, Eth7, Eth8, Eth9 ]
+        switch_ports: [ Ethernet12, Ethernet12, Ethernet13, Ethernet13 ]
+        switches: [ DC1-LEAF2A, DC1-LEAF2B, DC1-LEAF2A, DC1-LEAF2B ]
         mtu: 1601
         port_channel:
           description: PortChanne1

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/ethernet-interfaces.j2
@@ -3,7 +3,7 @@ ethernet_interfaces:
 {% for endpoint_key in connected_endpoints | arista.avd.natural_sort %}
 {%     for connected_endpoint in connected_endpoints[endpoint_key] | arista.avd.natural_sort %}
 {%         for adapter in connected_endpoints[endpoint_key][connected_endpoint].adapters | arista.avd.natural_sort %}
-{%             for switch in adapter.switches | arista.avd.natural_sort %}
+{%             for switch in adapter.switches | arista.avd.default([]) %}
 {%                 if switch == inventory_hostname %}
 {%                     if adapter.profile is arista.avd.defined %}
 {%                         set adapter_profile = port_profiles[adapter.profile] | arista.avd.default({}) %}
@@ -61,7 +61,7 @@ ethernet_interfaces:
 {%                     set channel_group_id = (adapter.switch_ports[0] | regex_findall("\d") | join) %}
 {%                     set endpoint_ports = adapter.server_ports | arista.avd.default(adapter.endpoint_ports) %}
 {%                     set peer_type = connected_endpoints_keys[endpoint_key].type %}
-  {{ adapter.switch_ports[loop.index0]}}:
+  {{ adapter.switch_ports[loop.index0] }}:
     peer: {{ connected_endpoint }}
     peer_interface: {{ endpoint_ports[loop.index0] }}
     peer_type: {{ peer_type }}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Bugfix endpoint adapters with unsorted `switches` variable

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Fixes #977 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->
Replaced wrong sort in template with default to empty list. Sorting the `servers` broke the later matches on index.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Added molecule test case and it indeed reproduced the issue.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
