### PR TITLE
eos_config_deploy_cvp(fix): galaxy importer issues

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v1/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v1/main.yml
@@ -18,6 +18,7 @@
   template:
     src: "cvp-devices.j2"
     dest: "{{ structured_cvp_dir }}/{{ inventory_hostname }}.yml"
+    mode: 0664
   delegate_to: localhost
   run_once: true
 

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v3/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v3/main.yml
@@ -1,4 +1,3 @@
-
 ---
 - name: "Generate intented variables"
   tags: [always]

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v3/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v3/main.yml
@@ -15,6 +15,7 @@
   template:
     src: "cvp-devices-v3.j2"
     dest: "{{ structured_cvp_dir }}/{{ inventory_hostname }}.yml"
+    mode: 0664
   delegate_to: localhost
   run_once: true
 


### PR DESCRIPTION
## Change Summary

Fix warning issued by galaxy-importer:

```shell
WARNING: roles/eos_config_deploy_cvp/tasks/v1/main.yml:16: risky-file-permissions File permissions unset or incorrect
WARNING: roles/eos_config_deploy_cvp/tasks/v3/main.yml:1: yaml too many blank lines (1 > 0) (empty-lines)
WARNING: roles/eos_config_deploy_cvp/tasks/v3/main.yml:14: risky-file-permissions File permissions unset or incorrect
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Component(s) name

`arista.avd.eos_config_deploy_cvp`

## Proposed changes

- Set file permission on templates to 0644.
- Remove blank line.

## How to test

run `make galaxy-importer`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
