### PR TITLE
CI(actions): Implement PR management for releases

### DIFF
--- a/.github/changelog.sh
+++ b/.github/changelog.sh
@@ -306,7 +306,7 @@ function display-release {
     # If no commits found of type $type, go to next type
     (( $#hashes != 0 )) || return 0
 
-    fmt:header "${TYPES[$type]}" 3
+    fmt:header "${TYPES[$type]}" 2
     for hash in $hashes; do
       echo " - $(fmt:hash) $(fmt:scope)$(fmt:subject)"
     done | sort -k3 # sort by scope
@@ -323,7 +323,7 @@ function display-release {
     # If no commits found under "other" types, don't display anything
     (( $#changes != 0 )) || return 0
 
-    fmt:header "Other changes" 3
+    fmt:header "Other changes" 2
     for hash type in ${(kv)changes}; do
       case "$type" in
       other) echo " - $(fmt:hash) $(fmt:scope)$(fmt:subject)" ;;

--- a/.github/workflows/devel-push.yml
+++ b/.github/workflows/devel-push.yml
@@ -70,6 +70,7 @@ jobs:
     name: Webhook to Docker Hub to build image
     runs-on: ubuntu-18.04
     container: avdteam/base:3.8-v2.0
+    needs: ['file-changes']
     if: needs.file-changes.outputs.requirements == 'true'
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -2,12 +2,6 @@
 name: "Collection code testing"
 
 on:
-  # push:
-  #   branches-ignore:
-  #     - devel
-  #     - releases/**
-  #     - ci/**
-  # For a pull_request event, only branches and tags on the base are evaluated.
   pull_request:
     branches-ignore:
       - releases/**
@@ -43,6 +37,7 @@ jobs:
               - '!ansible_collections/arista/avd/roles/eos_config_deploy_cvp/**/*'
               - '!ansible_collections/arista/avd/molecule/cvp_configlet_upload/*'
               - '!ansible_collections/arista/avd/molecule/cvp_configlet_upload/**/*'
+              - '!ansible_collections/arista/avd/galaxy.yml'
             config_gen:
               - 'ansible_collections/arista/avd/roles/eos_cli_config_gen/*'
               - 'ansible_collections/arista/avd/roles/eos_cli_config_gen/**/*'
@@ -51,24 +46,29 @@ jobs:
               - 'ansible_collections/arista/avd/molecule/eos_cli_config_gen/**/*'
               - 'ansible_collections/arista/avd/molecule/upgrade_eos_cli_config_gen/*'
               - 'ansible_collections/arista/avd/molecule/upgrade_eos_cli_config_gen/**/*'
+              - '!ansible_collections/arista/avd/galaxy.yml'
             cloudvision:
               - 'ansible_collections/arista/avd/roles/eos_config_deploy_cvp/*'
               - 'ansible_collections/arista/avd/roles/eos_config_deploy_cvp/**/*'
               - 'ansible_collections/arista/avd/molecule/cvp_configlet_upload/*'
               - 'ansible_collections/arista/avd/molecule/cvp_configlet_upload/**/*'
               - '.github/workflows/pull-request-management.yml'
+              - '!ansible_collections/arista/avd/galaxy.yml'
             dhcp:
               - 'ansible_collections/arista/avd/roles/dhcp_provisioner/*'
               - 'ansible_collections/arista/avd/roles/dhcp_provisioner/**/*'
               - '.github/workflows/pull-request-management.yml'
+              - '!ansible_collections/arista/avd/galaxy.yml'
             plugins:
               - 'ansible_collections/arista/avd/plugins/filter/**'
               - 'ansible_collections/arista/avd/plugins/test/**'
+              - '!ansible_collections/arista/avd/galaxy.yml'
             requirements:
               - 'ansible_collections/arista/avd/requirements.txt'
               - 'ansible_collections/arista/avd/requirements-dev.txt'
               - 'ansible_collections/arista/avd/meta/runtime.yml'
               - '.github/workflows/pull-request-management.yml'
+              - '!ansible_collections/arista/avd/galaxy.yml'
             docs:
               - '.github/workflows/pull-request-management.yml'
               - 'mkdocs.yml'
@@ -76,6 +76,7 @@ jobs:
               - 'ansible_collections/arista/avd/roles/**/*.md'
               - 'ansible_collections/arista/avd/**/*.md'
               - 'ansible_collections/arista/avd/README.md'
+              - '!ansible_collections/arista/avd/galaxy.yml'
   # ----------------------------------- #
   # Pre Commit code validation
   # ----------------------------------- #
@@ -289,57 +290,3 @@ jobs:
       #   with:
       #     name: molecule-${{ matrix.avd_scenario }}-artifacts
       #     path: ${PWD}/ansible_collections/arista/avd/molecule/${{ matrix.avd_scenario }}
-  # ----------------------------------- #
-  # Ansible tests
-  # ----------------------------------- #
-  ansible_test:
-    name: Run ansible-test validation
-    runs-on: ubuntu-20.04
-    needs: [ molecule_eos_designs, molecule_cloudvision ]
-    if: needs.cloudvision.status != 'failed' && needs.molecule_eos_designs.status != 'failed' && needs.file-changes.outputs.plugins == 'true'
-    strategy:
-      fail-fast: true
-      matrix:
-        python_version: [ 3.8 ]
-    steps:
-      - name: 'set environment variables'
-        run: |
-          echo "PY_COLORS=1" >> $GITHUB_ENV
-          echo "ANSIBLE_FORCE_COLOR=1" >> $GITHUB_ENV
-      - uses: actions/checkout@v2
-      - name: Set up Python 3
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python_version }}
-      - name: 'Install Python requirements'
-        run: make install-requirements
-      - name: 'ansible-test linting'
-        run: |
-          cd ansible_collections/arista/avd/
-          ansible-test sanity  -v --requirements --docker --skip-test yamllint --exclude docs/
-
-  galaxy_importer:
-    name: Test galaxy-importer
-    runs-on: ubuntu-latest
-    container: avdteam/base:3.8-v2.0
-    needs: [ molecule_eos_designs, molecule_cloudvision ]
-    if: needs.cloudvision.status != 'failed' && needs.molecule_eos_designs.status != 'failed' && needs.file-changes.outputs.plugins == 'true'
-    env:
-      PY_COLORS: 1 # allows molecule colors to be passed to GitHub Actions
-      ANSIBLE_FORCE_COLOR: 1 # allows ansible colors to be passed to GitHub Actions
-    steps:
-      - name: 'set environment variables'
-        run: |
-          echo "PY_COLORS=1" >> $GITHUB_ENV
-          echo "ANSIBLE_FORCE_COLOR=1" >> $GITHUB_ENV
-      - uses: actions/checkout@v2
-      - name: install requirements
-        run: make install-requirements
-      - name: 'build ansible package'
-        run: make collection-build
-      - name: 'run ansible-importer checks'
-        run: python -m galaxy_importer.main *.tar.gz
-      - uses: actions/upload-artifact@v2
-        with:
-          name: importer-logs
-          path: ./importer_result.json

--- a/.github/workflows/pull-request-releases.yml
+++ b/.github/workflows/pull-request-releases.yml
@@ -1,0 +1,63 @@
+
+---
+name: "Pre-release validation"
+on:
+  pull_request:
+    branches:
+      - releases/**
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  ansible_test:
+    name: Run ansible-test validation
+    runs-on: ubuntu-20.04]
+    if: needs.cloudvision.status != 'failed' && needs.molecule_eos_designs.status != 'failed' && needs.file-changes.outputs.plugins == 'true'
+    strategy:
+      fail-fast: true
+      matrix:
+        python_version: [ 3.8 ]
+    steps:
+      - name: 'set environment variables'
+        run: |
+          echo "PY_COLORS=1" >> $GITHUB_ENV
+          echo "ANSIBLE_FORCE_COLOR=1" >> $GITHUB_ENV
+      - uses: actions/checkout@v2
+      - name: Set up Python 3
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python_version }}
+      - name: 'Install Python requirements'
+        run: make install-requirements
+      - name: 'ansible-test linting'
+        run: |
+          cd ansible_collections/arista/avd/
+          ansible-test sanity  -v --requirements --docker --skip-test yamllint --exclude docs/
+
+  galaxy_importer:
+    name: Test galaxy-importer
+    runs-on: ubuntu-latest
+    container: avdteam/base:3.8-v2.0
+    needs: [ molecule_eos_designs ]
+    if: needs.cloudvision.status != 'failed' && needs.molecule_eos_designs.status != 'failed' && needs.file-changes.outputs.plugins == 'true'
+    env:
+      PY_COLORS: 1 # allows molecule colors to be passed to GitHub Actions
+      ANSIBLE_FORCE_COLOR: 1 # allows ansible colors to be passed to GitHub Actions
+    steps:
+      - name: 'set environment variables'
+        run: |
+          echo "PY_COLORS=1" >> $GITHUB_ENV
+          echo "ANSIBLE_FORCE_COLOR=1" >> $GITHUB_ENV
+      - uses: actions/checkout@v2
+      - name: install requirements
+        run: make install-requirements
+      - name: 'build ansible package'
+        run: make collection-build
+      - name: 'run ansible-importer checks'
+        run: python -m galaxy_importer.main *.tar.gz
+      - uses: actions/upload-artifact@v2
+        with:
+          name: importer-logs
+          path: ./importer_result.json


### PR DESCRIPTION
## Change Summary

Implement a PR management for new release.

## Related Issue(s)

N/A

## Component(s) name

github actions

## Proposed changes

- New PR management for base branches `releases/*`
	- Run ansible-test
	- Run galaxy-importer
- Fix an error where eos_design was marked as true when `galaxy.yml` only was changed
- Set section for changelog output to `Header2` instead of `Header3`


## How to test

Create a fake PR to `releases/*`

## Checklist

### User Checklist

- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
