### PR TITLE
Feat(eos_designs): Add support for setting VXLAN Source interface

### DIFF
--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -385,14 +385,12 @@ interface Ethernet7
 | Interface | Description | VRF | IP Address |
 | --------- | ----------- | --- | ---------- |
 | Loopback0 | EVPN_Overlay_Peering | default | 192.168.255.9/32 |
-| Loopback1 | VTEP_VXLAN_Tunnel_Source | default | 192.168.254.9/32 |
 
 #### IPv6
 
 | Interface | Description | VRF | IPv6 Address |
 | --------- | ----------- | --- | ------------ |
 | Loopback0 | EVPN_Overlay_Peering | default | - |
-| Loopback1 | VTEP_VXLAN_Tunnel_Source | default | - |
 
 
 ### Loopback Interfaces Device Configuration
@@ -403,11 +401,6 @@ interface Loopback0
    description EVPN_Overlay_Peering
    no shutdown
    ip address 192.168.255.9/32
-!
-interface Loopback1
-   description VTEP_VXLAN_Tunnel_Source
-   no shutdown
-   ip address 192.168.254.9/32
 ```
 
 ## VLAN Interfaces
@@ -493,7 +486,7 @@ interface Vlan131
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
+#### Source Interface: Loopback0
 
 #### UDP port: 4789
 
@@ -521,7 +514,7 @@ interface Vlan131
 ```eos
 !
 interface Vxlan1
-   vxlan source-interface Loopback1
+   vxlan source-interface Loopback0
    vxlan udp-port 4789
    vxlan vlan 120 vni 10120
    vxlan vlan 121 vni 10121
@@ -804,7 +797,6 @@ no ip igmp snooping vlan 120
 | Sequence | Action |
 | -------- | ------ |
 | 10 | permit 192.168.255.0/24 eq 32 |
-| 20 | permit 192.168.254.0/24 eq 32 |
 
 ### Prefix-lists Device Configuration
 
@@ -812,7 +804,6 @@ no ip igmp snooping vlan 120
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.255.0/24 eq 32
-   seq 20 permit 192.168.254.0/24 eq 32
 ```
 
 ## Route-maps

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -556,7 +556,7 @@ interface Port-Channel20
 | Interface | Description | VRF | IP Address |
 | --------- | ----------- | --- | ---------- |
 | Loopback0 | EVPN_Overlay_Peering | default | 192.168.255.10/32 |
-| Loopback1 | VTEP_VXLAN_Tunnel_Source | default | 192.168.254.10/32 |
+| Loopback10 | VTEP_VXLAN_Tunnel_Source | default | 192.168.254.10/32 |
 | Loopback100 | Tenant_A_OP_Zone_VTEP_DIAGNOSTICS | Tenant_A_OP_Zone | 10.255.1.10/32 |
 
 #### IPv6
@@ -564,7 +564,7 @@ interface Port-Channel20
 | Interface | Description | VRF | IPv6 Address |
 | --------- | ----------- | --- | ------------ |
 | Loopback0 | EVPN_Overlay_Peering | default | - |
-| Loopback1 | VTEP_VXLAN_Tunnel_Source | default | - |
+| Loopback10 | VTEP_VXLAN_Tunnel_Source | default | - |
 | Loopback100 | Tenant_A_OP_Zone_VTEP_DIAGNOSTICS | Tenant_A_OP_Zone | - |
 
 
@@ -577,7 +577,7 @@ interface Loopback0
    no shutdown
    ip address 192.168.255.10/32
 !
-interface Loopback1
+interface Loopback10
    description VTEP_VXLAN_Tunnel_Source
    no shutdown
    ip address 192.168.254.10/32
@@ -737,7 +737,7 @@ interface Vlan311
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
+#### Source Interface: Loopback10
 
 #### UDP port: 4789
 
@@ -780,7 +780,7 @@ interface Vlan311
 ```eos
 !
 interface Vxlan1
-   vxlan source-interface Loopback1
+   vxlan source-interface Loopback10
    vxlan udp-port 4789
    vxlan vlan 110 vni 10110
    vxlan vlan 111 vni 50111

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -556,7 +556,7 @@ interface Port-Channel20
 | Interface | Description | VRF | IP Address |
 | --------- | ----------- | --- | ---------- |
 | Loopback0 | EVPN_Overlay_Peering | default | 192.168.255.11/32 |
-| Loopback1 | VTEP_VXLAN_Tunnel_Source | default | 192.168.254.11/32 |
+| Loopback10 | VTEP_VXLAN_Tunnel_Source | default | 192.168.254.11/32 |
 | Loopback100 | Tenant_A_OP_Zone_VTEP_DIAGNOSTICS | Tenant_A_OP_Zone | 10.255.1.11/32 |
 
 #### IPv6
@@ -564,7 +564,7 @@ interface Port-Channel20
 | Interface | Description | VRF | IPv6 Address |
 | --------- | ----------- | --- | ------------ |
 | Loopback0 | EVPN_Overlay_Peering | default | - |
-| Loopback1 | VTEP_VXLAN_Tunnel_Source | default | - |
+| Loopback10 | VTEP_VXLAN_Tunnel_Source | default | - |
 | Loopback100 | Tenant_A_OP_Zone_VTEP_DIAGNOSTICS | Tenant_A_OP_Zone | - |
 
 
@@ -577,7 +577,7 @@ interface Loopback0
    no shutdown
    ip address 192.168.255.11/32
 !
-interface Loopback1
+interface Loopback10
    description VTEP_VXLAN_Tunnel_Source
    no shutdown
    ip address 192.168.254.11/32
@@ -737,7 +737,7 @@ interface Vlan311
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
+#### Source Interface: Loopback10
 
 #### UDP port: 4789
 
@@ -780,7 +780,7 @@ interface Vlan311
 ```eos
 !
 interface Vxlan1
-   vxlan source-interface Loopback1
+   vxlan source-interface Loopback10
    vxlan udp-port 4789
    vxlan vlan 110 vni 10110
    vxlan vlan 111 vni 50111

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/fabric/DC1_FABRIC-documentation.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/fabric/DC1_FABRIC-documentation.md
@@ -158,7 +158,7 @@
 
 | VTEP Loopback Pool | Available Addresses | Assigned addresses | Assigned Address % |
 | --------------------- | ------------------- | ------------------ | ------------------ |
-| 192.168.254.0/24 | 256 | 7 | 2.74 % |
+| 192.168.254.0/24 | 256 | 4 | 1.57 % |
 
 ## VTEP Loopback Node allocation
 
@@ -166,8 +166,5 @@
 | --- | ---- | --------- |
 | DC1_FABRIC | DC1-BL1A | 192.168.254.14/32 |
 | DC1_FABRIC | DC1-BL1B | 192.168.254.15/32 |
-| DC1_FABRIC | DC1-LEAF1A | 192.168.254.9/32 |
-| DC1_FABRIC | DC1-LEAF2A | 192.168.254.10/32 |
-| DC1_FABRIC | DC1-LEAF2B | 192.168.254.11/32 |
 | DC1_FABRIC | DC1-SVC3A | 192.168.254.12/32 |
 | DC1_FABRIC | DC1-SVC3B | 192.168.254.12/32 |

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
@@ -120,11 +120,6 @@ interface Loopback0
    no shutdown
    ip address 192.168.255.9/32
 !
-interface Loopback1
-   description VTEP_VXLAN_Tunnel_Source
-   no shutdown
-   ip address 192.168.254.9/32
-!
 interface Management1
    description oob_management
    no shutdown
@@ -179,7 +174,7 @@ interface Vlan131
    ip address virtual 10.1.31.1/24
 !
 interface Vxlan1
-   vxlan source-interface Loopback1
+   vxlan source-interface Loopback0
    vxlan udp-port 4789
    vxlan vlan 120 vni 10120
    vxlan vlan 121 vni 10121
@@ -200,7 +195,6 @@ ip routing vrf Tenant_A_WEB_Zone
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.255.0/24 eq 32
-   seq 20 permit 192.168.254.0/24 eq 32
 !
 ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
@@ -249,7 +249,7 @@ interface Loopback0
    no shutdown
    ip address 192.168.255.10/32
 !
-interface Loopback1
+interface Loopback10
    description VTEP_VXLAN_Tunnel_Source
    no shutdown
    ip address 192.168.254.10/32
@@ -363,7 +363,7 @@ interface Vlan311
    ip address virtual 10.3.11.1/24
 !
 interface Vxlan1
-   vxlan source-interface Loopback1
+   vxlan source-interface Loopback10
    vxlan udp-port 4789
    vxlan vlan 110 vni 10110
    vxlan vlan 111 vni 50111

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
@@ -249,7 +249,7 @@ interface Loopback0
    no shutdown
    ip address 192.168.255.11/32
 !
-interface Loopback1
+interface Loopback10
    description VTEP_VXLAN_Tunnel_Source
    no shutdown
    ip address 192.168.254.11/32
@@ -363,7 +363,7 @@ interface Vlan311
    ip address virtual 10.3.11.1/24
 !
 interface Vxlan1
-   vxlan source-interface Loopback1
+   vxlan source-interface Loopback10
    vxlan udp-port 4789
    vxlan vlan 110 vni 10110
    vxlan vlan 111 vni 50111

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
@@ -267,17 +267,11 @@ loopback_interfaces:
     description: EVPN_Overlay_Peering
     shutdown: false
     ip_address: 192.168.255.9/32
-  Loopback1:
-    description: VTEP_VXLAN_Tunnel_Source
-    shutdown: false
-    ip_address: 192.168.254.9/32
 prefix_lists:
   PL-LOOPBACKS-EVPN-OVERLAY:
     sequence_numbers:
       10:
         action: permit 192.168.255.0/24 eq 32
-      20:
-        action: permit 192.168.254.0/24 eq 32
 route_maps:
   RM-CONN-2-BGP:
     sequence_numbers:
@@ -320,7 +314,7 @@ ip_igmp_snooping:
 vxlan_tunnel_interface:
   Vxlan1:
     description: DC1-LEAF1A_VTEP
-    source_interface: Loopback1
+    source_interface: Loopback0
     vxlan_udp_port: 4789
     vxlan_vni_mappings:
       vlans:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -513,7 +513,7 @@ loopback_interfaces:
     description: EVPN_Overlay_Peering
     shutdown: false
     ip_address: 192.168.255.10/32
-  Loopback1:
+  Loopback10:
     description: VTEP_VXLAN_Tunnel_Source
     shutdown: false
     ip_address: 192.168.254.10/32
@@ -608,7 +608,7 @@ ip_igmp_snooping:
 vxlan_tunnel_interface:
   Vxlan1:
     description: DC1-LEAF2A_VTEP
-    source_interface: Loopback1
+    source_interface: Loopback10
     vxlan_udp_port: 4789
     vxlan_vni_mappings:
       vlans:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -513,7 +513,7 @@ loopback_interfaces:
     description: EVPN_Overlay_Peering
     shutdown: false
     ip_address: 192.168.255.11/32
-  Loopback1:
+  Loopback10:
     description: VTEP_VXLAN_Tunnel_Source
     shutdown: false
     ip_address: 192.168.254.11/32
@@ -608,7 +608,7 @@ ip_igmp_snooping:
 vxlan_tunnel_interface:
   Vxlan1:
     description: DC1-LEAF2B_VTEP
-    source_interface: Loopback1
+    source_interface: Loopback10
     vxlan_udp_port: 4789
     vxlan_vni_mappings:
       vlans:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
@@ -98,6 +98,7 @@ l3leaf:
           mgmt_ip: 192.168.200.105/24
           mac_address: '0c:1d:c0:1d:62:01'
           uplink_switch_interfaces: [ Ethernet1, Ethernet1, Ethernet1, Ethernet1 ]
+          vtep_loopback: Loopback0
     DC1_LEAF2:
       bgp_as: 65102
       rack: "rackD"
@@ -109,10 +110,12 @@ l3leaf:
           mgmt_ip: 192.168.200.106/24
           mac_address: '0c:1d:c0:1d:62:01'
           uplink_switch_interfaces: [ Ethernet2, Ethernet2, Ethernet2, Ethernet2 ]
+          vtep_loopback: Loopback10
         DC1-LEAF2B:
           id: 3
           mgmt_ip: 192.168.200.107/24
           uplink_switch_interfaces: [ Ethernet3, Ethernet3, Ethernet3, Ethernet3 ]
+          vtep_loopback: Loopback10
     DC1_SVC3:
       platform: 7050SX3
       bgp_as: 65103

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF1A.md
@@ -296,21 +296,18 @@ interface Ethernet4
 | Interface | Description | VRF | IP Address |
 | --------- | ----------- | --- | ---------- |
 | Loopback0 | EVPN_Overlay_Peering | default | 192.168.255.5/32 |
-| Loopback1 | VTEP_VXLAN_Tunnel_Source | default | 192.168.254.5/32 |
 
 #### IPv6
 
 | Interface | Description | VRF | IPv6 Address |
 | --------- | ----------- | --- | ------------ |
 | Loopback0 | EVPN_Overlay_Peering | default | - |
-| Loopback1 | VTEP_VXLAN_Tunnel_Source | default | - |
 
 #### ISIS
 
 | Interface | ISIS instance | ISIS metric | Interface mode |
 | -------- | -------- | -------- | -------- |
 | Loopback0 | EVPN_UNDERLAY |  - |  passive |
-| Loopback1 | EVPN_UNDERLAY |  - |  passive |
 
 ### Loopback Interfaces Device Configuration
 
@@ -322,20 +319,13 @@ interface Loopback0
    ip address 192.168.255.5/32
    isis enable EVPN_UNDERLAY
    isis passive
-!
-interface Loopback1
-   description VTEP_VXLAN_Tunnel_Source
-   no shutdown
-   ip address 192.168.254.5/32
-   isis enable EVPN_UNDERLAY
-   isis passive
 ```
 
 ## VXLAN Interface
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
+#### Source Interface: Loopback0
 
 #### UDP port: 4789
 
@@ -350,7 +340,7 @@ interface Loopback1
 ```eos
 !
 interface Vxlan1
-   vxlan source-interface Loopback1
+   vxlan source-interface Loopback0
    vxlan udp-port 4789
 ```
 
@@ -437,7 +427,6 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | Ethernet3 | EVPN_UNDERLAY |  50 |  point-to-point |
 | Ethernet4 | EVPN_UNDERLAY |  50 |  point-to-point |
 | Loopback0 | EVPN_UNDERLAY |  - |  passive |
-| Loopback1 | EVPN_UNDERLAY |  - |  passive |
 
 ### Router ISIS Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2A.md
@@ -401,21 +401,21 @@ interface Port-Channel7
 | Interface | Description | VRF | IP Address |
 | --------- | ----------- | --- | ---------- |
 | Loopback0 | EVPN_Overlay_Peering | default | 192.168.255.6/32 |
-| Loopback1 | VTEP_VXLAN_Tunnel_Source | default | 192.168.254.6/32 |
+| Loopback10 | VTEP_VXLAN_Tunnel_Source | default | 192.168.254.6/32 |
 
 #### IPv6
 
 | Interface | Description | VRF | IPv6 Address |
 | --------- | ----------- | --- | ------------ |
 | Loopback0 | EVPN_Overlay_Peering | default | - |
-| Loopback1 | VTEP_VXLAN_Tunnel_Source | default | - |
+| Loopback10 | VTEP_VXLAN_Tunnel_Source | default | - |
 
 #### ISIS
 
 | Interface | ISIS instance | ISIS metric | Interface mode |
 | -------- | -------- | -------- | -------- |
 | Loopback0 | EVPN_UNDERLAY |  - |  passive |
-| Loopback1 | EVPN_UNDERLAY |  - |  passive |
+| Loopback10 | EVPN_UNDERLAY |  - |  passive |
 
 ### Loopback Interfaces Device Configuration
 
@@ -428,7 +428,7 @@ interface Loopback0
    isis enable EVPN_UNDERLAY
    isis passive
 !
-interface Loopback1
+interface Loopback10
    description VTEP_VXLAN_Tunnel_Source
    no shutdown
    ip address 192.168.254.6/32
@@ -484,7 +484,7 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
+#### Source Interface: Loopback10
 
 #### UDP port: 4789
 
@@ -499,7 +499,7 @@ interface Vlan4094
 ```eos
 !
 interface Vxlan1
-   vxlan source-interface Loopback1
+   vxlan source-interface Loopback10
    vxlan virtual-router encapsulation mac-address mlag-system-id
    vxlan udp-port 4789
 ```
@@ -588,7 +588,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | Ethernet4 | EVPN_UNDERLAY |  50 |  point-to-point |
 | Vlan4093 | EVPN_UNDERLAY |  50 |  point-to-point |
 | Loopback0 | EVPN_UNDERLAY |  - |  passive |
-| Loopback1 | EVPN_UNDERLAY |  - |  passive |
+| Loopback10 | EVPN_UNDERLAY |  - |  passive |
 
 ### Router ISIS Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2B.md
@@ -401,21 +401,21 @@ interface Port-Channel7
 | Interface | Description | VRF | IP Address |
 | --------- | ----------- | --- | ---------- |
 | Loopback0 | EVPN_Overlay_Peering | default | 192.168.255.7/32 |
-| Loopback1 | VTEP_VXLAN_Tunnel_Source | default | 192.168.254.6/32 |
+| Loopback10 | VTEP_VXLAN_Tunnel_Source | default | 192.168.254.6/32 |
 
 #### IPv6
 
 | Interface | Description | VRF | IPv6 Address |
 | --------- | ----------- | --- | ------------ |
 | Loopback0 | EVPN_Overlay_Peering | default | - |
-| Loopback1 | VTEP_VXLAN_Tunnel_Source | default | - |
+| Loopback10 | VTEP_VXLAN_Tunnel_Source | default | - |
 
 #### ISIS
 
 | Interface | ISIS instance | ISIS metric | Interface mode |
 | -------- | -------- | -------- | -------- |
 | Loopback0 | EVPN_UNDERLAY |  - |  passive |
-| Loopback1 | EVPN_UNDERLAY |  - |  passive |
+| Loopback10 | EVPN_UNDERLAY |  - |  passive |
 
 ### Loopback Interfaces Device Configuration
 
@@ -428,7 +428,7 @@ interface Loopback0
    isis enable EVPN_UNDERLAY
    isis passive
 !
-interface Loopback1
+interface Loopback10
    description VTEP_VXLAN_Tunnel_Source
    no shutdown
    ip address 192.168.254.6/32
@@ -484,7 +484,7 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
+#### Source Interface: Loopback10
 
 #### UDP port: 4789
 
@@ -499,7 +499,7 @@ interface Vlan4094
 ```eos
 !
 interface Vxlan1
-   vxlan source-interface Loopback1
+   vxlan source-interface Loopback10
    vxlan virtual-router encapsulation mac-address mlag-system-id
    vxlan udp-port 4789
 ```
@@ -588,7 +588,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | Ethernet4 | EVPN_UNDERLAY |  50 |  point-to-point |
 | Vlan4093 | EVPN_UNDERLAY |  50 |  point-to-point |
 | Loopback0 | EVPN_UNDERLAY |  - |  passive |
-| Loopback1 | EVPN_UNDERLAY |  - |  passive |
+| Loopback10 | EVPN_UNDERLAY |  - |  passive |
 
 ### Router ISIS Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/fabric/DC1_FABRIC-documentation.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/fabric/DC1_FABRIC-documentation.md
@@ -171,7 +171,7 @@
 
 | VTEP Loopback Pool | Available Addresses | Assigned addresses | Assigned Address % |
 | --------------------- | ------------------- | ------------------ | ------------------ |
-| 192.168.254.0/24 | 256 | 7 | 2.74 % |
+| 192.168.254.0/24 | 256 | 4 | 1.57 % |
 
 ## VTEP Loopback Node allocation
 
@@ -179,8 +179,5 @@
 | --- | ---- | --------- |
 | DC1_FABRIC | DC1-BL1A | 192.168.254.10/32 |
 | DC1_FABRIC | DC1-BL1B | 192.168.254.10/32 |
-| DC1_FABRIC | DC1-LEAF1A | 192.168.254.5/32 |
-| DC1_FABRIC | DC1-LEAF2A | 192.168.254.6/32 |
-| DC1_FABRIC | DC1-LEAF2B | 192.168.254.6/32 |
 | DC1_FABRIC | DC1-SVC3A | 192.168.254.8/32 |
 | DC1_FABRIC | DC1-SVC3B | 192.168.254.8/32 |

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-LEAF1A.cfg
@@ -75,13 +75,6 @@ interface Loopback0
    isis enable EVPN_UNDERLAY
    isis passive
 !
-interface Loopback1
-   description VTEP_VXLAN_Tunnel_Source
-   no shutdown
-   ip address 192.168.254.5/32
-   isis enable EVPN_UNDERLAY
-   isis passive
-!
 interface Management1
    description oob_management
    no shutdown
@@ -89,7 +82,7 @@ interface Management1
    ip address 192.168.200.105/24
 !
 interface Vxlan1
-   vxlan source-interface Loopback1
+   vxlan source-interface Loopback0
    vxlan udp-port 4789
 !
 ip virtual-router mac-address 00:dc:00:00:00:0a

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-LEAF2A.cfg
@@ -115,7 +115,7 @@ interface Loopback0
    isis enable EVPN_UNDERLAY
    isis passive
 !
-interface Loopback1
+interface Loopback10
    description VTEP_VXLAN_Tunnel_Source
    no shutdown
    ip address 192.168.254.6/32
@@ -145,7 +145,7 @@ interface Vlan4094
    ip address 10.255.252.2/31
 !
 interface Vxlan1
-   vxlan source-interface Loopback1
+   vxlan source-interface Loopback10
    vxlan virtual-router encapsulation mac-address mlag-system-id
    vxlan udp-port 4789
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-LEAF2B.cfg
@@ -115,7 +115,7 @@ interface Loopback0
    isis enable EVPN_UNDERLAY
    isis passive
 !
-interface Loopback1
+interface Loopback10
    description VTEP_VXLAN_Tunnel_Source
    no shutdown
    ip address 192.168.254.6/32
@@ -145,7 +145,7 @@ interface Vlan4094
    ip address 10.255.252.3/31
 !
 interface Vxlan1
-   vxlan source-interface Loopback1
+   vxlan source-interface Loopback10
    vxlan virtual-router encapsulation mac-address mlag-system-id
    vxlan udp-port 4789
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF1A.yml
@@ -149,12 +149,6 @@ loopback_interfaces:
     ip_address: 192.168.255.5/32
     isis_enable: EVPN_UNDERLAY
     isis_passive: true
-  Loopback1:
-    description: VTEP_VXLAN_Tunnel_Source
-    shutdown: false
-    ip_address: 192.168.254.5/32
-    isis_enable: EVPN_UNDERLAY
-    isis_passive: true
 router_isis:
   instance: EVPN_UNDERLAY
   log_adjacency_changes: true
@@ -165,7 +159,7 @@ router_isis:
   - Ethernet2
   - Ethernet3
   - Ethernet4
-  - Loopback1
+  - Loopback0
   is_type: level-2
   address_family:
   - ipv4 unicast
@@ -200,7 +194,7 @@ ip_igmp_snooping:
 vxlan_tunnel_interface:
   Vxlan1:
     description: DC1-LEAF1A_VTEP
-    source_interface: Loopback1
+    source_interface: Loopback0
     vxlan_udp_port: 4789
     vxlan_vni_mappings: {}
 ip_virtual_router_mac_address: 00:dc:00:00:00:0a

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -229,7 +229,7 @@ loopback_interfaces:
     ip_address: 192.168.255.6/32
     isis_enable: EVPN_UNDERLAY
     isis_passive: true
-  Loopback1:
+  Loopback10:
     description: VTEP_VXLAN_Tunnel_Source
     shutdown: false
     ip_address: 192.168.254.6/32
@@ -246,7 +246,7 @@ router_isis:
   - Ethernet3
   - Ethernet4
   - Vlan4093
-  - Loopback1
+  - Loopback10
   is_type: level-2
   address_family:
   - ipv4 unicast
@@ -281,7 +281,7 @@ ip_igmp_snooping:
 vxlan_tunnel_interface:
   Vxlan1:
     description: DC1-LEAF2A_VTEP
-    source_interface: Loopback1
+    source_interface: Loopback10
     virtual_router:
       encapsulation_mac_address: mlag-system-id
     vxlan_udp_port: 4789

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -229,7 +229,7 @@ loopback_interfaces:
     ip_address: 192.168.255.7/32
     isis_enable: EVPN_UNDERLAY
     isis_passive: true
-  Loopback1:
+  Loopback10:
     description: VTEP_VXLAN_Tunnel_Source
     shutdown: false
     ip_address: 192.168.254.6/32
@@ -246,7 +246,7 @@ router_isis:
   - Ethernet3
   - Ethernet4
   - Vlan4093
-  - Loopback1
+  - Loopback10
   is_type: level-2
   address_family:
   - ipv4 unicast
@@ -281,7 +281,7 @@ ip_igmp_snooping:
 vxlan_tunnel_interface:
   Vxlan1:
     description: DC1-LEAF2B_VTEP
-    source_interface: Loopback1
+    source_interface: Loopback10
     virtual_router:
       encapsulation_mac_address: mlag-system-id
     vxlan_udp_port: 4789

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/inventory/group_vars/DC1_FABRIC.yml
@@ -79,6 +79,7 @@ l3leaf:
       filter:
         tenants: [ all ]
         tags: [ web, app ]
+      vtep_loopback: Loopback0
       nodes:
         DC1-LEAF1A:
           id: 1
@@ -94,10 +95,12 @@ l3leaf:
           id: 2
           mgmt_ip: 192.168.200.106/24
           uplink_switch_interfaces: ['Ethernet2', 'Ethernet2', 'Ethernet2', 'Ethernet2']
+          vtep_loopback: Loopback10
         DC1-LEAF2B:
           id: 3
           mgmt_ip: 192.168.200.107/24
           uplink_switch_interfaces: ['Ethernet3', 'Ethernet3', 'Ethernet3', 'Ethernet3']
+          vtep_loopback: Loopback10
     DC1_SVC3:
       bgp_as: 65103
       filter:

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/fabric-topology.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/fabric-topology.md
@@ -228,7 +228,7 @@ defaults <- node_group <- node_group.node <- node
     loopback_ipv4_offset: 2
 
     # Set VXLAN source interface. Loopback1 is default
-    vtep_loopback: Loopback1
+    vtep_loopback: < Loopback_interface_1 >
 
 ```
 

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/fabric-topology.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/fabric-topology.md
@@ -226,6 +226,10 @@ defaults <- node_group <- node_group.node <- node
 
     # Offset all assigned loopback IP addresses.
     loopback_ipv4_offset: 2
+
+    # Set VXLAN source interface. Loopback1 is default
+    vtep_loopback: Loopback1
+
 ```
 
 ### BGP & EVPN Control plane

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/facts/switch/switch.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/facts/switch/switch.j2
@@ -265,6 +265,9 @@ switch:
 {%     set switch_vtep_loopback_ipv4_pool = switch_data.combined.vtep_loopback_ipv4_pool %}
   vtep_loopback_ipv4_pool: {{ switch_vtep_loopback_ipv4_pool }}
 
+{# switch.vtep_loopback #}
+  vtep_loopback: {{ switch_data.combined.vtep_loopback | arista.avd.default('Loopback1') }}
+
 {# switch.vtep_ip #}
 {%     if switch_data.mlag_configured is arista.avd.defined(true) %}
   vtep_ip: {% include switch.ip_addressing.vtep_ip_mlag %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenants/vxlan-tunnel-interface.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenants/vxlan-tunnel-interface.j2
@@ -2,7 +2,7 @@ vxlan_tunnel_interface:
 {# vxlan-vtep interface #}
   Vxlan1:
     description: {{ inventory_hostname }}_VTEP
-    source_interface: {{ vxlan_source_interface | arista.avd.default('Loopback1') }}
+    source_interface: {{ switch.vtep_loopback }}
 {% if switch.mlag is arista.avd.defined(true) %}
     virtual_router:
       encapsulation_mac_address: "mlag-system-id"

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenants/vxlan-tunnel-interface.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenants/vxlan-tunnel-interface.j2
@@ -2,7 +2,7 @@ vxlan_tunnel_interface:
 {# vxlan-vtep interface #}
   Vxlan1:
     description: {{ inventory_hostname }}_VTEP
-    source_interface: Loopback1
+    source_interface: {{ vxlan_source_interface | arista.avd.default('Loopback1') }}
 {% if switch.mlag is arista.avd.defined(true) %}
     virtual_router:
       encapsulation_mac_address: "mlag-system-id"

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/underlay/ebgp/prefix-lists.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/underlay/ebgp/prefix-lists.j2
@@ -4,7 +4,7 @@ prefix_lists:
     sequence_numbers:
       10:
         action: "permit {{ switch.loopback_ipv4_pool }} eq 32"
-{% if switch.vtep_ip is arista.avd.defined %}
+{% if switch.vtep_ip is arista.avd.defined and switch.vtep_loopback | lower != 'loopback0' %}
       20:
         action: "permit {{ switch.vtep_loopback_ipv4_pool }} eq 32"
 {%     if vtep_vvtep_ip is arista.avd.defined and switch.evpn_services_l2_only is arista.avd.defined(false) %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/underlay/interfaces/loopback-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/underlay/interfaces/loopback-interfaces.j2
@@ -13,9 +13,9 @@ loopback_interfaces:
     isis_passive: true
 {%     endif %}
 {% endif %}
-{% if switch.vtep is arista.avd.defined(true) and vxlan_source_interface is arista.avd.defined and vxlan_source_interface == 'Loopback1' %}
+{% if switch.vtep is arista.avd.defined(true) and switch.vtep_loopback | lower != 'loopback0' %}
 {# Leaf VTEP vxlan tunnel loopback source interface #}
-  Loopback1:
+  {{ switch.vtep_loopback }}:
     description: VTEP_VXLAN_Tunnel_Source
     shutdown: false
     ip_address: {{ switch.vtep_ip }}/32

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/underlay/interfaces/loopback-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/underlay/interfaces/loopback-interfaces.j2
@@ -13,7 +13,7 @@ loopback_interfaces:
     isis_passive: true
 {%     endif %}
 {% endif %}
-{% if switch.vtep is arista.avd.defined(true) %}
+{% if switch.vtep is arista.avd.defined(true) and vxlan_source_interface is arista.avd.defined and vxlan_source_interface == 'Loopback1' %}
 {# Leaf VTEP vxlan tunnel loopback source interface #}
   Loopback1:
     description: VTEP_VXLAN_Tunnel_Source

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/underlay/isis/router-isis.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/underlay/isis/router-isis.j2
@@ -15,7 +15,7 @@ router_isis:
     - Vlan{{ switch.mlag_peer_l3_vlan }}
 {% endif %}
 {% if switch.vtep is arista.avd.defined(true) %}
-    - Loopback1
+    - {{ switch.vtep_loopback }}
 {% endif %}
   is_type: level-2
   address_family: ['ipv4 unicast']


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Fixes #704

## Component(s) name

`arista.avd.eos-designs`

## Proposed changes
Introducing new variable "vtep_loopback" with default value "Loopback1".
If "vtep_loopback" is not set then there will be no change to existing configurations, i.e. Loopback1.


## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
