### PR TITLE
Feat(eos_cli_config_gen): Add Port-Channel ISIS commands

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis.md
@@ -172,6 +172,7 @@ interface Port-Channel4
    isis enable EVPN_UNDERLAY
    isis metric 50
    isis network point-to-point
+   isis circuit-type level-2
 !
 interface Port-Channel5
    no switchport
@@ -185,6 +186,7 @@ interface Port-Channel6
    ip address 10.9.2.7/31
    isis enable EVPN_UNDERLAY
    isis metric 100
+   isis circuit-type level-1-2
 ```
 
 ## Loopback Interfaces

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis.md
@@ -10,6 +10,7 @@
   - [Internal VLAN Allocation Policy Summary](#internal-vlan-allocation-policy-summary)
 - [Interfaces](#interfaces)
   - [Ethernet Interfaces](#ethernet-interfaces)
+  - [Port-Channel Interfaces](#port-channel-interfaces)
   - [Loopback Interfaces](#loopback-interfaces)
   - [VLAN Interfaces](#vlan-interfaces)
 - [Routing](#routing)
@@ -84,6 +85,10 @@ interface Management1
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
 | Ethernet1 | P2P_LINK_TO_EAPI-SPINE1_Ethernet1 | routed | - | 172.31.255.1/31 | default | 1500 | - | - | - |
 | Ethernet2 | P2P_LINK_TO_EAPI-SPINE2_Ethernet1 | routed | - | 172.31.255.3/31 | default | 1500 | - | - | - |
+| Ethernet4 | - | *routed | 4 | *10.9.2.3/31 | **default | **- | **- | **- | **- |
+| Ethernet5 | - | *routed | 5 | *10.9.2.5/31 | **default | **- | **- | **- | **- |
+| Ethernet6 | - | *routed | 6 | *10.9.2.7/31 | **default | **- | **- | **- | **- |
+*Inherited from Port-Channel Interface
 
 #### ISIS
 
@@ -91,6 +96,10 @@ interface Management1
 | --------- | ------------- | ------------- | ----------- | ---- |
 | Ethernet1 | - | EVPN_UNDERLAY | 50 | point-to-point |
 | Ethernet2 | - | EVPN_UNDERLAY | 50 | point-to-point |
+| Ethernet4 | 4 | *EVPN_UNDERLAY | *50 | **point-to-point |
+| Ethernet5 | 5 | *EVPN_UNDERLAY | *50 | **passive |
+| Ethernet6 | 6 | *EVPN_UNDERLAY | *100 | **- |
+ *Inherited from Port-Channel Interface
 
 ### Ethernet Interfaces Device Configuration
 
@@ -117,6 +126,65 @@ interface Ethernet2
 interface Ethernet3
    description MLAG_PEER_EAPI-LEAF1B_Ethernet3
    channel-group 3 mode active
+!
+interface Ethernet4
+   channel-group 4 mode active
+!
+interface Ethernet5
+   channel-group 5 mode active
+!
+interface Ethernet6
+   channel-group 6 mode active
+```
+
+## Port-Channel Interfaces
+
+### Port-Channel Interfaces Summary
+
+#### L2
+
+| Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
+| --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
+
+#### IPv4
+
+| Interface | Description | Type | MLAG ID | IP Address | VRF | MTU | Shutdown | ACL In | ACL Out |
+| --------- | ----------- | ---- | ------- | ---------- | --- | --- | -------- | ------ | ------- |
+| Port-Channel4 | - | routed | - | 10.9.2.3/31 | default | - | - | - | - |
+| Port-Channel5 | - | routed | - | 10.9.2.5/31 | default | - | - | - | - |
+| Port-Channel6 | - | routed | - | 10.9.2.7/31 | default | - | - | - | - |
+
+#### ISIS
+
+| Interface | ISIS Instance | ISIS Metric | Type | ISIS Passive |
+| --------- | ------------- | ----------- | ---- | ------------ |
+| Port-Channel4 | EVPN_UNDERLAY | 50 | point-to-point | False |
+| Port-Channel5 | EVPN_UNDERLAY | 50 | - | True |
+| Port-Channel6 | EVPN_UNDERLAY | 100 | - | False |
+
+### Port-Channel Interfaces Device Configuration
+
+```eos
+!
+interface Port-Channel4
+   no switchport
+   ip address 10.9.2.3/31
+   isis enable EVPN_UNDERLAY
+   isis metric 50
+   isis network point-to-point
+!
+interface Port-Channel5
+   no switchport
+   ip address 10.9.2.5/31
+   isis enable EVPN_UNDERLAY
+   isis passive
+   isis metric 50
+!
+interface Port-Channel6
+   no switchport
+   ip address 10.9.2.7/31
+   isis enable EVPN_UNDERLAY
+   isis metric 100
 ```
 
 ## Loopback Interfaces

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-isis.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-isis.cfg
@@ -13,6 +13,7 @@ interface Port-Channel4
    isis enable EVPN_UNDERLAY
    isis metric 50
    isis network point-to-point
+   isis circuit-type level-2
 !
 interface Port-Channel5
    no switchport
@@ -26,6 +27,7 @@ interface Port-Channel6
    ip address 10.9.2.7/31
    isis enable EVPN_UNDERLAY
    isis metric 100
+   isis circuit-type level-1-2
 !
 interface Ethernet1
    description P2P_LINK_TO_EAPI-SPINE1_Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-isis.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-isis.cfg
@@ -7,6 +7,26 @@ hostname router-isis
 no aaa root
 no enable password
 !
+interface Port-Channel4
+   no switchport
+   ip address 10.9.2.3/31
+   isis enable EVPN_UNDERLAY
+   isis metric 50
+   isis network point-to-point
+!
+interface Port-Channel5
+   no switchport
+   ip address 10.9.2.5/31
+   isis enable EVPN_UNDERLAY
+   isis passive
+   isis metric 50
+!
+interface Port-Channel6
+   no switchport
+   ip address 10.9.2.7/31
+   isis enable EVPN_UNDERLAY
+   isis metric 100
+!
 interface Ethernet1
    description P2P_LINK_TO_EAPI-SPINE1_Ethernet1
    mtu 1500
@@ -28,6 +48,15 @@ interface Ethernet2
 interface Ethernet3
    description MLAG_PEER_EAPI-LEAF1B_Ethernet3
    channel-group 3 mode active
+!
+interface Ethernet4
+   channel-group 4 mode active
+!
+interface Ethernet5
+   channel-group 5 mode active
+!
+interface Ethernet6
+   channel-group 6 mode active
 !
 interface Loopback0
    description EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-isis.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-isis.yml
@@ -93,3 +93,25 @@ vlan_interfaces:
     shutdown: false
     vrf: TENANT_A_PROJECT01
     ip_address_virtual: 10.1.10.254/24
+
+### Port-Channel Interfaces ###
+port_channel_interfaces:
+  Port-Channel1:
+    type: routed
+    ip_address: 10.9.2.3/31
+    isis_enable: EVPN_UNDERLAY
+    isis_metric: 50
+    isis_network_point_to_point: true
+  Port-Channel2:
+    type: routed
+    ip_address: 10.9.2.5/31
+    isis_enable: EVPN_UNDERLAY
+    isis_metric: 50
+    isis_passive: true
+  Port-Channel3:
+    type: routed
+    ip_address: 10.9.2.7/31
+    isis_enable: EVPN_UNDERLAY
+    isis_metric: 100
+    isis_passive: false
+    isis_network_point_to_point: false

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-isis.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-isis.yml
@@ -49,6 +49,24 @@ ethernet_interfaces:
     channel_group:
       id: 3
       mode: active
+  Ethernet4:
+    peer: DC1-LEAF1B
+    peer_interface: Ethernet4
+    channel_group:
+      id: 4
+      mode: active
+  Ethernet5:
+    peer: DC1-LEAF1B
+    peer_interface: Ethernet5
+    channel_group:
+      id: 5
+      mode: active
+  Ethernet6:
+    peer: DC1-LEAF1B
+    peer_interface: Ethernet6
+    channel_group:
+      id: 6
+      mode: active
 
 ### Loopback Interfaces ###
 loopback_interfaces:
@@ -96,19 +114,19 @@ vlan_interfaces:
 
 ### Port-Channel Interfaces ###
 port_channel_interfaces:
-  Port-Channel1:
+  Port-Channel4:
     type: routed
     ip_address: 10.9.2.3/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
     isis_network_point_to_point: true
-  Port-Channel2:
+  Port-Channel5:
     type: routed
     ip_address: 10.9.2.5/31
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
     isis_passive: true
-  Port-Channel3:
+  Port-Channel6:
     type: routed
     ip_address: 10.9.2.7/31
     isis_enable: EVPN_UNDERLAY

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-isis.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-isis.yml
@@ -120,6 +120,7 @@ port_channel_interfaces:
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
     isis_network_point_to_point: true
+    isis_circuit_type: level-2
   Port-Channel5:
     type: routed
     ip_address: 10.9.2.5/31
@@ -133,3 +134,4 @@ port_channel_interfaces:
     isis_metric: 100
     isis_passive: false
     isis_network_point_to_point: false
+    isis_circuit_type: level-1-2

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -976,6 +976,10 @@ port_channel_interfaces:
       unknown_unicast:
         level: < Configure maximum storm-control level >
         unit: < percent* | pps (optional and is hardware dependant - default is percent)>
+    isis_enable: < ISIS Instance >
+    isis_passive: < boolean >
+    isis_metric: < integer >
+    isis_network_point_to_point: < boolean >
     # EOS CLI rendered directly on the port-channel interface in the final EOS configuration
     eos_cli: |
       < multiline eos cli >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/port-channel-interfaces.j2
@@ -161,7 +161,6 @@
 {%          endif %}
 {%     endfor %}
 {%     if port_channel_interface_isis.configured == true %}
-
 #### ISIS
 
 | Interface | ISIS Instance | ISIS Metric | Type | ISIS Passive |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/port-channel-interfaces.j2
@@ -156,7 +156,7 @@
 {%     set port_channel_interface_isis = namespace() %}
 {%     set port_channel_interface_isis.configured = false %}
 {%     for port_channel_interface in port_channel_interfaces | arista.avd.natural_sort %}
-{%          if port_channel_interfaces[port_channel_interface].isis_enable is arista.avd.defined(true) %}
+{%          if port_channel_interfaces[port_channel_interface].isis_enable is arista.avd.defined %}
 {%              set port_channel_interface_isis.configured = true %}
 {%          endif %}
 {%     endfor %}
@@ -168,8 +168,8 @@
 | --------- | ------------- | ----------- | ---- | ------------ |
 {%         for port_channel_interface in port_channel_interfaces | arista.avd.natural_sort %}
 {%             if port_channel_interfaces[port_channel_interface].isis_enable is arista.avd.defined %}
-{%                 set isis_instance = port_channel_interfaces[port_channel_interface].isis_enable | arista.avd.default("*-") %}
-{%                 set isis_metric = port_channel_interfaces[port_channel_interface].isis_metric | arista.avd.default("*-") %}
+{%                 set isis_instance = port_channel_interfaces[port_channel_interface].isis_enable | arista.avd.default("-") %}
+{%                 set isis_metric = port_channel_interfaces[port_channel_interface].isis_metric | arista.avd.default("-") %}
 {%                 if port_channel_interfaces[port_channel_interface].isis_network_point_to_point is arista.avd.defined(true) %}
 {%                     set type = "point-to-point" %}
 {%                 else %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/port-channel-interfaces.j2
@@ -152,6 +152,39 @@
 {%        endfor %}
 {%    endif %}
 
+{# ISIS #}
+{%     set port_channel_interface_isis = namespace() %}
+{%     set port_channel_interface_isis.configured = false %}
+{%     for port_channel_interface in port_channel_interfaces | arista.avd.natural_sort %}
+{%          if port_channel_interfaces[port_channel_interface].isis_enable is arista.avd.defined(true) %}
+{%              set port_channel_interface_isis.configured = true %}
+{%          endif %}
+{%     endfor %}
+{%     if port_channel_interface_isis.configured == true %}
+
+#### ISIS
+
+| Interface | ISIS Instance | ISIS Metric | Type | ISIS Passive |
+| --------- | ------------- | ----------- | ---- | ------------ |
+{%         for port_channel_interface in port_channel_interfaces | arista.avd.natural_sort %}
+{%             if port_channel_interfaces[port_channel_interface].isis_enable is arista.avd.defined %}
+{%                 set isis_instance = port_channel_interfaces[port_channel_interface].isis_enable | arista.avd.default("*-") %}
+{%                 set isis_metric = port_channel_interfaces[port_channel_interface].isis_metric | arista.avd.default("*-") %}
+{%                 if port_channel_interfaces[port_channel_interface].isis_network_point_to_point is arista.avd.defined(true) %}
+{%                     set type = "point-to-point" %}
+{%                 else %}
+{%                     set type = "-" %}
+{%                 endif %}
+{%                 if port_channel_interfaces[port_channel_interface].isis_passive is arista.avd.defined(true) %}
+{%                     set passive = true %}
+{%                 else %}
+{%                     set passive = false %}
+{%                 endif %}
+| {{ port_channel_interface }} | {{ isis_instance }} | {{ isis_metric }} | {{ type }} | {{ passive }} |
+{%             endif %}
+{%         endfor %}
+
+{%     endif %}
 ### Port-Channel Interfaces Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
@@ -234,6 +234,18 @@ interface {{ port_channel_interface }}
 {%     if port_channel_interfaces[port_channel_interface].service_policy.pbr.input is arista.avd.defined %}
    service-policy type pbr input {{ port_channel_interfaces[port_channel_interface].service_policy.pbr.input }}
 {%     endif %}
+{%     if port_channel_interfaces[port_channel_interface].isis_enable is arista.avd.defined(true) %}
+   isis enable {{ port_channel_interfaces[port_channel_interface].isis_enable }}
+{%         if port_channel_interfaces[port_channel_interface].isis_passive is arista.avd.defined(true) %}
+   isis passive
+{%         endif %}
+{%         if port_channel_interfaces[port_channel_interface].isis_metric is arista.avd.defined %}
+   isis metric {{ port_channel_interfaces[port_channel_interface].isis_metric }}
+{%         endif %}
+{%         if port_channel_interfaces[port_channel_interface].isis_network_point_to_point is arista.avd.defined(true) %}
+   isis network point-to-point
+{%         endif %}
+{%     endif %}
 {%     if port_channel_interfaces[port_channel_interface].eos_cli is arista.avd.defined %}
    {{ port_channel_interfaces[port_channel_interface].eos_cli | indent(3, false) }}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
@@ -245,6 +245,9 @@ interface {{ port_channel_interface }}
 {%         if port_channel_interfaces[port_channel_interface].isis_network_point_to_point is arista.avd.defined(true) %}
    isis network point-to-point
 {%         endif %}
+{%         if port_channel_interfaces[port_channel_interface].isis_circuit_type is arista.avd.defined %}
+   isis circuit-type {{ port_channel_interfaces[port_channel_interface].isis_circuit_type }}
+{%         endif %}
 {%     endif %}
 {%     if port_channel_interfaces[port_channel_interface].eos_cli is arista.avd.defined %}
    {{ port_channel_interfaces[port_channel_interface].eos_cli | indent(3, false) }}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
@@ -234,7 +234,7 @@ interface {{ port_channel_interface }}
 {%     if port_channel_interfaces[port_channel_interface].service_policy.pbr.input is arista.avd.defined %}
    service-policy type pbr input {{ port_channel_interfaces[port_channel_interface].service_policy.pbr.input }}
 {%     endif %}
-{%     if port_channel_interfaces[port_channel_interface].isis_enable is arista.avd.defined(true) %}
+{%     if port_channel_interfaces[port_channel_interface].isis_enable is arista.avd.defined %}
    isis enable {{ port_channel_interfaces[port_channel_interface].isis_enable }}
 {%         if port_channel_interfaces[port_channel_interface].isis_passive is arista.avd.defined(true) %}
    isis passive


### PR DESCRIPTION
## Change Summary

Adds isis commands data model to port-channel interfaces.

## Related Issue(s)

Fixes #524

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Adds the following data model to port-channel interfaces:

```yaml
port_channel_interfaces:
  < Port-Channel_interface_1 >:
    ...
    isis_enable: < ISIS Instance >
    isis_passive: < boolean >
    isis_metric: < integer >
    isis_network_point_to_point: < boolean >
```

## How to test
Tested with molecule.

### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
