### PR TITLE
Feat(plugin): Add var_type test to defined plugin

### DIFF
--- a/ansible_collections/arista/avd/plugins/README.md
+++ b/ansible_collections/arista/avd/plugins/README.md
@@ -106,15 +106,20 @@ Arista AVD provides built-in test plugins to help verify data efficiently in jin
 ### defined test
 
 The `arista.avd.defined` test will return `False` if the passed value is `Undefined` or `none`. Else it will return `True`.
-`arista.avd.defined` test also accepts an optional argument to test if the value equals this argument.
+`arista.avd.defined` test also accepts an optional `test_value` argument to test if the value equals this.
+The optional `var_type` argument can be used to also test if the variable is of the expected type.
+
 Optionally the test can emit warnings or errors if the test fails.
 
-Compared to the builtin `is defined` test, this test will also test for `none` and can even test for a specific value.
+Compared to the builtin `is defined` test, this test will also test for `none` and can even test for a specific value and/or class.
 
 Syntax:
 
 ```jinja
-{% <value> is arista.avd.defined(test_value=<test_value>,fail_action=['warning','error'],var_name=<string representing name of value>) %}
+{% <value> is arista.avd.defined(test_value=<test_value>,
+                                 var_type=['float', 'int', 'str', 'list', 'dict', 'tuple'],
+                                 fail_action=['warning','error'],
+                                 var_name=<string representing name of value>) %}
 ```
 
 To use this test:

--- a/ansible_collections/arista/avd/plugins/README.md
+++ b/ansible_collections/arista/avd/plugins/README.md
@@ -105,13 +105,13 @@ Arista AVD provides built-in test plugins to help verify data efficiently in jin
 
 ### defined test
 
-The `arista.avd.defined` test will return `False` if the passed value is `Undefined` or `none`. Else it will return `True`.
+The `arista.avd.defined` test will return `False` if the passed value is `Undefined` or `None`. Else it will return `True`.
 `arista.avd.defined` test also accepts an optional `test_value` argument to test if the value equals this.
 The optional `var_type` argument can be used to also test if the variable is of the expected type.
 
 Optionally the test can emit warnings or errors if the test fails.
 
-Compared to the builtin `is defined` test, this test will also test for `none` and can even test for a specific value and/or class.
+Compared to the builtin `is defined` test, this test will also test for `None` and can even test for a specific value and/or class.
 
 Syntax:
 


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Add var_type test to defined plugin

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

This is needed for the coming data model refactoring.

## Component(s) name

`arista.avd.defined`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->
Add a new keyword to the `arista.avd.defined` test, so it can verify the "type" or "class" of variables.

Syntax:

```jinja
{% <value> is arista.avd.defined(test_value=<test_value>,
                                 var_type=['float', 'int', 'str', 'list', 'dict', 'tuple'],
                                 fail_action=['warning','error'],
                                 var_name=<string representing name of value>) %}
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
No changes to existing molecule.
Tested successfully with new templates utilizing this extra feature.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
