### PR TITLE
Add support for setting vxlan flood vtep

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vxlan-interface-flood-vtep.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vxlan-interface-flood-vtep.md
@@ -1,0 +1,131 @@
+# vxlan-interface-flood-vtep
+# Table of Contents
+<!-- toc -->
+
+- [Management](#management)
+  - [Management Interfaces](#management-interfaces)
+- [Authentication](#authentication)
+- [Monitoring](#monitoring)
+- [Internal VLAN Allocation Policy](#internal-vlan-allocation-policy)
+  - [Internal VLAN Allocation Policy Summary](#internal-vlan-allocation-policy-summary)
+- [Interfaces](#interfaces)
+  - [VXLAN Interface](#vxlan-interface)
+- [Routing](#routing)
+  - [IP Routing](#ip-routing)
+  - [IPv6 Routing](#ipv6-routing)
+- [Multicast](#multicast)
+- [Filters](#filters)
+- [ACL](#acl)
+- [Quality Of Service](#quality-of-service)
+
+<!-- toc -->
+# Management
+
+## Management Interfaces
+
+### Management Interfaces Summary
+
+#### IPv4
+
+| Management Interface | description | Type | VRF | IP Address | Gateway |
+| -------------------- | ----------- | ---- | --- | ---------- | ------- |
+| Management1 | oob_management | oob | MGMT | 10.73.255.122/24 | 10.73.255.2 |
+
+#### IPv6
+
+| Management Interface | description | Type | VRF | IPv6 Address | IPv6 Gateway |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ |
+| Management1 | oob_management | oob | MGMT | -  | - |
+
+### Management Interfaces Device Configuration
+
+```eos
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+```
+
+# Authentication
+
+# Monitoring
+
+# Internal VLAN Allocation Policy
+
+## Internal VLAN Allocation Policy Summary
+
+**Default Allocation Policy**
+
+| Policy Allocation | Range Beginning | Range Ending |
+| ------------------| --------------- | ------------ |
+| ascending | 1006 | 4094 |
+
+# Interfaces
+
+## VXLAN Interface
+
+### VXLAN Interface Summary
+
+#### Source Interface: Loopback1
+
+#### UDP port: 4789
+
+#### VLAN to VNI Mappings
+
+| VLAN | VNI |
+| ---- | --- |
+| 110 | 10110 |
+| 111 | 10111 |
+
+#### VRF to VNI Mappings
+
+| VLAN | VNI |
+| ---- | --- |
+| Tenant_A_OP_Zone | 10 |
+| Tenant_A_WEB_Zone | 11 |
+
+### VXLAN Interface Device Configuration
+
+```eos
+!
+interface Vxlan1
+   vxlan source-interface Loopback1
+   vxlan virtual-router encapsulation mac-address mlag-system-id
+   vxlan udp-port 4789
+   vxlan vlan 110 vni 10110
+   vxlan vlan 111 vni 10111
+   vxlan vrf Tenant_A_OP_Zone vni 10
+   vxlan vrf Tenant_A_WEB_Zone vni 11
+   vxlan vlan 111 flood vtep 10.1.1.10 10.1.1.11
+   vxlan flood vtep 10.1.0.10 10.1.0.11
+```
+
+# Routing
+
+## IP Routing
+
+### IP Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | false|
+### IP Routing Device Configuration
+
+```eos
+```
+## IPv6 Routing
+
+### IPv6 Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | false |
+
+# Multicast
+
+# Filters
+
+# ACL
+
+# Quality Of Service

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vxlan-interface-flood-vtep.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vxlan-interface-flood-vtep.cfg
@@ -1,0 +1,26 @@
+!RANCID-CONTENT-TYPE: arista
+!
+transceiver qsfp default-mode 4x10G
+!
+hostname vxlan-interface-flood-vtep
+!
+no aaa root
+no enable password
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+!
+interface Vxlan1
+   vxlan source-interface Loopback1
+   vxlan virtual-router encapsulation mac-address mlag-system-id
+   vxlan udp-port 4789
+   vxlan vlan 110 vni 10110
+   vxlan vlan 111 vni 10111
+   vxlan vrf Tenant_A_OP_Zone vni 10
+   vxlan vrf Tenant_A_WEB_Zone vni 11
+   vxlan vlan 111 flood vtep 10.1.1.10 10.1.1.11
+   vxlan flood vtep 10.1.0.10 10.1.0.11
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vxlan-interface-flood-vtep.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vxlan-interface-flood-vtep.yml
@@ -1,0 +1,29 @@
+### VxLAN interface ###
+
+vxlan_tunnel_interface:
+  Vxlan1:
+    description: DC1-LEAF2A_VTEP
+    source_interface: Loopback1
+    virtual_router:
+      encapsulation_mac_address: "mlag-system-id"
+    vxlan_udp_port: 4789
+    vxlan_vni_mappings:
+      vlans:
+        110:
+          vni: 10110
+        111:
+          vni: 10111
+      vrfs:
+        Tenant_A_OP_Zone:
+          vni: 10
+        Tenant_A_WEB_Zone:
+          vni: 11
+    flood_vtep:
+      remotes:
+        - 10.1.0.10
+        - 10.1.0.11
+      vlans:
+        111:
+          remotes:
+            - 10.1.1.10
+            - 10.1.1.11

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts
@@ -83,4 +83,5 @@ vlan-internal-order
 vlans
 vmtracer-sessions
 vxlan-interface
+vxlan-interface-flood-vtep
 vrf-instances

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -986,6 +986,15 @@ vxlan_tunnel_interface:
     virtual_router:
       encapsulation_mac_address: < mlag-system-id | ethernet_address (H.H.H) >
     vxlan_udp_port: < udp_port >
+    flood_vtep:
+      remotes:
+        - < remote_1 >
+        - < remote_2 >
+      vlans:
+        < vlan_id_1 >:
+          remotes:
+            - < remote_1 >
+            - < remote_2 >
     vxlan_vni_mappings:
       vlans:
         < vlan_id_1 >:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vxlan-interface.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vxlan-interface.j2
@@ -22,7 +22,8 @@ interface Vxlan1
 {%            for vlan in vxlan_tunnel_interface.Vxlan1.flood_vtep.vlans | arista.avd.natural_sort %}
    vxlan vlan {{ vlan }} flood vtep {{ vxlan_tunnel_interface.Vxlan1.flood_vtep.vlans[vlan].remotes | join(' ') }}
 {%            endfor %}
-{%         elif vxlan_tunnel_interface.Vxlan1.flood_vtep.remotes is arista.avd.defined %}
+{%         endif %}
+{%         if vxlan_tunnel_interface.Vxlan1.flood_vtep.remotes is arista.avd.defined %}
    vxlan flood vtep {{ vxlan_tunnel_interface.Vxlan1.flood_vtep.remotes | join(' ') }}
 {%         endif %}
 {%    endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vxlan-interface.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vxlan-interface.j2
@@ -17,4 +17,13 @@ interface Vxlan1
 {%     for vrf in vxlan_tunnel_interface.Vxlan1.vxlan_vni_mappings.vrfs | arista.avd.natural_sort %}
    vxlan vrf {{ vrf }} vni {{ vxlan_tunnel_interface.Vxlan1.vxlan_vni_mappings.vrfs[vrf].vni }}
 {%     endfor %}
+{%     if vxlan_tunnel_interface.Vxlan1.flood_vtep is arista.avd.defined %}
+{%         if vxlan_tunnel_interface.Vxlan1.flood_vtep.vlans is arista.avd.defined %}
+{%            for vlan in vxlan_tunnel_interface.Vxlan1.flood_vtep.vlans | arista.avd.natural_sort %}
+   vxlan vlan {{ vlan }} flood vtep {{ vxlan_tunnel_interface.Vxlan1.flood_vtep.vlans[vlan].remotes | join(' ') }}
+{%            endfor %}
+{%         elif vxlan_tunnel_interface.Vxlan1.flood_vtep.remotes is arista.avd.defined %}
+   vxlan flood vtep {{ vxlan_tunnel_interface.Vxlan1.flood_vtep.remotes | join(' ') }}
+{%         endif %}
+{%    endif %}
 {% endif %}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Related to #979

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- Add supports for specifying `flood vtep` parameters on Vxlan1

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been rebased from devel before I start
- [X] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contributing/) document.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [X] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
