### PR TITLE
Feat(eos_designs): Add limited support for --limit flag with fact caching

### DIFF
--- a/ansible_collections/arista/avd/docs/how-to/run-with-limit.md
+++ b/ansible_collections/arista/avd/docs/how-to/run-with-limit.md
@@ -33,7 +33,10 @@ Now it is possible to run the playbook again _with_ `--limit` flag set, and the 
 
 ## Limitations and recommendations
 
+
 1. Avoid using `--limit` if possible because of the pitfalls below.
+1. When using the `eos_config_deploy_cvp` role the `--limit` must also contain the CVP server hostname.
+1. Before pushing any configuration to any devices, make sure to verify that important configuration is not affected in case the "Fact Cache" was not updated.
 1. Fabric documentation and CSV files cannot be generated while using `--limit`. The tasks are skipped automatically.
 1. When adding new devices, the playbook _must_ be run at least once without `--limit`. This is to set ensure that uplinks and downlinks are configured correctly on other switches.
 1. A warning will be shown during the play, if we detect that facts have not been cached once. _This warning will only be shown on the first run for this device._

--- a/ansible_collections/arista/avd/docs/how-to/run-with-limit.md
+++ b/ansible_collections/arista/avd/docs/how-to/run-with-limit.md
@@ -2,16 +2,16 @@
 
 First some background on the issue with `--limit`.
 
-The `eos_designs` role consists of many different templates which are run in stages across all devices.
-All stages run on all devices, but each stage must be completed for all devices, before continuing to the next stage.
-The first stage is "Switch Facts" which sets facts on every switch, only concerning that single switch.
+The `eos_designs` role consists of many different templates which are run in stages for all devices in the fabric.
+All stages run for all devices, but each stage must be completed for all devices, before continuing to the next stage.
+The first stage is "Switch Facts" which sets facts for every switch, only concerning that single switch.
 The second stage is "Topology Facts" which sets facts per switch based on the "Switch Facts" from this _and_ upstream/peer switches.
 The third stage is "Structured Config" which parses "Topology Facts" for _all_ switches in the `fabric`, to look for peers connecting to this switch and generates the full config in a structured data model.
 
 This method is what allows the high flexibility of AVD, while maintaining a simpler topology data model e.g. you only define connectivity from child perspective.
-It is also what allows variables to be scoped to only the single devices as necessary e.g. `POD1` only needs to know about the topology of `POD1`, even though it may have a direct connection to `POD2`.
+It is also what allows variables to be scoped to only the few devices as necessary e.g. `POD1` only needs to know about the topology of `POD1`, even though it may have a direct connection to `POD2`.
 
-If the playbook is executed with `--limit`, the facts are only computed for this switch, hence it will not be able to create "Topology Facts" nor "Structured Config" for anything outside of this switch.
+If the playbook is executed with `--limit`, the facts are computed only for this switch, hence it will not be able to create "Topology Facts" nor "Structured Config" for anything else than this switch.
 This means that ex. uplinks to spines will not be possible because we cannot look up the ASN of the spine.
 
 To work around this, it is possible to combine `--limit` with "Fact Caching". "Fact Caching" allows ansible to store all computed facts between plays.
@@ -31,20 +31,19 @@ fact_caching_connection = < path to directory >
 
 After adding the above config, run the playbook once _without_ `--limit`. This will store facts for all devices in the set path. Each switch will have it's own file.
 
-Now it is possible to run the playbook again _with_ `--limit` flag set, and the config will be completely the same because facts are loaded for all devices.
+Now it is possible to run the playbook again _with_ `--limit` flag set, and the config will be completely the same, because facts are loaded for all devices.
 
 ## Limitations and recommendations
 
-
 1. Avoid using `--limit` if possible because of the pitfalls below.
-1. When using the `eos_config_deploy_cvp` role the `--limit` must also contain the CVP server hostname.
-1. Before pushing any configuration to any devices, make sure to verify that important configuration is not affected in case the "Fact Cache" was not updated.
+1. When using the `eos_config_deploy_cvp` role the `--limit` must also contain the CVP server inventory hostname.
+1. Before pushing any configuration to any devices, make sure to verify that important configuration is not affected in case the "Fact Cache" was not updated correctly.
 1. Fabric documentation and CSV files cannot be generated while using `--limit`. The tasks are skipped automatically.
-1. When adding new devices, the playbook _must_ be run at least once without `--limit`. This is to set ensure that uplinks and downlinks are configured correctly on other switches.
-1. A warning will be shown during the play, if we detect that facts have not been cached once. _This warning will only be shown on the first run for this device._
+1. When adding new devices, the playbook _must_ be run at least once without `--limit`. This is to ensure that uplinks and downlinks are configured correctly on other switches.
+1. A warning will be shown during the play, if we detect that facts have not been cached once. _This warning will only be shown if no cached structured_config is found for this device._
    ```cli
    !!! Warning - The role 'arista.avd.eos_designs' only supports '--limit' flag in combination with fact caching
-   !!! Warning - UD-a02-LF-2-B not found in cache
+   !!! Warning - <inventory_hostname> not found in cache
    !!! Warning - When adding new devices, the playbook must be run once without '--limit'
    ```
 1. If any "Fabric Topology", "Network Services" or other general variables are changed, it may affect multiple devices, so it is recommended to run a full play without `--limit`.

--- a/ansible_collections/arista/avd/docs/how-to/run-with-limit.md
+++ b/ansible_collections/arista/avd/docs/how-to/run-with-limit.md
@@ -8,12 +8,14 @@ The first stage is "Switch Facts" which sets facts on every switch, only concern
 The second stage is "Topology Facts" which sets facts per switch based on the "Switch Facts" from this _and_ upstream/peer switches.
 The third stage is "Structured Config" which parses "Topology Facts" for _all_ switches in the `fabric`, to look for peers connecting to this switch and generates the full config in a structured data model.
 
-This method is what allows the high flexibility of AVD, while maintaining a simpler topology data model e.g. you only define connectivity from child perspective. 
+This method is what allows the high flexibility of AVD, while maintaining a simpler topology data model e.g. you only define connectivity from child perspective.
 It is also what allows variables to be scoped to only the single devices as necessary e.g. `POD1` only needs to know about the topology of `POD1`, even though it may have a direct connection to `POD2`.
 
-If the playbook is executed with `--limit`, the facts are only computed for this switch, hence it will not be able to create "Topology Facts" nor "Structured Config" for anything outside of this switch. This means that ex. uplinks to spines will not be possible because we cannot look up the ASN of the spine.
+If the playbook is executed with `--limit`, the facts are only computed for this switch, hence it will not be able to create "Topology Facts" nor "Structured Config" for anything outside of this switch.
+This means that ex. uplinks to spines will not be possible because we cannot look up the ASN of the spine.
 
-To work around this, it is possible to combine `--limit` with "Fact Caching". "Fact Caching" allows ansible to store all computed facts between plays. The stored facts will be loaded on the next play, even if that play is limited to one or a few switches.
+To work around this, it is possible to combine `--limit` with "Fact Caching". "Fact Caching" allows ansible to store all computed facts between plays.
+The stored facts will be loaded on the next play, even if that play is limited to one or a few switches.
 
 "Fact Caching" can be enabled in multiple ways and with various plugins. See [Ansible Documentation](https://docs.ansible.com/ansible/latest/plugins/cache.html) for details.
 

--- a/ansible_collections/arista/avd/docs/how-to/run-with-limit.md
+++ b/ansible_collections/arista/avd/docs/how-to/run-with-limit.md
@@ -1,0 +1,46 @@
+# How to run AVD eos_designs role with --limit flag
+
+First some background on the issue with `--limit`.
+
+The `eos_designs` role consists of many different templates which are run in stages across all devices.
+All stages run on all devices, but each stage must be completed for all devices, before continuing to the next stage.
+The first stage is "Switch Facts" which sets facts on every switch, only concerning that single switch.
+The second stage is "Topology Facts" which sets facts per switch based on the "Switch Facts" from this _and_ upstream/peer switches.
+The third stage is "Structured Config" which parses "Topology Facts" for _all_ switches in the `fabric`, to look for peers connecting to this switch and generates the full config in a structured data model.
+
+This method is what allows the high flexibility of AVD, while maintaining a simpler topology data model e.g. you only define connectivity from child perspective. 
+It is also what allows variables to be scoped to only the single devices as necessary e.g. `POD1` only needs to know about the topology of `POD1`, even though it may have a direct connection to `POD2`.
+
+If the playbook is executed with `--limit`, the facts are only computed for this switch, hence it will not be able to create "Topology Facts" nor "Structured Config" for anything outside of this switch. This means that ex. uplinks to spines will not be possible because we cannot look up the ASN of the spine.
+
+To work around this, it is possible to combine `--limit` with "Fact Caching". "Fact Caching" allows ansible to store all computed facts between plays. The stored facts will be loaded on the next play, even if that play is limited to one or a few switches.
+
+"Fact Caching" can be enabled in multiple ways and with various plugins. See [Ansible Documentation](https://docs.ansible.com/ansible/latest/plugins/cache.html) for details.
+
+## Example
+
+The simplest cache is to store a YAML file for each device. The cache plugin and path is configured in `ansible.cfg`:
+```ini
+[defaults]
+<...>
+fact_caching = jsonfile
+fact_caching_connection = < path to directory >
+```
+
+After adding the above config, run the playbook once _without_ `--limit`. This will store facts for all devices in the set path. Each switch will have it's own file.
+
+Now it is possible to run the playbook again _with_ `--limit` flag set, and the config will be completely the same because facts are loaded for all devices.
+
+## Limitations and recommendations
+
+1. Avoid using `--limit` if possible because of the pitfalls below.
+1. Fabric documentation and CSV files cannot be generated while using `--limit`. The tasks are skipped automatically.
+1. When adding new devices, the playbook _must_ be run at least once without `--limit`. This is to set ensure that uplinks and downlinks are configured correctly on other switches.
+1. A warning will be shown during the play, if we detect that facts have not been cached once. _This warning will only be shown on the first run for this device._
+   ```cli
+   !!! Warning - The role 'arista.avd.eos_designs' only supports '--limit' flag in combination with fact caching
+   !!! Warning - UD-a02-LF-2-B not found in cache
+   !!! Warning - When adding new devices, the playbook must be run once without '--limit'
+   ```
+1. If any "Fabric Topology", "Network Services" or other general variables are changed, it may affect multiple devices, so it is recommended to run a full play without `--limit`.
+1. To catch any missed changes and to keep Fabric Documentation up to date, it is recommended to run a full play without `--limit` in a schedule, and verify any changes.

--- a/ansible_collections/arista/avd/roles/eos_designs/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/tasks/main.yml
@@ -73,7 +73,7 @@
   run_once: true
   delegate_to: localhost
   check_mode: no
-  when: ansible_limit == None
+  when: ansible_limit is not arista.avd.defined
   block:
     - name: Store checksum of existing fabric documentation
       ansible.builtin.stat:
@@ -105,7 +105,7 @@
   delegate_to: localhost
   run_once: true
   check_mode: no
-  when: ansible_limit == None
+  when: ansible_limit is not arista.avd.defined
 
 - name: Generate fabric topology in csv format.
   tags: [build, provision, documentation]
@@ -116,4 +116,4 @@
   delegate_to: localhost
   run_once: true
   check_mode: no
-  when: ansible_limit == None
+  when: ansible_limit is not arista.avd.defined

--- a/ansible_collections/arista/avd/roles/eos_designs/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/tasks/main.yml
@@ -11,6 +11,15 @@
   delegate_to: localhost
   run_once: true
 
+- name: Check for limit and fact caching
+  delegate_to: localhost
+  when: ansible_limit is arista.avd.defined and structured_config is not arista.avd.defined
+  debug:
+    msg:
+      - "!!! Warning - The role 'arista.avd.eos_designs' only supports '--limit' flag in combination with fact caching"
+      - "!!! Warning - {{ inventory_hostname }} not found in cache"
+      - "!!! Warning - When adding new devices, the playbook must be run once without '--limit'"
+
 - name: Set AVD facts
   tags: [build, provision]
   yaml_templates_to_facts:
@@ -64,6 +73,7 @@
   run_once: true
   delegate_to: localhost
   check_mode: no
+  when: ansible_limit == None
   block:
     - name: Store checksum of existing fabric documentation
       ansible.builtin.stat:
@@ -95,6 +105,7 @@
   delegate_to: localhost
   run_once: true
   check_mode: no
+  when: ansible_limit == None
 
 - name: Generate fabric topology in csv format.
   tags: [build, provision, documentation]
@@ -105,3 +116,4 @@
   delegate_to: localhost
   run_once: true
   check_mode: no
+  when: ansible_limit == None

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -113,6 +113,7 @@ nav:
       - AWX & Tower Integration: docs/how-to/tower-integration.md
       - Configure ZTP server with CV collection: docs/how-to/ztp.md
       - VScode Container: docs/how-to/vscode-container.md
+      - Run AVD eos_designs role with --limit flag: docs/how-to/run-with-limit.md
   - Roles documentation:
       - eos_designs:
           - Overview: roles/eos_designs/README.md


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Add support for --limit flag with fact caching
## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->
- [x] Add documentation on fact caching
- [x] Skip fabric documentation and csv if --limit is used
- [x] Warn if --limit is used but it looks like caching is not enabled

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- Don't configure fact caching
- Run full playbook
- Run playbook with --limit and observe warning and bad config
- Configure fact caching
- Run playbook with --limit and observe warning and bad config
- Run full playbook
- Run playbook with --limit and observe no warning and correct config (no change since full run)
- Verify that Fabric documentation and CSVs are skipped when using --limit

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
