### PR TITLE
eos_designs(fix): Update documentation for l3_interface sub-interfaces

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/network-services.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/network-services.md
@@ -200,12 +200,21 @@ tenants:
             nodes: [ < node_1 >, < node_2 >, < node_1 > ]
             description: < description >
             enabled: < true | false >
-            mtu: <mtu >
+            mtu: < mtu >
             # EOS CLI rendered directly on the Ethernet interface in the final EOS configuration
             raw_eos_cli: |
               < multiline eos cli >
             # Custom structured config added under ethernet_interfaces.<interface> for eos_cli_config_gen
             structured_config: < dictionary >
+
+          # For sub-interfaces the dot1q vlan is derived from the interface name by default, but can also be specified.
+          - interfaces: [ <interface_name1.sub-if-id>, <interface_name2.sub-if-id> ]
+            encapsulation_dot1q_vlan: [ <vlan id>, <vlan id> ]
+            ip_addresses: [ <IPv4_address/Mask>, <IPv4_address/Mask> ]
+            nodes: [ < node_1 >, < node_2 > ]
+            description: < description >
+            enabled: < true | false >
+            mtu: < mtu - should only be used for platforms supporting mtu per subinterface >
 
         # Dictionary of static routes | Optional.
         # This will create static routes inside the tenant VRF, if none specified, all l3leafs that carry the VRF also get the static routes.


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Update documentation for l3_interface sub-interfaces

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [x] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Fixes #1051 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->
- Add subinterface documentation back (lost as part of PR 900 rebase)
- Add comment about platform support for setting mtu on subinterface

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contributing/) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
