### PR TITLE
Remove deprecated leaf_as_range from ci & md files

### DIFF
--- a/ansible_collections/arista/avd/docs/how-to/first-project.md
+++ b/ansible_collections/arista/avd/docs/how-to/first-project.md
@@ -203,8 +203,6 @@ Then, you have to describe devices for each role. Don't forget to set management
 spine:
   platform: vEOS-LAB
   bgp_as: 65001
-  # defines the range of acceptable remote ASNs from leaf switches
-  leaf_as_range: 65101-65132
   nodes:
     AVD-SPINE1:
       id: 1

--- a/ansible_collections/arista/avd/molecule/dhcp_configuration/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/dhcp_configuration/inventory/group_vars/DC1_FABRIC.yml
@@ -37,7 +37,6 @@ bgp_peer_groups:
 spine:
   platform: vEOS-LAB
   bgp_as: 65001
-  leaf_as_range: 65101-65132
   nodes:
     DC1-SPINE1:
       id: 1

--- a/ansible_collections/arista/avd/molecule/dhcp_provisionning/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/dhcp_provisionning/inventory/group_vars/DC1_FABRIC.yml
@@ -37,7 +37,6 @@ bgp_peer_groups:
 spine:
   platform: vEOS-LAB
   bgp_as: 65001
-  leaf_as_range: 65101-65132
   nodes:
     DC1-SPINE1:
       id: 1

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/inventory/group_vars/DC1_FABRIC.yml
@@ -37,7 +37,6 @@ bgp_peer_groups:
 spine:
   platform: vEOS-LAB
   bgp_as: 65001
-  leaf_as_range: 65101-65132
   nodes:
     DC1-SPINE1:
       id: 1

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp_list/inventory/group_vars/DC1_FABRIC.yml
@@ -37,7 +37,6 @@ bgp_peer_groups:
 spine:
   platform: vEOS-LAB
   bgp_as: 65001
-  leaf_as_range: 65101-65132
   nodes:
     DC1-SPINE1:
       id: 1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_FABRIC.yml
@@ -42,7 +42,6 @@ bgp_peer_groups:
 spine:
   platform: 7050SX3
   bgp_as: 65001
-  leaf_as_range: 65101-65132
   nodes:
     DC1-SPINE1:
       id: 1

--- a/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/eos_l3ls_evpn_deprecation_test/inventory/group_vars/DC1_FABRIC.yml
@@ -37,7 +37,6 @@ bgp_peer_groups:
 spine:
   platform: vEOS-LAB
   bgp_as: 65001
-  leaf_as_range: 65101-65132
   nodes:
     DC1-SPINE1:
       id: 1

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
@@ -50,7 +50,6 @@ bgp_peer_groups:
 spine:
   platform: 7050SX3
   bgp_as: 65001
-  leaf_as_range: 65101-65132
   nodes:
     DC1-SPINE1:
       id: 1

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/inventory/group_vars/DC1_FABRIC.yml
@@ -45,7 +45,6 @@ bgp_peer_groups:
 spine:
   platform: vEOS-LAB
   bgp_as: 65001
-  leaf_as_range: 65101-65132
   nodes:
     DC1-SPINE1:
       id: 1

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
@@ -52,7 +52,6 @@ bgp_peer_groups:
 spine:
   platform: vEOS-LAB
   bgp_as: 65001
-  leaf_as_range: 65101-65132
   nodes:
     DC1-SPINE1:
       id: 1

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
@@ -47,7 +47,6 @@ bgp_peer_groups:
 spine:
   platform: vEOS-LAB
   bgp_as: 65001
-  leaf_as_range: 65101-65132
   nodes:
     DC1-SPINE1:
       id: 1

--- a/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v1.0_to_v1.1/inventory/group_vars/DC1_FABRIC.yml
@@ -37,7 +37,6 @@ bgp_peer_groups:
 spine:
   platform: vEOS-LAB
   bgp_as: 65001
-  leaf_as_range: 65101-65132
   nodes:
     DC1-SPINE1:
       id: 1

--- a/ansible_collections/arista/avd/roles/dhcp_provisioner/README.md
+++ b/ansible_collections/arista/avd/roles/dhcp_provisioner/README.md
@@ -92,7 +92,6 @@ spine:
   platform: vEOS-LAB
   bgp_as: 65001
   # defines the range of acceptable remote ASNs from leaf switches
-  leaf_as_range: 65101-65132
   nodes:
     AVD2-SPINE1:
       id: 1


### PR DESCRIPTION
## Change Summary

Remove reference to deprecated knob `leaf_as_range`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [x] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Fixes #966

## Component(s) name

N/A

## Proposed changes

Remove reference to deprecated knob `leaf_as_range` in molecule inventories and in markdown files

## How to test

Run molecule

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contributing/) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
