### PR TITLE
Feat(eos_cli_config_gen): Add vpn-ipv6 AF + vpn-ipv4 change

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vpn-ipv4-vpn-ipv6.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vpn-ipv4-vpn-ipv6.md
@@ -90,7 +90,7 @@ interface Management1
 
 | BGP AS | Router ID |
 | ------ | --------- |
-| 65101|  192.168.255.3 |
+| 65102|  192.168.255.3 |
 
 | BGP Tuning |
 | ---------- |
@@ -129,7 +129,7 @@ interface Management1
 
 ```eos
 !
-router bgp 65101
+router bgp 65102
    router-id 192.168.255.3
    no bgp default ipv4-unicast
    distance bgp 20 200 200

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vpn-ipv4-vpn-ipv6.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vpn-ipv4-vpn-ipv6.md
@@ -90,7 +90,7 @@ interface Management1
 
 | BGP AS | Router ID |
 | ------ | --------- |
-| 65103|  192.168.255.3 |
+| 65101|  192.168.255.3 |
 
 | BGP Tuning |
 | ---------- |
@@ -129,7 +129,7 @@ interface Management1
 
 ```eos
 !
-router bgp 65103
+router bgp 65101
    router-id 192.168.255.3
    no bgp default ipv4-unicast
    distance bgp 20 200 200

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vpn-ipv4-vpn-ipv6.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vpn-ipv4-vpn-ipv6.md
@@ -90,7 +90,7 @@ interface Management1
 
 | BGP AS | Router ID |
 | ------ | --------- |
-| 65102|  192.168.255.3 |
+| 65103|  192.168.255.3 |
 
 | BGP Tuning |
 | ---------- |
@@ -129,7 +129,7 @@ interface Management1
 
 ```eos
 !
-router bgp 65102
+router bgp 65103
    router-id 192.168.255.3
    no bgp default ipv4-unicast
    distance bgp 20 200 200

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vpn-ipv4-vpn-ipv6.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vpn-ipv4-vpn-ipv6.md
@@ -1,0 +1,167 @@
+# router-bgp-vpn-ipv4-vpn-ipv6
+# Table of Contents
+<!-- toc -->
+
+- [Management](#management)
+  - [Management Interfaces](#management-interfaces)
+- [Authentication](#authentication)
+- [Monitoring](#monitoring)
+- [Internal VLAN Allocation Policy](#internal-vlan-allocation-policy)
+  - [Internal VLAN Allocation Policy Summary](#internal-vlan-allocation-policy-summary)
+- [Interfaces](#interfaces)
+- [Routing](#routing)
+  - [IP Routing](#ip-routing)
+  - [IPv6 Routing](#ipv6-routing)
+  - [Router BGP](#router-bgp)
+- [Multicast](#multicast)
+- [Filters](#filters)
+- [ACL](#acl)
+- [Quality Of Service](#quality-of-service)
+
+<!-- toc -->
+# Management
+
+## Management Interfaces
+
+### Management Interfaces Summary
+
+#### IPv4
+
+| Management Interface | description | Type | VRF | IP Address | Gateway |
+| -------------------- | ----------- | ---- | --- | ---------- | ------- |
+| Management1 | oob_management | oob | MGMT | 10.73.255.122/24 | 10.73.255.2 |
+
+#### IPv6
+
+| Management Interface | description | Type | VRF | IPv6 Address | IPv6 Gateway |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ |
+| Management1 | oob_management | oob | MGMT | -  | - |
+
+### Management Interfaces Device Configuration
+
+```eos
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+```
+
+# Authentication
+
+# Monitoring
+
+# Internal VLAN Allocation Policy
+
+## Internal VLAN Allocation Policy Summary
+
+**Default Allocation Policy**
+
+| Policy Allocation | Range Beginning | Range Ending |
+| ------------------| --------------- | ------------ |
+| ascending | 1006 | 4094 |
+
+# Interfaces
+
+# Routing
+
+## IP Routing
+
+### IP Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | false|
+### IP Routing Device Configuration
+
+```eos
+```
+## IPv6 Routing
+
+### IPv6 Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | false |
+
+## Router BGP
+
+### Router BGP Summary
+
+| BGP AS | Router ID |
+| ------ | --------- |
+| 65101|  192.168.255.3 |
+
+| BGP Tuning |
+| ---------- |
+| no bgp default ipv4-unicast |
+| distance bgp 20 200 200 |
+| graceful-restart restart-time 300 |
+| graceful-restart |
+| maximum-paths 2 ecmp 2 |
+
+### Router BGP Peer Groups
+
+#### MPLS-IBGP-PEERS
+
+| Settings | Value |
+| -------- | ----- |
+| Address Family | vpn-ipv4, vpn-ipv6 |
+| Remote AS | 65000 |
+| Local AS | 65000 |
+| Send community | all |
+| Maximum routes | 0 (no limit) |
+
+### BGP Neighbors
+
+| Neighbor | Remote AS | VRF | Send-community | Maximum-routes |
+| -------- | --------- | --- | -------------- | -------------- |
+| 192.168.255.1 | Inherited from peer group MPLS-IBGP-PEERS | default | Inherited from peer group MPLS-IBGP-PEERS | Inherited from peer group MPLS-IBGP-PEERS |
+| 192.168.255.2 | Inherited from peer group MPLS-IBGP-PEERS | default | Inherited from peer group MPLS-IBGP-PEERS | Inherited from peer group MPLS-IBGP-PEERS |
+
+### Router BGP EVPN Address Family
+
+#### Router BGP EVPN MAC-VRFs
+
+#### Router BGP EVPN VRFs
+
+### Router BGP Device Configuration
+
+```eos
+!
+router bgp 65101
+   router-id 192.168.255.3
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
+   graceful-restart restart-time 300
+   graceful-restart
+   maximum-paths 2 ecmp 2
+   neighbor MPLS-IBGP-PEERS peer group
+   neighbor MPLS-IBGP-PEERS remote-as 65000
+   neighbor MPLS-IBGP-PEERS local-as 65000 no-prepend replace-as
+   neighbor MPLS-IBGP-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor MPLS-IBGP-PEERS send-community
+   neighbor MPLS-IBGP-PEERS maximum-routes 0
+   neighbor 192.168.255.1 peer group MPLS-IBGP-PEERS
+   neighbor 192.168.255.2 peer group MPLS-IBGP-PEERS
+   !
+   address-family vpn-ipv4
+      domain identifier 3900000
+      neighbor MPLS-IBGP-PEERS activate
+      neighbor 192.168.255.4 activate
+      neighbor default encapsulation mpls next-hop-self source-interface Loopback0
+   !
+   address-family vpn-ipv6
+      domain identifier 3900000
+      neighbor MPLS-IBGP-PEERS activate
+      neighbor 192.168.255.4 activate
+      neighbor default encapsulation mpls next-hop-self source-interface Loopback0
+```
+
+# Multicast
+
+# Filters
+
+# ACL
+
+# Quality Of Service

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vpn-ipv4-vpn-ipv6.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vpn-ipv4-vpn-ipv6.md
@@ -90,7 +90,7 @@ interface Management1
 
 | BGP AS | Router ID |
 | ------ | --------- |
-| 65101|  192.168.255.3 |
+| 65103|  192.168.255.3 |
 
 | BGP Tuning |
 | ---------- |
@@ -129,7 +129,7 @@ interface Management1
 
 ```eos
 !
-router bgp 65101
+router bgp 65103
    router-id 192.168.255.3
    no bgp default ipv4-unicast
    distance bgp 20 200 200

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-vpn-ipv4-vpn-ipv6.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-vpn-ipv4-vpn-ipv6.cfg
@@ -2,7 +2,7 @@
 !
 transceiver qsfp default-mode 4x10G
 !
-hostname router-bgp-vpn-ipv4
+hostname router-bgp-vpn-ipv4-vpn-ipv6
 !
 no aaa root
 no enable password
@@ -29,6 +29,12 @@ router bgp 65101
    neighbor 192.168.255.2 peer group MPLS-IBGP-PEERS
    !
    address-family vpn-ipv4
+      domain identifier 3900000
+      neighbor MPLS-IBGP-PEERS activate
+      neighbor 192.168.255.4 activate
+      neighbor default encapsulation mpls next-hop-self source-interface Loopback0
+   !
+   address-family vpn-ipv6
       domain identifier 3900000
       neighbor MPLS-IBGP-PEERS activate
       neighbor 192.168.255.4 activate

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-vpn-ipv4-vpn-ipv6.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-vpn-ipv4-vpn-ipv6.cfg
@@ -12,7 +12,7 @@ interface Management1
    vrf MGMT
    ip address 10.73.255.122/24
 !
-router bgp 65101
+router bgp 65102
    router-id 192.168.255.3
    no bgp default ipv4-unicast
    distance bgp 20 200 200

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-vpn-ipv4-vpn-ipv6.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-vpn-ipv4-vpn-ipv6.cfg
@@ -12,7 +12,7 @@ interface Management1
    vrf MGMT
    ip address 10.73.255.122/24
 !
-router bgp 65102
+router bgp 65103
    router-id 192.168.255.3
    no bgp default ipv4-unicast
    distance bgp 20 200 200

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-vpn-ipv4-vpn-ipv6.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-vpn-ipv4-vpn-ipv6.yml
@@ -10,9 +10,7 @@ router_bgp:
     - maximum-paths 2 ecmp 2
   peer_groups:
     MPLS-IBGP-PEERS:
-      type:
-        - vpn-ipv4
-        - vpn-ipv6
+      type: "vpn-ipv4, vpn-ipv6"
       remote_as: 65000
       local_as: 65000
       password: "AQQvKeimxJu+uGQ/yYvv9w=="

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-vpn-ipv4-vpn-ipv6.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-vpn-ipv4-vpn-ipv6.yml
@@ -1,6 +1,6 @@
 ### Routing - BGP vpn-ipv4 ###
 router_bgp:
-  as: 65101
+  as: 65102
   router_id: 192.168.255.3
   bgp_defaults:
     - no bgp default ipv4-unicast

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-vpn-ipv4-vpn-ipv6.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-vpn-ipv4-vpn-ipv6.yml
@@ -10,7 +10,9 @@ router_bgp:
     - maximum-paths 2 ecmp 2
   peer_groups:
     MPLS-IBGP-PEERS:
-      type: ipv4
+      type:
+        - vpn-ipv4
+        - vpn-ipv6
       remote_as: 65000
       local_as: 65000
       password: "AQQvKeimxJu+uGQ/yYvv9w=="
@@ -22,6 +24,16 @@ router_bgp:
     192.168.255.2:
       peer_group: MPLS-IBGP-PEERS
   address_family_vpn_ipv4:
+    domain_identifier: 65000:0
+    peer_groups:
+      MPLS-IBGP-PEERS:
+        activate: true
+    neighbors:
+      192.168.255.4:
+        activate: true
+    neighbor_default_encapsulation_mpls_next_hop_self:
+      source_interface: Loopback0
+  address_family_vpn_ipv6:
     domain_identifier: 65000:0
     peer_groups:
       MPLS-IBGP-PEERS:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-vpn-ipv4-vpn-ipv6.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-vpn-ipv4-vpn-ipv6.yml
@@ -1,6 +1,6 @@
 ### Routing - BGP vpn-ipv4 ###
 router_bgp:
-  as: 65102
+  as: 65103
   router_id: 192.168.255.3
   bgp_defaults:
     - no bgp default ipv4-unicast

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
@@ -69,7 +69,7 @@ router-bgp-evpn-vpn-import-pruning
 router-bgp-rtc
 router-bgp-v4-evpn
 router-bgp-v4-v6-evpn
-router-bgp-vpn-ipv4
+router-bgp-vpn-ipv4-vpn-ipv6
 router-bgp-vrf-lite
 router-general
 router-isis

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -2275,21 +2275,15 @@ router_bgp:
     peer_groups:
       < peer_group_name >:
         activate: < true | false >
-    neighbor_default_encapsulation:
-      mpls: < true | false >
-      next_hop_self:
-        source_interface: < interface >
-    neighbor_default_encapsulation_mpls_next_hop_self: (old data model, also accepted)
+    neighbor_default_encapsulation_mpls_next_hop_self:
       source_interface: < interface >
   address_family_vpn_ipv6:
     domain_identifier: < string >
     peer_groups:
       < peer_group_name >:
         activate: < true | false >
-    neighbor_default_encapsulation:
-      mpls: < true | false >
-      next_hop_self:
-        source_interface: < interface >
+    neighbor_default_encapsulation_mpls_next_hop_self:
+      source_interface: < interface >
   vrfs:
     < vrf_name_1 >:
       rd: "< route distinguisher >"

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -2275,8 +2275,19 @@ router_bgp:
     peer_groups:
       < peer_group_name >:
         activate: < true | false >
-    neighbor_default_encapsulation_mpls_next_hop_self:
-      source_interface: < interface >
+    neighbor_default_encapsulation:
+      mpls: < true | false >
+      next_hop_self:
+        source_interface: < interface >
+  address_family_vpn_ipv6:
+    domain_identifier: < string >
+    peer_groups:
+      < peer_group_name >:
+        activate: < true | false >
+    neighbor_default_encapsulation:
+      mpls: < true | false >
+      next_hop_self:
+        source_interface: < interface >
   vrfs:
     < vrf_name_1 >:
       rd: "< route distinguisher >"

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -2279,6 +2279,8 @@ router_bgp:
       mpls: < true | false >
       next_hop_self:
         source_interface: < interface >
+    neighbor_default_encapsulation_mpls_next_hop_self: (old data model, also accepted)
+      source_interface: < interface >
   address_family_vpn_ipv6:
     domain_identifier: < string >
     peer_groups:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
@@ -34,12 +34,7 @@
 | Settings | Value |
 | -------- | ----- |
 {%             if router_bgp.peer_groups[peer_group].type is arista.avd.defined %}
-{%                 if router_bgp.peer_groups[peer_group].type is not string  %}
-{%                     set peer_group_type = router_bgp.peer_groups[peer_group].type | join(', ') %}
-{%                 else %}
-{%                     set peer_group_type = router_bgp.peer_groups[peer_group].type %}
-{%                 endif %}
-| Address Family | {{ peer_group_type }} |
+| Address Family | {{ router_bgp.peer_groups[peer_group].type }} |
 {%             endif %}
 {%             if router_bgp.peer_groups[peer_group].remote_as is arista.avd.defined %}
 | Remote AS | {{ router_bgp.peer_groups[peer_group].remote_as }} |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
@@ -34,7 +34,12 @@
 | Settings | Value |
 | -------- | ----- |
 {%             if router_bgp.peer_groups[peer_group].type is arista.avd.defined %}
-| Address Family | {{ router_bgp.peer_groups[peer_group].type }} |
+{%                 if router_bgp.peer_groups[peer_group].type is not string  %}
+{%                     set peer_group_type = router_bgp.peer_groups[peer_group].type | join(', ') %}
+{%                 else %}
+{%                     set peer_group_type = router_bgp.peer_groups[peer_group].type %}
+{%                 endif %}
+| Address Family | {{ peer_group_type }} |
 {%             endif %}
 {%             if router_bgp.peer_groups[peer_group].remote_as is arista.avd.defined %}
 | Remote AS | {{ router_bgp.peer_groups[peer_group].remote_as }} |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -459,10 +459,8 @@ router bgp {{ router_bgp.as }}
       no neighbor {{ neighbor }} activate
 {%             endif %}
 {%         endfor %}
-{%         if router_bgp.address_family_vpn_ipv4.neighbor_default_encapsulation.mpls is arista.avd.defined(true) %}
-{%             if router_bgp.address_family_vpn_ipv4.neighbor_default_encapsulation.next_hop_self.source_interface is arista.avd.defined %}
-      neighbor default encapsulation mpls next-hop-self source-interface {{ router_bgp.address_family_vpn_ipv4.neighbor_default_encapsulation.next_hop_self.source_interface }}
-{%             endif %}
+{%         if router_bgp.address_family_vpn_ipv4.neighbor_default_encapsulation_mpls_next_hop_self.source_interface is arista.avd.defined %}
+      neighbor default encapsulation mpls next-hop-self source-interface {{ router_bgp.address_family_vpn_ipv4.neighbor_default_encapsulation_mpls_next_hop_self.source_interface }}
 {%         endif %}
 {%     endif %}
 {# address family vpn-ipv6 activation #}
@@ -486,10 +484,8 @@ router bgp {{ router_bgp.as }}
       no neighbor {{ neighbor }} activate
 {%             endif %}
 {%         endfor %}
-{%         if router_bgp.address_family_vpn_ipv6.neighbor_default_encapsulation.mpls is arista.avd.defined(true) %}
-{%             if router_bgp.address_family_vpn_ipv6.neighbor_default_encapsulation.next_hop_self.source_interface is arista.avd.defined %}
-      neighbor default encapsulation mpls next-hop-self source-interface {{ router_bgp.address_family_vpn_ipv6.neighbor_default_encapsulation.next_hop_self.source_interface }}
-{%             endif %}
+{%         if router_bgp.address_family_vpn_ipv6.neighbor_default_encapsulation_mpls_next_hop_self.source_interface is arista.avd.defined %}
+      neighbor default encapsulation mpls next-hop-self source-interface {{ router_bgp.address_family_vpn_ipv6.neighbor_default_encapsulation_mpls_next_hop_self.source_interface }}
 {%         endif %}
 {%     endif %}
 {# address family vpn-ipv6 activation #}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -488,31 +488,6 @@ router bgp {{ router_bgp.as }}
       neighbor default encapsulation mpls next-hop-self source-interface {{ router_bgp.address_family_vpn_ipv6.neighbor_default_encapsulation_mpls_next_hop_self.source_interface }}
 {%         endif %}
 {%     endif %}
-{# address family vpn-ipv6 activation #}
-{%     if router_bgp.address_family_vpn_ipv6 is arista.avd.defined %}
-   !
-   address-family vpn-ipv6
-{%         if router_bgp.address_family_vpn_ipv6.domain_identifier is arista.avd.defined %}
-      domain identifier {{ router_bgp.address_family_vpn_ipv6.domain_identifier }}
-{%         endif %}
-{%         for peer_group in router_bgp.address_family_vpn_ipv6.peer_groups | arista.avd.natural_sort %}
-{%             if router_bgp.address_family_vpn_ipv6.peer_groups[peer_group].activate is arista.avd.defined(true) %}
-      neighbor {{ peer_group }} activate
-{%             elif router_bgp.address_family_vpn_ipv6.peer_groups[peer_group].activate is arista.avd.defined(false) %}
-      no neighbor {{ peer_group }} activate
-{%             endif %}
-{%         endfor %}
-{%         for neighbor in router_bgp.address_family_vpn_ipv6.neighbors | arista.avd.natural_sort %}
-{%             if router_bgp.address_family_vpn_ipv6.neighbors[neighbor].activate is arista.avd.defined(true) %}
-      neighbor {{ neighbor }} activate
-{%             elif router_bgp.address_family_vpn_ipv6.neighbors[neighbor].activate is arista.avd.defined(false) %}
-      no neighbor {{ neighbor }} activate
-{%             endif %}
-{%         endfor %}
-{%         if router_bgp.address_family_vpn_ipv6.neighbor_default_encapsulation_mpls_next_hop_self.source_interface is arista.avd.defined %}
-      neighbor default encapsulation mpls next-hop-self source-interface {{ router_bgp.address_family_vpn_ipv6.neighbor_default_encapsulation_mpls_next_hop_self.source_interface }}
-{%         endif %}
-{%     endif %}
 {# L3VPNs - (vxlan) VRFs #}
 {%     for vrf in router_bgp.vrfs | arista.avd.natural_sort %}
    !

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -459,11 +459,7 @@ router bgp {{ router_bgp.as }}
       no neighbor {{ neighbor }} activate
 {%             endif %}
 {%         endfor %}
-{%         if router_bgp.address_family_vpn_ipv4.neighbor_default_encapsulation.mpls is arista.avd.defined(true) %}
-{%             if router_bgp.address_family_vpn_ipv4.neighbor_default_encapsulation.next_hop_self.source_interface is arista.avd.defined %}
-      neighbor default encapsulation mpls next-hop-self source-interface {{ router_bgp.address_family_vpn_ipv4.neighbor_default_encapsulation.next_hop_self.source_interface }}
-{%             endif %}
-{%         elif router_bgp.address_family_vpn_ipv4.neighbor_default_encapsulation_mpls_next_hop_self.source_interface is arista.avd.defined %}
+{%         if router_bgp.address_family_vpn_ipv4.neighbor_default_encapsulation_mpls_next_hop_self.source_interface is arista.avd.defined %}
       neighbor default encapsulation mpls next-hop-self source-interface {{ router_bgp.address_family_vpn_ipv4.neighbor_default_encapsulation_mpls_next_hop_self.source_interface }}
 {%         endif %}
 {%     endif %}
@@ -488,10 +484,8 @@ router bgp {{ router_bgp.as }}
       no neighbor {{ neighbor }} activate
 {%             endif %}
 {%         endfor %}
-{%         if router_bgp.address_family_vpn_ipv6.neighbor_default_encapsulation.mpls is arista.avd.defined(true) %}
-{%             if router_bgp.address_family_vpn_ipv6.neighbor_default_encapsulation.next_hop_self.source_interface is arista.avd.defined %}
-      neighbor default encapsulation mpls next-hop-self source-interface {{ router_bgp.address_family_vpn_ipv6.neighbor_default_encapsulation.next_hop_self.source_interface }}
-{%             endif %}
+{%         if router_bgp.address_family_vpn_ipv6.neighbor_default_encapsulation_mpls_next_hop_self.source_interface is arista.avd.defined %}
+      neighbor default encapsulation mpls next-hop-self source-interface {{ router_bgp.address_family_vpn_ipv6.neighbor_default_encapsulation_mpls_next_hop_self.source_interface }}
 {%         endif %}
 {%     endif %}
 {# L3VPNs - (vxlan) VRFs #}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -463,6 +463,8 @@ router bgp {{ router_bgp.as }}
 {%             if router_bgp.address_family_vpn_ipv4.neighbor_default_encapsulation.next_hop_self.source_interface is arista.avd.defined %}
       neighbor default encapsulation mpls next-hop-self source-interface {{ router_bgp.address_family_vpn_ipv4.neighbor_default_encapsulation.next_hop_self.source_interface }}
 {%             endif %}
+{%         elif router_bgp.address_family_vpn_ipv4.neighbor_default_encapsulation_mpls_next_hop_self.source_interface is arista.avd.defined %}
+      neighbor default encapsulation mpls next-hop-self source-interface {{ router_bgp.address_family_vpn_ipv4.neighbor_default_encapsulation_mpls_next_hop_self.source_interface }}
 {%         endif %}
 {%     endif %}
 {# address family vpn-ipv6 activation #}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -459,8 +459,37 @@ router bgp {{ router_bgp.as }}
       no neighbor {{ neighbor }} activate
 {%             endif %}
 {%         endfor %}
-{%         if router_bgp.address_family_vpn_ipv4.neighbor_default_encapsulation_mpls_next_hop_self.source_interface is arista.avd.defined %}
-      neighbor default encapsulation mpls next-hop-self source-interface {{ router_bgp.address_family_vpn_ipv4.neighbor_default_encapsulation_mpls_next_hop_self.source_interface }}
+{%         if router_bgp.address_family_vpn_ipv4.neighbor_default_encapsulation.mpls is arista.avd.defined(true) %}
+{%             if router_bgp.address_family_vpn_ipv4.neighbor_default_encapsulation.next_hop_self.source_interface is arista.avd.defined %}
+      neighbor default encapsulation mpls next-hop-self source-interface {{ router_bgp.address_family_vpn_ipv4.neighbor_default_encapsulation.next_hop_self.source_interface }}
+{%             endif %}
+{%         endif %}
+{%     endif %}
+{# address family vpn-ipv6 activation #}
+{%     if router_bgp.address_family_vpn_ipv6 is arista.avd.defined %}
+   !
+   address-family vpn-ipv6
+{%         if router_bgp.address_family_vpn_ipv6.domain_identifier is arista.avd.defined %}
+      domain identifier {{ router_bgp.address_family_vpn_ipv6.domain_identifier }}
+{%         endif %}
+{%         for peer_group in router_bgp.address_family_vpn_ipv6.peer_groups | arista.avd.natural_sort %}
+{%             if router_bgp.address_family_vpn_ipv6.peer_groups[peer_group].activate is arista.avd.defined(true) %}
+      neighbor {{ peer_group }} activate
+{%             elif router_bgp.address_family_vpn_ipv6.peer_groups[peer_group].activate is arista.avd.defined(false) %}
+      no neighbor {{ peer_group }} activate
+{%             endif %}
+{%         endfor %}
+{%         for neighbor in router_bgp.address_family_vpn_ipv6.neighbors | arista.avd.natural_sort %}
+{%             if router_bgp.address_family_vpn_ipv6.neighbors[neighbor].activate is arista.avd.defined(true) %}
+      neighbor {{ neighbor }} activate
+{%             elif router_bgp.address_family_vpn_ipv6.neighbors[neighbor].activate is arista.avd.defined(false) %}
+      no neighbor {{ neighbor }} activate
+{%             endif %}
+{%         endfor %}
+{%         if router_bgp.address_family_vpn_ipv6.neighbor_default_encapsulation.mpls is arista.avd.defined(true) %}
+{%             if router_bgp.address_family_vpn_ipv6.neighbor_default_encapsulation.next_hop_self.source_interface is arista.avd.defined %}
+      neighbor default encapsulation mpls next-hop-self source-interface {{ router_bgp.address_family_vpn_ipv6.neighbor_default_encapsulation.next_hop_self.source_interface }}
+{%             endif %}
 {%         endif %}
 {%     endif %}
 {# address family vpn-ipv6 activation #}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -459,8 +459,37 @@ router bgp {{ router_bgp.as }}
       no neighbor {{ neighbor }} activate
 {%             endif %}
 {%         endfor %}
-{%         if router_bgp.address_family_vpn_ipv4.neighbor_default_encapsulation_mpls_next_hop_self.source_interface is arista.avd.defined %}
-      neighbor default encapsulation mpls next-hop-self source-interface {{ router_bgp.address_family_vpn_ipv4.neighbor_default_encapsulation_mpls_next_hop_self.source_interface }}
+{%         if router_bgp.address_family_vpn_ipv4.neighbor_default_encapsulation.mpls is arista.avd.defined(true) %}
+{%             if router_bgp.address_family_vpn_ipv4.neighbor_default_encapsulation.next_hop_self.source_interface is arista.avd.defined %}
+      neighbor default encapsulation mpls next-hop-self source-interface {{ router_bgp.address_family_vpn_ipv4.neighbor_default_encapsulation.next_hop_self.source_interface }}
+{%             endif %}
+{%         endif %}
+{%     endif %}
+{# address family vpn-ipv6 activation #}
+{%     if router_bgp.address_family_vpn_ipv6 is arista.avd.defined %}
+   !
+   address-family vpn-ipv6
+{%         if router_bgp.address_family_vpn_ipv6.domain_identifier is arista.avd.defined %}
+      domain identifier {{ router_bgp.address_family_vpn_ipv6.domain_identifier }}
+{%         endif %}
+{%         for peer_group in router_bgp.address_family_vpn_ipv6.peer_groups | arista.avd.natural_sort %}
+{%             if router_bgp.address_family_vpn_ipv6.peer_groups[peer_group].activate is arista.avd.defined(true) %}
+      neighbor {{ peer_group }} activate
+{%             elif router_bgp.address_family_vpn_ipv6.peer_groups[peer_group].activate is arista.avd.defined(false) %}
+      no neighbor {{ peer_group }} activate
+{%             endif %}
+{%         endfor %}
+{%         for neighbor in router_bgp.address_family_vpn_ipv6.neighbors | arista.avd.natural_sort %}
+{%             if router_bgp.address_family_vpn_ipv6.neighbors[neighbor].activate is arista.avd.defined(true) %}
+      neighbor {{ neighbor }} activate
+{%             elif router_bgp.address_family_vpn_ipv6.neighbors[neighbor].activate is arista.avd.defined(false) %}
+      no neighbor {{ neighbor }} activate
+{%             endif %}
+{%         endfor %}
+{%         if router_bgp.address_family_vpn_ipv6.neighbor_default_encapsulation.mpls is arista.avd.defined(true) %}
+{%             if router_bgp.address_family_vpn_ipv6.neighbor_default_encapsulation.next_hop_self.source_interface is arista.avd.defined %}
+      neighbor default encapsulation mpls next-hop-self source-interface {{ router_bgp.address_family_vpn_ipv6.neighbor_default_encapsulation.next_hop_self.source_interface }}
+{%             endif %}
 {%         endif %}
 {%     endif %}
 {# L3VPNs - (vxlan) VRFs #}


### PR DESCRIPTION
## Change Summary

Adds vpn-ipv6 address family.

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Adds data model for vpn-ipv6:

```yaml
router_bgp:
  address_family_vpn_ipv6:
    domain_identifier: < string >
    peer_groups:
      < peer_group_name >:
        activate: < true | false >
    neighbor_default_encapsulation_mpls_next_hop_self:
      source_interface: < interface >
```

## How to test
Tested in lab + with molecule

### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
