### PR TITLE
Remove Unused Profile from Structured Config

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF1A.yml
@@ -227,7 +227,6 @@ ethernet_interfaces:
     shutdown: false
     mode: access
     vlans: 110
-    profile: TENANT_A
   Ethernet6:
     peer: server02_SINGLE_NODE_TRUNK
     peer_interface: Eth1
@@ -237,7 +236,6 @@ ethernet_interfaces:
     shutdown: false
     mode: trunk
     vlans: 110-111,210-211
-    profile: TENANT_A_B
 prefix_lists:
   PL-LOOPBACKS-EVPN-OVERLAY:
     sequence_numbers:

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2A.yml
@@ -644,7 +644,6 @@ ethernet_interfaces:
     channel_group:
       id: 10
       mode: active
-    profile: TENANT_B
 mlag_configuration:
   domain_id: DC1_LEAF2
   local_interface: Vlan4094

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2B.yml
@@ -644,7 +644,6 @@ ethernet_interfaces:
     channel_group:
       id: 10
       mode: active
-    profile: TENANT_B
 mlag_configuration:
   domain_id: DC1_LEAF2
   local_interface: Vlan4094

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3A.yml
@@ -804,7 +804,6 @@ ethernet_interfaces:
     channel_group:
       id: 10
       mode: active
-    profile: TENANT_A_B
 mlag_configuration:
   domain_id: DC1_SVC3
   local_interface: Vlan4094

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2A.yml
@@ -409,7 +409,6 @@ ethernet_interfaces:
     channel_group:
       id: 16
       mode: active
-    profile: TENANT_A
     service_profile: bar
     eos_cli: 'comment
 
@@ -430,7 +429,6 @@ ethernet_interfaces:
     channel_group:
       id: 17
       mode: active
-    profile: TENANT_A
     service_profile: foo
     eos_cli: 'comment
 
@@ -451,7 +449,6 @@ ethernet_interfaces:
     channel_group:
       id: 18
       mode: active
-    profile: NESTED_TENANT_A
     service_profile: foo
     eos_cli: 'comment
 
@@ -472,7 +469,6 @@ ethernet_interfaces:
     channel_group:
       id: 19
       mode: active
-    profile: NESTED_TENANT_A
     service_profile: foo
     eos_cli: 'comment
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
@@ -421,7 +421,6 @@ ethernet_interfaces:
     channel_group:
       id: 16
       mode: active
-    profile: TENANT_A
     service_profile: bar
     eos_cli: 'comment
 
@@ -442,7 +441,6 @@ ethernet_interfaces:
     channel_group:
       id: 17
       mode: active
-    profile: TENANT_A
     service_profile: foo
     eos_cli: 'comment
 
@@ -463,7 +461,6 @@ ethernet_interfaces:
     channel_group:
       id: 18
       mode: active
-    profile: NESTED_TENANT_A
     service_profile: foo
     eos_cli: 'comment
 
@@ -484,7 +481,6 @@ ethernet_interfaces:
     channel_group:
       id: 19
       mode: active
-    profile: NESTED_TENANT_A
     service_profile: foo
     eos_cli: 'comment
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF1A.yml
@@ -235,7 +235,6 @@ ethernet_interfaces:
     shutdown: false
     mode: access
     vlans: 110
-    profile: TENANT_A
   Ethernet6:
     peer: server02_SINGLE_NODE_TRUNK
     peer_interface: Eth1
@@ -262,7 +261,6 @@ ethernet_interfaces:
       unknown-unicast:
         level: 2
         unit: percent
-    profile: ALL_WITH_SECURITY
 prefix_lists:
   PL-LOOPBACKS-EVPN-OVERLAY:
     sequence_numbers:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
@@ -399,7 +399,6 @@ ethernet_interfaces:
     channel_group:
       id: 20
       mode: active
-    profile: TENANT_A_B
   Ethernet21:
     peer: ROUTER01
     peer_interface: Eth0
@@ -409,7 +408,6 @@ ethernet_interfaces:
     shutdown: false
     mode: access
     vlans: 110
-    profile: TENANT_A
   Ethernet10:
     peer: server01_MLAG
     peer_interface: Eth2
@@ -422,7 +420,6 @@ ethernet_interfaces:
     channel_group:
       id: 10
       mode: active
-    profile: TENANT_B
   Ethernet12:
     peer: server01_MTU_ADAPTOR_MLAG
     peer_interface: Eth6
@@ -447,7 +444,6 @@ ethernet_interfaces:
     channel_group:
       id: 11
       mode: active
-    profile: TENANT_A_MTU
 port_channel_interfaces:
   Port-Channel7:
     description: DC1_L2LEAF1_Po1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
@@ -399,7 +399,6 @@ ethernet_interfaces:
     channel_group:
       id: 20
       mode: active
-    profile: TENANT_A_B
   Ethernet21:
     peer: ROUTER01
     peer_interface: Eth1
@@ -409,7 +408,6 @@ ethernet_interfaces:
     shutdown: false
     mode: access
     vlans: 110
-    profile: TENANT_A
   Ethernet10:
     peer: server01_MLAG
     peer_interface: Eth3
@@ -422,7 +420,6 @@ ethernet_interfaces:
     channel_group:
       id: 10
       mode: active
-    profile: TENANT_B
   Ethernet12:
     peer: server01_MTU_ADAPTOR_MLAG
     peer_interface: Eth7
@@ -447,7 +444,6 @@ ethernet_interfaces:
     channel_group:
       id: 11
       mode: active
-    profile: TENANT_A_MTU
 port_channel_interfaces:
   Port-Channel7:
     description: DC1_L2LEAF1_Po1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
@@ -962,7 +962,6 @@ ethernet_interfaces:
     channel_group:
       id: 10
       mode: active
-    profile: TENANT_A_B
   Ethernet11:
     peer: server04_inherit_all_from_profile
     peer_interface: Eth1
@@ -989,7 +988,6 @@ ethernet_interfaces:
       unknown-unicast:
         level: 2
         unit: percent
-    profile: ALL_WITH_SECURITY
   Ethernet12:
     peer: server05_no_profile
     peer_interface: Eth1
@@ -1041,7 +1039,6 @@ ethernet_interfaces:
       unknown-unicast:
         level: 2
         unit: percent
-    profile: ALL_WITH_SECURITY
   Ethernet14:
     peer: server07_inherit_all_from_profile_port_channel
     peer_interface: Eth1
@@ -1071,7 +1068,6 @@ ethernet_interfaces:
     channel_group:
       id: 14
       mode: active
-    profile: ALL_WITH_SECURITY_PORT_CHANNEL
   Ethernet15:
     peer: server08_no_profile_port_channel
     peer_interface: Eth1
@@ -1126,7 +1122,6 @@ ethernet_interfaces:
       unknown-unicast:
         level: 2
         unit: percent
-    profile: ALL_WITH_SECURITY_PORT_CHANNEL
   Ethernet17:
     peer: server10_no_profile_port_channel_lacp_fallback
     peer_interface: Eth1
@@ -1185,7 +1180,6 @@ ethernet_interfaces:
     channel_group:
       id: 18
       mode: active
-    profile: ALL_WITH_SECURITY_PORT_CHANNEL_LACP_FALLBACK
     lacp_port_priority: 8192
   Ethernet19:
     peer: server12_inherit_nested_profile_port_channel_lacp_fallback
@@ -1216,7 +1210,6 @@ ethernet_interfaces:
     channel_group:
       id: 19
       mode: active
-    profile: NESTED_PORT_PROFILE
     lacp_port_priority: 8192
 mlag_configuration:
   domain_id: DC1_SVC3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
@@ -969,7 +969,6 @@ ethernet_interfaces:
       unknown-unicast:
         level: 2
         unit: percent
-    profile: ALL_WITH_SECURITY
   Ethernet12:
     peer: server05_no_profile
     peer_interface: Eth2
@@ -1021,7 +1020,6 @@ ethernet_interfaces:
       unknown-unicast:
         level: 2
         unit: percent
-    profile: ALL_WITH_SECURITY
   Ethernet14:
     peer: server07_inherit_all_from_profile_port_channel
     peer_interface: Eth2
@@ -1051,7 +1049,6 @@ ethernet_interfaces:
     channel_group:
       id: 14
       mode: active
-    profile: ALL_WITH_SECURITY_PORT_CHANNEL
   Ethernet15:
     peer: server08_no_profile_port_channel
     peer_interface: Eth2
@@ -1106,7 +1103,6 @@ ethernet_interfaces:
       unknown-unicast:
         level: 2
         unit: percent
-    profile: ALL_WITH_SECURITY_PORT_CHANNEL
   Ethernet17:
     peer: server10_no_profile_port_channel_lacp_fallback
     peer_interface: Eth2
@@ -1165,7 +1161,6 @@ ethernet_interfaces:
     channel_group:
       id: 18
       mode: active
-    profile: ALL_WITH_SECURITY_PORT_CHANNEL_LACP_FALLBACK
     lacp_port_priority: 32768
   Ethernet19:
     peer: server12_inherit_nested_profile_port_channel_lacp_fallback
@@ -1196,7 +1191,6 @@ ethernet_interfaces:
     channel_group:
       id: 19
       mode: active
-    profile: NESTED_PORT_PROFILE
     lacp_port_priority: 32768
 mlag_configuration:
   domain_id: DC1_SVC3

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
@@ -239,7 +239,6 @@ ethernet_interfaces:
     shutdown: false
     mode: access
     vlans: 110
-    profile: TENANT_A
   Ethernet6:
     peer: server02_SINGLE_NODE_TRUNK
     peer_interface: Eth1
@@ -266,7 +265,6 @@ ethernet_interfaces:
       unknown-unicast:
         level: 2
         unit: percent
-    profile: ALL_WITH_SECURITY
 prefix_lists:
   PL-LOOPBACKS-EVPN-OVERLAY:
     sequence_numbers:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -403,7 +403,6 @@ ethernet_interfaces:
     channel_group:
       id: 20
       mode: active
-    profile: TENANT_A_B
   Ethernet21:
     peer: ROUTER01
     peer_interface: Eth0
@@ -413,7 +412,6 @@ ethernet_interfaces:
     shutdown: false
     mode: access
     vlans: 110
-    profile: TENANT_A
   Ethernet10:
     peer: server01_MLAG
     peer_interface: Eth2
@@ -426,7 +424,6 @@ ethernet_interfaces:
     channel_group:
       id: 10
       mode: active
-    profile: TENANT_B
   Ethernet12:
     peer: server01_MTU_ADAPTOR_MLAG
     peer_interface: Eth6
@@ -462,7 +459,6 @@ ethernet_interfaces:
     channel_group:
       id: 11
       mode: active
-    profile: TENANT_A_MTU
 port_channel_interfaces:
   Port-Channel7:
     description: DC1_L2LEAF1_Po1

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -403,7 +403,6 @@ ethernet_interfaces:
     channel_group:
       id: 20
       mode: active
-    profile: TENANT_A_B
   Ethernet21:
     peer: ROUTER01
     peer_interface: Eth1
@@ -413,7 +412,6 @@ ethernet_interfaces:
     shutdown: false
     mode: access
     vlans: 110
-    profile: TENANT_A
   Ethernet10:
     peer: server01_MLAG
     peer_interface: Eth3
@@ -426,7 +424,6 @@ ethernet_interfaces:
     channel_group:
       id: 10
       mode: active
-    profile: TENANT_B
   Ethernet12:
     peer: server01_MTU_ADAPTOR_MLAG
     peer_interface: Eth7
@@ -462,7 +459,6 @@ ethernet_interfaces:
     channel_group:
       id: 11
       mode: active
-    profile: TENANT_A_MTU
 port_channel_interfaces:
   Port-Channel7:
     description: DC1_L2LEAF1_Po1

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -968,7 +968,6 @@ ethernet_interfaces:
     channel_group:
       id: 10
       mode: active
-    profile: TENANT_A_B
   Ethernet11:
     peer: server04_inherit_all_from_profile
     peer_interface: Eth1
@@ -995,7 +994,6 @@ ethernet_interfaces:
       unknown-unicast:
         level: 2
         unit: percent
-    profile: ALL_WITH_SECURITY
   Ethernet12:
     peer: server05_no_profile
     peer_interface: Eth1
@@ -1047,7 +1045,6 @@ ethernet_interfaces:
       unknown-unicast:
         level: 2
         unit: percent
-    profile: ALL_WITH_SECURITY
   Ethernet14:
     peer: server07_inherit_all_from_profile_port_channel
     peer_interface: Eth1
@@ -1077,7 +1074,6 @@ ethernet_interfaces:
     channel_group:
       id: 14
       mode: active
-    profile: ALL_WITH_SECURITY_PORT_CHANNEL
   Ethernet15:
     peer: server08_no_profile_port_channel
     peer_interface: Eth1
@@ -1132,7 +1128,6 @@ ethernet_interfaces:
       unknown-unicast:
         level: 2
         unit: percent
-    profile: ALL_WITH_SECURITY_PORT_CHANNEL
   Ethernet17:
     peer: server10_no_profile_port_channel_lacp_fallback
     peer_interface: Eth1
@@ -1191,7 +1186,6 @@ ethernet_interfaces:
     channel_group:
       id: 18
       mode: active
-    profile: ALL_WITH_SECURITY_PORT_CHANNEL_LACP_FALLBACK
     lacp_port_priority: 8192
   Ethernet19:
     peer: server12_inherit_nested_profile_port_channel_lacp_fallback
@@ -1222,7 +1216,6 @@ ethernet_interfaces:
     channel_group:
       id: 19
       mode: active
-    profile: NESTED_PORT_PROFILE
     lacp_port_priority: 8192
 mlag_configuration:
   domain_id: DC1_SVC3

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -968,7 +968,6 @@ ethernet_interfaces:
     channel_group:
       id: 10
       mode: active
-    profile: TENANT_A_B
   Ethernet11:
     peer: server04_inherit_all_from_profile
     peer_interface: Eth2
@@ -995,7 +994,6 @@ ethernet_interfaces:
       unknown-unicast:
         level: 2
         unit: percent
-    profile: ALL_WITH_SECURITY
   Ethernet12:
     peer: server05_no_profile
     peer_interface: Eth2
@@ -1047,7 +1045,6 @@ ethernet_interfaces:
       unknown-unicast:
         level: 2
         unit: percent
-    profile: ALL_WITH_SECURITY
   Ethernet14:
     peer: server07_inherit_all_from_profile_port_channel
     peer_interface: Eth2
@@ -1077,7 +1074,6 @@ ethernet_interfaces:
     channel_group:
       id: 14
       mode: active
-    profile: ALL_WITH_SECURITY_PORT_CHANNEL
   Ethernet15:
     peer: server08_no_profile_port_channel
     peer_interface: Eth2
@@ -1132,7 +1128,6 @@ ethernet_interfaces:
       unknown-unicast:
         level: 2
         unit: percent
-    profile: ALL_WITH_SECURITY_PORT_CHANNEL
   Ethernet17:
     peer: server10_no_profile_port_channel_lacp_fallback
     peer_interface: Eth2
@@ -1191,7 +1186,6 @@ ethernet_interfaces:
     channel_group:
       id: 18
       mode: active
-    profile: ALL_WITH_SECURITY_PORT_CHANNEL_LACP_FALLBACK
     lacp_port_priority: 32768
   Ethernet19:
     peer: server12_inherit_nested_profile_port_channel_lacp_fallback
@@ -1222,7 +1216,6 @@ ethernet_interfaces:
     channel_group:
       id: 19
       mode: active
-    profile: NESTED_PORT_PROFILE
     lacp_port_priority: 32768
 mlag_configuration:
   domain_id: DC1_SVC3

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
@@ -244,7 +244,6 @@ ethernet_interfaces:
     shutdown: false
     mode: access
     vlans: 110
-    profile: TENANT_A
   Ethernet6:
     peer: server02_SINGLE_NODE_TRUNK
     peer_interface: Eth1
@@ -270,7 +269,6 @@ ethernet_interfaces:
       unknown-unicast:
         level: 2
         unit: percent
-    profile: ALL_WITH_SECURITY
 prefix_lists:
   PL-LOOPBACKS-EVPN-OVERLAY:
     sequence_numbers:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -700,7 +700,6 @@ ethernet_interfaces:
     channel_group:
       id: 10
       mode: active
-    profile: TENANT_B
   Ethernet12:
     peer: server01_MTU_ADAPTOR_MLAG
     peer_interface: Eth6
@@ -725,7 +724,6 @@ ethernet_interfaces:
     channel_group:
       id: 11
       mode: active
-    profile: TENANT_A_MTU
 mlag_configuration:
   domain_id: DC1_LEAF2
   local_interface: Vlan4094

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -700,7 +700,6 @@ ethernet_interfaces:
     channel_group:
       id: 10
       mode: active
-    profile: TENANT_B
   Ethernet12:
     peer: server01_MTU_ADAPTOR_MLAG
     peer_interface: Eth7
@@ -725,7 +724,6 @@ ethernet_interfaces:
     channel_group:
       id: 11
       mode: active
-    profile: TENANT_A_MTU
 mlag_configuration:
   domain_id: DC1_LEAF2
   local_interface: Vlan4094

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -892,7 +892,6 @@ ethernet_interfaces:
     channel_group:
       id: 10
       mode: active
-    profile: TENANT_A_B
   Ethernet11:
     peer: server04_inherit_all_from_profile
     peer_interface: Eth1
@@ -918,7 +917,6 @@ ethernet_interfaces:
       unknown-unicast:
         level: 2
         unit: percent
-    profile: ALL_WITH_SECURITY
   Ethernet12:
     peer: server05_no_profile
     peer_interface: Eth1
@@ -969,7 +967,6 @@ ethernet_interfaces:
       unknown-unicast:
         level: 2
         unit: percent
-    profile: ALL_WITH_SECURITY
   Ethernet14:
     peer: server07_inherit_all_from_profile_port_channel
     peer_interface: Eth1
@@ -998,7 +995,6 @@ ethernet_interfaces:
     channel_group:
       id: 14
       mode: active
-    profile: ALL_WITH_SECURITY_PORT_CHANNEL
   Ethernet15:
     peer: server08_no_profile_port_channel
     peer_interface: Eth1
@@ -1052,7 +1048,6 @@ ethernet_interfaces:
       unknown-unicast:
         level: 2
         unit: percent
-    profile: ALL_WITH_SECURITY_PORT_CHANNEL
 mlag_configuration:
   domain_id: DC1_SVC3
   local_interface: Vlan4094

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -898,7 +898,6 @@ ethernet_interfaces:
       unknown-unicast:
         level: 2
         unit: percent
-    profile: ALL_WITH_SECURITY
   Ethernet12:
     peer: server05_no_profile
     peer_interface: Eth2
@@ -949,7 +948,6 @@ ethernet_interfaces:
       unknown-unicast:
         level: 2
         unit: percent
-    profile: ALL_WITH_SECURITY
   Ethernet14:
     peer: server07_inherit_all_from_profile_port_channel
     peer_interface: Eth2
@@ -978,7 +976,6 @@ ethernet_interfaces:
     channel_group:
       id: 14
       mode: active
-    profile: ALL_WITH_SECURITY_PORT_CHANNEL
   Ethernet15:
     peer: server08_no_profile_port_channel
     peer_interface: Eth2
@@ -1032,7 +1029,6 @@ ethernet_interfaces:
       unknown-unicast:
         level: 2
         unit: percent
-    profile: ALL_WITH_SECURITY_PORT_CHANNEL
 mlag_configuration:
   domain_id: DC1_SVC3
   local_interface: Vlan4094

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/ethernet-interfaces.j2
@@ -115,9 +115,6 @@ ethernet_interfaces:
       received: {{ adapter_flowcontrol.received }}
 {%                         endif %}
 {%                     endif %}
-{%                     if adapter.profile is arista.avd.defined %}
-    profile: {{ adapter.profile }}
-{%                     endif %}
 {%                     if adapter_qos_profile is arista.avd.defined %}
     service_profile: {{ adapter_qos_profile }}
 {%                     endif %}


### PR DESCRIPTION
## Change Summary

Remove Unused Profile from Structured Config
<!-- Enter short PR description -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

This change is needed to avoid interference with PR #983.

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->
Removed `profile` key from `ethernet_interfaces` generated by `connected_endpoints`.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Verified only expected changes on molecule.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
