### PR TITLE
Feat(eos_cli_config_gen): Add BGP VRF prefix-list support (#1248)

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vrf-lite.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vrf-lite.md
@@ -153,6 +153,7 @@ ip route vrf BLUE-C1 193.1.2.0/24 Null0
 | 10.1.1.0 | Inherited from peer group OBS_WAN | BLUE-C1 | - | - |
 | 10.255.1.1 | Inherited from peer group WELCOME_ROUTERS | BLUE-C1 | - | - |
 | 101.0.3.1 | Inherited from peer group SEDI | BLUE-C1 | - | - |
+| 10.1.1.0 | Inherited from peer group OBS_WAN | RED-C1 | - | - |
 
 ### Router BGP EVPN Address Family
 
@@ -163,6 +164,7 @@ ip route vrf BLUE-C1 193.1.2.0/24 Null0
 | VRF | Route-Distinguisher | Redistribute |
 | --- | ------------------- | ------------ |
 | BLUE-C1 | 1.0.1.1:101 | static |
+| RED-C1 | 1.0.1.1:102 | - |
 
 ### Router BGP Device Configuration
 
@@ -208,6 +210,12 @@ router bgp 65001
       Comment created from eos_cli under router_bgp.vrfs.BLUE-C1
       EOF
 
+   !
+   vrf RED-C1
+      rd 1.0.1.1:102
+      neighbor 10.1.1.0 peer group OBS_WAN
+      neighbor 10.1.1.0 prefix-list PL-BGP-DEFAULT-RED-IN-C1 in
+      neighbor 10.1.1.0 prefix-list PL-BGP-DEFAULT-RED-OUT-C1 out
 ```
 
 # Multicast
@@ -224,12 +232,30 @@ router bgp 65001
 | -------- | ------ |
 | 10 | permit 0.0.0.0/0 le 1 |
 
+#### PL-BGP-DEFAULT-RED-IN-C1
+
+| Sequence | Action |
+| -------- | ------ |
+| 10 | permit 0.0.0.0/0 |
+
+#### PL-BGP-DEFAULT-RED-OUT-C1
+
+| Sequence | Action |
+| -------- | ------ |
+| 10 | permit 10.0.0.0/8 |
+
 ### Prefix-lists Device Configuration
 
 ```eos
 !
 ip prefix-list PL-BGP-DEFAULT-BLUE-C1
    seq 10 permit 0.0.0.0/0 le 1
+!
+ip prefix-list PL-BGP-DEFAULT-RED-IN-C1
+   seq 10 permit 0.0.0.0/0
+!
+ip prefix-list PL-BGP-DEFAULT-RED-OUT-C1
+   seq 10 permit 10.0.0.0/8
 ```
 
 ## Route-maps

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-vrf-lite.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-vrf-lite.cfg
@@ -15,6 +15,12 @@ interface Management1
 ip prefix-list PL-BGP-DEFAULT-BLUE-C1
    seq 10 permit 0.0.0.0/0 le 1
 !
+ip prefix-list PL-BGP-DEFAULT-RED-IN-C1
+   seq 10 permit 0.0.0.0/0
+!
+ip prefix-list PL-BGP-DEFAULT-RED-OUT-C1
+   seq 10 permit 10.0.0.0/8
+!
 ip route vrf BLUE-C1 193.1.0.0/24 Null0
 ip route vrf BLUE-C1 193.1.1.0/24 Null0
 ip route vrf BLUE-C1 193.1.2.0/24 Null0
@@ -67,5 +73,11 @@ router bgp 65001
       Comment created from eos_cli under router_bgp.vrfs.BLUE-C1
       EOF
 
+   !
+   vrf RED-C1
+      rd 1.0.1.1:102
+      neighbor 10.1.1.0 peer group OBS_WAN
+      neighbor 10.1.1.0 prefix-list PL-BGP-DEFAULT-RED-IN-C1 in
+      neighbor 10.1.1.0 prefix-list PL-BGP-DEFAULT-RED-OUT-C1 out
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-vrf-lite.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-vrf-lite.yml
@@ -3,6 +3,14 @@ prefix_lists:
     sequence_numbers:
       10:
         action: permit 0.0.0.0/0 le 1
+  PL-BGP-DEFAULT-RED-OUT-C1:
+    sequence_numbers:
+      10:
+        action: permit 10.0.0.0/8
+  PL-BGP-DEFAULT-RED-IN-C1:
+    sequence_numbers:
+      10:
+        action: permit 0.0.0.0/0
 
 route_maps:
   RM-BGP-AGG-APPLY-SET:
@@ -84,6 +92,13 @@ router_bgp:
         comment
         Comment created from eos_cli under router_bgp.vrfs.BLUE-C1
         EOF
+    RED-C1:
+      rd: 1.0.1.1:102
+      neighbors:
+        10.1.1.0:
+          peer_group: OBS_WAN
+          prefix_list_in: PL-BGP-DEFAULT-RED-IN-C1
+          prefix_list_out: PL-BGP-DEFAULT-RED-OUT-C1
 
 static_routes:
   - vrf: BLUE-C1

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -2264,6 +2264,8 @@ router_bgp:
           update_source: < interface >
           route_map_out: < route-map name >
           route_map_in: < route-map name >
+          prefix_list_in: < prefix_list_name >
+          prefix_list_out: < prefix_list_name >
         < neighbor_ip_address >:
           remote_as: < asn >
           description: < description >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -556,6 +556,12 @@ router bgp {{ router_bgp.as }}
 {%             if router_bgp.vrfs[vrf].neighbors[neighbor].route_map_in is arista.avd.defined %}
       neighbor {{ neighbor }} route-map {{ router_bgp.vrfs[vrf].neighbors[neighbor].route_map_in }} in
 {%             endif %}
+{%             if router_bgp.vrfs[vrf].neighbors[neighbor].prefix_list_in is arista.avd.defined %}
+      neighbor {{ neighbor }} prefix-list {{ router_bgp.vrfs[vrf].neighbors[neighbor].prefix_list_in }} in
+{%             endif %}
+{%             if router_bgp.vrfs[vrf].neighbors[neighbor].prefix_list_out is arista.avd.defined %}
+      neighbor {{ neighbor }} prefix-list {{ router_bgp.vrfs[vrf].neighbors[neighbor].prefix_list_out }} out
+{%             endif %}
 {%         endfor %}
 {%         for redistribute_route in router_bgp.vrfs[vrf].redistribute_routes | arista.avd.natural_sort %}
 {%             set redistribute_cli = "redistribute " ~ redistribute_route %}


### PR DESCRIPTION
## Change Summary

Extend BGP VRF to also support per neighbor prefix-filters

## Related Issue(s)

Fixes #1248

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

```yaml
router_bgp:
  vrfs:
    < vrf_name_1 >:
      neighbors:
        < neighbor_ip_address >:
          remote_as: < asn >
          prefix_list_in: < prefix_list_name >
          prefix_list_out: < prefix_list_name >
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Buildin molecule tests

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
