### PR TITLE
eos_designs(refactor): rfc5549 to avoid `eos_designs` variable from being parsed in `eos_cli_config_gen`

### DIFF
--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -683,7 +683,6 @@ router bgp 65104
       neighbor EVPN-OVERLAY-PEERS activate
    !
    address-family ipv4
-      neighbor EVPN-OVERLAY-PEERS next-hop address-family ipv6 originate
       no neighbor EVPN-OVERLAY-PEERS activate
       neighbor UNDERLAY_PEERS next-hop address-family ipv6 originate
       neighbor UNDERLAY_PEERS activate

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -664,7 +664,6 @@ router bgp 65105
       neighbor EVPN-OVERLAY-PEERS activate
    !
    address-family ipv4
-      neighbor EVPN-OVERLAY-PEERS next-hop address-family ipv6 originate
       no neighbor EVPN-OVERLAY-PEERS activate
       neighbor UNDERLAY_PEERS next-hop address-family ipv6 originate
       neighbor UNDERLAY_PEERS activate

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -671,7 +671,6 @@ router bgp 65101
       neighbor EVPN-OVERLAY-PEERS activate
    !
    address-family ipv4
-      neighbor EVPN-OVERLAY-PEERS next-hop address-family ipv6 originate
       no neighbor EVPN-OVERLAY-PEERS activate
       neighbor UNDERLAY_PEERS next-hop address-family ipv6 originate
       neighbor UNDERLAY_PEERS activate

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -1112,7 +1112,6 @@ router bgp 65102
       neighbor EVPN-OVERLAY-PEERS activate
    !
    address-family ipv4
-      neighbor EVPN-OVERLAY-PEERS next-hop address-family ipv6 originate
       no neighbor EVPN-OVERLAY-PEERS activate
       neighbor MLAG_PEER next-hop address-family ipv6 originate
       neighbor MLAG_PEER activate

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -1112,7 +1112,6 @@ router bgp 65102
       neighbor EVPN-OVERLAY-PEERS activate
    !
    address-family ipv4
-      neighbor EVPN-OVERLAY-PEERS next-hop address-family ipv6 originate
       no neighbor EVPN-OVERLAY-PEERS activate
       neighbor MLAG_PEER next-hop address-family ipv6 originate
       neighbor MLAG_PEER activate

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE1.md
@@ -483,7 +483,6 @@ router bgp 65001
       neighbor EVPN-OVERLAY-PEERS activate
    !
    address-family ipv4
-      neighbor EVPN-OVERLAY-PEERS next-hop address-family ipv6 originate
       no neighbor EVPN-OVERLAY-PEERS activate
       neighbor UNDERLAY_PEERS next-hop address-family ipv6 originate
       neighbor UNDERLAY_PEERS activate

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE2.md
@@ -483,7 +483,6 @@ router bgp 65001
       neighbor EVPN-OVERLAY-PEERS activate
    !
    address-family ipv4
-      neighbor EVPN-OVERLAY-PEERS next-hop address-family ipv6 originate
       no neighbor EVPN-OVERLAY-PEERS activate
       neighbor UNDERLAY_PEERS next-hop address-family ipv6 originate
       neighbor UNDERLAY_PEERS activate

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE3.md
@@ -483,7 +483,6 @@ router bgp 65001
       neighbor EVPN-OVERLAY-PEERS activate
    !
    address-family ipv4
-      neighbor EVPN-OVERLAY-PEERS next-hop address-family ipv6 originate
       no neighbor EVPN-OVERLAY-PEERS activate
       neighbor UNDERLAY_PEERS next-hop address-family ipv6 originate
       neighbor UNDERLAY_PEERS activate

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE4.md
@@ -483,7 +483,6 @@ router bgp 65001
       neighbor EVPN-OVERLAY-PEERS activate
    !
    address-family ipv4
-      neighbor EVPN-OVERLAY-PEERS next-hop address-family ipv6 originate
       no neighbor EVPN-OVERLAY-PEERS activate
       neighbor UNDERLAY_PEERS next-hop address-family ipv6 originate
       neighbor UNDERLAY_PEERS activate

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -1313,7 +1313,6 @@ router bgp 65103
       neighbor EVPN-OVERLAY-PEERS activate
    !
    address-family ipv4
-      neighbor EVPN-OVERLAY-PEERS next-hop address-family ipv6 originate
       no neighbor EVPN-OVERLAY-PEERS activate
       neighbor MLAG_PEER next-hop address-family ipv6 originate
       neighbor MLAG_PEER activate

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -1298,7 +1298,6 @@ router bgp 65103
       neighbor EVPN-OVERLAY-PEERS activate
    !
    address-family ipv4
-      neighbor EVPN-OVERLAY-PEERS next-hop address-family ipv6 originate
       no neighbor EVPN-OVERLAY-PEERS activate
       neighbor MLAG_PEER next-hop address-family ipv6 originate
       neighbor MLAG_PEER activate

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-BL1A.cfg
@@ -216,7 +216,6 @@ router bgp 65104
       neighbor EVPN-OVERLAY-PEERS activate
    !
    address-family ipv4
-      neighbor EVPN-OVERLAY-PEERS next-hop address-family ipv6 originate
       no neighbor EVPN-OVERLAY-PEERS activate
       neighbor UNDERLAY_PEERS next-hop address-family ipv6 originate
       neighbor UNDERLAY_PEERS activate

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-BL1B.cfg
@@ -216,7 +216,6 @@ router bgp 65105
       neighbor EVPN-OVERLAY-PEERS activate
    !
    address-family ipv4
-      neighbor EVPN-OVERLAY-PEERS next-hop address-family ipv6 originate
       no neighbor EVPN-OVERLAY-PEERS activate
       neighbor UNDERLAY_PEERS next-hop address-family ipv6 originate
       neighbor UNDERLAY_PEERS activate

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
@@ -226,7 +226,6 @@ router bgp 65101
       neighbor EVPN-OVERLAY-PEERS activate
    !
    address-family ipv4
-      neighbor EVPN-OVERLAY-PEERS next-hop address-family ipv6 originate
       no neighbor EVPN-OVERLAY-PEERS activate
       neighbor UNDERLAY_PEERS next-hop address-family ipv6 originate
       neighbor UNDERLAY_PEERS activate

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
@@ -534,7 +534,6 @@ router bgp 65102
       neighbor EVPN-OVERLAY-PEERS activate
    !
    address-family ipv4
-      neighbor EVPN-OVERLAY-PEERS next-hop address-family ipv6 originate
       no neighbor EVPN-OVERLAY-PEERS activate
       neighbor MLAG_PEER next-hop address-family ipv6 originate
       neighbor MLAG_PEER activate

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
@@ -534,7 +534,6 @@ router bgp 65102
       neighbor EVPN-OVERLAY-PEERS activate
    !
    address-family ipv4
-      neighbor EVPN-OVERLAY-PEERS next-hop address-family ipv6 originate
       no neighbor EVPN-OVERLAY-PEERS activate
       neighbor MLAG_PEER next-hop address-family ipv6 originate
       neighbor MLAG_PEER activate

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE1.cfg
@@ -155,7 +155,6 @@ router bgp 65001
       neighbor EVPN-OVERLAY-PEERS activate
    !
    address-family ipv4
-      neighbor EVPN-OVERLAY-PEERS next-hop address-family ipv6 originate
       no neighbor EVPN-OVERLAY-PEERS activate
       neighbor UNDERLAY_PEERS next-hop address-family ipv6 originate
       neighbor UNDERLAY_PEERS activate

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE2.cfg
@@ -155,7 +155,6 @@ router bgp 65001
       neighbor EVPN-OVERLAY-PEERS activate
    !
    address-family ipv4
-      neighbor EVPN-OVERLAY-PEERS next-hop address-family ipv6 originate
       no neighbor EVPN-OVERLAY-PEERS activate
       neighbor UNDERLAY_PEERS next-hop address-family ipv6 originate
       neighbor UNDERLAY_PEERS activate

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE3.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE3.cfg
@@ -155,7 +155,6 @@ router bgp 65001
       neighbor EVPN-OVERLAY-PEERS activate
    !
    address-family ipv4
-      neighbor EVPN-OVERLAY-PEERS next-hop address-family ipv6 originate
       no neighbor EVPN-OVERLAY-PEERS activate
       neighbor UNDERLAY_PEERS next-hop address-family ipv6 originate
       neighbor UNDERLAY_PEERS activate

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE4.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE4.cfg
@@ -155,7 +155,6 @@ router bgp 65001
       neighbor EVPN-OVERLAY-PEERS activate
    !
    address-family ipv4
-      neighbor EVPN-OVERLAY-PEERS next-hop address-family ipv6 originate
       no neighbor EVPN-OVERLAY-PEERS activate
       neighbor UNDERLAY_PEERS next-hop address-family ipv6 originate
       neighbor UNDERLAY_PEERS activate

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
@@ -697,7 +697,6 @@ router bgp 65103
       neighbor EVPN-OVERLAY-PEERS activate
    !
    address-family ipv4
-      neighbor EVPN-OVERLAY-PEERS next-hop address-family ipv6 originate
       no neighbor EVPN-OVERLAY-PEERS activate
       neighbor MLAG_PEER next-hop address-family ipv6 originate
       neighbor MLAG_PEER activate

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
@@ -684,7 +684,6 @@ router bgp 65103
       neighbor EVPN-OVERLAY-PEERS activate
    !
    address-family ipv4
-      neighbor EVPN-OVERLAY-PEERS next-hop address-family ipv6 originate
       no neighbor EVPN-OVERLAY-PEERS activate
       neighbor MLAG_PEER next-hop address-family ipv6 originate
       neighbor MLAG_PEER activate

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
@@ -24,6 +24,8 @@ router_bgp:
     peer_groups:
       UNDERLAY_PEERS:
         activate: true
+        next_hop:
+          address_family_ipv6_originate: true
       EVPN-OVERLAY-PEERS:
         activate: false
   redistribute_routes:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
@@ -24,6 +24,8 @@ router_bgp:
     peer_groups:
       UNDERLAY_PEERS:
         activate: true
+        next_hop:
+          address_family_ipv6_originate: true
       EVPN-OVERLAY-PEERS:
         activate: false
   redistribute_routes:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
@@ -24,6 +24,8 @@ router_bgp:
     peer_groups:
       UNDERLAY_PEERS:
         activate: true
+        next_hop:
+          address_family_ipv6_originate: true
       EVPN-OVERLAY-PEERS:
         activate: false
   redistribute_routes:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -32,8 +32,12 @@ router_bgp:
     peer_groups:
       MLAG_PEER:
         activate: true
+        next_hop:
+          address_family_ipv6_originate: true
       UNDERLAY_PEERS:
         activate: true
+        next_hop:
+          address_family_ipv6_originate: true
       EVPN-OVERLAY-PEERS:
         activate: false
   neighbor_interfaces:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -32,8 +32,12 @@ router_bgp:
     peer_groups:
       MLAG_PEER:
         activate: true
+        next_hop:
+          address_family_ipv6_originate: true
       UNDERLAY_PEERS:
         activate: true
+        next_hop:
+          address_family_ipv6_originate: true
       EVPN-OVERLAY-PEERS:
         activate: false
   neighbor_interfaces:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
@@ -24,6 +24,8 @@ router_bgp:
     peer_groups:
       UNDERLAY_PEERS:
         activate: true
+        next_hop:
+          address_family_ipv6_originate: true
       EVPN-OVERLAY-PEERS:
         activate: false
   redistribute_routes:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
@@ -24,6 +24,8 @@ router_bgp:
     peer_groups:
       UNDERLAY_PEERS:
         activate: true
+        next_hop:
+          address_family_ipv6_originate: true
       EVPN-OVERLAY-PEERS:
         activate: false
   redistribute_routes:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
@@ -24,6 +24,8 @@ router_bgp:
     peer_groups:
       UNDERLAY_PEERS:
         activate: true
+        next_hop:
+          address_family_ipv6_originate: true
       EVPN-OVERLAY-PEERS:
         activate: false
   redistribute_routes:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
@@ -24,6 +24,8 @@ router_bgp:
     peer_groups:
       UNDERLAY_PEERS:
         activate: true
+        next_hop:
+          address_family_ipv6_originate: true
       EVPN-OVERLAY-PEERS:
         activate: false
   redistribute_routes:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -32,8 +32,12 @@ router_bgp:
     peer_groups:
       MLAG_PEER:
         activate: true
+        next_hop:
+          address_family_ipv6_originate: true
       UNDERLAY_PEERS:
         activate: true
+        next_hop:
+          address_family_ipv6_originate: true
       EVPN-OVERLAY-PEERS:
         activate: false
   neighbor_interfaces:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -32,8 +32,12 @@ router_bgp:
     peer_groups:
       MLAG_PEER:
         activate: true
+        next_hop:
+          address_family_ipv6_originate: true
       UNDERLAY_PEERS:
         activate: true
+        next_hop:
+          address_family_ipv6_originate: true
       EVPN-OVERLAY-PEERS:
         activate: false
   neighbor_interfaces:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1842,6 +1842,8 @@ router_bgp:
         default_originate:
           always: < true | false >
           route_map: < route_map_name >
+        next_hop:
+          address_family_ipv6_originate: < true | false >
     neighbors:
       < neighbor_ip_address>:
         route_map_in: < route_map_name >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -293,7 +293,7 @@ router bgp {{ router_bgp.as }}
 {%                endif %}
       {{ neighbor_default_originate_cli }}
 {%             endif%}
-{%             if underlay_rfc5549 is arista.avd.defined(true) %}
+{%             if router_bgp.address_family_ipv4.peer_groups[peer_group].next_hop.address_family_ipv6_originate is arista.avd.defined(true) %}
       neighbor {{ peer_group }} next-hop address-family ipv6 originate
 {%             endif %}
 {%             if router_bgp.address_family_ipv4.peer_groups[peer_group].activate is arista.avd.defined(true) %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/underlay/ebgp/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/underlay/ebgp/router-bgp.j2
@@ -14,6 +14,10 @@ router_bgp:
     peer_groups:
       {{ bgp_peer_groups.IPv4_UNDERLAY_PEERS.name | arista.avd.default("IPv4-UNDERLAY-PEERS") }}:
         activate: true
+{% if underlay_rfc5549 is arista.avd.defined(true) %}
+        next_hop:
+          address_family_ipv6_originate: true
+{% endif %}
   redistribute_routes:
     connected:
       route_map: RM-CONN-2-BGP

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/mlag/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/mlag/router-bgp.j2
@@ -16,8 +16,9 @@ router_bgp:
     peer_groups:
       {{ bgp_peer_groups.MLAG_IPv4_UNDERLAY_PEER.name | arista.avd.default("MLAG-IPv4-UNDERLAY-PEER") }}:
         activate: true
-
 {%     if underlay_rfc5549 is arista.avd.defined(true) %}
+        next_hop:
+          address_family_ipv6_originate: true
   neighbor_interfaces:
     Vlan{{ switch.mlag_peer_l3_vlan }}:
       peer_group: {{ bgp_peer_groups.MLAG_IPv4_UNDERLAY_PEER.name | arista.avd.default("MLAG-IPv4-UNDERLAY-PEER") }}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Refactor rfc5549 to avoid `eos_designs` variable from being parsed in `eos_cli_config_gen`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [x] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Fixes #969 

## Component(s) name

`arista.avd.eos_designs`
`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

Add new knob to `eos_cli_config_gen`:
```yaml
router_bgp:
  address_family_ipv4:
    peer_groups:
      < peer_group_name >:
        next_hop:
          address_family_ipv6_originate: < true | false >
```

Modified `eos_designs` to leverage this knob.

This also fixed a wrongly generated configuration line where we set ipv6 next-hop for overlay peer-group.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Ran Molecule test scenario and it produced no unexpected changes. Only wrong config removed.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contributing/) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
