### PR TITLE
Doc(eos_cli_config_gen): fix ntp release notes

### DIFF
--- a/ansible_collections/arista/avd/docs/release-notes/3.x.x.md
+++ b/ansible_collections/arista/avd/docs/release-notes/3.x.x.md
@@ -361,7 +361,7 @@ ntp:
     name: < source_interface >
     vrf: < vrf_name >
   servers:
-  - name: < IP | hostname >:
+  - name: < IP | hostname >
     burst: < true | false >
     iburst:  < true | false >
     key: < 1 - 65535 >


### PR DESCRIPTION
## Change Summary

Fixed typo in release note on new data structure for NTP, removed extra ":" for server name

## Related Issue(s)


## Component(s) name

`arista.avd.<role-name>`

## Proposed changes
Update typo on devel branch release notes on new NTP syntax

## How to test
 

## Checklist

### User Checklist
 

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
