### PR TITLE
ci(action): Enable concurrency management in workflow

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -1,8 +1,17 @@
 ---
 name: "Collection code testing"
+
 on:
   push:
+    branches:
+      - devel
+      - releases/**
+      - ci/**
   pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
 
 jobs:
   file-changes:
@@ -326,7 +335,7 @@ jobs:
     runs-on: ubuntu-18.04
     container: avdteam/base:3.6-v1.0
     needs: [python_requirements]
-    if: needs.file-changes.outputs.requirements == 'true' && (startsWith(github.ref, 'refs/heads/releases') || startsWith(github.ref, 'refs/heads/devel'))
+    if: needs.file-changes.outputs.requirements == 'true' && (startsWith(github.ref, 'refs/heads/releases/**') || startsWith(github.ref, 'refs/heads/devel'))
     steps:
       - uses: actions/checkout@master
       - name: 'Send Webhook to docker hub'
@@ -342,7 +351,7 @@ jobs:
     runs-on: ubuntu-latest
     container: avdteam/base:3.6-v2.0
     needs: [galaxy_importer, ansible_test]
-    if: startsWith(github.ref, 'refs/heads/release') || startsWith(github.base_ref, 'refs/heads/release')
+    if: startsWith(github.ref, 'refs/heads/releases/**') || startsWith(github.base_ref, 'refs/heads/releases/**')
     steps:
       - name: 'set environment variables'
         run: |


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [x] Other (please describe): Github Actions

## Related Issue(s)
N/A

## Component(s) name

Github Actions

## Proposed changes

- Run workflow only on PR for all `base_ref` and on puh in branches `devel`, `releases/**`, 'ci/**'
- Enable [concurrency](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency) mode in workflow

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.head_ref }}
  cancel-in-progress: true
```

## How to test

Commit 2 times and push in less than 5 minutes in a branch starting with CI

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
