### PR TITLE
Bump: requirements-dev + yamllint

### DIFF
--- a/ansible_collections/arista/avd/requirements-dev.txt
+++ b/ansible_collections/arista/avd/requirements-dev.txt
@@ -11,3 +11,4 @@ identify>=1.4.20
 docker
 molecule>=3.2.0,<3.5.0
 molecule-docker>=0.2.4
+yamllint


### PR DESCRIPTION
## Change Summary

+ yamllint to requirements-dev.txt

When running CI tests I noticed yamllint was not installed with current requirement-dev

```shelll
(.venv) ➜  ansible-avd git:(cut-roles-meta-directories) ✗ make linting
sh .github/lint-yaml
------------------------------------------------------------------------------------------------------------
Validating YAML files in AVD collection ...
------------------------------------------------------------------------------------------------------------
.github/lint-yaml: 13: yamllint: not found
```

After install of requirement-dev + yamllint

```shell
(.venv) ➜  ansible-avd git:(cut-roles-meta-directories) ✗ make linting         
sh .github/lint-yaml
------------------------------------------------------------------------------------------------------------
Validating YAML files in AVD collection ...
------------------------------------------------------------------------------------------------------------
ansible_collections/arista/avd/roles/eos_designs/defaults/main/main.yml
  132:1     warning  too many blank lines (1 > 0)  (empty-lines)
```

## How to test

Run `make linting` from ./ansible-avd


### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
