### PR TITLE
Bump: limit ansible-core>=2.11.3,<2.12.0

### DIFF
--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -231,7 +231,7 @@ jobs:
           - 'upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp'
           - 'upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos'
           - 'upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp'
-        ansible_version: ['ansible-core==2.11.3', 'ansible-core>=2.11.3,<2.12.0,<2.12.0']
+        ansible_version: ['ansible-core==2.11.3', 'ansible-core>=2.11.3,<2.12.0']
     needs: [ pre_commit ]
     if: needs.file-changes.outputs.eos_design == 'true' || needs.file-changes.outputs.config_gen == 'true'
     steps:

--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -150,7 +150,7 @@ jobs:
       fail-fast: true
       matrix:
         avd_scenario: ['eos_cli_config_gen','upgrade_eos_cli_config_gen']
-        ansible_version: ['ansible-core==2.11.3', 'ansible-core>=2.11.3']
+        ansible_version: ['ansible-core==2.11.3', 'ansible-core>=2.11.3,<2.12.0']
     needs: [ pre_commit ]
     if: needs.file-changes.outputs.config_gen == 'true'
     steps:
@@ -185,7 +185,7 @@ jobs:
       fail-fast: true
       matrix:
         avd_scenario: ['dhcp_configuration', 'dhcp_provisionning']
-        ansible_version: ['ansible-core==2.11.3', 'ansible-core>=2.11.3']
+        ansible_version: ['ansible-core==2.11.3', 'ansible-core>=2.11.3,<2.12.0']
     needs: [ pre_commit ]
     if: needs.file-changes.outputs.dhcp == 'true'
     steps:
@@ -231,7 +231,7 @@ jobs:
           - 'upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp'
           - 'upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos'
           - 'upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp'
-        ansible_version: ['ansible-core==2.11.3', 'ansible-core>=2.11.3']
+        ansible_version: ['ansible-core==2.11.3', 'ansible-core>=2.11.3,<2.12.0,<2.12.0']
     needs: [ pre_commit ]
     if: needs.file-changes.outputs.eos_design == 'true' || needs.file-changes.outputs.config_gen == 'true'
     steps:
@@ -265,7 +265,7 @@ jobs:
       fail-fast: true
       matrix:
         avd_scenario: ['eos_config_deploy_cvp']
-        ansible_version: ['ansible-core==2.11.3', 'ansible-core>=2.11.3']
+        ansible_version: ['ansible-core==2.11.3', 'ansible-core>=2.11.3,<2.12.0']
     needs: [ pre_commit ]
     if: needs.file-changes.outputs.cloudvision == 'true'
     steps:

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The documentation how to leverage ansible-avd collection is located here:
 **Ansible + Additional Python Libraries Installation:**
 
 ```shell
-$ pip3 install ansible-core>=2.11.3
+$ pip3 install ansible-core>=2.11.3,<2.12.0
 
 $ pip3 install -r ansible_collections/arista/avd/requirements.txt
 ```

--- a/ansible_collections/arista/avd/README.md
+++ b/ansible_collections/arista/avd/README.md
@@ -98,7 +98,7 @@ This repository provides custom plugins for Ansible's collection __arista.avd__ 
 **Ansible + Additional Python Libraries Installation:**
 
 ```shell
-$ pip3 install ansible-core>=2.11.3
+$ pip3 install ansible-core>=2.11.3,<2.12.0
 
 $ pip3 install -r requirements.txt
 ```

--- a/ansible_collections/arista/avd/requirements-dev.txt
+++ b/ansible_collections/arista/avd/requirements-dev.txt
@@ -1,4 +1,4 @@
-ansible-core>=2.11.3
+ansible-core>=2.11.3,<2.12.0
 ansible-lint
 galaxy-importer>=0.3.1
 pycodestyle


### PR DESCRIPTION
## Change Summary

Limit ansible core version >=2.11.3,<2.12.0

## Issue Description

Due to change in lookup plugin in `ansible-core >2.12.0`, caused in issue with the `yaml_template_to_facts` plugin.

```shell
TASK [arista.avd.eos_designs : Set AVD facts] **********************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: AttributeError: 'LookupModule' object has no attribute '_load_name'
fatal: [DC1-LEAF1A -> localhost]: FAILED! => {"msg": "Unexpected failure during module execution.", "stdout": ""}
```

## Component(s) name

`yaml_template_to_facts`

## Proposed changes

Limit ansible version in requirements-dev.txt

## How to test

Success Molecule CI Run

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
