### PR TITLE
feat(eos_cli_config_gen): Add support for redistribution of bgp routes into ospf

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
@@ -202,10 +202,15 @@ interface Vlan24
 
 ### Router OSPF Router Redistribution
 
-| Process ID | Redistribute Connected | Redistribute Connected Route-map | Redistribute Static | Redistribute Static Route-map |
-| ---------- | ---------------------- | -------------------------------- | ------------------- | ----------------------------- |
-| 100 | enabled| - | enabled | - |
-| 200 | enabled| rm-ospf-connected | enabled | rm-ospf-static |
+| Process ID | Source Protocol | Route Map |
+| ---------- | --------------- | --------- |
+| 100 | connected | - |
+| 100 | static | - |
+| 100 | bgp | - |
+| 200 | connected | rm-ospf-connected |
+| 200 | static | rm-ospf-static |
+| 200 | bgp | rm-ospf-bgp |
+
 
 ### Router OSPF Router Max-Metric
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
@@ -271,6 +271,7 @@ router ospf 100
    default-information originate
    redistribute static
    redistribute connected
+   redistribute bgp
    auto-cost reference-bandwidth 100
    maximum-paths 10
    mpls ldp sync default
@@ -299,6 +300,7 @@ router ospf 200 vrf ospf_zone
    default-information originate always
    redistribute static route-map rm-ospf-static
    redistribute connected route-map rm-ospf-connected
+   redistribute bgp route-map rm-ospf-bgp
 !
 router ospf 300
    max-metric router-lsa

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-ospf.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-ospf.cfg
@@ -49,6 +49,7 @@ router ospf 100
    default-information originate
    redistribute static
    redistribute connected
+   redistribute bgp
    auto-cost reference-bandwidth 100
    maximum-paths 10
    mpls ldp sync default
@@ -77,6 +78,7 @@ router ospf 200 vrf ospf_zone
    default-information originate always
    redistribute static route-map rm-ospf-static
    redistribute connected route-map rm-ospf-connected
+   redistribute bgp route-map rm-ospf-bgp
 !
 router ospf 300
    max-metric router-lsa

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-ospf.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-ospf.yml
@@ -14,6 +14,7 @@ router_ospf:
       redistribute:
         static:
         connected:
+        bgp:
       auto_cost_reference_bandwidth: 100
       maximum_paths: 10
       mpls_ldp_sync_default: true
@@ -59,6 +60,8 @@ router_ospf:
           route_map: rm-ospf-static
         connected:
           route_map: rm-ospf-connected
+        bgp:
+          route_map: rm-ospf-bgp
       areas:
         '0.0.0.2':
           filter:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -2244,6 +2244,8 @@ router_ospf:
           route_map: < route_map_name >
         connected:
           route_map: < route_map_name >
+        bgp:
+          route_map: < route_map_name >
       auto_cost_reference_bandwidth: < bandwidth in mbps >
       areas:
         < area >:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-ospf.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-ospf.j2
@@ -59,25 +59,26 @@
 
 ### Router OSPF Router Redistribution
 
-| Process ID | Redistribute Connected | Redistribute Connected Route-map | Redistribute Static | Redistribute Static Route-map |
-| ---------- | ---------------------- | -------------------------------- | ------------------- | ----------------------------- |
+| Process ID | Source Protocol | Route Map |
+| ---------- | --------------- | --------- |
 {%         for process_id in router_ospf.process_ids | arista.avd.natural_sort %}
 {%             if router_ospf.process_ids[process_id].redistribute is arista.avd.defined %}
+{%                 set source_protocols = [] %}
 {%                 if router_ospf.process_ids[process_id].redistribute.connected is defined %}
-{%                     set connected = 'enabled' %}
-{%                 else %}
-{%                     set connected = 'disabled' %}
+{%                   do source_protocols.append(('connected', router_ospf.process_ids[process_id].redistribute.connected.route_map | arista.avd.default('-'))) %}
 {%                 endif %}
-{%                 set connected_rm = router_ospf.process_ids[process_id].redistribute.connected.route_map | arista.avd.default('-') %}
 {%                 if router_ospf.process_ids[process_id].redistribute.static is defined %}
-{%                     set static = 'enabled' %}
-{%                 else %}
-{%                     set static = 'disabled' %}
+{%                   do source_protocols.append(('static', router_ospf.process_ids[process_id].redistribute.static.route_map | arista.avd.default('-'))) %}
 {%                 endif %}
-{%                 set static_rm = router_ospf.process_ids[process_id].redistribute.static.route_map | arista.avd.default('-') %}
-| {{ process_id }} | {{ connected }}| {{ connected_rm }} | {{ static }} | {{ static_rm }} |
+{%                 if router_ospf.process_ids[process_id].redistribute.bgp is defined %}
+{%                   do source_protocols.append(('bgp', router_ospf.process_ids[process_id].redistribute.bgp.route_map | arista.avd.default('-'))) %}
+{%                 endif %}
+{%                 for source_protocol in source_protocols %}
+| {{ process_id }} | {{ source_protocol[0] }} | {{ source_protocol[1] }} |
+{%                 endfor %}
 {%             endif %}
 {%         endfor %}
+
 {%     endif %}
 {# Max-Metric #}
 {%     set has.found = false %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-ospf.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-ospf.j2
@@ -115,6 +115,13 @@ router ospf {{ process_id }}
 {%         endif %}
    {{ redistribute_connected_cli }}
 {%     endif %}
+{%     if router_ospf.process_ids[process_id].redistribute.bgp is defined %}
+{%         set redistribute_bgp_cli = "redistribute bgp" %}
+{%         if router_ospf.process_ids[process_id].redistribute.bgp.route_map is arista.avd.defined %}
+{%             set redistribute_bgp_cli = redistribute_bgp_cli ~ " route-map " ~ router_ospf.process_ids[process_id].redistribute.bgp.route_map %}
+{%         endif %}
+   {{ redistribute_bgp_cli }}
+{%     endif %}
 {%     if router_ospf.process_ids[process_id].auto_cost_reference_bandwidth is arista.avd.defined %}
    auto-cost reference-bandwidth {{ router_ospf.process_ids[process_id].auto_cost_reference_bandwidth }}
 {%     endif %}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [x] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Fixes #1081 

## Component(s) name

`arista.avd.<role-name>`

## Proposed changes
Extend Yaml definition to allow redistribution of bgp routes in ospf.
```yaml
router_ospf:
  process_ids:
    < process_id >:
      redistribute:
        static:
          route_map: < route_map_name >
        connected:
          route_map: < route_map_name >
        bgp:
          route_map: < route_map_name >

```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contributing/) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
