### PR TITLE
Feat(eos_cli_config_gen): Add support for logging synchronous

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/logging.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/logging.md
@@ -60,6 +60,7 @@ interface Management1
 | Console | debugging |
 | Buffer | informational  |
 | Trap | informational |
+| Synchronous | error |
 
 | VRF | Source Interface |
 | --- | ---------------- |
@@ -78,6 +79,7 @@ interface Management1
 logging console debugging
 logging buffered 1000000 informational
 logging trap informational
+logging synchronous level error
 logging source-interface Loopback0
 logging host 20.20.20.7
 logging vrf mgt source-interface Management0

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/logging.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/logging.cfg
@@ -5,6 +5,7 @@ transceiver qsfp default-mode 4x10G
 logging console debugging
 logging buffered 1000000 informational
 logging trap informational
+logging synchronous level error
 logging source-interface Loopback0
 logging host 20.20.20.7
 logging vrf mgt source-interface Management0

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/logging.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/logging.yml
@@ -5,6 +5,8 @@ logging:
     size: 1000000
     level: informational
   trap: informational
+  synchronous:
+    level: error
   source_interface:
   vrfs:
     mgt:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1547,6 +1547,8 @@ logging:
     size: < messages_nb (minimum of 10) >
     level: < severity_level >
   trap: < severity_level >
+  synchronous:
+    level: < severity_level | default --> critical >
   format:
     timestamp: < high-resolution | traditional >
     hostname: < fqdn | ipv4 >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/logging.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/logging.j2
@@ -18,6 +18,9 @@
 {%     if logging.trap is defined and logging.trap is not none %}
 | Trap | {{ logging.trap }} |
 {%     endif %}
+{%     if logging.synchronous is arista.avd.defined() %}
+| Synchronous | {{ logging.synchronous.level | arista.avd.default("critical") }} |
+{%     endif %}
 {%     if logging.format is defined and logging.format is not none %}
 
 | Format Type | Setting |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/logging.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/logging.j2
@@ -13,6 +13,9 @@ logging buffered {{ logging.buffered.size }} {{ logging.buffered.level }}
 {%     if logging.trap is arista.avd.defined %}
 logging trap {{ logging.trap }}
 {%     endif %}
+{%     if logging.synchronous is arista.avd.defined() %}
+logging synchronous level {{ logging.synchronous.level | arista.avd.default("critical") }}
+{%     endif %}
 {%     if logging.format.timestamp is arista.avd.defined('high-resolution') %}
 logging format timestamp high-resolution
 {%     endif %}


### PR DESCRIPTION
## Change Summary

Added documentation, jinja templates and molecule tests for logging synchronous.

even when "logging synchronous" is pushed to device, it is converted to "logging synchronous level critical", so this is the reason to have "critical" as default.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [x] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Fixes #1097

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
New variable under logging defined.

## How to test
Define the new variable "synchronous" under "logging" structure:
```
logging:
  synchronous:
    level: 
```
If level is not defined, "critical" will be used, and if anything else is defined, this will be the used value.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
