### PR TITLE
Feat(eos_cli_config_gen): Implement OSPF inter area filtering

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
@@ -230,11 +230,11 @@ interface Vlan24
 | 101 | 30.0.0.0/8 | - | RM-OSPF_SUMMARY | - |
 | 101 | 40.0.0.0/8 | - | - | True |
 
-### Router OSPF route filtering
+### Router OSPF Areas
 
-| Process ID | Area | Subnet filtering | Prefix List |
-| ---------- | ---- | ---------------- | ----------- |
-| 200 | 0.0.0.2 | 1.1.1.0/24 | - |
+| Process ID | Area | Filter Networks | Filter Prefix List |
+| ---------- | ---- | --------------- | ------------------ |
+| 200 | 0.0.0.2 | 1.1.1.0/24, 2.2.2.0/24 | - |
 | 200 | 0.0.0.3 | - | PL-OSPF-FILTERING |
 
 ### OSPF Interfaces
@@ -282,6 +282,7 @@ router ospf 200 vrf ospf_zone
    log-adjacency-changes detail
    router-id 192.168.254.1
    area 0.0.0.2 filter 1.1.1.0/24
+   area 0.0.0.2 filter 2.2.2.0/24
    area 0.0.0.3 filter prefix-list PL-OSPF-FILTERING
    max-lsa 5
    timers lsa rx min interval 100

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
@@ -230,6 +230,13 @@ interface Vlan24
 | 101 | 30.0.0.0/8 | - | RM-OSPF_SUMMARY | - |
 | 101 | 40.0.0.0/8 | - | - | True |
 
+### Router OSPF route filtering
+
+| Process ID | Area | Subnet filtering | Prefix List |
+| ---------- | ---- | ---------------- | ----------- |
+| 200 | 0.0.0.2 | 1.1.1.0/24 | - |
+| 200 | 0.0.0.3 | - | PL-OSPF-FILTERING |
+
 ### OSPF Interfaces
 
 | Interface | Area | Cost | Point To Point |
@@ -274,6 +281,8 @@ router ospf 101 vrf CUSTOMER01
 router ospf 200 vrf ospf_zone
    log-adjacency-changes detail
    router-id 192.168.254.1
+   area 0.0.0.2 filter 1.1.1.0/24
+   area 0.0.0.3 filter prefix-list PL-OSPF-FILTERING
    max-lsa 5
    timers lsa rx min interval 100
    default-information originate always

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-ospf.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-ospf.cfg
@@ -70,6 +70,7 @@ router ospf 200 vrf ospf_zone
    log-adjacency-changes detail
    router-id 192.168.254.1
    area 0.0.0.2 filter 1.1.1.0/24
+   area 0.0.0.2 filter 2.2.2.0/24
    area 0.0.0.3 filter prefix-list PL-OSPF-FILTERING
    max-lsa 5
    timers lsa rx min interval 100

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-ospf.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-ospf.cfg
@@ -69,6 +69,8 @@ router ospf 101 vrf CUSTOMER01
 router ospf 200 vrf ospf_zone
    log-adjacency-changes detail
    router-id 192.168.254.1
+   area 0.0.0.2 filter 1.1.1.0/24
+   area 0.0.0.3 filter prefix-list PL-OSPF-FILTERING
    max-lsa 5
    timers lsa rx min interval 100
    default-information originate always

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-ospf.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-ospf.yml
@@ -59,6 +59,13 @@ router_ospf:
           route_map: rm-ospf-static
         connected:
           route_map: rm-ospf-connected
+      areas:
+        '0.0.0.2':
+          filter:
+            network: 1.1.1.0/24
+        '0.0.0.3':
+          filter:
+            prefix_list: PL-OSPF-FILTERING
       max_metric: # not expected to produce config. Just here to test proper variable checks.
       timers:
         lsa:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-ospf.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-ospf.yml
@@ -62,7 +62,9 @@ router_ospf:
       areas:
         '0.0.0.2':
           filter:
-            network: 1.1.1.0/24
+            networks:
+              - 1.1.1.0/24
+              - 2.2.2.0/24
         '0.0.0.3':
           filter:
             prefix_list: PL-OSPF-FILTERING

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -2158,7 +2158,9 @@ router_ospf:
       areas:
         < area >:
           filter:
-            network: < IPv4 subnet / netmask >
+            networks:
+              - < IPv4 subnet / netmask >
+              - < IPv4 subnet / netmask >
             prefix_list: < prefix list name >
       maximum_paths: < Integer 1-32 >
       max_metric:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -2155,6 +2155,11 @@ router_ospf:
         connected:
           route_map: < route_map_name >
       auto_cost_reference_bandwidth: < bandwidth in mbps >
+      areas:
+        < area >:
+          filter:
+            network: < IPv4 subnet / netmask >
+            prefix_list: < prefix list name >
       maximum_paths: < Integer 1-32 >
       max_metric:
         router_lsa:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-ospf.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-ospf.j2
@@ -183,27 +183,28 @@
 {%             endif %}
 {%         endfor %}
 {%     endif %}
-{# Route Filtering #}
+{# OSPF Areas #}
 {%     set has.found = false %}
 {%     for process in router_ospf.process_ids | arista.avd.natural_sort %}
-{%         for area in router_ospf.process_ids[process].areas | arista.avd.natural_sort %}
-{%             if router_ospf.process_ids[process].areas[area].filter.network is arista.avd.defined
-                  or router_ospf.process_ids[process].areas[area].filter.prefix_list is arista.avd.defined  %}
-{%                 set has.found = true %}
-{%             endif %}
-{%         endfor %}
+{%         if router_ospf.process_ids[process].areas is arista.avd.defined %}
+{%             set has.found = true %}
+{%         endif %}
 {%     endfor %}
 {%     if has.found is arista.avd.defined(true) %}
 
-### Router OSPF route filtering
+### Router OSPF Areas
 
-| Process ID | Area | Subnet filtering | Prefix List |
-| ---------- | ---- | ---------------- | ----------- |
+| Process ID | Area | Filter Networks | Filter Prefix List |
+| ---------- | ---- | --------------- | ------------------ |
 {%         for process in router_ospf.process_ids | arista.avd.natural_sort %}
 {%             for area in router_ospf.process_ids[process].areas | arista.avd.natural_sort %}
-{%                 set subnet_filter = router_ospf.process_ids[process].areas[area].filter.network | arista.avd.default('-') %}
+{%                 if router_ospf.process_ids[process].areas[area].filter.networks is arista.avd.defined %}
+{%                     set network_filter = router_ospf.process_ids[process].areas[area].filter.networks | join(', ') %}
+{%                 else %}
+{%                     set network_filter = '-' %}
+{%                 endif %}
 {%                 set prefix_list_filter = router_ospf.process_ids[process].areas[area].filter.prefix_list | arista.avd.default('-') %}
-| {{ process }} | {{ area }} | {{ subnet_filter }} | {{ prefix_list_filter }} |
+| {{ process }} | {{ area }} | {{ network_filter }} | {{ prefix_list_filter }} |
 {%             endfor %}
 {%         endfor %}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-ospf.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-ospf.j2
@@ -183,6 +183,30 @@
 {%             endif %}
 {%         endfor %}
 {%     endif %}
+{# Route Filtering #}
+{%     set has.found = false %}
+{%     for process in router_ospf.process_ids | arista.avd.natural_sort %}
+{%         for area in router_ospf.process_ids[process].areas | arista.avd.natural_sort %}
+{%             if router_ospf.process_ids[process].areas[area].filter.network is arista.avd.defined
+                  or router_ospf.process_ids[process].areas[area].filter.prefix_list is arista.avd.defined  %}
+{%                 set has.found = true %}
+{%             endif %}
+{%         endfor %}
+{%     endfor %}
+{%     if has.found is arista.avd.defined(true) %}
+
+### Router OSPF route filtering
+
+| Process ID | Area | Subnet filtering | Prefix List |
+| ---------- | ---- | ---------------- | ----------- |
+{%         for process in router_ospf.process_ids | arista.avd.natural_sort %}
+{%             for area in router_ospf.process_ids[process].areas | arista.avd.natural_sort %}
+{%                 set subnet_filter = router_ospf.process_ids[process].areas[area].filter.network | arista.avd.default('-') %}
+{%                 set prefix_list_filter = router_ospf.process_ids[process].areas[area].filter.prefix_list | arista.avd.default('-') %}
+| {{ process }} | {{ area }} | {{ subnet_filter }} | {{ prefix_list_filter }} |
+{%             endfor %}
+{%         endfor %}
+{%     endif %}
 {# Interfaces #}
 {%     set ethernet_interface_ospf = namespace(configured=false) %}
 {%     set port_channel_interface_ospf = namespace(configured=false) %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-ospf.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-ospf.j2
@@ -26,6 +26,14 @@ router ospf {{ process_id }}
 {%     if router_ospf.process_ids[process_id].bfd_enable is arista.avd.defined and router_ospf.process_ids[process_id].bfd_enable %}
    bfd default
 {%     endif %}
+{%     for area in router_ospf.process_ids[process_id].areas | arista.avd.natural_sort %}
+{%         if router_ospf.process_ids[process_id].areas[area].filter.network is arista.avd.defined %}
+   area {{ area }} filter {{ router_ospf.process_ids[process_id].areas[area].filter.network }}
+{%         endif %}
+{%         if router_ospf.process_ids[process_id].areas[area].filter.prefix_list is arista.avd.defined %}
+   area {{ area }} filter prefix-list {{ router_ospf.process_ids[process_id].areas[area].filter.prefix_list }}
+{%         endif %}
+{%     endfor %}
 {%     if router_ospf.process_ids[process_id].max_lsa is arista.avd.defined %}
    max-lsa {{ router_ospf.process_ids[process_id].max_lsa }}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-ospf.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-ospf.j2
@@ -27,9 +27,9 @@ router ospf {{ process_id }}
    bfd default
 {%     endif %}
 {%     for area in router_ospf.process_ids[process_id].areas | arista.avd.natural_sort %}
-{%         if router_ospf.process_ids[process_id].areas[area].filter.network is arista.avd.defined %}
-   area {{ area }} filter {{ router_ospf.process_ids[process_id].areas[area].filter.network }}
-{%         endif %}
+{%         for filter_network in router_ospf.process_ids[process_id].areas[area].filter.networks | arista.avd.natural_sort %}
+   area {{ area }} filter {{ filter_network }}
+{%         endfor %}
 {%         if router_ospf.process_ids[process_id].areas[area].filter.prefix_list is arista.avd.defined %}
    area {{ area }} filter prefix-list {{ router_ospf.process_ids[process_id].areas[area].filter.prefix_list }}
 {%         endif %}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Fixes #1062 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Extend OSPF data model with inter area filtering:

```yaml
router_ospf:
  process_ids:
    < process_id >:
      areas:
        < area >:
          filter:
            networks: 
              - < IPv4 subnet / netmask >
              - < IPv4 subnet / netmask >
            prefix_list: < prefix list name >
```

## How to test

```bash
$ molecule converge -s eos_cli_config_gen -- --limit 'router-ospf'
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contributing/) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
