### PR TITLE
Feat(eos_cli_config_gen): Added support for bgp neighbors send-community

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
@@ -101,6 +101,24 @@ interface Management1
 | maximum-paths 2 ecmp 2 |
 | bgp bestpath d-path |
 
+### BGP Neighbors
+
+| Neighbor | Remote AS | VRF |
+| -------- | --------- | --- |
+| 192.0.3.1 | 65432 | default |
+| 192.0.3.2 | 65433 | default |
+| 192.0.3.3 | 65434 | default |
+| 192.0.3.4 | 65435 | default |
+
+### BGP Neighbor send-community
+
+| Neighbor | Value |
+| -------- | ----- |
+| 192.0.3.1 | all |
+| 192.0.3.2 | extended |
+| 192.0.3.3 | standard |
+| 192.0.3.4 | large |
+
 ### BGP Route Aggregation
 
 | Prefix | AS Set | Summary Only | Attribute Map | Match Map | Advertise Only |
@@ -127,6 +145,14 @@ router bgp 65101
    graceful-restart
    maximum-paths 2 ecmp 2
    bgp bestpath d-path
+   neighbor 192.0.3.1 remote-as 65432
+   neighbor 192.0.3.1 send-community
+   neighbor 192.0.3.2 remote-as 65433
+   neighbor 192.0.3.2 send-community extended
+   neighbor 192.0.3.3 remote-as 65434
+   neighbor 192.0.3.3 send-community standard
+   neighbor 192.0.3.4 remote-as 65435
+   neighbor 192.0.3.4 send-community large
    aggregate-address 1.1.1.0/24 advertise-only
    aggregate-address 1.12.1.0/24 as-set summary-only attribute-map RM-ATTRIBUTE match-map RM-MATCH advertise-only
    aggregate-address 2.2.1.0/24

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-base.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-base.cfg
@@ -20,6 +20,14 @@ router bgp 65101
    graceful-restart
    maximum-paths 2 ecmp 2
    bgp bestpath d-path
+   neighbor 192.0.3.1 remote-as 65432
+   neighbor 192.0.3.1 send-community
+   neighbor 192.0.3.2 remote-as 65433
+   neighbor 192.0.3.2 send-community extended
+   neighbor 192.0.3.3 remote-as 65434
+   neighbor 192.0.3.3 send-community standard
+   neighbor 192.0.3.4 remote-as 65435
+   neighbor 192.0.3.4 send-community large
    aggregate-address 1.1.1.0/24 advertise-only
    aggregate-address 1.12.1.0/24 as-set summary-only attribute-map RM-ATTRIBUTE match-map RM-MATCH advertise-only
    aggregate-address 2.2.1.0/24

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-base.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-base.yml
@@ -37,7 +37,6 @@ router_bgp:
       192.0.2.1:
         prefix_list_in: PL-FOO-v4-IN
         prefix_list_out: PL-FOO-v4-OUT
-
   address_family_ipv6:
     networks:
       2001:db8:100::/40:
@@ -51,4 +50,16 @@ router_bgp:
       2001:db8::1:
         prefix_list_in: PL-FOO-v6-IN
         prefix_list_out: PL-FOO-v6-OUT
-
+  neighbors:
+      192.0.3.1:
+        remote_as: 65432
+        send_community: all
+      192.0.3.2:
+        remote_as: 65433
+        send_community: extended
+      192.0.3.3:
+        remote_as: 65434
+        send_community: standard
+      192.0.3.4:
+        remote_as: 65435
+        send_community: large

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -2013,6 +2013,7 @@ router_bgp:
       timers: < keepalive_hold_timer_values >
       route_map_in: < inbound route-map >
       route_map_out: < outbound route-map >
+      send_community: < all | extended | large | standard >
     < IPv4_address_2 >:
       remote_as: < bgp_as >
       next_hop_self: < true | false >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
@@ -111,6 +111,26 @@
 {%             endif %}
 {%         endfor %}
 {%     endif %}
+{%     if router_bgp.neighbors is arista.avd.defined %}
+{%         set community = namespace(found=false) %}
+{%         for neighbor in router_bgp.neighbors %}
+{%             if router_bgp.neighbors[neighbor].send_community is arista.avd.defined %}
+{%                 set community.found = true %}
+{%             endif %}
+{%         endfor %}
+{%         if community.found is arista.avd.defined(true) %}
+
+### BGP Neighbor send-community
+
+| Neighbor | Value |
+| -------- | ----- |
+{%             for neighbor in router_bgp.neighbors %}
+{%                 if router_bgp.neighbors[neighbor].send_community is arista.avd.defined %}
+| {{ neighbor }} | {{ router_bgp.neighbors[neighbor].send_community }} |
+{%                 endif %}
+{%             endfor %}
+{%         endif %}
+{%     endif %}
 {%     if router_bgp.neighbor_interfaces is arista.avd.defined %}
 
 ### BGP Neighbor Interfaces

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
@@ -112,24 +112,18 @@
 {%         endfor %}
 {%     endif %}
 {%     if router_bgp.neighbors is arista.avd.defined %}
-{%         set community = namespace(found=false) %}
 {%         for neighbor in router_bgp.neighbors %}
 {%             if router_bgp.neighbors[neighbor].send_community is arista.avd.defined %}
-{%                 set community.found = true %}
-{%             endif %}
-{%         endfor %}
-{%         if community.found is arista.avd.defined(true) %}
+{%                 if loop.first %}
 
 ### BGP Neighbor send-community
 
 | Neighbor | Value |
 | -------- | ----- |
-{%             for neighbor in router_bgp.neighbors %}
-{%                 if router_bgp.neighbors[neighbor].send_community is arista.avd.defined %}
-| {{ neighbor }} | {{ router_bgp.neighbors[neighbor].send_community }} |
 {%                 endif %}
-{%             endfor %}
-{%         endif %}
+| {{ neighbor }} | {{ router_bgp.neighbors[neighbor].send_community }} |
+{%             endif %}
+{%         endfor %}
 {%     endif %}
 {%     if router_bgp.neighbor_interfaces is arista.avd.defined %}
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -125,6 +125,11 @@ router bgp {{ router_bgp.as }}
 {%         if router_bgp.neighbors[neighbor].route_map_out is arista.avd.defined %}
    neighbor {{ neighbor }} route-map {{ router_bgp.neighbors[neighbor].route_map_out }} out
 {%         endif %}
+{%         if router_bgp.neighbors[neighbor].send_community is arista.avd.defined('all') %}
+   neighbor {{ neighbor }} send-community
+{%         elif router_bgp.neighbors[neighbor].send_community is arista.avd.defined %}
+   neighbor {{ neighbor }} send-community {{ router_bgp.neighbors[neighbor].send_community }}
+{%         endif %}
 {%     endfor %}
 {%     for aggregate_address in router_bgp.aggregate_addresses | arista.avd.natural_sort %}
 {%         set aggregate_address_cli = "aggregate-address " ~ aggregate_address %}


### PR DESCRIPTION
Added send-community functionnality for BGP neighbors

## Change Summary

<!-- Enter short PR description -->

## Related Issue(s)

None

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Added neighbors send-community functionnality:

## CLI Config Gen
``` yaml
router_bgp:
  neighbors:
    < IPv4_address_1 >:
      send_community: < standard | extended | large | all >
```

## Checklist

### User Checklist
- [x] eos_cli_config_gen implementation

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
