### PR TITLE
Feat(eos_designs): interface storm-control feature can be set per platform

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_designs/defaults/main/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/defaults/main/main.yml
@@ -88,7 +88,6 @@ platform_settings:
       non_mlag: 330
     feature_support:
       queue_monitor_length_notify: false
-      interface_storm_control: false
   - platforms: [ 7280R, 7280R2, 7500R, 7500R2 ]
     tcam_profile: vxlan-routing
     lag_hardware_only: true

--- a/ansible_collections/arista/avd/roles/eos_designs/defaults/main/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/defaults/main/main.yml
@@ -88,6 +88,7 @@ platform_settings:
       non_mlag: 330
     feature_support:
       queue_monitor_length_notify: false
+      interface_storm_control: false
   - platforms: [ 7280R, 7280R2, 7500R, 7500R2 ]
     tcam_profile: vxlan-routing
     lag_hardware_only: true

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/common-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/common-settings.md
@@ -213,6 +213,7 @@ platform_settings:
     lag_hardware_only: < true | false >
     feature_support:
       queue_monitor_length_notify: < true | false | default -> true >
+      interface_storm_control: < true | false | default -> true >
     reload_delay:
       mlag: < seconds >
       non_mlag: < seconds >
@@ -233,6 +234,7 @@ platform_settings:
       non_mlag: 330
     feature_support:
       queue_monitor_length_notify: false
+      interface_storm_control: false
   - platforms: [ 7280R, 7280R2, 7500R, 7500R2 ]
     tcam_profile: vxlan-routing
     lag_hardware_only: true

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/ethernet-interfaces.j2
@@ -1,7 +1,5 @@
 {# Leaf connected_endpoint interfaces #}
 ethernet_interfaces:
-{# This must be assigned outside the loop as switch is overridden in the loop sinner scope and can no longer be referenced #}
-{% set support_storm_control = switch.platform_settings.feature_support.interface_storm_control is not arista.avd.defined(false) %}
 {% for endpoint_key in connected_endpoints | arista.avd.natural_sort %}
 {%     for connected_endpoint in connected_endpoints[endpoint_key] | arista.avd.natural_sort %}
 {%         for adapter in connected_endpoints[endpoint_key][connected_endpoint].adapters | arista.avd.natural_sort %}
@@ -101,7 +99,7 @@ ethernet_interfaces:
 {%                     if adapter_spanning_tree_bpduguard is arista.avd.defined %}
     spanning_tree_bpduguard: {{ adapter_spanning_tree_bpduguard }}
 {%                     endif %}
-{%                     if adapter_storm_control is arista.avd.defined and support_storm_control is arista.avd.defined(true) %}
+{%                     if adapter_storm_control is arista.avd.defined and switch.platform_settings.feature_support.interface_storm_control is not arista.avd.defined(false) %}
     storm_control:
 {%                         for section in adapter_storm_control %}
       {{ section }}:

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/ethernet-interfaces.j2
@@ -1,5 +1,7 @@
 {# Leaf connected_endpoint interfaces #}
 ethernet_interfaces:
+{# This must be assigned outside the loop as switch is overridden in the loop sinner scope and can no longer be referenced #}
+{% set support_storm_control = switch.platform_settings.feature_support.interface_storm_control is not arista.avd.defined(false) %}
 {% for endpoint_key in connected_endpoints | arista.avd.natural_sort %}
 {%     for connected_endpoint in connected_endpoints[endpoint_key] | arista.avd.natural_sort %}
 {%         for adapter in connected_endpoints[endpoint_key][connected_endpoint].adapters | arista.avd.natural_sort %}
@@ -99,7 +101,7 @@ ethernet_interfaces:
 {%                     if adapter_spanning_tree_bpduguard is arista.avd.defined %}
     spanning_tree_bpduguard: {{ adapter_spanning_tree_bpduguard }}
 {%                     endif %}
-{%                     if adapter_storm_control is arista.avd.defined %}
+{%                     if adapter_storm_control is arista.avd.defined and support_storm_control is arista.avd.defined(true) %}
     storm_control:
 {%                         for section in adapter_storm_control %}
       {{ section }}:

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/port-channel-interfaces.j2
@@ -1,7 +1,5 @@
 {# Leaf server port-channels #}
 port_channel_interfaces:
-{# This must be assigned outside the loop as switch is overridden in the loop sinner scope and can no longer be referenced #}
-{% set support_storm_control = switch.platform_settings.feature_support.interface_storm_control is not arista.avd.defined(false) %}
 {% for endpoint_key in connected_endpoints | arista.avd.natural_sort %}
 {%     for connected_endpoint in connected_endpoints[endpoint_key] | arista.avd.natural_sort %}
 {%         for adapter in connected_endpoints[endpoint_key][connected_endpoint].adapters | arista.avd.natural_sort %}
@@ -93,7 +91,7 @@ port_channel_interfaces:
 {%                         if adapter_spanning_tree_bpduguard is arista.avd.defined %}
     spanning_tree_bpduguard: {{ adapter_spanning_tree_bpduguard }}
 {%                         endif %}
-{%                         if adapter_storm_control is arista.avd.defined and support_storm_control is arista.avd.defined(true) %}
+{%                         if adapter_storm_control is arista.avd.defined and switch.platform_settings.feature_support.interface_storm_control is not arista.avd.defined(false) %}
     storm_control:
 {%                             for section in adapter_storm_control %}
       {{ section }}:

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/port-channel-interfaces.j2
@@ -1,5 +1,7 @@
 {# Leaf server port-channels #}
 port_channel_interfaces:
+{# This must be assigned outside the loop as switch is overridden in the loop sinner scope and can no longer be referenced #}
+{% set support_storm_control = switch.platform_settings.feature_support.interface_storm_control is not arista.avd.defined(false) %}
 {% for endpoint_key in connected_endpoints | arista.avd.natural_sort %}
 {%     for connected_endpoint in connected_endpoints[endpoint_key] | arista.avd.natural_sort %}
 {%         for adapter in connected_endpoints[endpoint_key][connected_endpoint].adapters | arista.avd.natural_sort %}
@@ -91,7 +93,7 @@ port_channel_interfaces:
 {%                         if adapter_spanning_tree_bpduguard is arista.avd.defined %}
     spanning_tree_bpduguard: {{ adapter_spanning_tree_bpduguard }}
 {%                         endif %}
-{%                         if adapter_storm_control is arista.avd.defined %}
+{%                         if adapter_storm_control is arista.avd.defined and support_storm_control is arista.avd.defined(true) %}
     storm_control:
 {%                             for section in adapter_storm_control %}
       {{ section }}:


### PR DESCRIPTION
## Change Summary
vEOS-LAB platform does not support storm-control configuration as of EOS 4.26 - remove the feature from the rendered configuration.

<!-- Enter short PR description -->

## Related Issue(s)

Fixes #1194

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

Use same approach as for `queue_monitor_length_notify` to disable the feature on the "default" platform
```
platform_settings:
  - platforms: [ < Arista Platform Family >, < Arista Platform Family > ]
    feature_support:
      interface_storm_control: < true | false | default -> true >
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Use a port profile that enables storm-control:

```yaml
port_profiles:
  ##### parent port-profiles to be inherited by device related port-profiles #####
  port_profile_DOT1Q_EDGE:
    mode: trunk
    spanning_tree_bpdufilter: false
    spanning_tree_bpduguard: true
    spanning_tree_portfast: edge
    storm_control:
      broadcast:
        level: 1
        unit: percent
      multicast:
        level: 1
        unit: percent
      unknown-unicast:
        level: 1
        unit: percent
```

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
