### PR TITLE
Doc(eos_designs): Update & Cleanup fabric variables

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn.md
@@ -36,6 +36,8 @@ all:
     < DC-group-name >:
       children:
         < Super Spines group name >:
+          vars:
+            type: < node type >
           hosts:
             < super-spine name >:
               ansible_host: < management IP >

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/common-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/common-settings.md
@@ -364,7 +364,9 @@ name_server:
 This feature enables the user to supply `structured_config` on various levels in the `eos_designs` data model.
 
 #### Connected Endpoints (a.k.a. "servers")
+
 All relevant `structured_config` sections will be merged.
+
 ```yaml
 < connected_endpoints_keys.key >:
   < endpoint_1 >:
@@ -380,7 +382,9 @@ All relevant `structured_config` sections will be merged.
 See [Connected Endpoints]('../common/connected-endpoints.md')
 
 #### Fabric Topology
+
 Only the most specific `structured_config` key will be used
+
 ```yaml
 < spine | super_spine | overlay_controller >:
   defaults:
@@ -409,7 +413,9 @@ Only the most specific `structured_config` key will be used
 See [Fabric Topology]('fabric-topology.md')
 
 #### Network Services (a.k.a. "tenants")
+
 All relevant `structured_config` sections will be merged. Note that setting `structured_config` under `svi.nodes` will override the setting on `svi`.
+
 ```yaml
 tenants:
   vrfs:

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/fabric-variables.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/fabric-variables.md
@@ -67,23 +67,6 @@ bgp_peer_groups:
       name: < name of peer group | default -> EVPN-OVERLAY-PEERS >
       password: "< encrypted password >"
 
-# Spine BGP Tuning | Optional.
-spine_bgp_defaults:
-  - update wait-for-convergence
-  - update wait-install
-  - no bgp default ipv4-unicast
-  - distance bgp 20 200 200
-  - graceful-restart restart-time 300
-  - graceful-restart
-
-# Leaf BGP Tuning | Optional.
-leaf_bgp_defaults:
-  - update wait-install
-  - no bgp default ipv4-unicast
-  - distance bgp 20 200 200
-  - graceful-restart restart-time 300
-  - graceful-restart
-
 # Enable vlan aware bundles for EVPN MAC-VRF | Required.
 vxlan_vlan_aware_bundles: < boolean | default -> false >
 


### PR DESCRIPTION
## Change Summary

Update documentation to remove deprecated knob in Fabric Variables

## Related Issue(s)

N/A

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

- Remove `spine_bgp_defaults` and `leaf_bgp_defaults` from documentation
- MD Lint of common section 
- Add knob in inventory structure

## How to test

Read MD file

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
