### PR TITLE
Reformat(eos_cli_config_gen): molecule yaml lint

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
@@ -269,4 +269,3 @@ ethernet_interfaces:
     description: 10% shape
     shape:
       rate: "10 percent"
-


### PR DESCRIPTION
## Change Summary

Fix yaml lint issue in molecule scenario:

```
ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
  272:1     warning  too many blank lines (1 > 0)  (empty-lines)
```

## Component(s) name

Molecule

## How to test

run `make linting`

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
