### PR TITLE
Feat(eos_cli_config_gen)!: Add support for multiple virtual router addresses for vlans

### DIFF
--- a/ansible_collections/arista/avd/docs/release-notes/3.x.x.md
+++ b/ansible_collections/arista/avd/docs/release-notes/3.x.x.md
@@ -157,6 +157,8 @@ Use migration role `arista.avd.upgrade_tools` to assist with the transition!
   - Change `evpn_rt_type.admin_subfield` == `"leaf_asn"` to `bgp_as`
   - Change from `tenants.{{ tenant }}.vrfs.{{ vrf }}.svis.{{ svi }}.ip_address_virtual_secondary` to `tenants.{{ tenant }}.vrfs.{{ vrf }}.svis.{{ svi }}.ip_address_virtual_secondaries`
   - Change from `svi_profiles.{{ profile }}.ip_address_virtual_secondary` to `svi_profiles.{{ profile }}.ip_address_virtual_secondaries`
+  - Change from `tenants.{{ tenant }}.vrfs.{{ vrf }}.svis.{{ svi }}.ip_virtual_router_address` to `tenants.{{ tenant }}.vrfs.{{ vrf }}.svis.{{ svi }}.ip_virtual_router_addresses`
+  - Change from `svi_profiles.{{ profile }}.ip_virtual_router_address` to `svi_profiles.{{ profile }}.ip_virtual_router_addresses`
 
 - __ntp_servers:__
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
@@ -107,7 +107,7 @@ interface Management1
 | Vlan42 |  default  |  -  |  10.10.42.1/24  |  -  |  -  |  -  |  -  |
 | Vlan75 |  default  |  -  |  10.10.75.1/24  |  -  |  -  |  -  |  -  |
 | Vlan83 |  default  |  -  |  10.10.83.1/24  |  -  |  -  |  -  |  -  |
-| Vlan84 |  default  |  10.10.84.1/24  |  -  |  10.10.84.254  |  -  |  -  |  -  |
+| Vlan84 |  default  |  10.10.84.1/24  |  -  |  10.10.84.254, 10.11.84.254/24  |  -  |  -  |  -  |
 | Vlan85 |  default  |  10.10.84.1/24  |  -  |  -  |  -  |  -  |  -  |
 | Vlan86 |  default  |  10.10.83.1/24  |  -  |  -  |  -  |  -  |  -  |
 | Vlan87 |  default  |  10.10.87.1/24  |  -  |  -  |  -  |  ACL_IN  |  ACL_OUT  |
@@ -181,6 +181,7 @@ interface Vlan84
    description SVI Description
    ip address 10.10.84.1/24
    ip virtual-router address 10.10.84.254
+   ip virtual-router address 10.11.84.254/24
 !
 interface Vlan85
    description SVI Description

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
@@ -54,6 +54,7 @@ interface Vlan84
    description SVI Description
    ip address 10.10.84.1/24
    ip virtual-router address 10.10.84.254
+   ip virtual-router address 10.11.84.254/24
 !
 interface Vlan85
    description SVI Description

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
@@ -26,7 +26,9 @@ vlan_interfaces:
   Vlan84:
     description: SVI Description
     ip_address: 10.10.84.1/24
-    ip_virtual_router_address: 10.10.84.254
+    ip_virtual_router_addresses:
+      - 10.10.84.254
+      - 10.11.84.254/24
 
   Vlan85:
     description: SVI Description

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF1A.yml
@@ -256,6 +256,7 @@ vlan_interfaces:
     shutdown: false
     mtu: 1500
     ip_address: 172.21.110.2/24
-    ip_virtual_router_address: 172.21.110.1
+    ip_virtual_router_addresses:
+    - 172.21.110.1
     ip_attached_host_route_export:
       distance: 19

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2A.yml
@@ -276,7 +276,8 @@ vlan_interfaces:
     shutdown: false
     mtu: 1500
     ip_address: 172.21.110.2/24
-    ip_virtual_router_address: 172.21.110.1
+    ip_virtual_router_addresses:
+    - 172.21.110.1
     ip_attached_host_route_export:
       distance: 19
 port_channel_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
@@ -282,7 +282,8 @@ vlan_interfaces:
     shutdown: false
     mtu: 1500
     ip_address: 172.21.110.3/24
-    ip_virtual_router_address: 172.21.110.1
+    ip_virtual_router_addresses:
+    - 172.21.110.1
     ip_attached_host_route_export:
       distance: 19
 port_channel_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF1A.yml
@@ -261,7 +261,8 @@ vlan_interfaces:
     shutdown: false
     mtu: 1500
     ip_address: 172.21.210.2/24
-    ip_virtual_router_address: 172.21.210.1
+    ip_virtual_router_addresses:
+    - 172.21.210.1
     ip_attached_host_route_export:
       distance: 19
 domain_list:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF1A.cfg
@@ -44,6 +44,9 @@ vlan 130
 vlan 131
    name Tenant_A_APP_Zone_2
 !
+vlan 132
+   name Tenant_A_APP_Zone_3
+!
 vrf instance MGMT
 !
 vrf instance Tenant_A_APP_Zone
@@ -147,6 +150,15 @@ interface Vlan131
    vrf Tenant_A_APP_Zone
    ip address virtual 10.1.31.1/24
 !
+interface Vlan132
+   description Tenant_A_APP_Zone_3
+   no shutdown
+   vrf Tenant_A_APP_Zone
+   ip address 10.1.32.1/24
+   ip virtual-router address 10.1.32.254
+   ip virtual-router address 10.2.32.254/24
+   ip virtual-router address 10.3.32.254/24
+!
 interface Vxlan1
    description DC1-LEAF1A_VTEP
    vxlan source-interface Loopback1
@@ -155,6 +167,7 @@ interface Vxlan1
    vxlan vlan 121 vni 10121
    vxlan vlan 130 vni 10130
    vxlan vlan 131 vni 10131
+   vxlan vlan 132 vni 10132
    vxlan vrf Tenant_A_APP_Zone vni 12
    vxlan vrf Tenant_A_WEB_Zone vni 11
 !
@@ -170,6 +183,8 @@ ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 20 permit 192.168.254.0/24 eq 32
 !
 ip route vrf MGMT 0.0.0.0/0 192.168.200.5
+ip route vrf Tenant_A_APP_Zone 10.2.32.0/24 Vlan132 name VARP
+ip route vrf Tenant_A_APP_Zone 10.3.32.0/24 Vlan132 name VARP
 !
 route-map RM-CONN-2-BGP permit 10
    match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
@@ -223,7 +238,7 @@ router bgp 65101
       rd 1.1.1.1:12
       route-target both 12:12
       redistribute learned
-      vlan 130-131
+      vlan 130-132
    !
    vlan-aware-bundle Tenant_A_WEB_Zone
       rd 1.1.1.1:11

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF1A.yml
@@ -98,7 +98,7 @@ router_bgp:
         - '12:12'
       redistribute_routes:
       - learned
-      vlan: 130-131
+      vlan: 130-132
     Tenant_A_WEB_Zone:
       rd: 1.1.1.1:11
       route_targets:
@@ -111,6 +111,14 @@ static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
+- destination_address_prefix: 10.2.32.0/24
+  vrf: Tenant_A_APP_Zone
+  name: VARP
+  interface: Vlan132
+- destination_address_prefix: 10.3.32.0/24
+  vrf: Tenant_A_APP_Zone
+  name: VARP
+  interface: Vlan132
 service_routing_protocols_model: multi-agent
 ip_routing: true
 daemon_terminattr:
@@ -284,6 +292,9 @@ vlans:
   131:
     tenant: Tenant_A
     name: Tenant_A_APP_Zone_2
+  132:
+    tenant: Tenant_A
+    name: Tenant_A_APP_Zone_3
   120:
     tenant: Tenant_A
     name: Tenant_A_WEB_Zone_1
@@ -306,6 +317,8 @@ vxlan_interface:
           vni: 10130
         131:
           vni: 10131
+        132:
+          vni: 10132
         120:
           vni: 10120
         121:
@@ -333,6 +346,18 @@ vlan_interfaces:
     shutdown: false
     vrf: Tenant_A_APP_Zone
     ip_address_virtual: 10.1.31.1/24
+  Vlan132:
+    tenant: Tenant_A
+    tags:
+    - erp2
+    description: Tenant_A_APP_Zone_3
+    shutdown: false
+    vrf: Tenant_A_APP_Zone
+    ip_address: 10.1.32.1/24
+    ip_virtual_router_addresses:
+    - 10.1.32.254
+    - 10.2.32.254/24
+    - 10.3.32.254/24
   Vlan120:
     tenant: Tenant_A
     tags:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_FABRIC.yml
@@ -80,7 +80,7 @@ l3leaf:
       platform: 7050SX3
       filter:
         tenants: [ all ]
-        tags: [ web, app ]
+        tags: [ web, app, erp2 ]
       nodes:
         DC1-LEAF1A:
           id: 1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS.yml
@@ -84,6 +84,17 @@ tenants:
             tags: ['app']
             enabled: True
             ip_address_virtual: 10.1.31.1/24
+          132:
+            name: Tenant_A_APP_Zone_3
+            tags: ['erp2']
+            enabled: True
+            nodes:
+              DC1-LEAF1A:
+                ip_address: 10.1.32.1/24
+            ip_virtual_router_addresses:
+              - 10.1.32.254
+              - 10.2.32.254/24
+              - 10.3.32.254/24
       Tenant_A_DB_Zone:
         vrf_vni: 13
         svis:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF1A.yml
@@ -263,6 +263,7 @@ vlan_interfaces:
     shutdown: false
     mtu: 1500
     ip_address: 172.21.110.2/24
-    ip_virtual_router_address: 172.21.110.1
+    ip_virtual_router_addresses:
+    - 172.21.110.1
     ip_attached_host_route_export:
       distance: 19

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2A.yml
@@ -265,7 +265,8 @@ vlan_interfaces:
     shutdown: false
     mtu: 1500
     ip_address: 172.21.110.2/24
-    ip_virtual_router_address: 172.21.110.1
+    ip_virtual_router_addresses:
+    - 172.21.110.1
     ip_attached_host_route_export:
       distance: 19
 port_channel_interfaces:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
@@ -275,7 +275,8 @@ vlan_interfaces:
     shutdown: false
     mtu: 1500
     ip_address: 172.21.110.3/24
-    ip_virtual_router_address: 172.21.110.1
+    ip_virtual_router_addresses:
+    - 172.21.110.1
     ip_attached_host_route_export:
       distance: 19
 port_channel_interfaces:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF1A.yml
@@ -269,6 +269,7 @@ vlan_interfaces:
     shutdown: false
     mtu: 1500
     ip_address: 172.21.210.2/24
-    ip_virtual_router_address: 172.21.210.1
+    ip_virtual_router_addresses:
+    - 172.21.210.1
     ip_attached_host_route_export:
       distance: 19

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1033,7 +1033,9 @@ vlan_interfaces:
     ip_address_secondaries:
       - < IPv4_address/Mask >
       - < IPv4_address/Mask >
-    ip_virtual_router_address: < IPv4_address >
+    ip_virtual_router_addresses:
+      - < IPv4_address/Mask | IPv4_address >
+      - < IPv4_address/Mask | IPv4_address >
     ip_address_virtual: < IPv4_address/Mask >
     ip_address_virtual_secondaries:
       - < IPv4_address/Mask >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vlan-interfaces.j2
@@ -36,7 +36,14 @@
 | Interface | VRF | IP Address | IP Address Virtual | IP Router Virtual Address | VRRP | ACL In | ACL Out |
 | --------- | --- | ---------- | ------------------ | ------------------------- | ---- | ------ | ------- |
 {%     for vlan_interface in vlan_interfaces | arista.avd.natural_sort %}
-| {{ vlan_interface }} | {% if vlan_interfaces[vlan_interface].vrf is defined and vlan_interfaces[vlan_interface].vrf is not none %} {{ vlan_interfaces[vlan_interface].vrf }} {% else %} default {% endif %} | {% if vlan_interfaces[vlan_interface].ip_address is defined and vlan_interfaces[vlan_interface].ip_address is not none %} {{ vlan_interfaces[vlan_interface].ip_address }} {% else %} - {% endif %} | {% if vlan_interfaces[vlan_interface].ip_address_virtual is defined and vlan_interfaces[vlan_interface].ip_address_virtual is not none %} {{ vlan_interfaces[vlan_interface].ip_address_virtual }} {% else %} - {% endif %} | {% if vlan_interfaces[vlan_interface].ip_virtual_router_address is defined and vlan_interfaces[vlan_interface].ip_virtual_router_address is not none %} {{ vlan_interfaces[vlan_interface].ip_virtual_router_address }} {% else %} - {% endif %} | {% if vlan_interfaces[vlan_interface].vrrp.ipv4 is defined and vlan_interfaces[vlan_interface].vrrp.ipv4 is not none %} {{ vlan_interfaces[vlan_interface].vrrp.ipv4 }} {% else %} - {% endif %} | {% if vlan_interfaces[vlan_interface].access_group_in is defined and vlan_interfaces[vlan_interface].access_group_in is not none %} {{ vlan_interfaces[vlan_interface].access_group_in }} {% else %} - {% endif %} | {% if vlan_interfaces[vlan_interface].access_group_out is defined and vlan_interfaces[vlan_interface].access_group_out is not none %} {{ vlan_interfaces[vlan_interface].access_group_out }} {% else %} - {% endif %} |
+{%         set row_vrf = vlan_interfaces[vlan_interface].vrf | arista.avd.default('default') %}
+{%         set row_ip_addr = vlan_interfaces[vlan_interface].ip_address | arista.avd.default('-') %}
+{%         set row_ip_vaddr = vlan_interfaces[vlan_interface].ip_address_virtual | arista.avd.default('-') %}
+{%         set row_varp = vlan_interfaces[vlan_interface].ip_virtual_router_addresses | arista.avd.default('-') | join(", ") %}
+{%         set row_vrrp = vlan_interfaces[vlan_interface].vrrp.ipv4 | arista.avd.default('-') %}
+{%         set row_acl_in = vlan_interfaces[vlan_interface].access_group_in | arista.avd.default('-') %}
+{%         set row_acl_out = vlan_interfaces[vlan_interface].access_group_out | arista.avd.default('-') %}
+| {{ vlan_interface }} |  {{ row_vrf }}  |  {{ row_ip_addr }}  |  {{ row_ip_vaddr }}  |  {{ row_varp }}  |  {{ row_vrrp }}  |  {{ row_acl_in }}  |  {{ row_acl_out }}  |
 {%     endfor %}
 {# IPv6 #}
 {%     set vlan_interface_ipv6 = namespace() %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
@@ -33,8 +33,10 @@ interface {{ vlan_interface }}
 {%             endfor %}
 {%         endif %}
 {%     endif %}
-{%     if vlan_interfaces[vlan_interface].ip_virtual_router_address is arista.avd.defined %}
-   ip virtual-router address {{ vlan_interfaces[vlan_interface].ip_virtual_router_address }}
+{%     if vlan_interfaces[vlan_interface].ip_virtual_router_addresses is arista.avd.defined %}
+{%         for ip_virtual_router_address in vlan_interfaces[vlan_interface].ip_virtual_router_addresses %}
+   ip virtual-router address {{ ip_virtual_router_address }}
+{%         endfor %}
 {%     endif %}
 {%     if vlan_interfaces[vlan_interface].ip_address_virtual is arista.avd.defined %}
    ip address virtual {{ vlan_interfaces[vlan_interface].ip_address_virtual }}

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/network-services.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/network-services.md
@@ -45,7 +45,9 @@ svi_profiles:
   < profile_name >:
     mtu: < mtu >
     enabled: < true | false >
-    ip_virtual_router_address: < IPv4_address/Mask >
+    ip_virtual_router_addresses:
+      - < IPv4_address/Mask | IPv4_address >
+      - < IPv4_address/Mask | IPv4_address >
     ip_address_virtual: < IPv4_address/Mask >
     ip_address_virtual_secondaries:
       - < IPv4_address/Mask >
@@ -159,7 +161,9 @@ tenants:
             # ip virtual-router address
             # note, also requires an IP address to be configured on the SVI where it is applied.
             # Optional
-            ip_virtual_router_address: < IPv4_address/Mask >
+            ip_virtual_router_addresses:
+              - < IPv4_address/Mask | IPv4_address >
+              - < IPv4_address/Mask | IPv4_address >
 
             # IP Helper for DHCP relay
             ip_helpers:
@@ -401,7 +405,9 @@ tenants:
             name: Tenant_A_OP_Zone_3
             tags: [ DC1_LEAF2 ]
             enabled: true
-            ip_virtual_router_address: 10.1.12.1/24
+            ip_virtual_router_addresses:
+              - 10.1.12.1
+              - 10.2.12.1/24
             nodes:
               DC1-LEAF2A:
                 ip_address: 10.1.12.2/24

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenants/static-routes.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenants/static-routes.j2
@@ -27,5 +27,25 @@ static_routes:
 {%                 endif %}
 {%             endfor %}
 {%         endif %}
+{%         for svi in switch.tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort %}
+{%             set svi_config = tenants[tenant].vrfs[vrf].svis[svi] %}
+{# Detect if a svi_profile exists #}
+{# If exists, create a shortpath to access profile data #}
+{%             if svi_config.profile is arista.avd.defined %}
+{%                 set svi_profile = svi_profiles[svi_config.profile] | arista.avd.default() %}
+{%             endif %}
+{%             set svi_varp = svi_config.ip_virtual_router_addresses | arista.avd.default(
+                              svi_profile.ip_virtual_router_addresses) %}
+{%             if svi_varp is arista.avd.defined %}
+{# Detect if VARP addresses with prefixes exist and loop through the ip_address/prefix #}
+{# If the VARP address with prefix doesn't exist then it will loop through empty_list [], so config is not generated in this scenario #}
+{%                 for dest_addr_prefix in svi_varp | ansible.netcommon.ipaddr(0) | ansible.netcommon.ipaddr('net') %}
+  - destination_address_prefix: {{ dest_addr_prefix }}
+    vrf: {{ vrf }}
+    name: "VARP"
+    interface: Vlan{{ svi | int }}
+{%                 endfor %}
+{%             endif %}
+{%         endfor %}
 {%     endfor %}
 {% endfor %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenants/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenants/vlan-interfaces.j2
@@ -18,8 +18,8 @@ vlan_interfaces:
                                      svi_name) %}
 {%             set svi_enabled = svi_config.enabled | arista.avd.default(
                                  svi_profile.enabled) %}
-{%             set svi_ip_virtual_router_address = svi_config.ip_virtual_router_address | arista.avd.default(
-                                                   svi_profile.ip_virtual_router_address) %}
+{%             set svi_ip_virtual_router_addresses = svi_config.ip_virtual_router_addresses | arista.avd.default(
+                                                     svi_profile.ip_virtual_router_addresses) %}
 {%             set svi_ip_address_virtual = svi_config.ip_address_virtual | arista.avd.default(
                                             svi_profile.ip_address_virtual) %}
 {%             set svi_ip_address_virtual_secondaries = svi_config.ip_address_virtual_secondaries | arista.avd.default(
@@ -52,8 +52,8 @@ vlan_interfaces:
     ip_address: {{ tenants[tenant].vrfs[vrf].svis[svi].nodes[inventory_hostname].ip_address }}
 {%             endif %}
 {# Virtual Router IP Address #}
-{%             if svi_ip_virtual_router_address is arista.avd.defined %}
-    ip_virtual_router_address: {{ svi_ip_virtual_router_address | ansible.netcommon.ipaddr('address') }}
+{%             if svi_ip_virtual_router_addresses is arista.avd.defined %}
+    ip_virtual_router_addresses: {{ svi_ip_virtual_router_addresses }}
 {%             endif %}
 {# Virtual IP address #}
 {%             if svi_ip_address_virtual is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/inband_management/parent-vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/inband_management/parent-vlan-interfaces.j2
@@ -9,7 +9,7 @@ vlan_interfaces:
 {%     else %}
     ip_address: {{ subnet | ansible.netcommon.ipaddr('network') | ansible.netcommon.ipmath(2) }}/{{ subnet | ansible.netcommon.ipaddr('prefix') }}
 {%     endif %}
-    ip_virtual_router_address: {{ subnet | ansible.netcommon.ipaddr('network') | ansible.netcommon.ipmath(1) }}
+    ip_virtual_router_addresses: [ {{ subnet | ansible.netcommon.ipaddr(1) }} ]
     ip_attached_host_route_export:
       distance: 19
 {% endfor %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/inband_management/parent-vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/inband_management/parent-vlan-interfaces.j2
@@ -9,7 +9,7 @@ vlan_interfaces:
 {%     else %}
     ip_address: {{ subnet | ansible.netcommon.ipaddr('network') | ansible.netcommon.ipmath(2) }}/{{ subnet | ansible.netcommon.ipaddr('prefix') }}
 {%     endif %}
-    ip_virtual_router_addresses: [ {{ subnet | ansible.netcommon.ipaddr(1) }} ]
+    ip_virtual_router_addresses: [ {{ subnet | ansible.netcommon.ipaddr(1) | ansible.netcommon.ipaddr('address') }} ]
     ip_attached_host_route_export:
       distance: 19
 {% endfor %}


### PR DESCRIPTION
- Modified design: In Network services, ip_virtual_router_address changed to ip_virtual_router_addresses to support multiple virtual router addresses. The new data type must be a list!
- Added molecule tests for eos_designs_unit_tests and eos_cli_config_gen
- Added design changes to release notes 3.x.x.md
- Modified documentation template in eos_cli_config_gen role to display all virtual-router IP addresses, used the join(", ") function over the array.

## Change Summary
eos_designs, eos_cli_config_gen

- Affected roles: eos_designs, eos_cli_config_gen. The vlan-interfaces.j2 is modified in both of the roles. 
- eos_designs template path: ansible-avd/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenants/vlan-interfaces.j2. Existing data model is modified.
- eos_cli_config_gen template path: ansible-avd/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2. Existing snippet is modified to support multiple IP addresses.
- Changes made to following eos_designs templates: static-routes, inband_management to make sure the static route for VARP (with IPv4/Mask type) are added to the SVI. 

<!-- Enter short PR description -->

## Related Issue(s)

Fixes #1167 

## Component(s) name

`eos_designs`, `eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
- tenants.{{ tenant }}.vrfs.{{ vrf }}.svis.{{ svi }}.ip_virtual_router_address **to** tenants.{{ tenant }}.vrfs.{{ vrf }}.svis.{{ svi }}.ip_virtual_router_addresses
- svi_profiles.{{ profile }}.ip_virtual_router_address **to** svi_profiles.{{ profile }}.ip_virtual_router_addresses
<!--- Describe data model implemented for new features -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
group_vars/DC1_TENANTS_NETWORKS.yml:
```
tenants:
  # Tenant A Specific Information - VRFs / VLANs
  Tenant_A:
    vrfs:
      Tenant_A_OP_Zone:
        vrf_vni: 10
        vtep_diagnostic:
          loopback: 100
          loopback_ip_range: 10.254.1.0/24
        svis:
          12:
            name: Tenant_A_OP_Zone_Test
            tags: [opzone]
            enabled: true
            ip_virtual_router_addresses: [<ipv4/mask>, <ipv4>] 
```
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code has been rebased from devel before I start
- [ x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ x] My change requires a change to the documentation and documentation have been updated accordingly.
- [ x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
