### PR TITLE
Optimize(molecule): Add ANSIBLE_OPTIONS to pass ansible options to molecule scenario

### DIFF
--- a/ansible_collections/arista/avd/molecule/Makefile
+++ b/ansible_collections/arista/avd/molecule/Makefile
@@ -1,5 +1,6 @@
 
 MOLECULE ?= eos_cli_config_gen
+LIMIT ?= 'all'
 
 .PHONY: help
 help: ## Display help message
@@ -17,7 +18,7 @@ run: ## Execute molecule TEST sequence. By default eos_cli_config_gen. Can be se
 .PHONY: converge
 converge: ## Execute molecule CONVERGE sequence. By default eos_cli_config_gen. Can be set with MOLECULE=
 	cd .. && \
-	molecule converge --scenario-name $(MOLECULE)
+	molecule converge --scenario-name $(MOLECULE) -- --limit $(LIMIT)
 
 .PHONY: refresh-facts
 refresh-facts: ## Run all molecule scenarios

--- a/ansible_collections/arista/avd/molecule/Makefile
+++ b/ansible_collections/arista/avd/molecule/Makefile
@@ -1,6 +1,6 @@
 
 MOLECULE ?= eos_cli_config_gen
-LIMIT ?= 'all'
+ANSIBLE_OPTIONS ?=
 
 .PHONY: help
 help: ## Display help message
@@ -13,12 +13,12 @@ help: ## Display help message
 .PHONY: run
 run: ## Execute molecule TEST sequence. By default eos_cli_config_gen. Can be set with MOLECULE=
 	cd .. && \
-	molecule test --scenario-name $(MOLECULE)
+	molecule test --scenario-name $(MOLECULE) -- $(ANSIBLE_OPTIONS)
 
 .PHONY: converge
 converge: ## Execute molecule CONVERGE sequence. By default eos_cli_config_gen. Can be set with MOLECULE=
 	cd .. && \
-	molecule converge --scenario-name $(MOLECULE) -- --limit $(LIMIT)
+	molecule converge --scenario-name $(MOLECULE) -- $(ANSIBLE_OPTIONS)
 
 .PHONY: refresh-facts
 refresh-facts: ## Run all molecule scenarios
@@ -26,7 +26,7 @@ refresh-facts: ## Run all molecule scenarios
 		if [ -d "$$MOLECULE_SCENARIO" ]; then\
 			echo "Run scenrario for "$$MOLECULE_SCENARIO && \
 			cd .. ; \
-			molecule converge --scenario-name $$MOLECULE_SCENARIO ; \
+			molecule converge --scenario-name $$MOLECULE_SCENARIO -- $(ANSIBLE_OPTIONS); \
 			cd ./molecule ; \
 		fi \
 	done <MOLECULE_SCENARIOS.txt
@@ -35,7 +35,7 @@ refresh-facts: ## Run all molecule scenarios
 commit-facts: ## Commit updated facts for CI
 	git status --short
 	git add .
-	git commit --no-verify -m 'ci(molecule): Update CI artifacts' ./
+	git commit --no-verify -m 'Ci(molecule): Update Molecule artifacts' ./
 
 .PHONY: test-git-status
 test-git-status: ## Run post molecule script to check git status
@@ -50,7 +50,7 @@ destroy: ## destroy all molecule scenarios
         if [ -d "$$MOLECULE_SCENARIO" ]; then\
         echo "Run scenrario for "$$MOLECULE_SCENARIO && \
 		cd .. ; \
-		molecule cleanup --scenario-name $$MOLECULE_SCENARIO ; \
+		molecule cleanup --scenario-name $$MOLECULE_SCENARIO -- $(ANSIBLE_OPTIONS); \
 		cd ./molecule ; \
         fi \
     done


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Documentation content changes
- [x] Other (please describe): Molecule

## Related Issue(s)

N/A

## Component(s) name

molecule

## Proposed changes

Add option to limit molecule execution:

```bash
$ make converge ANSIBLE_OPTIONS='--limit router-ospf'
cd .. && \
        molecule converge --scenario-name eos_cli_config_gen -- --limit router-ospf
```

> Specifically designed for eos_cli_config_gen

## How to test

Run molecule

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contributing/) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
