### PR TITLE
Fix(ansible): galaxy version must be semantic

### DIFF
--- a/ansible_collections/arista/avd/galaxy.yml
+++ b/ansible_collections/arista/avd/galaxy.yml
@@ -9,7 +9,7 @@ namespace: arista
 name: avd
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 3.0.0rc2
+version: 3.0.0-rc2
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md


### PR DESCRIPTION
## Change Summary

Update galaxy version to follow semantic version for RC releases.

## Related Issue(s)

Fixes issue with installing collection via Git.

## Component(s) name

galaxy-requirements 

## Proposed changes

Update version from `3.0.0rc2` -> `3.0.0-rc2`

## Tested with Galaxy installation from git

```
ansible-galaxy collection install -r ansible-galaxy.yml
[DEPRECATION WARNING]: Ansible will require Python 3.8 or newer on the controller starting with Ansible 2.12. Current version: 3.6.8 (default, Nov 16 2020, 16:55:22) [GCC 4.8.5 20150623 (Red Hat 
4.8.5-44)]. This feature will be removed from ansible-core in version 2.12. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
Starting galaxy collection install process
Process install dependency map
Cloning into '/home/cbuchmann/.ansible/tmp/ansible-local-6301k1buuf2s/tmpezual1j8/ansible-avdjiy879rv'...
remote: Enumerating objects: 39576, done.
remote: Counting objects: 100% (3339/3339), done.
remote: Compressing objects: 100% (1672/1672), done.
remote: Total 39576 (delta 2338), reused 2176 (delta 1487), pack-reused 36237
Receiving objects: 100% (39576/39576), 12.36 MiB | 6.07 MiB/s, done.
Resolving deltas: 100% (28049/28049), done.
Branch 'fix-galaxy-version' set up to track remote branch 'fix-galaxy-version' from 'origin'.
Switched to a new branch 'fix-galaxy-version'
Starting collection install process
Installing 'arista.avd:3.0.0-rc2' to '/home/cbuchmann/arista-ansible/ansible-avd/ansible_collections/arista/avd'
```

