### PR TITLE
Feat(eos_designs): Implement tag for documentation

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/tasks/main.yml
@@ -23,7 +23,7 @@
   tags: [build, provision]
 
 - name: Generate device documentation
-  tags: [build, provision]
+  tags: [build, provision, documentation]
   delegate_to: localhost
   when: generate_device_documentation | arista.avd.default(true)
   block:

--- a/ansible_collections/arista/avd/roles/eos_designs/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/tasks/main.yml
@@ -50,7 +50,7 @@
 
 - name: Generate fabric documentation
   run_once: true
-  tags: [build, provision]
+  tags: [build, provision, documentation]
   delegate_to: localhost
   check_mode: no
   block:
@@ -83,7 +83,7 @@
   delegate_to: localhost
   run_once: true
   check_mode: no
-  tags: [build, provision]
+  tags: [build, provision, documentation]
 
 - name: Generate fabric topology in csv format.
   template:
@@ -93,4 +93,4 @@
   delegate_to: localhost
   run_once: true
   check_mode: no
-  tags: [build, provision]
+  tags: [build, provision, documentation]


### PR DESCRIPTION
## Change Summary

Implement documentation tag to allow user to not generate AVD documentation

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

N/A

## Component(s) name

- `arista.avd.eos_designs`
- `arista.avd.eos_cli_config_gen`
- 
## Proposed changes

Create a new tag named `documentation` that can be skipped with ansible CLI

## How to test

```bash
> ansible-playbook playbooks/avd-eapi-generic.yml --tags build --skip-tags documentation
Playbook run took 0 days, 0 hours, 0 minutes, 33 seconds

> ansible-playbook playbooks/avd-eapi-generic.yml --tags build
Playbook run took 0 days, 0 hours, 1 minutes, 12 seconds
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
