### PR TITLE
Feat(eos_cli_config_gen)!: Add support for non-default port and protocol under logging options

### DIFF
--- a/ansible_collections/arista/avd/docs/release-notes/3.x.x.md
+++ b/ansible_collections/arista/avd/docs/release-notes/3.x.x.md
@@ -278,6 +278,34 @@ daemon_terminattr:
   sflowaddr: < IPV4_address:port >
 ```
 
+- __logging variables:__
+
+```yaml
+#Old data model
+logging:
+  vrfs:
+    < vrf_name >:
+      source_interface: < source_interface_name >
+      hosts:
+        - < syslog_server_1>
+        - < syslog_server_2>
+
+# New data model
+logging:
+  vrfs:
+    < vrf_name >:
+      source_interface: < source_interface_name >
+      hosts:
+        < syslog_server_1 >:
+          protocol: < tcp | udp (default udp) >
+          ports:
+            < custom_port_1 >
+            < custom_port_2 >
+        < syslog_server_2 >:
+          ports:
+            < custom_port_1 >
+```
+
 - __snmp_server.hosts variables:__
 
 ```yaml

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/logging.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/logging.md
@@ -70,11 +70,11 @@ interface Management1
 | VRF | Hosts | Ports | Protocol |
 | --- | ----- | ----- | -------- |
 | default | 20.20.20.7 | Default | UDP |
-| default | 50.50.50.7 |  100, 200 | TCP |
-| default | 60.60.60.7 |  100, 200 | UDP |
+| default | 50.50.50.7 | 100, 200 | TCP |
+| default | 60.60.60.7 | 100, 200 | UDP |
 | mgt | 10.10.10.7 | Default | UDP |
-| mgt | 30.30.30.7 |  100, 200 | TCP |
-| mgt | 40.40.40.7 |  300, 400 | UDP |
+| mgt | 30.30.30.7 | 100, 200 | TCP |
+| mgt | 40.40.40.7 | 300, 400 | UDP |
 
 ### Logging Servers and Features Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/logging.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/logging.md
@@ -67,10 +67,14 @@ interface Management1
 | default | Loopback0 |
 | mgt | Management0 |
 
-| VRF | Hosts |
-| --- | ---------------- |
-| default | 20.20.20.7 |
-| mgt | 10.10.10.7 |
+| VRF | Hosts | Ports | Protocol |
+| --- | ----- | ----- | -------- |
+| default | 20.20.20.7 | Default | UDP |
+| default | 50.50.50.7 |  100  200  | TCP |
+| default | 60.60.60.7 |  100  200  | UDP |
+| mgt | 10.10.10.7 | Default | UDP |
+| mgt | 30.30.30.7 |  100  200  | TCP |
+| mgt | 40.40.40.7 |  300  400  | UDP |
 
 ### Logging Servers and Features Device Configuration
 
@@ -82,8 +86,12 @@ logging trap informational
 logging synchronous level error
 logging source-interface Loopback0
 logging host 20.20.20.7
+logging host 50.50.50.7 100 200 protocol tcp
+logging host 60.60.60.7 100 200 
 logging vrf mgt source-interface Management0
 logging vrf mgt host 10.10.10.7
+logging vrf mgt host 30.30.30.7 100 200 protocol tcp
+logging vrf mgt host 40.40.40.7 300 400 
 ```
 
 # Internal VLAN Allocation Policy

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/logging.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/logging.md
@@ -58,7 +58,7 @@ interface Management1
 | Type | Level |
 | -----| ----- |
 | Console | debugging |
-| Buffer | informational  |
+| Buffer | informational |
 | Trap | informational |
 | Synchronous | error |
 
@@ -70,11 +70,11 @@ interface Management1
 | VRF | Hosts | Ports | Protocol |
 | --- | ----- | ----- | -------- |
 | default | 20.20.20.7 | Default | UDP |
-| default | 50.50.50.7 |  100  200  | TCP |
-| default | 60.60.60.7 |  100  200  | UDP |
+| default | 50.50.50.7 |  100, 200 | TCP |
+| default | 60.60.60.7 |  100, 200 | UDP |
 | mgt | 10.10.10.7 | Default | UDP |
-| mgt | 30.30.30.7 |  100  200  | TCP |
-| mgt | 40.40.40.7 |  300  400  | UDP |
+| mgt | 30.30.30.7 |  100, 200 | TCP |
+| mgt | 40.40.40.7 |  300, 400 | UDP |
 
 ### Logging Servers and Features Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/logging.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/logging.cfg
@@ -8,8 +8,12 @@ logging trap informational
 logging synchronous level error
 logging source-interface Loopback0
 logging host 20.20.20.7
+logging host 50.50.50.7 100 200 protocol tcp
+logging host 60.60.60.7 100 200 
 logging vrf mgt source-interface Management0
 logging vrf mgt host 10.10.10.7
+logging vrf mgt host 30.30.30.7 100 200 protocol tcp
+logging vrf mgt host 40.40.40.7 300 400 
 !
 hostname logging
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/logging.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/logging.yml
@@ -12,8 +12,27 @@ logging:
     mgt:
       source_interface: Management0
       hosts:
-        - 10.10.10.7
+        10.10.10.7:
+        30.30.30.7:
+          protocol: tcp
+          ports:
+            - 100
+            - 200
+        40.40.40.7:
+          ports:
+            - 300
+            - 400
     default:
       source_interface: Loopback0
       hosts:
-        - 20.20.20.7
+        20.20.20.7:
+        50.50.50.7:
+          protocol: tcp
+          ports:
+            - 100
+            - 200
+        60.60.60.7:
+          protocol: udp
+          ports:
+            - 100
+            - 200

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1645,8 +1645,14 @@ logging:
     < vrf_name >:
       source_interface: < source_interface_name >
       hosts:
-        - < syslog_server_1>
-        - < syslog_server_2>
+        < syslog_server_1 >:
+          protocol: < tcp | udp (default udp) >
+          ports:
+            < custom_port_1 >
+            < custom_port_2 >
+        < syslog_server_2 >:
+          ports:
+            < custom_port_1 >
   policy:
     match:
       match_lists:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/logging.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/logging.j2
@@ -1,4 +1,4 @@
-{% if logging is defined and logging is not none %}
+{% if logging is arista.avd.defined %}
 
 ## Logging
 
@@ -6,60 +6,60 @@
 
 | Type | Level |
 | -----| ----- |
-{%     if logging.console is defined and logging.console is not none %}
+{%     if logging.console is arista.avd.defined %}
 | Console | {{ logging.console }} |
 {%     endif %}
-{%     if logging.monitor is defined and logging.monitor is not none %}
+{%     if logging.monitor is arista.avd.defined %}
 | Monitor | {{ logging.monitor }} |
 {%     endif %}
-{%     if logging.buffered is defined and logging.buffered is not none %}
-| Buffer |{% if logging.buffered.level is defined and logging.buffered.level is not none %} {{ logging.buffered.level }} {% else %} - {% endif %} |
+{%     if logging.buffered is arista.avd.defined %}
+| Buffer |{% if logging.buffered.level is arista.avd.defined %} {{ logging.buffered.level }} {% else %} - {% endif %} |
 {%     endif %}
-{%     if logging.trap is defined and logging.trap is not none %}
+{%     if logging.trap is arista.avd.defined %}
 | Trap | {{ logging.trap }} |
 {%     endif %}
 {%     if logging.synchronous is arista.avd.defined() %}
 | Synchronous | {{ logging.synchronous.level | arista.avd.default("critical") }} |
 {%     endif %}
-{%     if logging.format is defined and logging.format is not none %}
+{%     if logging.format is arista.avd.defined %}
 
 | Format Type | Setting |
 | ----------- | ------- |
-{%        if logging.format.timestamp is defined and logging.format.timestamp == 'high-resolution' %}
+{%        if logging.format.timestamp is arista.avd.defined and logging.format.timestamp == 'high-resolution' %}
 | Timestamp | high-resolution |
 {%        else %}
 | Timestamp | traditional |
 {%        endif %}
-{%        if logging.format.hostname is defined and logging.format.hostname is not none %}
+{%        if logging.format.hostname is arista.avd.defined %}
 | Hostname | {{ logging.format.hostname }} |
 {%        else %}
 | Hostname | hostname |
 {%        endif %}
-{%        if logging.format.sequence_numbers is defined and logging.format.sequence_numbers == true %}
+{%        if logging.format.sequence_numbers is arista.avd.defined(true) %}
 | Sequence-numbers | true |
 {%        else %}
 | Sequence-numbers | false |
 {%        endif %}
 {%     endif %}
-{%     if logging.vrfs is defined and logging.vrfs is not none %}
+{%     if logging.vrfs is arista.avd.defined %}
 
 | VRF | Source Interface |
 | --- | ---------------- |
-{%         if logging.source_interface is defined and logging.source_interface is not none %}
+{%         if logging.source_interface is arista.avd.defined %}
 | - | {{ logging.source_interface }} |
 {%         endif %}
 {%          for vrf in logging.vrfs | arista.avd.natural_sort %}
-{%              if logging.vrfs[vrf].source_interface is defined and logging.vrfs[vrf].source_interface is not none %}
+{%              if logging.vrfs[vrf].source_interface is arista.avd.defined %}
 | {{ vrf }} | {{ logging.vrfs[vrf].source_interface }} |
 {%              endif %}
 {%          endfor %}
 
-| VRF | Hosts |
-| --- | ---------------- |
+| VRF | Hosts | Ports | Protocol |
+| --- | ----- | ----- | -------- |
 {%          for vrf in logging.vrfs | arista.avd.natural_sort %}
-{%              if logging.vrfs[vrf].hosts is defined and logging.vrfs[vrf].hosts is not none %}
+{%              if logging.vrfs[vrf].hosts is arista.avd.defined %}
 {%                  for host in logging.vrfs[vrf].hosts | arista.avd.natural_sort %}
-| {{ vrf }} | {{ host }} |
+| {{ vrf }} | {{ host }} | {% if logging.vrfs[vrf].hosts[host].ports is arista.avd.defined %}{% for port in logging.vrfs[vrf].hosts[host].ports %} {{ port }} {%endfor%}{%else%}Default{%endif%} | {{ logging.vrfs[vrf].hosts[host].protocol | arista.avd.default('UDP') | upper }} |
 {%                  endfor %}
 {%              endif %}
 {%          endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/logging.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/logging.j2
@@ -13,7 +13,7 @@
 | Monitor | {{ logging.monitor }} |
 {%     endif %}
 {%     if logging.buffered is arista.avd.defined %}
-| Buffer |{% if logging.buffered.level is arista.avd.defined %} {{ logging.buffered.level }} {% else %} - {% endif %} |
+| Buffer | {{ logging.buffered.level | arista.avd.default('-') }} |
 {%     endif %}
 {%     if logging.trap is arista.avd.defined %}
 | Trap | {{ logging.trap }} |
@@ -59,7 +59,7 @@
 {%          for vrf in logging.vrfs | arista.avd.natural_sort %}
 {%              if logging.vrfs[vrf].hosts is arista.avd.defined %}
 {%                  for host in logging.vrfs[vrf].hosts | arista.avd.natural_sort %}
-| {{ vrf }} | {{ host }} | {% if logging.vrfs[vrf].hosts[host].ports is arista.avd.defined %}{% for port in logging.vrfs[vrf].hosts[host].ports %} {{ port }} {% endfor %}{% else %}Default{% endif %} | {{ logging.vrfs[vrf].hosts[host].protocol | arista.avd.default('UDP') | upper }} |
+| {{ vrf }} | {{ host }} | {{ logging.vrfs[vrf].hosts[host].ports | arista.avd.default(['Default']) | join(', ') }} | {{ logging.vrfs[vrf].hosts[host].protocol | arista.avd.default('UDP') | upper }} |
 {%                  endfor %}
 {%              endif %}
 {%          endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/logging.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/logging.j2
@@ -59,7 +59,7 @@
 {%          for vrf in logging.vrfs | arista.avd.natural_sort %}
 {%              if logging.vrfs[vrf].hosts is arista.avd.defined %}
 {%                  for host in logging.vrfs[vrf].hosts | arista.avd.natural_sort %}
-| {{ vrf }} | {{ host }} | {% if logging.vrfs[vrf].hosts[host].ports is arista.avd.defined %}{% for port in logging.vrfs[vrf].hosts[host].ports %} {{ port }} {%endfor%}{%else%}Default{%endif%} | {{ logging.vrfs[vrf].hosts[host].protocol | arista.avd.default('UDP') | upper }} |
+| {{ vrf }} | {{ host }} | {% if logging.vrfs[vrf].hosts[host].ports is arista.avd.defined %}{% for port in logging.vrfs[vrf].hosts[host].ports %} {{ port }} {% endfor %}{% else %}Default{% endif %} | {{ logging.vrfs[vrf].hosts[host].protocol | arista.avd.default('UDP') | upper }} |
 {%                  endfor %}
 {%              endif %}
 {%          endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/logging.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/logging.j2
@@ -31,20 +31,31 @@ logging format sequence-numbers
 logging source-interface {{ logging.source_interface }}
 {%     endif %}
 {%     for vrf in logging.vrfs | arista.avd.natural_sort %}
-{%         if logging.vrfs[vrf].source_interface is arista.avd.defined and vrf != 'default' %}
-logging vrf {{ vrf }} source-interface {{ logging.vrfs[vrf].source_interface }}
-{%         elif logging.vrfs[vrf].source_interface is arista.avd.defined and vrf == 'default' %}
-logging source-interface {{ logging.vrfs[vrf].source_interface }}
+{%         set logging_cli = "logging" %}
+{%         if logging.vrfs[vrf].source_interface is arista.avd.defined and vrf is not arista.avd.defined('default') %}
+{%             set logging_cli = logging_cli ~ " vrf " ~ vrf %}
 {%         endif %}
-{%         if logging.vrfs[vrf].hosts is arista.avd.defined and vrf != 'default' %}
-{%             for host in logging.vrfs[vrf].hosts | arista.avd.natural_sort %}
-logging vrf {{ vrf }} host {{ host }}
-{%             endfor %}
-{%         elif logging.vrfs[vrf].hosts is arista.avd.defined and vrf == 'default' %}
-{%             for host in logging.vrfs[vrf].hosts | arista.avd.natural_sort %}
-logging host {{ host }}
-{%             endfor %}
-{%         endif %}
+{%         set logging_cli = logging_cli ~ " source-interface " ~ logging.vrfs[vrf].source_interface %}
+{{ logging_cli }}
+{%         for host in logging.vrfs[vrf].hosts | arista.avd.natural_sort %}
+{%             set logging_host_cli = "logging" %}
+{%             if logging.vrfs[vrf].hosts is arista.avd.defined and vrf is not arista.avd.defined('default') %}
+{%                 set logging_host_cli = logging_host_cli ~ " vrf " ~ vrf %}
+{%             endif %}
+{%             set logging_host_cli = logging_host_cli ~ " host " ~ host %}
+{%             if logging.vrfs[vrf].hosts[host].ports is arista.avd.defined() %}
+{%                 set logging_ports = namespace() %}
+{%                 set logging_ports.concatenate = " " %}
+{%                 for port in logging.vrfs[vrf].hosts[host].ports %}
+{%                     set logging_ports.concatenate = logging_ports.concatenate ~ port ~ " " %}
+{%                 endfor %}
+{%                 set logging_host_cli = logging_host_cli ~ logging_ports.concatenate %}
+{%             endif %}
+{%             if logging.vrfs[vrf].hosts[host].protocol is arista.avd.defined() and logging.vrfs[vrf].hosts[host].protocol is not arista.avd.defined("udp") %}
+{%                 set logging_host_cli = logging_host_cli ~ "protocol " ~ logging.vrfs[vrf].hosts[host].protocol | lower %}
+{%             endif %}
+{{ logging_host_cli }}
+{%         endfor %}
 {%     endfor %}
 {%     for match_list in logging.policy.match.match_lists | arista.avd.natural_sort %}
 logging policy match match-list {{ match_list }} {{ logging.policy.match.match_lists[match_list].action }}


### PR DESCRIPTION
## Change Summary

This PR allows configuration of non-default port and protocol for syslog services under all VRFs.

Also, updated style on template generation.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [x] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Fixes #626 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Current structure:
```
logging:
  vrfs:
    < vrf_name >:
      source_interface: < source_interface_name >
      hosts:
        - < syslog_server_1>
        - < syslog_server_2>
```
Is changed to following:
```
logging:
  vrfs:
    < vrf_name >:
      source_interface: < source_interface_name >
      hosts:
        < syslog_server_1 >:
          protocol: < tcp | udp (default udp) >
          ports:
            < custom_port_1 >
            < custom_port_2 >
        < syslog_server_2 >:
          ports:
            < custom_port_1 >
```
## How to test
Definition/Molecule

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
