### PR TITLE
Add support for setting router pim sparse-mode ssm range

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-pim-sparse-mode.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-pim-sparse-mode.md
@@ -120,6 +120,7 @@ router pim sparse-mode
       rp address 10.238.1.161 239.12.12.20/32
       rp address 10.238.1.161 239.12.12.21/32
       anycast-rp 10.38.1.161 10.50.64.16 register-count 15
+      ssm range standard
 ```
 
 # Filters

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-pim-sparse-mode.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-pim-sparse-mode.cfg
@@ -21,5 +21,6 @@ router pim sparse-mode
       rp address 10.238.1.161 239.12.12.20/32
       rp address 10.238.1.161 239.12.12.21/32
       anycast-rp 10.38.1.161 10.50.64.16 register-count 15
+      ssm range standard
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-pim-sparse-mode.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-pim-sparse-mode.yml
@@ -16,3 +16,4 @@ router_pim_sparse_mode:
         other_anycast_rp_addresses:
           10.50.64.16:
             register_count: 15
+    ssm_range: standard

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1242,6 +1242,7 @@ router_multicast:
 ```yaml
 router_pim_sparse_mode:
   ipv4:
+    ssm_range: < range >
     rp_addresses:
       < rp_address_1 >:
         groups:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-pim-sparse-mode.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-pim-sparse-mode.j2
@@ -18,5 +18,8 @@ router pim sparse-mode
       {{ other_anycast_rp_addresses_cli }}
 {%             endfor %}
 {%         endfor %}
+{%         if router_pim_sparse_mode.ipv4.ssm_range is arista.avd.defined %}
+      ssm range {{ router_pim_sparse_mode.ipv4.ssm_range }}
+{%         endif %}
 {%     endif %}
 {% endif %}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Related to #979

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- Add supports for specifying `ssm range` parameter on `router pim`

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been rebased from devel before I start
- [X] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contributing/) document.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [X] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
