### PR TITLE
fix switchport defaults

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/switchport-default.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/switchport-default.j2
@@ -7,15 +7,15 @@ switchport default mode routed
 switchport default mode access
 {% endif %}
 {# switchport default phone #}
-{% if switchport_default.phone.cos is is arista.avd.defined %}
+{% if switchport_default.phone.cos is arista.avd.defined %}
 switchport default phone cos {{ switchport_default.phone.cos }}
 !
 {% endif %}
-{% if switchport_default.phone.trunk is is arista.avd.defined and switchport_default.phone.trunk == 'untagged' %}
+{% if switchport_default.phone.trunk is arista.avd.defined and switchport_default.phone.trunk == 'untagged' %}
 switchport default phone trunk untagged
 !
 {% endif %}
-{% if switchport_default.phone.vlan is is arista.avd.defined and switchport_default.phone.vlan %}
+{% if switchport_default.phone.vlan is arista.avd.defined and switchport_default.phone.vlan %}
 switchport default phone vlan {{ switchport_default.phone.vlan }}
 !
 {% endif %}


### PR DESCRIPTION
## Change Summary

Fix syntax issue in switchport-defautls

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):


## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [ ] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
