### PR TITLE
Doc(eos_cli_config_gen): Replace deprecated command in documentation

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -58,7 +58,7 @@
       - [Port-Channel Interfaces](#port-channel-interfaces)
       - [VLAN Interfaces](#vlan-interfaces)
       - [VxLAN Interface](#vxlan-interface)
-    - [Internal VLAN Allocation Policy](#internal-vlan-allocation-policy)
+    - [Internal VLAN Order](#internal-vlan-order)
     - [IP DHCP Relay](#ip-dhcp-relay)
     - [IP ICMP Redirect](#ip-icmp-redirect)
     - [LLDP](#lldp)
@@ -1167,10 +1167,10 @@ vxlan_interface:
       < multiline eos cli >
 ```
 
-### Internal VLAN Allocation Policy
+### Internal VLAN Order
 
 ```yaml
-vlan_internal_allocation_policy:
+vlan_internal_order:
   allocation: < ascending | descending >
   range:
     beginning: < vlan_id >


### PR DESCRIPTION
## Change Summary

adjusting the documentation to reflect the current command.

## Related Issue(s)

no issue opened for this. 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
the j2 templates are using current command "vlan internal order" whereas the documentation is still showing the deprecated command "vlan internal allocation policy"

## How to test
no testing done, just and update for the documentation

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been rebased from devel before I start
- [ ] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x ] My change requires a change to the documentation and documentation have been updated accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
