### PR TITLE
Fix(upgrade_tools): Protect usage of underlay_routing_protocol

### DIFF
--- a/ansible_collections/arista/avd/roles/upgrade_tools/templates/upgrade-2.x-to-3.0.j2
+++ b/ansible_collections/arista/avd/roles/upgrade_tools/templates/upgrade-2.x-to-3.0.j2
@@ -50,7 +50,7 @@ spine:
       - graceful-restart restart-time 300
       - graceful-restart
 {%     endif %}
-{%     if underlay_routing_protocol | lower == 'isis' %}
+{%     if underlay_routing_protocol is arista.avd.defined and underlay_routing_protocol| lower is arista.avd.defined('isis') %}
 # Change from isis_site_id.0000 to spine.defaults.isis_system_id_prefix
     isis_system_id_prefix: '{{ isis_site_id | arista.avd.default("0001") ~ ".0000" }}'
 {%         set switch_max_spines = max_spines | arista.avd.default(spine.nodes | arista.avd.default([]) | length) %}
@@ -143,7 +143,7 @@ l3leaf:
       - graceful-restart restart-time 300
       - graceful-restart
 {%     endif %}
-{%     if underlay_routing_protocol | lower == 'isis' %}
+{%     if underlay_routing_protocol is arista.avd.defined and underlay_routing_protocol| lower is arista.avd.defined('isis') %}
 # Change from isis_site_id.0001 to l3leaf.defaults.isis_system_id_prefix
     isis_system_id_prefix: '{{ isis_site_id | arista.avd.default("0001") ~ ".0001" }}'
 {%         set switch_max_spines = max_spines | arista.avd.default(spine.nodes | arista.avd.default([]) | length) %}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Fixes #1158 

## Component(s) name

`arista.avd.upgrade_tools`

## Proposed changes

Add extra protection to `underlay_routing_protocol` before using `|lower` filter.

## How to test

Run Molecule

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [x] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
