### PR TITLE
eos_cli_config_gen(fix) molecule scenario duplicate key

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -82,6 +82,7 @@ interface Management1
 | Ethernet11 |  interface_in_mode_access_accepting_tagged_LACP | access | 200 | - | - | - |
 | Ethernet12 |  interface_with_dot1q_tunnel | dot1q-tunnel | 300 | - | - | - |
 | Ethernet13 |  interface_in_mode_access_with_voice | trunk phone | - | 100 | - | - |
+| Ethernet14 |  SRV-POD02_Eth1 | trunk | 110-111,210-211 | - | - | - |
 
 *Inherited from Port-Channel Interface
 
@@ -251,6 +252,13 @@ interface Ethernet13
    switchport phone vlan 70
    switchport phone trunk untagged
    switchport mode trunk phone
+!
+interface Ethernet14
+   description SRV-POD02_Eth1
+   logging event link-status
+   switchport
+   switchport trunk allowed vlan 110-111,210-211
+   switchport mode trunk
 ```
 
 # Routing

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
@@ -146,6 +146,13 @@ interface Ethernet13
    switchport phone trunk untagged
    switchport mode trunk phone
 !
+interface Ethernet14
+   description SRV-POD02_Eth1
+   logging event link-status
+   switchport
+   switchport trunk allowed vlan 110-111,210-211
+   switchport mode trunk
+!
 interface Management1
    description oob_management
    vrf MGMT

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
@@ -18,17 +18,6 @@ ethernet_interfaces:
       Comment created from eos_cli under ethernet_interfaces.Ethernet1
       EOF
 
-  Ethernet6:
-    logging:
-      event:
-        link_status: true
-    peer: SRV-POD02
-    peer_interface: Eth1
-    peer_type: server
-    description: SRV-POD02_Eth1
-    mode: trunk
-    vlans: 110-111,210-211
-
   Ethernet2:
     peer: SRV-POD03
     peer_interface: Eth1
@@ -204,3 +193,14 @@ ethernet_interfaces:
     phone:
       trunk: untagged
       vlan: 70
+
+  Ethernet14:
+    logging:
+      event:
+        link_status: true
+    peer: SRV-POD02
+    peer_interface: Eth1
+    peer_type: server
+    description: SRV-POD02_Eth1
+    mode: trunk
+    vlans: 110-111,210-211


### PR DESCRIPTION
## Change Summary

Fix molecule scenario for eos_cli_config_gen

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Move duplicate key for Ethernet6 to Ethernet14

## How to test

run molecule `make converge`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been rebased from devel before I start
- [ ] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
