### PR TITLE
Feat(eos_cli_config_gen): Add OSPF timers to router ospf

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
@@ -216,9 +216,9 @@ interface Vlan24
 
 ### Router OSPF timers
 
-| Process ID | LSA rx | LSA tx | SPF |
-| ---------- | ------ | ------ | --- |
-| 101 | 100 | 100 - 200 - 300 | 100 - 200 - 300 |
+| Process ID | LSA rx | LSA tx (initial/min/max) | SPF (initial/min/max) |
+| ---------- | ------ | ------------------------ | --------------------- |
+| 101 | 100 | 100 / 200 / 300 | 100 / 200 / 300 |
 
 ### Router OSPF route summary
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
@@ -214,6 +214,12 @@ interface Vlan24
 | 400 | enabled | enabled | enabled | wait-for-bgp | enabled |
 | 500 | enabled | enabled (123) | disabled | 222 | enabled (456) |
 
+### Router OSPF timers
+
+| Process ID | LSA rx | LSA tx | SPF |
+| ---------- | ------ | ------ | --- |
+| 101 | 100 | 100 - 200 - 300 | 100 - 200 - 300 |
+
 ### Router OSPF route summary
 
 | Process ID | Prefix | Tag | Attribute Route Map | Not Advertised |

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
@@ -219,6 +219,7 @@ interface Vlan24
 | Process ID | LSA rx | LSA tx (initial/min/max) | SPF (initial/min/max) |
 | ---------- | ------ | ------------------------ | --------------------- |
 | 101 | 100 | 100 / 200 / 300 | 100 / 200 / 300 |
+| 200 | 100 | - | - |
 
 ### Router OSPF route summary
 
@@ -274,6 +275,7 @@ router ospf 200 vrf ospf_zone
    log-adjacency-changes detail
    router-id 192.168.254.1
    max-lsa 5
+   timers lsa rx min interval 100
    default-information originate always
    redistribute static route-map rm-ospf-static
    redistribute connected route-map rm-ospf-connected

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
@@ -256,6 +256,9 @@ router ospf 101 vrf CUSTOMER01
    router-id 1.0.1.1
    passive-interface default
    no passive-interface Ethernet2.101
+   timers lsa rx min interval 100
+   timers lsa tx delay initial 100 200 300
+   timers spf delay initial 100 200 300
    summary-address 10.0.0.0/8
    summary-address 20.0.0.0/8 tag 10
    summary-address 30.0.0.0/8 attribute-map RM-OSPF_SUMMARY

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-ospf.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-ospf.cfg
@@ -70,6 +70,7 @@ router ospf 200 vrf ospf_zone
    log-adjacency-changes detail
    router-id 192.168.254.1
    max-lsa 5
+   timers lsa rx min interval 100
    default-information originate always
    redistribute static route-map rm-ospf-static
    redistribute connected route-map rm-ospf-connected

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-ospf.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-ospf.cfg
@@ -58,6 +58,9 @@ router ospf 101 vrf CUSTOMER01
    router-id 1.0.1.1
    passive-interface default
    no passive-interface Ethernet2.101
+   timers lsa rx min interval 100
+   timers lsa tx delay initial 100 200 300
+   timers spf delay initial 100 200 300
    summary-address 10.0.0.0/8
    summary-address 20.0.0.0/8 tag 10
    summary-address 30.0.0.0/8 attribute-map RM-OSPF_SUMMARY

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-ospf.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-ospf.yml
@@ -60,6 +60,9 @@ router_ospf:
         connected:
           route_map: rm-ospf-connected
       max_metric: # not expected to produce config. Just here to test proper variable checks.
+      timers:
+        lsa:
+          rx_min_interval: 100
     300:
       max_metric:
         router_lsa:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-ospf.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-ospf.yml
@@ -33,6 +33,20 @@ router_ospf:
           attribute_map: RM-OSPF_SUMMARY
         - prefix: 40.0.0.0/8
           not_advertise: true
+      timers:
+        lsa:
+          rx: 100
+          tx:
+            delay:
+              initial: 100
+              min: 200
+              max: 300
+        spf:
+          delay:
+            initial: 100
+            min: 200
+            max: 300
+
     200:
       vrf: ospf_zone
       passive_interface_default: false

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-ospf.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-ospf.yml
@@ -35,17 +35,15 @@ router_ospf:
           not_advertise: true
       timers:
         lsa:
-          rx: 100
-          tx:
-            delay:
-              initial: 100
-              min: 200
-              max: 300
-        spf:
-          delay:
+          rx_min_interval: 100
+          tx_delay:
             initial: 100
             min: 200
             max: 300
+        spf_delay:
+          initial: 100
+          min: 200
+          max: 300
 
     200:
       vrf: ospf_zone

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -2114,6 +2114,19 @@ router_ospf:
         - < interface_1 >
         - < interface_2 >
       max_lsa: < integer >
+      timers:
+        lsa:
+          rx: < 0-600000 - Min interval in msecs between accepting the same LSA >
+          tx:
+            delay:
+              initial: < 0-600000 - Delay to generate first occurrence of LSA in msecs >
+              min: < 1-600000 Min delay between originating the same LSA in msecs >
+              max: < 1-600000 Maximum delay between originating the same LSA in msecs >
+        spf:
+          delay:
+            initial: < 0-600000 - Initial SPF schedule delay in msecs >
+            min: < 0-65535000  Min Hold time between two SPFs in msecs >
+            max: < 0-65535000  Max wait time between two SPFs in msecs >
       default_information_originate:
         always: true
       summary_addresses:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -2116,17 +2116,15 @@ router_ospf:
       max_lsa: < integer >
       timers:
         lsa:
-          rx: < 0-600000 - Min interval in msecs between accepting the same LSA >
-          tx:
-            delay:
-              initial: < 0-600000 - Delay to generate first occurrence of LSA in msecs >
-              min: < 1-600000 Min delay between originating the same LSA in msecs >
-              max: < 1-600000 Maximum delay between originating the same LSA in msecs >
-        spf:
-          delay:
-            initial: < 0-600000 - Initial SPF schedule delay in msecs >
-            min: < 0-65535000  Min Hold time between two SPFs in msecs >
-            max: < 0-65535000  Max wait time between two SPFs in msecs >
+          rx_min_interval: < 0-600000 - Min interval in msecs between accepting the same LSA >
+          tx_delay:
+            initial: < 0-600000 - Delay to generate first occurrence of LSA in msecs >
+            min: < 1-600000 Min delay between originating the same LSA in msecs >
+            max: < 1-600000 Maximum delay between originating the same LSA in msecs >
+        spf_delay:
+          initial: < 0-600000 - Initial SPF schedule delay in msecs >
+          min: < 0-65535000  Min Hold time between two SPFs in msecs >
+          max: < 0-65535000  Max wait time between two SPFs in msecs >
       default_information_originate:
         always: true
       summary_addresses:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-ospf.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-ospf.j2
@@ -120,6 +120,44 @@
 {%             endif %}
 {%         endfor %}
 {%     endif %}
+{# OSPF Timers #}
+{%     set has.found = false %}
+{%     for process in router_ospf.process_ids %}
+{%         if router_ospf.process_ids[process].timers is arista.avd.defined %}
+{%             set has.found = true %}
+{%         endif %}
+{%     endfor %}
+{%     if has.found is arista.avd.defined(true) %}
+
+### Router OSPF timers
+
+| Process ID | LSA rx | LSA tx | SPF |
+| ---------- | ------ | ------ | --- |
+{%         for process in router_ospf.process_ids | arista.avd.natural_sort %}
+{%             if router_ospf.process_ids[process].timers is arista.avd.defined %}
+{%                 if router_ospf.process_ids[process].timers.lsa.rx is defined %}
+{%                     set lsa_rx = router_ospf.process_ids[process].timers.lsa.rx %}
+{%                 else %}
+{%                     set lsa_rx = 'unset' %}
+{%                 endif %}
+{%                 if router_ospf.process_ids[process].timers.lsa.tx is defined %}
+{%                     set lsa_tx = router_ospf.process_ids[process].timers.lsa.tx.delay.initial %}
+{%                     set lsa_tx = lsa_tx ~ " - " ~ router_ospf.process_ids[process].timers.lsa.tx.delay.min %}
+{%                     set lsa_tx = lsa_tx ~ " - " ~ router_ospf.process_ids[process].timers.lsa.tx.delay.max %}
+{%                 else %}
+{%                     set lsa_tx = 'unset' %}
+{%                 endif %}
+{%                 if router_ospf.process_ids[process].timers.spf.delay is defined %}
+{%                     set spf_timers = router_ospf.process_ids[process].timers.spf.delay.initial %}
+{%                     set spf_timers = spf_timers ~ " - " ~ router_ospf.process_ids[process].timers.spf.delay.min %}
+{%                     set spf_timers = spf_timers ~ " - " ~ router_ospf.process_ids[process].timers.spf.delay.max %}
+{%                 else %}
+{%                     set spf_timers = 'unset' %}
+{%                 endif %}
+| {{ process }} | {{ lsa_rx }} | {{ lsa_tx }} | {{ spf_timers }} |
+{%             endif %}
+{%         endfor %}
+{%     endif %}
 {# Route Summary #}
 {%     set has.found = false %}
 {%     for process in router_ospf.process_ids %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-ospf.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-ospf.j2
@@ -131,26 +131,30 @@
 
 ### Router OSPF timers
 
-| Process ID | LSA rx | LSA tx | SPF |
-| ---------- | ------ | ------ | --- |
+| Process ID | LSA rx | LSA tx (initial/min/max) | SPF (initial/min/max) |
+| ---------- | ------ | ------------------------ | --------------------- |
 {%         for process in router_ospf.process_ids | arista.avd.natural_sort %}
 {%             if router_ospf.process_ids[process].timers is arista.avd.defined %}
-{%                 if router_ospf.process_ids[process].timers.lsa.rx is defined %}
-{%                     set lsa_rx = router_ospf.process_ids[process].timers.lsa.rx %}
+{%                 if router_ospf.process_ids[process].timers.lsa.rx_min_interval is defined %}
+{%                     set lsa_rx = router_ospf.process_ids[process].timers.lsa.rx_min_interval %}
 {%                 else %}
 {%                     set lsa_rx = 'unset' %}
 {%                 endif %}
-{%                 if router_ospf.process_ids[process].timers.lsa.tx is defined %}
-{%                     set lsa_tx = router_ospf.process_ids[process].timers.lsa.tx.delay.initial %}
-{%                     set lsa_tx = lsa_tx ~ " - " ~ router_ospf.process_ids[process].timers.lsa.tx.delay.min %}
-{%                     set lsa_tx = lsa_tx ~ " - " ~ router_ospf.process_ids[process].timers.lsa.tx.delay.max %}
+{%                 if router_ospf.process_ids[process].timers.lsa.tx_delay.initial is arista.avd.defined
+                      and router_ospf.process_ids[process].timers.lsa.tx_delay.min is arista.avd.defined
+                      and router_ospf.process_ids[process].timers.lsa.tx_delay.max is arista.avd.defined %}
+{%                     set lsa_tx = router_ospf.process_ids[process].timers.lsa.tx_delay.initial %}
+{%                     set lsa_tx = lsa_tx ~ " / " ~ router_ospf.process_ids[process].timers.lsa.tx_delay.min %}
+{%                     set lsa_tx = lsa_tx ~ " / " ~ router_ospf.process_ids[process].timers.lsa.tx_delay.max %}
 {%                 else %}
 {%                     set lsa_tx = 'unset' %}
 {%                 endif %}
-{%                 if router_ospf.process_ids[process].timers.spf.delay is defined %}
-{%                     set spf_timers = router_ospf.process_ids[process].timers.spf.delay.initial %}
-{%                     set spf_timers = spf_timers ~ " - " ~ router_ospf.process_ids[process].timers.spf.delay.min %}
-{%                     set spf_timers = spf_timers ~ " - " ~ router_ospf.process_ids[process].timers.spf.delay.max %}
+{%                 if router_ospf.process_ids[process].timers.spf_delay.initial is arista.avd.defined
+                      and router_ospf.process_ids[process].timers.spf_delay.min is arista.avd.defined
+                      and router_ospf.process_ids[process].timers.spf_delay.max is arista.avd.defined %}
+{%                     set spf_timers = router_ospf.process_ids[process].timers.spf_delay.initial %}
+{%                     set spf_timers = spf_timers ~ " / " ~ router_ospf.process_ids[process].timers.spf_delay.min %}
+{%                     set spf_timers = spf_timers ~ " / " ~ router_ospf.process_ids[process].timers.spf_delay.max %}
 {%                 else %}
 {%                     set spf_timers = 'unset' %}
 {%                 endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-ospf.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-ospf.j2
@@ -122,7 +122,7 @@
 {%     endif %}
 {# OSPF Timers #}
 {%     set has.found = false %}
-{%     for process in router_ospf.process_ids %}
+{%     for process in router_ospf.process_ids | arista.avd.natural_sort %}
 {%         if router_ospf.process_ids[process].timers is arista.avd.defined %}
 {%             set has.found = true %}
 {%         endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-ospf.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-ospf.j2
@@ -135,11 +135,7 @@
 | ---------- | ------ | ------------------------ | --------------------- |
 {%         for process in router_ospf.process_ids | arista.avd.natural_sort %}
 {%             if router_ospf.process_ids[process].timers is arista.avd.defined %}
-{%                 if router_ospf.process_ids[process].timers.lsa.rx_min_interval is defined %}
-{%                     set lsa_rx = router_ospf.process_ids[process].timers.lsa.rx_min_interval %}
-{%                 else %}
-{%                     set lsa_rx = 'unset' %}
-{%                 endif %}
+{%                 set lsa_rx = router_ospf.process_ids[process].timers.lsa.rx_min_interval | arista.avd.default('-') %}
 {%                 if router_ospf.process_ids[process].timers.lsa.tx_delay.initial is arista.avd.defined
                       and router_ospf.process_ids[process].timers.lsa.tx_delay.min is arista.avd.defined
                       and router_ospf.process_ids[process].timers.lsa.tx_delay.max is arista.avd.defined %}
@@ -147,7 +143,7 @@
 {%                     set lsa_tx = lsa_tx ~ " / " ~ router_ospf.process_ids[process].timers.lsa.tx_delay.min %}
 {%                     set lsa_tx = lsa_tx ~ " / " ~ router_ospf.process_ids[process].timers.lsa.tx_delay.max %}
 {%                 else %}
-{%                     set lsa_tx = 'unset' %}
+{%                     set lsa_tx = '-' %}
 {%                 endif %}
 {%                 if router_ospf.process_ids[process].timers.spf_delay.initial is arista.avd.defined
                       and router_ospf.process_ids[process].timers.spf_delay.min is arista.avd.defined
@@ -156,7 +152,7 @@
 {%                     set spf_timers = spf_timers ~ " / " ~ router_ospf.process_ids[process].timers.spf_delay.min %}
 {%                     set spf_timers = spf_timers ~ " / " ~ router_ospf.process_ids[process].timers.spf_delay.max %}
 {%                 else %}
-{%                     set spf_timers = 'unset' %}
+{%                     set spf_timers = '-' %}
 {%                 endif %}
 | {{ process }} | {{ lsa_rx }} | {{ lsa_tx }} | {{ spf_timers }} |
 {%             endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-ospf.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-ospf.j2
@@ -29,6 +29,35 @@ router ospf {{ process_id }}
 {%     if router_ospf.process_ids[process_id].max_lsa is arista.avd.defined %}
    max-lsa {{ router_ospf.process_ids[process_id].max_lsa }}
 {%     endif %}
+{%     if router_ospf.process_ids[process_id].timers.lsa.rx is arista.avd.defined %}
+   timers lsa rx min interval {{ router_ospf.process_ids[process_id].timers.lsa.rx }}
+{%     endif %}
+{%     if router_ospf.process_ids[process_id].timers.lsa.tx.delay is arista.avd.defined %}
+{%         set timer_ospf_lsa_tx = "timers lsa tx delay initial" %}
+{%         if router_ospf.process_ids[process_id].timers.lsa.tx.delay.initial is arista.avd.defined %}
+{%             set timer_ospf_lsa_tx = timer_ospf_lsa_tx ~ " " ~ router_ospf.process_ids[process_id].timers.lsa.tx.delay.initial %}
+{%         endif %}
+{%         if router_ospf.process_ids[process_id].timers.lsa.tx.delay.min is arista.avd.defined %}
+{%             set timer_ospf_lsa_tx = timer_ospf_lsa_tx ~ " " ~ router_ospf.process_ids[process_id].timers.lsa.tx.delay.min %}
+{%         endif %}
+{%         if router_ospf.process_ids[process_id].timers.lsa.tx.delay.max is arista.avd.defined %}
+{%             set timer_ospf_lsa_tx = timer_ospf_lsa_tx ~ " " ~ router_ospf.process_ids[process_id].timers.lsa.tx.delay.max %}
+{%         endif %}
+   {{ timer_ospf_lsa_tx }}
+{%     endif %}
+{%     if router_ospf.process_ids[process_id].timers.spf.delay is arista.avd.defined %}
+{%         set timer_ospf_spf_delay = "timers spf delay initial" %}
+{%         if router_ospf.process_ids[process_id].timers.spf.delay.initial is arista.avd.defined %}
+{%             set timer_ospf_spf_delay = timer_ospf_spf_delay ~ " " ~ router_ospf.process_ids[process_id].timers.spf.delay.initial %}
+{%         endif %}
+{%         if router_ospf.process_ids[process_id].timers.spf.delay.min is arista.avd.defined %}
+{%             set timer_ospf_spf_delay = timer_ospf_spf_delay ~ " " ~ router_ospf.process_ids[process_id].timers.spf.delay.min %}
+{%         endif %}
+{%         if router_ospf.process_ids[process_id].timers.spf.delay.max is arista.avd.defined %}
+{%             set timer_ospf_spf_delay = timer_ospf_spf_delay ~ " " ~ router_ospf.process_ids[process_id].timers.spf.delay.max %}
+{%         endif %}
+   {{ timer_ospf_spf_delay }}
+{%     endif %}
 {%     if router_ospf.process_ids[process_id].default_information_originate is defined %}
 {%         set default_information_originate_cli = "default-information originate"%}
 {%         if router_ospf.process_ids[process_id].default_information_originate.always is arista.avd.defined(true) %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-ospf.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-ospf.j2
@@ -29,33 +29,25 @@ router ospf {{ process_id }}
 {%     if router_ospf.process_ids[process_id].max_lsa is arista.avd.defined %}
    max-lsa {{ router_ospf.process_ids[process_id].max_lsa }}
 {%     endif %}
-{%     if router_ospf.process_ids[process_id].timers.lsa.rx is arista.avd.defined %}
-   timers lsa rx min interval {{ router_ospf.process_ids[process_id].timers.lsa.rx }}
+{%     if router_ospf.process_ids[process_id].timers.lsa.rx_min_interval is arista.avd.defined %}
+   timers lsa rx min interval {{ router_ospf.process_ids[process_id].timers.lsa.rx_min_interval }}
 {%     endif %}
-{%     if router_ospf.process_ids[process_id].timers.lsa.tx.delay is arista.avd.defined %}
+{%     if router_ospf.process_ids[process_id].timers.lsa.tx_delay.initial is arista.avd.defined
+          and router_ospf.process_ids[process_id].timers.lsa.tx_delay.min is arista.avd.defined
+          and router_ospf.process_ids[process_id].timers.lsa.tx_delay.max is arista.avd.defined %}
 {%         set timer_ospf_lsa_tx = "timers lsa tx delay initial" %}
-{%         if router_ospf.process_ids[process_id].timers.lsa.tx.delay.initial is arista.avd.defined %}
-{%             set timer_ospf_lsa_tx = timer_ospf_lsa_tx ~ " " ~ router_ospf.process_ids[process_id].timers.lsa.tx.delay.initial %}
-{%         endif %}
-{%         if router_ospf.process_ids[process_id].timers.lsa.tx.delay.min is arista.avd.defined %}
-{%             set timer_ospf_lsa_tx = timer_ospf_lsa_tx ~ " " ~ router_ospf.process_ids[process_id].timers.lsa.tx.delay.min %}
-{%         endif %}
-{%         if router_ospf.process_ids[process_id].timers.lsa.tx.delay.max is arista.avd.defined %}
-{%             set timer_ospf_lsa_tx = timer_ospf_lsa_tx ~ " " ~ router_ospf.process_ids[process_id].timers.lsa.tx.delay.max %}
-{%         endif %}
+{%         set timer_ospf_lsa_tx = timer_ospf_lsa_tx ~ " " ~ router_ospf.process_ids[process_id].timers.lsa.tx_delay.initial %}
+{%         set timer_ospf_lsa_tx = timer_ospf_lsa_tx ~ " " ~ router_ospf.process_ids[process_id].timers.lsa.tx_delay.min %}
+{%         set timer_ospf_lsa_tx = timer_ospf_lsa_tx ~ " " ~ router_ospf.process_ids[process_id].timers.lsa.tx_delay.max %}
    {{ timer_ospf_lsa_tx }}
 {%     endif %}
-{%     if router_ospf.process_ids[process_id].timers.spf.delay is arista.avd.defined %}
+{%     if router_ospf.process_ids[process_id].timers.spf_delay.initial is arista.avd.defined
+          and router_ospf.process_ids[process_id].timers.spf_delay.min is arista.avd.defined
+          and router_ospf.process_ids[process_id].timers.spf_delay.max is arista.avd.defined %}
 {%         set timer_ospf_spf_delay = "timers spf delay initial" %}
-{%         if router_ospf.process_ids[process_id].timers.spf.delay.initial is arista.avd.defined %}
-{%             set timer_ospf_spf_delay = timer_ospf_spf_delay ~ " " ~ router_ospf.process_ids[process_id].timers.spf.delay.initial %}
-{%         endif %}
-{%         if router_ospf.process_ids[process_id].timers.spf.delay.min is arista.avd.defined %}
-{%             set timer_ospf_spf_delay = timer_ospf_spf_delay ~ " " ~ router_ospf.process_ids[process_id].timers.spf.delay.min %}
-{%         endif %}
-{%         if router_ospf.process_ids[process_id].timers.spf.delay.max is arista.avd.defined %}
-{%             set timer_ospf_spf_delay = timer_ospf_spf_delay ~ " " ~ router_ospf.process_ids[process_id].timers.spf.delay.max %}
-{%         endif %}
+{%         set timer_ospf_spf_delay = timer_ospf_spf_delay ~ " " ~ router_ospf.process_ids[process_id].timers.spf_delay.initial %}
+{%         set timer_ospf_spf_delay = timer_ospf_spf_delay ~ " " ~ router_ospf.process_ids[process_id].timers.spf_delay.min %}
+{%         set timer_ospf_spf_delay = timer_ospf_spf_delay ~ " " ~ router_ospf.process_ids[process_id].timers.spf_delay.max %}
    {{ timer_ospf_spf_delay }}
 {%     endif %}
 {%     if router_ospf.process_ids[process_id].default_information_originate is defined %}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Fixes #1067 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Extend data model to support OSPF timers:

```yaml
router_ospf:
  process_ids:
    <process-id>:
      timers:
        lsa:
          rx_min_interval: < 0-600000 - Min interval in msecs between accepting the same LSA >
          tx_delay:
            initial: < 0-600000 - Delay to generate first occurrence of LSA in msecs >
            min: < 1-600000 Min delay between originating the same LSA in msecs >
            max: < 1-600000 Maximum delay between originating the same LSA in msecs >
        spf_delay:
          initial: < 0-600000 - Initial SPF schedule delay in msecs >
          min: < 0-65535000  Min Hold time between two SPFs in msecs >
          max: < 0-65535000  Max wait time between two SPFs in msecs >
```

Status:

- [x] Config rendering
- [ ] Documentation rendering

## How to test

Run molecule

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contributing/) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
