### PR TITLE
Fix(eos_designs): Add missing tag on output directories task

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/main.yml
@@ -1,5 +1,6 @@
 ---
 - name: Create required output directories if not present
+  tags: [always]
   file:
     path: "{{ item }}"
     state: directory


### PR DESCRIPTION
## Change Summary

Add tag in eos_designs task "Create required output directories if not present"

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

Update tags on task with "always"

## How to test

Delete structured configuration folder and run playbook with build tags
example: `ansible-playbook playbooks/fabric-deploy-cvp.yml --tags build -i inventories/avd-lab/inventory.yml --diff`

## Checklist

### User Checklist

- [x] Tested in AVD validation lab

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
