### PR TITLE
Feat(eos_cli_config_gen): Add single-connection to tacacs

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/aaa.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/aaa.md
@@ -79,17 +79,17 @@ username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC9OuVC4D+ARBrc9s
 
 ### TACACS Servers
 
-| VRF | TACACS Servers |
-| --- | ---------------|
-|  mgt | 10.10.10.157 |
-|  default | 10.10.10.249 |
-|  default | 10.10.10.158 |
+| VRF | TACACS Servers | Single-Connection |
+| --- | -------------- | ----------------- |
+|  mgt | 10.10.10.157 | True |
+|  default | 10.10.10.249 | False |
+|  default | 10.10.10.158 | False |
 
 ### TACACS Servers Device Configuration
 
 ```eos
 !
-tacacs-server host 10.10.10.157 vrf mgt key 7 071B245F5A
+tacacs-server host 10.10.10.157 single-connection vrf mgt key 7 071B245F5A
 tacacs-server host 10.10.10.158 key 7 071B245F5A
 tacacs-server host 10.10.10.249 timeout 23 key 7 071B245F5A
 ```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/aaa.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/aaa.cfg
@@ -12,7 +12,7 @@ aaa group server tacacs+ TACACS
    server 10.10.10.157 vrf mgt
    server 10.10.10.249
 !
-tacacs-server host 10.10.10.157 vrf mgt key 7 071B245F5A
+tacacs-server host 10.10.10.157 single-connection vrf mgt key 7 071B245F5A
 tacacs-server host 10.10.10.158 key 7 071B245F5A
 tacacs-server host 10.10.10.249 timeout 23 key 7 071B245F5A
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/aaa.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/aaa.yml
@@ -4,9 +4,11 @@ tacacs_servers:
     - host: 10.10.10.157
       vrf: mgt
       key: 071B245F5A
+      single_connection: true
     - host: 10.10.10.249
       key: 071B245F5A
       timeout: 23
+      single_connection: false
     - host: 10.10.10.158
       vrf: default
       key: 071B245F5A

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -94,6 +94,7 @@
       - [Logging](#logging)
       - [Sflow](#sflow)
       - [SNMP Settings](#snmp-settings)
+    - [System Control-Plane](#system-control-plane)
       - [VM Tracer Sessions](#vm-tracer-sessions)
     - [PTP](#ptp)
     - [Prompt](#prompt)
@@ -371,6 +372,7 @@ tacacs_servers:
     - host: < host1_ip_address >
       vrf: < vrf_name >
       key: < encypted_key >
+      single_connection: < true | false >
     - host: < host2_ip_address >
       key: < encypted_key >
       timeout: < timeout in seconds >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/tacacs-servers.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/tacacs-servers.j2
@@ -4,10 +4,10 @@
 
 ### TACACS Servers
 
-| VRF | TACACS Servers |
-| --- | ---------------|
+| VRF | TACACS Servers | Single-Connection |
+| --- | -------------- | ----------------- |
 {%  for host in tacacs_servers.hosts %}
-| {% if host['vrf'] is defined and host['vrf'] is not none %} {{ host['vrf'] }} {% else %} default {% endif %}| {{ host['host'] }} |
+| {% if host['vrf'] is defined and host['vrf'] is not none %} {{ host['vrf'] }} {% else %} default {% endif %}| {{ host['host'] }} | {{ host['single_connection'] | default(false) }} |
 {%  endfor %}
 
 {%    if tacacs_servers.policy_unknown_mandatory_attribute_ignore is defined and tacacs_servers.policy_unknown_mandatory_attribute_ignore == true %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/tacacs-servers.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/tacacs-servers.j2
@@ -5,6 +5,9 @@
 {%         if host.host is arista.avd.defined %}
 {%             set host_cli = "tacacs-server host " ~ host.host %}
 {%         endif %}
+{%         if host.single_connection is arista.avd.defined(true) %}
+{%             set host_cli = host_cli ~ " single-connection" %}
+{%         endif %}
 {%         if host.vrf is arista.avd.defined %}
 {%             if host.vrf != 'default' %}
 {%                 set host_cli = host_cli ~ " vrf " ~ host.vrf %}


### PR DESCRIPTION
## Change Summary

Per the feature request submited:
"add single-connection knob to tacacs server"

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [X] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Fixes #837

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Per the issue linked, I only updated the configuration generation and documentation related to tacacs-server config.

## How to test
Molecule tests updated.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been rebased from devel before I start
- [X] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contributing/) document.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [X] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
