### PR TITLE
Doc(eos_cli_config_gen): fix ntp.servers typo

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1423,7 +1423,7 @@ ntp:
     name: < source_interface >
     vrf: < vrf_name >
   servers:
-  - name: < IP | hostname >:
+  - name: < IP | hostname >
     burst: < true | false >
     iburst:  < true | false >
     key: < 1 - 65535 >

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/common-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/common-settings.md
@@ -136,11 +136,6 @@ name_servers:
  - 192.168.2.1
  - 8.8.8.8
 
-# NTP Servers
-ntp_servers:
- - 0.north-america.pool.ntp.org
- - 1.north-america.pool.ntp.org
-
 # Internal vlan allocation order and range
 # internal_vlan_order:
 #   allocation: ascending


### PR DESCRIPTION
## Change Summary

Fix typo in eos_cli_config_gen

## Related Issue(s)

N/A

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Checklist

### User Checklist

- [x] correct typo

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
