### PR TITLE
Make(mkdoc): Add support for light/dark mode 

### DIFF
--- a/ansible_collections/arista/avd/docs/requirements.txt
+++ b/ansible_collections/arista/avd/docs/requirements.txt
@@ -1,8 +1,8 @@
 mkdocs
-mkdocs-bootswatch>=1.1
-mkdocs-material>=6.2.3
-mkdocs-material-extensions>=1.0.1
-fontawesome-markdown>=0.2.6
+mkdocs-bootswatch
+mkdocs-material==7.2.0
+mkdocs-material-extensions
+fontawesome-markdown
 pymdown-extensions
 mdx_truly_sane_lists
 mkdocs-git-revision-date-localized-plugin

--- a/ansible_collections/arista/avd/docs/stylesheets/extra.material.css
+++ b/ansible_collections/arista/avd/docs/stylesheets/extra.material.css
@@ -122,3 +122,9 @@
 .mdx-content__footer a:focus, .mdx-content__footer a:hover {
     transform: scale(1.2);
 }
+
+.md-typeset table:not([class]) th {
+    min-width: 5rem;
+    padding: .6rem .8rem;
+    color: var(--md-primary-fg-color--light);
+}

--- a/ansible_collections/arista/avd/docs/stylesheets/highlight.js
+++ b/ansible_collections/arista/avd/docs/stylesheets/highlight.js
@@ -1,0 +1,3 @@
+document$.subscribe(() => {
+  hljs.highlightAll()
+})

--- a/ansible_collections/arista/avd/docs/stylesheets/tables.js
+++ b/ansible_collections/arista/avd/docs/stylesheets/tables.js
@@ -1,0 +1,6 @@
+document$.subscribe(function() {
+  var tables = document.querySelectorAll("article table")
+  tables.forEach(function(table) {
+    new Tablesort(table)
+  })
+})

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@
 site_name: Arista AVD collection
 site_author: Arista Ansible Team
 site_description: Arista Validated Design collection's documentation
-copyright: Copyright &copy; 2019 - 2020 Arista Networks
+copyright: Copyright &copy; 2019 - 2021 Arista Networks
 
 # Repository information
 repo_name: AVD on Github

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,7 +12,7 @@ repo_url: https://github.com/aristanetworks/ansible-avd
 use_directory_urls: false
 theme:
   name: material
-  custom_dir: ansible_collections/arista/avd/docs/_overrides
+  # custom_dir: ansible_collections/arista/avd/docs/_overrides
   features:
     - navigation.instant
     - navigation.top
@@ -30,6 +30,17 @@ theme:
   language: en
   include_search_page: false
   search_index_only: true
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      toggle:
+        icon: material/toggle-switch-off-outline
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      toggle:
+        icon: material/toggle-switch
+        name: Switch to light mode
 
 extra_css:
   - docs/stylesheets/extra.material.css

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,6 +48,8 @@ extra_css:
 extra_javascript:
   - https://cdnjs.cloudflare.com/ajax/libs/tablesort/5.2.1/tablesort.min.js
   - docs/stylesheets/tables.js
+  - https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.7.2/highlight.min.js
+  - docs/stylesheets/highlight.js
 
 plugins:
   - search:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,6 +45,10 @@ theme:
 extra_css:
   - docs/stylesheets/extra.material.css
 
+extra_javascript:
+  - https://cdnjs.cloudflare.com/ajax/libs/tablesort/5.2.1/tablesort.min.js
+  - docs/stylesheets/tables.js
+
 plugins:
   - search:
       lang: en


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [x] Documentation content changes
- [ ] Other (please describe):

## Component(s) name

`mkdoc`

## Proposed changes

Enable toggle to switch from light to dark mode with specific CSS rendering

## How to test

Load Webdoc AVD and use toggle

![image](https://user-images.githubusercontent.com/4608573/126666012-0e689334-6066-4193-949b-3e6ce7328ec4.png)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
