### PR TITLE
update eos_validate_state role to make it more scalable

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_validate_state/README.md
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/README.md
@@ -89,6 +89,10 @@ eos_validate_state_dir: '{{ root_dir }}/{{ eos_validate_state_name }}'
 eos_validate_state_md_report_path: '{{ eos_validate_state_dir }}/{{ fabric_name }}-state.md'
 eos_validate_state_csv_report_path: '{{ eos_validate_state_dir }}/{{ fabric_name }}-state.csv'
 
+# Output level
+# Can be set to "verbose" to include details about successful tests
+eos_validate_output_level: "default"
+
 # Markdown flavor to support non-text rendering
 # Only support default and github
 validate_state_markdown_flavor: "default"
@@ -201,6 +205,10 @@ dns_domain: lab.local
 
 ```shell
 ansible-playbook playbooks/pb_validate_yml --inventory inventory/inventory.yml
+```
+
+```shell
+ansible-playbook playbooks/pb_validate_yml --inventory inventory/inventory.yml --extra-vars eos_validate_output_level=verbose
 ```
 
 ## License

--- a/ansible_collections/arista/avd/roles/eos_validate_state/defaults/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/defaults/main.yml
@@ -9,6 +9,10 @@ eos_validate_state_dir: '{{ root_dir }}/{{ eos_validate_state_name }}'
 eos_validate_state_md_report_path: '{{ eos_validate_state_dir }}/{{ fabric_name }}-state.md'
 eos_validate_state_csv_report_path: '{{ eos_validate_state_dir }}/{{ fabric_name }}-state.csv'
 
+# Output level
+# Can be set to "verbose" to include details about succesfull tests
+eos_validate_output_level: "default"
+
 # Markdown flavor to support non-text rendering
 # Only support default and github
 validate_state_markdown_flavor: "default"

--- a/ansible_collections/arista/avd/roles/eos_validate_state/defaults/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/defaults/main.yml
@@ -10,7 +10,7 @@ eos_validate_state_md_report_path: '{{ eos_validate_state_dir }}/{{ fabric_name 
 eos_validate_state_csv_report_path: '{{ eos_validate_state_dir }}/{{ fabric_name }}-state.csv'
 
 # Output level
-# Can be set to "verbose" to include details about succesfull tests
+# Can be set to "verbose" to include details about successful tests
 eos_validate_output_level: "default"
 
 # Markdown flavor to support non-text rendering

--- a/ansible_collections/arista/avd/roles/eos_validate_state/templates/validate_state_report-md.j2
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/templates/validate_state_report-md.j2
@@ -94,6 +94,7 @@
 {% endfor %}
 {% if eos_validate_output_level is arista.avd.defined %}
 {%     if eos_validate_output_level == "verbose" %}
+
 ## All Test Results
 
 | Test ID | Node | Test Category | Test Description | Test | Test Result | Failure Reason |

--- a/ansible_collections/arista/avd/roles/eos_validate_state/templates/validate_state_report-md.j2
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/templates/validate_state_report-md.j2
@@ -29,7 +29,11 @@
 - [Validate State Report](validate-state-report)
   - [Test Results Summary](#test-results-summary)
   - [Failed Test Results Summary](#failed-test-results-summary)
+{% if eos_validate_output_level is arista.avd.defined %}
+{%     if eos_validate_output_level == "verbose" %}
   - [All Test Results](#all-test-results)
+{%     endif %}
+{% endif %}
 
 ## Test Results Summary
 
@@ -38,6 +42,25 @@
 | Total Tests | Total Tests Passed | Total Tests Failed |
 | ----------- | ------------------ | ------------------ |
 | {{ validate_state_report.total_tests }} | {{ validate_state_report.total_tests_passed }} | {{ validate_state_report.total_tests_failed }} |
+
+### Summary Totals Per Category
+
+| Test Category | Total Tests | Tests Passed | Tests Failed |
+| ------------- | ----------- | ------------ | ------------ |
+{% for test_category in validate_state_report.test_categories %}
+{%     for test_id in validation_report_csv.dict %}
+{%         if validation_report_csv.dict[test_id].test_category == test_category %}
+{%             if validation_report_csv.dict[test_id].result == "PASS" %}
+{%                 set validate_state_report.tests_passed = validate_state_report.tests_passed + 1 %}
+{%             elif validation_report_csv.dict[test_id].result == "FAIL" %}
+{%                 set validate_state_report.tests_failed = validate_state_report.tests_failed + 1 %}
+{%             endif %}
+{%         endif %}
+{%     endfor %}
+| {{ test_category }} |  {{ validate_state_report.tests_passed + validate_state_report.tests_failed }} | {{ validate_state_report.tests_passed }} | {{ validate_state_report.tests_failed }} |
+{%     set validate_state_report.tests_passed = 0 %}
+{%     set validate_state_report.tests_failed = 0 %}
+{% endfor %}
 
 ### Summary Totals Devices Under Tests
 
@@ -60,25 +83,6 @@
 {%     set validate_state_report.test_categories_failed = [] %}
 {% endfor %}
 
-### Summary Totals Per Category
-
-| Test Category | Total Tests | Tests Passed | Tests Failed |
-| ------------- | ----------- | ------------ | ------------ |
-{% for test_category in validate_state_report.test_categories %}
-{%     for test_id in validation_report_csv.dict %}
-{%         if validation_report_csv.dict[test_id].test_category == test_category %}
-{%             if validation_report_csv.dict[test_id].result == "PASS" %}
-{%                 set validate_state_report.tests_passed = validate_state_report.tests_passed + 1 %}
-{%             elif validation_report_csv.dict[test_id].result == "FAIL" %}
-{%                 set validate_state_report.tests_failed = validate_state_report.tests_failed + 1 %}
-{%             endif %}
-{%         endif %}
-{%     endfor %}
-| {{ test_category }} |  {{ validate_state_report.tests_passed + validate_state_report.tests_failed }} | {{ validate_state_report.tests_passed }} | {{ validate_state_report.tests_failed }} |
-{%     set validate_state_report.tests_passed = 0 %}
-{%     set validate_state_report.tests_failed = 0 %}
-{% endfor %}
-
 ## Failed Test Results Summary
 
 | Test ID | Node | Test Category | Test Description | Test | Test Result | Failure Reason |
@@ -88,11 +92,14 @@
 | {{ test_id }} | {{ validation_report_csv.dict[test_id].node }} | {{ validation_report_csv.dict[test_id].test_category }} | {{ validation_report_csv.dict[test_id].test_description }} | {{ validation_report_csv.dict[test_id].test }} | {{ validation_report_csv.dict[test_id].result | arista.avd.status_render(validate_state_markdown_flavor) }} | {{ validation_report_csv.dict[test_id].failure_reason }} |
 {%     endif %}
 {% endfor %}
-
+{% if eos_validate_output_level is arista.avd.defined %}
+{%     if eos_validate_output_level == "verbose" %}
 ## All Test Results
 
 | Test ID | Node | Test Category | Test Description | Test | Test Result | Failure Reason |
 | ------- | ---- | ------------- | ---------------- | ---- | ----------- | -------------- |
-{% for test_id in validation_report_csv.dict %}
+{%         for test_id in validation_report_csv.dict %}
 | {{ test_id }} | {{ validation_report_csv.dict[test_id].node }} | {{ validation_report_csv.dict[test_id].test_category }} | {{ validation_report_csv.dict[test_id].test_description }} | {{ validation_report_csv.dict[test_id].test }} | {{ validation_report_csv.dict[test_id].result | arista.avd.status_render(validate_state_markdown_flavor) }} | {{ validation_report_csv.dict[test_id].failure_reason }} |
-{% endfor %}
+{%         endfor %}
+{%     endif %}
+{% endif %}


### PR DESCRIPTION
## Change Summary

`eos_validate_state` current output is verbose if we have many devices.   

- Moved `Summary Totals Per Category` above `Summary Totals Devices Under Tests` in the test report. So when we have many devices we can read `Summary Totals Per Category` from the top of the file (no need anymore to scroll down)

- Introduced a new var (`eos_validate_output_level`) defined in the role `default` dir with the default value `default` 

- The default output is now less verbose as it doesn't include anymore the last section (`All Test Results`) which is the longest one and the less interesting.

- if the var `eos_validate_output_level` is set to `verbose`, the role includes the details about successful tests (in the section `All Test Results`)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [x] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Fixes #1113 

## Component(s) name

`eos_validate_state`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test

Execute the role, and verify the output. 

`ansible-playbook playbooks/playbook_validate_states.yml -i inventories/inventory.yml`
should not include the section (`All Test Results`) 

`ansible-playbook playbooks/playbook_validate_states.yml -i inventories/inventory.yml --extra-vars eos_validate_output_level=default`
should not include the section (`All Test Results`) 

`ansible-playbook playbooks/playbook_validate_states.yml -i inventories/inventory.yml --extra-vars eos_validate_output_level=verbose`
should include the section (`All Test Results`) 

`ansible-playbook playbooks/playbook_validate_states.yml -i inventories/inventory.yml --extra-vars eos_validate_output_level=whatever_else`
should not include the section (`All Test Results`) 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
