### PR TITLE
Fix(eos_cli_config_gen): Jinja2 template on IPv6 standard ACL (#1242)

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ipv6-access-lists.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ipv6-access-lists.md
@@ -15,6 +15,7 @@
 - [Multicast](#multicast)
 - [Filters](#filters)
 - [ACL](#acl)
+  - [IPv6 Standard Access-lists](#ipv6-standard-access-lists)
   - [IPv6 Extended Access-lists](#ipv6-extended-access-lists)
 - [Quality Of Service](#quality-of-service)
 
@@ -90,6 +91,26 @@ interface Management1
 
 # ACL
 
+## IPv6 Standard Access-lists
+
+### IPv6 Standard Access-lists Summary
+
+#### TEST2
+
+| Sequence | Action |
+| -------- | ------ |
+| 5 | deny fe80::/64 |
+| 10 | permit 2001:db8::/64 |
+
+### IPv6 Standard Access-lists Device Configuration
+
+```eos
+!
+ipv6 access-list standard TEST2
+   5 deny fe80::/64
+   10 permit 2001:db8::/64
+```
+
 ## IPv6 Extended Access-lists
 
 ### IPv6 Extended Access-lists Summary
@@ -98,16 +119,16 @@ interface Management1
 
 | Sequence | Action |
 | -------- | ------ |
-| 5 | deny ip fe80::/64 |
-| 10 | permit ip fe90::/64 |
+| 5 | deny fe80::/64 |
+| 10 | permit fe90::/64 |
 
 ### IPv6 Extended Access-lists Device Configuration
 
 ```eos
 !
 ipv6 access-list TEST1
-   5 deny ip fe80::/64
-   10 permit ip fe90::/64
+   5 deny fe80::/64
+   10 permit fe90::/64
 ```
 
 # Quality Of Service

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ipv6-access-lists.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ipv6-access-lists.md
@@ -119,16 +119,16 @@ ipv6 access-list standard TEST2
 
 | Sequence | Action |
 | -------- | ------ |
-| 5 | deny fe80::/64 |
-| 10 | permit fe90::/64 |
+| 5 | deny ipv6 fe80::/64 any |
+| 10 | permit ipv6 fe90::/64 any |
 
 ### IPv6 Extended Access-lists Device Configuration
 
 ```eos
 !
 ipv6 access-list TEST1
-   5 deny fe80::/64
-   10 permit fe90::/64
+   5 deny ipv6 fe80::/64 any
+   10 permit ipv6 fe90::/64 any
 ```
 
 # Quality Of Service

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ipv6-access-lists.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ipv6-access-lists.cfg
@@ -13,7 +13,11 @@ interface Management1
    ip address 10.73.255.122/24
 !
 ipv6 access-list TEST1
-   5 deny ip fe80::/64
-   10 permit ip fe90::/64
+   5 deny fe80::/64
+   10 permit fe90::/64
+!
+ipv6 access-list standard TEST2
+   5 deny fe80::/64
+   10 permit 2001:db8::/64
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ipv6-access-lists.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ipv6-access-lists.cfg
@@ -13,8 +13,8 @@ interface Management1
    ip address 10.73.255.122/24
 !
 ipv6 access-list TEST1
-   5 deny fe80::/64
-   10 permit fe90::/64
+   5 deny ipv6 fe80::/64 any
+   10 permit ipv6 fe90::/64 any
 !
 ipv6 access-list standard TEST2
    5 deny fe80::/64

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ipv6-access-lists.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ipv6-access-lists.yml
@@ -1,10 +1,19 @@
 ### IPv6 ACLs ###
 
 ipv6_access_lists:
-  TEST1 : 
-    sequence_numbers: 
+  TEST1:
+    sequence_numbers:
       10:
-        action: "permit ip fe90::/64"
+        action: "permit fe90::/64"
       5:
-        action: "deny ip fe80::/64"
-        
+        action: "deny fe80::/64"
+
+### IPv6 Standard ACLs ###
+ipv6_standard_access_lists:
+  TEST2:
+    sequence_numbers:
+      10:
+        action: "permit 2001:db8::/64"
+      5:
+        action: "deny fe80::/64"
+

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ipv6-access-lists.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ipv6-access-lists.yml
@@ -4,9 +4,9 @@ ipv6_access_lists:
   TEST1:
     sequence_numbers:
       10:
-        action: "permit fe90::/64"
+        action: "permit ipv6 fe90::/64 any"
       5:
-        action: "deny fe80::/64"
+        action: "deny ipv6 fe80::/64 any"
 
 ### IPv6 Standard ACLs ###
 ipv6_standard_access_lists:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ipv6-standard-access-lists.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ipv6-standard-access-lists.j2
@@ -5,6 +5,6 @@ ipv6 access-list standard {{ ipv6_standard_access_list }}
 {%     for sequence in ipv6_standard_access_lists[ipv6_standard_access_list].sequence_numbers | arista.avd.natural_sort %}
 {%         if ipv6_standard_access_lists[ipv6_standard_access_list].sequence_numbers[sequence].action is arista.avd.defined %}
    {{ sequence }} {{ ipv6_standard_access_lists[ipv6_standard_access_list].sequence_numbers[sequence].action }}
-{%         endif %}}
+{%         endif %}
 {%     endfor %}
 {% endfor %}


### PR DESCRIPTION
## Change Summary

Remove superfluous `}` in Jinja2 template

## Related Issue(s)

Fixes #1242 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Buildin Molecule Tests

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
