### PR TITLE
eos_designs(feature): Add support for vlan_aware_bundle_number_base

### DIFF
--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -659,7 +659,7 @@ ip route vrf Tenant_A_WAN_Zone 10.3.4.0/24 1.2.3.4
 | ----------------- | ------------------- | ----------------- | ------------------- | ------------------- | ------------ | ----- |
 | Tenant_A_WAN_Zone | 192.168.255.14:14 | 14:14 | - | - | learned | 150 |
 | Tenant_B_WAN_Zone | 192.168.255.14:21 | 21:21 | - | - | learned | 250 |
-| Tenant_C_WAN_Zone | 192.168.255.14:31 | 31:31 | - | - | learned | 350 |
+| Tenant_C_WAN_Zone | 192.168.255.14:30031 | 30031:30031 | - | - | learned | 350 |
 
 #### Router BGP EVPN VRFs
 
@@ -727,8 +727,8 @@ router bgp 65104
       vlan 250
    !
    vlan-aware-bundle Tenant_C_WAN_Zone
-      rd 192.168.255.14:31
-      route-target both 31:31
+      rd 192.168.255.14:30031
+      route-target both 30031:30031
       redistribute learned
       vlan 350
    !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -657,7 +657,7 @@ ip route vrf Tenant_A_WAN_Zone 10.3.4.0/24 1.2.3.4
 | ----------------- | ------------------- | ----------------- | ------------------- | ------------------- | ------------ | ----- |
 | Tenant_A_WAN_Zone | 192.168.255.15:14 | 14:14 | - | - | learned | 150 |
 | Tenant_B_WAN_Zone | 192.168.255.15:21 | 21:21 | - | - | learned | 250 |
-| Tenant_C_WAN_Zone | 192.168.255.15:31 | 31:31 | - | - | learned | 350 |
+| Tenant_C_WAN_Zone | 192.168.255.15:30031 | 30031:30031 | - | - | learned | 350 |
 
 #### Router BGP EVPN VRFs
 
@@ -725,8 +725,8 @@ router bgp 65105
       vlan 250
    !
    vlan-aware-bundle Tenant_C_WAN_Zone
-      rd 192.168.255.15:31
-      route-target both 31:31
+      rd 192.168.255.15:30031
+      route-target both 30031:30031
       redistribute learned
       vlan 350
    !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -914,7 +914,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | Tenant_A_VMOTION | 192.168.255.10:10160 | 10160:10160 | - | - | learned | 160 |
 | Tenant_A_WEB_Zone | 192.168.255.10:11 | 11:11 | - | - | learned | 120-121 |
 | Tenant_B_OP_Zone | 192.168.255.10:20 | 20:20 | - | - | learned | 210-211 |
-| Tenant_C_OP_Zone | 192.168.255.10:30 | 30:30 | - | - | learned | 310-311 |
+| Tenant_C_OP_Zone | 192.168.255.10:30030 | 30030:30030 | - | - | learned | 310-311 |
 
 #### Router BGP EVPN VRFs
 
@@ -1019,8 +1019,8 @@ router bgp 65102
       vlan 210-211
    !
    vlan-aware-bundle Tenant_C_OP_Zone
-      rd 192.168.255.10:30
-      route-target both 30:30
+      rd 192.168.255.10:30030
+      route-target both 30030:30030
       redistribute learned
       vlan 310-311
    !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -914,7 +914,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | Tenant_A_VMOTION | 192.168.255.11:10160 | 10160:10160 | - | - | learned | 160 |
 | Tenant_A_WEB_Zone | 192.168.255.11:11 | 11:11 | - | - | learned | 120-121 |
 | Tenant_B_OP_Zone | 192.168.255.11:20 | 20:20 | - | - | learned | 210-211 |
-| Tenant_C_OP_Zone | 192.168.255.11:30 | 30:30 | - | - | learned | 310-311 |
+| Tenant_C_OP_Zone | 192.168.255.11:30030 | 30030:30030 | - | - | learned | 310-311 |
 
 #### Router BGP EVPN VRFs
 
@@ -1019,8 +1019,8 @@ router bgp 65102
       vlan 210-211
    !
    vlan-aware-bundle Tenant_C_OP_Zone
-      rd 192.168.255.11:30
-      route-target both 30:30
+      rd 192.168.255.11:30030
+      route-target both 30030:30030
       redistribute learned
       vlan 310-311
    !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -1277,8 +1277,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | Tenant_A_WEB_Zone | 192.168.255.12:11 | 11:11 | - | - | learned | 120-121 |
 | Tenant_B_OP_Zone | 192.168.255.12:20 | 20:20 | - | - | learned | 210-211 |
 | Tenant_B_WAN_Zone | 192.168.255.12:21 | 21:21 | - | - | learned | 250 |
-| Tenant_C_OP_Zone | 192.168.255.12:30 | 30:30 | - | - | learned | 310-311 |
-| Tenant_C_WAN_Zone | 192.168.255.12:31 | 31:31 | - | - | learned | 350 |
+| Tenant_C_OP_Zone | 192.168.255.12:30030 | 30030:30030 | - | - | learned | 310-311 |
+| Tenant_C_WAN_Zone | 192.168.255.12:30031 | 30031:30031 | - | - | learned | 350 |
 
 #### Router BGP EVPN VRFs
 
@@ -1407,14 +1407,14 @@ router bgp 65103
       vlan 250
    !
    vlan-aware-bundle Tenant_C_OP_Zone
-      rd 192.168.255.12:30
-      route-target both 30:30
+      rd 192.168.255.12:30030
+      route-target both 30030:30030
       redistribute learned
       vlan 310-311
    !
    vlan-aware-bundle Tenant_C_WAN_Zone
-      rd 192.168.255.12:31
-      route-target both 31:31
+      rd 192.168.255.12:30031
+      route-target both 30031:30031
       redistribute learned
       vlan 350
    !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -1277,8 +1277,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | Tenant_A_WEB_Zone | 192.168.255.13:11 | 11:11 | - | - | learned | 120-121 |
 | Tenant_B_OP_Zone | 192.168.255.13:20 | 20:20 | - | - | learned | 210-211 |
 | Tenant_B_WAN_Zone | 192.168.255.13:21 | 21:21 | - | - | learned | 250 |
-| Tenant_C_OP_Zone | 192.168.255.13:30 | 30:30 | - | - | learned | 310-311 |
-| Tenant_C_WAN_Zone | 192.168.255.13:31 | 31:31 | - | - | learned | 350 |
+| Tenant_C_OP_Zone | 192.168.255.13:30030 | 30030:30030 | - | - | learned | 310-311 |
+| Tenant_C_WAN_Zone | 192.168.255.13:30031 | 30031:30031 | - | - | learned | 350 |
 
 #### Router BGP EVPN VRFs
 
@@ -1407,14 +1407,14 @@ router bgp 65103
       vlan 250
    !
    vlan-aware-bundle Tenant_C_OP_Zone
-      rd 192.168.255.13:30
-      route-target both 30:30
+      rd 192.168.255.13:30030
+      route-target both 30030:30030
       redistribute learned
       vlan 310-311
    !
    vlan-aware-bundle Tenant_C_WAN_Zone
-      rd 192.168.255.13:31
-      route-target both 31:31
+      rd 192.168.255.13:30031
+      route-target both 30031:30031
       redistribute learned
       vlan 350
    !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1A.cfg
@@ -269,8 +269,8 @@ router bgp 65104
       vlan 250
    !
    vlan-aware-bundle Tenant_C_WAN_Zone
-      rd 192.168.255.14:31
-      route-target both 31:31
+      rd 192.168.255.14:30031
+      route-target both 30031:30031
       redistribute learned
       vlan 350
    !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1B.cfg
@@ -268,8 +268,8 @@ router bgp 65105
       vlan 250
    !
    vlan-aware-bundle Tenant_C_WAN_Zone
-      rd 192.168.255.15:31
-      route-target both 31:31
+      rd 192.168.255.15:30031
+      route-target both 30031:30031
       redistribute learned
       vlan 350
    !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
@@ -469,8 +469,8 @@ router bgp 65102
       vlan 210-211
    !
    vlan-aware-bundle Tenant_C_OP_Zone
-      rd 192.168.255.10:30
-      route-target both 30:30
+      rd 192.168.255.10:30030
+      route-target both 30030:30030
       redistribute learned
       vlan 310-311
    !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
@@ -469,8 +469,8 @@ router bgp 65102
       vlan 210-211
    !
    vlan-aware-bundle Tenant_C_OP_Zone
-      rd 192.168.255.11:30
-      route-target both 30:30
+      rd 192.168.255.11:30030
+      route-target both 30030:30030
       redistribute learned
       vlan 310-311
    !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
@@ -768,14 +768,14 @@ router bgp 65103
       vlan 250
    !
    vlan-aware-bundle Tenant_C_OP_Zone
-      rd 192.168.255.12:30
-      route-target both 30:30
+      rd 192.168.255.12:30030
+      route-target both 30030:30030
       redistribute learned
       vlan 310-311
    !
    vlan-aware-bundle Tenant_C_WAN_Zone
-      rd 192.168.255.12:31
-      route-target both 31:31
+      rd 192.168.255.12:30031
+      route-target both 30031:30031
       redistribute learned
       vlan 350
    !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
@@ -768,14 +768,14 @@ router bgp 65103
       vlan 250
    !
    vlan-aware-bundle Tenant_C_OP_Zone
-      rd 192.168.255.13:30
-      route-target both 30:30
+      rd 192.168.255.13:30030
+      route-target both 30030:30030
       redistribute learned
       vlan 310-311
    !
    vlan-aware-bundle Tenant_C_WAN_Zone
-      rd 192.168.255.13:31
-      route-target both 31:31
+      rd 192.168.255.13:30031
+      route-target both 30031:30031
       redistribute learned
       vlan 350
    !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
@@ -199,10 +199,10 @@ router_bgp:
       - learned
       vlan: 250
     Tenant_C_WAN_Zone:
-      rd: 192.168.255.14:31
+      rd: 192.168.255.14:30031
       route_targets:
         both:
-        - '31:31'
+        - 30031:30031
       redistribute_routes:
       - learned
       vlan: 350

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
@@ -199,10 +199,10 @@ router_bgp:
       - learned
       vlan: 250
     Tenant_C_WAN_Zone:
-      rd: 192.168.255.15:31
+      rd: 192.168.255.15:30031
       route_targets:
         both:
-        - '31:31'
+        - 30031:30031
       redistribute_routes:
       - learned
       vlan: 350

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -208,10 +208,10 @@ router_bgp:
       - learned
       vlan: 210-211
     Tenant_C_OP_Zone:
-      rd: 192.168.255.10:30
+      rd: 192.168.255.10:30030
       route_targets:
         both:
-        - '30:30'
+        - 30030:30030
       redistribute_routes:
       - learned
       vlan: 310-311

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -208,10 +208,10 @@ router_bgp:
       - learned
       vlan: 210-211
     Tenant_C_OP_Zone:
-      rd: 192.168.255.11:30
+      rd: 192.168.255.11:30030
       route_targets:
         both:
-        - '30:30'
+        - 30030:30030
       redistribute_routes:
       - learned
       vlan: 310-311

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -302,18 +302,18 @@ router_bgp:
       - learned
       vlan: 250
     Tenant_C_OP_Zone:
-      rd: 192.168.255.12:30
+      rd: 192.168.255.12:30030
       route_targets:
         both:
-        - '30:30'
+        - 30030:30030
       redistribute_routes:
       - learned
       vlan: 310-311
     Tenant_C_WAN_Zone:
-      rd: 192.168.255.12:31
+      rd: 192.168.255.12:30031
       route_targets:
         both:
-        - '31:31'
+        - 30031:30031
       redistribute_routes:
       - learned
       vlan: 350

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -302,18 +302,18 @@ router_bgp:
       - learned
       vlan: 250
     Tenant_C_OP_Zone:
-      rd: 192.168.255.13:30
+      rd: 192.168.255.13:30030
       route_targets:
         both:
-        - '30:30'
+        - 30030:30030
       redistribute_routes:
       - learned
       vlan: 310-311
     Tenant_C_WAN_Zone:
-      rd: 192.168.255.13:31
+      rd: 192.168.255.13:30031
       route_targets:
         both:
-        - '31:31'
+        - 30031:30031
       redistribute_routes:
       - learned
       vlan: 350

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_TENANTS_NETWORKS.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_TENANTS_NETWORKS.yml
@@ -239,6 +239,7 @@ tenants:
   # Tenant_C Specific Information - VRFs / VLANs
   Tenant_C:
     mac_vrf_vni_base: 30000
+    vlan_aware_bundle_number_base: 30000
     vrfs:
       Tenant_C_OP_Zone:
         vrf_vni: 30

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/network-services.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/network-services.md
@@ -67,6 +67,10 @@ tenants:
     # e.g. mac_vrf_vni_base = 10000, svi 100 = VNI 10100, svi 300 = VNI 10300.
     mac_vrf_vni_base: < 10000-16770000 >
 
+    # Base number for vlan_aware_bundle | Optional.
+    # The "Assigned Number" part of RD/RT is derived from vrf_vni + vlan_aware_bundle_number_base.
+    vlan_aware_bundle_number_base: < number | default -> 0 >
+
     # MLAG IBGP peering per VRF | Optional
     # By default an IBGP peering is configured per VRF between MLAG peers on separate VLANs.
     # Setting enable_mlag_ibgp_peering_vrfs: false under tenant will change this default to prevent configuration of these peerings and VLANs for all VRFs in the tenant.

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenants/router-bgp-vlan-aware-bundles.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenants/router-bgp-vlan-aware-bundles.j2
@@ -4,11 +4,13 @@
 {%     for tenant in switch.tenants | arista.avd.natural_sort %}
 {%         for vrf in switch.tenants[tenant].vrfs | arista.avd.natural_sort %}
 {%             if switch.tenants[tenant].vrfs[vrf].svis | arista.avd.default([]) | length > 0 %}
+{%                 set vrf_vni_int = tenants[tenant].vrfs[vrf].vrf_vni | int %}
+{%                 set bundle_number =  vrf_vni_int + tenants[tenant].vlan_aware_bundle_number_base | arista.avd.default(0) %}
     {{ vrf }}:
-      rd: "{{ tenants_data.evpn_rd_admin_subfield }}:{{ tenants[tenant].vrfs[vrf].vrf_vni }}"
+      rd: "{{ tenants_data.evpn_rd_admin_subfield }}:{{ bundle_number }}"
       route_targets:
         both:
-          - "{{ tenants_data.evpn_rt_admin_subfield or tenants[tenant].vrfs[vrf].vrf_vni }}:{{ tenants[tenant].vrfs[vrf].vrf_vni }}"
+          - "{{ tenants_data.evpn_rt_admin_subfield or bundle_number }}:{{ bundle_number }}"
       redistribute_routes:
         - learned
       vlan: {{ switch.tenants[tenant].vrfs[vrf].svis | map('int') | arista.avd.list_compress }}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Add support for vlan_aware_bundle_number_base

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [x] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Fixes #827 
## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

Add a knob to offset the last part of RD/RT for vlan_aware_bundles.

```yaml
tenants:
  < tenant name >:
    # Base number for vlan_aware_bundle | Optional.
    # The "Assigned Number" part of RD/RT is derived from vrf_vni + vlan_aware_bundle_number_base.
    vlan_aware_bundle_number_base: < number | default -> 0 >
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Added molecule test scenario

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contributing/) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
