### PR TITLE
Add option to not generate device documentation

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/generate_device_documentation.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/generate_device_documentation.cfg
@@ -1,0 +1,15 @@
+!RANCID-CONTENT-TYPE: arista
+!
+transceiver qsfp default-mode 4x10G
+!
+hostname generate_device_documentation
+!
+no aaa root
+no enable password
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/generate_device_documentation.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/generate_device_documentation.yml
@@ -1,0 +1,1 @@
+generate_device_documentation: false

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts
@@ -14,6 +14,7 @@ errdisable
 ethernet-interfaces
 event-handlers
 event-monitor
+generate_device_documentation
 hardware-counter
 hardware
 igmp-snooping

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -37,6 +37,7 @@
       - [IP Extended Community Lists RegExp](#ip-extended-community-lists-regexp)
       - [Peer Filters](#peer-filters)
       - [Route Maps](#route-maps)
+    - [Generate Device Documentation](#generate-device-documentation)
     - [Hardware](#hardware)
       - [Hardware Counters](#hardware-counters)
       - [Hardware TCAM Profiles](#hardware-tcam-profiles)
@@ -545,6 +546,12 @@ route_maps:
         set:
           - "< set rule 1 as string >"
           - "< set rule 2 as string >"
+```
+
+### Generate Device Documentation
+
+```yaml
+generate_device_documentation: < true | false | default -> true >
 ```
 
 ### Hardware

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/tasks/main.yml
@@ -25,6 +25,7 @@
 - name: Generate device documentation
   tags: [build, provision]
   delegate_to: localhost
+  when: generate_device_documentation | arista.avd.default(true)
   block:
     - name: Store checksum of existing device documentation
       ansible.builtin.stat:


### PR DESCRIPTION
## Change Summary

Add option to not generate device documentation
<!-- Enter short PR description -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Part of fix for #814

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

```yaml
generate_device_documentation: < true | false | default -> true >
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Added molecule scenario

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
