### PR TITLE
Feat(eos_cli_config_gen,eos_designs): Add support for setting multiple secondary virtual IP addresses for vlans

### DIFF
--- a/ansible_collections/arista/avd/docs/release-notes/3.x.x.md
+++ b/ansible_collections/arista/avd/docs/release-notes/3.x.x.md
@@ -155,6 +155,8 @@ Use migration role `arista.avd.upgrade_tools` to assist with the transition!
   - Deprecate `evpn_rt_type.admin_subfield` == `"spine_asn"` -> use value of `spine.bgp_as`
   - Change `evpn_rd_type.admin_subfield` == `"leaf_asn"` to `bgp_as`
   - Change `evpn_rt_type.admin_subfield` == `"leaf_asn"` to `bgp_as`
+  - Change from `tenants.{{ tenant }}.vrfs.{{ vrf }}.svis.{{ svi }}.ip_address_virtual_secondary` to `tenants.{{ tenant }}.vrfs.{{ vrf }}.svis.{{ svi }}.ip_address_virtual_secondaries`
+  - Change from `svi_profiles.{{ profile }}.ip_address_virtual_secondary` to `svi_profiles.{{ profile }}.ip_address_virtual_secondaries`
 
 #### Changes to eos_cli_config_gen role
 
@@ -328,6 +330,7 @@ snmp_server:
 - Add platform setting for `queue_monitor_length_notify_support` (#1016)
 - Add support for match_lists and using them in logging policy (#985)
 - Add support for setting vxlan flood vtep (#980)
+- Add support for setting multiple secondary virtual IP addresses for vlans (#1180)
 
 ### Fixed issues
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
@@ -174,6 +174,8 @@ interface Vlan83
    description SVI Description
    no shutdown
    ip address virtual 10.10.83.1/24
+   ip address virtual 10.11.83.1/24 secondary
+   ip address virtual 10.11.84.1/24 secondary
 !
 interface Vlan84
    description SVI Description

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
@@ -47,6 +47,8 @@ interface Vlan83
    description SVI Description
    no shutdown
    ip address virtual 10.10.83.1/24
+   ip address virtual 10.11.83.1/24 secondary
+   ip address virtual 10.11.84.1/24 secondary
 !
 interface Vlan84
    description SVI Description

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
@@ -19,6 +19,9 @@ vlan_interfaces:
     description: SVI Description
     shutdown: false
     ip_address_virtual: 10.10.83.1/24
+    ip_address_virtual_secondaries:
+      - 10.11.83.1/24
+      - 10.11.84.1/24
 
   Vlan84:
     description: SVI Description

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF1A.md
@@ -408,6 +408,8 @@ interface Vlan120
    no shutdown
    vrf Tenant_A_WEB_Zone
    ip address virtual 10.1.20.1/24
+   ip address virtual 10.2.20.1/24 secondary
+   ip address virtual 10.2.21.1/24 secondary
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
 !
 interface Vlan121

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2A.md
@@ -606,6 +606,8 @@ interface Vlan120
    no shutdown
    vrf Tenant_A_WEB_Zone
    ip address virtual 10.1.20.1/24
+   ip address virtual 10.2.20.1/24 secondary
+   ip address virtual 10.2.21.1/24 secondary
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
 !
 interface Vlan121

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2B.md
@@ -606,6 +606,8 @@ interface Vlan120
    no shutdown
    vrf Tenant_A_WEB_Zone
    ip address virtual 10.1.20.1/24
+   ip address virtual 10.2.20.1/24 secondary
+   ip address virtual 10.2.21.1/24 secondary
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
 !
 interface Vlan121

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3A.md
@@ -841,6 +841,8 @@ interface Vlan120
    no shutdown
    vrf Tenant_A_WEB_Zone
    ip address virtual 10.1.20.1/24
+   ip address virtual 10.2.20.1/24 secondary
+   ip address virtual 10.2.21.1/24 secondary
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
 !
 interface Vlan121

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3B.md
@@ -826,6 +826,8 @@ interface Vlan120
    no shutdown
    vrf Tenant_A_WEB_Zone
    ip address virtual 10.1.20.1/24
+   ip address virtual 10.2.20.1/24 secondary
+   ip address virtual 10.2.21.1/24 secondary
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
 !
 interface Vlan121

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF1A.cfg
@@ -124,6 +124,8 @@ interface Vlan120
    no shutdown
    vrf Tenant_A_WEB_Zone
    ip address virtual 10.1.20.1/24
+   ip address virtual 10.2.20.1/24 secondary
+   ip address virtual 10.2.21.1/24 secondary
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
 !
 interface Vlan121

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
@@ -262,6 +262,8 @@ interface Vlan120
    no shutdown
    vrf Tenant_A_WEB_Zone
    ip address virtual 10.1.20.1/24
+   ip address virtual 10.2.20.1/24 secondary
+   ip address virtual 10.2.21.1/24 secondary
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
 !
 interface Vlan121

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
@@ -262,6 +262,8 @@ interface Vlan120
    no shutdown
    vrf Tenant_A_WEB_Zone
    ip address virtual 10.1.20.1/24
+   ip address virtual 10.2.20.1/24 secondary
+   ip address virtual 10.2.21.1/24 secondary
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
 !
 interface Vlan121

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3A.cfg
@@ -436,6 +436,8 @@ interface Vlan120
    no shutdown
    vrf Tenant_A_WEB_Zone
    ip address virtual 10.1.20.1/24
+   ip address virtual 10.2.20.1/24 secondary
+   ip address virtual 10.2.21.1/24 secondary
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
 !
 interface Vlan121

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3B.cfg
@@ -423,6 +423,8 @@ interface Vlan120
    no shutdown
    vrf Tenant_A_WEB_Zone
    ip address virtual 10.1.20.1/24
+   ip address virtual 10.2.20.1/24 secondary
+   ip address virtual 10.2.21.1/24 secondary
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
 !
 interface Vlan121

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF1A.yml
@@ -348,6 +348,9 @@ vlan_interfaces:
     shutdown: false
     vrf: Tenant_A_WEB_Zone
     ip_address_virtual: 10.1.20.1/24
+    ip_address_virtual_secondaries:
+    - 10.2.20.1/24
+    - 10.2.21.1/24
     ip_helpers:
       1.1.1.1:
         source_interface: lo100

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
@@ -673,6 +673,9 @@ vlan_interfaces:
     shutdown: false
     vrf: Tenant_A_WEB_Zone
     ip_address_virtual: 10.1.20.1/24
+    ip_address_virtual_secondaries:
+    - 10.2.20.1/24
+    - 10.2.21.1/24
     ip_helpers:
       1.1.1.1:
         source_interface: lo100

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
@@ -673,6 +673,9 @@ vlan_interfaces:
     shutdown: false
     vrf: Tenant_A_WEB_Zone
     ip_address_virtual: 10.1.20.1/24
+    ip_address_virtual_secondaries:
+    - 10.2.20.1/24
+    - 10.2.21.1/24
     ip_helpers:
       1.1.1.1:
         source_interface: lo100

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
@@ -623,6 +623,9 @@ vlan_interfaces:
     shutdown: false
     vrf: Tenant_A_WEB_Zone
     ip_address_virtual: 10.1.20.1/24
+    ip_address_virtual_secondaries:
+    - 10.2.20.1/24
+    - 10.2.21.1/24
     ip_helpers:
       1.1.1.1:
         source_interface: lo100

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
@@ -623,6 +623,9 @@ vlan_interfaces:
     shutdown: false
     vrf: Tenant_A_WEB_Zone
     ip_address_virtual: 10.1.20.1/24
+    ip_address_virtual_secondaries:
+    - 10.2.20.1/24
+    - 10.2.21.1/24
     ip_helpers:
       1.1.1.1:
         source_interface: lo100

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS.yml
@@ -64,6 +64,9 @@ tenants:
             tags: ['web', 'erp1']
             profile: WITH_DHCP_AND_SNOOPING
             ip_address_virtual: 10.1.20.1/24
+            ip_address_virtual_secondaries: 
+              - 10.2.20.1/24
+              - 10.2.21.1/24
           121:
             name: Tenant_A_WEBZone_2
             tags: ['web']

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1020,7 +1020,7 @@ vlan_interfaces:
       - < IPv4_address/Mask >
     ip_virtual_router_address: < IPv4_address >
     ip_address_virtual: < IPv4_address/Mask >
-    ip_address_virtual_secondaries: 
+    ip_address_virtual_secondaries:
       - < IPv4_address/Mask >
       - < IPv4_address/Mask >
     ip_helpers:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1020,6 +1020,9 @@ vlan_interfaces:
       - < IPv4_address/Mask >
     ip_virtual_router_address: < IPv4_address >
     ip_address_virtual: < IPv4_address/Mask >
+    ip_address_virtual_secondaries: 
+      - < IPv4_address/Mask >
+      - < IPv4_address/Mask >
     ip_helpers:
       < ip_helper_address_1 >:
         source_interface: < source_interface_name >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
@@ -38,6 +38,11 @@ interface {{ vlan_interface }}
 {%     endif %}
 {%     if vlan_interfaces[vlan_interface].ip_address_virtual is arista.avd.defined %}
    ip address virtual {{ vlan_interfaces[vlan_interface].ip_address_virtual }}
+{%         if vlan_interfaces[vlan_interface].ip_address_virtual_secondaries is arista.avd.defined %}
+{%             for ip_address_virtual_secondary in vlan_interfaces[vlan_interface].ip_address_virtual_secondaries %}
+   ip address virtual {{ ip_address_virtual_secondary }} secondary
+{%             endfor %}
+{%         endif %}
 {%     endif %}
 {%     for ip_helper in vlan_interfaces[vlan_interface].ip_helpers | arista.avd.natural_sort %}
 {%         set ip_helper_cli = "ip helper-address " ~ ip_helper %}

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/network-services.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/network-services.md
@@ -47,7 +47,7 @@ svi_profiles:
     enabled: < true | false >
     ip_virtual_router_address: < IPv4_address/Mask >
     ip_address_virtual: < IPv4_address/Mask >
-    ip_address_virtual_secondaries: 
+    ip_address_virtual_secondaries:
       - < IPv4_address/Mask >
       - < IPv4_address/Mask >
     igmp_snooping_enabled: < true | false | default true (eos) >
@@ -149,7 +149,7 @@ tenants:
             # Conserves IP addresses in VXLAN deployments as it doesn't require unique IP addresses on each node.
             # Optional
             ip_address_virtual: < IPv4_address/Mask >
-            ip_address_virtual_secondaries: 
+            ip_address_virtual_secondaries:
               - < IPv4_address/Mask >
               - < IPv4_address/Mask >
 

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/network-services.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/network-services.md
@@ -47,7 +47,9 @@ svi_profiles:
     enabled: < true | false >
     ip_virtual_router_address: < IPv4_address/Mask >
     ip_address_virtual: < IPv4_address/Mask >
-    ip_address_virtual_secondary: < IPv4_address/Mask >
+    ip_address_virtual_secondaries: 
+      - < IPv4_address/Mask >
+      - < IPv4_address/Mask >
     igmp_snooping_enabled: < true | false | default true (eos) >
     ip_helpers:
       < IPv4 dhcp server IP >:
@@ -147,6 +149,9 @@ tenants:
             # Conserves IP addresses in VXLAN deployments as it doesn't require unique IP addresses on each node.
             # Optional
             ip_address_virtual: < IPv4_address/Mask >
+            ip_address_virtual_secondaries: 
+              - < IPv4_address/Mask >
+              - < IPv4_address/Mask >
 
             # ip virtual-router address
             # note, also requires an IP address to be configured on the SVI where it is applied.

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenants/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenants/vlan-interfaces.j2
@@ -19,8 +19,8 @@ vlan_interfaces:
                                                    svi_profile.ip_virtual_router_address) %}
 {%             set svi_ip_address_virtual = svi_config.ip_address_virtual | arista.avd.default(
                                             svi_profile.ip_address_virtual) %}
-{%             set svi_ip_address_virtual_secondary = svi_config.ip_address_virtual_secondary | arista.avd.default(
-                                                      svi_profile.ip_address_virtual_secondary) %}
+{%             set svi_ip_address_virtual_secondaries = svi_config.ip_address_virtual_secondaries | arista.avd.default(
+                                                      svi_profile.ip_address_virtual_secondaries) %}
 {%             set svi_mtu = svi_config.mtu | arista.avd.default(
                              svi_profile.mtu) %}
 {%             set svi_ip_helpers = svi_config.ip_helpers | arista.avd.default(
@@ -57,8 +57,8 @@ vlan_interfaces:
     ip_address_virtual: {{ svi_ip_address_virtual }}
 {%             endif %}
 {# Virtual Secondary IP address #}
-{%             if svi_ip_address_virtual_secondary is arista.avd.defined %}
-    ip_address_virtual_secondary: {{ svi_ip_address_virtual_secondary }}
+{%             if svi_ip_address_virtual_secondaries is arista.avd.defined %}
+    ip_address_virtual_secondaries: {{ svi_ip_address_virtual_secondaries }}
 {%             endif %}
 {# MTU definition #}
 {%             if svi_mtu is arista.avd.defined %}


### PR DESCRIPTION
The ”ip address virtual” command is specific to a VXLAN routing deployment and is used to conserve IP address space. Only one secondary virtual address is being supported by AVD which could have been multiple secondary IPs.

- Changes made: Under tenants.vrfs[vrf].svis[svi], ip_address_virtual_secondary is modified to ip_address_virtual_secondaries which is a list.
- This key can be used either in svi_profiles or in the above mentioned path.

## Change Summary

`arista.avd.eos_designs, arista.avd.eos_cli_config_gen`
- Affected roles: eos_designs, eos_cli_config_gen. The vlan-interfaces.j2 is modified in both of the roles.
- eos_designs template path: ansible-avd/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenants/vlan-interfaces.j2. Existing snippet is modified.
- eos_cli_config_gen template path: ansible-avd/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2. New snippet is added.

<!-- Enter short PR description -->
Support for multiple secondary virtual IPs for the SVIs.
## Related Issue(s)

Fixes #1170

## Component(s) name
arista.avd.eos_designs, arista.avd.eos_cli_config_gen

## Proposed changes
<!--- Describe your changes in detail -->
tenants.vrfs[<vrf>].svis[<svi>].ip_address_virtual_secondary is modified to tenants.vrfs[<vrf>].svis[<svi>].ip_address_virtual_secondaries which is a list.

- eos_designs: ip_address_virtual_secondary can hold only 1 virtual secondary IP and this variable is changed to ip_address_virtual_secondaries and it's value is a list of IPv4 IPs to support multiple IPs.
- eos_cli_config_gen: There is no configuration to generate ip_address_virtual_secondaries, which is added.
- Data model changed: ip_address_virtual_secondary : <ipv4>     changed to ip_address_virtual_secondaries : [ <list of ipv4 IPs> ]

<!--- Describe data model implemented for new features -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
group_vars/DC1_TENANTS_NETWORKS.yml:

```
tenants:
  # Tenant A Specific Information - VRFs / VLANs
  Tenant_A:
    vrfs:
      Tenant_A_OP_Zone:
        vrf_vni: 10
        vtep_diagnostic:
          loopback: 100
          loopback_ip_range: 10.254.1.0/24
        svis:
          12:
            name: Tenant_A_OP_Zone_Test
            tags: [opzone]
            enabled: true
            ip_address_virtual: <ipv4/mask>
            ip_address_virtual_secondaries: [<ipv4/mask>, <ipv4/mask>] 
```
<!--- Include details of your testing environment, and the tests you ran to -->
Used docker environment (downloaded as suggested in avd.sh docs and then updated avd to latest), python version = 3.6.14.
I created an example and then tested the modified AVD. Then checked the intended configuration, which actually generated the configuration as required. 

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
