### PR TITLE
Add support for `no logging event link-status`

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -247,6 +247,7 @@ interface Ethernet12
 !
 interface Ethernet13
    description interface_in_mode_access_with_voice
+   no logging event link-status
    switchport
    switchport trunk native vlan 100
    switchport phone vlan 70

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
@@ -258,6 +258,7 @@ interface Port-Channel100.101
 !
 interface Port-Channel100.102
    description IFL for TENANT02
+   no logging event link-status
    mtu 1500
    switchport
    vrf C2

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
@@ -140,6 +140,7 @@ interface Ethernet12
 !
 interface Ethernet13
    description interface_in_mode_access_with_voice
+   no logging event link-status
    switchport
    switchport trunk native vlan 100
    switchport phone vlan 70

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
@@ -109,6 +109,7 @@ interface Port-Channel100.101
 !
 interface Port-Channel100.102
    description IFL for TENANT02
+   no logging event link-status
    mtu 1500
    switchport
    vrf C2

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
@@ -186,6 +186,9 @@ ethernet_interfaces:
     vlans: 300
 
   Ethernet13:
+    logging:
+      event:
+        link_status: false
     description: interface_in_mode_access_with_voice
     type: switched
     native_vlan: 100

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
@@ -80,6 +80,9 @@ port_channel_interfaces:
     ip_address: 10.1.1.3/31
     encapsulation_dot1q_vlan: 101
   Port-Channel100.102:
+    logging:
+      event:
+        link_status: false
     description: IFL for TENANT02
     mtu: 1500
     ip_address: 10.1.2.3/31

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -7,6 +7,8 @@ interface {{ ethernet_interface }}
 {%     endif %}
 {%     if ethernet_interfaces[ethernet_interface].logging.event.link_status is arista.avd.defined(true) %}
    logging event link-status
+{%     elif ethernet_interfaces[ethernet_interface].logging.event.link_status is arista.avd.defined(false) %}
+   no logging event link-status
 {%     endif %}
 {%     if ethernet_interfaces[ethernet_interface].shutdown is arista.avd.defined(true) %}
    shutdown

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
@@ -7,6 +7,8 @@ interface {{ port_channel_interface }}
 {%     endif %}
 {%     if port_channel_interfaces[port_channel_interface].logging.event.link_status is arista.avd.defined(true) %}
    logging event link-status
+{%     elif port_channel_interfaces[port_channel_interface].logging.event.link_status is arista.avd.defined(false) %}
+   no logging event link-status
 {%     endif %}
 {%     if port_channel_interfaces[port_channel_interface].shutdown is arista.avd.defined(true) %}
    shutdown


### PR DESCRIPTION
## Change Summary

Add support for `no logging event link-status`
<!-- Enter short PR description -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Fixes #1026 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->
Detect `logging.event.link_status` value of `false` and configure `no logging event link-status`

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been rebased from devel before I start
- [ ] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
