### PR TITLE
Feat(eos_designs): Add support for vxlan: false on svis and l2vlans

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF2A.md
@@ -202,8 +202,10 @@ vlan internal order ascending range 1006 1199
 | 110 | Tenant_A_OP_Zone_1 | - |
 | 111 | Tenant_A_OP_Zone_2 | - |
 | 112 | Tenant_A_OP_Zone_3 | - |
+| 113 | SVI_with_no_vxlan | - |
 | 2500 | web-l2-vlan | - |
 | 2600 | web-l2-vlan-2 | - |
+| 2601 | l2vlan_with_no_vxlan | - |
 | 4085 | L2LEAF_INBAND_MGMT | - |
 | 4094 | MLAG_PEER | MLAG |
 
@@ -220,11 +222,17 @@ vlan 111
 vlan 112
    name Tenant_A_OP_Zone_3
 !
+vlan 113
+   name SVI_with_no_vxlan
+!
 vlan 2500
    name web-l2-vlan
 !
 vlan 2600
    name web-l2-vlan-2
+!
+vlan 2601
+   name l2vlan_with_no_vxlan
 !
 vlan 4085
    name L2LEAF_INBAND_MGMT
@@ -244,8 +252,8 @@ vlan 4094
 
 | Interface | Description | Mode | VLANs | Native VLAN | Trunk Group | Channel-Group |
 | --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
-| Ethernet1 | DC1-POD1-LEAF2A_Ethernet3 | *trunk | *110-112,2500,2600,4085 | *- | *- | 1 |
-| Ethernet2 | DC1-POD1-LEAF2B_Ethernet3 | *trunk | *110-112,2500,2600,4085 | *- | *- | 1 |
+| Ethernet1 | DC1-POD1-LEAF2A_Ethernet3 | *trunk | *110-113,2500,2600-2601,4085 | *- | *- | 1 |
+| Ethernet2 | DC1-POD1-LEAF2B_Ethernet3 | *trunk | *110-113,2500,2600-2601,4085 | *- | *- | 1 |
 | Ethernet3 | MLAG_PEER_DC1-POD1-L2LEAF2B_Ethernet3 | *trunk | *2-4094 | *- | *['MLAG'] | 3 |
 | Ethernet4 | MLAG_PEER_DC1-POD1-L2LEAF2B_Ethernet4 | *trunk | *2-4094 | *- | *['MLAG'] | 3 |
 
@@ -284,7 +292,7 @@ interface Ethernet4
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel1 | RACK2_MLAG_Po3 | switched | trunk | 110-112,2500,2600,4085 | - | - | - | - | 1 | - |
+| Port-Channel1 | RACK2_MLAG_Po3 | switched | trunk | 110-113,2500,2600-2601,4085 | - | - | - | - | 1 | - |
 | Port-Channel3 | MLAG_PEER_DC1-POD1-L2LEAF2B_Po3 | switched | trunk | 2-4094 | - | ['MLAG'] | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
@@ -295,7 +303,7 @@ interface Port-Channel1
    description RACK2_MLAG_Po3
    no shutdown
    switchport
-   switchport trunk allowed vlan 110-112,2500,2600,4085
+   switchport trunk allowed vlan 110-113,2500,2600-2601,4085
    switchport mode trunk
    mlag 1
    service-profile QOS-PROFILE

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF2B.md
@@ -210,8 +210,10 @@ vlan internal order ascending range 1006 1199
 | 110 | Tenant_A_OP_Zone_1 | - |
 | 111 | Tenant_A_OP_Zone_2 | - |
 | 112 | Tenant_A_OP_Zone_3 | - |
+| 113 | SVI_with_no_vxlan | - |
 | 2500 | web-l2-vlan | - |
 | 2600 | web-l2-vlan-2 | - |
+| 2601 | l2vlan_with_no_vxlan | - |
 | 4085 | L2LEAF_INBAND_MGMT | - |
 | 4094 | MLAG_PEER | MLAG |
 
@@ -228,11 +230,17 @@ vlan 111
 vlan 112
    name Tenant_A_OP_Zone_3
 !
+vlan 113
+   name SVI_with_no_vxlan
+!
 vlan 2500
    name web-l2-vlan
 !
 vlan 2600
    name web-l2-vlan-2
+!
+vlan 2601
+   name l2vlan_with_no_vxlan
 !
 vlan 4085
    name L2LEAF_INBAND_MGMT
@@ -252,8 +260,8 @@ vlan 4094
 
 | Interface | Description | Mode | VLANs | Native VLAN | Trunk Group | Channel-Group |
 | --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
-| Ethernet1 | DC1-POD1-LEAF2A_Ethernet4 | *trunk | *110-112,2500,2600,4085 | *- | *- | 1 |
-| Ethernet2 | DC1-POD1-LEAF2B_Ethernet4 | *trunk | *110-112,2500,2600,4085 | *- | *- | 1 |
+| Ethernet1 | DC1-POD1-LEAF2A_Ethernet4 | *trunk | *110-113,2500,2600-2601,4085 | *- | *- | 1 |
+| Ethernet2 | DC1-POD1-LEAF2B_Ethernet4 | *trunk | *110-113,2500,2600-2601,4085 | *- | *- | 1 |
 | Ethernet3 | MLAG_PEER_DC1-POD1-L2LEAF2A_Ethernet3 | *trunk | *2-4094 | *- | *['MLAG'] | 3 |
 | Ethernet4 | MLAG_PEER_DC1-POD1-L2LEAF2A_Ethernet4 | *trunk | *2-4094 | *- | *['MLAG'] | 3 |
 
@@ -292,7 +300,7 @@ interface Ethernet4
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel1 | RACK2_MLAG_Po3 | switched | trunk | 110-112,2500,2600,4085 | - | - | - | - | 1 | - |
+| Port-Channel1 | RACK2_MLAG_Po3 | switched | trunk | 110-113,2500,2600-2601,4085 | - | - | - | - | 1 | - |
 | Port-Channel3 | MLAG_PEER_DC1-POD1-L2LEAF2A_Po3 | switched | trunk | 2-4094 | - | ['MLAG'] | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
@@ -303,7 +311,7 @@ interface Port-Channel1
    description RACK2_MLAG_Po3
    no shutdown
    switchport
-   switchport trunk allowed vlan 110-112,2500,2600,4085
+   switchport trunk allowed vlan 110-113,2500,2600-2601,4085
    switchport mode trunk
    mlag 1
    service-profile QOS-PROFILE

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2A.md
@@ -201,8 +201,10 @@ vlan internal order ascending range 1006 1199
 | 110 | Tenant_A_OP_Zone_1 | - |
 | 111 | Tenant_A_OP_Zone_2 | - |
 | 112 | Tenant_A_OP_Zone_3 | - |
+| 113 | SVI_with_no_vxlan | - |
 | 2500 | web-l2-vlan | - |
 | 2600 | web-l2-vlan-2 | - |
+| 2601 | l2vlan_with_no_vxlan | - |
 | 4085 | L2LEAF_INBAND_MGMT | - |
 | 4094 | MLAG_PEER | MLAG |
 
@@ -219,11 +221,17 @@ vlan 111
 vlan 112
    name Tenant_A_OP_Zone_3
 !
+vlan 113
+   name SVI_with_no_vxlan
+!
 vlan 2500
    name web-l2-vlan
 !
 vlan 2600
    name web-l2-vlan-2
+!
+vlan 2601
+   name l2vlan_with_no_vxlan
 !
 vlan 4085
    name L2LEAF_INBAND_MGMT
@@ -243,8 +251,8 @@ vlan 4094
 
 | Interface | Description | Mode | VLANs | Native VLAN | Trunk Group | Channel-Group |
 | --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
-| Ethernet3 | DC1-POD1-L2LEAF2A_Ethernet1 | *trunk | *110-112,2500,2600,4085 | *- | *- | 3 |
-| Ethernet4 | DC1-POD1-L2LEAF2B_Ethernet1 | *trunk | *110-112,2500,2600,4085 | *- | *- | 3 |
+| Ethernet3 | DC1-POD1-L2LEAF2A_Ethernet1 | *trunk | *110-113,2500,2600-2601,4085 | *- | *- | 3 |
+| Ethernet4 | DC1-POD1-L2LEAF2B_Ethernet1 | *trunk | *110-113,2500,2600-2601,4085 | *- | *- | 3 |
 | Ethernet5 | MLAG_PEER_DC1-POD1-LEAF2B_Ethernet5 | *trunk | *2-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 5 |
 | Ethernet6 | MLAG_PEER_DC1-POD1-LEAF2B_Ethernet6 | *trunk | *2-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 5 |
 | Ethernet16 | server-1_Eth1 | *access | *110 | *- | *- | 16 |
@@ -376,7 +384,7 @@ interface Ethernet19
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel3 | RACK2_MLAG_Po1 | switched | trunk | 110-112,2500,2600,4085 | - | - | - | - | 3 | - |
+| Port-Channel3 | RACK2_MLAG_Po1 | switched | trunk | 110-113,2500,2600-2601,4085 | - | - | - | - | 3 | - |
 | Port-Channel5 | MLAG_PEER_DC1-POD1-LEAF2B_Po5 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
 | Port-Channel16 | server-1_PortChannel | switched | access | 110 | - | - | - | - | 16 | - |
 | Port-Channel17 | Set using structured_config on server adapter port-channel | switched | access | 110 | - | - | - | - | 17 | - |
@@ -391,7 +399,7 @@ interface Port-Channel3
    description RACK2_MLAG_Po1
    no shutdown
    switchport
-   switchport trunk allowed vlan 110-112,2500,2600,4085
+   switchport trunk allowed vlan 110-113,2500,2600-2601,4085
    switchport mode trunk
    mlag 3
    service-profile QOS-PROFILE
@@ -490,6 +498,7 @@ interface Loopback1
 | Vlan110 |  set from structured_config on svi for DC1-POD1-LEAF2A (was Tenant_A_OP_Zone_1)  |  Common_VRF  |  -  |  false  |
 | Vlan111 |  Tenant_A_OP_Zone_2  |  Common_VRF  |  -  |  true  |
 | Vlan112 |  Tenant_A_OP_Zone_3  |  Common_VRF  |  -  |  false  |
+| Vlan113 |  SVI_with_no_vxlan  |  Common_VRF  |  -  |  false  |
 | Vlan4085 |  L2LEAF_INBAND_MGMT  |  default  |  1500  |  false  |
 | Vlan4094 |  MLAG_PEER  |  default  |  1500  |  false  |
 
@@ -500,6 +509,7 @@ interface Loopback1
 | Vlan110 |  Common_VRF  |  -  |  10.1.10.1/24  |  -  |  -  |  -  |  -  |
 | Vlan111 |  Common_VRF  |  -  |  10.1.11.1/24  |  -  |  -  |  -  |  -  |
 | Vlan112 |  Common_VRF  |  -  |  10.1.12.1/24  |  -  |  -  |  -  |  -  |
+| Vlan113 |  Common_VRF  |  -  |  10.10.13.1/24  |  -  |  -  |  -  |  -  |
 | Vlan4085 |  default  |  172.21.110.2/24  |  -  |  172.21.110.1  |  -  |  -  |  -  |
 | Vlan4094 |  default  |  172.20.110.2/31  |  -  |  -  |  -  |  -  |  -  |
 
@@ -529,6 +539,12 @@ interface Vlan112
    Comment created from raw_eos_cli under SVI 112 in VRF Common_VRF
    EOF
 
+!
+interface Vlan113
+   description SVI_with_no_vxlan
+   no shutdown
+   vrf Common_VRF
+   ip address virtual 10.10.13.1/24
 !
 interface Vlan4085
    description L2LEAF_INBAND_MGMT

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
@@ -225,8 +225,10 @@ vlan internal order ascending range 1006 1199
 | 110 | Tenant_A_OP_Zone_1 | - |
 | 111 | Tenant_A_OP_Zone_2 | - |
 | 112 | Tenant_A_OP_Zone_3 | - |
+| 113 | SVI_with_no_vxlan | - |
 | 2500 | web-l2-vlan | - |
 | 2600 | web-l2-vlan-2 | - |
+| 2601 | l2vlan_with_no_vxlan | - |
 | 4085 | L2LEAF_INBAND_MGMT | - |
 | 4094 | MLAG_PEER | MLAG |
 
@@ -243,11 +245,17 @@ vlan 111
 vlan 112
    name Tenant_A_OP_Zone_3
 !
+vlan 113
+   name SVI_with_no_vxlan
+!
 vlan 2500
    name web-l2-vlan
 !
 vlan 2600
    name web-l2-vlan-2
+!
+vlan 2601
+   name l2vlan_with_no_vxlan
 !
 vlan 4085
    name L2LEAF_INBAND_MGMT
@@ -267,8 +275,8 @@ vlan 4094
 
 | Interface | Description | Mode | VLANs | Native VLAN | Trunk Group | Channel-Group |
 | --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
-| Ethernet3 | DC1-POD1-L2LEAF2A_Ethernet2 | *trunk | *110-112,2500,2600,4085 | *- | *- | 3 |
-| Ethernet4 | DC1-POD1-L2LEAF2B_Ethernet2 | *trunk | *110-112,2500,2600,4085 | *- | *- | 3 |
+| Ethernet3 | DC1-POD1-L2LEAF2A_Ethernet2 | *trunk | *110-113,2500,2600-2601,4085 | *- | *- | 3 |
+| Ethernet4 | DC1-POD1-L2LEAF2B_Ethernet2 | *trunk | *110-113,2500,2600-2601,4085 | *- | *- | 3 |
 | Ethernet5 | MLAG_PEER_DC1-POD1-LEAF2A_Ethernet5 | *trunk | *2-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 5 |
 | Ethernet6 | MLAG_PEER_DC1-POD1-LEAF2A_Ethernet6 | *trunk | *2-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 5 |
 | Ethernet16 | server-1_Eth2 | *access | *110 | *- | *- | 16 |
@@ -401,7 +409,7 @@ interface Ethernet19
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel3 | RACK2_MLAG_Po1 | switched | trunk | 110-112,2500,2600,4085 | - | - | - | - | 3 | - |
+| Port-Channel3 | RACK2_MLAG_Po1 | switched | trunk | 110-113,2500,2600-2601,4085 | - | - | - | - | 3 | - |
 | Port-Channel5 | MLAG_PEER_DC1-POD1-LEAF2A_Po5 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
 | Port-Channel16 | server-1_PortChannel | switched | access | 110 | - | - | - | - | 16 | - |
 | Port-Channel17 | Set using structured_config on server adapter port-channel | switched | access | 110 | - | - | - | - | 17 | - |
@@ -416,7 +424,7 @@ interface Port-Channel3
    description RACK2_MLAG_Po1
    no shutdown
    switchport
-   switchport trunk allowed vlan 110-112,2500,2600,4085
+   switchport trunk allowed vlan 110-113,2500,2600-2601,4085
    switchport mode trunk
    mlag 3
    service-profile QOS-PROFILE
@@ -515,6 +523,7 @@ interface Loopback1
 | Vlan110 |  set from structured_config on svi (was Tenant_A_OP_Zone_1)  |  Common_VRF  |  -  |  false  |
 | Vlan111 |  Tenant_A_OP_Zone_2  |  Common_VRF  |  -  |  true  |
 | Vlan112 |  Tenant_A_OP_Zone_3  |  Common_VRF  |  -  |  false  |
+| Vlan113 |  SVI_with_no_vxlan  |  Common_VRF  |  -  |  false  |
 | Vlan4085 |  L2LEAF_INBAND_MGMT  |  default  |  1500  |  false  |
 | Vlan4094 |  MLAG_PEER  |  default  |  1500  |  false  |
 
@@ -525,6 +534,7 @@ interface Loopback1
 | Vlan110 |  Common_VRF  |  -  |  10.1.10.1/24  |  -  |  -  |  -  |  -  |
 | Vlan111 |  Common_VRF  |  -  |  10.1.11.1/24  |  -  |  -  |  -  |  -  |
 | Vlan112 |  Common_VRF  |  -  |  10.1.12.1/24  |  -  |  -  |  -  |  -  |
+| Vlan113 |  Common_VRF  |  -  |  10.10.13.1/24  |  -  |  -  |  -  |  -  |
 | Vlan4085 |  default  |  172.21.110.3/24  |  -  |  172.21.110.1  |  -  |  -  |  -  |
 | Vlan4094 |  default  |  172.20.110.3/31  |  -  |  -  |  -  |  -  |  -  |
 
@@ -554,6 +564,12 @@ interface Vlan112
    Comment created from raw_eos_cli under SVI 112 in VRF Common_VRF
    EOF
 
+!
+interface Vlan113
+   description SVI_with_no_vxlan
+   no shutdown
+   vrf Common_VRF
+   ip address virtual 10.10.13.1/24
 !
 interface Vlan4085
    description L2LEAF_INBAND_MGMT

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-LEAF1A.md
@@ -189,8 +189,10 @@ vlan internal order ascending range 1006 1199
 | 110 | Tenant_A_OP_Zone_1 | - |
 | 111 | Tenant_A_OP_Zone_2 | - |
 | 112 | Tenant_A_OP_Zone_3 | - |
+| 113 | SVI_with_no_vxlan | - |
 | 2500 | web-l2-vlan | - |
 | 2600 | web-l2-vlan-2 | - |
+| 2601 | l2vlan_with_no_vxlan | - |
 
 ## VLANs Device Configuration
 
@@ -205,11 +207,17 @@ vlan 111
 vlan 112
    name Tenant_A_OP_Zone_3
 !
+vlan 113
+   name SVI_with_no_vxlan
+!
 vlan 2500
    name web-l2-vlan
 !
 vlan 2600
    name web-l2-vlan-2
+!
+vlan 2601
+   name l2vlan_with_no_vxlan
 ```
 
 # Interfaces
@@ -307,6 +315,7 @@ interface Loopback1
 | Vlan110 |  set from structured_config on svi (was Tenant_A_OP_Zone_1)  |  Common_VRF  |  -  |  false  |
 | Vlan111 |  Tenant_A_OP_Zone_2  |  Common_VRF  |  -  |  true  |
 | Vlan112 |  Tenant_A_OP_Zone_3  |  Common_VRF  |  -  |  false  |
+| Vlan113 |  SVI_with_no_vxlan  |  Common_VRF  |  -  |  false  |
 
 #### IPv4
 
@@ -315,6 +324,7 @@ interface Loopback1
 | Vlan110 |  Common_VRF  |  -  |  10.1.10.1/24  |  -  |  -  |  -  |  -  |
 | Vlan111 |  Common_VRF  |  -  |  10.1.11.1/24  |  -  |  -  |  -  |  -  |
 | Vlan112 |  Common_VRF  |  -  |  10.1.12.1/24  |  -  |  -  |  -  |  -  |
+| Vlan113 |  Common_VRF  |  -  |  10.10.13.1/24  |  -  |  -  |  -  |  -  |
 
 
 ### VLAN Interfaces Device Configuration
@@ -342,6 +352,12 @@ interface Vlan112
    Comment created from raw_eos_cli under SVI 112 in VRF Common_VRF
    EOF
 
+!
+interface Vlan113
+   description SVI_with_no_vxlan
+   no shutdown
+   vrf Common_VRF
+   ip address virtual 10.10.13.1/24
 ```
 
 ## VXLAN Interface

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-L2LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-L2LEAF2A.cfg
@@ -28,11 +28,17 @@ vlan 111
 vlan 112
    name Tenant_A_OP_Zone_3
 !
+vlan 113
+   name SVI_with_no_vxlan
+!
 vlan 2500
    name web-l2-vlan
 !
 vlan 2600
    name web-l2-vlan-2
+!
+vlan 2601
+   name l2vlan_with_no_vxlan
 !
 vlan 4085
    name L2LEAF_INBAND_MGMT
@@ -47,7 +53,7 @@ interface Port-Channel1
    description RACK2_MLAG_Po3
    no shutdown
    switchport
-   switchport trunk allowed vlan 110-112,2500,2600,4085
+   switchport trunk allowed vlan 110-113,2500,2600-2601,4085
    switchport mode trunk
    mlag 1
    service-profile QOS-PROFILE

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-L2LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-L2LEAF2B.cfg
@@ -28,11 +28,17 @@ vlan 111
 vlan 112
    name Tenant_A_OP_Zone_3
 !
+vlan 113
+   name SVI_with_no_vxlan
+!
 vlan 2500
    name web-l2-vlan
 !
 vlan 2600
    name web-l2-vlan-2
+!
+vlan 2601
+   name l2vlan_with_no_vxlan
 !
 vlan 4085
    name L2LEAF_INBAND_MGMT
@@ -47,7 +53,7 @@ interface Port-Channel1
    description RACK2_MLAG_Po3
    no shutdown
    switchport
-   switchport trunk allowed vlan 110-112,2500,2600,4085
+   switchport trunk allowed vlan 110-113,2500,2600-2601,4085
    switchport mode trunk
    mlag 1
    service-profile QOS-PROFILE

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2A.cfg
@@ -31,11 +31,17 @@ vlan 111
 vlan 112
    name Tenant_A_OP_Zone_3
 !
+vlan 113
+   name SVI_with_no_vxlan
+!
 vlan 2500
    name web-l2-vlan
 !
 vlan 2600
    name web-l2-vlan-2
+!
+vlan 2601
+   name l2vlan_with_no_vxlan
 !
 vlan 4085
    name L2LEAF_INBAND_MGMT
@@ -52,7 +58,7 @@ interface Port-Channel3
    description RACK2_MLAG_Po1
    no shutdown
    switchport
-   switchport trunk allowed vlan 110-112,2500,2600,4085
+   switchport trunk allowed vlan 110-113,2500,2600-2601,4085
    switchport mode trunk
    mlag 3
    service-profile QOS-PROFILE
@@ -237,6 +243,12 @@ interface Vlan112
    Comment created from raw_eos_cli under SVI 112 in VRF Common_VRF
    EOF
 
+!
+interface Vlan113
+   description SVI_with_no_vxlan
+   no shutdown
+   vrf Common_VRF
+   ip address virtual 10.10.13.1/24
 !
 interface Vlan4085
    description L2LEAF_INBAND_MGMT

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2B.cfg
@@ -30,11 +30,17 @@ vlan 111
 vlan 112
    name Tenant_A_OP_Zone_3
 !
+vlan 113
+   name SVI_with_no_vxlan
+!
 vlan 2500
    name web-l2-vlan
 !
 vlan 2600
    name web-l2-vlan-2
+!
+vlan 2601
+   name l2vlan_with_no_vxlan
 !
 vlan 4085
    name L2LEAF_INBAND_MGMT
@@ -51,7 +57,7 @@ interface Port-Channel3
    description RACK2_MLAG_Po1
    no shutdown
    switchport
-   switchport trunk allowed vlan 110-112,2500,2600,4085
+   switchport trunk allowed vlan 110-113,2500,2600-2601,4085
    switchport mode trunk
    mlag 3
    service-profile QOS-PROFILE
@@ -243,6 +249,12 @@ interface Vlan112
    Comment created from raw_eos_cli under SVI 112 in VRF Common_VRF
    EOF
 
+!
+interface Vlan113
+   description SVI_with_no_vxlan
+   no shutdown
+   vrf Common_VRF
+   ip address virtual 10.10.13.1/24
 !
 interface Vlan4085
    description L2LEAF_INBAND_MGMT

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD2-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD2-LEAF1A.cfg
@@ -28,11 +28,17 @@ vlan 111
 vlan 112
    name Tenant_A_OP_Zone_3
 !
+vlan 113
+   name SVI_with_no_vxlan
+!
 vlan 2500
    name web-l2-vlan
 !
 vlan 2600
    name web-l2-vlan-2
+!
+vlan 2601
+   name l2vlan_with_no_vxlan
 !
 vrf instance Common_VRF
 !
@@ -101,6 +107,12 @@ interface Vlan112
    Comment created from raw_eos_cli under SVI 112 in VRF Common_VRF
    EOF
 
+!
+interface Vlan113
+   description SVI_with_no_vxlan
+   no shutdown
+   vrf Common_VRF
+   ip address virtual 10.10.13.1/24
 !
 interface Vxlan1
    description DC1-POD2-LEAF1A_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF2A.yml
@@ -49,12 +49,18 @@ vlans:
   112:
     tenant: Tenant_A
     name: Tenant_A_OP_Zone_3
+  113:
+    tenant: Tenant_A
+    name: SVI_with_no_vxlan
   2500:
     tenant: Tenant_A
     name: web-l2-vlan
   2600:
     tenant: Tenant_A
     name: web-l2-vlan-2
+  2601:
+    tenant: Tenant_A
+    name: l2vlan_with_no_vxlan
   4085:
     tenant: system
     name: L2LEAF_INBAND_MGMT
@@ -79,7 +85,7 @@ port_channel_interfaces:
     description: RACK2_MLAG_Po3
     type: switched
     shutdown: false
-    vlans: 110-112,2500,2600,4085
+    vlans: 110-113,2500,2600-2601,4085
     mode: trunk
     service_profile: QOS-PROFILE
     mlag: 1

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF2B.yml
@@ -64,12 +64,18 @@ vlans:
   112:
     tenant: Tenant_A
     name: Tenant_A_OP_Zone_3
+  113:
+    tenant: Tenant_A
+    name: SVI_with_no_vxlan
   2500:
     tenant: Tenant_A
     name: web-l2-vlan
   2600:
     tenant: Tenant_A
     name: web-l2-vlan-2
+  2601:
+    tenant: Tenant_A
+    name: l2vlan_with_no_vxlan
   4085:
     tenant: system
     name: L2LEAF_INBAND_MGMT
@@ -94,7 +100,7 @@ port_channel_interfaces:
     description: RACK2_MLAG_Po3
     type: switched
     shutdown: false
-    vlans: 110-112,2500,2600,4085
+    vlans: 110-113,2500,2600-2601,4085
     mode: trunk
     service_profile: QOS-PROFILE
     mlag: 1

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2A.yml
@@ -206,12 +206,18 @@ vlans:
   112:
     tenant: Tenant_A
     name: Tenant_A_OP_Zone_3
+  113:
+    tenant: Tenant_A
+    name: SVI_with_no_vxlan
   2500:
     tenant: Tenant_A
     name: web-l2-vlan
   2600:
     tenant: Tenant_A
     name: web-l2-vlan-2
+  2601:
+    tenant: Tenant_A
+    name: l2vlan_with_no_vxlan
   4085:
     tenant: system
     name: L2LEAF_INBAND_MGMT
@@ -255,6 +261,14 @@ vlan_interfaces:
       EOF
 
       '
+  Vlan113:
+    tenant: Tenant_A
+    tags:
+    - opzone
+    description: SVI_with_no_vxlan
+    shutdown: false
+    vrf: Common_VRF
+    ip_address_virtual: 10.10.13.1/24
   Vlan4085:
     description: L2LEAF_INBAND_MGMT
     shutdown: false
@@ -278,7 +292,7 @@ port_channel_interfaces:
     description: RACK2_MLAG_Po1
     type: switched
     shutdown: false
-    vlans: 110-112,2500,2600,4085
+    vlans: 110-113,2500,2600-2601,4085
     mode: trunk
     service_profile: QOS-PROFILE
     mlag: 3

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
@@ -212,12 +212,18 @@ vlans:
   112:
     tenant: Tenant_A
     name: Tenant_A_OP_Zone_3
+  113:
+    tenant: Tenant_A
+    name: SVI_with_no_vxlan
   2500:
     tenant: Tenant_A
     name: web-l2-vlan
   2600:
     tenant: Tenant_A
     name: web-l2-vlan-2
+  2601:
+    tenant: Tenant_A
+    name: l2vlan_with_no_vxlan
   4085:
     tenant: system
     name: L2LEAF_INBAND_MGMT
@@ -261,6 +267,14 @@ vlan_interfaces:
       EOF
 
       '
+  Vlan113:
+    tenant: Tenant_A
+    tags:
+    - opzone
+    description: SVI_with_no_vxlan
+    shutdown: false
+    vrf: Common_VRF
+    ip_address_virtual: 10.10.13.1/24
   Vlan4085:
     description: L2LEAF_INBAND_MGMT
     shutdown: false
@@ -284,7 +298,7 @@ port_channel_interfaces:
     description: RACK2_MLAG_Po1
     type: switched
     shutdown: false
-    vlans: 110-112,2500,2600,4085
+    vlans: 110-113,2500,2600-2601,4085
     mode: trunk
     service_profile: QOS-PROFILE
     mlag: 3

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-LEAF1A.yml
@@ -245,12 +245,18 @@ vlans:
   112:
     tenant: Tenant_A
     name: Tenant_A_OP_Zone_3
+  113:
+    tenant: Tenant_A
+    name: SVI_with_no_vxlan
   2500:
     tenant: Tenant_A
     name: web-l2-vlan
   2600:
     tenant: Tenant_A
     name: web-l2-vlan-2
+  2601:
+    tenant: Tenant_A
+    name: l2vlan_with_no_vxlan
 ip_igmp_snooping:
   globally_enabled: true
 vxlan_interface:
@@ -307,6 +313,14 @@ vlan_interfaces:
       EOF
 
       '
+  Vlan113:
+    tenant: Tenant_A
+    tags:
+    - opzone
+    description: SVI_with_no_vxlan
+    shutdown: false
+    vrf: Common_VRF
+    ip_address_virtual: 10.10.13.1/24
 ip_virtual_router_mac_address: 00:1c:73:00:dc:01
 struct_cfg:
   domain_list:

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/TENANTS_NETWORKS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/TENANTS_NETWORKS.yml
@@ -42,6 +42,12 @@ tenants:
               comment
               Comment created from raw_eos_cli under SVI 112 in VRF Common_VRF
               EOF
+          113:
+            name: SVI_with_no_vxlan
+            tags: [opzone]
+            enabled: True
+            ip_address_virtual: 10.10.13.1/24
+            vxlan: False
         raw_eos_cli: |
           interface Loopback1000
             description Loopback created from raw_eos_cli under VRF Common_VRF
@@ -64,3 +70,7 @@ tenants:
         vni_override: 2600
         name: web-l2-vlan-2
         tags: [web]
+      2601:
+        name: l2vlan_with_no_vxlan
+        tags: [web]
+        vxlan: False

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -462,7 +462,6 @@ interface Vlan350
 | ---- | --- | ---------- |
 | 150 | 10150 | - |
 | 250 | 20250 | - |
-| 350 | 30350 | - |
 
 #### VRF to VNI Mappings
 
@@ -484,7 +483,6 @@ interface Vxlan1
    vxlan udp-port 4789
    vxlan vlan 150 vni 10150
    vxlan vlan 250 vni 20250
-   vxlan vlan 350 vni 30350
    vxlan vrf Tenant_A_WAN_Zone vni 14
    vxlan vrf Tenant_B_OP_Zone vni 20
    vxlan vrf Tenant_B_WAN_Zone vni 21
@@ -645,7 +643,6 @@ ip route vrf Tenant_A_WAN_Zone 10.3.5.0/24 Null0
 | ----------------- | ------------------- | ----------------- | ------------------- | ------------------- | ------------ | ----- |
 | Tenant_A_WAN_Zone | 192.168.255.14:14 | 14:14 | - | - | learned | 150 |
 | Tenant_B_WAN_Zone | 192.168.255.14:21 | 21:21 | - | - | learned | 250 |
-| Tenant_C_WAN_Zone | 192.168.255.14:30031 | 30031:30031 | - | - | learned | 350 |
 
 #### Router BGP EVPN VRFs
 
@@ -714,12 +711,6 @@ router bgp 65104
       route-target both 21:21
       redistribute learned
       vlan 250
-   !
-   vlan-aware-bundle Tenant_C_WAN_Zone
-      rd 192.168.255.14:30031
-      route-target both 30031:30031
-      redistribute learned
-      vlan 350
    !
    address-family evpn
       no host-flap detection

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -460,7 +460,6 @@ interface Vlan350
 | ---- | --- | ---------- |
 | 150 | 10150 | - |
 | 250 | 20250 | - |
-| 350 | 30350 | - |
 
 #### VRF to VNI Mappings
 
@@ -482,7 +481,6 @@ interface Vxlan1
    vxlan udp-port 4789
    vxlan vlan 150 vni 10150
    vxlan vlan 250 vni 20250
-   vxlan vlan 350 vni 30350
    vxlan vrf Tenant_A_WAN_Zone vni 14
    vxlan vrf Tenant_B_OP_Zone vni 20
    vxlan vrf Tenant_B_WAN_Zone vni 21
@@ -643,7 +641,6 @@ ip route vrf Tenant_A_WAN_Zone 10.3.5.0/24 Null0
 | ----------------- | ------------------- | ----------------- | ------------------- | ------------------- | ------------ | ----- |
 | Tenant_A_WAN_Zone | 192.168.255.15:14 | 14:14 | - | - | learned | 150 |
 | Tenant_B_WAN_Zone | 192.168.255.15:21 | 21:21 | - | - | learned | 250 |
-| Tenant_C_WAN_Zone | 192.168.255.15:30031 | 30031:30031 | - | - | learned | 350 |
 
 #### Router BGP EVPN VRFs
 
@@ -712,12 +709,6 @@ router bgp 65105
       route-target both 21:21
       redistribute learned
       vlan 250
-   !
-   vlan-aware-bundle Tenant_C_WAN_Zone
-      rd 192.168.255.15:30031
-      route-target both 30031:30031
-      redistribute learned
-      vlan 350
    !
    address-family evpn
       no host-flap detection

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -480,7 +480,6 @@ interface Vlan131
 | 123 | 10123 | - |
 | 124 | 10124 | - |
 | 130 | 10130 | - |
-| 131 | 10131 | - |
 
 #### VRF to VNI Mappings
 
@@ -503,7 +502,6 @@ interface Vxlan1
    vxlan vlan 123 vni 10123
    vxlan vlan 124 vni 10124
    vxlan vlan 130 vni 10130
-   vxlan vlan 131 vni 10131
    vxlan vrf Tenant_A_APP_Zone vni 12
    vxlan vrf Tenant_A_WEB_Zone vni 11
 ```
@@ -638,7 +636,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | VLAN Aware Bundle | Route-Distinguisher | Both Route-Target | Import Route Target | Export Route-Target | Redistribute | VLANs |
 | ----------------- | ------------------- | ----------------- | ------------------- | ------------------- | ------------ | ----- |
-| Tenant_A_APP_Zone | 192.168.255.9:12 | 12:12 | - | - | learned | 130-131 |
+| Tenant_A_APP_Zone | 192.168.255.9:12 | 12:12 | - | - | learned | 130 |
 | Tenant_A_WEB_Zone | 192.168.255.9:11 | 11:11 | - | - | learned | 120-124 |
 
 #### Router BGP EVPN VRFs
@@ -698,7 +696,7 @@ router bgp 65101
       rd 192.168.255.9:12
       route-target both 12:12
       redistribute learned
-      vlan 130-131
+      vlan 130
    !
    vlan-aware-bundle Tenant_A_WEB_Zone
       rd 192.168.255.9:11

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -733,7 +733,6 @@ interface Vlan311
 | 123 | 10123 | - |
 | 124 | 10124 | - |
 | 130 | 10130 | - |
-| 131 | 10131 | - |
 | 140 | 10140 | - |
 | 141 | 10141 | - |
 | 160 | 10160 | - |
@@ -771,7 +770,6 @@ interface Vxlan1
    vxlan vlan 123 vni 10123
    vxlan vlan 124 vni 10124
    vxlan vlan 130 vni 10130
-   vxlan vlan 131 vni 10131
    vxlan vlan 140 vni 10140
    vxlan vlan 141 vni 10141
    vxlan vlan 160 vni 10160
@@ -931,7 +929,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | VLAN Aware Bundle | Route-Distinguisher | Both Route-Target | Import Route Target | Export Route-Target | Redistribute | VLANs |
 | ----------------- | ------------------- | ----------------- | ------------------- | ------------------- | ------------ | ----- |
-| Tenant_A_APP_Zone | 192.168.255.10:12 | 12:12 | - | - | learned | 130-131 |
+| Tenant_A_APP_Zone | 192.168.255.10:12 | 12:12 | - | - | learned | 130 |
 | Tenant_A_DB_Zone | 192.168.255.10:13 | 13:13 | - | - | learned | 140-141 |
 | Tenant_A_FTP | 192.168.255.10:10162 | 10162:10162 | - | - | learned | 162 |
 | Tenant_A_NFS | 192.168.255.10:10161 | 10161:10161 | - | - | learned | 161 |
@@ -1002,7 +1000,7 @@ router bgp 65102
       rd 192.168.255.10:12
       route-target both 12:12
       redistribute learned
-      vlan 130-131
+      vlan 130
    !
    vlan-aware-bundle Tenant_A_DB_Zone
       rd 192.168.255.10:13

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -733,7 +733,6 @@ interface Vlan311
 | 123 | 10123 | - |
 | 124 | 10124 | - |
 | 130 | 10130 | - |
-| 131 | 10131 | - |
 | 140 | 10140 | - |
 | 141 | 10141 | - |
 | 160 | 10160 | - |
@@ -771,7 +770,6 @@ interface Vxlan1
    vxlan vlan 123 vni 10123
    vxlan vlan 124 vni 10124
    vxlan vlan 130 vni 10130
-   vxlan vlan 131 vni 10131
    vxlan vlan 140 vni 10140
    vxlan vlan 141 vni 10141
    vxlan vlan 160 vni 10160
@@ -931,7 +929,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | VLAN Aware Bundle | Route-Distinguisher | Both Route-Target | Import Route Target | Export Route-Target | Redistribute | VLANs |
 | ----------------- | ------------------- | ----------------- | ------------------- | ------------------- | ------------ | ----- |
-| Tenant_A_APP_Zone | 192.168.255.11:12 | 12:12 | - | - | learned | 130-131 |
+| Tenant_A_APP_Zone | 192.168.255.11:12 | 12:12 | - | - | learned | 130 |
 | Tenant_A_DB_Zone | 192.168.255.11:13 | 13:13 | - | - | learned | 140-141 |
 | Tenant_A_FTP | 192.168.255.11:10162 | 10162:10162 | - | - | learned | 162 |
 | Tenant_A_NFS | 192.168.255.11:10161 | 10161:10161 | - | - | learned | 161 |
@@ -1002,7 +1000,7 @@ router bgp 65102
       rd 192.168.255.11:12
       route-target both 12:12
       redistribute learned
-      vlan 130-131
+      vlan 130
    !
    vlan-aware-bundle Tenant_A_DB_Zone
       rd 192.168.255.11:13

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -1041,7 +1041,6 @@ interface Vlan4092
 | 123 | 10123 | - |
 | 124 | 10124 | - |
 | 130 | 10130 | - |
-| 131 | 10131 | - |
 | 140 | 10140 | - |
 | 141 | 10141 | - |
 | 150 | 10150 | - |
@@ -1053,7 +1052,6 @@ interface Vlan4092
 | 250 | 20250 | - |
 | 310 | 30310 | - |
 | 311 | 30311 | - |
-| 350 | 30350 | - |
 
 #### VRF to VNI Mappings
 
@@ -1086,7 +1084,6 @@ interface Vxlan1
    vxlan vlan 123 vni 10123
    vxlan vlan 124 vni 10124
    vxlan vlan 130 vni 10130
-   vxlan vlan 131 vni 10131
    vxlan vlan 140 vni 10140
    vxlan vlan 141 vni 10141
    vxlan vlan 150 vni 10150
@@ -1098,7 +1095,6 @@ interface Vxlan1
    vxlan vlan 250 vni 20250
    vxlan vlan 310 vni 30310
    vxlan vlan 311 vni 30311
-   vxlan vlan 350 vni 30350
    vxlan vrf Tenant_A_APP_Zone vni 12
    vxlan vrf Tenant_A_DB_Zone vni 13
    vxlan vrf Tenant_A_OP_Zone vni 10
@@ -1283,7 +1279,7 @@ ip route vrf Tenant_A_WAN_Zone 10.3.5.0/24 Null0
 
 | VLAN Aware Bundle | Route-Distinguisher | Both Route-Target | Import Route Target | Export Route-Target | Redistribute | VLANs |
 | ----------------- | ------------------- | ----------------- | ------------------- | ------------------- | ------------ | ----- |
-| Tenant_A_APP_Zone | 192.168.255.12:12 | 12:12 | - | - | learned | 130-131 |
+| Tenant_A_APP_Zone | 192.168.255.12:12 | 12:12 | - | - | learned | 130 |
 | Tenant_A_DB_Zone | 192.168.255.12:13 | 13:13 | - | - | learned | 140-141 |
 | Tenant_A_FTP | 192.168.255.12:10162 | 10162:10162 | - | - | learned | 162 |
 | Tenant_A_NFS | 192.168.255.12:10161 | 10161:10161 | - | - | learned | 161 |
@@ -1294,7 +1290,6 @@ ip route vrf Tenant_A_WAN_Zone 10.3.5.0/24 Null0
 | Tenant_B_OP_Zone | 192.168.255.12:20 | 20:20 | - | - | learned | 210-211 |
 | Tenant_B_WAN_Zone | 192.168.255.12:21 | 21:21 | - | - | learned | 250 |
 | Tenant_C_OP_Zone | 192.168.255.12:30030 | 30030:30030 | - | - | learned | 310-311 |
-| Tenant_C_WAN_Zone | 192.168.255.12:30031 | 30031:30031 | - | - | learned | 350 |
 
 #### Router BGP EVPN VRFs
 
@@ -1369,7 +1364,7 @@ router bgp 65103
       rd 192.168.255.12:12
       route-target both 12:12
       redistribute learned
-      vlan 130-131
+      vlan 130
    !
    vlan-aware-bundle Tenant_A_DB_Zone
       rd 192.168.255.12:13
@@ -1430,12 +1425,6 @@ router bgp 65103
       route-target both 30030:30030
       redistribute learned
       vlan 310-311
-   !
-   vlan-aware-bundle Tenant_C_WAN_Zone
-      rd 192.168.255.12:30031
-      route-target both 30031:30031
-      redistribute learned
-      vlan 350
    !
    address-family evpn
       no host-flap detection

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -1041,7 +1041,6 @@ interface Vlan4092
 | 123 | 10123 | - |
 | 124 | 10124 | - |
 | 130 | 10130 | - |
-| 131 | 10131 | - |
 | 140 | 10140 | - |
 | 141 | 10141 | - |
 | 150 | 10150 | - |
@@ -1053,7 +1052,6 @@ interface Vlan4092
 | 250 | 20250 | - |
 | 310 | 30310 | - |
 | 311 | 30311 | - |
-| 350 | 30350 | - |
 
 #### VRF to VNI Mappings
 
@@ -1086,7 +1084,6 @@ interface Vxlan1
    vxlan vlan 123 vni 10123
    vxlan vlan 124 vni 10124
    vxlan vlan 130 vni 10130
-   vxlan vlan 131 vni 10131
    vxlan vlan 140 vni 10140
    vxlan vlan 141 vni 10141
    vxlan vlan 150 vni 10150
@@ -1098,7 +1095,6 @@ interface Vxlan1
    vxlan vlan 250 vni 20250
    vxlan vlan 310 vni 30310
    vxlan vlan 311 vni 30311
-   vxlan vlan 350 vni 30350
    vxlan vrf Tenant_A_APP_Zone vni 12
    vxlan vrf Tenant_A_DB_Zone vni 13
    vxlan vrf Tenant_A_OP_Zone vni 10
@@ -1283,7 +1279,7 @@ ip route vrf Tenant_A_WAN_Zone 10.3.5.0/24 Null0
 
 | VLAN Aware Bundle | Route-Distinguisher | Both Route-Target | Import Route Target | Export Route-Target | Redistribute | VLANs |
 | ----------------- | ------------------- | ----------------- | ------------------- | ------------------- | ------------ | ----- |
-| Tenant_A_APP_Zone | 192.168.255.13:12 | 12:12 | - | - | learned | 130-131 |
+| Tenant_A_APP_Zone | 192.168.255.13:12 | 12:12 | - | - | learned | 130 |
 | Tenant_A_DB_Zone | 192.168.255.13:13 | 13:13 | - | - | learned | 140-141 |
 | Tenant_A_FTP | 192.168.255.13:10162 | 10162:10162 | - | - | learned | 162 |
 | Tenant_A_NFS | 192.168.255.13:10161 | 10161:10161 | - | - | learned | 161 |
@@ -1294,7 +1290,6 @@ ip route vrf Tenant_A_WAN_Zone 10.3.5.0/24 Null0
 | Tenant_B_OP_Zone | 192.168.255.13:20 | 20:20 | - | - | learned | 210-211 |
 | Tenant_B_WAN_Zone | 192.168.255.13:21 | 21:21 | - | - | learned | 250 |
 | Tenant_C_OP_Zone | 192.168.255.13:30030 | 30030:30030 | - | - | learned | 310-311 |
-| Tenant_C_WAN_Zone | 192.168.255.13:30031 | 30031:30031 | - | - | learned | 350 |
 
 #### Router BGP EVPN VRFs
 
@@ -1369,7 +1364,7 @@ router bgp 65103
       rd 192.168.255.13:12
       route-target both 12:12
       redistribute learned
-      vlan 130-131
+      vlan 130
    !
    vlan-aware-bundle Tenant_A_DB_Zone
       rd 192.168.255.13:13
@@ -1430,12 +1425,6 @@ router bgp 65103
       route-target both 30030:30030
       redistribute learned
       vlan 310-311
-   !
-   vlan-aware-bundle Tenant_C_WAN_Zone
-      rd 192.168.255.13:30031
-      route-target both 30031:30031
-      redistribute learned
-      vlan 350
    !
    address-family evpn
       no host-flap detection

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1A.cfg
@@ -183,7 +183,6 @@ interface Vxlan1
    vxlan udp-port 4789
    vxlan vlan 150 vni 10150
    vxlan vlan 250 vni 20250
-   vxlan vlan 350 vni 30350
    vxlan vrf Tenant_A_WAN_Zone vni 14
    vxlan vrf Tenant_B_OP_Zone vni 20
    vxlan vrf Tenant_B_WAN_Zone vni 21
@@ -278,12 +277,6 @@ router bgp 65104
       route-target both 21:21
       redistribute learned
       vlan 250
-   !
-   vlan-aware-bundle Tenant_C_WAN_Zone
-      rd 192.168.255.14:30031
-      route-target both 30031:30031
-      redistribute learned
-      vlan 350
    !
    address-family evpn
       no host-flap detection

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1B.cfg
@@ -182,7 +182,6 @@ interface Vxlan1
    vxlan udp-port 4789
    vxlan vlan 150 vni 10150
    vxlan vlan 250 vni 20250
-   vxlan vlan 350 vni 30350
    vxlan vrf Tenant_A_WAN_Zone vni 14
    vxlan vrf Tenant_B_OP_Zone vni 20
    vxlan vrf Tenant_B_WAN_Zone vni 21
@@ -277,12 +276,6 @@ router bgp 65105
       route-target both 21:21
       redistribute learned
       vlan 250
-   !
-   vlan-aware-bundle Tenant_C_WAN_Zone
-      rd 192.168.255.15:30031
-      route-target both 30031:30031
-      redistribute learned
-      vlan 350
    !
    address-family evpn
       no host-flap detection

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
@@ -183,7 +183,6 @@ interface Vxlan1
    vxlan vlan 123 vni 10123
    vxlan vlan 124 vni 10124
    vxlan vlan 130 vni 10130
-   vxlan vlan 131 vni 10131
    vxlan vrf Tenant_A_APP_Zone vni 12
    vxlan vrf Tenant_A_WEB_Zone vni 11
 !
@@ -251,7 +250,7 @@ router bgp 65101
       rd 192.168.255.9:12
       route-target both 12:12
       redistribute learned
-      vlan 130-131
+      vlan 130
    !
    vlan-aware-bundle Tenant_A_WEB_Zone
       rd 192.168.255.9:11

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
@@ -374,7 +374,6 @@ interface Vxlan1
    vxlan vlan 123 vni 10123
    vxlan vlan 124 vni 10124
    vxlan vlan 130 vni 10130
-   vxlan vlan 131 vni 10131
    vxlan vlan 140 vni 10140
    vxlan vlan 141 vni 10141
    vxlan vlan 160 vni 10160
@@ -465,7 +464,7 @@ router bgp 65102
       rd 192.168.255.10:12
       route-target both 12:12
       redistribute learned
-      vlan 130-131
+      vlan 130
    !
    vlan-aware-bundle Tenant_A_DB_Zone
       rd 192.168.255.10:13

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
@@ -374,7 +374,6 @@ interface Vxlan1
    vxlan vlan 123 vni 10123
    vxlan vlan 124 vni 10124
    vxlan vlan 130 vni 10130
-   vxlan vlan 131 vni 10131
    vxlan vlan 140 vni 10140
    vxlan vlan 141 vni 10141
    vxlan vlan 160 vni 10160
@@ -465,7 +464,7 @@ router bgp 65102
       rd 192.168.255.11:12
       route-target both 12:12
       redistribute learned
-      vlan 130-131
+      vlan 130
    !
    vlan-aware-bundle Tenant_A_DB_Zone
       rd 192.168.255.11:13

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
@@ -623,7 +623,6 @@ interface Vxlan1
    vxlan vlan 123 vni 10123
    vxlan vlan 124 vni 10124
    vxlan vlan 130 vni 10130
-   vxlan vlan 131 vni 10131
    vxlan vlan 140 vni 10140
    vxlan vlan 141 vni 10141
    vxlan vlan 150 vni 10150
@@ -635,7 +634,6 @@ interface Vxlan1
    vxlan vlan 250 vni 20250
    vxlan vlan 310 vni 30310
    vxlan vlan 311 vni 30311
-   vxlan vlan 350 vni 30350
    vxlan vrf Tenant_A_APP_Zone vni 12
    vxlan vrf Tenant_A_DB_Zone vni 13
    vxlan vrf Tenant_A_OP_Zone vni 10
@@ -742,7 +740,7 @@ router bgp 65103
       rd 192.168.255.12:12
       route-target both 12:12
       redistribute learned
-      vlan 130-131
+      vlan 130
    !
    vlan-aware-bundle Tenant_A_DB_Zone
       rd 192.168.255.12:13
@@ -803,12 +801,6 @@ router bgp 65103
       route-target both 30030:30030
       redistribute learned
       vlan 310-311
-   !
-   vlan-aware-bundle Tenant_C_WAN_Zone
-      rd 192.168.255.12:30031
-      route-target both 30031:30031
-      redistribute learned
-      vlan 350
    !
    address-family evpn
       no host-flap detection

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
@@ -623,7 +623,6 @@ interface Vxlan1
    vxlan vlan 123 vni 10123
    vxlan vlan 124 vni 10124
    vxlan vlan 130 vni 10130
-   vxlan vlan 131 vni 10131
    vxlan vlan 140 vni 10140
    vxlan vlan 141 vni 10141
    vxlan vlan 150 vni 10150
@@ -635,7 +634,6 @@ interface Vxlan1
    vxlan vlan 250 vni 20250
    vxlan vlan 310 vni 30310
    vxlan vlan 311 vni 30311
-   vxlan vlan 350 vni 30350
    vxlan vrf Tenant_A_APP_Zone vni 12
    vxlan vrf Tenant_A_DB_Zone vni 13
    vxlan vrf Tenant_A_OP_Zone vni 10
@@ -742,7 +740,7 @@ router bgp 65103
       rd 192.168.255.13:12
       route-target both 12:12
       redistribute learned
-      vlan 130-131
+      vlan 130
    !
    vlan-aware-bundle Tenant_A_DB_Zone
       rd 192.168.255.13:13
@@ -803,12 +801,6 @@ router bgp 65103
       route-target both 30030:30030
       redistribute learned
       vlan 310-311
-   !
-   vlan-aware-bundle Tenant_C_WAN_Zone
-      rd 192.168.255.13:30031
-      route-target both 30031:30031
-      redistribute learned
-      vlan 350
    !
    address-family evpn
       no host-flap detection

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
@@ -201,14 +201,6 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: 250
-    Tenant_C_WAN_Zone:
-      rd: 192.168.255.14:30031
-      route_targets:
-        both:
-        - 30031:30031
-      redistribute_routes:
-      - learned
-      vlan: 350
 static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0
@@ -482,8 +474,6 @@ vxlan_interface:
           vni: 10150
         250:
           vni: 20250
-        350:
-          vni: 30350
       vrfs:
         Tenant_A_WAN_Zone:
           vni: 14

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
@@ -201,14 +201,6 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: 250
-    Tenant_C_WAN_Zone:
-      rd: 192.168.255.15:30031
-      route_targets:
-        both:
-        - 30031:30031
-      redistribute_routes:
-      - learned
-      vlan: 350
 static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0
@@ -481,8 +473,6 @@ vxlan_interface:
           vni: 10150
         250:
           vni: 20250
-        350:
-          vni: 30350
       vrfs:
         Tenant_A_WAN_Zone:
           vni: 14

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
@@ -102,7 +102,7 @@ router_bgp:
         - '12:12'
       redistribute_routes:
       - learned
-      vlan: 130-131
+      vlan: 130
     Tenant_A_WEB_Zone:
       rd: 192.168.255.9:11
       route_targets:
@@ -320,8 +320,6 @@ vxlan_interface:
       vlans:
         130:
           vni: 10130
-        131:
-          vni: 10131
         120:
           vni: 10120
         121:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -150,7 +150,7 @@ router_bgp:
         - '12:12'
       redistribute_routes:
       - learned
-      vlan: 130-131
+      vlan: 130
     Tenant_A_DB_Zone:
       rd: 192.168.255.10:13
       route_targets:
@@ -614,8 +614,6 @@ vxlan_interface:
       vlans:
         130:
           vni: 10130
-        131:
-          vni: 10131
         140:
           vni: 10140
         141:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -150,7 +150,7 @@ router_bgp:
         - '12:12'
       redistribute_routes:
       - learned
-      vlan: 130-131
+      vlan: 130
     Tenant_A_DB_Zone:
       rd: 192.168.255.11:13
       route_targets:
@@ -614,8 +614,6 @@ vxlan_interface:
       vlans:
         130:
           vni: 10130
-        131:
-          vni: 10131
         140:
           vni: 10140
         141:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -229,7 +229,7 @@ router_bgp:
         - '12:12'
       redistribute_routes:
       - learned
-      vlan: 130-131
+      vlan: 130
     Tenant_A_DB_Zone:
       rd: 192.168.255.12:13
       route_targets:
@@ -313,14 +313,6 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: 310-311
-    Tenant_C_WAN_Zone:
-      rd: 192.168.255.12:30031
-      route_targets:
-        both:
-        - 30031:30031
-      redistribute_routes:
-      - learned
-      vlan: 350
 static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0
@@ -1337,8 +1329,6 @@ vxlan_interface:
       vlans:
         130:
           vni: 10130
-        131:
-          vni: 10131
         140:
           vni: 10140
         141:
@@ -1375,8 +1365,6 @@ vxlan_interface:
           vni: 30310
         311:
           vni: 30311
-        350:
-          vni: 30350
       vrfs:
         Tenant_A_APP_Zone:
           vni: 12

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -229,7 +229,7 @@ router_bgp:
         - '12:12'
       redistribute_routes:
       - learned
-      vlan: 130-131
+      vlan: 130
     Tenant_A_DB_Zone:
       rd: 192.168.255.13:13
       route_targets:
@@ -313,14 +313,6 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: 310-311
-    Tenant_C_WAN_Zone:
-      rd: 192.168.255.13:30031
-      route_targets:
-        both:
-        - 30031:30031
-      redistribute_routes:
-      - learned
-      vlan: 350
 static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0
@@ -1337,8 +1329,6 @@ vxlan_interface:
       vlans:
         130:
           vni: 10130
-        131:
-          vni: 10131
         140:
           vni: 10140
         141:
@@ -1375,8 +1365,6 @@ vxlan_interface:
           vni: 30310
         311:
           vni: 30311
-        350:
-          vni: 30350
       vrfs:
         Tenant_A_APP_Zone:
           vni: 12

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_TENANTS_NETWORKS.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_TENANTS_NETWORKS.yml
@@ -108,6 +108,7 @@ tenants:
             tags: ['app']
             enabled: True
             ip_address_virtual: 10.1.31.1/24
+            vxlan: false
       Tenant_A_DB_Zone:
         vrf_vni: 13
         svis:
@@ -304,3 +305,4 @@ tenants:
             tags: ['wan']
             enabled: True
             ip_address_virtual: 10.3.50.1/24
+            vxlan: False

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/network-services.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/network-services.md
@@ -164,6 +164,10 @@ tenants:
                 source_interface: < interface-name >
                 source_vrf: < VRF to originate DHCP relay packets to DHCP server. If not set, uses current VRF >
 
+            # VXLAN | Optional - default true
+            # Extend this SVI over VXLAN
+            vxlan: < true | false | default -> true >
+
             # Define node specific configuration, such as unique IP addresses.
             nodes:
               < l3_leaf_inventory_hostname_1 >:
@@ -321,6 +325,10 @@ tenants:
 
         # Tags leveraged for networks services filtering.
         tags: [ < tag_1 >, < tag_2 > ]
+
+        # VXLAN | Optional - default true
+        # Extend this L2VLAN over VXLAN
+        vxlan: < true | false | default -> true >
 
       < 1-4096 >:
         name: < description >

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenants/router-bgp-vlan-aware-bundles.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenants/router-bgp-vlan-aware-bundles.j2
@@ -4,6 +4,16 @@
 {%     for tenant in switch.tenants | arista.avd.natural_sort %}
 {%         for vrf in switch.tenants[tenant].vrfs | arista.avd.natural_sort %}
 {%             if switch.tenants[tenant].vrfs[vrf].svis | arista.avd.default([]) | length > 0 %}
+{%                 set svi_int_list = [] %}
+{%                 for svi in switch.tenants[tenant].vrfs[vrf].svis %}
+{%                     if tenants[tenant].vrfs[vrf].svis[svi].vxlan is arista.avd.defined(false) %}
+{%                         continue %}
+{%                     endif %}
+{%                     do svi_int_list.append(svi | int) %}
+{%                 endfor %}
+{%                 if svi_int_list | length == 0 %}
+{%                     continue %}
+{%                 endif %}
 {%                 set vrf_vni_int = tenants[tenant].vrfs[vrf].vrf_vni | int %}
 {%                 set bundle_number =  vrf_vni_int + tenants[tenant].vlan_aware_bundle_number_base | arista.avd.default(0) %}
     {{ vrf }}:
@@ -13,10 +23,13 @@
           - "{{ tenants_data.evpn_rt_admin_subfield or bundle_number }}:{{ bundle_number }}"
       redistribute_routes:
         - learned
-      vlan: {{ switch.tenants[tenant].vrfs[vrf].svis | map('int') | arista.avd.list_compress }}
+      vlan: {{ svi_int_list | map('int') | arista.avd.list_compress }}
 {%             endif %}
 {%         endfor %}
 {%         for l2vlan in switch.tenants[tenant].l2vlans | arista.avd.natural_sort %}
+{%             if tenants[tenant].l2vlans[l2vlan].vxlan is arista.avd.defined(false) %}
+{%                 continue %}
+{%             endif %}
 {%             set l2vlan_int = l2vlan | int %}
 {%             set vni = tenants[tenant].l2vlans[l2vlan].vni_override | arista.avd.default(
                          tenants[tenant].mac_vrf_vni_base + l2vlan_int) %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenants/router-bgp-vlans.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenants/router-bgp-vlans.j2
@@ -4,6 +4,9 @@
 {%     for tenant in switch.tenants | arista.avd.natural_sort %}
 {%         for vrf in switch.tenants[tenant].vrfs | arista.avd.natural_sort %}
 {%             for svi in switch.tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort %}
+{%                 if tenants[tenant].vrfs[vrf].svis[svi].vxlan is arista.avd.defined(false) %}
+{%                     continue %}
+{%                 endif %}
 {%                 set svi_int = svi | int %}
 {%                 set vni = tenants[tenant].vrfs[vrf].svis[svi].vni_override | arista.avd.default(
                              tenants[tenant].mac_vrf_vni_base + svi_int) %}
@@ -18,6 +21,9 @@
 {%             endfor %}
 {%         endfor %}
 {%         for l2vlan in switch.tenants[tenant].l2vlans | arista.avd.natural_sort %}
+{%             if tenants[tenant].l2vlans[l2vlan].vxlan is arista.avd.defined(false) %}
+{%                 continue %}
+{%             endif %}
 {%             set l2vlan_int = l2vlan | int %}
 {%             set vni = tenants[tenant].l2vlans[l2vlan].vni_override | arista.avd.default(
                          tenants[tenant].mac_vrf_vni_base + l2vlan_int) %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenants/vxlan-interface.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenants/vxlan-interface.j2
@@ -12,13 +12,19 @@ vxlan_interface:
 {% for tenant in switch.tenants | arista.avd.natural_sort %}
 {%     for vrf in switch.tenants[tenant].vrfs | arista.avd.natural_sort %}
 {%         for svi in switch.tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort %}
+{%             if tenants[tenant].vrfs[vrf].svis[svi].vxlan is arista.avd.defined(false) %}
+{%                 continue %}
+{%             endif %}
 {%             set svi_int = svi | int %}
         {{ svi_int }}:
           vni: {{ tenants[tenant].vrfs[vrf].svis[svi].vni_override | arista.avd.default(
                   tenants[tenant].mac_vrf_vni_base + svi_int) }}
 {%         endfor %}
 {%     endfor %}
-{%     for l2vlan in switch.tenants[tenant].l2vlans | arista.avd.natural_sort %}
+{%     for l2vlan in switch.tenants[tenant].l2vlans | arista.avd.natural_sort | rejectattr('vxlan','false') %}
+{%         if tenants[tenant].l2vlans[l2vlan].vxlan is arista.avd.defined(false) %}
+{%             continue %}
+{%         endif %}
 {%         set l2vlan_int = l2vlan | int %}
         {{ l2vlan_int }}:
           vni: {{ tenants[tenant].l2vlans[l2vlan].vni_override | arista.avd.default(

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenants/vxlan-interface.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/tenants/vxlan-interface.j2
@@ -21,7 +21,7 @@ vxlan_interface:
                   tenants[tenant].mac_vrf_vni_base + svi_int) }}
 {%         endfor %}
 {%     endfor %}
-{%     for l2vlan in switch.tenants[tenant].l2vlans | arista.avd.natural_sort | rejectattr('vxlan','false') %}
+{%     for l2vlan in switch.tenants[tenant].l2vlans | arista.avd.natural_sort %}
 {%         if tenants[tenant].l2vlans[l2vlan].vxlan is arista.avd.defined(false) %}
 {%             continue %}
 {%         endif %}


### PR DESCRIPTION
## Change Summary
Add support for vxlan:False on svis and l2vlans
<!-- Enter short PR description -->

## Related Issue(s)

Fixes #967 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->
```
tenants:
  < tenants >:
    vrfs:
      < vrf >:
        svis:
          < 1-4096 >:
            # VXLAN | Optional - default true
            # Extend this SVI over VXLAN
            vxlan: < true | false | default -> true >

    l2vlans:
      < 1-4096 >:
        # VXLAN | Optional - default true
        # Extend this VLAN over VXLAN
        vxlan: < true | false | default -> true >
```
## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Added molecule coverage for
- [x] SVI with vxlan bundles
- [x] L2VLAN with vxlan bundles
- [x] SVI without vxlan bundles
- [x] L2VLAN without vxlan bundles

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
