### PR TITLE
Add support for additional PTP parameters

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ptp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ptp.md
@@ -76,6 +76,10 @@ ptp ttl 200
 ptp domain 1
 ptp message-type general dscp 4 default
 ptp message-type event dscp 8 default
+ptp mode boundary
+ptp forward-unicast
+ptp monitor threshold offset-from-master 1234
+ptp monitor threshold mean-path-delay 4321
 ```
 
 # Authentication

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ptp.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ptp.cfg
@@ -12,6 +12,10 @@ ptp ttl 200
 ptp domain 1
 ptp message-type general dscp 4 default
 ptp message-type event dscp 8 default
+ptp mode boundary
+ptp forward-unicast
+ptp monitor threshold offset-from-master 1234
+ptp monitor threshold mean-path-delay 4321
 !
 no aaa root
 no enable password

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ptp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ptp.yml
@@ -13,6 +13,12 @@ ptp:
       dscp: 4
     event:
       dscp: 8
+  monitor:
+    threshold:
+      offset_from_master: 1234
+      mean_path_delay: 4321
+  mode: boundary
+  forward_unicast: true
 
 # port-channels
 port_channel_interfaces:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1480,7 +1480,7 @@ vmtracer_sessions:
 ```yaml
 ptp:
   mode: < mode >
-    forward_unicast: < true | false >
+  forward_unicast: < true | false >
   clock_identity: < clock-id >
   source:
     ip: < source-ip>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1479,6 +1479,8 @@ vmtracer_sessions:
 
 ```yaml
 ptp:
+  mode: < mode >
+    forward_unicast: < true | false >
   clock_identity: < clock-id >
   source:
     ip: < source-ip>
@@ -1491,6 +1493,10 @@ ptp:
       dscp: < dscp-value >
     event:
       dscp: < dscp-Value >
+  monitor:
+    threshold:
+      offset_from_master: < offset >
+      mean_path_delay: < delay >
 ```
 
 ### Prompt

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ptp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ptp.j2
@@ -25,4 +25,16 @@ ptp message-type general dscp {{ ptp.message_type.general.dscp }} default
 {%     if ptp.message_type.event.dscp is arista.avd.defined %}
 ptp message-type event dscp {{ ptp.message_type.event.dscp }} default
 {%     endif %}
+{%     if ptp.mode is arista.avd.defined %}
+ptp mode {{ ptp.mode }}
+{%     endif %}
+{%     if ptp.forward_unicast is arista.avd.defined(true) %}
+ptp forward-unicast
+{%     endif %}
+{%     if ptp.monitor.threshold.offset_from_master is arista.avd.defined %}
+ptp monitor threshold offset-from-master {{ ptp.monitor.threshold.offset_from_master }}
+{%     endif %}
+{%     if ptp.monitor.threshold.mean_path_delay is arista.avd.defined %}
+ptp monitor threshold mean-path-delay {{ ptp.monitor.threshold.mean_path_delay }}
+{%     endif %}
 {% endif %}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Related to #979

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- Add supports for specifying `mode fordard-unicast` and `monitor threshold` parameters on PTP

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been rebased from devel before I start
- [X] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contributing/) document.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [X] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
