### PR TITLE
CI(actions): Implement stale process for PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,4 +1,4 @@
-name: "Close stale issues"
+name: "Issue and PR stale management"
 on:
   schedule:
   - cron: "0 0 * * *"
@@ -7,17 +7,22 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v3
+      # Issue stale management
+    - uses: actions/stale@v4
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         days-before-stale: 90
         days-before-close: 15
-        # only-labels: 'awaiting-feedback,awaiting-answers'
-        # Issue stale management
         stale-issue-message: 'This issue is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 15 days'
         stale-issue-label: 'state: stale'
         exempt-issue-labels: 'state: accepted, state: in-progress'
-        # PR Stale Management
-        # stale-pr-message: 'This PR is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 15 days'
-        # stale-pr-label: 'state: stale'
-        # exempt-pr-labels: 'state: accepted, state: in-progress'
+
+      # PR Stale Management
+    - uses: actions/stale@v4
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        days-before-stale: 30
+        days-before-close: 15
+        stale-pr-message: 'This PR is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 15 days'
+        stale-pr-label: 'state: stale'
+        exempt-pr-labels: 'state: accepted, state: in-progress'


### PR DESCRIPTION
## Change Summary

Implement an action to add label for PRs with no activity for 30 days and automatic closure for PRs with no activity for 45 days (30 days + 15 days).

## Related Issue(s)

N/A

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
