### PR TITLE
Fix(eos_designs): Add protection on switch_filter_tenants

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/facts/switch/switch.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/facts/switch/switch.j2
@@ -301,55 +301,57 @@ switch:
 {% endif %}
 
 
-
-{% set leaf = namespace() %}
-{% set leaf.vlans = []  %}
-{% set leaf.tenants = {} %}
-{% for tenant in tenants | arista.avd.natural_sort if switch_filter_tenants is arista.avd.defined and ( tenant in switch_filter_tenants or "all" in switch_filter_tenants) %}
-{%     set add_vrfs = {} %}
-{%     for vrf in tenants[tenant].vrfs | arista.avd.natural_sort %}
-{%         set add_svis = [] %}
-{%         for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort %}
-{%             for svi_tag in tenants[tenant].vrfs[vrf].svis[svi].tags | arista.avd.natural_sort %}
-{%                 if svi_tag in switch_filter_tags or svi_tag == switch_data.group or "all" in switch_filter_tags %}
-{%                     do add_svis.append(svi) %}
-{%                     do leaf.vlans.append(svi | int) %}
+{% if switch.network_services_l2 is arista.avd.defined(true) or
+      switch.network_services_l3 is arista.avd.defined(true) %}
+{%     set leaf = namespace() %}
+{%     set leaf.vlans = []  %}
+{%     set leaf.tenants = {} %}
+{%     for tenant in tenants | arista.avd.natural_sort if tenant in switch_filter_tenants or "all" in switch_filter_tenants %}
+{%         set add_vrfs = {} %}
+{%         for vrf in tenants[tenant].vrfs | arista.avd.natural_sort %}
+{%             set add_svis = [] %}
+{%             for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort %}
+{%                 for svi_tag in tenants[tenant].vrfs[vrf].svis[svi].tags | arista.avd.natural_sort %}
+{%                     if svi_tag in switch_filter_tags or svi_tag == switch_data.group or "all" in switch_filter_tags %}
+{%                         do add_svis.append(svi) %}
+{%                         do leaf.vlans.append(svi | int) %}
+{%                         break %}
+{%                     endif %}
+{%                 endfor %}
+{%             endfor %}
+{# Append VRF if we found SVIs #}
+{%             if add_svis | length > 0 %}
+{%                 do add_vrfs.update({ vrf: {"svis": add_svis}}) %}
+{# Or Append VRF for tenants set in "always_include_vrfs_in_tenants" is set #}
+{%             elif switch_always_include_vrfs_in_tenants is arista.avd.contains([tenant, 'all']) %}
+{%                 do add_vrfs.update({ vrf: {}}) %}
+{%             else %}
+{# Or Append VRF if there is a BGP neighbor defined under tenants for this switch #}
+{%                 for l3_interface in tenants[tenant].vrfs[vrf].l3_interfaces | arista.avd.natural_sort %}
+{%                     if l3_interface.nodes is arista.avd.defined and l3_interface.ip_addresses is arista.avd.defined and l3_interface.interfaces is arista.avd.defined and inventory_hostname in l3_interface.nodes %}
+{%                         do add_vrfs.update({ vrf: {}}) %}
+{%                     endif %}
+{%                 endfor %}
+{%             endif %}
+{%         endfor %}
+{%         set add_l2vlans = [] %}
+{%         for l2vlan in tenants[tenant].l2vlans | arista.avd.natural_sort %}
+{%             for vlan_tag in tenants[tenant].l2vlans[l2vlan].tags | arista.avd.natural_sort %}
+{%                 if vlan_tag in switch_filter_tags or vlan_tag == switch_data.group or "all" in switch_filter_tags %}
+{%                     do add_l2vlans.append(l2vlan) %}
+{%                     do leaf.vlans.append(l2vlan | int) %}
 {%                     break %}
 {%                 endif %}
 {%             endfor %}
 {%         endfor %}
-{# Append VRF if we found SVIs #}
-{%         if add_svis | length > 0 %}
-{%             do add_vrfs.update({ vrf: {"svis": add_svis}}) %}
-{# Or Append VRF for tenants set in "always_include_vrfs_in_tenants" is set #}
-{%         elif switch_always_include_vrfs_in_tenants is arista.avd.contains([tenant, 'all']) %}
-{%             do add_vrfs.update({ vrf: {}}) %}
-{%         else %}
-{# Or Append VRF if there is a BGP neighbor defined under tenants for this switch #}
-{%             for l3_interface in tenants[tenant].vrfs[vrf].l3_interfaces | arista.avd.natural_sort %}
-{%                 if l3_interface.nodes is arista.avd.defined and l3_interface.ip_addresses is arista.avd.defined and l3_interface.interfaces is arista.avd.defined and inventory_hostname in l3_interface.nodes %}
-{%                     do add_vrfs.update({ vrf: {}}) %}
-{%                 endif %}
-{%             endfor %}
+{%         if add_vrfs | length > 0 or add_l2vlans | length > 0 %}
+{%             do leaf.tenants.update({ tenant: {"vrfs": add_vrfs, "l2vlans": add_l2vlans}}) %}
 {%         endif %}
 {%     endfor %}
-{%     set add_l2vlans = [] %}
-{%     for l2vlan in tenants[tenant].l2vlans | arista.avd.natural_sort %}
-{%         for vlan_tag in tenants[tenant].l2vlans[l2vlan].tags | arista.avd.natural_sort %}
-{%             if vlan_tag in switch_filter_tags or vlan_tag == switch_data.group or "all" in switch_filter_tags %}
-{%                 do add_l2vlans.append(l2vlan) %}
-{%                 do leaf.vlans.append(l2vlan | int) %}
-{%                 break %}
-{%             endif %}
-{%         endfor %}
-{%     endfor %}
-{%     if add_vrfs | length > 0 or add_l2vlans | length > 0 %}
-{%         do leaf.tenants.update({ tenant: {"vrfs": add_vrfs, "l2vlans": add_l2vlans}}) %}
-{%     endif %}
-{% endfor %}
 
 {# switch.tenants #}
   tenants: {{ leaf.tenants }}
 
 {# switch.vlans #}
   vlans: {{ leaf.vlans | unique }}
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/facts/switch/switch.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/facts/switch/switch.j2
@@ -305,7 +305,7 @@ switch:
 {% set leaf = namespace() %}
 {% set leaf.vlans = []  %}
 {% set leaf.tenants = {} %}
-{% for tenant in tenants | arista.avd.natural_sort if tenant in switch_filter_tenants or "all" in switch_filter_tenants %}
+{% for tenant in tenants | arista.avd.natural_sort if switch_filter_tenants is arista.avd.defined and ( tenant in switch_filter_tenants or "all" in switch_filter_tenants) %}
 {%     set add_vrfs = {} %}
 {%     for vrf in tenants[tenant].vrfs | arista.avd.natural_sort %}
 {%         set add_svis = [] %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/facts/topology/p2p-uplinks.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/facts/topology/p2p-uplinks.j2
@@ -43,4 +43,4 @@ topology:
 {# topology.vlans #}
 {# Vlan list taking parent switch vlans into consideration #}
 {# Since this switch is not using port-channels it is just the same as switch.vlans #}
-  vlans: {{ switch.vlans | arista.avd.default("") }}
+  vlans: {{ switch.vlans | arista.avd.default([]) }}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/facts/topology/p2p-uplinks.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/facts/topology/p2p-uplinks.j2
@@ -43,4 +43,4 @@ topology:
 {# topology.vlans #}
 {# Vlan list taking parent switch vlans into consideration #}
 {# Since this switch is not using port-channels it is just the same as switch.vlans #}
-  vlans: {{ switch.vlans }}
+  vlans: {{ switch.vlans | arista.avd.default("") }}


### PR DESCRIPTION
## Change Summary

Add an additional condition using `switch_filter_tenants` in for loop only
if this variable is defined

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

N/A

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

When following nodes type is defined, ansible fails with error message about `switch_filter_tenants`

- Node type definition

```yaml
node_type_keys:
  backbone:
    type: backbone
    uplink_type: p2p
```

- Ansible error message

```bash
fatal: [tls-backbone01]: FAILED! =>
  msg: '''switch_filter_tenants'' is undefined'
fatal: [tls-backbone02]: FAILED! =>
  msg: '''switch_filter_tenants'' is undefined'
```

Change add an additional test in the for loop to only use this loop if variable is defined.

```diff
diff --git a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/facts/switch/switch.j2 b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/facts/switch/switch.j2
index 509b4cc1..8e1c2d3a 100644
--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/facts/switch/switch.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/facts/switch/switch.j2
@@ -305,7 +305,7 @@ switch:
 {% set leaf = namespace() %}
 {% set leaf.vlans = []  %}
 {% set leaf.tenants = {} %}
-{% for tenant in tenants | arista.avd.natural_sort if tenant in switch_filter_tenants or "all" in switch_filter_tenants %}
+{% for tenant in tenants | arista.avd.natural_sort if switch_filter_tenants is arista.avd.defined and ( tenant in switch_filter_tenants or "all" in switch_filter_tenants) %}

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
