### PR TITLE
Fix(eos_validate_state): Hardware tests

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/main.yml
@@ -67,6 +67,7 @@
   include_tasks: "hardware.yml"
   when:
     - eos_version.stdout_lines.0.modelName != 'vEOS'
+    - eos_version.stdout_lines.0.modelName != 'vEOS-lab'
     - eos_version.stdout_lines.0.modelName != 'cEOSLab'
   tags:
     - hardware


### PR DESCRIPTION
## Change Summary
Exclude "vEOS-lab" from hardware tests
In newer version of EOS observed in 4.26.2F  "modelName"  has been updated from `vEOS` to `vEOS-lab`

## Component(s) name

`arista.avd.eos_validate_state`

## Proposed changes
exclude vEOS-lab from hardware tests

## How to test

Test eos_validate_state role with EOS version >= 4.26.2F

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
