### PR TITLE
Feat(eos_cli_config_gen): Add support for ip ssh client source-interface

### DIFF
--- a/ansible_collections/arista/avd/docs/release-notes/3.x.x.md
+++ b/ansible_collections/arista/avd/docs/release-notes/3.x.x.md
@@ -408,6 +408,7 @@ ntp:
 - Add support for setting vxlan flood vtep (#980)
 - Add support for setting multiple secondary virtual IP addresses for vlans (#1180)
 - Add support for Management SSH conection limit and per-host connections (#1200)
+- Add support for ip ssh client source-interface (#1212)
 
 ### Fixed issues
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-ssh-client-source-interface.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-ssh-client-source-interface.md
@@ -53,19 +53,19 @@ interface Management1
 
 | VRF | Source Interface Name |
 | --- | --------------- |
+| default | Ethernet10 |
 | default | Loopback0 |
 | MGMT | Management0 |
-| default | Ethernet10 |
 
 ### IP ssh Client Source Interfaces Device Configuration
 
 ```eos
 !
+ip ssh client source-interface Ethernet10
+!
 ip ssh client source-interface Loopback0 vrf default
 !
 ip ssh client source-interface Management0 vrf MGMT
-!
-ip ssh client source-interface Ethernet10
 ```
 
 # Authentication

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-ssh-client-source-interface.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-ssh-client-source-interface.md
@@ -62,9 +62,7 @@ interface Management1
 ```eos
 !
 ip ssh client source-interface Ethernet10
-!
 ip ssh client source-interface Loopback0 vrf default
-!
 ip ssh client source-interface Management0 vrf MGMT
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-ssh-client-source-interface.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-ssh-client-source-interface.md
@@ -1,0 +1,114 @@
+# ip-ssh-client-source-interface
+# Table of Contents
+<!-- toc -->
+
+- [Management](#management)
+  - [Management Interfaces](#management-interfaces)
+  - [IP ssh Client Source Interfaces](#ip-ssh-client-source-interfaces)
+- [Authentication](#authentication)
+- [Monitoring](#monitoring)
+- [Internal VLAN Allocation Policy](#internal-vlan-allocation-policy)
+  - [Internal VLAN Allocation Policy Summary](#internal-vlan-allocation-policy-summary)
+- [Interfaces](#interfaces)
+- [Routing](#routing)
+  - [IP Routing](#ip-routing)
+  - [IPv6 Routing](#ipv6-routing)
+- [Multicast](#multicast)
+- [Filters](#filters)
+- [ACL](#acl)
+- [Quality Of Service](#quality-of-service)
+
+<!-- toc -->
+# Management
+
+## Management Interfaces
+
+### Management Interfaces Summary
+
+#### IPv4
+
+| Management Interface | description | Type | VRF | IP Address | Gateway |
+| -------------------- | ----------- | ---- | --- | ---------- | ------- |
+| Management1 | oob_management | oob | MGMT | 10.73.255.122/24 | 10.73.255.2 |
+
+#### IPv6
+
+| Management Interface | description | Type | VRF | IPv6 Address | IPv6 Gateway |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ |
+| Management1 | oob_management | oob | MGMT | -  | - |
+
+### Management Interfaces Device Configuration
+
+```eos
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+```
+
+## IP ssh Client Source Interfaces
+
+### IP ssh Client Source Interfaces
+
+| VRF | Source Interface Name |
+| --- | --------------- |
+| default | Loopback0 |
+| MGMT | Management0 |
+| default | Ethernet10 |
+
+### IP ssh Client Source Interfaces Device Configuration
+
+```eos
+!
+ip ssh client source-interface Loopback0 vrf default
+!
+ip ssh client source-interface Management0 vrf MGMT
+!
+ip ssh client source-interface Ethernet10
+```
+
+# Authentication
+
+# Monitoring
+
+# Internal VLAN Allocation Policy
+
+## Internal VLAN Allocation Policy Summary
+
+**Default Allocation Policy**
+
+| Policy Allocation | Range Beginning | Range Ending |
+| ------------------| --------------- | ------------ |
+| ascending | 1006 | 4094 |
+
+# Interfaces
+
+# Routing
+
+## IP Routing
+
+### IP Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | false|
+### IP Routing Device Configuration
+
+```eos
+```
+## IPv6 Routing
+
+### IPv6 Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | false |
+
+# Multicast
+
+# Filters
+
+# ACL
+
+# Quality Of Service

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-ssh-client-source-interface.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-ssh-client-source-interface.md
@@ -4,7 +4,7 @@
 
 - [Management](#management)
   - [Management Interfaces](#management-interfaces)
-  - [IP ssh Client Source Interfaces](#ip-ssh-client-source-interfaces)
+  - [IP SSH Client Source Interfaces](#ip-ssh-client-source-interfaces)
 - [Authentication](#authentication)
 - [Monitoring](#monitoring)
 - [Internal VLAN Allocation Policy](#internal-vlan-allocation-policy)
@@ -47,9 +47,9 @@ interface Management1
    ip address 10.73.255.122/24
 ```
 
-## IP ssh Client Source Interfaces
+## IP SSH Client Source Interfaces
 
-### IP ssh Client Source Interfaces
+### IP SSH Client Source Interfaces
 
 | VRF | Source Interface Name |
 | --- | --------------- |
@@ -57,7 +57,7 @@ interface Management1
 | default | Loopback0 |
 | MGMT | Management0 |
 
-### IP ssh Client Source Interfaces Device Configuration
+### IP SSH Client Source Interfaces Device Configuration
 
 ```eos
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ip-ssh-client-source-interface.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ip-ssh-client-source-interface.cfg
@@ -13,9 +13,7 @@ interface Management1
    ip address 10.73.255.122/24
 !
 ip ssh client source-interface Ethernet10
-!
 ip ssh client source-interface Loopback0 vrf default
-!
 ip ssh client source-interface Management0 vrf MGMT
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ip-ssh-client-source-interface.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ip-ssh-client-source-interface.cfg
@@ -1,0 +1,21 @@
+!RANCID-CONTENT-TYPE: arista
+!
+transceiver qsfp default-mode 4x10G
+!
+hostname ip-ssh-client-source-interface
+!
+no aaa root
+no enable password
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+!
+ip ssh client source-interface Loopback0 vrf default
+!
+ip ssh client source-interface Management0 vrf MGMT
+!
+ip ssh client source-interface Ethernet10
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ip-ssh-client-source-interface.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ip-ssh-client-source-interface.cfg
@@ -12,10 +12,10 @@ interface Management1
    vrf MGMT
    ip address 10.73.255.122/24
 !
+ip ssh client source-interface Ethernet10
+!
 ip ssh client source-interface Loopback0 vrf default
 !
 ip ssh client source-interface Management0 vrf MGMT
-!
-ip ssh client source-interface Ethernet10
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ip-ssh-client-source-interface.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ip-ssh-client-source-interface.yml
@@ -1,0 +1,9 @@
+### IP SSH Client Source Interface ###
+
+ip_ssh_client_source_interfaces:
+  - vrf : default
+    name: Loopback0
+  - vrf : MGMT
+    name: manaGement0
+  - vrf : 
+    name: Ethernet10

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ip-ssh-client-source-interface.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ip-ssh-client-source-interface.yml
@@ -5,5 +5,4 @@ ip_ssh_client_source_interfaces:
     name: Loopback0
   - vrf : MGMT
     name: manaGement0
-  - vrf : 
-    name: Ethernet10
+  - name: ethernet10

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
@@ -29,6 +29,7 @@ ip-routing
 ip-radius-source-interface
 ip-tacacs-source-interface
 ip-http-client-source-interface
+ip-ssh-client-source-interface
 ipv6-access-lists
 ipv6-static-routes
 lldp

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ip-ssh-client-source-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ip-ssh-client-source-interfaces.j2
@@ -1,0 +1,18 @@
+{% if ip_ssh_client_source_interfaces is arista.avd.defined %}
+
+## IP ssh Client Source Interfaces
+
+### IP ssh Client Source Interfaces
+
+| VRF | Source Interface Name |
+| --- | --------------- |
+{%     for ip_ssh_client_source_interface in ip_ssh_client_source_interfaces | arista.avd.natural_sort %}
+| {{ ip_ssh_client_source_interface['vrf'] | arista.avd.default('default') }} | {{ ip_ssh_client_source_interface['name'] | capitalize }} |
+{%     endfor %}
+
+### IP ssh Client Source Interfaces Device Configuration
+
+```eos
+{% include 'eos/ip-ssh-client-source-interfaces.j2' %}
+```
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ip-ssh-client-source-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ip-ssh-client-source-interfaces.j2
@@ -1,8 +1,8 @@
 {% if ip_ssh_client_source_interfaces is arista.avd.defined %}
 
-## IP ssh Client Source Interfaces
+## IP SSH Client Source Interfaces
 
-### IP ssh Client Source Interfaces
+### IP SSH Client Source Interfaces
 
 | VRF | Source Interface Name |
 | --- | --------------- |
@@ -12,7 +12,7 @@
 {%         endif %}
 {%     endfor %}
 
-### IP ssh Client Source Interfaces Device Configuration
+### IP SSH Client Source Interfaces Device Configuration
 
 ```eos
 {% include 'eos/ip-ssh-client-source-interfaces.j2' %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ip-ssh-client-source-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ip-ssh-client-source-interfaces.j2
@@ -7,8 +7,8 @@
 | VRF | Source Interface Name |
 | --- | --------------- |
 {%     for ip_ssh_client_source_interface in ip_ssh_client_source_interfaces | arista.avd.natural_sort %}
-{%         if ip_ssh_client_source_interface['name'] is arista.avd.defined %}
-| {{ ip_ssh_client_source_interface['vrf'] | arista.avd.default('default') }} | {{ ip_ssh_client_source_interface['name'] | capitalize }} |
+{%         if ip_ssh_client_source_interface.name is arista.avd.defined %}
+| {{ ip_ssh_client_source_interface.vrf | arista.avd.default('default') }} | {{ ip_ssh_client_source_interface.name | capitalize }} |
 {%         endif %}
 {%     endfor %}
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ip-ssh-client-source-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ip-ssh-client-source-interfaces.j2
@@ -7,7 +7,9 @@
 | VRF | Source Interface Name |
 | --- | --------------- |
 {%     for ip_ssh_client_source_interface in ip_ssh_client_source_interfaces | arista.avd.natural_sort %}
+{%         if ip_ssh_client_source_interface['name'] is arista.avd.defined %}
 | {{ ip_ssh_client_source_interface['vrf'] | arista.avd.default('default') }} | {{ ip_ssh_client_source_interface['name'] | capitalize }} |
+{%         endif %}
 {%     endfor %}
 
 ### IP ssh Client Source Interfaces Device Configuration

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-device-documentation.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-device-documentation.j2
@@ -21,6 +21,8 @@
 {% include 'documentation/system-control-plane.j2' %}
 {## Management SSH #}
 {% include 'documentation/management-ssh.j2' %}
+{## IP SSH Client Source Interfaces #}
+{% include 'documentation/ip-ssh-client-source-interfaces.j2' %}
 {## Management API GNMI #}
 {% include 'documentation/management-api-gnmi.j2' %}
 {## Management API HTTP #}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
@@ -215,6 +215,8 @@
 {% include 'eos/management-security.j2' %}
 {# management ssh #}
 {% include 'eos/management-ssh.j2' %}
+{# ip ssh client source interfaces #}
+{% include 'eos/ip-ssh-client-source-interfaces.j2' %}
 {# EOS CLI #}
 {% include 'eos/eos-cli.j2' %}
 {# custom templates #}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-ssh-client-source-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-ssh-client-source-interfaces.j2
@@ -1,11 +1,11 @@
 {# eos - IP ssh Client Source Interfaces#}
 {% for ip_ssh_client_source_interface in ip_ssh_client_source_interfaces | arista.avd.natural_sort %}
-!
 {%     if ip_ssh_client_source_interface.name is arista.avd.defined %}
 {%         set ip_ssh_client_cli = "ip ssh client source-interface " ~ ip_ssh_client_source_interface.name | capitalize %}
 {%         if ip_ssh_client_source_interface.vrf is arista.avd.defined %}
 {%             set ip_ssh_client_cli = ip_ssh_client_cli ~ " vrf " ~ ip_ssh_client_source_interface.vrf %}
 {%         endif %}
-{%     endif %}
+!
 {{ ip_ssh_client_cli }}
+{%     endif %}
 {% endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-ssh-client-source-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-ssh-client-source-interfaces.j2
@@ -1,11 +1,13 @@
 {# eos - IP ssh Client Source Interfaces#}
-{% for ip_ssh_client_source_interface in ip_ssh_client_source_interfaces | arista.avd.natural_sort %}
-{%     if ip_ssh_client_source_interface.name is arista.avd.defined %}
-{%         set ip_ssh_client_cli = "ip ssh client source-interface " ~ ip_ssh_client_source_interface.name | capitalize %}
-{%         if ip_ssh_client_source_interface.vrf is arista.avd.defined %}
-{%             set ip_ssh_client_cli = ip_ssh_client_cli ~ " vrf " ~ ip_ssh_client_source_interface.vrf %}
-{%         endif %}
+{% if ip_ssh_client_source_interfaces is arista.avd.defined %}
 !
+{%     for ip_ssh_client_source_interface in ip_ssh_client_source_interfaces | arista.avd.natural_sort %}
+{%         if ip_ssh_client_source_interface.name is arista.avd.defined %}
+{%             set ip_ssh_client_cli = "ip ssh client source-interface " ~ ip_ssh_client_source_interface.name | capitalize %}
+{%             if ip_ssh_client_source_interface.vrf is arista.avd.defined %}
+{%                 set ip_ssh_client_cli = ip_ssh_client_cli ~ " vrf " ~ ip_ssh_client_source_interface.vrf %}
+{%             endif %}
 {{ ip_ssh_client_cli }}
-{%     endif %}
-{% endfor %}
+{%         endif %}
+{%     endfor %}
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-ssh-client-source-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-ssh-client-source-interfaces.j2
@@ -1,0 +1,11 @@
+{# eos - IP ssh Client Source Interfaces#}
+{% for ip_ssh_client_source_interface in ip_ssh_client_source_interfaces | arista.avd.natural_sort %}
+!
+{%     if ip_ssh_client_source_interface.name is arista.avd.defined %}
+{%         set ip_ssh_client_cli = "ip ssh client source-interface " ~ ip_ssh_client_source_interface.name | capitalize %}
+{%         if ip_ssh_client_source_interface.vrf is arista.avd.defined %}
+{%             set ip_ssh_client_cli = ip_ssh_client_cli ~ " vrf " ~ ip_ssh_client_source_interface.vrf %}
+{%         endif %}
+{%     endif %}
+{{ ip_ssh_client_cli }}
+{% endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-ssh-client-source-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-ssh-client-source-interfaces.j2
@@ -1,4 +1,4 @@
-{# eos - IP ssh Client Source Interfaces#}
+{# eos - IP SSH Client Source Interfaces#}
 {% if ip_ssh_client_source_interfaces is arista.avd.defined %}
 !
 {%     for ip_ssh_client_source_interface in ip_ssh_client_source_interfaces | arista.avd.natural_sort %}


### PR DESCRIPTION
## Change Summary

New_feature:
    - ip_ssh_client_source_interfaces
    - ip_ssh_client_source_interfaces is a list, [name: <interface_name>, vrf: <vrf_name>]
    - The vrf is optional and will be set to default if not provided any value

## Related Issue(s)

Fixes #1151

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
No changes to data models but new data model was added
Changes made:
    - Added new template ip-ssh-client-source-interface.j2 to both eos and documentation
    - Made changes to molecule and ran it successfully
    - Added new feature in relase-notes/3.x.x.md
<!--- Describe data model implemented for new features -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
Refer to the molecule tests
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
