### PR TITLE
Bump: collections reqs + community.general

### DIFF
--- a/ansible_collections/arista/avd/collections.yml
+++ b/ansible_collections/arista/avd/collections.yml
@@ -2,3 +2,4 @@ collections:
   - arista.cvp
   - arista.eos
   - ansible.netcommon
+  - community.general


### PR DESCRIPTION
## Change Summary

Bump collections requirements to include community.general required for eos_validate_state role.

## Related Issue(s)

Fixes #1272 

## Component(s) name

Collection requirements

## Proposed changes

Add community.general to collections requirements.

