### PR TITLE
Feat(eos_cli_config_gen): Add EVPN Neighbor Default Encapsulation

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-evpn-mpls.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-evpn-mpls.md
@@ -122,12 +122,12 @@ interface Management1
 | 192.168.255.2 | Inherited from peer group EVPN-OVERLAY-PEERS | default | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS |
 
 ### Router BGP EVPN Address Family
-#### EVPN Default Encapsulation
 
-| Default Neighbor Encapsulation | Next-hop-self Source Interface |
+#### EVPN Neighbor Default Encapsulation
+
+| Neighbor Default Encapsulation | Next-hop-self Source Interface |
 | ------------------------------ | ------------------------------ |
-| MPLS | Loopback0 |
-
+| mpls | Loopback0 |
 
 #### Router BGP EVPN MAC-VRFs
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-evpn-mpls.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-evpn-mpls.md
@@ -1,0 +1,169 @@
+# router-bgp-evpn-mpls
+# Table of Contents
+<!-- toc -->
+
+- [Management](#management)
+  - [Management Interfaces](#management-interfaces)
+- [Authentication](#authentication)
+- [Monitoring](#monitoring)
+- [Internal VLAN Allocation Policy](#internal-vlan-allocation-policy)
+  - [Internal VLAN Allocation Policy Summary](#internal-vlan-allocation-policy-summary)
+- [Interfaces](#interfaces)
+- [Routing](#routing)
+  - [IP Routing](#ip-routing)
+  - [IPv6 Routing](#ipv6-routing)
+  - [Router BGP](#router-bgp)
+- [Multicast](#multicast)
+- [Filters](#filters)
+- [ACL](#acl)
+- [Quality Of Service](#quality-of-service)
+
+<!-- toc -->
+# Management
+
+## Management Interfaces
+
+### Management Interfaces Summary
+
+#### IPv4
+
+| Management Interface | description | Type | VRF | IP Address | Gateway |
+| -------------------- | ----------- | ---- | --- | ---------- | ------- |
+| Management1 | oob_management | oob | MGMT | 10.73.255.122/24 | 10.73.255.2 |
+
+#### IPv6
+
+| Management Interface | description | Type | VRF | IPv6 Address | IPv6 Gateway |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ |
+| Management1 | oob_management | oob | MGMT | -  | - |
+
+### Management Interfaces Device Configuration
+
+```eos
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+```
+
+# Authentication
+
+# Monitoring
+
+# Internal VLAN Allocation Policy
+
+## Internal VLAN Allocation Policy Summary
+
+**Default Allocation Policy**
+
+| Policy Allocation | Range Beginning | Range Ending |
+| ------------------| --------------- | ------------ |
+| ascending | 1006 | 4094 |
+
+# Interfaces
+
+# Routing
+
+## IP Routing
+
+### IP Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | false|
+### IP Routing Device Configuration
+
+```eos
+```
+## IPv6 Routing
+
+### IPv6 Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | false |
+
+## Router BGP
+
+### Router BGP Summary
+
+| BGP AS | Router ID |
+| ------ | --------- |
+| 65101|  192.168.255.3 |
+
+| BGP Tuning |
+| ---------- |
+| no bgp default ipv4-unicast |
+| distance bgp 20 200 200 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
+| maximum-paths 2 ecmp 2 |
+
+### Router BGP Peer Groups
+
+#### EVPN-OVERLAY-PEERS
+
+| Settings | Value |
+| -------- | ----- |
+| Address Family | evpn |
+| Remote AS | 65001 |
+| Source | Loopback0 |
+| Bfd | true |
+| Ebgp multihop | 3 |
+| Send community | all |
+| Maximum routes | 0 (no limit) |
+
+### BGP Neighbors
+
+| Neighbor | Remote AS | VRF | Send-community | Maximum-routes |
+| -------- | --------- | --- | -------------- | -------------- |
+| 192.168.255.1 | Inherited from peer group EVPN-OVERLAY-PEERS | default | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS |
+| 192.168.255.2 | Inherited from peer group EVPN-OVERLAY-PEERS | default | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS |
+
+### Router BGP EVPN Address Family
+#### EVPN Default Encapsulation
+
+| Default Neighbor Encapsulation | Next-hop-self Source Interface |
+| ------------------------------ | ------------------------------ |
+| MPLS | Loopback0 |
+
+
+#### Router BGP EVPN MAC-VRFs
+
+#### Router BGP EVPN VRFs
+
+### Router BGP Device Configuration
+
+```eos
+!
+router bgp 65101
+   router-id 192.168.255.3
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
+   graceful-restart restart-time 300
+   graceful-restart
+   maximum-paths 2 ecmp 2
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS remote-as 65001
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.2 peer group EVPN-OVERLAY-PEERS
+   !
+   address-family evpn
+      neighbor default encapsulation mpls next-hop-self source-interface Loopback0
+      neighbor EVPN-OVERLAY-PEERS activate
+```
+
+# Multicast
+
+# Filters
+
+# ACL
+
+# Quality Of Service

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-evpn-mpls.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-evpn-mpls.cfg
@@ -1,0 +1,37 @@
+!RANCID-CONTENT-TYPE: arista
+!
+transceiver qsfp default-mode 4x10G
+!
+hostname router-bgp-evpn-mpls
+!
+no aaa root
+no enable password
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+!
+router bgp 65101
+   router-id 192.168.255.3
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
+   graceful-restart restart-time 300
+   graceful-restart
+   maximum-paths 2 ecmp 2
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS remote-as 65001
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.2 peer group EVPN-OVERLAY-PEERS
+   !
+   address-family evpn
+      neighbor default encapsulation mpls next-hop-self source-interface Loopback0
+      neighbor EVPN-OVERLAY-PEERS activate
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-evpn-mpls.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-evpn-mpls.yml
@@ -23,10 +23,9 @@ router_bgp:
     192.168.255.2:
       peer_group: EVPN-OVERLAY-PEERS
   address_family_evpn:
-    neighbor_default_encapsulation:
-      mpls: true
-      next_hop_self:
-        source_interface: Loopback0
+    neighbor_default:
+      encapsulation: mpls
+      next_hop_self_source_interface: Loopback0
     peer_groups:
       EVPN-OVERLAY-PEERS:
         activate: true

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-evpn-mpls.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-evpn-mpls.yml
@@ -1,0 +1,32 @@
+router_bgp:
+  as: 65101
+  router_id: 192.168.255.3
+  bgp_defaults:
+    - no bgp default ipv4-unicast
+    - distance bgp 20 200 200
+    - graceful-restart restart-time 300
+    - graceful-restart
+    - maximum-paths 2 ecmp 2
+  peer_groups:
+    EVPN-OVERLAY-PEERS:
+      type: evpn
+      remote_as: 65001
+      update_source: Loopback0
+      bfd: true
+      ebgp_multihop: 3
+      password: "q+VNViP5i4rVjW1cxFv2wA=="
+      send_community: all
+      maximum_routes: 0
+  neighbors:
+    192.168.255.1:
+      peer_group: EVPN-OVERLAY-PEERS
+    192.168.255.2:
+      peer_group: EVPN-OVERLAY-PEERS
+  address_family_evpn:
+    neighbor_default_encapsulation:
+      mpls: true
+      next_hop_self:
+        source_interface: Loopback0
+    peer_groups:
+      EVPN-OVERLAY-PEERS:
+        activate: true

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
@@ -66,6 +66,7 @@ router-bfd
 router-bgp-base
 router-bgp-evpn
 router-bgp-evpn-vpn-import-pruning
+router-bgp-evpn-mpls
 router-bgp-rtc
 router-bgp-v4-evpn
 router-bgp-v4-v6-evpn

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -2180,10 +2180,9 @@ router_bgp:
         - < learned >
   address_family_evpn:
     domain_identifier: < string >
-    neighbor_default_encapsulation:
-      mpls: < true | false >
-      next_hop_self:
-        source_interface: < source interface >
+    neighbor_default:
+      encapsulation: < vxlan | mpls >
+      next_hop_self_source_interface: < source interface >
     peer_groups:
       < peer_group_name >:
         activate: < true | false >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -2180,6 +2180,10 @@ router_bgp:
         - < learned >
   address_family_evpn:
     domain_identifier: < string >
+    neighbor_default_encapsulation:
+      mpls: < true | false >
+      next_hop_self:
+        source_interface: < source interface >
     peer_groups:
       < peer_group_name >:
         activate: < true | false >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
@@ -186,6 +186,16 @@
 
 - VPN import pruning is __enabled__
 {%     endif %}
+{%     if router_bgp.address_family_evpn.neighbor_default_encapsulation.mpls is arista.avd.defined(true) %}
+#### EVPN Default Encapsulation
+
+| Default Neighbor Encapsulation | Next-hop-self Source Interface |
+| ------------------------------ | ------------------------------ |
+{%         set row_default_encapsulation = "MPLS" %}
+{%         set row_nhs_source_interface = router_bgp.address_family_evpn.neighbor_default_encapsulation.next_hop_self.source_interface | arista.avd.default('-') %}
+| {{ row_default_encapsulation }} | {{ row_nhs_source_interface }} |
+
+{%     endif %}
 {%     if router_bgp.address_family_evpn.evpn_hostflap_detection is arista.avd.defined %}
 
 #### EVPN Host Flapping Settings

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
@@ -186,16 +186,16 @@
 
 - VPN import pruning is __enabled__
 {%     endif %}
-{%     if router_bgp.address_family_evpn.neighbor_default_encapsulation.mpls is arista.avd.defined(true) %}
-#### EVPN Default Encapsulation
+{%     if router_bgp.address_family_evpn.neighbor_default.encapsulation is arista.avd.defined %}
 
-| Default Neighbor Encapsulation | Next-hop-self Source Interface |
+#### EVPN Neighbor Default Encapsulation
+
+| Neighbor Default Encapsulation | Next-hop-self Source Interface |
 | ------------------------------ | ------------------------------ |
-{%         set row_default_encapsulation = "MPLS" %}
-{%         set row_nhs_source_interface = router_bgp.address_family_evpn.neighbor_default_encapsulation.next_hop_self.source_interface | arista.avd.default('-') %}
+{%         set row_default_encapsulation = router_bgp.address_family_evpn.neighbor_default.encapsulation | arista.avd.default("vxlan") %}
+{%         set row_nhs_source_interface = router_bgp.address_family_evpn.neighbor_default.next_hop_self_source_interface | arista.avd.default('-') %}
 | {{ row_default_encapsulation }} | {{ row_nhs_source_interface }} |
-
-{%     endif %}
+{%     endif%}
 {%     if router_bgp.address_family_evpn.evpn_hostflap_detection is arista.avd.defined %}
 
 #### EVPN Host Flapping Settings

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -231,6 +231,13 @@ router bgp {{ router_bgp.as }}
 {%         if router_bgp.address_family_evpn.domain_identifier is arista.avd.defined %}
       domain identifier {{ router_bgp.address_family_evpn.domain_identifier }}
 {%         endif %}
+{%         if router_bgp.address_family_evpn.neighbor_default_encapsulation.mpls is arista.avd.defined(true) %}
+{%             if router_bgp.address_family_evpn.neighbor_default_encapsulation.next_hop_self.source_interface is arista.avd.defined %}
+      neighbor default encapsulation mpls next-hop-self source-interface {{ router_bgp.address_family_evpn.neighbor_default_encapsulation.next_hop_self.source_interface }}
+{%             else %}
+      neighbor default encapsulation mpls
+{%             endif %}
+{%         endif %}
 {%         for peer_group in router_bgp.address_family_evpn.peer_groups | arista.avd.natural_sort %}
 {%             if router_bgp.address_family_evpn.peer_groups[peer_group].route_map_in is arista.avd.defined %}
       neighbor {{ peer_group }} route-map {{ router_bgp.address_family_evpn.peer_groups[peer_group].route_map_in }} in

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -231,12 +231,12 @@ router bgp {{ router_bgp.as }}
 {%         if router_bgp.address_family_evpn.domain_identifier is arista.avd.defined %}
       domain identifier {{ router_bgp.address_family_evpn.domain_identifier }}
 {%         endif %}
-{%         if router_bgp.address_family_evpn.neighbor_default_encapsulation.mpls is arista.avd.defined(true) %}
-{%             if router_bgp.address_family_evpn.neighbor_default_encapsulation.next_hop_self.source_interface is arista.avd.defined %}
-      neighbor default encapsulation mpls next-hop-self source-interface {{ router_bgp.address_family_evpn.neighbor_default_encapsulation.next_hop_self.source_interface }}
-{%             else %}
-      neighbor default encapsulation mpls
+{%         if router_bgp.address_family_evpn.neighbor_default.encapsulation is arista.avd.defined("mpls") %}
+{%             set evpn_neighbor_default_encap_cli = "neighbor default encapsulation mpls" %}
+{%             if router_bgp.address_family_evpn.neighbor_default.next_hop_self_source_interface is arista.avd.defined %}
+{%                 set evpn_neighbor_default_encap_cli = evpn_neighbor_default_encap_cli ~ " next-hop-self source-interface " ~ router_bgp.address_family_evpn.neighbor_default.next_hop_self_source_interface %}
 {%             endif %}
+      {{ evpn_neighbor_default_encap_cli }}
 {%         endif %}
 {%         for peer_group in router_bgp.address_family_evpn.peer_groups | arista.avd.natural_sort %}
 {%             if router_bgp.address_family_evpn.peer_groups[peer_group].route_map_in is arista.avd.defined %}


### PR DESCRIPTION
## Change Summary

Adds neighbor default encapsulation and next-hop-self source interaface data model for MPLS.

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Adds this data model under evpn address-family:

```yaml
router_bgp:
  address_family_evpn:
    neighbor_default_encapsulation:
      mpls: true
      next_hop_self:
        source_interface: Loopback0
```

## How to test

Tested in lab + with molecule.

### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
