### PR TITLE
Feat(eos_cli_config_gen): Add support for IPv6 address virtual in vlan_interfaces

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
@@ -75,6 +75,7 @@ interface Management1
 | Vlan41 |  SVI Description  |  default  |  -  |  false  |
 | Vlan42 |  SVI Description  |  default  |  -  |  false  |
 | Vlan75 |  SVI Description  |  default  |  -  |  false  |
+| Vlan81 |  IPv6 Virtual Address  |  Tenant_C  |  -  |  -  |
 | Vlan83 |  SVI Description  |  default  |  -  |  false  |
 | Vlan84 |  SVI Description  |  default  |  -  |  -  |
 | Vlan85 |  SVI Description  |  default  |  -  |  -  |
@@ -106,6 +107,7 @@ interface Management1
 | Vlan41 |  default  |  -  |  10.10.41.1/24  |  -  |  -  |  -  |  -  |
 | Vlan42 |  default  |  -  |  10.10.42.1/24  |  -  |  -  |  -  |  -  |
 | Vlan75 |  default  |  -  |  10.10.75.1/24  |  -  |  -  |  -  |  -  |
+| Vlan81 |  Tenant_C  |  -  |  10.10.81.1/24  |  -  |  -  |  -  |  -  |
 | Vlan83 |  default  |  -  |  10.10.83.1/24  |  -  |  -  |  -  |  -  |
 | Vlan84 |  default  |  10.10.84.1/24  |  -  |  10.10.84.254, 10.11.84.254/24  |  -  |  -  |  -  |
 | Vlan85 |  default  |  10.10.84.1/24  |  -  |  -  |  -  |  -  |  -  |
@@ -125,14 +127,15 @@ interface Management1
 
 #### IPv6
 
-| Interface | VRF | IPv6 Address | Virtual Router Address | VRRP | ND RA Disabled | Managed Config Flag | IPv6 ACL In | IPv6 ACL Out |
-| --------- | --- | ------------ | ----------------------- | --- | -------------- | ----------- | --------- | ----------- | ------------ |
-| Vlan24 |  default  |  1b11:3a00:22b0:6::15/64  |  1b11:3a00:22b0:6::1  |  -  |  -  |  true  |  -  |  -  |
-| Vlan75 |  default  |  1b11:3a00:22b0:1000::15/64  |  1b11:3a00:22b0:1000::1  |  -  |  -  |  true  |  -  |  -  |
-| Vlan89 |  default  |  1b11:3a00:22b0:5200::15/64  |  1b11:3a00:22b0:5200::3  |  -  |  -  |  true  |  -  |  -  |
-| Vlan501 |  default  |  1b11:3a00:22b0:0088::207/127  |  -  |  -  |  true  |  -  |  -  |  -  |
-| Vlan1001 |  Tenant_A  |  a1::1/64  |  -  |  -  |  -  |  true  |  -  |  -  |
-| Vlan1002 |  Tenant_A  |  a2::1/64  |  -  |  -  |  true  |  true  |  -  |  -  |
+| Interface | VRF | IPv6 Address | IPv6 Virtual Address | Virtual Router Address | VRRP | ND RA Disabled | Managed Config Flag | IPv6 ACL In | IPv6 ACL Out |
+| --------- | --- | ------------ | -------------------- | ---------------------- | ---- | -------------- | ------------------- | ----------- | ------------ |
+| Vlan24 | default | 1b11:3a00:22b0:6::15/64 | - | 1b11:3a00:22b0:6::1 | - | - | true | - | - |
+| Vlan75 | default | 1b11:3a00:22b0:1000::15/64 | - | 1b11:3a00:22b0:1000::1 | - | - | true | - | - |
+| Vlan81 | Tenant_C | - | fc00:10:10:81::1/64 | - | - | - | - | - | - |
+| Vlan89 | default | 1b11:3a00:22b0:5200::15/64 | - | 1b11:3a00:22b0:5200::3 | - | - | true | - | - |
+| Vlan501 | default | 1b11:3a00:22b0:0088::207/127 | - | - | - | true | - | - | - |
+| Vlan1001 | Tenant_A | a1::1/64 | - | - | - | - | true | - | - |
+| Vlan1002 | Tenant_A | a2::1/64 | - | - | - | true | true | - | - |
 
 
 ### VLAN Interfaces Device Configuration
@@ -169,6 +172,13 @@ interface Vlan75
    ipv6 nd managed-config-flag
    ipv6 nd prefix 1b11:3a00:22b0:1000::/64 infinite infinite no-autoconfig
    ipv6 virtual-router address 1b11:3a00:22b0:1000::1
+!
+interface Vlan81
+   description IPv6 Virtual Address
+   vrf Tenant_C
+   ip address virtual 10.10.81.1/24
+   ipv6 enable
+   ipv6 address virtual fc00:10:10:81::1/64
 !
 interface Vlan83
    description SVI Description

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
@@ -43,6 +43,13 @@ interface Vlan75
    ipv6 nd prefix 1b11:3a00:22b0:1000::/64 infinite infinite no-autoconfig
    ipv6 virtual-router address 1b11:3a00:22b0:1000::1
 !
+interface Vlan81
+   description IPv6 Virtual Address
+   vrf Tenant_C
+   ip address virtual 10.10.81.1/24
+   ipv6 enable
+   ipv6 address virtual fc00:10:10:81::1/64
+!
 interface Vlan83
    description SVI Description
    no shutdown

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
@@ -15,6 +15,13 @@ vlan_interfaces:
     vrf: Tenant_B
     ip_address_virtual: 10.2.2.1/24
 
+  Vlan81:
+    description: IPv6 Virtual Address
+    vrf: Tenant_C
+    ip_address_virtual: 10.10.81.1/24
+    ipv6_enable: true
+    ipv6_address_virtual: fc00:10:10:81::1/64
+
   Vlan83:
     description: SVI Description
     shutdown: false

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1085,6 +1085,7 @@ vlan_interfaces:
         source_interface: < source_interface_name >
     ipv6_enable: < true | false >
     ipv6_address: < IPv6_address/Mask >
+    ipv6_address_virtual: < IPv6_address/Mask >
     ipv6_address_link_local: < link_local_IPv6_address/Mask >
     ipv6_nd_ra_disabled: < true | false >
     ipv6_nd_managed_config_flag: < true | false >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vlan-interfaces.j2
@@ -46,24 +46,21 @@
 | {{ vlan_interface }} |  {{ row_vrf }}  |  {{ row_ip_addr }}  |  {{ row_ip_vaddr }}  |  {{ row_varp }}  |  {{ row_vrrp }}  |  {{ row_acl_in }}  |  {{ row_acl_out }}  |
 {%     endfor %}
 {# IPv6 #}
-{%     set vlan_interface_ipv6 = namespace() %}
-{%     set vlan_interface_ipv6.configured = false %}
+{%     set vlan_interfaces_ipv6 = [] %}
 {%     for vlan_interface in vlan_interfaces | arista.avd.natural_sort %}
-{%          if vlan_interfaces[vlan_interface].ipv6_address is defined %}
+{%         if vlan_interfaces[vlan_interface].ipv6_address is arista.avd.defined or vlan_interfaces[vlan_interface].ipv6_address_virtual is arista.avd.defined %}
 {# add also a test against ipv6_address_virtual when supported #}
-{%              set vlan_interface_ipv6.configured = true %}
-{%          endif %}
+{%             do vlan_interfaces_ipv6.append(vlan_interface) %}
+{%         endif %}
 {%     endfor %}
-{%     if vlan_interface_ipv6.configured == true %}
+{%     if vlan_interfaces_ipv6 | length > 0 %}
 
 #### IPv6
 
-| Interface | VRF | IPv6 Address | Virtual Router Address | VRRP | ND RA Disabled | Managed Config Flag | IPv6 ACL In | IPv6 ACL Out |
-| --------- | --- | ------------ | ----------------------- | --- | -------------- | ----------- | --------- | ----------- | ------------ |
-{%         for vlan_interface in vlan_interfaces | arista.avd.natural_sort %}
-{%             if vlan_interfaces[vlan_interface].ipv6_address is defined and vlan_interfaces[vlan_interface].ipv6_address is not none %}
-| {{ vlan_interface }} | {% if vlan_interfaces[vlan_interface].vrf is defined and vlan_interfaces[vlan_interface].vrf is not none %} {{ vlan_interfaces[vlan_interface].vrf }} {% else %} default {% endif %} | {% if vlan_interfaces[vlan_interface].ipv6_address is defined and vlan_interfaces[vlan_interface].ipv6_address is not none %} {{ vlan_interfaces[vlan_interface].ipv6_address }} {% else %} - {% endif %} | {% if vlan_interfaces[vlan_interface].ipv6_virtual_router_address is defined and vlan_interfaces[vlan_interface].ipv6_virtual_router_address is not none %} {{ vlan_interfaces[vlan_interface].ipv6_virtual_router_address }} {% else %} - {% endif %} | {% if vlan_interfaces[vlan_interface].vrrp.ipv6 is defined and vlan_interfaces[vlan_interface].vrrp.ipv6 is not none %} {{ vlan_interfaces[vlan_interface].vrrp.ipv6 }} {% else %} - {% endif %} | {% if vlan_interfaces[vlan_interface].ipv6_nd_ra_disabled is defined and vlan_interfaces[vlan_interface].ipv6_nd_ra_disabled is not none %} {{ vlan_interfaces[vlan_interface].ipv6_nd_ra_disabled | lower }} {% else %} - {% endif %} | {% if vlan_interfaces[vlan_interface].ipv6_nd_managed_config_flag is defined and vlan_interfaces[vlan_interface].ipv6_nd_managed_config_flag is not none %} {{ vlan_interfaces[vlan_interface].ipv6_nd_managed_config_flag | lower }} {% else %} - {% endif %} | {% if vlan_interfaces[vlan_interface].ipv6_access_group_in is defined and vlan_interfaces[vlan_interface].ipv6_access_group_in is not none %} {{ vlan_interfaces[vlan_interface].ipv6_access_group_in }} {% else %} - {% endif %} | {% if vlan_interfaces[vlan_interface].ipv6_access_group_out is defined and vlan_interfaces[vlan_interface].ipv6_access_group_out is not none %} {{ vlan_interfaces[vlan_interface].ipv6_access_group_out }} {% else %} - {% endif %} |
-{%             endif %}
+| Interface | VRF | IPv6 Address | IPv6 Virtual Address | Virtual Router Address | VRRP | ND RA Disabled | Managed Config Flag | IPv6 ACL In | IPv6 ACL Out |
+| --------- | --- | ------------ | -------------------- | ---------------------- | ---- | -------------- | ------------------- | ----------- | ------------ |
+{%         for vlan_interface in vlan_interfaces_ipv6 | arista.avd.natural_sort %}
+| {{ vlan_interface }} | {{ vlan_interfaces[vlan_interface].vrf | arista.avd.default('default') }} | {{ vlan_interfaces[vlan_interface].ipv6_address | arista.avd.default('-') }} | {{ vlan_interfaces[vlan_interface].ipv6_address_virtual | arista.avd.default('-') }} | {{ vlan_interfaces[vlan_interface].ipv6_virtual_router_address | arista.avd.default('-') }} | {{ vlan_interfaces[vlan_interface].vrrp.ipv6 | arista.avd.default('-') }} | {{ vlan_interfaces[vlan_interface].ipv6_nd_ra_disabled | arista.avd.default('-') | lower }} | {{ vlan_interfaces[vlan_interface].ipv6_nd_managed_config_flag | arista.avd.default('-') | lower }} | {{ vlan_interfaces[vlan_interface].ipv6_access_group_in | arista.avd.default('-') }} | {{ vlan_interfaces[vlan_interface].ipv6_access_group_out | arista.avd.default('-') }} |
 {%         endfor %}
 {%     endif %}
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vlan-interfaces.j2
@@ -47,7 +47,7 @@
 {%     endfor %}
 {# IPv6 #}
 {%     set vlan_interfaces_ipv6 = [] %}
-{%     for vlan_interface in vlan_interfaces %}
+{%     for vlan_interface in vlan_interfaces | arista.avd.default([]) %}
 {%         if vlan_interfaces[vlan_interface].ipv6_address is arista.avd.defined or vlan_interfaces[vlan_interface].ipv6_address_virtual is arista.avd.defined %}
 {# add also a test against ipv6_address_virtual when supported #}
 {%             do vlan_interfaces_ipv6.append(vlan_interface) %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vlan-interfaces.j2
@@ -47,7 +47,7 @@
 {%     endfor %}
 {# IPv6 #}
 {%     set vlan_interfaces_ipv6 = [] %}
-{%     for vlan_interface in vlan_interfaces | arista.avd.natural_sort %}
+{%     for vlan_interface in vlan_interfaces %}
 {%         if vlan_interfaces[vlan_interface].ipv6_address is arista.avd.defined or vlan_interfaces[vlan_interface].ipv6_address_virtual is arista.avd.defined %}
 {# add also a test against ipv6_address_virtual when supported #}
 {%             do vlan_interfaces_ipv6.append(vlan_interface) %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
@@ -65,6 +65,9 @@ interface {{ vlan_interface }}
 {%     if vlan_interfaces[vlan_interface].ipv6_address_link_local is arista.avd.defined %}
    ipv6 address {{ vlan_interfaces[vlan_interface].ipv6_address_link_local }} link-local
 {%     endif %}
+{%     if vlan_interfaces[vlan_interface].ipv6_address_virtual is arista.avd.defined %}
+   ipv6 address virtual {{ vlan_interfaces[vlan_interface].ipv6_address_virtual }}
+{%     endif %}
 {%     if vlan_interfaces[vlan_interface].ipv6_nd_ra_disabled is arista.avd.defined(true) %}
    ipv6 nd ra disabled
 {%     endif %}


### PR DESCRIPTION
## Change Summary

Adds SVI support for IPv6 following the latest CLI feature: 
    `IPv6 address virtual A:B:C:D:E:F:G:H/I`

## Related Issue(s)

Fixes #1106

## Component(s) name

`arista.avd.eos_cli_config_gen `

## Proposed changes
EOS config example of dual-stack SVI and "ipv6 address virtual":

```
interface Vlan10
   vrf red
   ipv6 enable
   ipv6 address virtual fc00:10::254/64  
   ip address virtual 10.10.10.254/24
```

Can be defined as:
```
vlan_interfaces:
    Vlan10:
      ip_address_virtual: 10.10.10.254/24
      ipv6_address_virtual: fc00:10::254/64
```


## How to test
Generate configuration with the the data model feature on a Vlan interface.

## Checklist

### User Checklist
- N/A

### Repository Checklist
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
