### PR TITLE
Feat(eos_cli_config_gen): Add support for interface level no lldp rx/tx commands

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -86,6 +86,7 @@ interface Management1
 | Ethernet15 |  PVLAN Promiscuous Access - only one secondary | access | 110 | - | - | - |
 | Ethernet16 |  PVLAN Promiscuous Trunk - vlan translation out | trunk | 110-112 | - | - | - |
 | Ethernet17 |  PVLAN Secondary Trunk | trunk | 110-112 | - | - | - |
+| Ethernet18 |  Switched port with no LLDP rx/tx | access | 110 | - | - | - |
 
 *Inherited from Port-Channel Interface
 
@@ -228,6 +229,8 @@ interface Ethernet7
 interface Ethernet8
    description to WAN-ISP1-01 Ethernet2
    no switchport
+   no lldp transmit
+   no lldp receive
 !
 interface Ethernet8.101
    description to WAN-ISP-01 Ethernet2.101 - VRF-C1
@@ -306,6 +309,18 @@ interface Ethernet18
    no switchport
    ip address 192.0.2.1/31
    service-policy type pbr input MyLANServicePolicy
+   description Switched port with no LLDP rx/tx
+   switchport
+   switchport access vlan 110
+   switchport mode access
+   no lldp transmit
+   no lldp receive
+!
+interface Ethernet19
+   description Port patched through patch-panel to pseudowire
+   no switchport
+   no lldp transmit
+   no lldp receive
 ```
 
 # Routing

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -317,7 +317,7 @@ interface Ethernet18
    no lldp receive
 !
 interface Ethernet19
-   description Port patched through patch-panel to pseudowire
+   description Interface patched through patch-panel to pseudowire
    no switchport
    no lldp transmit
    no lldp receive

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -86,7 +86,7 @@ interface Management1
 | Ethernet15 |  PVLAN Promiscuous Access - only one secondary | access | 110 | - | - | - |
 | Ethernet16 |  PVLAN Promiscuous Trunk - vlan translation out | trunk | 110-112 | - | - | - |
 | Ethernet17 |  PVLAN Secondary Trunk | trunk | 110-112 | - | - | - |
-| Ethernet18 |  Switched port with no LLDP rx/tx | access | 110 | - | - | - |
+| Ethernet19 |  Switched port with no LLDP rx/tx | access | 110 | - | - | - |
 
 *Inherited from Port-Channel Interface
 
@@ -309,6 +309,8 @@ interface Ethernet18
    no switchport
    ip address 192.0.2.1/31
    service-policy type pbr input MyLANServicePolicy
+!
+interface Ethernet19
    description Switched port with no LLDP rx/tx
    switchport
    switchport access vlan 110
@@ -316,8 +318,8 @@ interface Ethernet18
    no lldp transmit
    no lldp receive
 !
-interface Ethernet19
-   description Interface patched through patch-panel to pseudowire
+interface Ethernet20
+   description Port patched through patch-panel to pseudowire
    no switchport
    no lldp transmit
    no lldp receive

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
@@ -184,6 +184,8 @@ interface Ethernet18
    no switchport
    ip address 192.0.2.1/31
    service-policy type pbr input MyLANServicePolicy
+!
+interface Ethernet19
    description Switched port with no LLDP rx/tx
    switchport
    switchport access vlan 110
@@ -191,8 +193,8 @@ interface Ethernet18
    no lldp transmit
    no lldp receive
 !
-interface Ethernet19
-   description Interface patched through patch-panel to pseudowire
+interface Ethernet20
+   description Port patched through patch-panel to pseudowire
    no switchport
    no lldp transmit
    no lldp receive

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
@@ -104,6 +104,8 @@ interface Ethernet7
 interface Ethernet8
    description to WAN-ISP1-01 Ethernet2
    no switchport
+   no lldp transmit
+   no lldp receive
 !
 interface Ethernet8.101
    description to WAN-ISP-01 Ethernet2.101 - VRF-C1
@@ -182,6 +184,18 @@ interface Ethernet18
    no switchport
    ip address 192.0.2.1/31
    service-policy type pbr input MyLANServicePolicy
+   description Switched port with no LLDP rx/tx
+   switchport
+   switchport access vlan 110
+   switchport mode access
+   no lldp transmit
+   no lldp receive
+!
+interface Ethernet19
+   description Port patched through patch-panel to pseudowire
+   no switchport
+   no lldp transmit
+   no lldp receive
 !
 interface Management1
    description oob_management

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
@@ -192,7 +192,7 @@ interface Ethernet18
    no lldp receive
 !
 interface Ethernet19
-   description Port patched through patch-panel to pseudowire
+   description Interface patched through patch-panel to pseudowire
    no switchport
    no lldp transmit
    no lldp receive

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
@@ -148,6 +148,8 @@ ethernet_interfaces:
   Ethernet8:
     description: to WAN-ISP1-01 Ethernet2
     type: routed
+    lldp_transmit: false
+    lldp_receive: false
   Ethernet8.101:
     description: to WAN-ISP-01 Ethernet2.101 - VRF-C1
     type: l3dot1q
@@ -240,3 +242,16 @@ ethernet_interfaces:
     service_policy:
       pbr:
         input: MyLANServicePolicy
+
+  Ethernet19:
+    description: Switched port with no LLDP rx/tx
+    mode: access
+    vlans: 110
+    lldp_transmit: false
+    lldp_receive: false
+
+  Ethernet20:
+    description: Port patched through patch-panel to pseudowire
+    type: routed
+    lldp_transmit: false
+    lldp_receive: false

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
@@ -148,8 +148,9 @@ ethernet_interfaces:
   Ethernet8:
     description: to WAN-ISP1-01 Ethernet2
     type: routed
-    lldp_transmit: false
-    lldp_receive: false
+    lldp:
+      transmit: false
+      receive: false
   Ethernet8.101:
     description: to WAN-ISP-01 Ethernet2.101 - VRF-C1
     type: l3dot1q
@@ -247,11 +248,13 @@ ethernet_interfaces:
     description: Switched port with no LLDP rx/tx
     mode: access
     vlans: 110
-    lldp_transmit: false
-    lldp_receive: false
+    lldp:
+      transmit: false
+      receive: false
 
   Ethernet20:
     description: Port patched through patch-panel to pseudowire
     type: routed
-    lldp_transmit: false
-    lldp_receive: false
+    lldp:
+      transmit: false
+      receive: false

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -757,6 +757,8 @@ ethernet_interfaces:
     logging:
       event:
         link_status: < true | false >
+    lldp_transmit: < true | false >
+    lldp_receive: < true | false >
     service_profile: < qos_profile >
     qos:
       trust: < dscp | cos >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -757,8 +757,9 @@ ethernet_interfaces:
     logging:
       event:
         link_status: < true | false >
-    lldp_transmit: < true | false >
-    lldp_receive: < true | false >
+    lldp:
+      transmit: < true | false >
+      receive: < true | false >
     service_profile: < qos_profile >
     qos:
       trust: < dscp | cos >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -248,6 +248,12 @@ interface {{ ethernet_interface }}
 {%         if ethernet_interfaces[ethernet_interface].profile is arista.avd.defined %}
    profile {{ ethernet_interfaces[ethernet_interface].profile }}
 {%         endif %}
+{%         if ethernet_interfaces[ethernet_interface].lldp_transmit is arista.avd.defined(false) %}
+   no lldp transmit
+{%         endif %}
+{%         if ethernet_interfaces[ethernet_interface].lldp_receive is arista.avd.defined(false) %}
+   no lldp receive
+{%         endif %}
 {%         for section in ethernet_interfaces[ethernet_interface].storm_control | arista.avd.natural_sort %}
 {%             if ethernet_interfaces[ethernet_interface].storm_control[section].level is arista.avd.defined %}
 {%                 if ethernet_interfaces[ethernet_interface].storm_control[section].unit is arista.avd.defined('pps') %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -248,10 +248,10 @@ interface {{ ethernet_interface }}
 {%         if ethernet_interfaces[ethernet_interface].profile is arista.avd.defined %}
    profile {{ ethernet_interfaces[ethernet_interface].profile }}
 {%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].lldp_transmit is arista.avd.defined(false) %}
+{%         if ethernet_interfaces[ethernet_interface].lldp.transmit is arista.avd.defined(false) %}
    no lldp transmit
 {%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].lldp_receive is arista.avd.defined(false) %}
+{%         if ethernet_interfaces[ethernet_interface].lldp.receive is arista.avd.defined(false) %}
    no lldp receive
 {%         endif %}
 {%         for section in ethernet_interfaces[ethernet_interface].storm_control | arista.avd.natural_sort %}


### PR DESCRIPTION
## Change Summary

Adds support for (no) lldp transmit/receive on Ethernet interfaces.

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Adds the following keys to interfaces:
```
lldp_transmit: < true | false >
lldp_receive: < true | false >
```

### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
