### PR TITLE
Feat(plugin): Support natural sort based on item key values

### DIFF
--- a/ansible_collections/arista/avd/plugins/README.md
+++ b/ansible_collections/arista/avd/plugins/README.md
@@ -42,14 +42,19 @@ To use this filter:
 ### natural_sort filter
 
 The `arista.avd.natural_sort` filter provides the capabilities to sort a list or a dictionary of integers and/or strings that contain alphanumeric characters naturally. When leveraged on a dictionary, only the key value will be returned.
+An optional `sort_key` can be specified, to sort on content of certain key if the items are dictionaries.
 
-The filter will return an empty list if the value parsed to `arista.avd.natural_sort` is `none` or `undefined`.
+The filter will return an empty list if the value parsed to `arista.avd.natural_sort` is `None` or `undefined`.
 
 To use this filter:
 
 ```jinja
 {% for item in dictionary_to_natural_sort | arista.avd.natural_sort %}
 {{ natural_sorted_item }}
+{% endfor %}
+
+{% for item in list_of_dicts_to_natural_sort | arista.avd.natural_sort('name') %}
+{{ dict_sorted_on_name }}
 {% endfor %}
 ```
 

--- a/ansible_collections/arista/avd/plugins/filter/natural_sort.py
+++ b/ansible_collections/arista/avd/plugins/filter/natural_sort.py
@@ -12,15 +12,18 @@ def convert(text):
     return int(text) if text.isdigit() else text.lower()
 
 
-def alphanum_key(key):
-    return [convert(c) for c in re.split('([0-9]+)', str(key))]
-
-
 class FilterModule(object):
 
-    def natural_sort(self, iterable):
+    def natural_sort(self, iterable, sort_key=None):
         if isinstance(iterable, Undefined) or iterable is None:
             return list()
+
+        def alphanum_key(key):
+            if sort_key is not None and isinstance(key, dict):
+                return [convert(c) for c in re.split('([0-9]+)', str(key.get(sort_key, key)))]
+            else:
+                return [convert(c) for c in re.split('([0-9]+)', str(key))]
+
         return sorted(iterable, key=alphanum_key)
 
     def filters(self):


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Support natural sort based on item key values

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

This is needed to support future data model migration

## Component(s) name

`arista.avd.natural_sort`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->
### natural_sort filter

The `arista.avd.natural_sort` filter provides the capabilities to sort a list or a dictionary of integers and/or strings that contain alphanumeric characters naturally. When leveraged on a dictionary, only the key value will be returned.
An optional `sort_key` can be specified, to sort on content of certain key if the items are dictionaries.

The filter will return an empty list if the value parsed to `arista.avd.natural_sort` is `None` or `undefined`.

To use this filter:

```jinja
{% for item in dictionary_to_natural_sort | arista.avd.natural_sort %}
{{ natural_sorted_item }}
{% endfor %}

{% for item in list_of_dicts_to_natural_sort | arista.avd.natural_sort('name') %}
{{ dict_sorted_on_name }}
{% endfor %}
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Molecule did not show any changes as long as the `sort_key` is not specified.
Successfully ran local tests with migrated data and new templates.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
