### PR TITLE
Feat(eos_cli_config_gen): Add IS-IS circuit type on Ethernet & Port Channels interfaces

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -124,9 +124,9 @@ interface Management1
 
 #### ISIS
 
-| Interface | Channel Group | ISIS Instance | ISIS Metric | Mode |
-| --------- | ------------- | ------------- | ----------- | ---- |
-| Ethernet5 | - | ISIS_TEST | 99 | point-to-point |
+| Interface | Channel Group | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type |
+| --------- | ------------- | ------------- | ----------- | ---- | ----------------- |
+| Ethernet5 | - | ISIS_TEST | 99 | point-to-point |  level-1-2 |
 
 ### Ethernet Interfaces Device Configuration
 
@@ -190,6 +190,7 @@ interface Ethernet5
    isis enable ISIS_TEST
    isis metric 99
    isis network point-to-point
+   isis circuit-type level-1-2
    pim ipv4 sparse-mode
 !
 interface Ethernet6

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -188,9 +188,9 @@ interface Ethernet5
    ip ospf authentication-key 7 asfddja23452
    ip ospf message-digest-key 1 sha512 7 asfddja23452
    isis enable ISIS_TEST
+   isis circuit-type level-2
    isis metric 99
    isis network point-to-point
-   isis circuit-type level-2
    pim ipv4 sparse-mode
 !
 interface Ethernet6

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -126,7 +126,7 @@ interface Management1
 
 | Interface | Channel Group | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type |
 | --------- | ------------- | ------------- | ----------- | ---- | ----------------- |
-| Ethernet5 | - | ISIS_TEST | 99 | point-to-point | level-1-2 |
+| Ethernet5 | - | ISIS_TEST | 99 | point-to-point | level-2 |
 
 ### Ethernet Interfaces Device Configuration
 
@@ -190,7 +190,7 @@ interface Ethernet5
    isis enable ISIS_TEST
    isis metric 99
    isis network point-to-point
-   isis circuit-type level-1-2
+   isis circuit-type level-2
    pim ipv4 sparse-mode
 !
 interface Ethernet6

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -126,7 +126,7 @@ interface Management1
 
 | Interface | Channel Group | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type |
 | --------- | ------------- | ------------- | ----------- | ---- | ----------------- |
-| Ethernet5 | - | ISIS_TEST | 99 | point-to-point |  level-1-2 |
+| Ethernet5 | - | ISIS_TEST | 99 | point-to-point | level-1-2 |
 
 ### Ethernet Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis.md
@@ -92,13 +92,13 @@ interface Management1
 
 #### ISIS
 
-| Interface | Channel Group | ISIS Instance | ISIS Metric | Mode |
-| --------- | ------------- | ------------- | ----------- | ---- |
-| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet4 | 4 | *EVPN_UNDERLAY | *50 | **point-to-point |
-| Ethernet5 | 5 | *EVPN_UNDERLAY | *50 | **passive |
-| Ethernet6 | 6 | *EVPN_UNDERLAY | *100 | **- |
+| Interface | Channel Group | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type |
+| --------- | ------------- | ------------- | ----------- | ---- | ----------------- |
+| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet4 | 4 | *EVPN_UNDERLAY | *50 | *point-to-point | - |
+| Ethernet5 | 5 | *EVPN_UNDERLAY | *50 | *passive | - |
+| Ethernet6 | 6 | *EVPN_UNDERLAY | *100 | *- | - |
  *Inherited from Port-Channel Interface
 
 ### Ethernet Interfaces Device Configuration

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis.md
@@ -96,9 +96,9 @@ interface Management1
 | --------- | ------------- | ------------- | ----------- | ---- | ----------------- |
 | Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
 | Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
-| Ethernet4 | 4 | *EVPN_UNDERLAY | *50 | *point-to-point | - |
-| Ethernet5 | 5 | *EVPN_UNDERLAY | *50 | *passive | - |
-| Ethernet6 | 6 | *EVPN_UNDERLAY | *100 | *- | - |
+| Ethernet4 | 4 | *EVPN_UNDERLAY | *50 | **point-to-point | *level-2 |
+| Ethernet5 | 5 | *EVPN_UNDERLAY | *50 | **passive | **- |
+| Ethernet6 | 6 | *EVPN_UNDERLAY | *100 | **- | *level-1-2 |
  *Inherited from Port-Channel Interface
 
 ### Ethernet Interfaces Device Configuration

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis.md
@@ -120,9 +120,9 @@ interface Ethernet2
    no switchport
    ip address 172.31.255.3/31
    isis enable EVPN_UNDERLAY
+   isis circuit-type level-1-2
    isis metric 50
    isis network point-to-point
-   isis circuit-type level-1-2
 !
 interface Ethernet3
    description MLAG_PEER_EAPI-LEAF1B_Ethernet3
@@ -171,23 +171,23 @@ interface Port-Channel4
    no switchport
    ip address 10.9.2.3/31
    isis enable EVPN_UNDERLAY
+   isis circuit-type level-2
    isis metric 50
    isis network point-to-point
-   isis circuit-type level-2
 !
 interface Port-Channel5
    no switchport
    ip address 10.9.2.5/31
    isis enable EVPN_UNDERLAY
-   isis passive
    isis metric 50
+   isis passive
 !
 interface Port-Channel6
    no switchport
    ip address 10.9.2.7/31
    isis enable EVPN_UNDERLAY
-   isis metric 100
    isis circuit-type level-1-2
+   isis metric 100
 ```
 
 ## Loopback Interfaces

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis.md
@@ -95,10 +95,10 @@ interface Management1
 | Interface | Channel Group | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type |
 | --------- | ------------- | ------------- | ----------- | ---- | ----------------- |
 | Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
-| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
-| Ethernet4 | 4 | *EVPN_UNDERLAY | *50 | *point-to-point | - |
-| Ethernet5 | 5 | *EVPN_UNDERLAY | *50 | *passive | - |
-| Ethernet6 | 6 | *EVPN_UNDERLAY | *100 | *- | - |
+| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point | level-1-2 |
+| Ethernet4 | 4 | *EVPN_UNDERLAY | *50 | *point-to-point | *level-2 |
+| Ethernet5 | 5 | *EVPN_UNDERLAY | *50 | *passive | *- |
+| Ethernet6 | 6 | *EVPN_UNDERLAY | *100 | *- | *level-1-2 |
  *Inherited from Port-Channel Interface
 
 ### Ethernet Interfaces Device Configuration
@@ -122,6 +122,7 @@ interface Ethernet2
    isis enable EVPN_UNDERLAY
    isis metric 50
    isis network point-to-point
+   isis circuit-type level-1-2
 !
 interface Ethernet3
    description MLAG_PEER_EAPI-LEAF1B_Ethernet3
@@ -156,11 +157,11 @@ interface Ethernet6
 
 #### ISIS
 
-| Interface | ISIS Instance | ISIS Metric | Type | ISIS Passive |
-| --------- | ------------- | ----------- | ---- | ------------ |
-| Port-Channel4 | EVPN_UNDERLAY | 50 | point-to-point | False |
-| Port-Channel5 | EVPN_UNDERLAY | 50 | - | True |
-| Port-Channel6 | EVPN_UNDERLAY | 100 | - | False |
+| Interface | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type |
+| --------- | ------------- | ----------- | ---- | ----------------- |
+| Port-Channel4 | EVPN_UNDERLAY | 50 | point-to-point | level-2 |
+| Port-Channel5 | EVPN_UNDERLAY | 50 | passive | - |
+| Port-Channel6 | EVPN_UNDERLAY | 100 | - | level-1-2 |
 
 ### Port-Channel Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
@@ -65,7 +65,7 @@ interface Ethernet5
    isis enable ISIS_TEST
    isis metric 99
    isis network point-to-point
-   isis circuit-type level-1-2
+   isis circuit-type level-2
    pim ipv4 sparse-mode
 !
 interface Ethernet6

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
@@ -65,6 +65,7 @@ interface Ethernet5
    isis enable ISIS_TEST
    isis metric 99
    isis network point-to-point
+   isis circuit-type level-1-2
    pim ipv4 sparse-mode
 !
 interface Ethernet6

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
@@ -63,9 +63,9 @@ interface Ethernet5
    ip ospf authentication-key 7 asfddja23452
    ip ospf message-digest-key 1 sha512 7 asfddja23452
    isis enable ISIS_TEST
+   isis circuit-type level-2
    isis metric 99
    isis network point-to-point
-   isis circuit-type level-2
    pim ipv4 sparse-mode
 !
 interface Ethernet6

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-isis.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-isis.cfg
@@ -11,23 +11,23 @@ interface Port-Channel4
    no switchport
    ip address 10.9.2.3/31
    isis enable EVPN_UNDERLAY
+   isis circuit-type level-2
    isis metric 50
    isis network point-to-point
-   isis circuit-type level-2
 !
 interface Port-Channel5
    no switchport
    ip address 10.9.2.5/31
    isis enable EVPN_UNDERLAY
-   isis passive
    isis metric 50
+   isis passive
 !
 interface Port-Channel6
    no switchport
    ip address 10.9.2.7/31
    isis enable EVPN_UNDERLAY
-   isis metric 100
    isis circuit-type level-1-2
+   isis metric 100
 !
 interface Ethernet1
    description P2P_LINK_TO_EAPI-SPINE1_Ethernet1
@@ -44,9 +44,9 @@ interface Ethernet2
    no switchport
    ip address 172.31.255.3/31
    isis enable EVPN_UNDERLAY
+   isis circuit-type level-1-2
    isis metric 50
    isis network point-to-point
-   isis circuit-type level-1-2
 !
 interface Ethernet3
    description MLAG_PEER_EAPI-LEAF1B_Ethernet3

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-isis.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-isis.cfg
@@ -46,6 +46,7 @@ interface Ethernet2
    isis enable EVPN_UNDERLAY
    isis metric 50
    isis network point-to-point
+   isis circuit-type level-1-2
 !
 interface Ethernet3
    description MLAG_PEER_EAPI-LEAF1B_Ethernet3

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
@@ -91,7 +91,7 @@ ethernet_interfaces:
     isis_passive: false
     isis_metric: 99
     isis_network_point_to_point: true
-    isis_circuit_type: level-1-2
+    isis_circuit_type: level-2
 
   Ethernet6:
     logging:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
@@ -91,6 +91,7 @@ ethernet_interfaces:
     isis_passive: false
     isis_metric: 99
     isis_network_point_to_point: true
+    isis_circuit_type: level-1-2
 
   Ethernet6:
     logging:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-isis.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-isis.yml
@@ -41,6 +41,7 @@ ethernet_interfaces:
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
     isis_network_point_to_point: true
+    isis_circuit_type: level-1-2
   Ethernet3:
     peer: EAPI-LEAF1B
     peer_interface: Ethernet3

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1A.md
@@ -298,10 +298,10 @@ vlan 4094
 
 | Interface | Channel Group | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type |
 | --------- | ------------- | ------------- | ----------- | ---- | ----------------- |
-| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
 
 ### Ethernet Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1A.md
@@ -296,12 +296,12 @@ vlan 4094
 
 #### ISIS
 
-| Interface | Channel Group | ISIS Instance | ISIS Metric | Mode |
-| --------- | ------------- | ------------- | ----------- | ---- |
-| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |
+| Interface | Channel Group | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type |
+| --------- | ------------- | ------------- | ----------- | ---- | ----------------- |
+| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
 
 ### Ethernet Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1B.md
@@ -298,10 +298,10 @@ vlan 4094
 
 | Interface | Channel Group | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type |
 | --------- | ------------- | ------------- | ----------- | ---- | ----------------- |
-| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
 
 ### Ethernet Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1B.md
@@ -296,12 +296,12 @@ vlan 4094
 
 #### ISIS
 
-| Interface | Channel Group | ISIS Instance | ISIS Metric | Mode |
-| --------- | ------------- | ------------- | ----------- | ---- |
-| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |
+| Interface | Channel Group | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type |
+| --------- | ------------- | ------------- | ----------- | ---- | ----------------- |
+| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
 
 ### Ethernet Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF1A.md
@@ -239,12 +239,12 @@ vlan internal order ascending range 1006 1199
 
 #### ISIS
 
-| Interface | Channel Group | ISIS Instance | ISIS Metric | Mode |
-| --------- | ------------- | ------------- | ----------- | ---- |
-| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |
+| Interface | Channel Group | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type |
+| --------- | ------------- | ------------- | ----------- | ---- | ----------------- |
+| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
 
 ### Ethernet Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF1A.md
@@ -241,10 +241,10 @@ vlan internal order ascending range 1006 1199
 
 | Interface | Channel Group | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type |
 | --------- | ------------- | ------------- | ----------- | ---- | ----------------- |
-| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
 
 ### Ethernet Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2A.md
@@ -299,10 +299,10 @@ vlan 4094
 
 | Interface | Channel Group | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type |
 | --------- | ------------- | ------------- | ----------- | ---- | ----------------- |
-| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
 
 ### Ethernet Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2A.md
@@ -297,12 +297,12 @@ vlan 4094
 
 #### ISIS
 
-| Interface | Channel Group | ISIS Instance | ISIS Metric | Mode |
-| --------- | ------------- | ------------- | ----------- | ---- |
-| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |
+| Interface | Channel Group | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type |
+| --------- | ------------- | ------------- | ----------- | ---- | ----------------- |
+| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
 
 ### Ethernet Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2B.md
@@ -299,10 +299,10 @@ vlan 4094
 
 | Interface | Channel Group | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type |
 | --------- | ------------- | ------------- | ----------- | ---- | ----------------- |
-| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
 
 ### Ethernet Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2B.md
@@ -297,12 +297,12 @@ vlan 4094
 
 #### ISIS
 
-| Interface | Channel Group | ISIS Instance | ISIS Metric | Mode |
-| --------- | ------------- | ------------- | ----------- | ---- |
-| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |
+| Interface | Channel Group | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type |
+| --------- | ------------- | ------------- | ----------- | ---- | ----------------- |
+| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
 
 ### Ethernet Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE1.md
@@ -230,15 +230,15 @@ vlan internal order ascending range 1006 1199
 
 #### ISIS
 
-| Interface | Channel Group | ISIS Instance | ISIS Metric | Mode |
-| --------- | ------------- | ------------- | ----------- | ---- |
-| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet5 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet6 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet7 | - | EVPN_UNDERLAY | 50 | point-to-point |
+| Interface | Channel Group | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type |
+| --------- | ------------- | ------------- | ----------- | ---- | ----------------- |
+| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet5 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet6 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet7 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
 
 ### Ethernet Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE1.md
@@ -232,13 +232,13 @@ vlan internal order ascending range 1006 1199
 
 | Interface | Channel Group | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type |
 | --------- | ------------- | ------------- | ----------- | ---- | ----------------- |
-| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet5 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet6 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet7 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet5 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet6 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet7 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
 
 ### Ethernet Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE2.md
@@ -228,15 +228,15 @@ vlan internal order ascending range 1006 1199
 
 #### ISIS
 
-| Interface | Channel Group | ISIS Instance | ISIS Metric | Mode |
-| --------- | ------------- | ------------- | ----------- | ---- |
-| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet5 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet6 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet7 | - | EVPN_UNDERLAY | 50 | point-to-point |
+| Interface | Channel Group | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type |
+| --------- | ------------- | ------------- | ----------- | ---- | ----------------- |
+| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet5 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet6 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet7 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
 
 ### Ethernet Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE2.md
@@ -230,13 +230,13 @@ vlan internal order ascending range 1006 1199
 
 | Interface | Channel Group | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type |
 | --------- | ------------- | ------------- | ----------- | ---- | ----------------- |
-| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet5 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet6 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet7 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet5 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet6 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet7 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
 
 ### Ethernet Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE3.md
@@ -228,15 +228,15 @@ vlan internal order ascending range 1006 1199
 
 #### ISIS
 
-| Interface | Channel Group | ISIS Instance | ISIS Metric | Mode |
-| --------- | ------------- | ------------- | ----------- | ---- |
-| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet5 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet6 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet7 | - | EVPN_UNDERLAY | 50 | point-to-point |
+| Interface | Channel Group | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type |
+| --------- | ------------- | ------------- | ----------- | ---- | ----------------- |
+| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet5 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet6 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet7 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
 
 ### Ethernet Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE3.md
@@ -230,13 +230,13 @@ vlan internal order ascending range 1006 1199
 
 | Interface | Channel Group | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type |
 | --------- | ------------- | ------------- | ----------- | ---- | ----------------- |
-| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet5 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet6 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet7 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet5 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet6 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet7 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
 
 ### Ethernet Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE4.md
@@ -230,15 +230,15 @@ vlan internal order ascending range 1006 1199
 
 #### ISIS
 
-| Interface | Channel Group | ISIS Instance | ISIS Metric | Mode |
-| --------- | ------------- | ------------- | ----------- | ---- |
-| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet5 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet6 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet7 | - | EVPN_UNDERLAY | 50 | point-to-point |
+| Interface | Channel Group | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type |
+| --------- | ------------- | ------------- | ----------- | ---- | ----------------- |
+| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet5 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet6 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet7 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
 
 ### Ethernet Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE4.md
@@ -232,13 +232,13 @@ vlan internal order ascending range 1006 1199
 
 | Interface | Channel Group | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type |
 | --------- | ------------- | ------------- | ----------- | ---- | ----------------- |
-| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet5 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet6 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet7 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet5 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet6 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet7 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
 
 ### Ethernet Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3A.md
@@ -298,12 +298,12 @@ vlan 4094
 
 #### ISIS
 
-| Interface | Channel Group | ISIS Instance | ISIS Metric | Mode |
-| --------- | ------------- | ------------- | ----------- | ---- |
-| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |
+| Interface | Channel Group | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type |
+| --------- | ------------- | ------------- | ----------- | ---- | ----------------- |
+| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
 
 ### Ethernet Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3A.md
@@ -300,10 +300,10 @@ vlan 4094
 
 | Interface | Channel Group | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type |
 | --------- | ------------- | ------------- | ----------- | ---- | ----------------- |
-| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
 
 ### Ethernet Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3B.md
@@ -298,12 +298,12 @@ vlan 4094
 
 #### ISIS
 
-| Interface | Channel Group | ISIS Instance | ISIS Metric | Mode |
-| --------- | ------------- | ------------- | ----------- | ---- |
-| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |
+| Interface | Channel Group | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type |
+| --------- | ------------- | ------------- | ----------- | ---- | ----------------- |
+| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
 
 ### Ethernet Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3B.md
@@ -300,10 +300,10 @@ vlan 4094
 
 | Interface | Channel Group | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type |
 | --------- | ------------- | ------------- | ----------- | ---- | ----------------- |
-| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
 
 ### Ethernet Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1A.md
@@ -298,10 +298,10 @@ vlan 4094
 
 | Interface | Channel Group | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type |
 | --------- | ------------- | ------------- | ----------- | ---- | ----------------- |
-| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
 
 ### Ethernet Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1A.md
@@ -296,12 +296,12 @@ vlan 4094
 
 #### ISIS
 
-| Interface | Channel Group | ISIS Instance | ISIS Metric | Mode |
-| --------- | ------------- | ------------- | ----------- | ---- |
-| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |
+| Interface | Channel Group | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type |
+| --------- | ------------- | ------------- | ----------- | ---- | ----------------- |
+| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
 
 ### Ethernet Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1B.md
@@ -298,10 +298,10 @@ vlan 4094
 
 | Interface | Channel Group | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type |
 | --------- | ------------- | ------------- | ----------- | ---- | ----------------- |
-| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
 
 ### Ethernet Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1B.md
@@ -296,12 +296,12 @@ vlan 4094
 
 #### ISIS
 
-| Interface | Channel Group | ISIS Instance | ISIS Metric | Mode |
-| --------- | ------------- | ------------- | ----------- | ---- |
-| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |
+| Interface | Channel Group | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type |
+| --------- | ------------- | ------------- | ----------- | ---- | ----------------- |
+| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
 
 ### Ethernet Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF1A.md
@@ -239,12 +239,12 @@ vlan internal order ascending range 1006 1199
 
 #### ISIS
 
-| Interface | Channel Group | ISIS Instance | ISIS Metric | Mode |
-| --------- | ------------- | ------------- | ----------- | ---- |
-| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |
+| Interface | Channel Group | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type |
+| --------- | ------------- | ------------- | ----------- | ---- | ----------------- |
+| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
 
 ### Ethernet Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF1A.md
@@ -241,10 +241,10 @@ vlan internal order ascending range 1006 1199
 
 | Interface | Channel Group | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type |
 | --------- | ------------- | ------------- | ----------- | ---- | ----------------- |
-| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
 
 ### Ethernet Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2A.md
@@ -299,10 +299,10 @@ vlan 4094
 
 | Interface | Channel Group | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type |
 | --------- | ------------- | ------------- | ----------- | ---- | ----------------- |
-| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
 
 ### Ethernet Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2A.md
@@ -297,12 +297,12 @@ vlan 4094
 
 #### ISIS
 
-| Interface | Channel Group | ISIS Instance | ISIS Metric | Mode |
-| --------- | ------------- | ------------- | ----------- | ---- |
-| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |
+| Interface | Channel Group | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type |
+| --------- | ------------- | ------------- | ----------- | ---- | ----------------- |
+| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
 
 ### Ethernet Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2B.md
@@ -299,10 +299,10 @@ vlan 4094
 
 | Interface | Channel Group | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type |
 | --------- | ------------- | ------------- | ----------- | ---- | ----------------- |
-| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
 
 ### Ethernet Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2B.md
@@ -297,12 +297,12 @@ vlan 4094
 
 #### ISIS
 
-| Interface | Channel Group | ISIS Instance | ISIS Metric | Mode |
-| --------- | ------------- | ------------- | ----------- | ---- |
-| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |
+| Interface | Channel Group | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type |
+| --------- | ------------- | ------------- | ----------- | ---- | ----------------- |
+| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
 
 ### Ethernet Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE1.md
@@ -230,15 +230,15 @@ vlan internal order ascending range 1006 1199
 
 #### ISIS
 
-| Interface | Channel Group | ISIS Instance | ISIS Metric | Mode |
-| --------- | ------------- | ------------- | ----------- | ---- |
-| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet5 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet6 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet7 | - | EVPN_UNDERLAY | 50 | point-to-point |
+| Interface | Channel Group | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type |
+| --------- | ------------- | ------------- | ----------- | ---- | ----------------- |
+| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet5 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet6 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet7 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
 
 ### Ethernet Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE1.md
@@ -232,13 +232,13 @@ vlan internal order ascending range 1006 1199
 
 | Interface | Channel Group | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type |
 | --------- | ------------- | ------------- | ----------- | ---- | ----------------- |
-| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet5 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet6 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet7 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet5 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet6 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet7 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
 
 ### Ethernet Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE2.md
@@ -228,15 +228,15 @@ vlan internal order ascending range 1006 1199
 
 #### ISIS
 
-| Interface | Channel Group | ISIS Instance | ISIS Metric | Mode |
-| --------- | ------------- | ------------- | ----------- | ---- |
-| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet5 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet6 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet7 | - | EVPN_UNDERLAY | 50 | point-to-point |
+| Interface | Channel Group | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type |
+| --------- | ------------- | ------------- | ----------- | ---- | ----------------- |
+| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet5 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet6 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet7 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
 
 ### Ethernet Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE2.md
@@ -230,13 +230,13 @@ vlan internal order ascending range 1006 1199
 
 | Interface | Channel Group | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type |
 | --------- | ------------- | ------------- | ----------- | ---- | ----------------- |
-| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet5 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet6 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet7 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet5 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet6 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet7 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
 
 ### Ethernet Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE3.md
@@ -228,15 +228,15 @@ vlan internal order ascending range 1006 1199
 
 #### ISIS
 
-| Interface | Channel Group | ISIS Instance | ISIS Metric | Mode |
-| --------- | ------------- | ------------- | ----------- | ---- |
-| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet5 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet6 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet7 | - | EVPN_UNDERLAY | 50 | point-to-point |
+| Interface | Channel Group | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type |
+| --------- | ------------- | ------------- | ----------- | ---- | ----------------- |
+| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet5 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet6 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet7 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
 
 ### Ethernet Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE3.md
@@ -230,13 +230,13 @@ vlan internal order ascending range 1006 1199
 
 | Interface | Channel Group | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type |
 | --------- | ------------- | ------------- | ----------- | ---- | ----------------- |
-| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet5 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet6 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet7 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet5 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet6 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet7 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
 
 ### Ethernet Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE4.md
@@ -230,15 +230,15 @@ vlan internal order ascending range 1006 1199
 
 #### ISIS
 
-| Interface | Channel Group | ISIS Instance | ISIS Metric | Mode |
-| --------- | ------------- | ------------- | ----------- | ---- |
-| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet5 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet6 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet7 | - | EVPN_UNDERLAY | 50 | point-to-point |
+| Interface | Channel Group | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type |
+| --------- | ------------- | ------------- | ----------- | ---- | ----------------- |
+| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet5 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet6 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet7 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
 
 ### Ethernet Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE4.md
@@ -232,13 +232,13 @@ vlan internal order ascending range 1006 1199
 
 | Interface | Channel Group | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type |
 | --------- | ------------- | ------------- | ----------- | ---- | ----------------- |
-| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet5 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet6 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet7 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet5 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet6 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet7 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
 
 ### Ethernet Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3A.md
@@ -298,12 +298,12 @@ vlan 4094
 
 #### ISIS
 
-| Interface | Channel Group | ISIS Instance | ISIS Metric | Mode |
-| --------- | ------------- | ------------- | ----------- | ---- |
-| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |
+| Interface | Channel Group | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type |
+| --------- | ------------- | ------------- | ----------- | ---- | ----------------- |
+| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
 
 ### Ethernet Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3A.md
@@ -300,10 +300,10 @@ vlan 4094
 
 | Interface | Channel Group | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type |
 | --------- | ------------- | ------------- | ----------- | ---- | ----------------- |
-| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
 
 ### Ethernet Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3B.md
@@ -298,12 +298,12 @@ vlan 4094
 
 #### ISIS
 
-| Interface | Channel Group | ISIS Instance | ISIS Metric | Mode |
-| --------- | ------------- | ------------- | ----------- | ---- |
-| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |
-| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |
+| Interface | Channel Group | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type |
+| --------- | ------------- | ------------- | ----------- | ---- | ----------------- |
+| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
 
 ### Ethernet Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3B.md
@@ -300,10 +300,10 @@ vlan 4094
 
 | Interface | Channel Group | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type |
 | --------- | ------------- | ------------- | ----------- | ---- | ----------------- |
-| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
-| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point |  - |
+| Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet3 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
+| Ethernet4 | - | EVPN_UNDERLAY | 50 | point-to-point | - |
 
 ### Ethernet Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -743,6 +743,7 @@ ethernet_interfaces:
     isis_passive: < boolean >
     isis_metric: < integer >
     isis_network_point_to_point: < boolean >
+    isis_circuit_type: < level-1-2 | level-1 | level-2 >
     ptp:
       enable: < true | false >
       announce:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -984,6 +984,7 @@ port_channel_interfaces:
     isis_passive: < boolean >
     isis_metric: < integer >
     isis_network_point_to_point: < boolean >
+    isis_circuit_type: < level-1-2 | level-1 | level-2 >
     # EOS CLI rendered directly on the port-channel interface in the final EOS configuration
     eos_cli: |
       < multiline eos cli >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ethernet-interfaces.j2
@@ -221,25 +221,31 @@
 {%             endif %}
 {%         endfor %}
 {%     endif %}
-{% if port_channel_interface_ipv6.configured == true %} *Inherited from Port-Channel Interface {% endif %}
+{% if port_channel_interface_ipv6.configured == true %}
+ *Inherited from Port-Channel Interface
+{% endif %}
 {# ISIS #}
-{%     set ethernet_interface_isis = namespace() %}
-{%     set ethernet_interface_isis.configured = false %}
+{%     set ethernet_interfaces_isis = [] %}
 {%     for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort %}
-{%          if ethernet_interfaces[ethernet_interface].isis_enable is arista.avd.defined %}
-{%              set ethernet_interface_isis.configured = true %}
+{%          if ethernet_interfaces[ethernet_interface].isis_enable is arista.avd.defined or
+               ethernet_interfaces[ethernet_interface].isis_metric is arista.avd.defined or
+               ethernet_interfaces[ethernet_interface].isis_circuit_type is arista.avd.defined or
+               ethernet_interfaces[ethernet_interface].isis_network_point_to_point is arista.avd.defined or
+               ethernet_interfaces[ethernet_interface].isis_passive is arista.avd.defined %}
+{%              do ethernet_interfaces_isis.append(ethernet_interface) %}
 {%          endif %}
 {%     endfor %}
-{%     set port_channel_interface_isis = namespace() %}
-{%     set port_channel_interface_isis.configured = false %}
-{%     if port_channel_interfaces is defined and port_channel_interfaces is not none %}
-{%         for port_channel_interface in port_channel_interfaces | arista.avd.natural_sort %}
-{%              if port_channel_interfaces[port_channel_interface].isis_enable is arista.avd.defined %}
-{%                  set port_channel_interface_isis.configured = true %}
-{%              endif %}
-{%         endfor %}
-{%     endif %}
-{%     if ethernet_interface_isis.configured == true or port_channel_interface_isis.configured == true %}
+{%     set port_channel_interfaces_isis = [] %}
+{%     for port_channel_interface in port_channel_interfaces | arista.avd.natural_sort %}
+{%          if port_channel_interfaces[port_channel_interface].isis_enable is arista.avd.defined or 
+               port_channel_interfaces[port_channel_interface].isis_metric is arista.avd.defined or
+               port_channel_interfaces[port_channel_interface].isis_circuit_type is arista.avd.defined or
+               port_channel_interfaces[port_channel_interface].isis_network_point_to_point is arista.avd.defined or
+               port_channel_interfaces[port_channel_interface].isis_passive is arista.avd.defined %}
+{%              do port_channel_interfaces_isis.append(port_channel_interface) %}
+{%          endif %}
+{%     endfor %}
+{%     if ethernet_interfaces_isis | length > 0 or port_channel_interfaces_isis | length > 0 %}
 
 #### ISIS
 
@@ -248,7 +254,7 @@
 {%         for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort %}
 {%             if ethernet_interfaces[ethernet_interface].channel_group.id is arista.avd.defined %}
 {%                 set port_channel_interface = 'Port-Channel' + ethernet_interfaces[ethernet_interface].channel_group.id | string %}
-{%                 if port_channel_interfaces[port_channel_interface].isis_enable is arista.avd.defined %}
+{%                 if port_channel_interface in port_channel_interfaces_isis %}
 {%                     set channel_group = ethernet_interfaces[ethernet_interface].channel_group.id | arista.avd.default("-") %}
 {%                     set isis_instance = port_channel_interfaces[port_channel_interface].isis_enable | arista.avd.default("-") %}
 {%                     set isis_metric = port_channel_interfaces[port_channel_interface].isis_metric | arista.avd.default("-") %}
@@ -263,7 +269,7 @@
 | {{ ethernet_interface }} | {{ channel_group }} | *{{ isis_instance }} | *{{ isis_metric }} | *{{ mode }} | *{{ isis_circuit_type }} |
 {%                 endif %}
 {%             else %}
-{%                 if ethernet_interfaces[ethernet_interface].isis_enable is arista.avd.defined %}
+{%                 if ethernet_interface in ethernet_interfaces_isis %}
 {%                     set channel_group = ethernet_interfaces[ethernet_interface].channel_group.id | arista.avd.default("-") %}
 {%                     set isis_instance = ethernet_interfaces[ethernet_interface].isis_enable | arista.avd.default("-") %}
 {%                     set isis_metric = ethernet_interfaces[ethernet_interface].isis_metric | arista.avd.default("-") %}
@@ -280,7 +286,7 @@
 {%             endif %}
 {%         endfor %}
 {%     endif %}
-{%     if port_channel_interface_isis.configured == true %}
+{%     if port_channel_interfaces_isis | length > 0 %}
  *Inherited from Port-Channel Interface
 {%     endif %}
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ethernet-interfaces.j2
@@ -250,15 +250,15 @@
 {%                 set port_channel_interface = 'Port-Channel' + ethernet_interfaces[ethernet_interface].channel_group.id | string %}
 {%                 if port_channel_interfaces[port_channel_interface].isis_enable is arista.avd.defined %}
 {%                     set channel_group = ethernet_interfaces[ethernet_interface].channel_group.id | arista.avd.default("-") %}
-{%                     set isis_instance = port_channel_interfaces[port_channel_interface].isis_enable | arista.avd.default("*-") %}
-{%                     set isis_metric = port_channel_interfaces[port_channel_interface].isis_metric | arista.avd.default("*-") %}
-{%                     set isis_circuit_type = port_channel_interfaces[port_channel_interface].isis_circuit_type | arista.avd.default("*-") %}
+{%                     set isis_instance = port_channel_interfaces[port_channel_interface].isis_enable | arista.avd.default("-") %}
+{%                     set isis_metric = port_channel_interfaces[port_channel_interface].isis_metric | arista.avd.default("-") %}
+{%                     set isis_circuit_type = port_channel_interfaces[port_channel_interface].isis_circuit_type | arista.avd.default("-") %}
 {%                     if port_channel_interfaces[port_channel_interface].isis_network_point_to_point is arista.avd.defined(true) %}
-{%                         set mode = "*point-to-point" %}
+{%                         set mode = "point-to-point" %}
 {%                     elif port_channel_interfaces[port_channel_interface].isis_passive is arista.avd.defined(true) %}
-{%                         set mode = "*passive" %}
+{%                         set mode = "passive" %}
 {%                     else %}
-{%                         set mode = "*-" %}
+{%                         set mode = "-" %}
 {%                     endif %}
 | {{ ethernet_interface }} | {{ channel_group }} | *{{ isis_instance }} | *{{ isis_metric }} | *{{ mode }} | *{{ isis_circuit_type }} |
 {%                 endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ethernet-interfaces.j2
@@ -237,7 +237,7 @@
 {%     endfor %}
 {%     set port_channel_interfaces_isis = [] %}
 {%     for port_channel_interface in port_channel_interfaces | arista.avd.natural_sort %}
-{%          if port_channel_interfaces[port_channel_interface].isis_enable is arista.avd.defined or 
+{%          if port_channel_interfaces[port_channel_interface].isis_enable is arista.avd.defined or
                port_channel_interfaces[port_channel_interface].isis_metric is arista.avd.defined or
                port_channel_interfaces[port_channel_interface].isis_circuit_type is arista.avd.defined or
                port_channel_interfaces[port_channel_interface].isis_network_point_to_point is arista.avd.defined or

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ethernet-interfaces.j2
@@ -243,8 +243,8 @@
 
 #### ISIS
 
-| Interface | Channel Group | ISIS Instance | ISIS Metric | Mode |
-| --------- | ------------- | ------------- | ----------- | ---- |
+| Interface | Channel Group | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type |
+| --------- | ------------- | ------------- | ----------- | ---- | ----------------- |
 {%         for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort %}
 {%             if ethernet_interfaces[ethernet_interface].channel_group.id is arista.avd.defined %}
 {%                 set port_channel_interface = 'Port-Channel' + ethernet_interfaces[ethernet_interface].channel_group.id | string %}
@@ -252,6 +252,7 @@
 {%                     set channel_group = ethernet_interfaces[ethernet_interface].channel_group.id | arista.avd.default("-") %}
 {%                     set isis_instance = port_channel_interfaces[port_channel_interface].isis_enable | arista.avd.default("*-") %}
 {%                     set isis_metric = port_channel_interfaces[port_channel_interface].isis_metric | arista.avd.default("*-") %}
+{%                     set isis_circuit_type = port_channel_interfaces[port_channel_interface].isis_circuit_type | arista.avd.default("*-") %}
 {%                     if port_channel_interfaces[port_channel_interface].isis_network_point_to_point is arista.avd.defined(true) %}
 {%                         set mode = "*point-to-point" %}
 {%                     elif port_channel_interfaces[port_channel_interface].isis_passive is arista.avd.defined(true) %}
@@ -259,13 +260,14 @@
 {%                     else %}
 {%                         set mode = "*-" %}
 {%                     endif %}
-| {{ ethernet_interface }} | {{ channel_group }} | *{{ isis_instance }} | *{{ isis_metric }} | *{{ mode }} |
+| {{ ethernet_interface }} | {{ channel_group }} | *{{ isis_instance }} | *{{ isis_metric }} | *{{ mode }} | {{ isis_circuit_type }} |
 {%                 endif %}
 {%             else %}
 {%                 if ethernet_interfaces[ethernet_interface].isis_enable is arista.avd.defined %}
 {%                     set channel_group = ethernet_interfaces[ethernet_interface].channel_group.id | arista.avd.default("-") %}
 {%                     set isis_instance = ethernet_interfaces[ethernet_interface].isis_enable | arista.avd.default("-") %}
 {%                     set isis_metric = ethernet_interfaces[ethernet_interface].isis_metric | arista.avd.default("-") %}
+{%                     set isis_circuit_type = ethernet_interfaces[ethernet_interface].isis_circuit_type | arista.avd.default("-") %}
 {%                     if ethernet_interfaces[ethernet_interface].isis_network_point_to_point is arista.avd.defined(true) %}
 {%                         set mode = "point-to-point" %}
 {%                     elif ethernet_interfaces[ethernet_interface].isis_passive is arista.avd.defined(true) %}
@@ -273,7 +275,7 @@
 {%                     else %}
 {%                         set mode = "-" %}
 {%                     endif %}
-| {{ ethernet_interface }} | {{ channel_group }} | {{ isis_instance }} | {{ isis_metric }} | {{ mode }} |
+| {{ ethernet_interface }} | {{ channel_group }} | {{ isis_instance }} | {{ isis_metric }} | {{ mode }} |  {{ isis_circuit_type }} |
 {%                endif %}
 {%             endif %}
 {%         endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ethernet-interfaces.j2
@@ -260,7 +260,7 @@
 {%                     else %}
 {%                         set mode = "*-" %}
 {%                     endif %}
-| {{ ethernet_interface }} | {{ channel_group }} | *{{ isis_instance }} | *{{ isis_metric }} | *{{ mode }} | {{ isis_circuit_type }} |
+| {{ ethernet_interface }} | {{ channel_group }} | *{{ isis_instance }} | *{{ isis_metric }} | *{{ mode }} | *{{ isis_circuit_type }} |
 {%                 endif %}
 {%             else %}
 {%                 if ethernet_interfaces[ethernet_interface].isis_enable is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ethernet-interfaces.j2
@@ -275,7 +275,7 @@
 {%                     else %}
 {%                         set mode = "-" %}
 {%                     endif %}
-| {{ ethernet_interface }} | {{ channel_group }} | {{ isis_instance }} | {{ isis_metric }} | {{ mode }} |  {{ isis_circuit_type }} |
+| {{ ethernet_interface }} | {{ channel_group }} | {{ isis_instance }} | {{ isis_metric }} | {{ mode }} | {{ isis_circuit_type }} |
 {%                endif %}
 {%             endif %}
 {%         endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/port-channel-interfaces.j2
@@ -154,7 +154,7 @@
 {# ISIS #}
 {%     set port_channel_interfaces_isis = [] %}
 {%     for port_channel_interface in port_channel_interfaces | arista.avd.natural_sort %}
-{%          if port_channel_interfaces[port_channel_interface].isis_enable is arista.avd.defined or 
+{%          if port_channel_interfaces[port_channel_interface].isis_enable is arista.avd.defined or
                port_channel_interfaces[port_channel_interface].isis_metric is arista.avd.defined or
                port_channel_interfaces[port_channel_interface].isis_circuit_type is arista.avd.defined or
                port_channel_interfaces[port_channel_interface].isis_network_point_to_point is arista.avd.defined or

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/port-channel-interfaces.j2
@@ -152,33 +152,34 @@
 {%        endfor %}
 {%    endif %}
 {# ISIS #}
-{%     set port_channel_interface_isis = namespace() %}
-{%     set port_channel_interface_isis.configured = false %}
+{%     set port_channel_interfaces_isis = [] %}
 {%     for port_channel_interface in port_channel_interfaces | arista.avd.natural_sort %}
-{%          if port_channel_interfaces[port_channel_interface].isis_enable is arista.avd.defined %}
-{%              set port_channel_interface_isis.configured = true %}
+{%          if port_channel_interfaces[port_channel_interface].isis_enable is arista.avd.defined or 
+               port_channel_interfaces[port_channel_interface].isis_metric is arista.avd.defined or
+               port_channel_interfaces[port_channel_interface].isis_circuit_type is arista.avd.defined or
+               port_channel_interfaces[port_channel_interface].isis_network_point_to_point is arista.avd.defined or
+               port_channel_interfaces[port_channel_interface].isis_passive is arista.avd.defined %}
+{%              do port_channel_interfaces_isis.append(port_channel_interface) %}
 {%          endif %}
 {%     endfor %}
-{%     if port_channel_interface_isis.configured == true %}
+{%     if port_channel_interfaces_isis | length > 0 %}
 
 #### ISIS
 
 | Interface | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type |
 | --------- | ------------- | ----------- | ---- | ----------------- |
-{%         for port_channel_interface in port_channel_interfaces | arista.avd.natural_sort %}
-{%             if port_channel_interfaces[port_channel_interface].isis_enable is arista.avd.defined %}
-{%                 set isis_instance = port_channel_interfaces[port_channel_interface].isis_enable | arista.avd.default("-") %}
-{%                 set isis_metric = port_channel_interfaces[port_channel_interface].isis_metric | arista.avd.default("-") %}
-{%                 set isis_circuit_type = port_channel_interfaces[port_channel_interface].isis_circuit_type | arista.avd.default("-") %}
-{%                 if port_channel_interfaces[port_channel_interface].isis_network_point_to_point is arista.avd.defined(true) %}
-{%                     set mode = "point-to-point" %}
-{%                 elif port_channel_interfaces[port_channel_interface].isis_passive is arista.avd.defined(true) %}
-{%                     set mode = "passive" %}
-{%                 else %}
-{%                     set mode = "-" %}
-{%                 endif %}
-| {{ port_channel_interface }} | {{ isis_instance }} | {{ isis_metric }} | {{ mode }} | {{ isis_circuit_type }} |
+{%         for port_channel_interface in port_channel_interfaces_isis | arista.avd.natural_sort %}
+{%             set isis_instance = port_channel_interfaces[port_channel_interface].isis_enable | arista.avd.default("-") %}
+{%             set isis_metric = port_channel_interfaces[port_channel_interface].isis_metric | arista.avd.default("-") %}
+{%             set isis_circuit_type = port_channel_interfaces[port_channel_interface].isis_circuit_type | arista.avd.default("-") %}
+{%             if port_channel_interfaces[port_channel_interface].isis_network_point_to_point is arista.avd.defined(true) %}
+{%                 set mode = "point-to-point" %}
+{%             elif port_channel_interfaces[port_channel_interface].isis_passive is arista.avd.defined(true) %}
+{%                 set mode = "passive" %}
+{%             else %}
+{%                 set mode = "-" %}
 {%             endif %}
+| {{ port_channel_interface }} | {{ isis_instance }} | {{ isis_metric }} | {{ mode }} | {{ isis_circuit_type }} |
 {%         endfor %}
 {%     endif %}
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/port-channel-interfaces.j2
@@ -151,7 +151,6 @@
 {%            endif %}
 {%        endfor %}
 {%    endif %}
-
 {# ISIS #}
 {%     set port_channel_interface_isis = namespace() %}
 {%     set port_channel_interface_isis.configured = false %}
@@ -161,29 +160,28 @@
 {%          endif %}
 {%     endfor %}
 {%     if port_channel_interface_isis.configured == true %}
+
 #### ISIS
 
-| Interface | ISIS Instance | ISIS Metric | Type | ISIS Passive |
-| --------- | ------------- | ----------- | ---- | ------------ |
+| Interface | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type |
+| --------- | ------------- | ----------- | ---- | ----------------- |
 {%         for port_channel_interface in port_channel_interfaces | arista.avd.natural_sort %}
 {%             if port_channel_interfaces[port_channel_interface].isis_enable is arista.avd.defined %}
 {%                 set isis_instance = port_channel_interfaces[port_channel_interface].isis_enable | arista.avd.default("-") %}
 {%                 set isis_metric = port_channel_interfaces[port_channel_interface].isis_metric | arista.avd.default("-") %}
+{%                 set isis_circuit_type = port_channel_interfaces[port_channel_interface].isis_circuit_type | arista.avd.default("-") %}
 {%                 if port_channel_interfaces[port_channel_interface].isis_network_point_to_point is arista.avd.defined(true) %}
-{%                     set type = "point-to-point" %}
+{%                     set mode = "point-to-point" %}
+{%                 elif port_channel_interfaces[port_channel_interface].isis_passive is arista.avd.defined(true) %}
+{%                     set mode = "passive" %}
 {%                 else %}
-{%                     set type = "-" %}
+{%                     set mode = "-" %}
 {%                 endif %}
-{%                 if port_channel_interfaces[port_channel_interface].isis_passive is arista.avd.defined(true) %}
-{%                     set passive = true %}
-{%                 else %}
-{%                     set passive = false %}
-{%                 endif %}
-| {{ port_channel_interface }} | {{ isis_instance }} | {{ isis_metric }} | {{ type }} | {{ passive }} |
+| {{ port_channel_interface }} | {{ isis_instance }} | {{ isis_metric }} | {{ mode }} | {{ isis_circuit_type }} |
 {%             endif %}
 {%         endfor %}
-
 {%     endif %}
+
 ### Port-Channel Interfaces Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -200,17 +200,17 @@ interface {{ ethernet_interface }}
 {%         if ethernet_interfaces[ethernet_interface].isis_enable is arista.avd.defined %}
    isis enable {{ ethernet_interfaces[ethernet_interface].isis_enable }}
 {%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].isis_passive is arista.avd.defined(true) %}
-   isis passive
+{%         if ethernet_interfaces[ethernet_interface].isis_circuit_type is arista.avd.defined %}
+   isis circuit-type {{ ethernet_interfaces[ethernet_interface].isis_circuit_type }}
 {%         endif %}
 {%         if ethernet_interfaces[ethernet_interface].isis_metric is arista.avd.defined %}
    isis metric {{ ethernet_interfaces[ethernet_interface].isis_metric }}
 {%         endif %}
+{%         if ethernet_interfaces[ethernet_interface].isis_passive is arista.avd.defined(true) %}
+   isis passive
+{%         endif %}
 {%         if ethernet_interfaces[ethernet_interface].isis_network_point_to_point is arista.avd.defined(true) %}
    isis network point-to-point
-{%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].isis_circuit_type is arista.avd.defined %}
-   isis circuit-type {{ ethernet_interfaces[ethernet_interface].isis_circuit_type }}
 {%         endif %}
 {%         if ethernet_interfaces[ethernet_interface].pim.ipv4.sparse_mode is arista.avd.defined(true) %}
    pim ipv4 sparse-mode

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -209,6 +209,9 @@ interface {{ ethernet_interface }}
 {%         if ethernet_interfaces[ethernet_interface].isis_network_point_to_point is arista.avd.defined(true) %}
    isis network point-to-point
 {%         endif %}
+{%         if ethernet_interfaces[ethernet_interface].isis_circuit_type is arista.avd.defined %}
+   isis circuit-type {{ ethernet_interfaces[ethernet_interface].isis_circuit_type }}
+{%         endif %}
 {%         if ethernet_interfaces[ethernet_interface].pim.ipv4.sparse_mode is arista.avd.defined(true) %}
    pim ipv4 sparse-mode
 {%         endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
@@ -236,18 +236,18 @@ interface {{ port_channel_interface }}
 {%     endif %}
 {%     if port_channel_interfaces[port_channel_interface].isis_enable is arista.avd.defined %}
    isis enable {{ port_channel_interfaces[port_channel_interface].isis_enable }}
-{%         if port_channel_interfaces[port_channel_interface].isis_passive is arista.avd.defined(true) %}
-   isis passive
-{%         endif %}
-{%         if port_channel_interfaces[port_channel_interface].isis_metric is arista.avd.defined %}
-   isis metric {{ port_channel_interfaces[port_channel_interface].isis_metric }}
-{%         endif %}
-{%         if port_channel_interfaces[port_channel_interface].isis_network_point_to_point is arista.avd.defined(true) %}
-   isis network point-to-point
-{%         endif %}
-{%         if port_channel_interfaces[port_channel_interface].isis_circuit_type is arista.avd.defined %}
+{%     endif %}
+{%     if port_channel_interfaces[port_channel_interface].isis_circuit_type is arista.avd.defined %}
    isis circuit-type {{ port_channel_interfaces[port_channel_interface].isis_circuit_type }}
-{%         endif %}
+{%     endif %}
+{%     if port_channel_interfaces[port_channel_interface].isis_metric is arista.avd.defined %}
+   isis metric {{ port_channel_interfaces[port_channel_interface].isis_metric }}
+{%     endif %}
+{%     if port_channel_interfaces[port_channel_interface].isis_passive is arista.avd.defined(true) %}
+   isis passive
+{%     endif %}
+{%     if port_channel_interfaces[port_channel_interface].isis_network_point_to_point is arista.avd.defined(true) %}
+   isis network point-to-point
 {%     endif %}
 {%     if port_channel_interfaces[port_channel_interface].eos_cli is arista.avd.defined %}
    {{ port_channel_interfaces[port_channel_interface].eos_cli | indent(3, false) }}


### PR DESCRIPTION
## Change Summary

Customizable IS-IS circuit type in ethernet interfaces.

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Add isis_circuit_type key under Ethernet interfaces.

### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
