### PR TITLE
Bump: Limit version due to molecule issue #3243

### DIFF
--- a/ansible_collections/arista/avd/requirements-dev.txt
+++ b/ansible_collections/arista/avd/requirements-dev.txt
@@ -9,5 +9,5 @@ pre-commit>=2.9.2
 pre-commit-hooks>=3.3.0
 identify>=1.4.20
 docker
-molecule>=3.2.0
+molecule>=3.2.0,<3.5.0
 molecule-docker>=0.2.4


### PR DESCRIPTION
## Change Summary

Limit Molecule version for development due to molecule issue [#3243](https://github.com/ansible-community/molecule/issues/3243)

## Component(s) name

Molecule CI

## Proposed changes

limit molecule version to <3.5.0
