### PR TITLE
feat(eos_cli_config): Ensure required directories are present

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/tasks/main.yml
@@ -1,4 +1,16 @@
 ---
+- name: Create required output directories if not present
+  file:
+    path: "{{ item }}"
+    state: directory
+    mode: 0775
+  loop:
+    - "{{ structured_dir }}"
+    - "{{ eos_config_dir }}"
+    - "{{ devices_dir }}"
+  delegate_to: localhost
+  run_once: true
+
 - name: Check if structure configuration file exists
   tags: [build, provision]
   stat:


### PR DESCRIPTION
Someone using this role for the first time, and just loading the `eos_cli_config_gen` role shouldn't have to create the directories required by this role, beforehand.

```yaml
- hosts: all

  tasks:
    - import_role:
        name: arista.avd.eos_cli_config_gen
```