### PR TITLE
Feat(eos_cli_config_gen):Add support for mlag heartbeat-interval and system control-plane section

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mlag-configuration.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mlag-configuration.md
@@ -1,0 +1,122 @@
+# mlag-configuration
+# Table of Contents
+<!-- toc -->
+
+- [Management](#management)
+  - [Management Interfaces](#management-interfaces)
+- [Authentication](#authentication)
+- [Monitoring](#monitoring)
+- [MLAG](#mlag)
+  - [MLAG Summary](#mlag-summary)
+  - [MLAG Device Configuration](#mlag-device-configuration)
+- [Internal VLAN Allocation Policy](#internal-vlan-allocation-policy)
+  - [Internal VLAN Allocation Policy Summary](#internal-vlan-allocation-policy-summary)
+- [Interfaces](#interfaces)
+- [Routing](#routing)
+  - [IP Routing](#ip-routing)
+  - [IPv6 Routing](#ipv6-routing)
+- [Multicast](#multicast)
+- [Filters](#filters)
+- [ACL](#acl)
+- [Quality Of Service](#quality-of-service)
+
+<!-- toc -->
+# Management
+
+## Management Interfaces
+
+### Management Interfaces Summary
+
+#### IPv4
+
+| Management Interface | description | Type | VRF | IP Address | Gateway |
+| -------------------- | ----------- | ---- | --- | ---------- | ------- |
+| Management1 | oob_management | oob | MGMT | 10.73.255.122/24 | 10.73.255.2 |
+
+#### IPv6
+
+| Management Interface | description | Type | VRF | IPv6 Address | IPv6 Gateway |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ |
+| Management1 | oob_management | oob | MGMT | -  | - |
+
+### Management Interfaces Device Configuration
+
+```eos
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+```
+
+# Authentication
+
+# Monitoring
+
+# MLAG
+
+## MLAG Summary
+
+| Domain-id | Local-interface | Peer-address | Peer-link |
+| --------- | --------------- | ------------ | --------- |
+| sw1-sw2-mlag-domain | Vlan4094 | 172.16.0.1 | Port-Channel12 |
+
+Heartbeat Interval is 5000 milliseconds.
+  
+Dual primary detection is enabled. The detection delay is 5 seconds.
+
+## MLAG Device Configuration
+
+```eos
+!
+mlag configuration
+   domain-id sw1-sw2-mlag-domain
+   heartbeat-interval 5000
+   local-interface Vlan4094
+   peer-address 172.16.0.1
+   peer-link Port-Channel12
+   dual-primary detection delay 5 action errdisable all-interfaces
+   reload-delay mlag 400
+   reload-delay non-mlag 450
+```
+
+# Internal VLAN Allocation Policy
+
+## Internal VLAN Allocation Policy Summary
+
+**Default Allocation Policy**
+
+| Policy Allocation | Range Beginning | Range Ending |
+| ------------------| --------------- | ------------ |
+| ascending | 1006 | 4094 |
+
+# Interfaces
+
+# Routing
+
+## IP Routing
+
+### IP Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | false|
+### IP Routing Device Configuration
+
+```eos
+```
+## IPv6 Routing
+
+### IPv6 Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | false |
+
+# Multicast
+
+# Filters
+
+# ACL
+
+# Quality Of Service

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mlag-configuration.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mlag-configuration.md
@@ -62,7 +62,6 @@ interface Management1
 | sw1-sw2-mlag-domain | Vlan4094 | 172.16.0.1 | Port-Channel12 |
 
 Heartbeat Interval is 5000 milliseconds.
-  
 Dual primary detection is enabled. The detection delay is 5 seconds.
 
 ## MLAG Device Configuration

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/system-control-plane.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/system-control-plane.md
@@ -53,8 +53,8 @@ interface Management1
 
 | Protocol | Segment Size |
 | -------- | -------------|
-| ipv4 | 1344 |
-| ipv6 | 1366 |
+| IPv4 | 1344 |
+| IPv6 | 1366 |
 
 #### Control-Plane Access-Groups
 
@@ -72,13 +72,13 @@ interface Management1
 ```eos
 !
 system control-plane
-  tcp mss ceiling ipv4 1344 ipv6 1366
-  ip access-group acl4_1 in 
-  ip access-group acl4_2 vrf red in 
-  ip access-group acl4_3 vrf default in 
-  ipv6 access-group acl6_1 in 
-  ipv6 access-group acl6_2 vrf blue in 
-  ipv6 access-group acl6_3 vrf default in 
+   tcp mss ceiling ipv4 1344 ipv6 1366
+   ip access-group acl4_1 in
+   ip access-group acl4_2 vrf red in
+   ip access-group acl4_3 vrf default in
+   ipv6 access-group acl6_1 in
+   ipv6 access-group acl6_2 vrf blue in
+   ipv6 access-group acl6_3 vrf default in
 ```
 
 # Authentication

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/system-control-plane.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/system-control-plane.md
@@ -1,0 +1,127 @@
+# system-control-plane
+# Table of Contents
+<!-- toc -->
+
+- [Management](#management)
+  - [Management Interfaces](#management-interfaces)
+  - [System Control-Plane](#system-control-plane)
+- [Authentication](#authentication)
+- [Monitoring](#monitoring)
+- [Internal VLAN Allocation Policy](#internal-vlan-allocation-policy)
+  - [Internal VLAN Allocation Policy Summary](#internal-vlan-allocation-policy-summary)
+- [Interfaces](#interfaces)
+- [Routing](#routing)
+  - [IP Routing](#ip-routing)
+  - [IPv6 Routing](#ipv6-routing)
+- [Multicast](#multicast)
+- [Filters](#filters)
+- [ACL](#acl)
+- [Quality Of Service](#quality-of-service)
+
+<!-- toc -->
+# Management
+
+## Management Interfaces
+
+### Management Interfaces Summary
+
+#### IPv4
+
+| Management Interface | description | Type | VRF | IP Address | Gateway |
+| -------------------- | ----------- | ---- | --- | ---------- | ------- |
+| Management1 | oob_management | oob | MGMT | 10.73.255.122/24 | 10.73.255.2 |
+
+#### IPv6
+
+| Management Interface | description | Type | VRF | IPv6 Address | IPv6 Gateway |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ |
+| Management1 | oob_management | oob | MGMT | -  | - |
+
+### Management Interfaces Device Configuration
+
+```eos
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+```
+
+## System Control-Plane
+
+#### TCP MSS Ceiling
+
+| Protocol | Segment Size |
+| -------- | -------------|
+| ipv4 | 1344 |
+| ipv6 | 1366 |
+
+#### Control-Plane Access-Groups
+
+| Protocol | VRF | Access-list |
+| -------- | --- | ------------|
+| IPv4 | default | acl4_1 |
+| IPv4 | red | acl4_2 |
+| IPv4 | default | acl4_3 |
+| IPv6 | default | acl6_1 |
+| IPv6 | blue | acl6_2 |
+| IPv6 | default | acl6_3 |
+
+### System Control-Plane Configuration
+
+```eos
+!
+system control-plane
+  tcp mss ceiling ipv4 1344 ipv6 1366
+  ip access-group acl4_1 in 
+  ip access-group acl4_2 vrf red in 
+  ip access-group acl4_3 vrf default in 
+  ipv6 access-group acl6_1 in 
+  ipv6 access-group acl6_2 vrf blue in 
+  ipv6 access-group acl6_3 vrf default in 
+```
+
+# Authentication
+
+# Monitoring
+
+# Internal VLAN Allocation Policy
+
+## Internal VLAN Allocation Policy Summary
+
+**Default Allocation Policy**
+
+| Policy Allocation | Range Beginning | Range Ending |
+| ------------------| --------------- | ------------ |
+| ascending | 1006 | 4094 |
+
+# Interfaces
+
+# Routing
+
+## IP Routing
+
+### IP Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | false|
+### IP Routing Device Configuration
+
+```eos
+```
+## IPv6 Routing
+
+### IPv6 Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | false |
+
+# Multicast
+
+# Filters
+
+# ACL
+
+# Quality Of Service

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/mlag-configuration.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/mlag-configuration.cfg
@@ -1,0 +1,25 @@
+!RANCID-CONTENT-TYPE: arista
+!
+transceiver qsfp default-mode 4x10G
+!
+hostname mlag-configuration
+!
+no aaa root
+no enable password
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+!
+mlag configuration
+   domain-id sw1-sw2-mlag-domain
+   heartbeat-interval 5000
+   local-interface Vlan4094
+   peer-address 172.16.0.1
+   peer-link Port-Channel12
+   dual-primary detection delay 5 action errdisable all-interfaces
+   reload-delay mlag 400
+   reload-delay non-mlag 450
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/system-control-plane.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/system-control-plane.cfg
@@ -1,0 +1,24 @@
+!RANCID-CONTENT-TYPE: arista
+!
+transceiver qsfp default-mode 4x10G
+!
+hostname system-control-plane
+!
+no aaa root
+no enable password
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+!
+system control-plane
+  tcp mss ceiling ipv4 1344 ipv6 1366
+  ip access-group acl4_1 in 
+  ip access-group acl4_2 vrf red in 
+  ip access-group acl4_3 vrf default in 
+  ipv6 access-group acl6_1 in 
+  ipv6 access-group acl6_2 vrf blue in 
+  ipv6 access-group acl6_3 vrf default in 
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/system-control-plane.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/system-control-plane.cfg
@@ -13,12 +13,12 @@ interface Management1
    ip address 10.73.255.122/24
 !
 system control-plane
-  tcp mss ceiling ipv4 1344 ipv6 1366
-  ip access-group acl4_1 in 
-  ip access-group acl4_2 vrf red in 
-  ip access-group acl4_3 vrf default in 
-  ipv6 access-group acl6_1 in 
-  ipv6 access-group acl6_2 vrf blue in 
-  ipv6 access-group acl6_3 vrf default in 
+   tcp mss ceiling ipv4 1344 ipv6 1366
+   ip access-group acl4_1 in
+   ip access-group acl4_2 vrf red in
+   ip access-group acl4_3 vrf default in
+   ipv6 access-group acl6_1 in
+   ipv6 access-group acl6_2 vrf blue in
+   ipv6 access-group acl6_3 vrf default in
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/mlag-configuration.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/mlag-configuration.yml
@@ -1,0 +1,9 @@
+mlag_configuration:
+  domain_id: sw1-sw2-mlag-domain
+  local_interface: Vlan4094
+  peer_address: 172.16.0.1
+  peer_link: Port-Channel12
+  heartbeat_interval: 5000
+  dual_primary_detection_delay: 5
+  reload_delay_mlag: 400
+  reload_delay_non_mlag: 450

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/system-control-plane.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/system-control-plane.yml
@@ -1,0 +1,17 @@
+system:
+  control_plane:
+    tcp_mss:
+      ipv4: 1344
+      ipv6: 1366
+    ipv4_access_group:
+      - acl_name: "acl4_1"
+      - acl_name: "acl4_2"
+        vrf: red
+      - acl_name: "acl4_3"
+        vrf: default
+    ipv6_access_group:
+      - acl_name: "acl6_1"
+      - acl_name: "acl6_2"
+        vrf: blue
+      - acl_name: "acl6_3"
+        vrf: default

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/system-control-plane.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/system-control-plane.yml
@@ -3,13 +3,13 @@ system:
     tcp_mss:
       ipv4: 1344
       ipv6: 1366
-    ipv4_access_group:
+    ipv4_access_groups:
       - acl_name: "acl4_1"
       - acl_name: "acl4_2"
         vrf: red
       - acl_name: "acl4_3"
         vrf: default
-    ipv6_access_group:
+    ipv6_access_groups:
       - acl_name: "acl6_1"
       - acl_name: "acl6_2"
         vrf: blue

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
@@ -43,6 +43,7 @@ management-ssh
 management-ssh-custom-cipher
 mac-security-eth-po-entropy
 match-lists
+mlag-configuration
 mpls
 none_configuration
 ntp
@@ -79,6 +80,7 @@ spanning-tree
 spanning-tree-rstp
 spanning-tree-rapid-pvst
 switchport-mode
+system-control-plane
 tcam-profile
 static-routes
 terminattr-cloud

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1608,10 +1608,10 @@ system:
     tcp_mss:
       ipv4: < Segment size >
       ipv6: < Segment size >
-    ipv4_access_group:
+    ipv4_access_groups:
       - acl_name: < access-list name >
         vrf: < Optional vrf field >
-    ipv6_access_group:
+    ipv6_access_groups:
       - acl_name: < access-list name >
         vrf: < Optional vrf field >
 ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1349,6 +1349,7 @@ mpls:
 ```yaml
 mlag_configuration:
   domain_id: < domain_id_name >
+  heartbeat_interval: < milliseconds >
   local_interface: < interface_name >
   peer_address: < IPv4_address >
   peer_address_heartbeat:
@@ -1598,6 +1599,21 @@ snmp_server:
       enable: < true | false >
     - name: < vrf_name >
       enable: < true | false >
+```
+
+###  System Control-Plane
+```yaml
+system:
+  control_plane:
+    tcp_mss:
+      ipv4: < Segment size >
+      ipv6: < Segment size >
+    ipv4_access_group:
+      - acl_name: < access-list name >
+        vrf: < Optional vrf field >
+    ipv6_access_group:
+      - acl_name: < access-list name >
+        vrf: < Optional vrf field >
 ```
 
 #### VM Tracer Sessions

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/mlag-configuration.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/mlag-configuration.j2
@@ -8,6 +8,11 @@
 | --------- | --------------- | ------------ | --------- |
 | {{ mlag_configuration.domain_id }} | {{ mlag_configuration.local_interface }} | {{ mlag_configuration.peer_address }} | {{ mlag_configuration.peer_link }} |
 
+{%   if mlag_configuration.heartbeat_interval is arista.avd.defined %}
+Heartbeat Interval is {{ mlag_configuration.heartbeat_interval }} milliseconds.
+{%   else %}
+Heartbeat Interval is 4000 milliseconds.
+{%   endif %}  
 {%   if mlag_configuration.dual_primary_detection_delay is defined and mlag_configuration.peer_mlag_configuration.dual_primary_detection_delay
 is not none %}
 Dual primary detection is enabled. The detection delay is {{ mlag_configuration.dual_primary_detection_delay }} seconds.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/mlag-configuration.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/mlag-configuration.j2
@@ -10,9 +10,7 @@
 
 {%   if mlag_configuration.heartbeat_interval is arista.avd.defined %}
 Heartbeat Interval is {{ mlag_configuration.heartbeat_interval }} milliseconds.
-{%   else %}
-Heartbeat Interval is 4000 milliseconds.
-{%   endif %}  
+{%   endif %}
 {%   if mlag_configuration.dual_primary_detection_delay is defined and mlag_configuration.peer_mlag_configuration.dual_primary_detection_delay
 is not none %}
 Dual primary detection is enabled. The detection delay is {{ mlag_configuration.dual_primary_detection_delay }} seconds.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/system-control-plane.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/system-control-plane.j2
@@ -1,44 +1,36 @@
 {% if system.control_plane is arista.avd.defined %}
 
 ## System Control-Plane
+{%     if system.control_plane.tcp_mss.ipv4 is arista.avd.defined or system.control_plane.tcp_mss.ipv6 is arista.avd.defined %}
 
-{%    if system.control_plane.tcp_mss.ipv4 is arista.avd.defined or system.control_plane.tcp_mss.ipv6 is arista.avd.defined %}
 #### TCP MSS Ceiling
 
 | Protocol | Segment Size |
 | -------- | -------------|
-{%      if system.control_plane.tcp_mss.ipv4 is arista.avd.defined %}| ipv4 | {{ system.control_plane.tcp_mss.ipv4 }} |
-{%      endif %}
-{%      if system.control_plane.tcp_mss.ipv6 is arista.avd.defined %}| ipv6 | {{ system.control_plane.tcp_mss.ipv6 }} |
-{%      endif %}
-{%    endif %}
+{%         if system.control_plane.tcp_mss.ipv4 is arista.avd.defined %}| ipv4 | {{ system.control_plane.tcp_mss.ipv4 }} |
+{%         endif %}
+{%         if system.control_plane.tcp_mss.ipv6 is arista.avd.defined %}| ipv6 | {{ system.control_plane.tcp_mss.ipv6 }} |
+{%         endif %}
+{%     endif %}
+{%     if system.control_plane.ipv4_access_group is arista.avd.defined or system.control_plane.ipv6_access_group is arista.avd.defined %}
 
-{%    if system.control_plane.ipv4_access_group is arista.avd.defined or system.control_plane.ipv6_access_group is arista.avd.defined %}
 #### Control-Plane Access-Groups
 
 | Protocol | VRF | Access-list |
 | -------- | --- | ------------|
-{#      IPv4 Access-groups #}
-{%      if system.control_plane.ipv4_access_group is arista.avd.defined %}
-{%        for acl_set in system.control_plane.ipv4_access_group | arista.avd.natural_sort %}
-{%          if acl_set.vrf is arista.avd.defined and acl_set.vrf is not none %}| IPv4 | {{ acl_set.vrf }} | {{ acl_set.acl_name }} |
-{%          elif acl_set.vrf is not arista.avd.defined or acl_set.vrf is none %}| IPv4 | default | {{ acl_set.acl_name }} |
-{%          endif %}
-{%        endfor %}
-{%      endif %}
-{#      IPv6 Access-groups #}
-{%      if system.control_plane.ipv6_access_group is arista.avd.defined %}
-{%        for acl_set in system.control_plane.ipv6_access_group | arista.avd.natural_sort %}
-{%          if acl_set.vrf is arista.avd.defined and acl_set.vrf is not none %}| IPv6 | {{ acl_set.vrf }} | {{ acl_set.acl_name }} |
-{%          elif acl_set.vrf is not arista.avd.defined or acl_set.vrf is none %}| IPv6 | default | {{ acl_set.acl_name }} |
-{%          endif %}
-{%        endfor %}
-{%      endif %}
-{%    endif %}
+{#         IPv4 Access-groups #}
+{%         for acl_set in system.control_plane.ipv4_access_group | arista.avd.natural_sort %}
+| IPv4 | {%    if acl_set.vrf is arista.avd.defined %}{{ acl_set.vrf }}{% else %}default{% endif %} | {{ acl_set.acl_name }} |
+{%         endfor %}
+{#         IPv6 Access-groups #}
+{%         for acl_set in system.control_plane.ipv6_access_group | arista.avd.natural_sort %}
+| IPv6 | {%    if acl_set.vrf is arista.avd.defined %}{{ acl_set.vrf }}{% else %}default{% endif %} | {{ acl_set.acl_name }} |
+{%         endfor %}
+{%     endif %}
 
 ### System Control-Plane Configuration
 
 ```eos
-{% include 'eos/system-control-plane.j2' %}
+{%     include 'eos/system-control-plane.j2' %}
 ```
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/system-control-plane.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/system-control-plane.j2
@@ -7,24 +7,26 @@
 
 | Protocol | Segment Size |
 | -------- | -------------|
-{%         if system.control_plane.tcp_mss.ipv4 is arista.avd.defined %}| ipv4 | {{ system.control_plane.tcp_mss.ipv4 }} |
+{%         if system.control_plane.tcp_mss.ipv4 is arista.avd.defined %}
+| IPv4 | {{ system.control_plane.tcp_mss.ipv4 }} |
 {%         endif %}
-{%         if system.control_plane.tcp_mss.ipv6 is arista.avd.defined %}| ipv6 | {{ system.control_plane.tcp_mss.ipv6 }} |
+{%         if system.control_plane.tcp_mss.ipv6 is arista.avd.defined %}
+| IPv6 | {{ system.control_plane.tcp_mss.ipv6 }} |
 {%         endif %}
 {%     endif %}
-{%     if system.control_plane.ipv4_access_group is arista.avd.defined or system.control_plane.ipv6_access_group is arista.avd.defined %}
+{%     if system.control_plane.ipv4_access_groups is arista.avd.defined or system.control_plane.ipv6_access_groups is arista.avd.defined %}
 
 #### Control-Plane Access-Groups
 
 | Protocol | VRF | Access-list |
 | -------- | --- | ------------|
 {#         IPv4 Access-groups #}
-{%         for acl_set in system.control_plane.ipv4_access_group | arista.avd.natural_sort %}
-| IPv4 | {%    if acl_set.vrf is arista.avd.defined %}{{ acl_set.vrf }}{% else %}default{% endif %} | {{ acl_set.acl_name }} |
+{%         for acl_set in system.control_plane.ipv4_access_groups | arista.avd.natural_sort %}
+| IPv4 | {{ acl_set.vrf | arista.avd.default('default') }} | {{ acl_set.acl_name }} |
 {%         endfor %}
 {#         IPv6 Access-groups #}
-{%         for acl_set in system.control_plane.ipv6_access_group | arista.avd.natural_sort %}
-| IPv6 | {%    if acl_set.vrf is arista.avd.defined %}{{ acl_set.vrf }}{% else %}default{% endif %} | {{ acl_set.acl_name }} |
+{%         for acl_set in system.control_plane.ipv6_access_groups | arista.avd.natural_sort %}
+| IPv6 | {{ acl_set.vrf | arista.avd.default('default') }} | {{ acl_set.acl_name }} |
 {%         endfor %}
 {%     endif %}
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/system-control-plane.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/system-control-plane.j2
@@ -1,0 +1,44 @@
+{% if system.control_plane is arista.avd.defined %}
+
+## System Control-Plane
+
+{%    if system.control_plane.tcp_mss.ipv4 is arista.avd.defined or system.control_plane.tcp_mss.ipv6 is arista.avd.defined %}
+#### TCP MSS Ceiling
+
+| Protocol | Segment Size |
+| -------- | -------------|
+{%      if system.control_plane.tcp_mss.ipv4 is arista.avd.defined %}| ipv4 | {{ system.control_plane.tcp_mss.ipv4 }} |
+{%      endif %}
+{%      if system.control_plane.tcp_mss.ipv6 is arista.avd.defined %}| ipv6 | {{ system.control_plane.tcp_mss.ipv6 }} |
+{%      endif %}
+{%    endif %}
+
+{%    if system.control_plane.ipv4_access_group is arista.avd.defined or system.control_plane.ipv6_access_group is arista.avd.defined %}
+#### Control-Plane Access-Groups
+
+| Protocol | VRF | Access-list |
+| -------- | --- | ------------|
+{#      IPv4 Access-groups #}
+{%      if system.control_plane.ipv4_access_group is arista.avd.defined %}
+{%        for acl_set in system.control_plane.ipv4_access_group | arista.avd.natural_sort %}
+{%          if acl_set.vrf is arista.avd.defined and acl_set.vrf is not none %}| IPv4 | {{ acl_set.vrf }} | {{ acl_set.acl_name }} |
+{%          elif acl_set.vrf is not arista.avd.defined or acl_set.vrf is none %}| IPv4 | default | {{ acl_set.acl_name }} |
+{%          endif %}
+{%        endfor %}
+{%      endif %}
+{#      IPv6 Access-groups #}
+{%      if system.control_plane.ipv6_access_group is arista.avd.defined %}
+{%        for acl_set in system.control_plane.ipv6_access_group | arista.avd.natural_sort %}
+{%          if acl_set.vrf is arista.avd.defined and acl_set.vrf is not none %}| IPv6 | {{ acl_set.vrf }} | {{ acl_set.acl_name }} |
+{%          elif acl_set.vrf is not arista.avd.defined or acl_set.vrf is none %}| IPv6 | default | {{ acl_set.acl_name }} |
+{%          endif %}
+{%        endfor %}
+{%      endif %}
+{%    endif %}
+
+### System Control-Plane Configuration
+
+```eos
+{% include 'eos/system-control-plane.j2' %}
+```
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-device-documentation.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-device-documentation.j2
@@ -17,6 +17,8 @@
 {% include 'documentation/ntp.j2' %}
 {## PTP #}
 {% include 'documentation/ptp.j2' %}
+{## System Control-Plane#}
+{% include 'documentation/system-control-plane.j2' %}
 {## Management SSH #}
 {% include 'documentation/management-ssh.j2' %}
 {## Management API GNMI #}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
@@ -153,6 +153,8 @@
 {% include 'eos/prefix-lists.j2' %}
 {# IPv6 Prefix-lists #}
 {% include 'eos/ipv6-prefix-lists.j2' %}
+{# System Control-Plane#}
+{% include 'eos/system-control-plane.j2' %}
 {# mlag configuration #}
 {% include 'eos/mlag-configuration.j2' %}
 {# Static Route #}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/mlag-configuration.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/mlag-configuration.j2
@@ -5,6 +5,9 @@ mlag configuration
 {%     if mlag_configuration.domain_id is arista.avd.defined %}
    domain-id {{ mlag_configuration.domain_id }}
 {%     endif %}
+{%     if mlag_configuration.heartbeat_interval is arista.avd.defined %}
+   heartbeat-interval {{ mlag_configuration.heartbeat_interval }}
+{%     endif %}
 {%     if mlag_configuration.local_interface is arista.avd.defined %}
    local-interface {{ mlag_configuration.local_interface }}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/system-control-plane.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/system-control-plane.j2
@@ -2,37 +2,33 @@
 {% if system.control_plane is arista.avd.defined %}
 !
 system control-plane
-{# control_plane tcp mss ceiling #}
-{%    if system.control_plane.tcp_mss.ipv4 is arista.avd.defined and system.control_plane.tcp_mss.ipv6 is arista.avd.defined %}
-{%       set cp_mss_cli = "tcp mss ceiling ipv4 " ~ system.control_plane.tcp_mss.ipv4 ~ " ipv6 " ~ system.control_plane.tcp_mss.ipv6 %}
-{%    elif system.control_plane.tcp_mss.ipv4 is arista.avd.defined and system.control_plane.tcp_mss.ipv6 is not arista.avd.defined %}
-{%       set cp_mss_cli = "tcp mss ceiling ipv4 " ~ system.control_plane.tcp_mss.ipv4 %}
-{%    elif system.control_plane.tcp_mss.ipv4 is not arista.avd.defined and system.control_plane.tcp_mss.ipv6 is arista.avd.defined %}
-{%       set cp_mss_cli = "tcp mss ceiling ipv6 " ~ system.control_plane.tcp_mss.ipv6 %}
-{%    endif %}
+{#     control_plane tcp mss ceiling #}
+{%     if system.control_plane.tcp_mss.ipv4 is arista.avd.defined or system.control_plane.tcp_mss.ipv6 is arista.avd.defined %}
+{%         set cp_mss_cli = "tcp mss ceiling " %}
+{%         if system.control_plane.tcp_mss.ipv4 is arista.avd.defined %}
+{%             set cp_mss_cli = cp_mss_cli ~ "ipv4 " ~ system.control_plane.tcp_mss.ipv4 ~ " " %}
+{%         endif %}
+{%         if system.control_plane.tcp_mss.ipv6 is arista.avd.defined %}
+{%             set cp_mss_cli = cp_mss_cli ~ "ipv6 " ~ system.control_plane.tcp_mss.ipv6 %}
+{%         endif %}
   {{ cp_mss_cli }}
-{# control_plane access_group ipv4 #}
-{%    if system.control_plane.ipv4_access_group is arista.avd.defined %}
-{%      for acl_set in system.control_plane.ipv4_access_group | arista.avd.natural_sort %}
-{%        set cp_ipv4_access_grp = "ip access-group " ~ acl_set.acl_name %}
-{%        if acl_set.vrf is arista.avd.defined and acl_set.vrf is not none %}
-{%          set cp_ipv4_access_grp = cp_ipv4_access_grp ~ " vrf " ~ acl_set.vrf ~ " in " %}
-{%        elif acl_set.vrf is not arista.avd.defined %}
-{%          set cp_ipv4_access_grp = cp_ipv4_access_grp ~ " in " %}
-{%        endif %}
+{%     endif %}
+{#     control_plane access_group ipv4 #}
+{%     for acl_set in system.control_plane.ipv4_access_group | arista.avd.natural_sort %}
+{%         set cp_ipv4_access_grp = "ip access-group " ~ acl_set.acl_name %}
+{%         if acl_set.vrf is arista.avd.defined %}
+{%             set cp_ipv4_access_grp = cp_ipv4_access_grp ~ " vrf " ~ acl_set.vrf %}
+{%         endif %}
+{%         set cp_ipv4_access_grp = cp_ipv4_access_grp ~ " in " %}
   {{ cp_ipv4_access_grp }}
-{%      endfor %}
-{%    endif %}
-{# control_plane access_group ipv6 #}
-{%    if system.control_plane.ipv6_access_group is arista.avd.defined %}
-{%      for acl_set in system.control_plane.ipv6_access_group | arista.avd.natural_sort %}
-{%        set cp_ipv6_access_grp = "ipv6 access-group " ~ acl_set.acl_name %}
-{%        if acl_set.vrf is arista.avd.defined and acl_set.vrf is not none %}
-{%          set cp_ipv6_access_grp = cp_ipv6_access_grp ~ " vrf " ~ acl_set.vrf ~ " in " %}
-{%        elif acl_set.vrf is not arista.avd.defined %}
-{%          set cp_ipv6_access_grp = cp_ipv6_access_grp ~ " in " %}
-{%        endif %}
+{%     endfor %}
+{#     control_plane access_group ipv6 #}
+{%     for acl_set in system.control_plane.ipv6_access_group | arista.avd.natural_sort %}
+{%         set cp_ipv6_access_grp = "ipv6 access-group " ~ acl_set.acl_name %}
+{%         if acl_set.vrf is arista.avd.defined %}
+{%             set cp_ipv6_access_grp = cp_ipv6_access_grp ~ " vrf " ~ acl_set.vrf %}
+{%         endif %}
+{%         set cp_ipv6_access_grp = cp_ipv6_access_grp ~ " in " %}
   {{ cp_ipv6_access_grp }}
-{%      endfor %}
-{%    endif %}
+{%     endfor %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/system-control-plane.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/system-control-plane.j2
@@ -1,0 +1,38 @@
+{# eos - system #}
+{% if system.control_plane is arista.avd.defined %}
+!
+system control-plane
+{# control_plane tcp mss ceiling #}
+{%    if system.control_plane.tcp_mss.ipv4 is arista.avd.defined and system.control_plane.tcp_mss.ipv6 is arista.avd.defined %}
+{%       set cp_mss_cli = "tcp mss ceiling ipv4 " ~ system.control_plane.tcp_mss.ipv4 ~ " ipv6 " ~ system.control_plane.tcp_mss.ipv6 %}
+{%    elif system.control_plane.tcp_mss.ipv4 is arista.avd.defined and system.control_plane.tcp_mss.ipv6 is not arista.avd.defined %}
+{%       set cp_mss_cli = "tcp mss ceiling ipv4 " ~ system.control_plane.tcp_mss.ipv4 %}
+{%    elif system.control_plane.tcp_mss.ipv4 is not arista.avd.defined and system.control_plane.tcp_mss.ipv6 is arista.avd.defined %}
+{%       set cp_mss_cli = "tcp mss ceiling ipv6 " ~ system.control_plane.tcp_mss.ipv6 %}
+{%    endif %}
+  {{ cp_mss_cli }}
+{# control_plane access_group ipv4 #}
+{%    if system.control_plane.ipv4_access_group is arista.avd.defined %}
+{%      for acl_set in system.control_plane.ipv4_access_group | arista.avd.natural_sort %}
+{%        set cp_ipv4_access_grp = "ip access-group " ~ acl_set.acl_name %}
+{%        if acl_set.vrf is arista.avd.defined and acl_set.vrf is not none %}
+{%          set cp_ipv4_access_grp = cp_ipv4_access_grp ~ " vrf " ~ acl_set.vrf ~ " in " %}
+{%        elif acl_set.vrf is not arista.avd.defined %}
+{%          set cp_ipv4_access_grp = cp_ipv4_access_grp ~ " in " %}
+{%        endif %}
+  {{ cp_ipv4_access_grp }}
+{%      endfor %}
+{%    endif %}
+{# control_plane access_group ipv6 #}
+{%    if system.control_plane.ipv6_access_group is arista.avd.defined %}
+{%      for acl_set in system.control_plane.ipv6_access_group | arista.avd.natural_sort %}
+{%        set cp_ipv6_access_grp = "ipv6 access-group " ~ acl_set.acl_name %}
+{%        if acl_set.vrf is arista.avd.defined and acl_set.vrf is not none %}
+{%          set cp_ipv6_access_grp = cp_ipv6_access_grp ~ " vrf " ~ acl_set.vrf ~ " in " %}
+{%        elif acl_set.vrf is not arista.avd.defined %}
+{%          set cp_ipv6_access_grp = cp_ipv6_access_grp ~ " in " %}
+{%        endif %}
+  {{ cp_ipv6_access_grp }}
+{%      endfor %}
+{%    endif %}
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/system-control-plane.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/system-control-plane.j2
@@ -4,31 +4,31 @@
 system control-plane
 {#     control_plane tcp mss ceiling #}
 {%     if system.control_plane.tcp_mss.ipv4 is arista.avd.defined or system.control_plane.tcp_mss.ipv6 is arista.avd.defined %}
-{%         set cp_mss_cli = "tcp mss ceiling " %}
+{%         set cp_mss_cli = "tcp mss ceiling" %}
 {%         if system.control_plane.tcp_mss.ipv4 is arista.avd.defined %}
-{%             set cp_mss_cli = cp_mss_cli ~ "ipv4 " ~ system.control_plane.tcp_mss.ipv4 ~ " " %}
+{%             set cp_mss_cli = cp_mss_cli ~ " ipv4 " ~ system.control_plane.tcp_mss.ipv4 %}
 {%         endif %}
 {%         if system.control_plane.tcp_mss.ipv6 is arista.avd.defined %}
-{%             set cp_mss_cli = cp_mss_cli ~ "ipv6 " ~ system.control_plane.tcp_mss.ipv6 %}
+{%             set cp_mss_cli = cp_mss_cli ~ " ipv6 " ~ system.control_plane.tcp_mss.ipv6 %}
 {%         endif %}
-  {{ cp_mss_cli }}
+   {{ cp_mss_cli }}
 {%     endif %}
-{#     control_plane access_group ipv4 #}
-{%     for acl_set in system.control_plane.ipv4_access_group | arista.avd.natural_sort %}
+{#     control_plane access_groups ipv4 #}
+{%     for acl_set in system.control_plane.ipv4_access_groups | arista.avd.natural_sort %}
 {%         set cp_ipv4_access_grp = "ip access-group " ~ acl_set.acl_name %}
 {%         if acl_set.vrf is arista.avd.defined %}
 {%             set cp_ipv4_access_grp = cp_ipv4_access_grp ~ " vrf " ~ acl_set.vrf %}
 {%         endif %}
-{%         set cp_ipv4_access_grp = cp_ipv4_access_grp ~ " in " %}
-  {{ cp_ipv4_access_grp }}
+{%         set cp_ipv4_access_grp = cp_ipv4_access_grp ~ " in" %}
+   {{ cp_ipv4_access_grp }}
 {%     endfor %}
-{#     control_plane access_group ipv6 #}
-{%     for acl_set in system.control_plane.ipv6_access_group | arista.avd.natural_sort %}
+{#     control_plane access_groups ipv6 #}
+{%     for acl_set in system.control_plane.ipv6_access_groups | arista.avd.natural_sort %}
 {%         set cp_ipv6_access_grp = "ipv6 access-group " ~ acl_set.acl_name %}
 {%         if acl_set.vrf is arista.avd.defined %}
 {%             set cp_ipv6_access_grp = cp_ipv6_access_grp ~ " vrf " ~ acl_set.vrf %}
 {%         endif %}
-{%         set cp_ipv6_access_grp = cp_ipv6_access_grp ~ " in " %}
-  {{ cp_ipv6_access_grp }}
+{%         set cp_ipv6_access_grp = cp_ipv6_access_grp ~ " in" %}
+   {{ cp_ipv6_access_grp }}
 {%     endfor %}
 {% endif %}


### PR DESCRIPTION
## Change Summary

* Add missing molecule component for mlag-configuration in host_vars where there was no artifact before
* Add new mlag configuration option for heartbeat interval
* Add new section System Control-Plane

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [x] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Related to #998 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
1. Add missing molecule host ```mlag-configuration.yml``` in host_vars where there was no corresponding artifact:
```eos
mlag configuration
   domain-id sw1-sw2-mlag-domain
   heartbeat-interval 5000
   local-interface Vlan4094
   peer-address 172.16.0.1
   peer-link Port-Channel12
   dual-primary detection delay 5 action errdisable all-interfaces
   reload-delay mlag 400
   reload-delay non-mlag 450
!
```

2. Add new mlag configuration option for heartbeat interval:
```yaml
mlag_configuration:
  domain_id: 
  local_interface: Vlan4094
  peer_address: 172.16.0.1
  peer_link: Port-Channel12
  heartbeat_interval: 5000
  dual_primary_detection_delay: 5
  reload_delay_mlag: 400
  reload_delay_non_mlag: 450
```

3. Add new section System Control-Plane, structure as follows:
```yaml
system:
  control_plane:
    tcp_mss:
      ipv4: < Segment size >
      ipv6: < Segment size >
    ipv4_access_group:
      - acl_name: < access-list name >
        vrf: < Optional vrf field >
    ipv6_access_group:
      - acl_name: < access-list name >
        vrf: < Optional vrf field >
```

## How to test
molecule test --scenario-name eos_cli_config_gen

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contributing/) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
