### PR TITLE
added delegate_to: localhost to some eos_designs tasks

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_designs/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/tasks/main.yml
@@ -3,6 +3,7 @@
 - name: Set AVD facts
   yaml_templates_to_facts:
     templates: "{{ templates[design.type].facts }}"
+  delegate_to: localhost
   check_mode: no
   changed_when: False
   tags: [build, provision]
@@ -10,6 +11,7 @@
 - name: Set AVD topology facts
   yaml_templates_to_facts:
     templates: "{{ templates[design.type].topology_facts }}"
+  delegate_to: localhost
   check_mode: no
   changed_when: False
   tags: [build, provision]
@@ -27,6 +29,7 @@
   yaml_templates_to_facts:
     root_key: structured_config
     templates: "{{ templates[design.type].structured_config }}"
+  delegate_to: localhost
   check_mode: no
   changed_when: False
   tags: [build, provision]


### PR DESCRIPTION
## Change Summary
Changes to eos_designs tasks were worked out with Claus today, lack of delegate_to: localhost on some facts tasks were breaking playbook execution due to undefined variables.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Component(s) name

`arista.avd.eos_designs

## Proposed changes
Added delegate_to: localhost on some facts tasks.

## How to test
At fabric level, define something like:

# Ansible Variables needed for the validation role where ansible connect directly to the switches
...
ansible_host: '{{ loopback_interfaces.Loopback0.ip_address | arista.avd.default(management_interfaces.Vlan4092.ip_address) | ipaddr("address") }}'
...

This will create undefined variable errors in the facts tasks for the referred variables. This works again if we put delegate_to: localhost on the facts tasks.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
