### PR TITLE
Cut(eos_designs): aaa_authorization

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_designs/templates/base/aaa-authorization.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/base/aaa-authorization.j2
@@ -1,6 +1,0 @@
-{% if aaa_authorization is defined %}
-{%     if aaa_authorization.exec_default is defined %}
-aaa_authorization:
-  exec_default: {{ aaa_authorization.exec_default }}
-{%     endif %}
-{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/base/main.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/base/main.j2
@@ -31,8 +31,6 @@
 
 {% include 'base/unsupported-transceiver.j2' %}
 
-{% include 'base/aaa-authorization.j2' %}
-
 {% include 'base/local-users.j2' %}
 
 {% include 'base/clock.j2' %}


### PR DESCRIPTION
## Change Summary

Cute aaa_authorization from eos_designs and leverage eos_cli_config_gen data model for aaa.

Note: this feature was not documented in the `eos_designs` role, so PR has no documentation update!

## Related Issue(s)

Fixes #719

## Component(s) name

`arista.avd.eos_designs`

## How to test

Molecule scenario succeeds.

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
