### PR TITLE
Feat(eos_cli_config_gen): Add RADIUS Source-Interface

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-radius-source-interface.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-radius-source-interface.md
@@ -1,0 +1,114 @@
+# ip-radius-source-interface
+# Table of Contents
+<!-- toc -->
+
+- [Management](#management)
+  - [Management Interfaces](#management-interfaces)
+- [Authentication](#authentication)
+  - [IP RADIUS Source Interfaces](#ip-radius-source-interfaces)
+- [Monitoring](#monitoring)
+- [Internal VLAN Allocation Policy](#internal-vlan-allocation-policy)
+  - [Internal VLAN Allocation Policy Summary](#internal-vlan-allocation-policy-summary)
+- [Interfaces](#interfaces)
+- [Routing](#routing)
+  - [IP Routing](#ip-routing)
+  - [IPv6 Routing](#ipv6-routing)
+- [Multicast](#multicast)
+- [Filters](#filters)
+- [ACL](#acl)
+- [Quality Of Service](#quality-of-service)
+
+<!-- toc -->
+# Management
+
+## Management Interfaces
+
+### Management Interfaces Summary
+
+#### IPv4
+
+| Management Interface | description | Type | VRF | IP Address | Gateway |
+| -------------------- | ----------- | ---- | --- | ---------- | ------- |
+| Management1 | oob_management | oob | MGMT | 10.73.255.122/24 | 10.73.255.2 |
+
+#### IPv6
+
+| Management Interface | description | Type | VRF | IPv6 Address | IPv6 Gateway |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ |
+| Management1 | oob_management | oob | MGMT | -  | - |
+
+### Management Interfaces Device Configuration
+
+```eos
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+```
+
+# Authentication
+
+## IP RADIUS Source Interfaces
+
+### IP RADIUS Source Interfaces
+
+| VRF | Source Interface Name |
+| --- | --------------- |
+|  default  | loopback1 |
+|  MGMT  | Ma1 |
+|   default  | loopback10 |
+
+### IP SOURCE Source Interfaces Device Configuration
+
+```eos
+!
+ip radius vrf default source-interface loopback1
+!
+ip radius vrf MGMT source-interface Ma1
+!
+ip radius source-interface loopback10
+```
+
+# Monitoring
+
+# Internal VLAN Allocation Policy
+
+## Internal VLAN Allocation Policy Summary
+
+**Default Allocation Policy**
+
+| Policy Allocation | Range Beginning | Range Ending |
+| ------------------| --------------- | ------------ |
+| ascending | 1006 | 4094 |
+
+# Interfaces
+
+# Routing
+
+## IP Routing
+
+### IP Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | false|
+### IP Routing Device Configuration
+
+```eos
+```
+## IPv6 Routing
+
+### IPv6 Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | false |
+
+# Multicast
+
+# Filters
+
+# ACL
+
+# Quality Of Service

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-radius-source-interface.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-radius-source-interface.md
@@ -55,9 +55,9 @@ interface Management1
 
 | VRF | Source Interface Name |
 | --- | --------------- |
-|  default  | loopback1 |
-|  MGMT  | Ma1 |
-|   default  | loopback10 |
+| default | loopback1 |
+| MGMT | Ma1 |
+| default | loopback10 |
 
 ### IP SOURCE Source Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ip-radius-source-interface.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ip-radius-source-interface.cfg
@@ -1,0 +1,21 @@
+!RANCID-CONTENT-TYPE: arista
+!
+transceiver qsfp default-mode 4x10G
+!
+hostname ip-radius-source-interface
+!
+no aaa root
+no enable password
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+!
+ip radius vrf default source-interface loopback1
+!
+ip radius vrf MGMT source-interface Ma1
+!
+ip radius source-interface loopback10
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ip-radius-source-interface.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ip-radius-source-interface.yml
@@ -1,0 +1,9 @@
+### IP RADIUSsource interface ###
+
+ip_radius_source_interfaces:
+  - vrf : default
+    name: loopback1
+  - vrf : MGMT
+    name: Ma1
+  - vrf :
+    name: loopback10

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
@@ -26,6 +26,7 @@ ip-dhcp-relay
 ip-extended-community-lists
 ip-extended-community-lists-regexp
 ip-routing
+ip-radius-source-interface
 ip-tacacs-source-interface
 ipv6-access-lists
 ipv6-static-routes

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -20,6 +20,7 @@
       - [AAA Root](#aaa-root)
       - [AAA Server Groups](#aaa-server-groups)
       - [Enable Password](#enable-password)
+      - [IP RADIUS Source Interfaces](#ip-radius-source-interfaces)
       - [IP TACACS+ Source Interfaces](#ip-tacacs-source-interfaces)
       - [Local Users](#local-users)
       - [Radius Servers](#radius-servers)
@@ -326,6 +327,16 @@ aaa_server_groups:
 enable_password:
   hash_algorithm: < md5 | sha512 >
   key: "< hashed_password >"
+```
+
+#### IP RADIUS Source Interfaces
+
+```yaml
+ip_radius_source_interfaces:
+    - name: <interface_name_1 >
+      vrf: < vrf_name_1 >
+    - name: <interface_name_2 >
+      vrf: < vrf_name_2 >
 ```
 
 #### IP TACACS+ Source Interfaces

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ip-radius-source-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ip-radius-source-interfaces.j2
@@ -1,0 +1,18 @@
+{% if ip_radius_source_interfaces is defined and ip_radius_source_interfaces is not none %}
+
+## IP RADIUS Source Interfaces
+
+### IP RADIUS Source Interfaces
+
+| VRF | Source Interface Name |
+| --- | --------------- |
+{%     for ip_radius_source_interface in ip_radius_source_interfaces %}
+| {% if ip_radius_source_interface['vrf'] is defined and ip_radius_source_interface['vrf'] is not none %} {{ ip_radius_source_interface['vrf'] }} {% else %}  default {% endif %} | {{ ip_radius_source_interface['name'] }} |
+{%      endfor %}
+
+### IP SOURCE Source Interfaces Device Configuration
+
+```eos
+{% include 'eos/ip-radius-source-interfaces.j2' %}
+```
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ip-radius-source-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ip-radius-source-interfaces.j2
@@ -6,9 +6,9 @@
 
 | VRF | Source Interface Name |
 | --- | --------------- |
-{%     for ip_radius_source_interface in ip_radius_source_interfaces %}
-| {% if ip_radius_source_interface['vrf'] is defined and ip_radius_source_interface['vrf'] is not none %} {{ ip_radius_source_interface['vrf'] }} {% else %}  default {% endif %} | {{ ip_radius_source_interface['name'] }} |
-{%      endfor %}
+{%     for ip_radius_source_interface in ip_radius_source_interfaces | arista.avd.natural_sort %}
+| {{ ip_radius_source_interface['vrf'] | arista.avd.default('default') }} | {{ ip_radius_source_interface['name'] }} |
+{%     endfor %}
 
 ### IP SOURCE Source Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-device-documentation.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-device-documentation.j2
@@ -37,6 +37,8 @@
 {% include 'documentation/ip-tacacs-source-interfaces.j2' %}
 {## RADIUS Servers #}
 {% include 'documentation/radius-servers.j2' %}
+{## IP RADIUS Source Interfaces #}
+{% include 'documentation/ip-radius-source-interfaces.j2' %}
 {## AAA Server Groups #}
 {% include 'documentation/aaa-server-groups.j2' %}
 {## AAA Authentication #}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
@@ -195,6 +195,8 @@
 {% include 'eos/queue-monitor-streaming.j2' %}
 {# ip tacacs+ source interfaces #}
 {% include 'eos/ip-tacacs-source-interfaces.j2' %}
+{# ip radius source interfaces #}
+{% include 'eos/ip-radius-source-interfaces.j2' %}
 {# vmtracer sessions #}
 {% include 'eos/vmtracer-sessions.j2' %}
 {# traffic policies #}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-radius-source-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-radius-source-interfaces.j2
@@ -1,0 +1,12 @@
+{# eos - IP radius Source interfaces#}
+{% for ip_radius_source_interface in ip_radius_source_interfaces | arista.avd.natural_sort %}
+!
+{%     set ip_radius_cli = "ip radius" %}
+{%     if ip_radius_source_interface.vrf is arista.avd.defined %}
+{%         set ip_radius_cli = ip_radius_cli ~ " vrf " ~ ip_radius_source_interface.vrf %}
+{%     endif %}
+{%     if ip_radius_source_interface.name is arista.avd.defined %}
+{%         set ip_radius_cli = ip_radius_cli ~ " source-interface " ~ ip_radius_source_interface.name %}
+{%     endif %}
+{{ ip_radius_cli }}
+{% endfor %}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [x] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Fixes #1102 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Will create a new Data Model for IP Radius Source Interface as follows:
```
ip_radius_source_interfaces:
    - name: <interface_name_1 >
      vrf: < vrf_name_1 >
    - name: <interface_name_2 >
      vrf: < vrf_name_2 >
```
To create the following rendered Cli:
```
ip radius vrf MGMT source-interface Management1
ip radius vrf RED source-interface Ethernet1
```
## How to test
Ran Molecule Test
```
make converge
```
and verified Intended config and Documentation rendered properly.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

Not sure on these - Need help here.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
