### PR TITLE
Feat(eos_designs)!: Add "VEOS" to default platform_settings

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_designs/defaults/main/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/defaults/main/main.yml
@@ -79,7 +79,7 @@ mlag_ibgp_peering_vrfs:
 
 # Set platform specific settings, TCAM profile and reload delay.
 # The reload delay values should be reviewed and tuned to the specific environment.
-# Recommended default values for Jericho based platform, and all other platforms default tag.
+# Recommended default values for Jericho based platform, VEOS and all other platforms default tag.
 
 platform_settings:
   - platforms: [default]
@@ -87,6 +87,7 @@ platform_settings:
       mlag: 300
       non_mlag: 330
     feature_support:
+      # "queue-monitor length notify" is only valid for R-Series so should be disabled on default platform.
       queue_monitor_length_notify: false
   - platforms: [ 7280R, 7280R2, 7500R, 7500R2 ]
     tcam_profile: vxlan-routing
@@ -98,6 +99,13 @@ platform_settings:
     reload_delay:
       mlag: 900
       non_mlag: 1020
+  - platforms: ["VEOS", "VEOS-LAB"]
+    reload_delay:
+      mlag: 300
+      non_mlag: 330
+    feature_support:
+      queue_monitor_length_notify: false
+      interface_storm_control: false
 
 # Infrastructure Elements Keys
 

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/common-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/common-settings.md
@@ -221,7 +221,9 @@ platform_settings:
       < multiline eos cli >
 ```
 
-note: Recommended default values for Jericho based platform, and all other platforms `default` tag.
+note: 
+Recommended default values for Jericho based platform, VEOS and all other platforms `default` tag. 
+The reload delay values should be reviewed and tuned to the specific environment.
 
 **Example:**
 
@@ -232,6 +234,7 @@ platform_settings:
       mlag: 300
       non_mlag: 330
     feature_support:
+      # "queue-monitor length notify" is only valid for R-Series so should be disabled on default platform.
       queue_monitor_length_notify: false
   - platforms: [ 7280R, 7280R2, 7500R, 7500R2 ]
     tcam_profile: vxlan-routing
@@ -243,6 +246,13 @@ platform_settings:
     reload_delay:
       mlag: 900
       non_mlag: 1020
+  - platforms: ["VEOS", "VEOS-LAB"]
+    reload_delay:
+      mlag: 300
+      non_mlag: 330
+    feature_support:
+      queue_monitor_length_notify: false
+      interface_storm_control: false
 ```
 
 ## Custom EOS Structured Configuration

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/common-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/common-settings.md
@@ -221,7 +221,7 @@ platform_settings:
       < multiline eos cli >
 ```
 
-note: 
+note:
 Recommended default values for Jericho based platform, VEOS and all other platforms `default` tag.
 The reload delay values should be reviewed and tuned to the specific environment.
 

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/common-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/l3ls-evpn/common-settings.md
@@ -222,7 +222,7 @@ platform_settings:
 ```
 
 note: 
-Recommended default values for Jericho based platform, VEOS and all other platforms `default` tag. 
+Recommended default values for Jericho based platform, VEOS and all other platforms `default` tag.
 The reload delay values should be reviewed and tuned to the specific environment.
 
 **Example:**


### PR DESCRIPTION
## Change Summary

Add "VEOS" to default `platform_settings`
<!-- Enter short PR description -->

## Related Issue(s)

Related to PR #1201 for new "VEOS" platform

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->
```yaml
platform_settings:
  - platforms: ["VEOS", "VEOS-LAB"]
    reload_delay:
      mlag: 300
      non_mlag: 330
    feature_support:
      queue_monitor_length_notify: false
      interface_storm_control: false
```

Other minor comments to help understand the defaults.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

No changes to molecule.
## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
