### PR TITLE
Refactor raw_eos_cli to produce consistent newline

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_designs/templates/base/eos-cli.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/base/eos-cli.j2
@@ -1,10 +1,10 @@
-{% set tmp_eos_clis = [] %}
-{% if switch.raw_eos_cli is arista.avd.defined %}
-{%     do tmp_eos_clis.append(switch.raw_eos_cli) %}
-{% endif %}
-{% if switch.platform_settings.raw_eos_cli is arista.avd.defined %}
-{%     do tmp_eos_clis.append(switch.platform_settings.raw_eos_cli) %}
-{% endif %}
-{% if tmp_eos_clis | length > 0 %}
-eos_cli: {{ tmp_eos_clis | join('\n') | to_json }}
+{% if switch.raw_eos_cli is arista.avd.defined or
+      switch.platform_settings.raw_eos_cli is arista.avd.defined %}
+eos_cli: |
+{%     if switch.raw_eos_cli is arista.avd.defined %}
+  {{ switch.raw_eos_cli | indent(2,false) }}
+{%     endif %}
+{%     if switch.platform_settings.raw_eos_cli is arista.avd.defined %}
+  {{ switch.platform_settings.raw_eos_cli | indent(2,false) }}
+{%     endif %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/ethernet-interfaces.j2
@@ -135,7 +135,8 @@ ethernet_interfaces:
 {%                         endif %}
 {%                     endif %}
 {%                     if adapter_raw_eos_cli is arista.avd.defined %}
-    eos_cli: {{ adapter_raw_eos_cli | to_json }}
+    eos_cli: |
+      {{ adapter_raw_eos_cli | indent(6,false) }}
 {%                     endif %}
 {%                 endif %}
 {%             endfor %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/port-channel-interfaces.j2
@@ -118,7 +118,8 @@ port_channel_interfaces:
     service_profile: {{ adapter_qos_profile }}
 {%                         endif %}
 {%                         if adapter_raw_eos_cli is arista.avd.defined %}
-    eos_cli: {{ adapter_raw_eos_cli | to_json }}
+    eos_cli: |
+      {{ adapter_raw_eos_cli | indent(6,false) }}
 {%                         endif %}
 {%                         break %}
 {%                     endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/facts/switch/l2leaf.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/facts/switch/l2leaf.j2
@@ -42,9 +42,13 @@ switch:
            l2leaf.defaults.rack) }}
 
 {# switch.raw_eos_cli #}
-  raw_eos_cli: {{ l2leaf.node_groups[l2leaf_node_group].nodes[node].raw_eos_cli | arista.avd.default(
-                  l2leaf.node_groups[l2leaf_node_group].raw_eos_cli,
-                  l2leaf.defaults.raw_eos_cli) | to_json() }}
+{%             set switch_raw_eos_cli = l2leaf.node_groups[l2leaf_node_group].nodes[node].raw_eos_cli | arista.avd.default(
+                                        l2leaf.node_groups[l2leaf_node_group].raw_eos_cli,
+                                        l2leaf.defaults.raw_eos_cli) %}
+{%             if switch_raw_eos_cli is arista.avd.defined %}
+  raw_eos_cli: |
+    {{ switch_raw_eos_cli | indent(4,false) }}
+{%             endif %}
 
 {# switch.configure_tenants #}
   configure_tenants: true

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/facts/switch/l3leaf.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/facts/switch/l3leaf.j2
@@ -76,9 +76,13 @@ switch:
            l3leaf.defaults.rack) }}
 
 {# switch.raw_eos_cli #}
-  raw_eos_cli: {{ l3leaf.node_groups[l3leaf_node_group].nodes[node].raw_eos_cli | arista.avd.default(
-                  l3leaf.node_groups[l3leaf_node_group].raw_eos_cli,
-                  l3leaf.defaults.raw_eos_cli) | to_json() }}
+{%             set switch_raw_eos_cli = l3leaf.node_groups[l3leaf_node_group].nodes[node].raw_eos_cli | arista.avd.default(
+                                        l3leaf.node_groups[l3leaf_node_group].raw_eos_cli,
+                                        l3leaf.defaults.raw_eos_cli) %}
+{%             if switch_raw_eos_cli is arista.avd.defined %}
+  raw_eos_cli: |
+    {{ switch_raw_eos_cli | indent(4,false) }}
+{%             endif %}
 
 {# switch.router_id #}
   router_id: {% include templates[design.type].ip_addressing[type].router_id %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/facts/switch/overlay-controller.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/facts/switch/overlay-controller.j2
@@ -33,8 +33,12 @@ switch:
            overlay_controller.defaults.rack) }}
 
 {# switch.raw_eos_cli #}
-  raw_eos_cli: {{ overlay_controller.nodes[node].raw_eos_cli | arista.avd.default(
-                  overlay_controller.defaults.raw_eos_cli) | to_json() }}
+{%         set switch_raw_eos_cli = overlay_controller.nodes[node].raw_eos_cli | arista.avd.default(
+                                        overlay_controller.defaults.raw_eos_cli) %}
+{%         if switch_raw_eos_cli is arista.avd.defined %}
+  raw_eos_cli: |
+    {{ switch_raw_eos_cli | indent(4,false) }}
+{%         endif %}
 
 {# switch.bgp_defaults #}
   bgp_defaults: {{ overlay_controller_bgp_defaults | arista.avd.default([]) }}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/facts/switch/spine.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/facts/switch/spine.j2
@@ -16,8 +16,12 @@ switch:
   rack: {{ spine.nodes[node].rack | arista.avd.default() }}
 
 {# switch.raw_eos_cli #}
-  raw_eos_cli: {{ spine.nodes[node].raw_eos_cli | arista.avd.default(
-                  spine.defaults.raw_eos_cli) | to_json }}
+{%         set switch_raw_eos_cli = spine.nodes[node].raw_eos_cli | arista.avd.default(
+                                    spine.defaults.raw_eos_cli) %}
+{%         if switch_raw_eos_cli is arista.avd.defined %}
+  raw_eos_cli: |
+    {{ switch_raw_eos_cli | indent(4,false) }}
+{%         endif %}
 
 {# switch.bgp_defaults #}
   bgp_defaults: {{ spine_bgp_defaults | arista.avd.default([]) }}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/facts/switch/super-spine.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/facts/switch/super-spine.j2
@@ -16,8 +16,12 @@ switch:
   rack: {{ super_spine.nodes[inventory_hostname].rack | arista.avd.default() }}
 
 {# switch.raw_eos_cli #}
-  raw_eos_cli: {{ super_spine.nodes[node].raw_eos_cli | arista.avd.default(
-                  super_spine.defaults.raw_eos_cli) | to_json() }}
+{%         set switch_raw_eos_cli = super_spine.nodes[node].raw_eos_cli | arista.avd.default(
+                                    super_spine.defaults.raw_eos_cli) %}
+{%         if switch_raw_eos_cli is arista.avd.defined %}
+  raw_eos_cli: |
+    {{ switch_raw_eos_cli | indent(4,false) }}
+{%         endif %}
 
 {# switch.bgp_defaults #}
   bgp_defaults: {{ super_spine_bgp_defaults | arista.avd.default([]) }}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenants/eos-cli.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenants/eos-cli.j2
@@ -11,5 +11,8 @@
 {%     endfor %}
 {% endfor %}
 {% if tmp_eos_clis | length > 0 %}
-eos_cli: {{ tmp_eos_clis | join('\n') | to_json }}
+eos_cli: |
+{%     for tmp_eos_cli in tmp_eos_clis %}
+  {{ tmp_eos_cli | indent(2,false) }}
+{%     endfor %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenants/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenants/ethernet-interfaces.j2
@@ -34,7 +34,8 @@ ethernet_interfaces:
     description: {{ l3_interface.description }}
 {%                         endif %}
 {%                         if l3_interface.raw_eos_cli is arista.avd.defined %}
-    eos_cli: {{ l3_interface.raw_eos_cli }}
+    eos_cli: |
+      {{ l3_interface.raw_eos_cli | indent(6,false) }}
 {%                         endif %}
 {%                     endif %}
 {%                 endfor %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenants/router-bgp-vrfs.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenants/router-bgp-vrfs.j2
@@ -104,7 +104,8 @@
 {%                 endfor %}
 {%             endif %}
 {%             if tenants[tenant].vrfs[vrf].bgp.raw_eos_cli is arista.avd.defined %}
-      eos_cli: {{ tenants[tenant].vrfs[vrf].bgp.raw_eos_cli | to_json }}
+      eos_cli: |
+        {{ tenants[tenant].vrfs[vrf].bgp.raw_eos_cli | indent(8,false) }}
 {%             endif %}
 {%         endfor %}
 {%     endfor %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenants/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenants/vlan-interfaces.j2
@@ -74,7 +74,8 @@ vlan_interfaces:
 {%                 endfor %}
 {%             endif %}
 {%             if svi_raw_eos_cli is arista.avd.defined %}
-    eos_cli: {{ svi_raw_eos_cli | to_json }}
+    eos_cli: |
+      {{ svi_raw_eos_cli | indent(6,false) }}
 {%             endif %}
 {%         endfor %}
 {# VLAN interface for iBGP peering in overlay VRFs #}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Refactor raw_eos_cli to produce consistent newline

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)


## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->
Output `raw_eos_cli` using:
```jinja
eos_cli: |
   {{ raw_eos_cli_var | indent(2,false) }}
``` 
in all templates.
## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
No changes to molecule output.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
