### PR TITLE
Make: Deactivate minify as workaround for Read the Doc

### DIFF
--- a/ansible_collections/arista/avd/docs/requirements.txt
+++ b/ansible_collections/arista/avd/docs/requirements.txt
@@ -7,4 +7,3 @@ pymdown-extensions
 mdx_truly_sane_lists
 mkdocs-git-revision-date-localized-plugin
 mkdocs-git-revision-date-plugin
-mkdocs-minify-plugin

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,8 +56,10 @@ plugins:
       lang: en
   - git-revision-date-localized:
       type: date
-  - minify:
-      minify_html: true
+  # Deactivated due to https://github.com/tikitu/jsmin/issues/33
+  # Issue in progress: https://github.com/byrnereese/mkdocs-minify-plugin/issues/15
+  # - minify:
+  #     minify_html: true
   #     minify_js: true
 
 markdown_extensions:


### PR DESCRIPTION
## Change Summary

Current RTD build is broken as a dependency of `mkdocs-minify-plugin` is not compatible with latest `setup_tools`. 
This PR deactivate minify until issue is fixed on either [`jsmin`](https://github.com/tikitu/jsmin/issues/33) or [`mkdocs-minify-plugin`](https://github.com/byrnereese/mkdocs-minify-plugin/issues/15)

## Related Issue(s)

N/A

## Component(s) name

mkdocs

## How to test

A temporary build on RTD should be valid

![image](https://user-images.githubusercontent.com/4608573/133592144-f36e3df5-e2a9-4272-8228-29fd91b9cb45.png)

Result is available [here](https://ansible-avd-fork.readthedocs.io/en/doc-mkdoc-rtd-minify-fix/)

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- [x] Test build on Read the Docs

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
