### PR TITLE
Fix(eos_cli_config_gen): daemon terminattr documentation

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/terminattr-multi-cluster.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/terminattr-multi-cluster.md
@@ -65,7 +65,7 @@ interface Management1
 ```eos
 !
 daemon TerminAttr
-   exec /usr/bin/TerminAttr -cvopt DC1.addr=10.20.20.1:9910 -cvopt DC1.auth=key,arista -cvopt DC1.vrf=mgt -cvopt DC2.addr=10.30.30.1:9910 -cvopt DC2.auth=token,/tmp/tokenDC2 -cvopt DC2.vrf=mgt -cvvrf=mgt -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   exec /usr/bin/TerminAttr -cvopt DC1.addr=10.20.20.1:9910 -cvopt DC1.auth=key,arista -cvopt DC1.vrf=mgt -cvopt DC2.addr=10.30.30.1:9910 -cvopt DC2.auth=token,/tmp/tokenDC2 -cvopt DC2.vrf=mgt -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/terminattr-multi-cluster.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/terminattr-multi-cluster.md
@@ -59,14 +59,13 @@ interface Management1
 | -------------- | ------------------- | --- | -------------- | -------------- | -------------- | ---------- |
 | gzip | 10.20.20.1:9910 | mgt | key,arista | ale,flexCounter,hardware,kni,pulse,strata | /Sysdb/cell/1/agent,/Sysdb/cell/2/agent | False |
 | gzip | 10.30.30.1:9910 | mgt | token,/tmp/tokenDC2 | ale,flexCounter,hardware,kni,pulse,strata | /Sysdb/cell/1/agent,/Sysdb/cell/2/agent | False |
-| gzip | 10.10.10.8:9910,10.10.10.9:9910,10.10.10.10:9910 | mgt | key,magickey | ale,flexCounter,hardware,kni,pulse,strata | /Sysdb/cell/1/agent,/Sysdb/cell/2/agent | False |
 
 ### TerminAttr Daemon Device Configuration
 
 ```eos
 !
 daemon TerminAttr
-   exec /usr/bin/TerminAttr -cvopt DC1.addr=10.20.20.1:9910 -cvopt DC1.auth=key,arista -cvopt DC1.vrf=mgt -cvopt DC2.addr=10.30.30.1:9910 -cvopt DC2.auth=token,/tmp/tokenDC2 -cvopt DC2.vrf=mgt -cvaddr=10.10.10.8:9910,10.10.10.9:9910,10.10.10.10:9910 -cvauth=key,magickey -cvvrf=mgt -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   exec /usr/bin/TerminAttr -cvopt DC1.addr=10.20.20.1:9910 -cvopt DC1.auth=key,arista -cvopt DC1.vrf=mgt -cvopt DC2.addr=10.30.30.1:9910 -cvopt DC2.auth=token,/tmp/tokenDC2 -cvopt DC2.vrf=mgt -cvvrf=mgt -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/terminattr-multi-cluster.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/terminattr-multi-cluster.cfg
@@ -1,7 +1,7 @@
 !RANCID-CONTENT-TYPE: arista
 !
 daemon TerminAttr
-   exec /usr/bin/TerminAttr -cvopt DC1.addr=10.20.20.1:9910 -cvopt DC1.auth=key,arista -cvopt DC1.vrf=mgt -cvopt DC2.addr=10.30.30.1:9910 -cvopt DC2.auth=token,/tmp/tokenDC2 -cvopt DC2.vrf=mgt -cvaddr=10.10.10.8:9910,10.10.10.9:9910,10.10.10.10:9910 -cvauth=key,magickey -cvvrf=mgt -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   exec /usr/bin/TerminAttr -cvopt DC1.addr=10.20.20.1:9910 -cvopt DC1.auth=key,arista -cvopt DC1.vrf=mgt -cvopt DC2.addr=10.30.30.1:9910 -cvopt DC2.auth=token,/tmp/tokenDC2 -cvopt DC2.vrf=mgt -cvvrf=mgt -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
 !
 transceiver qsfp default-mode 4x10G

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/terminattr-multi-cluster.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/terminattr-multi-cluster.cfg
@@ -1,7 +1,7 @@
 !RANCID-CONTENT-TYPE: arista
 !
 daemon TerminAttr
-   exec /usr/bin/TerminAttr -cvopt DC1.addr=10.20.20.1:9910 -cvopt DC1.auth=key,arista -cvopt DC1.vrf=mgt -cvopt DC2.addr=10.30.30.1:9910 -cvopt DC2.auth=token,/tmp/tokenDC2 -cvopt DC2.vrf=mgt -cvvrf=mgt -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   exec /usr/bin/TerminAttr -cvopt DC1.addr=10.20.20.1:9910 -cvopt DC1.auth=key,arista -cvopt DC1.vrf=mgt -cvopt DC2.addr=10.30.30.1:9910 -cvopt DC2.auth=token,/tmp/tokenDC2 -cvopt DC2.vrf=mgt -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
 !
 transceiver qsfp default-mode 4x10G

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/terminattr-multi-cluster.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/terminattr-multi-cluster.yml
@@ -1,9 +1,5 @@
 ### Daemon TerminAttr
 daemon_terminattr:
-  cvaddrs:
-      - 10.10.10.8:9910
-      - 10.10.10.9:9910
-      - 10.10.10.10:9910
   clusters:
       DC1:
           cvaddrs:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/terminattr-multi-cluster.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/terminattr-multi-cluster.yml
@@ -15,9 +15,5 @@ daemon_terminattr:
               method: "token"
               token_file: "/tmp/tokenDC2"
           cvvrf: mgt
-  cvauth:
-      method: "key"
-      key: magickey
-  cvvrf: mgt
   smashexcludes: "ale,flexCounter,hardware,kni,pulse,strata"
   ingestexclude: "/Sysdb/cell/1/agent,/Sysdb/cell/2/agent"

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/daemon-terminattr.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/daemon-terminattr.j2
@@ -24,15 +24,15 @@
 {%     endfor %}
 {%     if daemon_terminattr.cvaddrs is arista.avd.defined %}
 {%         set url = daemon_terminattr.cvaddrs | arista.avd.default([]) | join(',') %}
-{%     endif %}
-{%     if daemon_terminattr.cvauth.method is arista.avd.defined('key') %}
-{%         set auth = 'key,' ~ daemon_terminattr.cvauth.key | arista.avd.default('') %}
-{%     elif daemon_terminattr.cvauth.method is arista.avd.defined('token') and daemon_terminattr.cvauth.token_file is arista.avd.defined %}
-{%         set auth = 'token,' ~ daemon_terminattr.cvauth.token_file %}
-{%     elif daemon_terminattr.cvauth.method is arista.avd.defined('token-secure') and daemon_terminattr.cvauth.token_file is arista.avd.defined %}
-{%         set auth = 'token-secure,' ~ daemon_terminattr.cvauth.token_file %}
-{%     endif %}
+{%         if daemon_terminattr.cvauth.method is arista.avd.defined('key') %}
+{%             set auth = 'key,' ~ daemon_terminattr.cvauth.key | arista.avd.default('') %}
+{%         elif daemon_terminattr.cvauth.method is arista.avd.defined('token') and daemon_terminattr.cvauth.token_file is arista.avd.defined %}
+{%             set auth = 'token,' ~ daemon_terminattr.cvauth.token_file %}
+{%         elif daemon_terminattr.cvauth.method is arista.avd.defined('token-secure') and daemon_terminattr.cvauth.token_file is arista.avd.defined %}
+{%             set auth = 'token-secure,' ~ daemon_terminattr.cvauth.token_file %}
+{%         endif %}
 | gzip | {{ url }} | {{ daemon_terminattr.cvvrf | arista.avd.default('-') }} | {{ auth | arista.avd.default('-') }} | {{ daemon_terminattr.smashexcludes | arista.avd.default('-') }} | {{ daemon_terminattr.ingestexclude | arista.avd.default('-') }} | {{ daemon_terminattr.disable_aaa | arista.avd.default (false) }} |
+{%     endif %}
 
 ### TerminAttr Daemon Device Configuration
 


### PR DESCRIPTION
## Change Summary

Fix issue with daemon_terminattr documentation, would not generate when daemon_terminattr.cvaddrs was not defined

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Move table content for daemon_terminattr.cvaddrs insideif/endif block

## How to test

See updated molecule scenario


### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
