### PR TITLE
Feat(eos_cli_config_gen): PBR service-policy support for routed interfaces

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -111,6 +111,7 @@ interface Management1
 | Ethernet8.101 | to WAN-ISP-01 Ethernet2.101 - VRF-C1 | l3dot1q | - | 172.31.128.1/31 | default | - | - | - | - |
 | Ethernet9 | interface_with_mpls_enabled | routed | - | 172.31.128.9/31 | default | - | - | - | - |
 | Ethernet10 | interface_with_mpls_disabled | routed | - | 172.31.128.10/31 | default | - | - | - | - |
+| Ethernet18 | PBR Description | routed | - | 192.0.2.1/31 | default | 1500 | - | - | - |
 
 #### IPv6
 
@@ -298,6 +299,13 @@ interface Ethernet17
    switchport trunk allowed vlan 110-112
    switchport mode trunk
    switchport trunk private-vlan secondary
+!
+interface Ethernet18
+   description PBR Description
+   mtu 1500
+   no switchport
+   ip address 192.0.2.1/31
+   service-policy type pbr input MyLANServicePolicy
 ```
 
 # Routing

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
@@ -90,6 +90,7 @@ interface Management1
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
+| Ethernet17 | LAG Member | *routed | 17 | *192.0.2.3/31 | **default | **- | **- | **- | **- |
 *Inherited from Port-Channel Interface
 
 ### Ethernet Interfaces Device Configuration
@@ -135,6 +136,10 @@ interface Ethernet16
    description DC1-AGG04_Ethernet1
    channel-group 16 mode active
    lacp timer normal
+!
+interface Ethernet17
+   description LAG Member
+   channel-group 17 mode active
 !
 interface Ethernet50
    description SRV-POD03_Eth1
@@ -183,6 +188,7 @@ interface Ethernet50
 | --------- | ----------- | ---- | ------- | ---------- | --- | --- | -------- | ------ | ------- |
 | Port-Channel8.101 | to Dev02 Port-Channel8.101 - VRF-C1 | routed | - | 10.1.2.3/31 | default | - | - | - | - |
 | Port-Channel9 | - | routed | - | 10.9.2.3/31 | default | - | - | - | - |
+| Port-Channel17 | PBR Description | routed | - | 192.0.2.3/31 | default | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -253,6 +259,12 @@ interface Port-Channel16
    switchport trunk allowed vlan 110,201
    switchport mode trunk
    mlag 16
+!
+interface Port-Channel17
+   description PBR Description
+   no switchport
+   ip address 192.0.2.3/31
+   service-policy type pbr input MyPolicy
 !
 interface Port-Channel20
    description Po_in_mode_access_accepting_tagged_LACP_frames

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
@@ -176,6 +176,13 @@ interface Ethernet17
    switchport mode trunk
    switchport trunk private-vlan secondary
 !
+interface Ethernet18
+   description PBR Description
+   mtu 1500
+   no switchport
+   ip address 192.0.2.1/31
+   service-policy type pbr input MyLANServicePolicy
+!
 interface Management1
    description oob_management
    vrf MGMT

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
@@ -73,6 +73,12 @@ interface Port-Channel16
    switchport mode trunk
    mlag 16
 !
+interface Port-Channel17
+   description PBR Description
+   no switchport
+   ip address 192.0.2.3/31
+   service-policy type pbr input MyPolicy
+!
 interface Port-Channel20
    description Po_in_mode_access_accepting_tagged_LACP_frames
    switchport
@@ -174,6 +180,10 @@ interface Ethernet16
    description DC1-AGG04_Ethernet1
    channel-group 16 mode active
    lacp timer normal
+!
+interface Ethernet17
+   description LAG Member
+   channel-group 17 mode active
 !
 interface Ethernet50
    description SRV-POD03_Eth1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
@@ -231,3 +231,12 @@ ethernet_interfaces:
     mode: trunk
     vlans: 110-112
     trunk_private_vlan_secondary: true
+
+  Ethernet18:
+    description: PBR Description
+    mtu: 1500
+    type: routed
+    ip_address: 192.0.2.1/31
+    service_policy:
+      pbr:
+        input: MyLANServicePolicy

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
@@ -124,6 +124,13 @@ port_channel_interfaces:
       trunk: untagged
       vlan: 70
 
+  Port-Channel17:
+    description: PBR Description
+    type: routed
+    ip_address: 192.0.2.3/31
+    service_policy:
+      pbr:
+        input: MyPolicy
 
   Port-Channel101:
     description: PVLAN Promiscuous Access - only one secondary
@@ -145,7 +152,6 @@ port_channel_interfaces:
     mode: trunk
     vlans: 110-112
     trunk_private_vlan_secondary: true
-
 
 # Children interfaces
 ethernet_interfaces:
@@ -198,7 +204,6 @@ ethernet_interfaces:
       id: 8
       mode: active
 
-
   Ethernet15:
     peer: DC1-AGG03
     peer_interface: Ethernet1
@@ -222,6 +227,12 @@ ethernet_interfaces:
     lacp_timer:
       mode: normal
 
+  Ethernet17:
+    description: LAG Member
+    channel_group:
+      id: 17
+      mode: active
+
   Ethernet10/1:
     description: LAG Member
     channel_group:
@@ -239,3 +250,4 @@ ethernet_interfaces:
     channel_group:
       id: 103
       mode: active
+

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -753,6 +753,9 @@ ethernet_interfaces:
       interval: < rate in milliseconds >
       min_rx: < rate in milliseconds >
       multiplier: < 3-50 >
+    service_policy:
+      pbr:
+        input: < policy-map name >
     mpls:
       ip: < true | false >
       ldp:
@@ -935,6 +938,9 @@ port_channel_interfaces:
       interval: < rate in milliseconds >
       min_rx: < rate in milliseconds >
       multiplier: < 3-50 >
+    service_policy:
+      pbr:
+        input: < policy-map name >
     trunk_private_vlan_secondary: < true | false >
     pvlan_mapping: "< list of vlans as string >"
     vlan_translations:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -262,6 +262,9 @@ interface {{ ethernet_interface }}
               ethernet_interfaces[ethernet_interface].bfd.multiplier is arista.avd.defined %}
    bfd interval {{ ethernet_interfaces[ethernet_interface].bfd.interval }} min-rx {{ ethernet_interfaces[ethernet_interface].bfd.min_rx }} multiplier {{ ethernet_interfaces[ethernet_interface].bfd.multiplier }}
 {%         endif %}
+{%         if ethernet_interfaces[ethernet_interface].service_policy.pbr.input is arista.avd.defined %}
+   service-policy type pbr input {{ ethernet_interfaces[ethernet_interface].service_policy.pbr.input }}
+{%         endif %}
 {%         if ethernet_interfaces[ethernet_interface].mpls.ip is arista.avd.defined(true) %}
    mpls ip
 {%         elif ethernet_interfaces[ethernet_interface].mpls.ip is arista.avd.defined(false) %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
@@ -231,6 +231,9 @@ interface {{ port_channel_interface }}
           port_channel_interfaces[port_channel_interface].bfd.multiplier is arista.avd.defined %}
    bfd interval {{ port_channel_interfaces[port_channel_interface].bfd.interval }} min-rx {{ port_channel_interfaces[port_channel_interface].bfd.min_rx }} multiplier {{ port_channel_interfaces[port_channel_interface].bfd.multiplier }}
 {%     endif %}
+{%     if port_channel_interfaces[port_channel_interface].service_policy.pbr.input is arista.avd.defined %}
+   service-policy type pbr input {{ port_channel_interfaces[port_channel_interface].service_policy.pbr.input }}
+{%     endif %}
 {%     if port_channel_interfaces[port_channel_interface].eos_cli is arista.avd.defined %}
    {{ port_channel_interfaces[port_channel_interface].eos_cli | indent(3, false) }}
 {%     endif %}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->

Support policy based routing on routed ports (ethernet, port-channel)

## Related Issue(s)

Fixes #1260
Extends #890

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

```yaml
ethernet_interfaces:
  <Ethernet_interface_1 >:
    description: < description >
    service_policy:
      pbr:
        input: < policy-map name >

port_channel_interfaces:
  < Port-Channel_interface_1 >:
    description: < description >
    service_policy:
      pbr:
        input: < policy-map name >
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
