### PR TITLE
Fix l2vlan igmp snooping enabled not being configurable

### DIFF
--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF1A.md
@@ -286,6 +286,7 @@ vlan internal order ascending range 1006 1199
 | 131 | Tenant_A_APP_Zone_2 | none  |
 | 160 | Tenant_A_VMOTION | none  |
 | 161 | Tenant_A_NFS | none  |
+| 162 | Tenant_A_FTP | none  |
 | 4091 | MLAG_PEER | MLAG  |
 
 ## VLANs Device Configuration
@@ -316,6 +317,9 @@ vlan 160
 vlan 161
    name Tenant_A_NFS
 !
+vlan 162
+   name Tenant_A_FTP
+!
 vlan 4091
    name MLAG_PEER
    trunk group MLAG
@@ -331,8 +335,8 @@ vlan 4091
 
 | Interface | Description | Mode | VLANs | Native VLAN | Trunk Group | Channel-Group |
 | --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
-| Ethernet1 | DC1-LEAF2A_Ethernet7 | *trunk | *110-111,120-121,130-131,160-161 | *- | *- | 1 |
-| Ethernet2 | DC1-LEAF2B_Ethernet7 | *trunk | *110-111,120-121,130-131,160-161 | *- | *- | 1 |
+| Ethernet1 | DC1-LEAF2A_Ethernet7 | *trunk | *110-111,120-121,130-131,160-162 | *- | *- | 1 |
+| Ethernet2 | DC1-LEAF2B_Ethernet7 | *trunk | *110-111,120-121,130-131,160-162 | *- | *- | 1 |
 | Ethernet3 | MLAG_PEER_DC1-L2LEAF1B_Ethernet3 | *trunk | *2-4094 | *- | *['MLAG'] | 3 |
 | Ethernet4 | MLAG_PEER_DC1-L2LEAF1B_Ethernet4 | *trunk | *2-4094 | *- | *['MLAG'] | 3 |
 
@@ -371,7 +375,7 @@ interface Ethernet4
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel1 | DC1_LEAF2_Po7 | switched | trunk | 110-111,120-121,130-131,160-161 | - | - | - | - | 1 | - |
+| Port-Channel1 | DC1_LEAF2_Po7 | switched | trunk | 110-111,120-121,130-131,160-162 | - | - | - | - | 1 | - |
 | Port-Channel3 | MLAG_PEER_DC1-L2LEAF1B_Po3 | switched | trunk | 2-4094 | - | ['MLAG'] | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
@@ -382,7 +386,7 @@ interface Port-Channel1
    description DC1_LEAF2_Po7
    no shutdown
    switchport
-   switchport trunk allowed vlan 110-111,120-121,130-131,160-161
+   switchport trunk allowed vlan 110-111,120-121,130-131,160-162
    switchport mode trunk
    mlag 1
 !
@@ -483,12 +487,15 @@ IGMP snooping is globally enabled.
 | VLAN | IGMP Snooping |
 | --- | --------------- |
 | 120 | disabled |
+| 160 | enabled |
+| 161 | disabled |
 
 ### IP IGMP Snooping Device Configuration
 
 ```eos
 !
 no ip igmp snooping vlan 120
+no ip igmp snooping vlan 161
 ```
 
 # Filters

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF1B.md
@@ -286,6 +286,7 @@ vlan internal order ascending range 1006 1199
 | 131 | Tenant_A_APP_Zone_2 | none  |
 | 160 | Tenant_A_VMOTION | none  |
 | 161 | Tenant_A_NFS | none  |
+| 162 | Tenant_A_FTP | none  |
 | 4091 | MLAG_PEER | MLAG  |
 
 ## VLANs Device Configuration
@@ -316,6 +317,9 @@ vlan 160
 vlan 161
    name Tenant_A_NFS
 !
+vlan 162
+   name Tenant_A_FTP
+!
 vlan 4091
    name MLAG_PEER
    trunk group MLAG
@@ -331,8 +335,8 @@ vlan 4091
 
 | Interface | Description | Mode | VLANs | Native VLAN | Trunk Group | Channel-Group |
 | --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
-| Ethernet1 | DC1-LEAF2A_Ethernet8 | *trunk | *110-111,120-121,130-131,160-161 | *- | *- | 1 |
-| Ethernet2 | DC1-LEAF2B_Ethernet8 | *trunk | *110-111,120-121,130-131,160-161 | *- | *- | 1 |
+| Ethernet1 | DC1-LEAF2A_Ethernet8 | *trunk | *110-111,120-121,130-131,160-162 | *- | *- | 1 |
+| Ethernet2 | DC1-LEAF2B_Ethernet8 | *trunk | *110-111,120-121,130-131,160-162 | *- | *- | 1 |
 | Ethernet3 | MLAG_PEER_DC1-L2LEAF1A_Ethernet3 | *trunk | *2-4094 | *- | *['MLAG'] | 3 |
 | Ethernet4 | MLAG_PEER_DC1-L2LEAF1A_Ethernet4 | *trunk | *2-4094 | *- | *['MLAG'] | 3 |
 
@@ -371,7 +375,7 @@ interface Ethernet4
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel1 | DC1_LEAF2_Po7 | switched | trunk | 110-111,120-121,130-131,160-161 | - | - | - | - | 1 | - |
+| Port-Channel1 | DC1_LEAF2_Po7 | switched | trunk | 110-111,120-121,130-131,160-162 | - | - | - | - | 1 | - |
 | Port-Channel3 | MLAG_PEER_DC1-L2LEAF1A_Po3 | switched | trunk | 2-4094 | - | ['MLAG'] | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
@@ -382,7 +386,7 @@ interface Port-Channel1
    description DC1_LEAF2_Po7
    no shutdown
    switchport
-   switchport trunk allowed vlan 110-111,120-121,130-131,160-161
+   switchport trunk allowed vlan 110-111,120-121,130-131,160-162
    switchport mode trunk
    mlag 1
 !
@@ -483,12 +487,15 @@ IGMP snooping is globally enabled.
 | VLAN | IGMP Snooping |
 | --- | --------------- |
 | 120 | disabled |
+| 160 | enabled |
+| 161 | disabled |
 
 ### IP IGMP Snooping Device Configuration
 
 ```eos
 !
 no ip igmp snooping vlan 120
+no ip igmp snooping vlan 161
 ```
 
 # Filters

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF2A.md
@@ -291,6 +291,7 @@ vlan internal order ascending range 1006 1199
 | 150 | Tenant_A_WAN_Zone_1 | none  |
 | 160 | Tenant_A_VMOTION | none  |
 | 161 | Tenant_A_NFS | none  |
+| 162 | Tenant_A_FTP | none  |
 | 210 | Tenant_B_OP_Zone_1 | none  |
 | 211 | Tenant_B_OP_Zone_2 | none  |
 | 250 | Tenant_B_WAN_Zone_1 | none  |
@@ -336,6 +337,9 @@ vlan 160
 vlan 161
    name Tenant_A_NFS
 !
+vlan 162
+   name Tenant_A_FTP
+!
 vlan 210
    name Tenant_B_OP_Zone_1
 !
@@ -369,8 +373,8 @@ vlan 4091
 
 | Interface | Description | Mode | VLANs | Native VLAN | Trunk Group | Channel-Group |
 | --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
-| Ethernet1 | DC1-SVC3A_Ethernet7 | *trunk | *110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350 | *- | *- | 1 |
-| Ethernet2 | DC1-SVC3B_Ethernet7 | *trunk | *110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350 | *- | *- | 1 |
+| Ethernet1 | DC1-SVC3A_Ethernet7 | *trunk | *110-111,120-121,130-131,140-141,150,160-162,210-211,250,310-311,350 | *- | *- | 1 |
+| Ethernet2 | DC1-SVC3B_Ethernet7 | *trunk | *110-111,120-121,130-131,140-141,150,160-162,210-211,250,310-311,350 | *- | *- | 1 |
 | Ethernet3 | MLAG_PEER_DC1-L2LEAF2B_Ethernet3 | *trunk | *2-4094 | *- | *['MLAG'] | 3 |
 | Ethernet4 | MLAG_PEER_DC1-L2LEAF2B_Ethernet4 | *trunk | *2-4094 | *- | *['MLAG'] | 3 |
 
@@ -409,7 +413,7 @@ interface Ethernet4
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel1 | DC1_SVC3_Po7 | switched | trunk | 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350 | - | - | - | - | 1 | - |
+| Port-Channel1 | DC1_SVC3_Po7 | switched | trunk | 110-111,120-121,130-131,140-141,150,160-162,210-211,250,310-311,350 | - | - | - | - | 1 | - |
 | Port-Channel3 | MLAG_PEER_DC1-L2LEAF2B_Po3 | switched | trunk | 2-4094 | - | ['MLAG'] | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
@@ -420,7 +424,7 @@ interface Port-Channel1
    description DC1_SVC3_Po7
    no shutdown
    switchport
-   switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350
+   switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,160-162,210-211,250,310-311,350
    switchport mode trunk
    mlag 1
 !
@@ -521,12 +525,15 @@ IGMP snooping is globally enabled.
 | VLAN | IGMP Snooping |
 | --- | --------------- |
 | 120 | disabled |
+| 160 | enabled |
+| 161 | disabled |
 
 ### IP IGMP Snooping Device Configuration
 
 ```eos
 !
 no ip igmp snooping vlan 120
+no ip igmp snooping vlan 161
 ```
 
 # Filters

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF2B.md
@@ -291,6 +291,7 @@ vlan internal order ascending range 1006 1199
 | 150 | Tenant_A_WAN_Zone_1 | none  |
 | 160 | Tenant_A_VMOTION | none  |
 | 161 | Tenant_A_NFS | none  |
+| 162 | Tenant_A_FTP | none  |
 | 210 | Tenant_B_OP_Zone_1 | none  |
 | 211 | Tenant_B_OP_Zone_2 | none  |
 | 250 | Tenant_B_WAN_Zone_1 | none  |
@@ -336,6 +337,9 @@ vlan 160
 vlan 161
    name Tenant_A_NFS
 !
+vlan 162
+   name Tenant_A_FTP
+!
 vlan 210
    name Tenant_B_OP_Zone_1
 !
@@ -369,8 +373,8 @@ vlan 4091
 
 | Interface | Description | Mode | VLANs | Native VLAN | Trunk Group | Channel-Group |
 | --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
-| Ethernet1 | DC1-SVC3A_Ethernet8 | *trunk | *110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350 | *- | *- | 1 |
-| Ethernet2 | DC1-SVC3B_Ethernet8 | *trunk | *110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350 | *- | *- | 1 |
+| Ethernet1 | DC1-SVC3A_Ethernet8 | *trunk | *110-111,120-121,130-131,140-141,150,160-162,210-211,250,310-311,350 | *- | *- | 1 |
+| Ethernet2 | DC1-SVC3B_Ethernet8 | *trunk | *110-111,120-121,130-131,140-141,150,160-162,210-211,250,310-311,350 | *- | *- | 1 |
 | Ethernet3 | MLAG_PEER_DC1-L2LEAF2A_Ethernet3 | *trunk | *2-4094 | *- | *['MLAG'] | 3 |
 | Ethernet4 | MLAG_PEER_DC1-L2LEAF2A_Ethernet4 | *trunk | *2-4094 | *- | *['MLAG'] | 3 |
 
@@ -409,7 +413,7 @@ interface Ethernet4
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel1 | DC1_SVC3_Po7 | switched | trunk | 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350 | - | - | - | - | 1 | - |
+| Port-Channel1 | DC1_SVC3_Po7 | switched | trunk | 110-111,120-121,130-131,140-141,150,160-162,210-211,250,310-311,350 | - | - | - | - | 1 | - |
 | Port-Channel3 | MLAG_PEER_DC1-L2LEAF2A_Po3 | switched | trunk | 2-4094 | - | ['MLAG'] | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
@@ -420,7 +424,7 @@ interface Port-Channel1
    description DC1_SVC3_Po7
    no shutdown
    switchport
-   switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350
+   switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,160-162,210-211,250,310-311,350
    switchport mode trunk
    mlag 1
 !
@@ -521,12 +525,15 @@ IGMP snooping is globally enabled.
 | VLAN | IGMP Snooping |
 | --- | --------------- |
 | 120 | disabled |
+| 160 | enabled |
+| 161 | disabled |
 
 ### IP IGMP Snooping Device Configuration
 
 ```eos
 !
 no ip igmp snooping vlan 120
+no ip igmp snooping vlan 161
 ```
 
 # Filters

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-L2LEAF3A.md
@@ -257,6 +257,7 @@ vlan internal order ascending range 1006 1199
 | 131 | Tenant_A_APP_Zone_2 | none  |
 | 160 | Tenant_A_VMOTION | none  |
 | 161 | Tenant_A_NFS | none  |
+| 162 | Tenant_A_FTP | none  |
 
 ## VLANs Device Configuration
 
@@ -285,6 +286,9 @@ vlan 160
 !
 vlan 161
    name Tenant_A_NFS
+!
+vlan 162
+   name Tenant_A_FTP
 ```
 
 # Interfaces
@@ -297,8 +301,8 @@ vlan 161
 
 | Interface | Description | Mode | VLANs | Native VLAN | Trunk Group | Channel-Group |
 | --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
-| Ethernet1 | DC1-LEAF2A_Ethernet9 | *trunk | *110-111,120-121,130-131,160-161 | *- | *- | 1 |
-| Ethernet2 | DC1-LEAF2B_Ethernet9 | *trunk | *110-111,120-121,130-131,160-161 | *- | *- | 1 |
+| Ethernet1 | DC1-LEAF2A_Ethernet9 | *trunk | *110-111,120-121,130-131,160-162 | *- | *- | 1 |
+| Ethernet2 | DC1-LEAF2B_Ethernet9 | *trunk | *110-111,120-121,130-131,160-162 | *- | *- | 1 |
 
 *Inherited from Port-Channel Interface
 
@@ -325,7 +329,7 @@ interface Ethernet2
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel1 | DC1_LEAF2_Po9 | switched | trunk | 110-111,120-121,130-131,160-161 | - | - | - | - | - | - |
+| Port-Channel1 | DC1_LEAF2_Po9 | switched | trunk | 110-111,120-121,130-131,160-162 | - | - | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -335,7 +339,7 @@ interface Port-Channel1
    description DC1_LEAF2_Po9
    no shutdown
    switchport
-   switchport trunk allowed vlan 110-111,120-121,130-131,160-161
+   switchport trunk allowed vlan 110-111,120-121,130-131,160-162
    switchport mode trunk
 ```
 
@@ -400,12 +404,15 @@ IGMP snooping is globally enabled.
 | VLAN | IGMP Snooping |
 | --- | --------------- |
 | 120 | disabled |
+| 160 | enabled |
+| 161 | disabled |
 
 ### IP IGMP Snooping Device Configuration
 
 ```eos
 !
 no ip igmp snooping vlan 120
+no ip igmp snooping vlan 161
 ```
 
 # Filters

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -291,6 +291,7 @@ vlan internal order ascending range 1006 1199
 | 141 | Tenant_A_DB_Zone_2 | none  |
 | 160 | Tenant_A_VMOTION | none  |
 | 161 | Tenant_A_NFS | none  |
+| 162 | Tenant_A_FTP | none  |
 | 210 | Tenant_B_OP_Zone_1 | none  |
 | 211 | Tenant_B_OP_Zone_2 | none  |
 | 310 | Tenant_C_OP_Zone_1 | none  |
@@ -330,6 +331,9 @@ vlan 160
 vlan 161
    name Tenant_A_NFS
 !
+vlan 162
+   name Tenant_A_FTP
+!
 vlan 210
    name Tenant_B_OP_Zone_1
 !
@@ -353,9 +357,9 @@ vlan 311
 
 | Interface | Description | Mode | VLANs | Native VLAN | Trunk Group | Channel-Group |
 | --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
-| Ethernet7 | DC1-L2LEAF1A_Ethernet1 | *trunk | *110-111,120-121,130-131,160-161 | *- | *- | 7 |
-| Ethernet8 | DC1-L2LEAF1B_Ethernet1 | *trunk | *110-111,120-121,130-131,160-161 | *- | *- | 7 |
-| Ethernet9 | DC1-L2LEAF3A_Ethernet1 | *trunk | *110-111,120-121,130-131,160-161 | *- | *- | 9 |
+| Ethernet7 | DC1-L2LEAF1A_Ethernet1 | *trunk | *110-111,120-121,130-131,160-162 | *- | *- | 7 |
+| Ethernet8 | DC1-L2LEAF1B_Ethernet1 | *trunk | *110-111,120-121,130-131,160-162 | *- | *- | 7 |
+| Ethernet9 | DC1-L2LEAF3A_Ethernet1 | *trunk | *110-111,120-121,130-131,160-162 | *- | *- | 9 |
 | Ethernet10 | server01_MLAG_Eth2 | *trunk | *210-211 | *- | *- | 10 |
 | Ethernet11 | server01_MTU_PROFILE_MLAG_Eth4 | *access | *110 | *- | *- | 11 |
 | Ethernet12 | server01_MTU_ADAPTOR_MLAG_Eth6 | *access | *- | *- | *- | 12 |
@@ -466,8 +470,8 @@ interface Ethernet21
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel7 | DC1_L2LEAF1_Po1 | switched | trunk | 110-111,120-121,130-131,160-161 | - | - | - | - | - | 0000:1234:0808:0707:0606 |
-| Port-Channel9 | DC1-L2LEAF3A_Po1 | switched | trunk | 110-111,120-121,130-131,160-161 | - | - | - | - | - | 0000:1234:0606:0707:0808 |
+| Port-Channel7 | DC1_L2LEAF1_Po1 | switched | trunk | 110-111,120-121,130-131,160-162 | - | - | - | - | - | 0000:1234:0808:0707:0606 |
+| Port-Channel9 | DC1-L2LEAF3A_Po1 | switched | trunk | 110-111,120-121,130-131,160-162 | - | - | - | - | - | 0000:1234:0606:0707:0808 |
 | Port-Channel10 | server01_MLAG_PortChanne1 | switched | trunk | 210-211 | - | - | - | - | 10 | - |
 | Port-Channel11 | server01_MTU_PROFILE_MLAG_PortChanne1 | switched | access | 110 | - | - | - | - | 11 | - |
 | Port-Channel12 | server01_MTU_ADAPTOR_MLAG_PortChanne1 | switched | access | - | - | - | - | - | 12 | - |
@@ -481,7 +485,7 @@ interface Port-Channel7
    description DC1_L2LEAF1_Po1
    no shutdown
    switchport
-   switchport trunk allowed vlan 110-111,120-121,130-131,160-161
+   switchport trunk allowed vlan 110-111,120-121,130-131,160-162
    switchport mode trunk
    evpn ethernet-segment
       identifier 0000:1234:0808:0707:0606
@@ -492,7 +496,7 @@ interface Port-Channel9
    description DC1-L2LEAF3A_Po1
    no shutdown
    switchport
-   switchport trunk allowed vlan 110-111,120-121,130-131,160-161
+   switchport trunk allowed vlan 110-111,120-121,130-131,160-162
    switchport mode trunk
    evpn ethernet-segment
       identifier 0000:1234:0606:0707:0808
@@ -712,6 +716,7 @@ interface Vlan311
 | 141 | 10141 |
 | 160 | 10160 |
 | 161 | 10161 |
+| 162 | 10162 |
 | 210 | 20210 |
 | 211 | 20211 |
 | 310 | 30310 |
@@ -745,6 +750,7 @@ interface Vxlan1
    vxlan vlan 141 vni 10141
    vxlan vlan 160 vni 10160
    vxlan vlan 161 vni 10161
+   vxlan vlan 162 vni 10162
    vxlan vlan 210 vni 20210
    vxlan vlan 211 vni 20211
    vxlan vlan 310 vni 30310
@@ -902,6 +908,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | ----------------- | ------------------- | ----------------- | ------------------- | ------------------- | ------------ | ----- |
 | Tenant_A_APP_Zone | 192.168.255.10:12 | 12:12 | - | - | learned | 130-131 |
 | Tenant_A_DB_Zone | 192.168.255.10:13 | 13:13 | - | - | learned | 140-141 |
+| Tenant_A_FTP | 192.168.255.10:10162 | 10162:10162 | - | - | learned | 162 |
 | Tenant_A_NFS | 192.168.255.10:10161 | 10161:10161 | - | - | learned | 161 |
 | Tenant_A_OP_Zone | 192.168.255.10:10 | 10:10 | - | - | learned | 110-111 |
 | Tenant_A_VMOTION | 192.168.255.10:10160 | 10160:10160 | - | - | learned | 160 |
@@ -974,6 +981,12 @@ router bgp 65102
       route-target both 13:13
       redistribute learned
       vlan 140-141
+   !
+   vlan-aware-bundle Tenant_A_FTP
+      rd 192.168.255.10:10162
+      route-target both 10162:10162
+      redistribute learned
+      vlan 162
    !
    vlan-aware-bundle Tenant_A_NFS
       rd 192.168.255.10:10161
@@ -1092,12 +1105,15 @@ IGMP snooping is globally enabled.
 | VLAN | IGMP Snooping |
 | --- | --------------- |
 | 120 | disabled |
+| 160 | enabled |
+| 161 | disabled |
 
 ### IP IGMP Snooping Device Configuration
 
 ```eos
 !
 no ip igmp snooping vlan 120
+no ip igmp snooping vlan 161
 ```
 
 # Filters

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -291,6 +291,7 @@ vlan internal order ascending range 1006 1199
 | 141 | Tenant_A_DB_Zone_2 | none  |
 | 160 | Tenant_A_VMOTION | none  |
 | 161 | Tenant_A_NFS | none  |
+| 162 | Tenant_A_FTP | none  |
 | 210 | Tenant_B_OP_Zone_1 | none  |
 | 211 | Tenant_B_OP_Zone_2 | none  |
 | 310 | Tenant_C_OP_Zone_1 | none  |
@@ -330,6 +331,9 @@ vlan 160
 vlan 161
    name Tenant_A_NFS
 !
+vlan 162
+   name Tenant_A_FTP
+!
 vlan 210
    name Tenant_B_OP_Zone_1
 !
@@ -353,9 +357,9 @@ vlan 311
 
 | Interface | Description | Mode | VLANs | Native VLAN | Trunk Group | Channel-Group |
 | --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
-| Ethernet7 | DC1-L2LEAF1A_Ethernet2 | *trunk | *110-111,120-121,130-131,160-161 | *- | *- | 7 |
-| Ethernet8 | DC1-L2LEAF1B_Ethernet2 | *trunk | *110-111,120-121,130-131,160-161 | *- | *- | 7 |
-| Ethernet9 | DC1-L2LEAF3A_Ethernet2 | *trunk | *110-111,120-121,130-131,160-161 | *- | *- | 9 |
+| Ethernet7 | DC1-L2LEAF1A_Ethernet2 | *trunk | *110-111,120-121,130-131,160-162 | *- | *- | 7 |
+| Ethernet8 | DC1-L2LEAF1B_Ethernet2 | *trunk | *110-111,120-121,130-131,160-162 | *- | *- | 7 |
+| Ethernet9 | DC1-L2LEAF3A_Ethernet2 | *trunk | *110-111,120-121,130-131,160-162 | *- | *- | 9 |
 | Ethernet10 | server01_MLAG_Eth3 | *trunk | *210-211 | *- | *- | 10 |
 | Ethernet11 | server01_MTU_PROFILE_MLAG_Eth5 | *access | *110 | *- | *- | 11 |
 | Ethernet12 | server01_MTU_ADAPTOR_MLAG_Eth7 | *access | *- | *- | *- | 12 |
@@ -466,8 +470,8 @@ interface Ethernet21
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel7 | DC1_L2LEAF1_Po1 | switched | trunk | 110-111,120-121,130-131,160-161 | - | - | - | - | - | 0000:1234:0808:0707:0606 |
-| Port-Channel9 | DC1-L2LEAF3A_Po1 | switched | trunk | 110-111,120-121,130-131,160-161 | - | - | - | - | - | 0000:1234:0606:0707:0808 |
+| Port-Channel7 | DC1_L2LEAF1_Po1 | switched | trunk | 110-111,120-121,130-131,160-162 | - | - | - | - | - | 0000:1234:0808:0707:0606 |
+| Port-Channel9 | DC1-L2LEAF3A_Po1 | switched | trunk | 110-111,120-121,130-131,160-162 | - | - | - | - | - | 0000:1234:0606:0707:0808 |
 | Port-Channel10 | server01_MLAG_PortChanne1 | switched | trunk | 210-211 | - | - | - | - | 10 | - |
 | Port-Channel11 | server01_MTU_PROFILE_MLAG_PortChanne1 | switched | access | 110 | - | - | - | - | 11 | - |
 | Port-Channel12 | server01_MTU_ADAPTOR_MLAG_PortChanne1 | switched | access | - | - | - | - | - | 12 | - |
@@ -481,7 +485,7 @@ interface Port-Channel7
    description DC1_L2LEAF1_Po1
    no shutdown
    switchport
-   switchport trunk allowed vlan 110-111,120-121,130-131,160-161
+   switchport trunk allowed vlan 110-111,120-121,130-131,160-162
    switchport mode trunk
    evpn ethernet-segment
       identifier 0000:1234:0808:0707:0606
@@ -492,7 +496,7 @@ interface Port-Channel9
    description DC1-L2LEAF3A_Po1
    no shutdown
    switchport
-   switchport trunk allowed vlan 110-111,120-121,130-131,160-161
+   switchport trunk allowed vlan 110-111,120-121,130-131,160-162
    switchport mode trunk
    evpn ethernet-segment
       identifier 0000:1234:0606:0707:0808
@@ -712,6 +716,7 @@ interface Vlan311
 | 141 | 10141 |
 | 160 | 10160 |
 | 161 | 10161 |
+| 162 | 10162 |
 | 210 | 20210 |
 | 211 | 20211 |
 | 310 | 30310 |
@@ -745,6 +750,7 @@ interface Vxlan1
    vxlan vlan 141 vni 10141
    vxlan vlan 160 vni 10160
    vxlan vlan 161 vni 10161
+   vxlan vlan 162 vni 10162
    vxlan vlan 210 vni 20210
    vxlan vlan 211 vni 20211
    vxlan vlan 310 vni 30310
@@ -902,6 +908,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | ----------------- | ------------------- | ----------------- | ------------------- | ------------------- | ------------ | ----- |
 | Tenant_A_APP_Zone | 192.168.255.11:12 | 12:12 | - | - | learned | 130-131 |
 | Tenant_A_DB_Zone | 192.168.255.11:13 | 13:13 | - | - | learned | 140-141 |
+| Tenant_A_FTP | 192.168.255.11:10162 | 10162:10162 | - | - | learned | 162 |
 | Tenant_A_NFS | 192.168.255.11:10161 | 10161:10161 | - | - | learned | 161 |
 | Tenant_A_OP_Zone | 192.168.255.11:10 | 10:10 | - | - | learned | 110-111 |
 | Tenant_A_VMOTION | 192.168.255.11:10160 | 10160:10160 | - | - | learned | 160 |
@@ -974,6 +981,12 @@ router bgp 65102
       route-target both 13:13
       redistribute learned
       vlan 140-141
+   !
+   vlan-aware-bundle Tenant_A_FTP
+      rd 192.168.255.11:10162
+      route-target both 10162:10162
+      redistribute learned
+      vlan 162
    !
    vlan-aware-bundle Tenant_A_NFS
       rd 192.168.255.11:10161
@@ -1092,12 +1105,15 @@ IGMP snooping is globally enabled.
 | VLAN | IGMP Snooping |
 | --- | --------------- |
 | 120 | disabled |
+| 160 | enabled |
+| 161 | disabled |
 
 ### IP IGMP Snooping Device Configuration
 
 ```eos
 !
 no ip igmp snooping vlan 120
+no ip igmp snooping vlan 161
 ```
 
 # Filters

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -304,6 +304,7 @@ vlan internal order ascending range 1006 1199
 | 150 | Tenant_A_WAN_Zone_1 | none  |
 | 160 | Tenant_A_VMOTION | none  |
 | 161 | Tenant_A_NFS | none  |
+| 162 | Tenant_A_FTP | none  |
 | 210 | Tenant_B_OP_Zone_1 | none  |
 | 211 | Tenant_B_OP_Zone_2 | none  |
 | 250 | Tenant_B_WAN_Zone_1 | none  |
@@ -361,6 +362,9 @@ vlan 160
 !
 vlan 161
    name Tenant_A_NFS
+!
+vlan 162
+   name Tenant_A_FTP
 !
 vlan 210
    name Tenant_B_OP_Zone_1
@@ -433,8 +437,8 @@ vlan 4092
 | --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
 | Ethernet5 | MLAG_PEER_DC1-SVC3B_Ethernet5 | *trunk | *2-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 5 |
 | Ethernet6 | MLAG_PEER_DC1-SVC3B_Ethernet6 | *trunk | *2-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 5 |
-| Ethernet7 | DC1-L2LEAF2A_Ethernet1 | *trunk | *110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350 | *- | *- | 7 |
-| Ethernet8 | DC1-L2LEAF2B_Ethernet1 | *trunk | *110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350 | *- | *- | 7 |
+| Ethernet7 | DC1-L2LEAF2A_Ethernet1 | *trunk | *110-111,120-121,130-131,140-141,150,160-162,210-211,250,310-311,350 | *- | *- | 7 |
+| Ethernet8 | DC1-L2LEAF2B_Ethernet1 | *trunk | *110-111,120-121,130-131,140-141,150,160-162,210-211,250,310-311,350 | *- | *- | 7 |
 | Ethernet10 | server03_ESI_Eth1 | *trunk | *110-111,210-211 | *- | *- | 10 |
 | Ethernet11 |  server04_inherit_all_from_profile_Eth1 | trunk | 1-4094 | - | - | - |
 | Ethernet12 |  server05_no_profile_Eth1 | trunk | 1-4094 | - | - | - |
@@ -611,7 +615,7 @@ interface Ethernet44
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
 | Port-Channel5 | MLAG_PEER_DC1-SVC3B_Po5 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
-| Port-Channel7 | DC1_L2LEAF2_Po1 | switched | trunk | 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350 | - | - | - | - | 7 | - |
+| Port-Channel7 | DC1_L2LEAF2_Po1 | switched | trunk | 110-111,120-121,130-131,140-141,150,160-162,210-211,250,310-311,350 | - | - | - | - | 7 | - |
 | Port-Channel10 | server03_ESI_PortChanne1 | switched | trunk | 110-111,210-211 | - | - | - | - | - | 0000:1234:0303:0202:0101 |
 | Port-Channel14 | server07_inherit_all_from_profile_port_channel_ALL_WITH_SECURITY_PORT_CHANNEL | switched | trunk | 1-4094 | - | - | - | - | 14 | - |
 | Port-Channel15 | server08_no_profile_port_channel_server08_no_profile_port_channel | switched | trunk | 1-4094 | - | - | - | - | 15 | - |
@@ -636,7 +640,7 @@ interface Port-Channel7
    description DC1_L2LEAF2_Po1
    no shutdown
    switchport
-   switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350
+   switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,160-162,210-211,250,310-311,350
    switchport mode trunk
    mlag 7
 !
@@ -1032,6 +1036,7 @@ interface Vlan4092
 | 150 | 10150 |
 | 160 | 10160 |
 | 161 | 10161 |
+| 162 | 10162 |
 | 210 | 20210 |
 | 211 | 20211 |
 | 250 | 20250 |
@@ -1072,6 +1077,7 @@ interface Vxlan1
    vxlan vlan 150 vni 10150
    vxlan vlan 160 vni 10160
    vxlan vlan 161 vni 10161
+   vxlan vlan 162 vni 10162
    vxlan vlan 210 vni 20210
    vxlan vlan 211 vni 20211
    vxlan vlan 250 vni 20250
@@ -1263,6 +1269,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | ----------------- | ------------------- | ----------------- | ------------------- | ------------------- | ------------ | ----- |
 | Tenant_A_APP_Zone | 192.168.255.12:12 | 12:12 | - | - | learned | 130-131 |
 | Tenant_A_DB_Zone | 192.168.255.12:13 | 13:13 | - | - | learned | 140-141 |
+| Tenant_A_FTP | 192.168.255.12:10162 | 10162:10162 | - | - | learned | 162 |
 | Tenant_A_NFS | 192.168.255.12:10161 | 10161:10161 | - | - | learned | 161 |
 | Tenant_A_OP_Zone | 192.168.255.12:10 | 10:10 | - | - | learned | 110-111 |
 | Tenant_A_VMOTION | 192.168.255.12:10160 | 10160:10160 | - | - | learned | 160 |
@@ -1350,6 +1357,12 @@ router bgp 65103
       route-target both 13:13
       redistribute learned
       vlan 140-141
+   !
+   vlan-aware-bundle Tenant_A_FTP
+      rd 192.168.255.12:10162
+      route-target both 10162:10162
+      redistribute learned
+      vlan 162
    !
    vlan-aware-bundle Tenant_A_NFS
       rd 192.168.255.12:10161
@@ -1519,12 +1532,15 @@ IGMP snooping is globally enabled.
 | VLAN | IGMP Snooping |
 | --- | --------------- |
 | 120 | disabled |
+| 160 | enabled |
+| 161 | disabled |
 
 ### IP IGMP Snooping Device Configuration
 
 ```eos
 !
 no ip igmp snooping vlan 120
+no ip igmp snooping vlan 161
 ```
 
 # Filters

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -304,6 +304,7 @@ vlan internal order ascending range 1006 1199
 | 150 | Tenant_A_WAN_Zone_1 | none  |
 | 160 | Tenant_A_VMOTION | none  |
 | 161 | Tenant_A_NFS | none  |
+| 162 | Tenant_A_FTP | none  |
 | 210 | Tenant_B_OP_Zone_1 | none  |
 | 211 | Tenant_B_OP_Zone_2 | none  |
 | 250 | Tenant_B_WAN_Zone_1 | none  |
@@ -361,6 +362,9 @@ vlan 160
 !
 vlan 161
    name Tenant_A_NFS
+!
+vlan 162
+   name Tenant_A_FTP
 !
 vlan 210
    name Tenant_B_OP_Zone_1
@@ -433,8 +437,8 @@ vlan 4092
 | --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
 | Ethernet5 | MLAG_PEER_DC1-SVC3A_Ethernet5 | *trunk | *2-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 5 |
 | Ethernet6 | MLAG_PEER_DC1-SVC3A_Ethernet6 | *trunk | *2-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 5 |
-| Ethernet7 | DC1-L2LEAF2A_Ethernet2 | *trunk | *110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350 | *- | *- | 7 |
-| Ethernet8 | DC1-L2LEAF2B_Ethernet2 | *trunk | *110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350 | *- | *- | 7 |
+| Ethernet7 | DC1-L2LEAF2A_Ethernet2 | *trunk | *110-111,120-121,130-131,140-141,150,160-162,210-211,250,310-311,350 | *- | *- | 7 |
+| Ethernet8 | DC1-L2LEAF2B_Ethernet2 | *trunk | *110-111,120-121,130-131,140-141,150,160-162,210-211,250,310-311,350 | *- | *- | 7 |
 | Ethernet10 | server03_ESI_Eth2 | *trunk | *110-111,210-211 | *- | *- | 10 |
 | Ethernet11 |  server04_inherit_all_from_profile_Eth2 | trunk | 1-4094 | - | - | - |
 | Ethernet12 |  server05_no_profile_Eth2 | trunk | 1-4094 | - | - | - |
@@ -611,7 +615,7 @@ interface Ethernet44
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
 | Port-Channel5 | MLAG_PEER_DC1-SVC3A_Po5 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
-| Port-Channel7 | DC1_L2LEAF2_Po1 | switched | trunk | 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350 | - | - | - | - | 7 | - |
+| Port-Channel7 | DC1_L2LEAF2_Po1 | switched | trunk | 110-111,120-121,130-131,140-141,150,160-162,210-211,250,310-311,350 | - | - | - | - | 7 | - |
 | Port-Channel10 | server03_ESI_PortChanne1 | switched | trunk | 110-111,210-211 | - | - | - | - | - | 0000:1234:0303:0202:0101 |
 | Port-Channel14 | server07_inherit_all_from_profile_port_channel_ALL_WITH_SECURITY_PORT_CHANNEL | switched | trunk | 1-4094 | - | - | - | - | 14 | - |
 | Port-Channel15 | server08_no_profile_port_channel_server08_no_profile_port_channel | switched | trunk | 1-4094 | - | - | - | - | 15 | - |
@@ -636,7 +640,7 @@ interface Port-Channel7
    description DC1_L2LEAF2_Po1
    no shutdown
    switchport
-   switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350
+   switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,160-162,210-211,250,310-311,350
    switchport mode trunk
    mlag 7
 !
@@ -1032,6 +1036,7 @@ interface Vlan4092
 | 150 | 10150 |
 | 160 | 10160 |
 | 161 | 10161 |
+| 162 | 10162 |
 | 210 | 20210 |
 | 211 | 20211 |
 | 250 | 20250 |
@@ -1072,6 +1077,7 @@ interface Vxlan1
    vxlan vlan 150 vni 10150
    vxlan vlan 160 vni 10160
    vxlan vlan 161 vni 10161
+   vxlan vlan 162 vni 10162
    vxlan vlan 210 vni 20210
    vxlan vlan 211 vni 20211
    vxlan vlan 250 vni 20250
@@ -1263,6 +1269,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | ----------------- | ------------------- | ----------------- | ------------------- | ------------------- | ------------ | ----- |
 | Tenant_A_APP_Zone | 192.168.255.13:12 | 12:12 | - | - | learned | 130-131 |
 | Tenant_A_DB_Zone | 192.168.255.13:13 | 13:13 | - | - | learned | 140-141 |
+| Tenant_A_FTP | 192.168.255.13:10162 | 10162:10162 | - | - | learned | 162 |
 | Tenant_A_NFS | 192.168.255.13:10161 | 10161:10161 | - | - | learned | 161 |
 | Tenant_A_OP_Zone | 192.168.255.13:10 | 10:10 | - | - | learned | 110-111 |
 | Tenant_A_VMOTION | 192.168.255.13:10160 | 10160:10160 | - | - | learned | 160 |
@@ -1350,6 +1357,12 @@ router bgp 65103
       route-target both 13:13
       redistribute learned
       vlan 140-141
+   !
+   vlan-aware-bundle Tenant_A_FTP
+      rd 192.168.255.13:10162
+      route-target both 10162:10162
+      redistribute learned
+      vlan 162
    !
    vlan-aware-bundle Tenant_A_NFS
       rd 192.168.255.13:10161
@@ -1519,12 +1532,15 @@ IGMP snooping is globally enabled.
 | VLAN | IGMP Snooping |
 | --- | --------------- |
 | 120 | disabled |
+| 160 | enabled |
+| 161 | disabled |
 
 ### IP IGMP Snooping Device Configuration
 
 ```eos
 !
 no ip igmp snooping vlan 120
+no ip igmp snooping vlan 161
 ```
 
 # Filters

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF1A.cfg
@@ -7,6 +7,7 @@ daemon TerminAttr
 vlan internal order ascending range 1006 1199
 !
 no ip igmp snooping vlan 120
+no ip igmp snooping vlan 161
 !
 transceiver qsfp default-mode 4x10G
 !
@@ -56,6 +57,9 @@ vlan 160
 vlan 161
    name Tenant_A_NFS
 !
+vlan 162
+   name Tenant_A_FTP
+!
 vlan 4091
    name MLAG_PEER
    trunk group MLAG
@@ -66,7 +70,7 @@ interface Port-Channel1
    description DC1_LEAF2_Po7
    no shutdown
    switchport
-   switchport trunk allowed vlan 110-111,120-121,130-131,160-161
+   switchport trunk allowed vlan 110-111,120-121,130-131,160-162
    switchport mode trunk
    mlag 1
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF1B.cfg
@@ -7,6 +7,7 @@ daemon TerminAttr
 vlan internal order ascending range 1006 1199
 !
 no ip igmp snooping vlan 120
+no ip igmp snooping vlan 161
 !
 transceiver qsfp default-mode 4x10G
 !
@@ -56,6 +57,9 @@ vlan 160
 vlan 161
    name Tenant_A_NFS
 !
+vlan 162
+   name Tenant_A_FTP
+!
 vlan 4091
    name MLAG_PEER
    trunk group MLAG
@@ -66,7 +70,7 @@ interface Port-Channel1
    description DC1_LEAF2_Po7
    no shutdown
    switchport
-   switchport trunk allowed vlan 110-111,120-121,130-131,160-161
+   switchport trunk allowed vlan 110-111,120-121,130-131,160-162
    switchport mode trunk
    mlag 1
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF2A.cfg
@@ -7,6 +7,7 @@ daemon TerminAttr
 vlan internal order ascending range 1006 1199
 !
 no ip igmp snooping vlan 120
+no ip igmp snooping vlan 161
 !
 transceiver qsfp default-mode 4x10G
 !
@@ -65,6 +66,9 @@ vlan 160
 vlan 161
    name Tenant_A_NFS
 !
+vlan 162
+   name Tenant_A_FTP
+!
 vlan 210
    name Tenant_B_OP_Zone_1
 !
@@ -93,7 +97,7 @@ interface Port-Channel1
    description DC1_SVC3_Po7
    no shutdown
    switchport
-   switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350
+   switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,160-162,210-211,250,310-311,350
    switchport mode trunk
    mlag 1
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF2B.cfg
@@ -7,6 +7,7 @@ daemon TerminAttr
 vlan internal order ascending range 1006 1199
 !
 no ip igmp snooping vlan 120
+no ip igmp snooping vlan 161
 !
 transceiver qsfp default-mode 4x10G
 !
@@ -65,6 +66,9 @@ vlan 160
 vlan 161
    name Tenant_A_NFS
 !
+vlan 162
+   name Tenant_A_FTP
+!
 vlan 210
    name Tenant_B_OP_Zone_1
 !
@@ -93,7 +97,7 @@ interface Port-Channel1
    description DC1_SVC3_Po7
    no shutdown
    switchport
-   switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350
+   switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,160-162,210-211,250,310-311,350
    switchport mode trunk
    mlag 1
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF3A.cfg
@@ -7,6 +7,7 @@ daemon TerminAttr
 vlan internal order ascending range 1006 1199
 !
 no ip igmp snooping vlan 120
+no ip igmp snooping vlan 161
 !
 transceiver qsfp default-mode 4x10G
 !
@@ -55,13 +56,16 @@ vlan 160
 vlan 161
    name Tenant_A_NFS
 !
+vlan 162
+   name Tenant_A_FTP
+!
 vrf instance MGMT
 !
 interface Port-Channel1
    description DC1_LEAF2_Po9
    no shutdown
    switchport
-   switchport trunk allowed vlan 110-111,120-121,130-131,160-161
+   switchport trunk allowed vlan 110-111,120-121,130-131,160-162
    switchport mode trunk
 !
 interface Ethernet1

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
@@ -7,6 +7,7 @@ daemon TerminAttr
 vlan internal order ascending range 1006 1199
 !
 no ip igmp snooping vlan 120
+no ip igmp snooping vlan 161
 !
 transceiver qsfp default-mode 4x10G
 !
@@ -69,6 +70,9 @@ vlan 160
 vlan 161
    name Tenant_A_NFS
 !
+vlan 162
+   name Tenant_A_FTP
+!
 vlan 210
    name Tenant_B_OP_Zone_1
 !
@@ -99,7 +103,7 @@ interface Port-Channel7
    description DC1_L2LEAF1_Po1
    no shutdown
    switchport
-   switchport trunk allowed vlan 110-111,120-121,130-131,160-161
+   switchport trunk allowed vlan 110-111,120-121,130-131,160-162
    switchport mode trunk
    evpn ethernet-segment
       identifier 0000:1234:0808:0707:0606
@@ -110,7 +114,7 @@ interface Port-Channel9
    description DC1-L2LEAF3A_Po1
    no shutdown
    switchport
-   switchport trunk allowed vlan 110-111,120-121,130-131,160-161
+   switchport trunk allowed vlan 110-111,120-121,130-131,160-162
    switchport mode trunk
    evpn ethernet-segment
       identifier 0000:1234:0606:0707:0808
@@ -337,6 +341,7 @@ interface Vxlan1
    vxlan vlan 141 vni 10141
    vxlan vlan 160 vni 10160
    vxlan vlan 161 vni 10161
+   vxlan vlan 162 vni 10162
    vxlan vlan 210 vni 20210
    vxlan vlan 211 vni 20211
    vxlan vlan 310 vni 30310
@@ -426,6 +431,12 @@ router bgp 65102
       route-target both 13:13
       redistribute learned
       vlan 140-141
+   !
+   vlan-aware-bundle Tenant_A_FTP
+      rd 192.168.255.10:10162
+      route-target both 10162:10162
+      redistribute learned
+      vlan 162
    !
    vlan-aware-bundle Tenant_A_NFS
       rd 192.168.255.10:10161

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
@@ -7,6 +7,7 @@ daemon TerminAttr
 vlan internal order ascending range 1006 1199
 !
 no ip igmp snooping vlan 120
+no ip igmp snooping vlan 161
 !
 transceiver qsfp default-mode 4x10G
 !
@@ -69,6 +70,9 @@ vlan 160
 vlan 161
    name Tenant_A_NFS
 !
+vlan 162
+   name Tenant_A_FTP
+!
 vlan 210
    name Tenant_B_OP_Zone_1
 !
@@ -99,7 +103,7 @@ interface Port-Channel7
    description DC1_L2LEAF1_Po1
    no shutdown
    switchport
-   switchport trunk allowed vlan 110-111,120-121,130-131,160-161
+   switchport trunk allowed vlan 110-111,120-121,130-131,160-162
    switchport mode trunk
    evpn ethernet-segment
       identifier 0000:1234:0808:0707:0606
@@ -110,7 +114,7 @@ interface Port-Channel9
    description DC1-L2LEAF3A_Po1
    no shutdown
    switchport
-   switchport trunk allowed vlan 110-111,120-121,130-131,160-161
+   switchport trunk allowed vlan 110-111,120-121,130-131,160-162
    switchport mode trunk
    evpn ethernet-segment
       identifier 0000:1234:0606:0707:0808
@@ -337,6 +341,7 @@ interface Vxlan1
    vxlan vlan 141 vni 10141
    vxlan vlan 160 vni 10160
    vxlan vlan 161 vni 10161
+   vxlan vlan 162 vni 10162
    vxlan vlan 210 vni 20210
    vxlan vlan 211 vni 20211
    vxlan vlan 310 vni 30310
@@ -426,6 +431,12 @@ router bgp 65102
       route-target both 13:13
       redistribute learned
       vlan 140-141
+   !
+   vlan-aware-bundle Tenant_A_FTP
+      rd 192.168.255.11:10162
+      route-target both 10162:10162
+      redistribute learned
+      vlan 162
    !
    vlan-aware-bundle Tenant_A_NFS
       rd 192.168.255.11:10161

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
@@ -7,6 +7,7 @@ daemon TerminAttr
 vlan internal order ascending range 1006 1199
 !
 no ip igmp snooping vlan 120
+no ip igmp snooping vlan 161
 !
 transceiver qsfp default-mode 4x10G
 !
@@ -69,6 +70,9 @@ vlan 160
 !
 vlan 161
    name Tenant_A_NFS
+!
+vlan 162
+   name Tenant_A_FTP
 !
 vlan 210
    name Tenant_B_OP_Zone_1
@@ -161,7 +165,7 @@ interface Port-Channel7
    description DC1_L2LEAF2_Po1
    no shutdown
    switchport
-   switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350
+   switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,160-162,210-211,250,310-311,350
    switchport mode trunk
    mlag 7
 !
@@ -598,6 +602,7 @@ interface Vxlan1
    vxlan vlan 150 vni 10150
    vxlan vlan 160 vni 10160
    vxlan vlan 161 vni 10161
+   vxlan vlan 162 vni 10162
    vxlan vlan 210 vni 20210
    vxlan vlan 211 vni 20211
    vxlan vlan 250 vni 20250
@@ -713,6 +718,12 @@ router bgp 65103
       route-target both 13:13
       redistribute learned
       vlan 140-141
+   !
+   vlan-aware-bundle Tenant_A_FTP
+      rd 192.168.255.12:10162
+      route-target both 10162:10162
+      redistribute learned
+      vlan 162
    !
    vlan-aware-bundle Tenant_A_NFS
       rd 192.168.255.12:10161

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
@@ -7,6 +7,7 @@ daemon TerminAttr
 vlan internal order ascending range 1006 1199
 !
 no ip igmp snooping vlan 120
+no ip igmp snooping vlan 161
 !
 transceiver qsfp default-mode 4x10G
 !
@@ -69,6 +70,9 @@ vlan 160
 !
 vlan 161
    name Tenant_A_NFS
+!
+vlan 162
+   name Tenant_A_FTP
 !
 vlan 210
    name Tenant_B_OP_Zone_1
@@ -161,7 +165,7 @@ interface Port-Channel7
    description DC1_L2LEAF2_Po1
    no shutdown
    switchport
-   switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350
+   switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,160-162,210-211,250,310-311,350
    switchport mode trunk
    mlag 7
 !
@@ -598,6 +602,7 @@ interface Vxlan1
    vxlan vlan 150 vni 10150
    vxlan vlan 160 vni 10160
    vxlan vlan 161 vni 10161
+   vxlan vlan 162 vni 10162
    vxlan vlan 210 vni 20210
    vxlan vlan 211 vni 20211
    vxlan vlan 250 vni 20250
@@ -713,6 +718,12 @@ router bgp 65103
       route-target both 13:13
       redistribute learned
       vlan 140-141
+   !
+   vlan-aware-bundle Tenant_A_FTP
+      rd 192.168.255.13:10162
+      route-target both 10162:10162
+      redistribute learned
+      vlan 162
    !
    vlan-aware-bundle Tenant_A_NFS
       rd 192.168.255.13:10161

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -94,6 +94,9 @@ vlans:
   161:
     tenant: Tenant_A
     name: Tenant_A_NFS
+  162:
+    tenant: Tenant_A
+    name: Tenant_A_FTP
 vlan_interfaces:
   Vlan4091:
     description: MLAG_PEER
@@ -114,7 +117,7 @@ port_channel_interfaces:
     description: DC1_LEAF2_Po7
     type: switched
     shutdown: false
-    vlans: 110-111,120-121,130-131,160-161
+    vlans: 110-111,120-121,130-131,160-162
     mode: trunk
     mlag: 1
 ethernet_interfaces:
@@ -169,4 +172,8 @@ ip_igmp_snooping:
   globally_enabled: true
   vlans:
     120:
+      enabled: false
+    160:
+      enabled: true
+    161:
       enabled: false

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1B.yml
@@ -94,6 +94,9 @@ vlans:
   161:
     tenant: Tenant_A
     name: Tenant_A_NFS
+  162:
+    tenant: Tenant_A
+    name: Tenant_A_FTP
 vlan_interfaces:
   Vlan4091:
     description: MLAG_PEER
@@ -114,7 +117,7 @@ port_channel_interfaces:
     description: DC1_LEAF2_Po7
     type: switched
     shutdown: false
-    vlans: 110-111,120-121,130-131,160-161
+    vlans: 110-111,120-121,130-131,160-162
     mode: trunk
     mlag: 1
 ethernet_interfaces:
@@ -169,4 +172,8 @@ ip_igmp_snooping:
   globally_enabled: true
   vlans:
     120:
+      enabled: false
+    160:
+      enabled: true
+    161:
       enabled: false

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -103,6 +103,9 @@ vlans:
   161:
     tenant: Tenant_A
     name: Tenant_A_NFS
+  162:
+    tenant: Tenant_A
+    name: Tenant_A_FTP
   210:
     tenant: Tenant_B
     name: Tenant_B_OP_Zone_1
@@ -141,7 +144,7 @@ port_channel_interfaces:
     description: DC1_SVC3_Po7
     type: switched
     shutdown: false
-    vlans: 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350
+    vlans: 110-111,120-121,130-131,140-141,150,160-162,210-211,250,310-311,350
     mode: trunk
     mlag: 1
 ethernet_interfaces:
@@ -200,4 +203,8 @@ ip_igmp_snooping:
   globally_enabled: true
   vlans:
     120:
+      enabled: false
+    160:
+      enabled: true
+    161:
       enabled: false

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -103,6 +103,9 @@ vlans:
   161:
     tenant: Tenant_A
     name: Tenant_A_NFS
+  162:
+    tenant: Tenant_A
+    name: Tenant_A_FTP
   210:
     tenant: Tenant_B
     name: Tenant_B_OP_Zone_1
@@ -141,7 +144,7 @@ port_channel_interfaces:
     description: DC1_SVC3_Po7
     type: switched
     shutdown: false
-    vlans: 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350
+    vlans: 110-111,120-121,130-131,140-141,150,160-162,210-211,250,310-311,350
     mode: trunk
     mlag: 1
 ethernet_interfaces:
@@ -200,4 +203,8 @@ ip_igmp_snooping:
   globally_enabled: true
   vlans:
     120:
+      enabled: false
+    160:
+      enabled: true
+    161:
       enabled: false

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF3A.yml
@@ -89,12 +89,16 @@ port_channel_interfaces:
     description: DC1_LEAF2_Po9
     type: switched
     shutdown: false
-    vlans: 110-111,120-121,130-131,160-161
+    vlans: 110-111,120-121,130-131,160-162
     mode: trunk
 ip_igmp_snooping:
   globally_enabled: true
   vlans:
     120:
+      enabled: false
+    160:
+      enabled: true
+    161:
       enabled: false
 vlans:
   130:
@@ -121,3 +125,6 @@ vlans:
   161:
     tenant: Tenant_A
     name: Tenant_A_NFS
+  162:
+    tenant: Tenant_A
+    name: Tenant_A_FTP

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -190,6 +190,15 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: 161
+    Tenant_A_FTP:
+      tenant: Tenant_A
+      rd: 192.168.255.10:10162
+      route_targets:
+        both:
+        - 10162:10162
+      redistribute_routes:
+      - learned
+      vlan: 162
     Tenant_B_OP_Zone:
       rd: 192.168.255.10:20
       route_targets:
@@ -468,7 +477,7 @@ port_channel_interfaces:
     description: DC1_L2LEAF1_Po1
     type: switched
     shutdown: false
-    vlans: 110-111,120-121,130-131,160-161
+    vlans: 110-111,120-121,130-131,160-162
     mode: trunk
     esi: 0000:1234:0808:0707:0606
     rt: 08:08:07:07:06:06
@@ -477,7 +486,7 @@ port_channel_interfaces:
     description: DC1-L2LEAF3A_Po1
     type: switched
     shutdown: false
-    vlans: 110-111,120-121,130-131,160-161
+    vlans: 110-111,120-121,130-131,160-162
     mode: trunk
     esi: 0000:1234:0606:0707:0808
     rt: 06:06:07:07:08:08
@@ -534,6 +543,10 @@ ip_igmp_snooping:
   vlans:
     120:
       enabled: false
+    160:
+      enabled: true
+    161:
+      enabled: false
 vlans:
   130:
     tenant: Tenant_A
@@ -565,6 +578,9 @@ vlans:
   161:
     tenant: Tenant_A
     name: Tenant_A_NFS
+  162:
+    tenant: Tenant_A
+    name: Tenant_A_FTP
   210:
     tenant: Tenant_B
     name: Tenant_B_OP_Zone_1
@@ -604,6 +620,8 @@ vxlan_tunnel_interface:
           vni: 10160
         161:
           vni: 10161
+        162:
+          vni: 10162
         210:
           vni: 20210
         211:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -190,6 +190,15 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: 161
+    Tenant_A_FTP:
+      tenant: Tenant_A
+      rd: 192.168.255.11:10162
+      route_targets:
+        both:
+        - 10162:10162
+      redistribute_routes:
+      - learned
+      vlan: 162
     Tenant_B_OP_Zone:
       rd: 192.168.255.11:20
       route_targets:
@@ -468,7 +477,7 @@ port_channel_interfaces:
     description: DC1_L2LEAF1_Po1
     type: switched
     shutdown: false
-    vlans: 110-111,120-121,130-131,160-161
+    vlans: 110-111,120-121,130-131,160-162
     mode: trunk
     esi: 0000:1234:0808:0707:0606
     rt: 08:08:07:07:06:06
@@ -477,7 +486,7 @@ port_channel_interfaces:
     description: DC1-L2LEAF3A_Po1
     type: switched
     shutdown: false
-    vlans: 110-111,120-121,130-131,160-161
+    vlans: 110-111,120-121,130-131,160-162
     mode: trunk
     esi: 0000:1234:0606:0707:0808
     rt: 06:06:07:07:08:08
@@ -534,6 +543,10 @@ ip_igmp_snooping:
   vlans:
     120:
       enabled: false
+    160:
+      enabled: true
+    161:
+      enabled: false
 vlans:
   130:
     tenant: Tenant_A
@@ -565,6 +578,9 @@ vlans:
   161:
     tenant: Tenant_A
     name: Tenant_A_NFS
+  162:
+    tenant: Tenant_A
+    name: Tenant_A_FTP
   210:
     tenant: Tenant_B
     name: Tenant_B_OP_Zone_1
@@ -604,6 +620,8 @@ vxlan_tunnel_interface:
           vni: 10160
         161:
           vni: 10161
+        162:
+          vni: 10162
         210:
           vni: 20210
         211:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -276,6 +276,15 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: 161
+    Tenant_A_FTP:
+      tenant: Tenant_A
+      rd: 192.168.255.12:10162
+      route_targets:
+        both:
+        - 10162:10162
+      redistribute_routes:
+      - learned
+      vlan: 162
     Tenant_B_OP_Zone:
       rd: 192.168.255.12:20
       route_targets:
@@ -471,6 +480,9 @@ vlans:
   161:
     tenant: Tenant_A
     name: Tenant_A_NFS
+  162:
+    tenant: Tenant_A
+    name: Tenant_A_FTP
   210:
     tenant: Tenant_B
     name: Tenant_B_OP_Zone_1
@@ -739,7 +751,7 @@ port_channel_interfaces:
     description: DC1_L2LEAF2_Po1
     type: switched
     shutdown: false
-    vlans: 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350
+    vlans: 110-111,120-121,130-131,140-141,150,160-162,210-211,250,310-311,350
     mode: trunk
     mlag: 7
   Port-Channel10:
@@ -1277,6 +1289,10 @@ ip_igmp_snooping:
   vlans:
     120:
       enabled: false
+    160:
+      enabled: true
+    161:
+      enabled: false
 vxlan_tunnel_interface:
   Vxlan1:
     description: DC1-SVC3A_VTEP
@@ -1308,6 +1324,8 @@ vxlan_tunnel_interface:
           vni: 10160
         161:
           vni: 10161
+        162:
+          vni: 10162
         210:
           vni: 20210
         211:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -276,6 +276,15 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: 161
+    Tenant_A_FTP:
+      tenant: Tenant_A
+      rd: 192.168.255.13:10162
+      route_targets:
+        both:
+        - 10162:10162
+      redistribute_routes:
+      - learned
+      vlan: 162
     Tenant_B_OP_Zone:
       rd: 192.168.255.13:20
       route_targets:
@@ -471,6 +480,9 @@ vlans:
   161:
     tenant: Tenant_A
     name: Tenant_A_NFS
+  162:
+    tenant: Tenant_A
+    name: Tenant_A_FTP
   210:
     tenant: Tenant_B
     name: Tenant_B_OP_Zone_1
@@ -739,7 +751,7 @@ port_channel_interfaces:
     description: DC1_L2LEAF2_Po1
     type: switched
     shutdown: false
-    vlans: 110-111,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350
+    vlans: 110-111,120-121,130-131,140-141,150,160-162,210-211,250,310-311,350
     mode: trunk
     mlag: 7
   Port-Channel10:
@@ -1277,6 +1289,10 @@ ip_igmp_snooping:
   vlans:
     120:
       enabled: false
+    160:
+      enabled: true
+    161:
+      enabled: false
 vxlan_tunnel_interface:
   Vxlan1:
     description: DC1-SVC3B_VTEP
@@ -1308,6 +1324,8 @@ vxlan_tunnel_interface:
           vni: 10160
         161:
           vni: 10161
+        162:
+          vni: 10162
         210:
           vni: 20210
         211:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_TENANTS_NETWORKS.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_TENANTS_NETWORKS.yml
@@ -202,9 +202,14 @@ tenants:
       '160':
         name: Tenant_A_VMOTION
         tags: ['opzone']
+        igmp_snooping_enabled: true
       # L2 vlan as integer
       161:
         name: Tenant_A_NFS
+        tags: ['opzone']
+        igmp_snooping_enabled: false
+      162:
+        name: Tenant_A_FTP
         tags: ['opzone']
   # Tenant_B Specific Information - VRFs / VLANs
   Tenant_B:

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenants/ip-igmp-snooping.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenants/ip-igmp-snooping.j2
@@ -31,7 +31,7 @@ ip_igmp_snooping:
 {%             set l2vlan_igmp_snooping_enabled = tenants[tenant].l2vlans[l2vlan].igmp_snooping_enabled | arista.avd.default() %}
 {%             if l2vlan_igmp_snooping_enabled is arista.avd.defined %}
     {{ l2vlan | int }}:
-      enabled: false
+      enabled: {{ l2vlan_igmp_snooping_enabled }}
 {%             endif %}
 {%         endfor %}
 {%     endfor %}


### PR DESCRIPTION
## Change Summary

Seems like with the introduction of #897, the tenant igmp snooping enabled option was changed correctly but this was overlooked.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)


## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been rebased from devel before I start
- [X] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [X] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
