### PR TITLE
CI(actions): Update webhook to refresh docker base image

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -352,9 +352,16 @@ jobs:
       - uses: actions/checkout@master
       - name: 'Send Webhook to docker hub'
         env:
-          DOCKER_WEBHOOK: ${{secrets.DOCKER_WEBHOOK}}
+          AUTH_TOKEN: ${{secrets.AVD_BUILDER_TOKEN}}
+          AVD_BASE_DISPATCH: ${{secrets.AVD_BUILDER_WEBHOOK}}
+          AVD_BASE_ACTION: ${{secret.AVD_BASE_ACTION}}
         run: |
-          curl  -H "Content-Type: application/json" --data '{}' -X POST $DOCKER_WEBHOOK
+          curl \
+          -X POST \
+          -H "Accept: application/vnd.github.v3+json" \
+          -H "Authorization: token $AUTH_TOKEN" \
+          https://api.github.com/repos/$AVD_BASE_DISPATCH/dispatches \
+          -d '{"event_type":"refresh"}'
   # ----------------------------------- #
   # Generate an ansible-galaxy package
   # ----------------------------------- #


### PR DESCRIPTION
## Change Summary

Implement Webhook to GH to refresh AVD base image build

## Proposed changes

Redirect WEBHOOK in CI to github [AVD-BASE repo](https://github.com/arista-netdevops-community/docker-avd-base)

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
