### PR TITLE
CI(github): Add new action to attach PR to GH projects

### DIFF
--- a/.github/workflows/pr_labeler.yml
+++ b/.github/workflows/pr_labeler.yml
@@ -43,8 +43,3 @@ jobs:
           project: Priority
           column: Needs Triage
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: alex-page/github-project-automation-plus@v0.8.1
-        with:
-          project: General AVD Enhancements
-          column: Medium
-          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr_labeler.yml
+++ b/.github/workflows/pr_labeler.yml
@@ -32,3 +32,19 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config: .github/reviewers.yml
+
+  pr_projects:
+    name: "Assign PR to projects"
+    # https://github.com/alex-page/github-project-automation-plus
+    runs-on: ubuntu-latest
+    steps:
+      - uses: alex-page/github-project-automation-plus@v0.8.1
+        with:
+          project: Priority
+          column: Needs Triage
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: alex-page/github-project-automation-plus@v0.8.1
+        with:
+          project: General AVD Enhancements
+          column: Medium
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/project_triage.yml
+++ b/.github/workflows/project_triage.yml
@@ -1,0 +1,20 @@
+name: "PR Triage"
+on:
+  pull_request_target:
+    types: [opened]
+jobs:
+  pr_projects:
+    name: "Assign PR to projects"
+    # https://github.com/alex-page/github-project-automation-plus
+    runs-on: ubuntu-latest
+    steps:
+      - uses: alex-page/github-project-automation-plus@v0.8.1
+        with:
+          project: Priority
+          column: Needs Triage
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: alex-page/github-project-automation-plus@v0.8.1
+        with:
+          project: General AVD Enhancements
+          column: Medium
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Change Summary

Enable Project allocation when user open PR

## Related Issue(s)

N/A

## Component(s) name

Github Actions

## Proposed changes

Update `pr-labeller` with [new action](https://github.com/alex-page/github-project-automation-plus):

```yaml
  pr_projects:
    name: "Assign PR to projects"
    # https://github.com/alex-page/github-project-automation-plus
    runs-on: ubuntu-latest
    steps:
      - uses: alex-page/github-project-automation-plus@v0.8.1
        with:
          project: Priority
          column: Needs Triage
          repo-token: ${{ secrets.GITHUB_TOKEN }}
      - uses: alex-page/github-project-automation-plus@v0.8.1
        with:
          project: General AVD Enhancements
          column: Medium
          repo-token: ${{ secrets.GITHUB_TOKEN }}
```

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
