### PR TITLE
Feat(eos_cli_config_gen): Add Role argument_spec support

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -155,7 +155,7 @@ jobs:
           echo "ANSIBLE_FORCE_COLOR=1" >> $GITHUB_ENV
       - uses: actions/checkout@v2
       - name: Run molecule action
-        uses: arista-netdevops-community/action-molecule-avd@v1.2
+        uses: arista-netdevops-community/action-molecule-avd@master
         with:
           molecule_parentdir: 'ansible_collections/arista/avd'
           molecule_command: 'test'
@@ -190,7 +190,7 @@ jobs:
           echo "ANSIBLE_FORCE_COLOR=1" >> $GITHUB_ENV
       - uses: actions/checkout@v2
       - name: Run molecule action
-        uses: arista-netdevops-community/action-molecule-avd@v1.2
+        uses: arista-netdevops-community/action-molecule-avd@master
         with:
           molecule_parentdir: 'ansible_collections/arista/avd'
           molecule_command: 'test'
@@ -236,7 +236,7 @@ jobs:
           echo "ANSIBLE_FORCE_COLOR=1" >> $GITHUB_ENV
       - uses: actions/checkout@v2
       - name: Run molecule action
-        uses: arista-netdevops-community/action-molecule-avd@v1.2
+        uses: arista-netdevops-community/action-molecule-avd@master
         with:
           molecule_parentdir: 'ansible_collections/arista/avd'
           molecule_command: 'test'
@@ -270,7 +270,7 @@ jobs:
           echo "ANSIBLE_FORCE_COLOR=1" >> $GITHUB_ENV
       - uses: actions/checkout@v2
       - name: Run molecule action
-        uses: arista-netdevops-community/action-molecule-avd@v1.2
+        uses: arista-netdevops-community/action-molecule-avd@master
         with:
           molecule_parentdir: 'ansible_collections/arista/avd'
           molecule_command: 'test'

--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,10 @@ webdoc: ## Build documentation to publish static content
 check-avd-404: ## Check local 404 links for AVD documentation
 	docker run --rm --network container:webdoc_avd raviqqe/muffet:1.5.7 http://127.0.0.1:8000 -e ".*fonts.gstatic.com.*" -e ".*edit.*" -f --limit-redirections=3 --timeout=$(MUFFET_TIMEOUT)
 
+.PHONY: roledocs
+roledocs:
+	( cd $(WEBDOC_BUILD) ; \
+    ansible-playbook playbook_roles_documentation.yml --tags role_docs )
 #########################################
 # Misc Actions (configure CI runner) 	#
 #########################################

--- a/ansible_collections/arista/avd/docs/_build/ansible.cfg
+++ b/ansible_collections/arista/avd/docs/_build/ansible.cfg
@@ -1,0 +1,3 @@
+[defaults]
+collections_paths = ../../../../../:~/.ansible/collections:/usr/share/ansible/collections
+jinja2_extensions = jinja2.ext.loopcontrols,jinja2.ext.do,jinja2.ext.i18n

--- a/ansible_collections/arista/avd/docs/_build/playbook_roles_documentation.yml
+++ b/ansible_collections/arista/avd/docs/_build/playbook_roles_documentation.yml
@@ -1,0 +1,13 @@
+---
+- name: Generate Roles Documentation
+  hosts: localhost
+  gather_facts: false
+  tasks:
+
+    - name: Role eos_cli_config_gen
+      import_role:
+        name: arista.avd.eos_cli_config_gen
+        tasks_from: role_docs
+        rolespec_validate: false
+      vars:
+        dest: '{{ role_path }}/doc/role_documentation.md'

--- a/ansible_collections/arista/avd/meta/runtime.yml
+++ b/ansible_collections/arista/avd/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: '>=2.10,<2.11'
+requires_ansible: '>=2.11.3'

--- a/ansible_collections/arista/avd/plugins/filter/migrate_dicts.py
+++ b/ansible_collections/arista/avd/plugins/filter/migrate_dicts.py
@@ -1,0 +1,62 @@
+#
+# def arista.avd.migrate_dicts
+#
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from jinja2.runtime import Undefined
+
+
+def migrate_dicts(dictionary, primary_key="name"):
+    """
+    migrate_dicts will convert dictionary to list.
+
+    Arista.avd.migrate_dicts will convert nested dictionaries to list of dictionaries
+    and insert the outer dictionary keys into each list item using the primary_key name.
+
+    This filter is intended for seemless data model migration.
+    If variable is already converted to list, it will pass through untouched
+
+    Example
+    -------
+    {# Migrate access_lists data model from dict to list #}
+    {% set access_lists = access_lists | arista.avd.migrate_dicts %}
+    {% for access_list in access_lists %}
+    {#     Migrate access-lists.sequence_numbers data model from dict to list #}
+    {%     do access_lists[loop.index0].update({'sequence_numbers': access_list.sequence_numbers | arista.avd.migrate_dicts('sequence')}) %}
+    {% endfor %}
+    access_lists: {{ access_lists }}
+
+    Parameters
+    ----------
+    dictionary : any
+        Nested Dictionary to convert - returned untouched if not a nested dictionary
+    primary_key : str, optional
+        Name of primary key used when inserting outer dictionary keys into items.
+
+    Returns
+    -------
+    any
+        Returns list of dictionaries or input variable untouched if not a nested dictionary
+    """
+    if not isinstance(dictionary, dict):
+        # Not a dictionary, return the original
+        return dictionary
+    else:
+        output = list()
+        for key in dictionary.keys():
+            if not isinstance(dictionary[key], dict):
+                # Not a nested dictionary, return the original
+                return dictionary
+            else:
+                item = dictionary[key]
+                item.update({primary_key: key})
+                output.append(item)
+        return output
+
+
+class FilterModule(object):
+    def filters(self):
+        return {
+            'migrate_dicts': migrate_dicts,
+        }

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/doc/role_documentation.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/doc/role_documentation.md
@@ -1,0 +1,3 @@
+# arista.avd.eos_cli_config_gen
+
+## Data Model

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/meta/argument_specs.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/meta/argument_specs.yml
@@ -1,0 +1,5 @@
+---
+# arista.avd.eos_cli_config_gen argument_specs
+argument_specs:
+  main:
+    options: "{{ schemas }}"

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/meta/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/meta/main.yml
@@ -4,6 +4,6 @@ galaxy_info:
   issue_tracker_url: https://github.com/aristanetworks/ansible-avd/issues
   company: Arista Networks
   license: Apache-2.0
-  min_ansible_version: 2.9
+  min_ansible_version: 2.11.3
   galaxy_tags: ['arista', 'network', 'networking', 'eos', 'avd', 'cloudvision', 'cvp']
-dependencies: []
+dependencies: [eos_cli_config_gen_upgrade]

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/tasks/role_docs.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/tasks/role_docs.yml
@@ -1,0 +1,8 @@
+---
+- name: Generate Role Documentation
+  tags: [role_docs]
+  template:
+    src: "role_docs/role_docs.j2"
+    dest: "{{ dest }}"
+    mode: 0664
+  delegate_to: localhost

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/role_docs/role_docs.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/role_docs/role_docs.j2
@@ -1,0 +1,57 @@
+{# TODO: Find out how to print required for dict / list keys #}
+{% macro print_line(key, value, prefix='', indentation=0) %}
+{%     set required = ' | Optional' %}
+{%     set unique = '' %}
+{%     set choices = '' %}
+{%     set def = '' %}
+{%     if value.required | arista.avd.default(false) %}
+{%         set required = ' | Required' %}
+{%     endif %}
+{%     if value.unique | arista.avd.default(false) == true %}
+{%         set unique = ' (unique)' %}
+{%     endif %}
+{%     if value.choices | arista.avd.default([]) | length > 0 %}
+{%         set choices = ', options: [' ~ value.choices | join(' | ') ~ ']' %}
+{%     endif %}
+{%     if value.default is arista.avd.defined %}
+{%         set def = ', default: ' ~ value.default %}
+{%     endif %}
+{%     set line = key ~ ':' %}
+{%     if value.type | arista.avd.default('str') not in ['list', 'dict'] %}
+{%         set line = line ~ ' <' ~ value.type ~ unique ~ choices ~ def ~ '>' %}
+{%     endif %}
+{%     set line_indent = indentation - prefix | length %}
+{%     if indentation > 0 %}
+{{ ('# ' ~ value.description | arista.avd.default(key) ~ required) | indent(indentation,first=true) }}
+{%     endif %}
+{{ (prefix ~ line) | indent(line_indent,first=true) }}
+{%     if value.type | arista.avd.default in ['list', 'dict'] %}
+{%         if value.elements | default == 'dict' and value.options is arista.avd.defined(var_type='dict') %}
+{#             print options with unique=true first #}
+{%             set unique_options = [] %}
+{%             for option in value.options if value.options[option].unique | arista.avd.default(false) %}
+{%                 do unique_options.append(option) %}
+{%             endfor %}
+{%             set non_unique_options = value.options | reject('in', unique_options) | list %}
+{%             for option in unique_options + non_unique_options %}
+{%                 if value.type == 'list' and loop.first %}
+{%                     set option_prefix = '- ' %}
+{%                 else %}
+{%                     set option_prefix = '' %}
+{%                 endif %}
+{{                 print_line(option, value.options[option], prefix=option_prefix, indentation=(indentation + 2)) -}}
+{%             endfor %}
+{%         endif %}
+{%     endif %}
+{% endmacro %}
+# {{ ansible_role_name }}
+
+## Data Model
+{% for key in schemas %}
+
+### {{ schemas[key].description | arista.avd.default(key) }}
+
+```yaml
+{{ print_line(key, schemas[key]) -}}
+```
+{% endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/vars/main/schemas/schemas.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/vars/main/schemas/schemas.yml
@@ -1,0 +1,2 @@
+schemas_vars: []
+schemas: "{{ {} | combine(schemas_vars) }}"

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen_upgrade/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen_upgrade/README.md
@@ -1,0 +1,3 @@
+# Ansible Role: eos_cli_config_gen_upgrade
+
+Role to upgrade input data for `eos_cli_config_gen` between major versions.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen_upgrade/meta/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen_upgrade/meta/main.yml
@@ -1,0 +1,9 @@
+galaxy_info:
+  author: Arista Ansible Team <ansible@arista.com>
+  description: Upgrade input data for arista.avd.eos_cli_config_gen
+  issue_tracker_url: https://github.com/aristanetworks/ansible-avd/issues
+  company: Arista Networks
+  license: Apache-2.0
+  min_ansible_version: 2.11.3
+  galaxy_tags: ['arista', 'network', 'networking', 'eos', 'avd', 'cloudvision', 'cvp']
+dependencies: []

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen_upgrade/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen_upgrade/tasks/main.yml
@@ -1,0 +1,32 @@
+---
+# create required directories
+- name: "Create directory for updated data model {{ root_dir }}/upgrade_eos_cli_config_gen/"
+  tags: [build, provision, migration]
+  file:
+    path: "{{ root_dir }}/upgrade_eos_cli_config_gen/"
+    state: directory
+    mode: 0775
+  delegate_to: localhost
+  run_once: true
+
+# Upgrade AVD data model for eos_cli_config_gen
+- name: Upgrade Data Model for eos_cli_config_gen AVD 3.0
+  tags: [build, provision, data_model_migration]
+  delegate_to: localhost
+  yaml_templates_to_facts:
+    templates:
+      - template: main.j2
+        strip_empty_keys: false
+  check_mode: no
+  register: upgrade_result
+
+# Write upgraded data model To file
+- name: Write upgraded data model To file
+  tags: [build, provision, migration]
+  copy:
+    content: "{{ upgrade_result.ansible_facts | to_nice_yaml(indent=2) }}"
+    dest: "{{ root_dir }}/upgrade_eos_cli_config_gen/{{ inventory_hostname }}.yml"
+    mode: 0664
+  delegate_to: localhost
+  check_mode: no
+  when: upgrade_result.ansible_facts

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen_upgrade/templates/main.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen_upgrade/templates/main.j2
@@ -1,0 +1,1 @@
+{# Include upgrade templates. Leave one empty line after each include #}

--- a/ansible_collections/arista/avd/roles/eos_designs/meta/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/meta/main.yml
@@ -4,6 +4,6 @@ galaxy_info:
   issue_tracker_url: https://github.com/aristanetworks/ansible-avd/issues
   company: Arista Networks
   license: Apache-2.0
-  min_ansible_version: 2.10
+  min_ansible_version: 2.11.3
   galaxy_tags: ['arista', 'network', 'networking', 'eos', 'avd', 'cloudvision', 'cvp']
 dependencies: []

--- a/ansible_collections/arista/avd/roles/eos_l3ls_evpn/meta/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_l3ls_evpn/meta/main.yml
@@ -4,6 +4,6 @@ galaxy_info:
   issue_tracker_url: https://github.com/aristanetworks/ansible-avd/issues
   company: Arista Networks
   license: Apache-2.0
-  min_ansible_version: 2.10
+  min_ansible_version: 2.11.3
   galaxy_tags: ['arista', 'network', 'networking', 'eos', 'avd', 'cloudvision', 'cvp']
 dependencies: []


### PR DESCRIPTION
## Change Summary

Add support for specifying data models with `argument_specs` supported by Ansible>=2.11.3.
Add infrastructure for data-model upgrade for `eos_cli_config_gen`
<!-- Enter short PR description -->

## Related Issue(s)

This is the basis for future refactor/upgrade of `eos_cli_config_gen` data model.

## Component(s) name

Roles:
`arista.avd.eos_cli_config_gen`
`arista.avd.eos_cli_config_gen_upgrade`

Filters:
`arista.avd.migrate_dicts`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been rebased from devel before I start
- [ ] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
