### PR TITLE
Feat(eos_cli_config_gen): Add support for LDP IGP sync

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -333,8 +333,8 @@ interface Ethernet17
 
 ## MPLS Interfaces
 
-| Interface | MPLS IP Enabled | LDP Enabled | LDP-IGP Sync Configured |
-| --------- | --------------- | ----------- | ----------------------- |
+| Interface | MPLS IP Enabled | LDP Enabled | IGP Sync |
+| --------- | --------------- | ----------- | -------- |
 | Ethernet9 | True | True | False |
 | Ethernet10 | False | False | False |
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -335,8 +335,8 @@ interface Ethernet17
 
 | Interface | MPLS IP Enabled | LDP Enabled | IGP Sync |
 | --------- | --------------- | ----------- | -------- |
-| Ethernet9 | True | True | False |
-| Ethernet10 | False | False | False |
+| Ethernet9 | True | True | - |
+| Ethernet10 | False | False | - |
 
 # Multicast
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -333,10 +333,10 @@ interface Ethernet17
 
 ## MPLS Interfaces
 
-| Interface | MPLS IP Enabled | LDP Enabled |
-| --------- | --------------- | ----------- |
-| Ethernet9 | True | True |
-| Ethernet10 | False | False |
+| Interface | MPLS IP Enabled | LDP Enabled | LDP-IGP Sync Configured |
+| --------- | --------------- | ----------- | ----------------------- |
+| Ethernet9 | True | True | False |
+| Ethernet10 | False | False | False |
 
 # Multicast
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/loopbacks-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/loopbacks-interfaces.md
@@ -152,8 +152,8 @@ interface Loopback100
 
 ## MPLS Interfaces
 
-| Interface | MPLS IP Enabled | LDP Enabled | LDP-IGP Sync Configured |
-| --------- | --------------- | ----------- | ----------------------- |
+| Interface | MPLS IP Enabled | LDP Enabled | IGP Sync |
+| --------- | --------------- | ----------- | -------- |
 | Loopback99 | - | True | - |
 
 # Multicast

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/loopbacks-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/loopbacks-interfaces.md
@@ -152,9 +152,9 @@ interface Loopback100
 
 ## MPLS Interfaces
 
-| Interface | MPLS IP Enabled | LDP Enabled |
-| --------- | --------------- | ----------- |
-| Loopback99 | - | True |
+| Interface | MPLS IP Enabled | LDP Enabled | LDP-IGP Sync Configured |
+| --------- | --------------- | ----------- | ----------------------- |
+| Loopback99 | - | True | - |
 
 # Multicast
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mpls.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mpls.md
@@ -172,8 +172,8 @@ mpls ldp
 
 ## MPLS Interfaces
 
-| Interface | MPLS IP Enabled | LDP Enabled | LDP-IGP Sync Configured |
-| --------- | --------------- | ----------- | ----------------------- |
+| Interface | MPLS IP Enabled | LDP Enabled | IGP Sync |
+| --------- | --------------- | ----------- | -------- |
 | Ethernet1 | True | True | True |
 | Loopback0 | - | True | - |
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mpls.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mpls.md
@@ -93,6 +93,7 @@ interface Ethernet1
    ip address 192.168.100.1/31
    mpls ip
    mpls ldp interface
+   mpls ldp igp sync
 ```
 
 ## Loopback Interfaces
@@ -171,10 +172,10 @@ mpls ldp
 
 ## MPLS Interfaces
 
-| Interface | MPLS IP Enabled | LDP Enabled |
-| --------- | --------------- | ----------- |
-| Ethernet1 | True | True |
-| Loopback0 | - | True |
+| Interface | MPLS IP Enabled | LDP Enabled | LDP-IGP Sync Configured |
+| --------- | --------------- | ----------- | ----------------------- |
+| Ethernet1 | True | True | True |
+| Loopback0 | - | True | - |
 
 # Multicast
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/mpls.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/mpls.cfg
@@ -12,6 +12,7 @@ interface Ethernet1
    ip address 192.168.100.1/31
    mpls ip
    mpls ldp interface
+   mpls ldp igp sync
 !
 interface Loopback0
    ip address 192.168.1.1/32

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/mpls.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/mpls.yml
@@ -14,6 +14,7 @@ ethernet_interfaces:
       ip: true
       ldp:
         interface: true
+        igp_sync: true
 
 loopback_interfaces:
   Loopback0:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -757,6 +757,7 @@ ethernet_interfaces:
       ip: < true | false >
       ldp:
         interface: < true | false >
+        ldp_igp_sync: < true | false >
     lacp_timer:
       mode: < fast | normal >
       multiplier: < 3 - 3000 >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -757,7 +757,7 @@ ethernet_interfaces:
       ip: < true | false >
       ldp:
         interface: < true | false >
-        ldp_igp_sync: < true | false >
+        igp_sync: < true | false >
     lacp_timer:
       mode: < fast | normal >
       multiplier: < 3 - 3000 >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/mpls-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/mpls-interfaces.j2
@@ -3,8 +3,8 @@
 
 ## MPLS Interfaces
 
-| Interface | MPLS IP Enabled | LDP Enabled | LDP-IGP Sync Configured |
-| --------- | --------------- | ----------- | ----------------------- |
+| Interface | MPLS IP Enabled | LDP Enabled | IGP Sync |
+| --------- | --------------- | ----------- | -------- |
 {%     for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort %}
 {%         if ethernet_interfaces[ethernet_interface].mpls is arista.avd.defined %}
 {%             set row_mpls_ip = ethernet_interfaces[ethernet_interface].mpls.ip | arista.avd.default('-') %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/mpls-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/mpls-interfaces.j2
@@ -9,7 +9,7 @@
 {%         if ethernet_interfaces[ethernet_interface].mpls is arista.avd.defined %}
 {%             set row_mpls_ip = ethernet_interfaces[ethernet_interface].mpls.ip | arista.avd.default('-') %}
 {%             set row_ldp_interface = ethernet_interfaces[ethernet_interface].mpls.ldp.interface | arista.avd.default('-') %}
-{%             set row_ldp_igp_sync = ethernet_interfaces[ethernet_interface].mpls.ldp.igp_sync | arista.avd.default(false) %}
+{%             set row_ldp_igp_sync = ethernet_interfaces[ethernet_interface].mpls.ldp.igp_sync | arista.avd.default('-') %}
 | {{ ethernet_interface }} | {{ row_mpls_ip }} | {{ row_ldp_interface }} | {{ row_ldp_igp_sync }} |
 {%         endif %}
 {%     endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/mpls-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/mpls-interfaces.j2
@@ -9,7 +9,7 @@
 {%         if ethernet_interfaces[ethernet_interface].mpls is arista.avd.defined %}
 {%             set row_mpls_ip = ethernet_interfaces[ethernet_interface].mpls.ip | arista.avd.default('-') %}
 {%             set row_ldp_interface = ethernet_interfaces[ethernet_interface].mpls.ldp.interface | arista.avd.default('-') %}
-{%             set row_ldp_igp_sync = ethernet_interfaces[ethernet_interface].mpls.ldp.igp_sync | arista.avd.defined(false) %}
+{%             set row_ldp_igp_sync = ethernet_interfaces[ethernet_interface].mpls.ldp.igp_sync | arista.avd.default(false) %}
 | {{ ethernet_interface }} | {{ row_mpls_ip }} | {{ row_ldp_interface }} | {{ row_ldp_igp_sync }} |
 {%         endif %}
 {%     endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/mpls-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/mpls-interfaces.j2
@@ -3,19 +3,20 @@
 
 ## MPLS Interfaces
 
-| Interface | MPLS IP Enabled | LDP Enabled |
-| --------- | --------------- | ----------- |
+| Interface | MPLS IP Enabled | LDP Enabled | LDP-IGP Sync Configured |
+| --------- | --------------- | ----------- | ----------------------- |
 {%     for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort %}
 {%         if ethernet_interfaces[ethernet_interface].mpls is arista.avd.defined %}
 {%             set row_mpls_ip = ethernet_interfaces[ethernet_interface].mpls.ip | arista.avd.default('-') %}
 {%             set row_ldp_interface = ethernet_interfaces[ethernet_interface].mpls.ldp.interface | arista.avd.default('-') %}
-| {{ ethernet_interface }} | {{ row_mpls_ip }} | {{ row_ldp_interface }} |
+{%             set row_ldp_igp_sync = ethernet_interfaces[ethernet_interface].mpls.ldp.igp_sync | arista.avd.defined(false) %}
+| {{ ethernet_interface }} | {{ row_mpls_ip }} | {{ row_ldp_interface }} | {{ row_ldp_igp_sync }} |
 {%         endif %}
 {%     endfor %}
 {%     for loopback_interface in loopback_interfaces | arista.avd.natural_sort %}
 {%         if loopback_interfaces[loopback_interface].mpls is arista.avd.defined %}
 {%             set row_ldp_interface = loopback_interfaces[loopback_interface].mpls.ldp.interface | arista.avd.default('-') %}
-| {{ loopback_interface }} | - | {{ row_ldp_interface }} |
+| {{ loopback_interface }} | - | {{ row_ldp_interface }} | - |
 {%         endif %}
 {%     endfor %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -272,6 +272,9 @@ interface {{ ethernet_interface }}
 {%         elif ethernet_interfaces[ethernet_interface].mpls.ldp.interface is arista.avd.defined(false) %}
    no mpls ldp interface
 {%         endif %}
+{%         if ethernet_interfaces[ethernet_interface].mpls.ldp.igp_sync is arista.avd.defined(true) %}
+   mpls ldp igp sync
+{%         endif %}
 {%     endif %}
 {%     if ethernet_interfaces[ethernet_interface].transceiver.media.override is arista.avd.defined %}
    transceiver media override {{ ethernet_interfaces[ethernet_interface].transceiver.media.override }}


### PR DESCRIPTION
## Change Summary

Adds support for mpls ldp igp sync command on Ethernet interfaces.

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Adds key under interface to render mpls ldp igp sync command:
 
```
ethernet_interfaces:
  EthernetX:
    mpls:
      ip: true
      ldp:
        interface: true
        igp_sync: true
```

### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
