### PR TITLE
Feat(eos_cli_config_gen): Add BGP vpws support

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vpws.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vpws.md
@@ -104,13 +104,13 @@ interface Management1
 
 #### Router BGP EVPN MAC-VRFs
 
-#### Router BGP VPWS Pseudowires
+#### Router BGP VPWS Instances
 
-| Tenant | Pseudowire | Route-Distinguisher | Both Route-Target | Local ID | Remote ID |
-| ------ | ---------- | ------------------- | ----------------- | -------- | --------- |
-| TENANT_A | TEN_A_site1_site3_pw | 100.70.0.2:1000 | 65000:1000 | 15 | 35 |
-| TENANT_A | TEN_A_site2_site5_pw | 100.70.0.2:1000 | 65000:1000 | 25 | 57 |
-| TENANT_B | TEN_B_site2_site5_pw | 100.70.0.2:2000 | 65000:2000 | 26 | 58 |
+| Instance | Route-Distinguisher | Both Route-Target| Pseudowire | Local ID | Remote ID |
+| -------- | ------------------- | -----------------| ---------- | -------- | --------- |
+| TENANT_A | 100.70.0.2:1000 | 65000:1000 | TEN_A_site1_site3_pw | 15 | 35 |
+| TENANT_A | 100.70.0.2:1000 | 65000:1000 | TEN_A_site2_site5_pw | 25 | 57 |
+| TENANT_B | 100.70.0.2:2000 | 65000:2000 | TEN_B_site2_site5_pw | 26 | 58 |
 
 #### Router BGP EVPN VRFs
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vpws.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vpws.md
@@ -1,0 +1,153 @@
+# router-bgp-vpws
+# Table of Contents
+<!-- toc -->
+
+- [Management](#management)
+  - [Management Interfaces](#management-interfaces)
+- [Authentication](#authentication)
+- [Monitoring](#monitoring)
+- [Internal VLAN Allocation Policy](#internal-vlan-allocation-policy)
+  - [Internal VLAN Allocation Policy Summary](#internal-vlan-allocation-policy-summary)
+- [Interfaces](#interfaces)
+- [Routing](#routing)
+  - [IP Routing](#ip-routing)
+  - [IPv6 Routing](#ipv6-routing)
+  - [Router BGP](#router-bgp)
+- [Multicast](#multicast)
+- [Filters](#filters)
+- [ACL](#acl)
+- [Quality Of Service](#quality-of-service)
+
+<!-- toc -->
+# Management
+
+## Management Interfaces
+
+### Management Interfaces Summary
+
+#### IPv4
+
+| Management Interface | description | Type | VRF | IP Address | Gateway |
+| -------------------- | ----------- | ---- | --- | ---------- | ------- |
+| Management1 | oob_management | oob | MGMT | 10.73.255.122/24 | 10.73.255.2 |
+
+#### IPv6
+
+| Management Interface | description | Type | VRF | IPv6 Address | IPv6 Gateway |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ |
+| Management1 | oob_management | oob | MGMT | -  | - |
+
+### Management Interfaces Device Configuration
+
+```eos
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+```
+
+# Authentication
+
+# Monitoring
+
+# Internal VLAN Allocation Policy
+
+## Internal VLAN Allocation Policy Summary
+
+**Default Allocation Policy**
+
+| Policy Allocation | Range Beginning | Range Ending |
+| ------------------| --------------- | ------------ |
+| ascending | 1006 | 4094 |
+
+# Interfaces
+
+# Routing
+
+## IP Routing
+
+### IP Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | false|
+### IP Routing Device Configuration
+
+```eos
+```
+## IPv6 Routing
+
+### IPv6 Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | false |
+
+## Router BGP
+
+### Router BGP Summary
+
+| BGP AS | Router ID |
+| ------ | --------- |
+| 65101|  192.168.255.3 |
+
+| BGP Tuning |
+| ---------- |
+| no bgp default ipv4-unicast |
+| distance bgp 20 200 200 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
+| maximum-paths 2 ecmp 2 |
+
+### Router BGP EVPN Address Family
+
+#### Router BGP EVPN MAC-VRFs
+
+#### Router BGP VPWS Pseudowires
+
+| Tenant | Pseudowire | Route-Distinguisher | Both Route-Target | Local ID | Remote ID |
+| ------ | ---------- | ------------------- | ----------------- | -------- | --------- |
+| TENANT_A | TEN_A_site1_site3_pw | 100.70.0.2:1000 | 65000:1000 | 15 | 35 |
+| TENANT_A | TEN_A_site2_site5_pw | 100.70.0.2:1000 | 65000:1000 | 25 | 57 |
+| TENANT_B | TEN_B_site2_site5_pw | 100.70.0.2:2000 | 65000:2000 | 26 | 58 |
+
+#### Router BGP EVPN VRFs
+
+### Router BGP Device Configuration
+
+```eos
+!
+router bgp 65101
+   router-id 192.168.255.3
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
+   graceful-restart restart-time 300
+   graceful-restart
+   maximum-paths 2 ecmp 2
+   !
+   vpws TENANT_A
+      rd 100.70.0.2:1000
+      route-target import export evpn 65000:1000
+      !
+      pseudowire TEN_A_site1_site3_pw
+         evpn vpws id local 15 remote 35
+      !
+      pseudowire TEN_A_site2_site5_pw
+         evpn vpws id local 25 remote 57
+   !
+   vpws TENANT_B
+      rd 100.70.0.2:2000
+      route-target import export evpn 65000:2000
+      !
+      pseudowire TEN_B_site2_site5_pw
+         evpn vpws id local 26 remote 58
+```
+
+# Multicast
+
+# Filters
+
+# ACL
+
+# Quality Of Service

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-vpws.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-vpws.cfg
@@ -1,0 +1,40 @@
+!RANCID-CONTENT-TYPE: arista
+!
+transceiver qsfp default-mode 4x10G
+!
+hostname router-bgp-vpws
+!
+no aaa root
+no enable password
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+!
+router bgp 65101
+   router-id 192.168.255.3
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
+   graceful-restart restart-time 300
+   graceful-restart
+   maximum-paths 2 ecmp 2
+   !
+   vpws TENANT_A
+      rd 100.70.0.2:1000
+      route-target import export evpn 65000:1000
+      !
+      pseudowire TEN_A_site1_site3_pw
+         evpn vpws id local 15 remote 35
+      !
+      pseudowire TEN_A_site2_site5_pw
+         evpn vpws id local 25 remote 57
+   !
+   vpws TENANT_B
+      rd 100.70.0.2:2000
+      route-target import export evpn 65000:2000
+      !
+      pseudowire TEN_B_site2_site5_pw
+         evpn vpws id local 26 remote 58
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-vpws.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-vpws.yml
@@ -1,0 +1,29 @@
+router_bgp:
+  as: 65101
+  router_id: 192.168.255.3
+  bgp_defaults:
+    - no bgp default ipv4-unicast
+    - distance bgp 20 200 200
+    - graceful-restart restart-time 300
+    - graceful-restart
+    - maximum-paths 2 ecmp 2
+  vpws:
+  - tenant: TENANT_A
+    rd: 100.70.0.2:1000
+    route_targets:
+      import_export: 65000:1000
+    pseudowires:
+    - name: TEN_A_site2_site5_pw
+      id_local: 25
+      id_remote: 57
+    - name: TEN_A_site1_site3_pw
+      id_local: 15
+      id_remote: 35
+  - tenant: TENANT_B
+    rd: 100.70.0.2:2000
+    route_targets:
+      import_export: 65000:2000
+    pseudowires:
+    - name: TEN_B_site2_site5_pw
+      id_local: 26
+      id_remote: 58

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-vpws.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-vpws.yml
@@ -8,7 +8,7 @@ router_bgp:
     - graceful-restart
     - maximum-paths 2 ecmp 2
   vpws:
-  - tenant: TENANT_A
+  - name: TENANT_A
     rd: 100.70.0.2:1000
     route_targets:
       import_export: 65000:1000
@@ -19,7 +19,7 @@ router_bgp:
     - name: TEN_A_site1_site3_pw
       id_local: 15
       id_remote: 35
-  - tenant: TENANT_B
+  - name: TENANT_B
     rd: 100.70.0.2:2000
     route_targets:
       import_export: 65000:2000

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
@@ -71,6 +71,7 @@ router-bgp-rtc
 router-bgp-v4-evpn
 router-bgp-v4-v6-evpn
 router-bgp-vpn-ipv4-vpn-ipv6
+router-bgp-vpws
 router-bgp-vrf-lite
 router-general
 router-isis

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -2207,6 +2207,15 @@ router_bgp:
       redistribute_routes:
         - < connected >
         - < learned >
+  vpws:
+  - tenant: < tenant >
+    rd: < route distinguisher >
+    route_targets:
+      import_export: < route target >
+    pseudowires:
+    - name: < pseudowire name >
+      id_local: < integer, must match id_remote on other pe >
+      id_remote: < integer, must match id_local on other pe >
   address_family_evpn:
     domain_identifier: < string >
     peer_groups:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -2208,14 +2208,14 @@ router_bgp:
         - < connected >
         - < learned >
   vpws:
-  - name: < vpws instance name >
-    rd: < route distinguisher >
-    route_targets:
-      import_export: < route target >
-    pseudowires:
-    - name: < pseudowire name >
-      id_local: < integer, must match id_remote on other pe >
-      id_remote: < integer, must match id_local on other pe >
+    - name: < vpws instance name >
+      rd: < route distinguisher >
+      route_targets:
+        import_export: < route target >
+      pseudowires:
+        - name: < pseudowire name >
+          id_local: < integer, must match id_remote on other pe >
+          id_remote: < integer, must match id_local on other pe >
   address_family_evpn:
     domain_identifier: < string >
     peer_groups:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -2208,7 +2208,7 @@ router_bgp:
         - < connected >
         - < learned >
   vpws:
-  - tenant: < tenant >
+  - name: < vpws instance name >
     rd: < route distinguisher >
     route_targets:
       import_export: < route target >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
@@ -238,15 +238,15 @@
 {%     endif %}
 
 {%     if router_bgp.vpws is arista.avd.defined %}
-#### Router BGP VPWS Pseudowires
+#### Router BGP VPWS Instances
 
-| Tenant | Pseudowire | Route-Distinguisher | Both Route-Target | Local ID | Remote ID |
-| ------ | ---------- | ------------------- | ----------------- | -------- | --------- |
+| Instance | Route-Distinguisher | Both Route-Target| Pseudowire | Local ID | Remote ID |
+| -------- | ------------------- | -----------------| ---------- | -------- | --------- |
 {% for vpws_service in router_bgp.vpws %}
 {%     if vpws_service.name is arista.avd.defined and vpws_service.rd is arista.avd.defined and vpws_service.route_targets.import_export is arista.avd.defined %}
 {%         for pseudowire in vpws_service.pseudowires | arista.avd.natural_sort %}
 {%             if pseudowire.name is arista.avd.defined %}
-| {{ vpws_service.name }} | {{ pseudowire.name }} | {{ vpws_service.rd }} | {{ vpws_service.route_targets.import_export }} | {{ pseudowire.id_local }} | {{ pseudowire.id_remote }} |
+| {{ vpws_service.name }} | {{ vpws_service.rd }} | {{ vpws_service.route_targets.import_export }} | {{ pseudowire.name }} | {{ pseudowire.id_local }} | {{ pseudowire.id_remote }} |
 {%             endif %}
 {%         endfor %}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
@@ -236,23 +236,23 @@
 | {{ vlan }} | {{ route_distinguisher }} | {{ both_route_target | join("<br>") }} | {{ import_route_target | join("<br>") }} | {{ export_route_target | join("<br>") }} | {{ redistribute | join("<br>") }} |
 {%         endfor %}
 {%     endif %}
-
 {%     if router_bgp.vpws is arista.avd.defined %}
+
 #### Router BGP VPWS Instances
 
 | Instance | Route-Distinguisher | Both Route-Target| Pseudowire | Local ID | Remote ID |
 | -------- | ------------------- | -----------------| ---------- | -------- | --------- |
-{% for vpws_service in router_bgp.vpws %}
-{%     if vpws_service.name is arista.avd.defined and vpws_service.rd is arista.avd.defined and vpws_service.route_targets.import_export is arista.avd.defined %}
-{%         for pseudowire in vpws_service.pseudowires | arista.avd.natural_sort %}
-{%             if pseudowire.name is arista.avd.defined %}
+{%         for vpws_service in router_bgp.vpws %}
+{%             if vpws_service.name is arista.avd.defined and vpws_service.rd is arista.avd.defined and vpws_service.route_targets.import_export is arista.avd.defined %}
+{%                 for pseudowire in vpws_service.pseudowires | arista.avd.natural_sort("name") %}
+{%                     if pseudowire.name is arista.avd.defined %}
 | {{ vpws_service.name }} | {{ vpws_service.rd }} | {{ vpws_service.route_targets.import_export }} | {{ pseudowire.name }} | {{ pseudowire.id_local }} | {{ pseudowire.id_remote }} |
+{%                     endif %}
+{%                 endfor %}
 {%             endif %}
 {%         endfor %}
 {%     endif %}
-{% endfor %}
 
-{% endif %}
 #### Router BGP EVPN VRFs
 {%     if router_bgp.vrfs is defined and router_bgp.vrfs is not none %}
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
@@ -237,6 +237,22 @@
 {%         endfor %}
 {%     endif %}
 
+{%     if router_bgp.vpws is arista.avd.defined %}
+#### Router BGP VPWS Pseudowires
+
+| Tenant | Pseudowire | Route-Distinguisher | Both Route-Target | Local ID | Remote ID |
+| ------ | ---------- | ------------------- | ----------------- | -------- | --------- |
+{% for vpws_service in router_bgp.vpws %}
+{%     if vpws_service.tenant is arista.avd.defined and vpws_service.rd is arista.avd.defined and vpws_service.route_targets.import_export is arista.avd.defined %}
+{%         for pseudowire in vpws_service.pseudowires | arista.avd.natural_sort %}
+{%             if pseudowire.name is arista.avd.defined %}
+| {{ vpws_service.tenant }} | {{ pseudowire.name }} | {{ vpws_service.rd }} | {{ vpws_service.route_targets.import_export }} | {{ pseudowire.id_local }} | {{ pseudowire.id_remote }} |
+{%             endif %}
+{%         endfor %}
+{%     endif %}
+{% endfor %}
+
+{% endif %}
 #### Router BGP EVPN VRFs
 {%     if router_bgp.vrfs is defined and router_bgp.vrfs is not none %}
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
@@ -243,10 +243,10 @@
 | Tenant | Pseudowire | Route-Distinguisher | Both Route-Target | Local ID | Remote ID |
 | ------ | ---------- | ------------------- | ----------------- | -------- | --------- |
 {% for vpws_service in router_bgp.vpws %}
-{%     if vpws_service.tenant is arista.avd.defined and vpws_service.rd is arista.avd.defined and vpws_service.route_targets.import_export is arista.avd.defined %}
+{%     if vpws_service.name is arista.avd.defined and vpws_service.rd is arista.avd.defined and vpws_service.route_targets.import_export is arista.avd.defined %}
 {%         for pseudowire in vpws_service.pseudowires | arista.avd.natural_sort %}
 {%             if pseudowire.name is arista.avd.defined %}
-| {{ vpws_service.tenant }} | {{ pseudowire.name }} | {{ vpws_service.rd }} | {{ vpws_service.route_targets.import_export }} | {{ pseudowire.id_local }} | {{ pseudowire.id_remote }} |
+| {{ vpws_service.name }} | {{ pseudowire.name }} | {{ vpws_service.rd }} | {{ vpws_service.route_targets.import_export }} | {{ pseudowire.id_local }} | {{ pseudowire.id_remote }} |
 {%             endif %}
 {%         endfor %}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -213,6 +213,28 @@ router bgp {{ router_bgp.as }}
 {%         endfor %}
       vlan {{ router_bgp.vlan_aware_bundles[vlan_aware_bundle].vlan }}
 {%     endfor %}
+{# bgp vpws services #}
+{%     if router_bgp.vpws is arista.avd.defined %}
+{%         for vpws_service in router_bgp.vpws | arista.avd.natural_sort %}
+   !
+{%             if vpws_service.tenant is arista.avd.defined %}
+   vpws {{ vpws_service.tenant }}
+{%                 if vpws_service.rd is arista.avd.defined %}
+      rd {{ vpws_service.rd }}
+{%                 endif %}
+{%                 if vpws_service.route_targets.import_export is arista.avd.defined %}
+      route-target import export evpn {{ vpws_service.route_targets.import_export }}
+{%                 endif %}
+{%                 for pw in vpws_service.pseudowires | arista.avd.natural_sort %}
+{%                     if pw.name is arista.avd.defined and pw.id_local is arista.avd.defined and pw.id_remote is arista.avd.defined %}
+      !
+      pseudowire {{ pw.name }}
+         evpn vpws id local {{ pw.id_local }} remote {{ pw.id_remote }}
+{%                     endif %}
+{%                 endfor %}
+{%             endif %}
+{%         endfor %}
+{%     endif %}
 {# address families activation #}
 {# address family evpn activation #}
 {%     if router_bgp.address_family_evpn is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -217,8 +217,8 @@ router bgp {{ router_bgp.as }}
 {%     if router_bgp.vpws is arista.avd.defined %}
 {%         for vpws_service in router_bgp.vpws | arista.avd.natural_sort %}
    !
-{%             if vpws_service.tenant is arista.avd.defined %}
-   vpws {{ vpws_service.tenant }}
+{%             if vpws_service.name is arista.avd.defined %}
+   vpws {{ vpws_service.name }}
 {%                 if vpws_service.rd is arista.avd.defined %}
       rd {{ vpws_service.rd }}
 {%                 endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -215,7 +215,7 @@ router bgp {{ router_bgp.as }}
 {%     endfor %}
 {# bgp vpws services #}
 {%     if router_bgp.vpws is arista.avd.defined %}
-{%         for vpws_service in router_bgp.vpws | arista.avd.natural_sort %}
+{%         for vpws_service in router_bgp.vpws | arista.avd.natural_sort("name") %}
    !
 {%             if vpws_service.name is arista.avd.defined %}
    vpws {{ vpws_service.name }}


### PR DESCRIPTION
## Change Summary

Adds bgp virtual private wire service data model to eos_cli_config_gen

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

```yaml
router_bgp:
  vpws:
  - name: < vpws instance name >
    rd: < route distinguisher >
    route_targets:
      import_export: < route target >
    pseudowires:
    - name: < pseudowire name >
      id_local: < integer, must match id_remote on other pe >
      id_remote: < integer, must match id_local on other pe >
```

## How to test

Tested in lab + molecule

### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
