### PR TITLE
Feat(eos_cli_config_gen): Http client source interface

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-http-client-source-interface.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-http-client-source-interface.md
@@ -1,0 +1,114 @@
+# ip-http-client-source-interface
+# Table of Contents
+<!-- toc -->
+
+- [Management](#management)
+  - [Management Interfaces](#management-interfaces)
+  - [IP HTTP Client Source Interfaces](#ip-http-client-source-interfaces)
+- [Authentication](#authentication)
+- [Monitoring](#monitoring)
+- [Internal VLAN Allocation Policy](#internal-vlan-allocation-policy)
+  - [Internal VLAN Allocation Policy Summary](#internal-vlan-allocation-policy-summary)
+- [Interfaces](#interfaces)
+- [Routing](#routing)
+  - [IP Routing](#ip-routing)
+  - [IPv6 Routing](#ipv6-routing)
+- [Multicast](#multicast)
+- [Filters](#filters)
+- [ACL](#acl)
+- [Quality Of Service](#quality-of-service)
+
+<!-- toc -->
+# Management
+
+## Management Interfaces
+
+### Management Interfaces Summary
+
+#### IPv4
+
+| Management Interface | description | Type | VRF | IP Address | Gateway |
+| -------------------- | ----------- | ---- | --- | ---------- | ------- |
+| Management1 | oob_management | oob | MGMT | 10.73.255.122/24 | 10.73.255.2 |
+
+#### IPv6
+
+| Management Interface | description | Type | VRF | IPv6 Address | IPv6 Gateway |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ |
+| Management1 | oob_management | oob | MGMT | -  | - |
+
+### Management Interfaces Device Configuration
+
+```eos
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+```
+
+## IP HTTP Client Source Interfaces
+
+### IP HTTP Client Source Interfaces
+
+| VRF | Source Interface Name |
+| --- | --------------- |
+ default |Loopback0 |
+ MGMT |Management0 |
+  default |Ethernet10 |
+
+### IP HTTP Client Source Interfaces Device Configuration
+
+```eos
+!
+ip http client local-interface Loopback0 vrf default
+!
+ip http client local-interface Management0 vrf MGMT
+!
+ip http client local-interface Ethernet10
+```
+
+# Authentication
+
+# Monitoring
+
+# Internal VLAN Allocation Policy
+
+## Internal VLAN Allocation Policy Summary
+
+**Default Allocation Policy**
+
+| Policy Allocation | Range Beginning | Range Ending |
+| ------------------| --------------- | ------------ |
+| ascending | 1006 | 4094 |
+
+# Interfaces
+
+# Routing
+
+## IP Routing
+
+### IP Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | false|
+### IP Routing Device Configuration
+
+```eos
+```
+## IPv6 Routing
+
+### IPv6 Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | false |
+
+# Multicast
+
+# Filters
+
+# ACL
+
+# Quality Of Service

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-http-client-source-interface.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-http-client-source-interface.md
@@ -53,9 +53,9 @@ interface Management1
 
 | VRF | Source Interface Name |
 | --- | --------------- |
- default |Loopback0 |
- MGMT |Management0 |
-  default |Ethernet10 |
+| default | Loopback0 |
+| MGMT | Management0 |
+| default | Ethernet10 |
 
 ### IP HTTP Client Source Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ip-http-client-source-interface.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ip-http-client-source-interface.cfg
@@ -1,0 +1,21 @@
+!RANCID-CONTENT-TYPE: arista
+!
+transceiver qsfp default-mode 4x10G
+!
+hostname ip-http-client-source-interface
+!
+no aaa root
+no enable password
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+!
+ip http client local-interface Loopback0 vrf default
+!
+ip http client local-interface Management0 vrf MGMT
+!
+ip http client local-interface Ethernet10
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ip-http-client-source-interface.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ip-http-client-source-interface.yml
@@ -1,0 +1,9 @@
+### IP HTTP Client Source Interface ###
+
+ip_http_client_source_interfaces:
+  - vrf : default
+    name: Loopback0
+  - vrf : MGMT
+    name: Management0
+  - vrf : 
+    name: Ethernet10

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
@@ -27,6 +27,7 @@ ip-extended-community-lists
 ip-extended-community-lists-regexp
 ip-routing
 ip-tacacs-source-interface
+ip-http-client-source-interface
 ipv6-access-lists
 ipv6-static-routes
 lldp

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -74,6 +74,7 @@
       - [Domain-List](#domain-list)
       - [Management Interfaces](#management-interfaces)
       - [Management HTTP](#management-http)
+      - [IP HTTP Client Source Interfaces](#ip-http-client-source-interfaces)
       - [Management GNMI](#management-gnmi)
       - [Management Console](#management-console)
       - [Management Security](#management-security)
@@ -1288,6 +1289,16 @@ management_api_http:
       access_group: < Standard IPv4 ACL name >
       ipv6_access_group: < Standard IPv6 ACL name >
     < vrf_name_2 >:
+```
+
+#### IP HTTP Client Source Interfaces
+
+```yaml
+ip_http_client_source_interfaces:
+    - name: <interface_name_1>
+      vrf: <vrf_name_1>
+    - name: <interface_name_2>
+      vrf: <vrf_name_2>
 ```
 
 #### Management GNMI

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ip-http-client-source-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ip-http-client-source-interfaces.j2
@@ -6,9 +6,9 @@
 
 | VRF | Source Interface Name |
 | --- | --------------- |
-{%     for ip_http_client_source_interface in ip_http_client_source_interfaces %}
-{% if ip_http_client_source_interface['vrf'] is defined and ip_http_client_source_interface['vrf'] is not none %} {{ ip_http_client_source_interface['vrf'] }} {% else %}  default {% endif %}|{{ ip_http_client_source_interface['name'] }} |
-{%      endfor %}
+{%     for ip_http_client_source_interface in ip_http_client_source_interfaces | arista.avd.natural_sort %}
+| {{ ip_http_client_source_interface['vrf'] | arista.avd.default('default') }} | {{ ip_http_client_source_interface['name'] }} |
+{%     endfor %}
 
 ### IP HTTP Client Source Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ip-http-client-source-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ip-http-client-source-interfaces.j2
@@ -1,0 +1,18 @@
+{% if ip_http_client_source_interfaces is defined and ip_http_client_source_interfaces is not none %}
+
+## IP HTTP Client Source Interfaces
+
+### IP HTTP Client Source Interfaces
+
+| VRF | Source Interface Name |
+| --- | --------------- |
+{%     for ip_http_client_source_interface in ip_http_client_source_interfaces %}
+{% if ip_http_client_source_interface['vrf'] is defined and ip_http_client_source_interface['vrf'] is not none %} {{ ip_http_client_source_interface['vrf'] }} {% else %}  default {% endif %}|{{ ip_http_client_source_interface['name'] }} |
+{%      endfor %}
+
+### IP HTTP Client Source Interfaces Device Configuration
+
+```eos
+{% include 'eos/ip-http-client-source-interfaces.j2' %}
+```
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-device-documentation.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-device-documentation.j2
@@ -25,6 +25,8 @@
 {% include 'documentation/management-api-gnmi.j2' %}
 {## Management API HTTP #}
 {% include 'documentation/management-api-http.j2' %}
+{## IP HTTP Client Source Interfaces #}
+{% include 'documentation/ip-http-client-source-interfaces.j2' %}
 
 # Authentication
 {## Local Users #}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
@@ -205,6 +205,8 @@
 {% include 'eos/banners.j2' %}
 {# management api http #}
 {% include 'eos/management-api-http.j2' %}
+{# ip http client source interfaces #}
+{% include 'eos/ip-http-client-source-interfaces.j2' %}
 {# management api gnmi #}
 {% include 'eos/management-api-gnmi.j2' %}
 {# management console #}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-http-client-source-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-http-client-source-interfaces.j2
@@ -1,0 +1,12 @@
+{# eos - IP HTTP Client Source Interfaces#}
+{% for ip_http_client_source_interface in ip_http_client_source_interfaces | arista.avd.natural_sort %}
+!
+{%     set ip_http_client_cli = "ip http client" %}
+{%     if ip_http_client_source_interface.name is arista.avd.defined %}
+{%         set ip_http_client_cli = ip_http_client_cli ~ " local-interface " ~ ip_http_client_source_interface.name %}
+{%     endif %}
+{%     if ip_http_client_source_interface.vrf is arista.avd.defined %}
+{%         set ip_http_client_cli = ip_http_client_cli ~ " vrf " ~ ip_http_client_source_interface.vrf %}
+{%     endif %}
+{{ ip_http_client_cli }}
+{% endfor %}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [x] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Fixes #1098 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
New model added for IP HTTP Client Source Interface:
```yaml
ip_http_client_source_interfaces:
    - name: <interface_name_1>
      vrf: <vrf_name_1>
    - name: <interface_name_2>
      vrf: <vrf_name_2>
```

Resulting in following EOS configuration:
```yaml
!
ip http client local-interface Loopback0 vrf default
!
ip http client local-interface Management0 vrf MGMT
!
ip http client local-interface Ethernet10
!
```

<!--- Describe data model implemented for new features -->

## How to test
<!--- Please describe in detail how you tested your changes. -->

Ran molecule test which resulted in generation of TOC documentation and intended configuration
`molecule test --scenario-name eos_cli_config_gen`
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
