### PR TITLE
Feat(eos_cli_config_gen): Support LACP global configuration parameters

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/lacp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/lacp.md
@@ -1,0 +1,112 @@
+# lacp
+# Table of Contents
+<!-- toc -->
+
+- [Management](#management)
+  - [Management Interfaces](#management-interfaces)
+- [Authentication](#authentication)
+- [Monitoring](#monitoring)
+- [LACP](#lacp)
+  - [LACP Summary](#lacp-summary)
+  - [LACP Device Configuration](#lacp-device-configuration)
+- [Internal VLAN Allocation Policy](#internal-vlan-allocation-policy)
+  - [Internal VLAN Allocation Policy Summary](#internal-vlan-allocation-policy-summary)
+- [Interfaces](#interfaces)
+- [Routing](#routing)
+  - [IP Routing](#ip-routing)
+  - [IPv6 Routing](#ipv6-routing)
+- [Multicast](#multicast)
+- [Filters](#filters)
+- [ACL](#acl)
+- [Quality Of Service](#quality-of-service)
+
+<!-- toc -->
+# Management
+
+## Management Interfaces
+
+### Management Interfaces Summary
+
+#### IPv4
+
+| Management Interface | description | Type | VRF | IP Address | Gateway |
+| -------------------- | ----------- | ---- | --- | ---------- | ------- |
+| Management1 | oob_management | oob | MGMT | 10.73.255.122/24 | 10.73.255.2 |
+
+#### IPv6
+
+| Management Interface | description | Type | VRF | IPv6 Address | IPv6 Gateway |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ |
+| Management1 | oob_management | oob | MGMT | -  | - |
+
+### Management Interfaces Device Configuration
+
+```eos
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+```
+
+# Authentication
+
+# Monitoring
+
+# LACP
+
+## LACP Summary
+
+| Port-id range | Rate-limit default | System-priority |
+| ------------- | ------------------ | --------------- |
+| 1 - 128 | False | 0 |
+
+## LACP Device Configuration
+
+```eos
+!
+lacp port-id range 1 128
+no lacp rate-limit default
+lacp system-priority 0
+```
+
+# Internal VLAN Allocation Policy
+
+## Internal VLAN Allocation Policy Summary
+
+**Default Allocation Policy**
+
+| Policy Allocation | Range Beginning | Range Ending |
+| ------------------| --------------- | ------------ |
+| ascending | 1006 | 4094 |
+
+# Interfaces
+
+# Routing
+
+## IP Routing
+
+### IP Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | false|
+### IP Routing Device Configuration
+
+```eos
+```
+## IPv6 Routing
+
+### IPv6 Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | false |
+
+# Multicast
+
+# Filters
+
+# ACL
+
+# Quality Of Service

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/lacp.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/lacp.cfg
@@ -1,0 +1,19 @@
+!RANCID-CONTENT-TYPE: arista
+!
+transceiver qsfp default-mode 4x10G
+!
+lacp port-id range 1 128
+no lacp rate-limit default
+lacp system-priority 0
+!
+hostname lacp
+!
+no aaa root
+no enable password
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/lacp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/lacp.yml
@@ -1,0 +1,8 @@
+lacp:
+  port_id:
+    range:
+      begin: 1
+      end: 128
+  rate_limit:
+    default: false
+  system_priority: 0

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
@@ -32,6 +32,7 @@ ip-http-client-source-interface
 ip-ssh-client-source-interface
 ipv6-access-lists
 ipv6-static-routes
+lacp
 lldp
 load-interval
 logging-match-list

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -61,6 +61,7 @@
     - [Internal VLAN Order](#internal-vlan-order)
     - [IP DHCP Relay](#ip-dhcp-relay)
     - [IP ICMP Redirect](#ip-icmp-redirect)
+    - [LACP](#lacp)
     - [LLDP](#lldp)
     - [MACsec](#macsec)
     - [Maintenance Mode](#maintenance-mode)
@@ -1197,6 +1198,19 @@ ip_dhcp_relay:
 ```yaml
 ip_icmp_redirect: < true | false >
 ipv6_icmp_redirect: < true | false >
+```
+
+### LACP
+
+```yaml
+lacp:
+  port_id:
+    range:
+      begin: < min_port >
+      end: < max_port >
+  rate_limit:
+    default: < true | false >
+  system_priority: < 0-65535 >
 ```
 
 ### LLDP

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/lacp-configuration.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/lacp-configuration.j2
@@ -1,0 +1,21 @@
+{% if lacp is arista.avd.defined %}
+
+# LACP
+
+## LACP Summary
+
+| Port-id range | Rate-limit default | System-priority |
+| ------------- | ------------------ | --------------- |
+{%     if lacp.port_id.range.begin is arista.avd.defined and lacp.port_id.range.end is arista.avd.defined %}
+{%         set row_range = lacp.port_id.range.begin ~ ' - ' ~ lacp.port_id.range.end %}
+{%     else %}
+{%         set row_range = '-' %}
+{%     endif %}
+| {{ row_range }} | {{ lacp.rate_limit.default | arista.avd.default('-') }} | {{ lacp.system_priority | arista.avd.default('-') }} |
+
+## LACP Device Configuration
+
+```eos
+{%     include 'eos/lacp.j2' %}
+```
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-device-documentation.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-device-documentation.j2
@@ -79,6 +79,8 @@
 {% include 'documentation/tcam-profile.j2' %}
 {# MLAG #}
 {% include 'documentation/mlag-configuration.j2' %}
+{# LACP #}
+{% include 'documentation/lacp-configuration.j2' %}
 {# Spanning Tree #}
 {% include 'documentation/spanning-tree.j2' %}
 {# Internal VLAN Allocation Policy #}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
@@ -17,7 +17,7 @@
 {# ip dhcp relay #}
 {% include 'eos/ip-dhcp-relay.j2' %}
 {# switchport default #}
-{% include 'eos/switchport-default.j2'%}
+{% include 'eos/switchport-default.j2' %}
 {# internal vlan allocation policy #}
 {% include 'eos/vlan-internal-order.j2' %}
 {# ip igmp snooping #}
@@ -40,6 +40,8 @@
 {% include 'eos/queue-monitor-length.j2' %}
 {# lldp #}
 {% include 'eos/lldp.j2' %}
+{# lacp #}
+{% include 'eos/lacp.j2' %}
 {# logging #}
 {% include 'eos/logging.j2' %}
 {# match-list #}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/lacp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/lacp.j2
@@ -1,0 +1,15 @@
+{# eos - lacp #}
+{% if lacp is arista.avd.defined %}
+!
+{%     if lacp.port_id.range.begin is arista.avd.defined and lacp.port_id.range.end is arista.avd.defined %}
+lacp port-id range {{ lacp.port_id.range.begin }} {{ lacp.port_id.range.end }}
+{%     endif %}
+{%     if lacp.rate_limit.default is arista.avd.defined(true) %}
+lacp rate-limit default
+{%     elif lacp.rate_limit.default is arista.avd.defined(false) %}
+no lacp rate-limit default
+{%     endif %}
+{%     if lacp.system_priority is arista.avd.defined %}
+lacp system-priority {{ lacp.system_priority }}
+{%     endif %}
+{% endif %}


### PR DESCRIPTION
## Change Summary

LACP global parameters like port-id and system-priority can be set with this enhancement.

## Related Issue(s)

Fixes #1295 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Added the below data-model:

```yaml
lacp:
  port_id:
    range:
      begin: < min_port >
      end: < max_port >
  rate_limit:
    default: < true | false >
  system_priority: < 0-65535 >
```

## How to test
molecule test ```lacp```

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code has been rebased from devel before I start
- [ x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ x] My change requires a change to the documentation and documentation have been updated accordingly.
- [ x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
