### PR TITLE
Add platform setting for `queue_monitor_length_notify_support`

### DIFF
--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1A.cfg
@@ -10,6 +10,10 @@ transceiver qsfp default-mode 4x10G
 !
 service routing protocols model multi-agent
 !
+queue-monitor length
+queue-monitor length log 5
+queue-monitor length notifying
+!
 hostname DC1-BL1A
 ip name-server vrf MGMT 1.1.1.1
 ip name-server vrf MGMT 8.8.8.8

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1B.cfg
@@ -10,6 +10,10 @@ transceiver qsfp default-mode 4x10G
 !
 service routing protocols model multi-agent
 !
+queue-monitor length
+queue-monitor length log 5
+queue-monitor length notifying
+!
 hostname DC1-BL1B
 ip name-server vrf MGMT 8.8.8.8
 ip name-server vrf MGMT 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF1A.cfg
@@ -13,6 +13,9 @@ transceiver qsfp default-mode 4x10G
 !
 service routing protocols model multi-agent
 !
+queue-monitor length
+queue-monitor length log 5
+!
 hostname DC1-L2LEAF1A
 ip name-server vrf MGMT 8.8.8.8
 ip name-server vrf MGMT 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF1B.cfg
@@ -13,6 +13,9 @@ transceiver qsfp default-mode 4x10G
 !
 service routing protocols model multi-agent
 !
+queue-monitor length
+queue-monitor length log 5
+!
 hostname DC1-L2LEAF1B
 ip name-server vrf MGMT 8.8.8.8
 ip name-server vrf MGMT 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF2A.cfg
@@ -13,6 +13,9 @@ transceiver qsfp default-mode 4x10G
 !
 service routing protocols model multi-agent
 !
+queue-monitor length
+queue-monitor length log 5
+!
 hostname DC1-L2LEAF2A
 ip name-server vrf MGMT 8.8.8.8
 ip name-server vrf MGMT 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF2B.cfg
@@ -13,6 +13,9 @@ transceiver qsfp default-mode 4x10G
 !
 service routing protocols model multi-agent
 !
+queue-monitor length
+queue-monitor length log 5
+!
 hostname DC1-L2LEAF2B
 ip name-server vrf MGMT 8.8.8.8
 ip name-server vrf MGMT 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF3A.cfg
@@ -13,6 +13,9 @@ transceiver qsfp default-mode 4x10G
 !
 service routing protocols model multi-agent
 !
+queue-monitor length
+queue-monitor length log 5
+!
 hostname DC1-L2LEAF3A
 ip name-server vrf MGMT 8.8.8.8
 ip name-server vrf MGMT 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
@@ -12,6 +12,9 @@ transceiver qsfp default-mode 4x10G
 !
 service routing protocols model multi-agent
 !
+queue-monitor length
+queue-monitor length log 5
+!
 hostname DC1-LEAF1A
 ip name-server vrf MGMT 8.8.8.8
 ip name-server vrf MGMT 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
@@ -13,6 +13,10 @@ transceiver qsfp default-mode 4x10G
 !
 service routing protocols model multi-agent
 !
+queue-monitor length
+queue-monitor length log 5
+queue-monitor length notifying
+!
 hostname DC1-LEAF2A
 ip name-server vrf MGMT 8.8.8.8
 ip name-server vrf MGMT 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
@@ -13,6 +13,10 @@ transceiver qsfp default-mode 4x10G
 !
 service routing protocols model multi-agent
 !
+queue-monitor length
+queue-monitor length log 5
+queue-monitor length notifying
+!
 hostname DC1-LEAF2B
 ip name-server vrf MGMT 8.8.8.8
 ip name-server vrf MGMT 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE1.cfg
@@ -10,6 +10,9 @@ transceiver qsfp default-mode 4x10G
 !
 service routing protocols model multi-agent
 !
+queue-monitor length
+queue-monitor length log 5
+!
 hostname DC1-SPINE1
 ip name-server vrf MGMT 8.8.8.8
 ip name-server vrf MGMT 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE2.cfg
@@ -10,6 +10,9 @@ transceiver qsfp default-mode 4x10G
 !
 service routing protocols model multi-agent
 !
+queue-monitor length
+queue-monitor length log 5
+!
 hostname DC1-SPINE2
 ip name-server vrf MGMT 8.8.8.8
 ip name-server vrf MGMT 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE3.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE3.cfg
@@ -10,6 +10,9 @@ transceiver qsfp default-mode 4x10G
 !
 service routing protocols model multi-agent
 !
+queue-monitor length
+queue-monitor length log 5
+!
 hostname DC1-SPINE3
 ip name-server vrf MGMT 8.8.8.8
 ip name-server vrf MGMT 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE4.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE4.cfg
@@ -10,6 +10,9 @@ transceiver qsfp default-mode 4x10G
 !
 service routing protocols model multi-agent
 !
+queue-monitor length
+queue-monitor length log 5
+!
 hostname DC1-SPINE4
 ip name-server vrf MGMT 8.8.8.8
 ip name-server vrf MGMT 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
@@ -13,6 +13,9 @@ transceiver qsfp default-mode 4x10G
 !
 service routing protocols model multi-agent
 !
+queue-monitor length
+queue-monitor length log 5
+!
 hostname DC1-SVC3A
 ip name-server vrf MGMT 8.8.8.8
 ip name-server vrf MGMT 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
@@ -13,6 +13,9 @@ transceiver qsfp default-mode 4x10G
 !
 service routing protocols model multi-agent
 !
+queue-monitor length
+queue-monitor length log 5
+!
 hostname DC1-SVC3B
 ip name-server vrf MGMT 8.8.8.8
 ip name-server vrf MGMT 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
@@ -240,6 +240,10 @@ vlan_internal_order:
   range:
     beginning: 1006
     ending: 1199
+queue_monitor_length:
+  enabled: true
+  notifying: true
+  log: 5
 name_server:
   source:
     vrf: MGMT

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
@@ -240,6 +240,10 @@ vlan_internal_order:
   range:
     beginning: 1006
     ending: 1199
+queue_monitor_length:
+  enabled: true
+  notifying: true
+  log: 5
 name_server:
   source:
     vrf: MGMT

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -19,6 +19,9 @@ vlan_internal_order:
   range:
     beginning: 1006
     ending: 1199
+queue_monitor_length:
+  enabled: true
+  log: 5
 name_server:
   source:
     vrf: MGMT

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1B.yml
@@ -19,6 +19,9 @@ vlan_internal_order:
   range:
     beginning: 1006
     ending: 1199
+queue_monitor_length:
+  enabled: true
+  log: 5
 name_server:
   source:
     vrf: MGMT

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -19,6 +19,9 @@ vlan_internal_order:
   range:
     beginning: 1006
     ending: 1199
+queue_monitor_length:
+  enabled: true
+  log: 5
 name_server:
   source:
     vrf: MGMT

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -19,6 +19,9 @@ vlan_internal_order:
   range:
     beginning: 1006
     ending: 1199
+queue_monitor_length:
+  enabled: true
+  log: 5
 name_server:
   source:
     vrf: MGMT

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF3A.yml
@@ -19,6 +19,9 @@ vlan_internal_order:
   range:
     beginning: 1006
     ending: 1199
+queue_monitor_length:
+  enabled: true
+  log: 5
 name_server:
   source:
     vrf: MGMT

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
@@ -129,6 +129,9 @@ vlan_internal_order:
   range:
     beginning: 1006
     ending: 1199
+queue_monitor_length:
+  enabled: true
+  log: 5
 name_server:
   source:
     vrf: MGMT

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -246,6 +246,10 @@ vlan_internal_order:
   range:
     beginning: 1006
     ending: 1199
+queue_monitor_length:
+  enabled: true
+  notifying: true
+  log: 5
 name_server:
   source:
     vrf: MGMT

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -246,6 +246,10 @@ vlan_internal_order:
   range:
     beginning: 1006
     ending: 1199
+queue_monitor_length:
+  enabled: true
+  notifying: true
+  log: 5
 name_server:
   source:
     vrf: MGMT

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
@@ -111,6 +111,9 @@ vlan_internal_order:
   range:
     beginning: 1006
     ending: 1199
+queue_monitor_length:
+  enabled: true
+  log: 5
 name_server:
   source:
     vrf: MGMT

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
@@ -111,6 +111,9 @@ vlan_internal_order:
   range:
     beginning: 1006
     ending: 1199
+queue_monitor_length:
+  enabled: true
+  log: 5
 name_server:
   source:
     vrf: MGMT

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
@@ -111,6 +111,9 @@ vlan_internal_order:
   range:
     beginning: 1006
     ending: 1199
+queue_monitor_length:
+  enabled: true
+  log: 5
 name_server:
   source:
     vrf: MGMT

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
@@ -111,6 +111,9 @@ vlan_internal_order:
   range:
     beginning: 1006
     ending: 1199
+queue_monitor_length:
+  enabled: true
+  log: 5
 name_server:
   source:
     vrf: MGMT

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -338,6 +338,9 @@ vlan_internal_order:
   range:
     beginning: 1006
     ending: 1199
+queue_monitor_length:
+  enabled: true
+  log: 5
 name_server:
   source:
     vrf: MGMT

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -338,6 +338,9 @@ vlan_internal_order:
   range:
     beginning: 1006
     ending: 1199
+queue_monitor_length:
+  enabled: true
+  log: 5
 name_server:
   source:
     vrf: MGMT

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/AVD_LAB.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/AVD_LAB.yml
@@ -35,3 +35,9 @@ name_servers:
 # NTP Servers IP or DNS name, first NTP server will be prefered, and sourced from Managment
 ntp_servers:
   - 192.168.200.5
+
+queue_monitor_length:
+  log: 5
+  notifying: true 
+  # Note "notifying" should only be rendered on 7280R since default 
+  # platform_settings for default has queue_monitor_length_notify_support: false

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1671,7 +1671,7 @@ qos_profiles:
 ```yaml
 queue_monitor_length:
   log: < seconds >
-  notifying: < true | false >
+  notifying: < true | false - should only be used for platforms supporting the "queue-monitor length notifying" CLI >
 ```
 
 #### Queue Monitor Streaming

--- a/ansible_collections/arista/avd/roles/eos_designs/defaults/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/defaults/main.yml
@@ -178,6 +178,8 @@ platform_settings:
     reload_delay:
       mlag: 300
       non_mlag: 330
+    feature_support:
+      queue_monitor_length_notify: false
   - platforms: [7800R3, 7500R3, 7500R, 7280R3, 7280R2, 7280R]
     tcam_profile: vxlan-routing
     lag_hardware_only: true

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/common-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/common-settings.md
@@ -219,6 +219,8 @@ platform_settings:
   - platforms: [ < Arista Platform Family >, < Arista Platform Family > ]
     tcam_profile: < tcam_profile >
     lag_hardware_only: < true | false >
+    feature_support:
+      queue_monitor_length_notify: < true | false | default -> true >
     reload_delay:
       mlag: < seconds >
       non_mlag: < seconds >
@@ -237,6 +239,8 @@ platform_settings:
     reload_delay:
       mlag: 300
       non_mlag: 330
+    feature_support:
+      queue_monitor_length_notify: false
   - platforms: [ 7800R3, 7500R3, 7500R, 7280R3, 7280R2, 7280R ]
     tcam_profile: vxlan-routing
     lag_hardware_only: true

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/base/queue-monitor-length.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/base/queue-monitor-length.j2
@@ -1,7 +1,8 @@
 {% if queue_monitor_length is defined %}
 queue_monitor_length:
   enabled: true
-{%    if queue_monitor_length.notifying is defined %}
+{%    if queue_monitor_length.notifying is arista.avd.defined and
+         switch.platform_settings.feature_support.queue_monitor_length_notify is not arista.avd.defined(false) %}
   notifying: {{ queue_monitor_length.notifying }}
 {%    endif %}
 {%    if queue_monitor_length.log is defined %}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Add platform setting for `queue_monitor_length_notify_support`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Fixes #1005 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

Introduce a new knob under `platform_settings` to specify if the CLI `queue-monitor length notify` is supported.
This is needed since EOS from 4.25.x rejects this command on unsupported platforms.

```yaml
platform_settings:
  - platforms: [ < Arista Platform Family >, < Arista Platform Family > ]
    queue_monitor_length_notify_support: < true | false | default -> true >
```

Also updating the default `platform_settings` to leverage this knob:
```yaml
platform_settings:
  - platforms: [ default ]
    reload_delay:
      mlag: 300
      non_mlag: 330
    queue_monitor_length_notify_support: false
  - platforms: [ 7800R3, 7500R3, 7500R, 7280R3, 7280R2, 7280R ]
    tcam_profile: vxlan-routing
    lag_hardware_only: true
    reload_delay:
      mlag: 780
      non_mlag: 1020
```

The impact for running networks should be none, since the command would be ignored on non-R-series platforms anyway, but since this will change the defaults, we will merge this in for next major release (3.0.0)

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
We did not have molecule testing of `queue_monitor_length` so added that on scenario where we have different platforms.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contributing/) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
