### PR TITLE
Fix(upgrade_tools): Avoid generating excess upgrade vars

### DIFF
--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/upgrade_2.x_to_3.0/DC1-POD1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/upgrade_2.x_to_3.0/DC1-POD1-L2LEAF1A.yml
@@ -45,9 +45,9 @@ l3leaf:
     uplink_ipv4_pool: 172.17.110.0/24
 # Change from p2p_uplinks_ptp.* to l3leaf.defaults.uplink_ptp.*
     uplink_ptp: {'enable': True}
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 172.19.110.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 172.20.110.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200', 'graceful-restart restart-time 300', 'graceful-restart']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/upgrade_2.x_to_3.0/DC1-POD1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/upgrade_2.x_to_3.0/DC1-POD1-L2LEAF1A.yml
@@ -82,9 +82,9 @@ l2leaf:
     inband_management_subnet: 172.21.110.0/24
 # Change from l2leaf_inband_management_vlan to l2leaf.defaults.inband_management_vlan
     inband_management_vlan: 4085
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 172.19.110.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 172.20.110.0/24
   node_groups:
     RACK2_SINGLE:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/upgrade_2.x_to_3.0/DC1-POD1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/upgrade_2.x_to_3.0/DC1-POD1-L2LEAF2A.yml
@@ -45,9 +45,9 @@ l3leaf:
     uplink_ipv4_pool: 172.17.110.0/24
 # Change from p2p_uplinks_ptp.* to l3leaf.defaults.uplink_ptp.*
     uplink_ptp: {'enable': True}
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 172.19.110.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 172.20.110.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200', 'graceful-restart restart-time 300', 'graceful-restart']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/upgrade_2.x_to_3.0/DC1-POD1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/upgrade_2.x_to_3.0/DC1-POD1-L2LEAF2A.yml
@@ -82,9 +82,9 @@ l2leaf:
     inband_management_subnet: 172.21.110.0/24
 # Change from l2leaf_inband_management_vlan to l2leaf.defaults.inband_management_vlan
     inband_management_vlan: 4085
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 172.19.110.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 172.20.110.0/24
   node_groups:
     RACK2_SINGLE:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/upgrade_2.x_to_3.0/DC1-POD1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/upgrade_2.x_to_3.0/DC1-POD1-L2LEAF2B.yml
@@ -45,9 +45,9 @@ l3leaf:
     uplink_ipv4_pool: 172.17.110.0/24
 # Change from p2p_uplinks_ptp.* to l3leaf.defaults.uplink_ptp.*
     uplink_ptp: {'enable': True}
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 172.19.110.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 172.20.110.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200', 'graceful-restart restart-time 300', 'graceful-restart']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/upgrade_2.x_to_3.0/DC1-POD1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/upgrade_2.x_to_3.0/DC1-POD1-L2LEAF2B.yml
@@ -82,9 +82,9 @@ l2leaf:
     inband_management_subnet: 172.21.110.0/24
 # Change from l2leaf_inband_management_vlan to l2leaf.defaults.inband_management_vlan
     inband_management_vlan: 4085
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 172.19.110.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 172.20.110.0/24
   node_groups:
     RACK2_SINGLE:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/upgrade_2.x_to_3.0/DC1-POD1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/upgrade_2.x_to_3.0/DC1-POD1-LEAF1A.yml
@@ -45,9 +45,9 @@ l3leaf:
     uplink_ipv4_pool: 172.17.110.0/24
 # Change from p2p_uplinks_ptp.* to l3leaf.defaults.uplink_ptp.*
     uplink_ptp: {'enable': True}
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 172.19.110.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 172.20.110.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200', 'graceful-restart restart-time 300', 'graceful-restart']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/upgrade_2.x_to_3.0/DC1-POD1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/upgrade_2.x_to_3.0/DC1-POD1-LEAF1A.yml
@@ -82,9 +82,9 @@ l2leaf:
     inband_management_subnet: 172.21.110.0/24
 # Change from l2leaf_inband_management_vlan to l2leaf.defaults.inband_management_vlan
     inband_management_vlan: 4085
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 172.19.110.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 172.20.110.0/24
   node_groups:
     RACK2_SINGLE:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/upgrade_2.x_to_3.0/DC1-POD1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/upgrade_2.x_to_3.0/DC1-POD1-LEAF2A.yml
@@ -45,9 +45,9 @@ l3leaf:
     uplink_ipv4_pool: 172.17.110.0/24
 # Change from p2p_uplinks_ptp.* to l3leaf.defaults.uplink_ptp.*
     uplink_ptp: {'enable': True}
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 172.19.110.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 172.20.110.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200', 'graceful-restart restart-time 300', 'graceful-restart']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/upgrade_2.x_to_3.0/DC1-POD1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/upgrade_2.x_to_3.0/DC1-POD1-LEAF2A.yml
@@ -82,9 +82,9 @@ l2leaf:
     inband_management_subnet: 172.21.110.0/24
 # Change from l2leaf_inband_management_vlan to l2leaf.defaults.inband_management_vlan
     inband_management_vlan: 4085
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 172.19.110.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 172.20.110.0/24
   node_groups:
     RACK2_SINGLE:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/upgrade_2.x_to_3.0/DC1-POD1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/upgrade_2.x_to_3.0/DC1-POD1-LEAF2B.yml
@@ -45,9 +45,9 @@ l3leaf:
     uplink_ipv4_pool: 172.17.110.0/24
 # Change from p2p_uplinks_ptp.* to l3leaf.defaults.uplink_ptp.*
     uplink_ptp: {'enable': True}
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 172.19.110.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 172.20.110.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200', 'graceful-restart restart-time 300', 'graceful-restart']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/upgrade_2.x_to_3.0/DC1-POD1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/upgrade_2.x_to_3.0/DC1-POD1-LEAF2B.yml
@@ -82,9 +82,9 @@ l2leaf:
     inband_management_subnet: 172.21.110.0/24
 # Change from l2leaf_inband_management_vlan to l2leaf.defaults.inband_management_vlan
     inband_management_vlan: 4085
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 172.19.110.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 172.20.110.0/24
   node_groups:
     RACK2_SINGLE:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/upgrade_2.x_to_3.0/DC1-POD1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/upgrade_2.x_to_3.0/DC1-POD1-SPINE1.yml
@@ -45,9 +45,9 @@ l3leaf:
     uplink_ipv4_pool: 172.17.110.0/24
 # Change from p2p_uplinks_ptp.* to l3leaf.defaults.uplink_ptp.*
     uplink_ptp: {'enable': True}
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 172.19.110.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 172.20.110.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200', 'graceful-restart restart-time 300', 'graceful-restart']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/upgrade_2.x_to_3.0/DC1-POD1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/upgrade_2.x_to_3.0/DC1-POD1-SPINE1.yml
@@ -82,9 +82,9 @@ l2leaf:
     inband_management_subnet: 172.21.110.0/24
 # Change from l2leaf_inband_management_vlan to l2leaf.defaults.inband_management_vlan
     inband_management_vlan: 4085
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 172.19.110.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 172.20.110.0/24
   node_groups:
     RACK2_SINGLE:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/upgrade_2.x_to_3.0/DC1-POD1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/upgrade_2.x_to_3.0/DC1-POD1-SPINE2.yml
@@ -45,9 +45,9 @@ l3leaf:
     uplink_ipv4_pool: 172.17.110.0/24
 # Change from p2p_uplinks_ptp.* to l3leaf.defaults.uplink_ptp.*
     uplink_ptp: {'enable': True}
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 172.19.110.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 172.20.110.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200', 'graceful-restart restart-time 300', 'graceful-restart']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/upgrade_2.x_to_3.0/DC1-POD1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/upgrade_2.x_to_3.0/DC1-POD1-SPINE2.yml
@@ -82,9 +82,9 @@ l2leaf:
     inband_management_subnet: 172.21.110.0/24
 # Change from l2leaf_inband_management_vlan to l2leaf.defaults.inband_management_vlan
     inband_management_vlan: 4085
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 172.19.110.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 172.20.110.0/24
   node_groups:
     RACK2_SINGLE:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/upgrade_2.x_to_3.0/DC1-POD2-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/upgrade_2.x_to_3.0/DC1-POD2-LEAF1A.yml
@@ -45,9 +45,9 @@ l3leaf:
     uplink_ipv4_pool: 172.17.120.0/24
 # Change from p2p_uplinks_ptp.* to l3leaf.defaults.uplink_ptp.*
     uplink_ptp: {'enable': True}
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 172.19.120.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 172.20.120.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200', 'graceful-restart restart-time 300', 'graceful-restart']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/upgrade_2.x_to_3.0/DC1-POD2-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/upgrade_2.x_to_3.0/DC1-POD2-SPINE1.yml
@@ -45,9 +45,9 @@ l3leaf:
     uplink_ipv4_pool: 172.17.120.0/24
 # Change from p2p_uplinks_ptp.* to l3leaf.defaults.uplink_ptp.*
     uplink_ptp: {'enable': True}
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 172.19.120.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 172.20.120.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200', 'graceful-restart restart-time 300', 'graceful-restart']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/upgrade_2.x_to_3.0/DC1-POD2-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/upgrade_2.x_to_3.0/DC1-POD2-SPINE2.yml
@@ -45,9 +45,9 @@ l3leaf:
     uplink_ipv4_pool: 172.17.120.0/24
 # Change from p2p_uplinks_ptp.* to l3leaf.defaults.uplink_ptp.*
     uplink_ptp: {'enable': True}
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 172.19.120.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 172.20.120.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200', 'graceful-restart restart-time 300', 'graceful-restart']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/upgrade_2.x_to_3.0/DC2-POD1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/upgrade_2.x_to_3.0/DC2-POD1-L2LEAF1A.yml
@@ -49,9 +49,9 @@ l3leaf:
     uplink_ipv4_pool: 172.17.210.0/24
 # Change from p2p_uplinks_ptp.* to l3leaf.defaults.uplink_ptp.*
     uplink_ptp: {'enable': True}
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 172.19.210.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 172.20.210.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200', 'graceful-restart restart-time 300', 'graceful-restart']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/upgrade_2.x_to_3.0/DC2-POD1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/upgrade_2.x_to_3.0/DC2-POD1-L2LEAF1A.yml
@@ -68,9 +68,9 @@ l2leaf:
   defaults:
 # Change from l2leaf_inband_management_subnet to l2leaf.defaults.inband_management_subnet
     inband_management_subnet: 172.21.210.0/24
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 172.19.210.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 172.20.210.0/24
   node_groups:
     RACK1_SINGLE:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/upgrade_2.x_to_3.0/DC2-POD1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/upgrade_2.x_to_3.0/DC2-POD1-LEAF1A.yml
@@ -49,9 +49,9 @@ l3leaf:
     uplink_ipv4_pool: 172.17.210.0/24
 # Change from p2p_uplinks_ptp.* to l3leaf.defaults.uplink_ptp.*
     uplink_ptp: {'enable': True}
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 172.19.210.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 172.20.210.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200', 'graceful-restart restart-time 300', 'graceful-restart']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/upgrade_2.x_to_3.0/DC2-POD1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/upgrade_2.x_to_3.0/DC2-POD1-LEAF1A.yml
@@ -68,9 +68,9 @@ l2leaf:
   defaults:
 # Change from l2leaf_inband_management_subnet to l2leaf.defaults.inband_management_subnet
     inband_management_subnet: 172.21.210.0/24
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 172.19.210.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 172.20.210.0/24
   node_groups:
     RACK1_SINGLE:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/upgrade_2.x_to_3.0/DC2-POD1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/upgrade_2.x_to_3.0/DC2-POD1-SPINE1.yml
@@ -49,9 +49,9 @@ l3leaf:
     uplink_ipv4_pool: 172.17.210.0/24
 # Change from p2p_uplinks_ptp.* to l3leaf.defaults.uplink_ptp.*
     uplink_ptp: {'enable': True}
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 172.19.210.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 172.20.210.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200', 'graceful-restart restart-time 300', 'graceful-restart']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/upgrade_2.x_to_3.0/DC2-POD1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/upgrade_2.x_to_3.0/DC2-POD1-SPINE1.yml
@@ -68,9 +68,9 @@ l2leaf:
   defaults:
 # Change from l2leaf_inband_management_subnet to l2leaf.defaults.inband_management_subnet
     inband_management_subnet: 172.21.210.0/24
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 172.19.210.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 172.20.210.0/24
   node_groups:
     RACK1_SINGLE:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/upgrade_2.x_to_3.0/DC2-POD1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/upgrade_2.x_to_3.0/DC2-POD1-SPINE2.yml
@@ -49,9 +49,9 @@ l3leaf:
     uplink_ipv4_pool: 172.17.210.0/24
 # Change from p2p_uplinks_ptp.* to l3leaf.defaults.uplink_ptp.*
     uplink_ptp: {'enable': True}
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 172.19.210.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 172.20.210.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200', 'graceful-restart restart-time 300', 'graceful-restart']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/upgrade_2.x_to_3.0/DC2-POD1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/upgrade_2.x_to_3.0/DC2-POD1-SPINE2.yml
@@ -68,9 +68,9 @@ l2leaf:
   defaults:
 # Change from l2leaf_inband_management_subnet to l2leaf.defaults.inband_management_subnet
     inband_management_subnet: 172.21.210.0/24
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 172.19.210.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 172.20.210.0/24
   node_groups:
     RACK1_SINGLE:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-BL1A.yml
@@ -88,9 +88,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-BL1A.yml
@@ -39,9 +39,9 @@ l3leaf:
     uplink_ipv4_pool: 172.31.255.0/24
 # Change from l3leaf.defaults.p2p_link_interface_speed to l3leaf.defaults.uplink_interface_speed
     uplink_interface_speed: forced 100gfull
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-BL1B.yml
@@ -88,9 +88,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-BL1B.yml
@@ -39,9 +39,9 @@ l3leaf:
     uplink_ipv4_pool: 172.31.255.0/24
 # Change from l3leaf.defaults.p2p_link_interface_speed to l3leaf.defaults.uplink_interface_speed
     uplink_interface_speed: forced 100gfull
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-L2LEAF1A.yml
@@ -88,9 +88,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-L2LEAF1A.yml
@@ -39,9 +39,9 @@ l3leaf:
     uplink_ipv4_pool: 172.31.255.0/24
 # Change from l3leaf.defaults.p2p_link_interface_speed to l3leaf.defaults.uplink_interface_speed
     uplink_interface_speed: forced 100gfull
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-L2LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-L2LEAF1B.yml
@@ -88,9 +88,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-L2LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-L2LEAF1B.yml
@@ -39,9 +39,9 @@ l3leaf:
     uplink_ipv4_pool: 172.31.255.0/24
 # Change from l3leaf.defaults.p2p_link_interface_speed to l3leaf.defaults.uplink_interface_speed
     uplink_interface_speed: forced 100gfull
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-L2LEAF2A.yml
@@ -88,9 +88,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-L2LEAF2A.yml
@@ -39,9 +39,9 @@ l3leaf:
     uplink_ipv4_pool: 172.31.255.0/24
 # Change from l3leaf.defaults.p2p_link_interface_speed to l3leaf.defaults.uplink_interface_speed
     uplink_interface_speed: forced 100gfull
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-L2LEAF2B.yml
@@ -88,9 +88,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-L2LEAF2B.yml
@@ -39,9 +39,9 @@ l3leaf:
     uplink_ipv4_pool: 172.31.255.0/24
 # Change from l3leaf.defaults.p2p_link_interface_speed to l3leaf.defaults.uplink_interface_speed
     uplink_interface_speed: forced 100gfull
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-L2LEAF3A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-L2LEAF3A.yml
@@ -88,9 +88,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-L2LEAF3A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-L2LEAF3A.yml
@@ -39,9 +39,9 @@ l3leaf:
     uplink_ipv4_pool: 172.31.255.0/24
 # Change from l3leaf.defaults.p2p_link_interface_speed to l3leaf.defaults.uplink_interface_speed
     uplink_interface_speed: forced 100gfull
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-LEAF1A.yml
@@ -88,9 +88,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-LEAF1A.yml
@@ -39,9 +39,9 @@ l3leaf:
     uplink_ipv4_pool: 172.31.255.0/24
 # Change from l3leaf.defaults.p2p_link_interface_speed to l3leaf.defaults.uplink_interface_speed
     uplink_interface_speed: forced 100gfull
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-LEAF2A.yml
@@ -88,9 +88,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-LEAF2A.yml
@@ -39,9 +39,9 @@ l3leaf:
     uplink_ipv4_pool: 172.31.255.0/24
 # Change from l3leaf.defaults.p2p_link_interface_speed to l3leaf.defaults.uplink_interface_speed
     uplink_interface_speed: forced 100gfull
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-LEAF2B.yml
@@ -88,9 +88,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-LEAF2B.yml
@@ -39,9 +39,9 @@ l3leaf:
     uplink_ipv4_pool: 172.31.255.0/24
 # Change from l3leaf.defaults.p2p_link_interface_speed to l3leaf.defaults.uplink_interface_speed
     uplink_interface_speed: forced 100gfull
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SPINE1.yml
@@ -88,9 +88,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SPINE1.yml
@@ -39,9 +39,9 @@ l3leaf:
     uplink_ipv4_pool: 172.31.255.0/24
 # Change from l3leaf.defaults.p2p_link_interface_speed to l3leaf.defaults.uplink_interface_speed
     uplink_interface_speed: forced 100gfull
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SPINE2.yml
@@ -88,9 +88,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SPINE2.yml
@@ -39,9 +39,9 @@ l3leaf:
     uplink_ipv4_pool: 172.31.255.0/24
 # Change from l3leaf.defaults.p2p_link_interface_speed to l3leaf.defaults.uplink_interface_speed
     uplink_interface_speed: forced 100gfull
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SPINE3.yml
@@ -88,9 +88,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SPINE3.yml
@@ -39,9 +39,9 @@ l3leaf:
     uplink_ipv4_pool: 172.31.255.0/24
 # Change from l3leaf.defaults.p2p_link_interface_speed to l3leaf.defaults.uplink_interface_speed
     uplink_interface_speed: forced 100gfull
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SPINE4.yml
@@ -88,9 +88,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SPINE4.yml
@@ -39,9 +39,9 @@ l3leaf:
     uplink_ipv4_pool: 172.31.255.0/24
 # Change from l3leaf.defaults.p2p_link_interface_speed to l3leaf.defaults.uplink_interface_speed
     uplink_interface_speed: forced 100gfull
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SVC3A.yml
@@ -88,9 +88,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SVC3A.yml
@@ -39,9 +39,9 @@ l3leaf:
     uplink_ipv4_pool: 172.31.255.0/24
 # Change from l3leaf.defaults.p2p_link_interface_speed to l3leaf.defaults.uplink_interface_speed
     uplink_interface_speed: forced 100gfull
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SVC3B.yml
@@ -88,9 +88,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SVC3B.yml
@@ -39,9 +39,9 @@ l3leaf:
     uplink_ipv4_pool: 172.31.255.0/24
 # Change from l3leaf.defaults.p2p_link_interface_speed to l3leaf.defaults.uplink_interface_speed
     uplink_interface_speed: forced 100gfull
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/upgrade_2.x_to_3.0/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/upgrade_2.x_to_3.0/DC1-BL1A.yml
@@ -39,9 +39,9 @@ l3leaf:
     uplink_switches: ['DC1-SPINE1', 'DC1-SPINE2', 'DC1-SPINE3', 'DC1-SPINE4']
 # Change from underlay_p2p_network_summary to l3leaf.defaults.uplink_ipv4_pool
     uplink_ipv4_pool: 172.31.255.0/24
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/upgrade_2.x_to_3.0/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/upgrade_2.x_to_3.0/DC1-BL1A.yml
@@ -86,9 +86,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/upgrade_2.x_to_3.0/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/upgrade_2.x_to_3.0/DC1-BL1B.yml
@@ -39,9 +39,9 @@ l3leaf:
     uplink_switches: ['DC1-SPINE1', 'DC1-SPINE2', 'DC1-SPINE3', 'DC1-SPINE4']
 # Change from underlay_p2p_network_summary to l3leaf.defaults.uplink_ipv4_pool
     uplink_ipv4_pool: 172.31.255.0/24
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/upgrade_2.x_to_3.0/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/upgrade_2.x_to_3.0/DC1-BL1B.yml
@@ -86,9 +86,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/upgrade_2.x_to_3.0/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/upgrade_2.x_to_3.0/DC1-L2LEAF1A.yml
@@ -39,9 +39,9 @@ l3leaf:
     uplink_switches: ['DC1-SPINE1', 'DC1-SPINE2', 'DC1-SPINE3', 'DC1-SPINE4']
 # Change from underlay_p2p_network_summary to l3leaf.defaults.uplink_ipv4_pool
     uplink_ipv4_pool: 172.31.255.0/24
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/upgrade_2.x_to_3.0/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/upgrade_2.x_to_3.0/DC1-L2LEAF1A.yml
@@ -86,9 +86,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/upgrade_2.x_to_3.0/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/upgrade_2.x_to_3.0/DC1-L2LEAF2A.yml
@@ -39,9 +39,9 @@ l3leaf:
     uplink_switches: ['DC1-SPINE1', 'DC1-SPINE2', 'DC1-SPINE3', 'DC1-SPINE4']
 # Change from underlay_p2p_network_summary to l3leaf.defaults.uplink_ipv4_pool
     uplink_ipv4_pool: 172.31.255.0/24
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/upgrade_2.x_to_3.0/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/upgrade_2.x_to_3.0/DC1-L2LEAF2A.yml
@@ -86,9 +86,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/upgrade_2.x_to_3.0/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/upgrade_2.x_to_3.0/DC1-L2LEAF2B.yml
@@ -39,9 +39,9 @@ l3leaf:
     uplink_switches: ['DC1-SPINE1', 'DC1-SPINE2', 'DC1-SPINE3', 'DC1-SPINE4']
 # Change from underlay_p2p_network_summary to l3leaf.defaults.uplink_ipv4_pool
     uplink_ipv4_pool: 172.31.255.0/24
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/upgrade_2.x_to_3.0/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/upgrade_2.x_to_3.0/DC1-L2LEAF2B.yml
@@ -86,9 +86,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/upgrade_2.x_to_3.0/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/upgrade_2.x_to_3.0/DC1-LEAF1A.yml
@@ -39,9 +39,9 @@ l3leaf:
     uplink_switches: ['DC1-SPINE1', 'DC1-SPINE2', 'DC1-SPINE3', 'DC1-SPINE4']
 # Change from underlay_p2p_network_summary to l3leaf.defaults.uplink_ipv4_pool
     uplink_ipv4_pool: 172.31.255.0/24
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/upgrade_2.x_to_3.0/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/upgrade_2.x_to_3.0/DC1-LEAF1A.yml
@@ -86,9 +86,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/upgrade_2.x_to_3.0/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/upgrade_2.x_to_3.0/DC1-LEAF2A.yml
@@ -39,9 +39,9 @@ l3leaf:
     uplink_switches: ['DC1-SPINE1', 'DC1-SPINE2', 'DC1-SPINE3', 'DC1-SPINE4']
 # Change from underlay_p2p_network_summary to l3leaf.defaults.uplink_ipv4_pool
     uplink_ipv4_pool: 172.31.255.0/24
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/upgrade_2.x_to_3.0/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/upgrade_2.x_to_3.0/DC1-LEAF2A.yml
@@ -86,9 +86,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/upgrade_2.x_to_3.0/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/upgrade_2.x_to_3.0/DC1-LEAF2B.yml
@@ -39,9 +39,9 @@ l3leaf:
     uplink_switches: ['DC1-SPINE1', 'DC1-SPINE2', 'DC1-SPINE3', 'DC1-SPINE4']
 # Change from underlay_p2p_network_summary to l3leaf.defaults.uplink_ipv4_pool
     uplink_ipv4_pool: 172.31.255.0/24
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/upgrade_2.x_to_3.0/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/upgrade_2.x_to_3.0/DC1-LEAF2B.yml
@@ -86,9 +86,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/upgrade_2.x_to_3.0/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/upgrade_2.x_to_3.0/DC1-SPINE1.yml
@@ -39,9 +39,9 @@ l3leaf:
     uplink_switches: ['DC1-SPINE1', 'DC1-SPINE2', 'DC1-SPINE3', 'DC1-SPINE4']
 # Change from underlay_p2p_network_summary to l3leaf.defaults.uplink_ipv4_pool
     uplink_ipv4_pool: 172.31.255.0/24
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/upgrade_2.x_to_3.0/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/upgrade_2.x_to_3.0/DC1-SPINE1.yml
@@ -86,9 +86,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/upgrade_2.x_to_3.0/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/upgrade_2.x_to_3.0/DC1-SPINE2.yml
@@ -39,9 +39,9 @@ l3leaf:
     uplink_switches: ['DC1-SPINE1', 'DC1-SPINE2', 'DC1-SPINE3', 'DC1-SPINE4']
 # Change from underlay_p2p_network_summary to l3leaf.defaults.uplink_ipv4_pool
     uplink_ipv4_pool: 172.31.255.0/24
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/upgrade_2.x_to_3.0/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/upgrade_2.x_to_3.0/DC1-SPINE2.yml
@@ -86,9 +86,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/upgrade_2.x_to_3.0/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/upgrade_2.x_to_3.0/DC1-SPINE3.yml
@@ -39,9 +39,9 @@ l3leaf:
     uplink_switches: ['DC1-SPINE1', 'DC1-SPINE2', 'DC1-SPINE3', 'DC1-SPINE4']
 # Change from underlay_p2p_network_summary to l3leaf.defaults.uplink_ipv4_pool
     uplink_ipv4_pool: 172.31.255.0/24
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/upgrade_2.x_to_3.0/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/upgrade_2.x_to_3.0/DC1-SPINE3.yml
@@ -86,9 +86,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/upgrade_2.x_to_3.0/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/upgrade_2.x_to_3.0/DC1-SPINE4.yml
@@ -39,9 +39,9 @@ l3leaf:
     uplink_switches: ['DC1-SPINE1', 'DC1-SPINE2', 'DC1-SPINE3', 'DC1-SPINE4']
 # Change from underlay_p2p_network_summary to l3leaf.defaults.uplink_ipv4_pool
     uplink_ipv4_pool: 172.31.255.0/24
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/upgrade_2.x_to_3.0/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/upgrade_2.x_to_3.0/DC1-SPINE4.yml
@@ -86,9 +86,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/upgrade_2.x_to_3.0/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/upgrade_2.x_to_3.0/DC1-SVC3A.yml
@@ -39,9 +39,9 @@ l3leaf:
     uplink_switches: ['DC1-SPINE1', 'DC1-SPINE2', 'DC1-SPINE3', 'DC1-SPINE4']
 # Change from underlay_p2p_network_summary to l3leaf.defaults.uplink_ipv4_pool
     uplink_ipv4_pool: 172.31.255.0/24
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/upgrade_2.x_to_3.0/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/upgrade_2.x_to_3.0/DC1-SVC3A.yml
@@ -86,9 +86,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/upgrade_2.x_to_3.0/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/upgrade_2.x_to_3.0/DC1-SVC3B.yml
@@ -39,9 +39,9 @@ l3leaf:
     uplink_switches: ['DC1-SPINE1', 'DC1-SPINE2', 'DC1-SPINE3', 'DC1-SPINE4']
 # Change from underlay_p2p_network_summary to l3leaf.defaults.uplink_ipv4_pool
     uplink_ipv4_pool: 172.31.255.0/24
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/upgrade_2.x_to_3.0/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/upgrade_2.x_to_3.0/DC1-SVC3B.yml
@@ -86,9 +86,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/upgrade_2.x_to_3.0/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/upgrade_2.x_to_3.0/DC1-BL1A.yml
@@ -35,9 +35,9 @@ l3leaf:
     uplink_switches: ['DC1-SPINE1', 'DC1-SPINE2', 'DC1-SPINE3', 'DC1-SPINE4']
 # Change from underlay_p2p_network_summary to l3leaf.defaults.uplink_ipv4_pool
     uplink_ipv4_pool: 172.31.255.0/24
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/upgrade_2.x_to_3.0/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/upgrade_2.x_to_3.0/DC1-BL1A.yml
@@ -78,9 +78,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/upgrade_2.x_to_3.0/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/upgrade_2.x_to_3.0/DC1-BL1B.yml
@@ -35,9 +35,9 @@ l3leaf:
     uplink_switches: ['DC1-SPINE1', 'DC1-SPINE2', 'DC1-SPINE3', 'DC1-SPINE4']
 # Change from underlay_p2p_network_summary to l3leaf.defaults.uplink_ipv4_pool
     uplink_ipv4_pool: 172.31.255.0/24
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/upgrade_2.x_to_3.0/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/upgrade_2.x_to_3.0/DC1-BL1B.yml
@@ -78,9 +78,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/upgrade_2.x_to_3.0/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/upgrade_2.x_to_3.0/DC1-L2LEAF1A.yml
@@ -35,9 +35,9 @@ l3leaf:
     uplink_switches: ['DC1-SPINE1', 'DC1-SPINE2', 'DC1-SPINE3', 'DC1-SPINE4']
 # Change from underlay_p2p_network_summary to l3leaf.defaults.uplink_ipv4_pool
     uplink_ipv4_pool: 172.31.255.0/24
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/upgrade_2.x_to_3.0/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/upgrade_2.x_to_3.0/DC1-L2LEAF1A.yml
@@ -78,9 +78,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/upgrade_2.x_to_3.0/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/upgrade_2.x_to_3.0/DC1-L2LEAF2A.yml
@@ -35,9 +35,9 @@ l3leaf:
     uplink_switches: ['DC1-SPINE1', 'DC1-SPINE2', 'DC1-SPINE3', 'DC1-SPINE4']
 # Change from underlay_p2p_network_summary to l3leaf.defaults.uplink_ipv4_pool
     uplink_ipv4_pool: 172.31.255.0/24
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/upgrade_2.x_to_3.0/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/upgrade_2.x_to_3.0/DC1-L2LEAF2A.yml
@@ -78,9 +78,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/upgrade_2.x_to_3.0/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/upgrade_2.x_to_3.0/DC1-L2LEAF2B.yml
@@ -35,9 +35,9 @@ l3leaf:
     uplink_switches: ['DC1-SPINE1', 'DC1-SPINE2', 'DC1-SPINE3', 'DC1-SPINE4']
 # Change from underlay_p2p_network_summary to l3leaf.defaults.uplink_ipv4_pool
     uplink_ipv4_pool: 172.31.255.0/24
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/upgrade_2.x_to_3.0/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/upgrade_2.x_to_3.0/DC1-L2LEAF2B.yml
@@ -78,9 +78,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/upgrade_2.x_to_3.0/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/upgrade_2.x_to_3.0/DC1-LEAF1A.yml
@@ -35,9 +35,9 @@ l3leaf:
     uplink_switches: ['DC1-SPINE1', 'DC1-SPINE2', 'DC1-SPINE3', 'DC1-SPINE4']
 # Change from underlay_p2p_network_summary to l3leaf.defaults.uplink_ipv4_pool
     uplink_ipv4_pool: 172.31.255.0/24
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/upgrade_2.x_to_3.0/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/upgrade_2.x_to_3.0/DC1-LEAF1A.yml
@@ -78,9 +78,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/upgrade_2.x_to_3.0/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/upgrade_2.x_to_3.0/DC1-LEAF2A.yml
@@ -35,9 +35,9 @@ l3leaf:
     uplink_switches: ['DC1-SPINE1', 'DC1-SPINE2', 'DC1-SPINE3', 'DC1-SPINE4']
 # Change from underlay_p2p_network_summary to l3leaf.defaults.uplink_ipv4_pool
     uplink_ipv4_pool: 172.31.255.0/24
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/upgrade_2.x_to_3.0/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/upgrade_2.x_to_3.0/DC1-LEAF2A.yml
@@ -78,9 +78,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/upgrade_2.x_to_3.0/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/upgrade_2.x_to_3.0/DC1-LEAF2B.yml
@@ -35,9 +35,9 @@ l3leaf:
     uplink_switches: ['DC1-SPINE1', 'DC1-SPINE2', 'DC1-SPINE3', 'DC1-SPINE4']
 # Change from underlay_p2p_network_summary to l3leaf.defaults.uplink_ipv4_pool
     uplink_ipv4_pool: 172.31.255.0/24
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/upgrade_2.x_to_3.0/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/upgrade_2.x_to_3.0/DC1-LEAF2B.yml
@@ -78,9 +78,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SPINE1.yml
@@ -35,9 +35,9 @@ l3leaf:
     uplink_switches: ['DC1-SPINE1', 'DC1-SPINE2', 'DC1-SPINE3', 'DC1-SPINE4']
 # Change from underlay_p2p_network_summary to l3leaf.defaults.uplink_ipv4_pool
     uplink_ipv4_pool: 172.31.255.0/24
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SPINE1.yml
@@ -78,9 +78,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SPINE2.yml
@@ -35,9 +35,9 @@ l3leaf:
     uplink_switches: ['DC1-SPINE1', 'DC1-SPINE2', 'DC1-SPINE3', 'DC1-SPINE4']
 # Change from underlay_p2p_network_summary to l3leaf.defaults.uplink_ipv4_pool
     uplink_ipv4_pool: 172.31.255.0/24
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SPINE2.yml
@@ -78,9 +78,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SPINE3.yml
@@ -35,9 +35,9 @@ l3leaf:
     uplink_switches: ['DC1-SPINE1', 'DC1-SPINE2', 'DC1-SPINE3', 'DC1-SPINE4']
 # Change from underlay_p2p_network_summary to l3leaf.defaults.uplink_ipv4_pool
     uplink_ipv4_pool: 172.31.255.0/24
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SPINE3.yml
@@ -78,9 +78,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SPINE4.yml
@@ -35,9 +35,9 @@ l3leaf:
     uplink_switches: ['DC1-SPINE1', 'DC1-SPINE2', 'DC1-SPINE3', 'DC1-SPINE4']
 # Change from underlay_p2p_network_summary to l3leaf.defaults.uplink_ipv4_pool
     uplink_ipv4_pool: 172.31.255.0/24
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SPINE4.yml
@@ -78,9 +78,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SVC3A.yml
@@ -35,9 +35,9 @@ l3leaf:
     uplink_switches: ['DC1-SPINE1', 'DC1-SPINE2', 'DC1-SPINE3', 'DC1-SPINE4']
 # Change from underlay_p2p_network_summary to l3leaf.defaults.uplink_ipv4_pool
     uplink_ipv4_pool: 172.31.255.0/24
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SVC3A.yml
@@ -78,9 +78,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SVC3B.yml
@@ -35,9 +35,9 @@ l3leaf:
     uplink_switches: ['DC1-SPINE1', 'DC1-SPINE2', 'DC1-SPINE3', 'DC1-SPINE4']
 # Change from underlay_p2p_network_summary to l3leaf.defaults.uplink_ipv4_pool
     uplink_ipv4_pool: 172.31.255.0/24
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SVC3B.yml
@@ -78,9 +78,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/upgrade_2.x_to_3.0/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/upgrade_2.x_to_3.0/DC1-BL1A.yml
@@ -76,9 +76,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/upgrade_2.x_to_3.0/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/upgrade_2.x_to_3.0/DC1-BL1A.yml
@@ -33,9 +33,9 @@ l3leaf:
     uplink_interfaces: ['Ethernet1', 'Ethernet2', 'Ethernet3', 'Ethernet4']
 # Change from l3leaf.defaults.spines to l3leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SPINE1', 'DC1-SPINE2', 'DC1-SPINE3', 'DC1-SPINE4']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/upgrade_2.x_to_3.0/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/upgrade_2.x_to_3.0/DC1-BL1B.yml
@@ -76,9 +76,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/upgrade_2.x_to_3.0/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/upgrade_2.x_to_3.0/DC1-BL1B.yml
@@ -33,9 +33,9 @@ l3leaf:
     uplink_interfaces: ['Ethernet1', 'Ethernet2', 'Ethernet3', 'Ethernet4']
 # Change from l3leaf.defaults.spines to l3leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SPINE1', 'DC1-SPINE2', 'DC1-SPINE3', 'DC1-SPINE4']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/upgrade_2.x_to_3.0/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/upgrade_2.x_to_3.0/DC1-L2LEAF1A.yml
@@ -76,9 +76,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/upgrade_2.x_to_3.0/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/upgrade_2.x_to_3.0/DC1-L2LEAF1A.yml
@@ -33,9 +33,9 @@ l3leaf:
     uplink_interfaces: ['Ethernet1', 'Ethernet2', 'Ethernet3', 'Ethernet4']
 # Change from l3leaf.defaults.spines to l3leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SPINE1', 'DC1-SPINE2', 'DC1-SPINE3', 'DC1-SPINE4']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/upgrade_2.x_to_3.0/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/upgrade_2.x_to_3.0/DC1-L2LEAF2A.yml
@@ -76,9 +76,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/upgrade_2.x_to_3.0/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/upgrade_2.x_to_3.0/DC1-L2LEAF2A.yml
@@ -33,9 +33,9 @@ l3leaf:
     uplink_interfaces: ['Ethernet1', 'Ethernet2', 'Ethernet3', 'Ethernet4']
 # Change from l3leaf.defaults.spines to l3leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SPINE1', 'DC1-SPINE2', 'DC1-SPINE3', 'DC1-SPINE4']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/upgrade_2.x_to_3.0/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/upgrade_2.x_to_3.0/DC1-L2LEAF2B.yml
@@ -76,9 +76,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/upgrade_2.x_to_3.0/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/upgrade_2.x_to_3.0/DC1-L2LEAF2B.yml
@@ -33,9 +33,9 @@ l3leaf:
     uplink_interfaces: ['Ethernet1', 'Ethernet2', 'Ethernet3', 'Ethernet4']
 # Change from l3leaf.defaults.spines to l3leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SPINE1', 'DC1-SPINE2', 'DC1-SPINE3', 'DC1-SPINE4']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/upgrade_2.x_to_3.0/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/upgrade_2.x_to_3.0/DC1-LEAF1A.yml
@@ -76,9 +76,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/upgrade_2.x_to_3.0/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/upgrade_2.x_to_3.0/DC1-LEAF1A.yml
@@ -33,9 +33,9 @@ l3leaf:
     uplink_interfaces: ['Ethernet1', 'Ethernet2', 'Ethernet3', 'Ethernet4']
 # Change from l3leaf.defaults.spines to l3leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SPINE1', 'DC1-SPINE2', 'DC1-SPINE3', 'DC1-SPINE4']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/upgrade_2.x_to_3.0/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/upgrade_2.x_to_3.0/DC1-LEAF2A.yml
@@ -76,9 +76,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/upgrade_2.x_to_3.0/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/upgrade_2.x_to_3.0/DC1-LEAF2A.yml
@@ -33,9 +33,9 @@ l3leaf:
     uplink_interfaces: ['Ethernet1', 'Ethernet2', 'Ethernet3', 'Ethernet4']
 # Change from l3leaf.defaults.spines to l3leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SPINE1', 'DC1-SPINE2', 'DC1-SPINE3', 'DC1-SPINE4']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/upgrade_2.x_to_3.0/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/upgrade_2.x_to_3.0/DC1-LEAF2B.yml
@@ -76,9 +76,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/upgrade_2.x_to_3.0/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/upgrade_2.x_to_3.0/DC1-LEAF2B.yml
@@ -33,9 +33,9 @@ l3leaf:
     uplink_interfaces: ['Ethernet1', 'Ethernet2', 'Ethernet3', 'Ethernet4']
 # Change from l3leaf.defaults.spines to l3leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SPINE1', 'DC1-SPINE2', 'DC1-SPINE3', 'DC1-SPINE4']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SPINE1.yml
@@ -76,9 +76,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SPINE1.yml
@@ -33,9 +33,9 @@ l3leaf:
     uplink_interfaces: ['Ethernet1', 'Ethernet2', 'Ethernet3', 'Ethernet4']
 # Change from l3leaf.defaults.spines to l3leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SPINE1', 'DC1-SPINE2', 'DC1-SPINE3', 'DC1-SPINE4']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SPINE2.yml
@@ -76,9 +76,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SPINE2.yml
@@ -33,9 +33,9 @@ l3leaf:
     uplink_interfaces: ['Ethernet1', 'Ethernet2', 'Ethernet3', 'Ethernet4']
 # Change from l3leaf.defaults.spines to l3leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SPINE1', 'DC1-SPINE2', 'DC1-SPINE3', 'DC1-SPINE4']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SPINE3.yml
@@ -76,9 +76,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SPINE3.yml
@@ -33,9 +33,9 @@ l3leaf:
     uplink_interfaces: ['Ethernet1', 'Ethernet2', 'Ethernet3', 'Ethernet4']
 # Change from l3leaf.defaults.spines to l3leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SPINE1', 'DC1-SPINE2', 'DC1-SPINE3', 'DC1-SPINE4']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SPINE4.yml
@@ -76,9 +76,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SPINE4.yml
@@ -33,9 +33,9 @@ l3leaf:
     uplink_interfaces: ['Ethernet1', 'Ethernet2', 'Ethernet3', 'Ethernet4']
 # Change from l3leaf.defaults.spines to l3leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SPINE1', 'DC1-SPINE2', 'DC1-SPINE3', 'DC1-SPINE4']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SVC3A.yml
@@ -76,9 +76,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SVC3A.yml
@@ -33,9 +33,9 @@ l3leaf:
     uplink_interfaces: ['Ethernet1', 'Ethernet2', 'Ethernet3', 'Ethernet4']
 # Change from l3leaf.defaults.spines to l3leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SPINE1', 'DC1-SPINE2', 'DC1-SPINE3', 'DC1-SPINE4']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SVC3B.yml
@@ -76,9 +76,9 @@ l2leaf:
   defaults:
 # Change from l2leaf.defaults.parent_l3leafs to l2leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SVC3A', 'DC1-SVC3B']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
   node_groups:
     DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/upgrade_2.x_to_3.0/DC1-SVC3B.yml
@@ -33,9 +33,9 @@ l3leaf:
     uplink_interfaces: ['Ethernet1', 'Ethernet2', 'Ethernet3', 'Ethernet4']
 # Change from l3leaf.defaults.spines to l3leaf.defaults.uplink_switches
     uplink_switches: ['DC1-SPINE1', 'DC1-SPINE2', 'DC1-SPINE3', 'DC1-SPINE4']
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: 10.255.252.0/24
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']

--- a/ansible_collections/arista/avd/roles/upgrade_tools/templates/upgrade-2.x-to-3.0.j2
+++ b/ansible_collections/arista/avd/roles/upgrade_tools/templates/upgrade-2.x-to-3.0.j2
@@ -209,11 +209,11 @@ l2leaf:
     uplink_interface_speed: {{ l2leaf.defaults.p2p_link_interface_speed }}
 {%     endif %}
 {%     if mlag_ips.mlag_peer is arista.avd.defined %}
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l2leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: {{ mlag_ips.mlag_peer }}
 {%     endif %}
 {%     if mlag_ips.leaf_peer_l3 is arista.avd.defined %}
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l2leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: {{ mlag_ips.leaf_peer_l3 }}
 {%     endif %}
   node_groups:

--- a/ansible_collections/arista/avd/roles/upgrade_tools/templates/upgrade-2.x-to-3.0.j2
+++ b/ansible_collections/arista/avd/roles/upgrade_tools/templates/upgrade-2.x-to-3.0.j2
@@ -40,7 +40,7 @@ spine:
 {%     if spine_bgp_defaults is arista.avd.defined %}
 # Change from spine_bgp_defaults to spine.defaults.bgp_defaults
     bgp_defaults: {{ spine_bgp_defaults }}
-{%     else %}
+{%     elif spine.defaults.bgp_defaults is not arista.avd.defined %}
 # Change from old default value of spine_bgp_defaults to spine.defaults.bgp_defaults
     bgp_defaults:
       - update wait-for-convergence
@@ -84,12 +84,12 @@ l3leaf:
 {%     if overlay_loopback_network_summary is arista.avd.defined %}
 # Change from overlay_loopback_network_summary to l3leaf.defaults.loopback_ipv4_pool
     loopback_ipv4_pool: {{ overlay_loopback_network_summary }}
-{%     endif %}
-{%     set switch_max_spines = max_spines | arista.avd.default(
-                               spine.nodes | arista.avd.default([]) | length) %}
-{%     if switch_max_spines > 0 %}
+{%         set switch_max_spines = max_spines | arista.avd.default(
+                                   spine.nodes | arista.avd.default([]) | length) %}
+{%         if switch_max_spines > 0 %}
 # New loopback_network_offset variable based on max_spines or length of spine.nodes
     loopback_ipv4_offset: {{ switch_max_spines }}
+{%         endif %}
 {%     endif %}
 {%     if vtep_loopback_network_summary is arista.avd.defined %}
 # Change from vtep_loopback_network_summary to l3leaf.defaults.vtep_loopback_ipv4_pool
@@ -134,7 +134,7 @@ l3leaf:
 {%     if leaf_bgp_defaults is arista.avd.defined %}
 # Change from leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults: {{ leaf_bgp_defaults }}
-{%     else %}
+{%     elif l3leaf.defaults.bgp_defaults is not arista.avd.defined %}
 # Change from old default value of leaf_bgp_defaults to l3leaf.defaults.bgp_defaults
     bgp_defaults:
       - update wait-install
@@ -261,7 +261,7 @@ super_spine:
 {%     if super_spine_bgp_defaults is arista.avd.defined %}
 # Change from super_spine_bgp_defaults to super_spine.defaults.bgp_defaults
     bgp_defaults: {{ super_spine_bgp_defaults }}
-{%     else %}
+{%     elif super_spine.defaults.bgp_defaults is not arista.avd.defined %}
 # Change from old default value of super_spine_bgp_defaults to super_spine.defaults.bgp_defaults
     bgp_defaults:
       - update wait-for-convergence
@@ -312,7 +312,7 @@ overlay_controller:
 {%     if overlay_controller_bgp_defaults is arista.avd.defined %}
 # Change from overlay_controller_bgp_defaults to overlay_controller.defaults.bgp_defaults
     bgp_defaults: {{ overlay_controller_bgp_defaults }}
-{%     else %}
+{%     elif overlay_controller.defaults.bgp_defaults is not arista.avd.defined %}
 # Change from old default value of overlay_controller_bgp_defaults to overlay_controller.defaults.bgp_defaults
     bgp_defaults:
       - no bgp default ipv4-unicast

--- a/ansible_collections/arista/avd/roles/upgrade_tools/templates/upgrade-2.x-to-3.0.j2
+++ b/ansible_collections/arista/avd/roles/upgrade_tools/templates/upgrade-2.x-to-3.0.j2
@@ -124,11 +124,11 @@ l3leaf:
     uplink_interface_speed: {{ l3leaf.defaults.p2p_link_interface_speed }}
 {%     endif %}
 {%     if mlag_ips.mlag_peer is arista.avd.defined %}
-# Change from mlag_ips.mlag_peer to spine.defaults.mlag_peer_ipv4_pool
+# Change from mlag_ips.mlag_peer to l3leaf.defaults.mlag_peer_ipv4_pool
     mlag_peer_ipv4_pool: {{ mlag_ips.mlag_peer }}
 {%     endif %}
 {%     if mlag_ips.leaf_peer_l3 is arista.avd.defined %}
-# Change from mlag_ips.mlag_peer_l3_ipv4_pool to spine.defaults.mlag_peer_l3_ipv4_pool
+# Change from mlag_ips.mlag_peer_l3_ipv4_pool to l3leaf.defaults.mlag_peer_l3_ipv4_pool
     mlag_peer_l3_ipv4_pool: {{ mlag_ips.leaf_peer_l3 }}
 {%     endif %}
 {%     if leaf_bgp_defaults is arista.avd.defined %}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)


## Component(s) name

`arista.avd.upgrade_tools`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->
Add extra conditions to avoid generating upgrade variables after everything has been migrated to new data models.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Xavier tested.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
