### PR TITLE
Feat(eos_designs): Support configuration of vtep_diagnostic loopback pool per POD

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF2A.md
@@ -203,6 +203,9 @@ vlan internal order ascending range 1006 1199
 | 111 | Tenant_A_OP_Zone_2 | - |
 | 112 | Tenant_A_OP_Zone_3 | - |
 | 113 | SVI_with_no_vxlan | - |
+| 1100 | test_svi | - |
+| 1101 | test_svi | - |
+| 1102 | test_svi | - |
 | 2500 | web-l2-vlan | - |
 | 2600 | web-l2-vlan-2 | - |
 | 2601 | l2vlan_with_no_vxlan | - |
@@ -224,6 +227,15 @@ vlan 112
 !
 vlan 113
    name SVI_with_no_vxlan
+!
+vlan 1100
+   name test_svi
+!
+vlan 1101
+   name test_svi
+!
+vlan 1102
+   name test_svi
 !
 vlan 2500
    name web-l2-vlan
@@ -252,8 +264,8 @@ vlan 4094
 
 | Interface | Description | Mode | VLANs | Native VLAN | Trunk Group | Channel-Group |
 | --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
-| Ethernet1 | DC1-POD1-LEAF2A_Ethernet3 | *trunk | *110-113,2500,2600-2601,4085 | *- | *- | 1 |
-| Ethernet2 | DC1-POD1-LEAF2B_Ethernet3 | *trunk | *110-113,2500,2600-2601,4085 | *- | *- | 1 |
+| Ethernet1 | DC1-POD1-LEAF2A_Ethernet3 | *trunk | *110-113,1100-1102,2500,2600-2601,4085 | *- | *- | 1 |
+| Ethernet2 | DC1-POD1-LEAF2B_Ethernet3 | *trunk | *110-113,1100-1102,2500,2600-2601,4085 | *- | *- | 1 |
 | Ethernet3 | MLAG_PEER_DC1-POD1-L2LEAF2B_Ethernet3 | *trunk | *2-4094 | *- | *['MLAG'] | 3 |
 | Ethernet4 | MLAG_PEER_DC1-POD1-L2LEAF2B_Ethernet4 | *trunk | *2-4094 | *- | *['MLAG'] | 3 |
 
@@ -292,7 +304,7 @@ interface Ethernet4
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel1 | RACK2_MLAG_Po3 | switched | trunk | 110-113,2500,2600-2601,4085 | - | - | - | - | 1 | - |
+| Port-Channel1 | RACK2_MLAG_Po3 | switched | trunk | 110-113,1100-1102,2500,2600-2601,4085 | - | - | - | - | 1 | - |
 | Port-Channel3 | MLAG_PEER_DC1-POD1-L2LEAF2B_Po3 | switched | trunk | 2-4094 | - | ['MLAG'] | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
@@ -303,7 +315,7 @@ interface Port-Channel1
    description RACK2_MLAG_Po3
    no shutdown
    switchport
-   switchport trunk allowed vlan 110-113,2500,2600-2601,4085
+   switchport trunk allowed vlan 110-113,1100-1102,2500,2600-2601,4085
    switchport mode trunk
    mlag 1
    service-profile QOS-PROFILE

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-L2LEAF2B.md
@@ -211,6 +211,9 @@ vlan internal order ascending range 1006 1199
 | 111 | Tenant_A_OP_Zone_2 | - |
 | 112 | Tenant_A_OP_Zone_3 | - |
 | 113 | SVI_with_no_vxlan | - |
+| 1100 | test_svi | - |
+| 1101 | test_svi | - |
+| 1102 | test_svi | - |
 | 2500 | web-l2-vlan | - |
 | 2600 | web-l2-vlan-2 | - |
 | 2601 | l2vlan_with_no_vxlan | - |
@@ -232,6 +235,15 @@ vlan 112
 !
 vlan 113
    name SVI_with_no_vxlan
+!
+vlan 1100
+   name test_svi
+!
+vlan 1101
+   name test_svi
+!
+vlan 1102
+   name test_svi
 !
 vlan 2500
    name web-l2-vlan
@@ -260,8 +272,8 @@ vlan 4094
 
 | Interface | Description | Mode | VLANs | Native VLAN | Trunk Group | Channel-Group |
 | --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
-| Ethernet1 | DC1-POD1-LEAF2A_Ethernet4 | *trunk | *110-113,2500,2600-2601,4085 | *- | *- | 1 |
-| Ethernet2 | DC1-POD1-LEAF2B_Ethernet4 | *trunk | *110-113,2500,2600-2601,4085 | *- | *- | 1 |
+| Ethernet1 | DC1-POD1-LEAF2A_Ethernet4 | *trunk | *110-113,1100-1102,2500,2600-2601,4085 | *- | *- | 1 |
+| Ethernet2 | DC1-POD1-LEAF2B_Ethernet4 | *trunk | *110-113,1100-1102,2500,2600-2601,4085 | *- | *- | 1 |
 | Ethernet3 | MLAG_PEER_DC1-POD1-L2LEAF2A_Ethernet3 | *trunk | *2-4094 | *- | *['MLAG'] | 3 |
 | Ethernet4 | MLAG_PEER_DC1-POD1-L2LEAF2A_Ethernet4 | *trunk | *2-4094 | *- | *['MLAG'] | 3 |
 
@@ -300,7 +312,7 @@ interface Ethernet4
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel1 | RACK2_MLAG_Po3 | switched | trunk | 110-113,2500,2600-2601,4085 | - | - | - | - | 1 | - |
+| Port-Channel1 | RACK2_MLAG_Po3 | switched | trunk | 110-113,1100-1102,2500,2600-2601,4085 | - | - | - | - | 1 | - |
 | Port-Channel3 | MLAG_PEER_DC1-POD1-L2LEAF2A_Po3 | switched | trunk | 2-4094 | - | ['MLAG'] | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
@@ -311,7 +323,7 @@ interface Port-Channel1
    description RACK2_MLAG_Po3
    no shutdown
    switchport
-   switchport trunk allowed vlan 110-113,2500,2600-2601,4085
+   switchport trunk allowed vlan 110-113,1100-1102,2500,2600-2601,4085
    switchport mode trunk
    mlag 1
    service-profile QOS-PROFILE

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2A.md
@@ -45,6 +45,9 @@
 - [VRF Instances](#vrf-instances)
   - [VRF Instances Summary](#vrf-instances-summary)
   - [VRF Instances Device Configuration](#vrf-instances-device-configuration)
+- [Virtual Source NAT](#virtual-source-nat)
+  - [Virtual Source NAT Summary](#virtual-source-nat-summary)
+  - [Virtual Source NAT Configuration](#virtual-source-nat-configuration)
 - [Quality Of Service](#quality-of-service)
 - [EOS CLI](#eos-cli)
 
@@ -202,6 +205,9 @@ vlan internal order ascending range 1006 1199
 | 111 | Tenant_A_OP_Zone_2 | - |
 | 112 | Tenant_A_OP_Zone_3 | - |
 | 113 | SVI_with_no_vxlan | - |
+| 1100 | test_svi | - |
+| 1101 | test_svi | - |
+| 1102 | test_svi | - |
 | 2500 | web-l2-vlan | - |
 | 2600 | web-l2-vlan-2 | - |
 | 2601 | l2vlan_with_no_vxlan | - |
@@ -223,6 +229,15 @@ vlan 112
 !
 vlan 113
    name SVI_with_no_vxlan
+!
+vlan 1100
+   name test_svi
+!
+vlan 1101
+   name test_svi
+!
+vlan 1102
+   name test_svi
 !
 vlan 2500
    name web-l2-vlan
@@ -251,8 +266,8 @@ vlan 4094
 
 | Interface | Description | Mode | VLANs | Native VLAN | Trunk Group | Channel-Group |
 | --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
-| Ethernet3 | DC1-POD1-L2LEAF2A_Ethernet1 | *trunk | *110-113,2500,2600-2601,4085 | *- | *- | 3 |
-| Ethernet4 | DC1-POD1-L2LEAF2B_Ethernet1 | *trunk | *110-113,2500,2600-2601,4085 | *- | *- | 3 |
+| Ethernet3 | DC1-POD1-L2LEAF2A_Ethernet1 | *trunk | *110-113,1100-1102,2500,2600-2601,4085 | *- | *- | 3 |
+| Ethernet4 | DC1-POD1-L2LEAF2B_Ethernet1 | *trunk | *110-113,1100-1102,2500,2600-2601,4085 | *- | *- | 3 |
 | Ethernet5 | MLAG_PEER_DC1-POD1-LEAF2B_Ethernet5 | *trunk | *2-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 5 |
 | Ethernet6 | MLAG_PEER_DC1-POD1-LEAF2B_Ethernet6 | *trunk | *2-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 5 |
 | Ethernet16 | server-1_Eth1 | *access | *110 | *- | *- | 16 |
@@ -384,7 +399,7 @@ interface Ethernet19
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel3 | RACK2_MLAG_Po1 | switched | trunk | 110-113,2500,2600-2601,4085 | - | - | - | - | 3 | - |
+| Port-Channel3 | RACK2_MLAG_Po1 | switched | trunk | 110-113,1100-1102,2500,2600-2601,4085 | - | - | - | - | 3 | - |
 | Port-Channel5 | MLAG_PEER_DC1-POD1-LEAF2B_Po5 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
 | Port-Channel16 | server-1_PortChannel | switched | access | 110 | - | - | - | - | 16 | - |
 | Port-Channel17 | Set using structured_config on server adapter port-channel | switched | access | 110 | - | - | - | - | 17 | - |
@@ -399,7 +414,7 @@ interface Port-Channel3
    description RACK2_MLAG_Po1
    no shutdown
    switchport
-   switchport trunk allowed vlan 110-113,2500,2600-2601,4085
+   switchport trunk allowed vlan 110-113,1100-1102,2500,2600-2601,4085
    switchport mode trunk
    mlag 3
    service-profile QOS-PROFILE
@@ -465,6 +480,9 @@ interface Port-Channel19
 | --------- | ----------- | --- | ---------- |
 | Loopback0 | EVPN_Overlay_Peering | default | 172.16.110.4/32 |
 | Loopback1 | VTEP_VXLAN_Tunnel_Source | default | 172.18.110.4/32 |
+| Loopback100 | vrf_with_loopbacks_from_overlapping_pool_VTEP_DIAGNOSTICS | vrf_with_loopbacks_from_overlapping_pool | 10.100.0.4/32 |
+| Loopback101 | vrf_with_loopbacks_from_pod_pools_VTEP_DIAGNOSTICS | vrf_with_loopbacks_from_pod_pools | 10.101.101.4/32 |
+| Loopback102 | vrf_with_loopbacks_dc1_pod1_only_VTEP_DIAGNOSTICS | vrf_with_loopbacks_dc1_pod1_only | 10.102.101.4/32 |
 
 #### IPv6
 
@@ -472,6 +490,9 @@ interface Port-Channel19
 | --------- | ----------- | --- | ------------ |
 | Loopback0 | EVPN_Overlay_Peering | default | - |
 | Loopback1 | VTEP_VXLAN_Tunnel_Source | default | - |
+| Loopback100 | vrf_with_loopbacks_from_overlapping_pool_VTEP_DIAGNOSTICS | vrf_with_loopbacks_from_overlapping_pool | - |
+| Loopback101 | vrf_with_loopbacks_from_pod_pools_VTEP_DIAGNOSTICS | vrf_with_loopbacks_from_pod_pools | - |
+| Loopback102 | vrf_with_loopbacks_dc1_pod1_only_VTEP_DIAGNOSTICS | vrf_with_loopbacks_dc1_pod1_only | - |
 
 
 ### Loopback Interfaces Device Configuration
@@ -487,6 +508,24 @@ interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
    no shutdown
    ip address 172.18.110.4/32
+!
+interface Loopback100
+   description vrf_with_loopbacks_from_overlapping_pool_VTEP_DIAGNOSTICS
+   no shutdown
+   vrf vrf_with_loopbacks_from_overlapping_pool
+   ip address 10.100.0.4/32
+!
+interface Loopback101
+   description vrf_with_loopbacks_from_pod_pools_VTEP_DIAGNOSTICS
+   no shutdown
+   vrf vrf_with_loopbacks_from_pod_pools
+   ip address 10.101.101.4/32
+!
+interface Loopback102
+   description vrf_with_loopbacks_dc1_pod1_only_VTEP_DIAGNOSTICS
+   no shutdown
+   vrf vrf_with_loopbacks_dc1_pod1_only
+   ip address 10.102.101.4/32
 ```
 
 ## VLAN Interfaces
@@ -499,6 +538,9 @@ interface Loopback1
 | Vlan111 |  Tenant_A_OP_Zone_2  |  Common_VRF  |  -  |  true  |
 | Vlan112 |  Tenant_A_OP_Zone_3  |  Common_VRF  |  -  |  false  |
 | Vlan113 |  SVI_with_no_vxlan  |  Common_VRF  |  -  |  false  |
+| Vlan1100 |  test_svi  |  vrf_with_loopbacks_from_overlapping_pool  |  -  |  false  |
+| Vlan1101 |  test_svi  |  vrf_with_loopbacks_from_pod_pools  |  -  |  false  |
+| Vlan1102 |  test_svi  |  vrf_with_loopbacks_dc1_pod1_only  |  -  |  false  |
 | Vlan4085 |  L2LEAF_INBAND_MGMT  |  default  |  1500  |  false  |
 | Vlan4094 |  MLAG_PEER  |  default  |  1500  |  false  |
 
@@ -510,6 +552,9 @@ interface Loopback1
 | Vlan111 |  Common_VRF  |  -  |  10.1.11.1/24  |  -  |  -  |  -  |  -  |
 | Vlan112 |  Common_VRF  |  -  |  10.1.12.1/24  |  -  |  -  |  -  |  -  |
 | Vlan113 |  Common_VRF  |  -  |  10.10.13.1/24  |  -  |  -  |  -  |  -  |
+| Vlan1100 |  vrf_with_loopbacks_from_overlapping_pool  |  -  |  10.100.100.1/24  |  -  |  -  |  -  |  -  |
+| Vlan1101 |  vrf_with_loopbacks_from_pod_pools  |  -  |  10.101.100.1/24  |  -  |  -  |  -  |  -  |
+| Vlan1102 |  vrf_with_loopbacks_dc1_pod1_only  |  -  |  10.102.100.1/24  |  -  |  -  |  -  |  -  |
 | Vlan4085 |  default  |  172.21.110.2/24  |  -  |  172.21.110.1  |  -  |  -  |  -  |
 | Vlan4094 |  default  |  172.20.110.2/31  |  -  |  -  |  -  |  -  |  -  |
 
@@ -545,6 +590,24 @@ interface Vlan113
    no shutdown
    vrf Common_VRF
    ip address virtual 10.10.13.1/24
+!
+interface Vlan1100
+   description test_svi
+   no shutdown
+   vrf vrf_with_loopbacks_from_overlapping_pool
+   ip address virtual 10.100.100.1/24
+!
+interface Vlan1101
+   description test_svi
+   no shutdown
+   vrf vrf_with_loopbacks_from_pod_pools
+   ip address virtual 10.101.100.1/24
+!
+interface Vlan1102
+   description test_svi
+   no shutdown
+   vrf vrf_with_loopbacks_dc1_pod1_only
+   ip address virtual 10.102.100.1/24
 !
 interface Vlan4085
    description L2LEAF_INBAND_MGMT
@@ -587,6 +650,9 @@ interface Vlan4094
 | VLAN | VNI |
 | ---- | --- |
 | Common_VRF | 1025 |
+| vrf_with_loopbacks_dc1_pod1_only | 1102 |
+| vrf_with_loopbacks_from_overlapping_pool | 1100 |
+| vrf_with_loopbacks_from_pod_pools | 1101 |
 
 ### VXLAN Interface Device Configuration
 
@@ -603,6 +669,9 @@ interface Vxlan1
    vxlan vlan 2500 vni 2500
    vxlan vlan 2600 vni 2600
    vxlan vrf Common_VRF vni 1025
+   vxlan vrf vrf_with_loopbacks_dc1_pod1_only vni 1102
+   vxlan vrf vrf_with_loopbacks_from_overlapping_pool vni 1100
+   vxlan vrf vrf_with_loopbacks_from_pod_pools vni 1101
 ```
 
 # Routing
@@ -636,6 +705,9 @@ ip virtual-router mac-address 00:1c:73:00:dc:01
 | --- | --------------- |
 | default | true|| Common_VRF | true |
 | MGMT | false |
+| vrf_with_loopbacks_dc1_pod1_only | true |
+| vrf_with_loopbacks_from_overlapping_pool | true |
+| vrf_with_loopbacks_from_pod_pools | true |
 
 ### IP Routing Device Configuration
 
@@ -644,6 +716,9 @@ ip virtual-router mac-address 00:1c:73:00:dc:01
 ip routing
 ip routing vrf Common_VRF
 no ip routing vrf MGMT
+ip routing vrf vrf_with_loopbacks_dc1_pod1_only
+ip routing vrf vrf_with_loopbacks_from_overlapping_pool
+ip routing vrf vrf_with_loopbacks_from_pod_pools
 ```
 ## IPv6 Routing
 
@@ -653,6 +728,9 @@ no ip routing vrf MGMT
 | --- | --------------- |
 | default | false || Common_VRF | false |
 | MGMT | false |
+| vrf_with_loopbacks_dc1_pod1_only | false |
+| vrf_with_loopbacks_from_overlapping_pool | false |
+| vrf_with_loopbacks_from_pod_pools | false |
 
 
 ## Static Routes
@@ -752,6 +830,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 | VRF | Route-Distinguisher | Redistribute |
 | --- | ------------------- | ------------ |
 | Common_VRF | 172.16.110.4:1025 | connected |
+| vrf_with_loopbacks_dc1_pod1_only | 172.16.110.4:1102 | connected |
+| vrf_with_loopbacks_from_overlapping_pool | 172.16.110.4:1100 | connected |
+| vrf_with_loopbacks_from_pod_pools | 172.16.110.4:1101 | connected |
 
 ### Router BGP Device Configuration
 
@@ -862,6 +943,27 @@ router bgp 65112.100
       Comment created from raw_eos_cli under BGP for VRF Common_VRF
       EOF
 
+   !
+   vrf vrf_with_loopbacks_dc1_pod1_only
+      rd 172.16.110.4:1102
+      route-target import evpn 1102:1102
+      route-target export evpn 1102:1102
+      router-id 172.16.110.4
+      redistribute connected
+   !
+   vrf vrf_with_loopbacks_from_overlapping_pool
+      rd 172.16.110.4:1100
+      route-target import evpn 1100:1100
+      route-target export evpn 1100:1100
+      router-id 172.16.110.4
+      redistribute connected
+   !
+   vrf vrf_with_loopbacks_from_pod_pools
+      rd 172.16.110.4:1101
+      route-target import evpn 1101:1101
+      route-target export evpn 1101:1101
+      router-id 172.16.110.4
+      redistribute connected
 ```
 
 # BFD
@@ -1002,6 +1104,9 @@ route-map RM-MLAG-PEER-IN permit 10
 | -------- | ---------- |
 | Common_VRF | enabled |
 | MGMT | disabled |
+| vrf_with_loopbacks_dc1_pod1_only | enabled |
+| vrf_with_loopbacks_from_overlapping_pool | enabled |
+| vrf_with_loopbacks_from_pod_pools | enabled |
 
 ## VRF Instances Device Configuration
 
@@ -1010,6 +1115,31 @@ route-map RM-MLAG-PEER-IN permit 10
 vrf instance Common_VRF
 !
 vrf instance MGMT
+!
+vrf instance vrf_with_loopbacks_dc1_pod1_only
+!
+vrf instance vrf_with_loopbacks_from_overlapping_pool
+!
+vrf instance vrf_with_loopbacks_from_pod_pools
+```
+
+# Virtual Source NAT
+
+## Virtual Source NAT Summary
+
+| Source NAT VRF | Source NAT IP Address |
+| -------------- | --------------------- |
+| vrf_with_loopbacks_dc1_pod1_only | 10.102.101.4 |
+| vrf_with_loopbacks_from_overlapping_pool | 10.100.0.4 |
+| vrf_with_loopbacks_from_pod_pools | 10.101.101.4 |
+
+## Virtual Source NAT Configuration
+
+```eos
+!
+ip address virtual source-nat vrf vrf_with_loopbacks_dc1_pod1_only address 10.102.101.4
+ip address virtual source-nat vrf vrf_with_loopbacks_from_overlapping_pool address 10.100.0.4
+ip address virtual source-nat vrf vrf_with_loopbacks_from_pod_pools address 10.101.101.4
 ```
 
 # Quality Of Service

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
@@ -46,6 +46,9 @@
 - [VRF Instances](#vrf-instances)
   - [VRF Instances Summary](#vrf-instances-summary)
   - [VRF Instances Device Configuration](#vrf-instances-device-configuration)
+- [Virtual Source NAT](#virtual-source-nat)
+  - [Virtual Source NAT Summary](#virtual-source-nat-summary)
+  - [Virtual Source NAT Configuration](#virtual-source-nat-configuration)
 - [Quality Of Service](#quality-of-service)
 - [EOS CLI](#eos-cli)
 
@@ -226,6 +229,9 @@ vlan internal order ascending range 1006 1199
 | 111 | Tenant_A_OP_Zone_2 | - |
 | 112 | Tenant_A_OP_Zone_3 | - |
 | 113 | SVI_with_no_vxlan | - |
+| 1100 | test_svi | - |
+| 1101 | test_svi | - |
+| 1102 | test_svi | - |
 | 2500 | web-l2-vlan | - |
 | 2600 | web-l2-vlan-2 | - |
 | 2601 | l2vlan_with_no_vxlan | - |
@@ -247,6 +253,15 @@ vlan 112
 !
 vlan 113
    name SVI_with_no_vxlan
+!
+vlan 1100
+   name test_svi
+!
+vlan 1101
+   name test_svi
+!
+vlan 1102
+   name test_svi
 !
 vlan 2500
    name web-l2-vlan
@@ -275,8 +290,8 @@ vlan 4094
 
 | Interface | Description | Mode | VLANs | Native VLAN | Trunk Group | Channel-Group |
 | --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
-| Ethernet3 | DC1-POD1-L2LEAF2A_Ethernet2 | *trunk | *110-113,2500,2600-2601,4085 | *- | *- | 3 |
-| Ethernet4 | DC1-POD1-L2LEAF2B_Ethernet2 | *trunk | *110-113,2500,2600-2601,4085 | *- | *- | 3 |
+| Ethernet3 | DC1-POD1-L2LEAF2A_Ethernet2 | *trunk | *110-113,1100-1102,2500,2600-2601,4085 | *- | *- | 3 |
+| Ethernet4 | DC1-POD1-L2LEAF2B_Ethernet2 | *trunk | *110-113,1100-1102,2500,2600-2601,4085 | *- | *- | 3 |
 | Ethernet5 | MLAG_PEER_DC1-POD1-LEAF2A_Ethernet5 | *trunk | *2-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 5 |
 | Ethernet6 | MLAG_PEER_DC1-POD1-LEAF2A_Ethernet6 | *trunk | *2-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 5 |
 | Ethernet16 | server-1_Eth2 | *access | *110 | *- | *- | 16 |
@@ -409,7 +424,7 @@ interface Ethernet19
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel3 | RACK2_MLAG_Po1 | switched | trunk | 110-113,2500,2600-2601,4085 | - | - | - | - | 3 | - |
+| Port-Channel3 | RACK2_MLAG_Po1 | switched | trunk | 110-113,1100-1102,2500,2600-2601,4085 | - | - | - | - | 3 | - |
 | Port-Channel5 | MLAG_PEER_DC1-POD1-LEAF2A_Po5 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
 | Port-Channel16 | server-1_PortChannel | switched | access | 110 | - | - | - | - | 16 | - |
 | Port-Channel17 | Set using structured_config on server adapter port-channel | switched | access | 110 | - | - | - | - | 17 | - |
@@ -424,7 +439,7 @@ interface Port-Channel3
    description RACK2_MLAG_Po1
    no shutdown
    switchport
-   switchport trunk allowed vlan 110-113,2500,2600-2601,4085
+   switchport trunk allowed vlan 110-113,1100-1102,2500,2600-2601,4085
    switchport mode trunk
    mlag 3
    service-profile QOS-PROFILE
@@ -490,6 +505,9 @@ interface Port-Channel19
 | --------- | ----------- | --- | ---------- |
 | Loopback0 | EVPN_Overlay_Peering | default | 172.16.110.5/32 |
 | Loopback1 | VTEP_VXLAN_Tunnel_Source | default | 172.18.110.4/32 |
+| Loopback100 | vrf_with_loopbacks_from_overlapping_pool_VTEP_DIAGNOSTICS | vrf_with_loopbacks_from_overlapping_pool | 10.100.0.5/32 |
+| Loopback101 | vrf_with_loopbacks_from_pod_pools_VTEP_DIAGNOSTICS | vrf_with_loopbacks_from_pod_pools | 10.101.101.5/32 |
+| Loopback102 | vrf_with_loopbacks_dc1_pod1_only_VTEP_DIAGNOSTICS | vrf_with_loopbacks_dc1_pod1_only | 10.102.101.5/32 |
 
 #### IPv6
 
@@ -497,6 +515,9 @@ interface Port-Channel19
 | --------- | ----------- | --- | ------------ |
 | Loopback0 | EVPN_Overlay_Peering | default | - |
 | Loopback1 | VTEP_VXLAN_Tunnel_Source | default | - |
+| Loopback100 | vrf_with_loopbacks_from_overlapping_pool_VTEP_DIAGNOSTICS | vrf_with_loopbacks_from_overlapping_pool | - |
+| Loopback101 | vrf_with_loopbacks_from_pod_pools_VTEP_DIAGNOSTICS | vrf_with_loopbacks_from_pod_pools | - |
+| Loopback102 | vrf_with_loopbacks_dc1_pod1_only_VTEP_DIAGNOSTICS | vrf_with_loopbacks_dc1_pod1_only | - |
 
 
 ### Loopback Interfaces Device Configuration
@@ -512,6 +533,24 @@ interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
    no shutdown
    ip address 172.18.110.4/32
+!
+interface Loopback100
+   description vrf_with_loopbacks_from_overlapping_pool_VTEP_DIAGNOSTICS
+   no shutdown
+   vrf vrf_with_loopbacks_from_overlapping_pool
+   ip address 10.100.0.5/32
+!
+interface Loopback101
+   description vrf_with_loopbacks_from_pod_pools_VTEP_DIAGNOSTICS
+   no shutdown
+   vrf vrf_with_loopbacks_from_pod_pools
+   ip address 10.101.101.5/32
+!
+interface Loopback102
+   description vrf_with_loopbacks_dc1_pod1_only_VTEP_DIAGNOSTICS
+   no shutdown
+   vrf vrf_with_loopbacks_dc1_pod1_only
+   ip address 10.102.101.5/32
 ```
 
 ## VLAN Interfaces
@@ -524,6 +563,9 @@ interface Loopback1
 | Vlan111 |  Tenant_A_OP_Zone_2  |  Common_VRF  |  -  |  true  |
 | Vlan112 |  Tenant_A_OP_Zone_3  |  Common_VRF  |  -  |  false  |
 | Vlan113 |  SVI_with_no_vxlan  |  Common_VRF  |  -  |  false  |
+| Vlan1100 |  test_svi  |  vrf_with_loopbacks_from_overlapping_pool  |  -  |  false  |
+| Vlan1101 |  test_svi  |  vrf_with_loopbacks_from_pod_pools  |  -  |  false  |
+| Vlan1102 |  test_svi  |  vrf_with_loopbacks_dc1_pod1_only  |  -  |  false  |
 | Vlan4085 |  L2LEAF_INBAND_MGMT  |  default  |  1500  |  false  |
 | Vlan4094 |  MLAG_PEER  |  default  |  1500  |  false  |
 
@@ -535,6 +577,9 @@ interface Loopback1
 | Vlan111 |  Common_VRF  |  -  |  10.1.11.1/24  |  -  |  -  |  -  |  -  |
 | Vlan112 |  Common_VRF  |  -  |  10.1.12.1/24  |  -  |  -  |  -  |  -  |
 | Vlan113 |  Common_VRF  |  -  |  10.10.13.1/24  |  -  |  -  |  -  |  -  |
+| Vlan1100 |  vrf_with_loopbacks_from_overlapping_pool  |  -  |  10.100.100.1/24  |  -  |  -  |  -  |  -  |
+| Vlan1101 |  vrf_with_loopbacks_from_pod_pools  |  -  |  10.101.100.1/24  |  -  |  -  |  -  |  -  |
+| Vlan1102 |  vrf_with_loopbacks_dc1_pod1_only  |  -  |  10.102.100.1/24  |  -  |  -  |  -  |  -  |
 | Vlan4085 |  default  |  172.21.110.3/24  |  -  |  172.21.110.1  |  -  |  -  |  -  |
 | Vlan4094 |  default  |  172.20.110.3/31  |  -  |  -  |  -  |  -  |  -  |
 
@@ -570,6 +615,24 @@ interface Vlan113
    no shutdown
    vrf Common_VRF
    ip address virtual 10.10.13.1/24
+!
+interface Vlan1100
+   description test_svi
+   no shutdown
+   vrf vrf_with_loopbacks_from_overlapping_pool
+   ip address virtual 10.100.100.1/24
+!
+interface Vlan1101
+   description test_svi
+   no shutdown
+   vrf vrf_with_loopbacks_from_pod_pools
+   ip address virtual 10.101.100.1/24
+!
+interface Vlan1102
+   description test_svi
+   no shutdown
+   vrf vrf_with_loopbacks_dc1_pod1_only
+   ip address virtual 10.102.100.1/24
 !
 interface Vlan4085
    description L2LEAF_INBAND_MGMT
@@ -612,6 +675,9 @@ interface Vlan4094
 | VLAN | VNI |
 | ---- | --- |
 | Common_VRF | 1025 |
+| vrf_with_loopbacks_dc1_pod1_only | 1102 |
+| vrf_with_loopbacks_from_overlapping_pool | 1100 |
+| vrf_with_loopbacks_from_pod_pools | 1101 |
 
 ### VXLAN Interface Device Configuration
 
@@ -628,6 +694,9 @@ interface Vxlan1
    vxlan vlan 2500 vni 2500
    vxlan vlan 2600 vni 2600
    vxlan vrf Common_VRF vni 1025
+   vxlan vrf vrf_with_loopbacks_dc1_pod1_only vni 1102
+   vxlan vrf vrf_with_loopbacks_from_overlapping_pool vni 1100
+   vxlan vrf vrf_with_loopbacks_from_pod_pools vni 1101
 ```
 
 # Routing
@@ -661,6 +730,9 @@ ip virtual-router mac-address 00:1c:73:00:dc:01
 | --- | --------------- |
 | default | true|| Common_VRF | true |
 | MGMT | false |
+| vrf_with_loopbacks_dc1_pod1_only | true |
+| vrf_with_loopbacks_from_overlapping_pool | true |
+| vrf_with_loopbacks_from_pod_pools | true |
 
 ### IP Routing Device Configuration
 
@@ -669,6 +741,9 @@ ip virtual-router mac-address 00:1c:73:00:dc:01
 ip routing
 ip routing vrf Common_VRF
 no ip routing vrf MGMT
+ip routing vrf vrf_with_loopbacks_dc1_pod1_only
+ip routing vrf vrf_with_loopbacks_from_overlapping_pool
+ip routing vrf vrf_with_loopbacks_from_pod_pools
 ```
 ## IPv6 Routing
 
@@ -678,6 +753,9 @@ no ip routing vrf MGMT
 | --- | --------------- |
 | default | false || Common_VRF | false |
 | MGMT | false |
+| vrf_with_loopbacks_dc1_pod1_only | false |
+| vrf_with_loopbacks_from_overlapping_pool | false |
+| vrf_with_loopbacks_from_pod_pools | false |
 
 
 ## Static Routes
@@ -777,6 +855,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 | VRF | Route-Distinguisher | Redistribute |
 | --- | ------------------- | ------------ |
 | Common_VRF | 172.16.110.5:1025 | connected |
+| vrf_with_loopbacks_dc1_pod1_only | 172.16.110.5:1102 | connected |
+| vrf_with_loopbacks_from_overlapping_pool | 172.16.110.5:1100 | connected |
+| vrf_with_loopbacks_from_pod_pools | 172.16.110.5:1101 | connected |
 
 ### Router BGP Device Configuration
 
@@ -889,6 +970,27 @@ router bgp 65112.100
       Comment created from raw_eos_cli under BGP for VRF Common_VRF
       EOF
 
+   !
+   vrf vrf_with_loopbacks_dc1_pod1_only
+      rd 172.16.110.5:1102
+      route-target import evpn 1102:1102
+      route-target export evpn 1102:1102
+      router-id 172.16.110.5
+      redistribute connected
+   !
+   vrf vrf_with_loopbacks_from_overlapping_pool
+      rd 172.16.110.5:1100
+      route-target import evpn 1100:1100
+      route-target export evpn 1100:1100
+      router-id 172.16.110.5
+      redistribute connected
+   !
+   vrf vrf_with_loopbacks_from_pod_pools
+      rd 172.16.110.5:1101
+      route-target import evpn 1101:1101
+      route-target export evpn 1101:1101
+      router-id 172.16.110.5
+      redistribute connected
 ```
 
 # BFD
@@ -1029,6 +1131,9 @@ route-map RM-MLAG-PEER-IN permit 10
 | -------- | ---------- |
 | Common_VRF | enabled |
 | MGMT | disabled |
+| vrf_with_loopbacks_dc1_pod1_only | enabled |
+| vrf_with_loopbacks_from_overlapping_pool | enabled |
+| vrf_with_loopbacks_from_pod_pools | enabled |
 
 ## VRF Instances Device Configuration
 
@@ -1037,6 +1142,31 @@ route-map RM-MLAG-PEER-IN permit 10
 vrf instance Common_VRF
 !
 vrf instance MGMT
+!
+vrf instance vrf_with_loopbacks_dc1_pod1_only
+!
+vrf instance vrf_with_loopbacks_from_overlapping_pool
+!
+vrf instance vrf_with_loopbacks_from_pod_pools
+```
+
+# Virtual Source NAT
+
+## Virtual Source NAT Summary
+
+| Source NAT VRF | Source NAT IP Address |
+| -------------- | --------------------- |
+| vrf_with_loopbacks_dc1_pod1_only | 10.102.101.5 |
+| vrf_with_loopbacks_from_overlapping_pool | 10.100.0.5 |
+| vrf_with_loopbacks_from_pod_pools | 10.101.101.5 |
+
+## Virtual Source NAT Configuration
+
+```eos
+!
+ip address virtual source-nat vrf vrf_with_loopbacks_dc1_pod1_only address 10.102.101.5
+ip address virtual source-nat vrf vrf_with_loopbacks_from_overlapping_pool address 10.100.0.5
+ip address virtual source-nat vrf vrf_with_loopbacks_from_pod_pools address 10.101.101.5
 ```
 
 # Quality Of Service

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-LEAF1A.md
@@ -42,6 +42,9 @@
 - [VRF Instances](#vrf-instances)
   - [VRF Instances Summary](#vrf-instances-summary)
   - [VRF Instances Device Configuration](#vrf-instances-device-configuration)
+- [Virtual Source NAT](#virtual-source-nat)
+  - [Virtual Source NAT Summary](#virtual-source-nat-summary)
+  - [Virtual Source NAT Configuration](#virtual-source-nat-configuration)
 - [Quality Of Service](#quality-of-service)
 - [EOS CLI](#eos-cli)
 
@@ -190,6 +193,9 @@ vlan internal order ascending range 1006 1199
 | 111 | Tenant_A_OP_Zone_2 | - |
 | 112 | Tenant_A_OP_Zone_3 | - |
 | 113 | SVI_with_no_vxlan | - |
+| 1100 | test_svi | - |
+| 1101 | test_svi | - |
+| 1102 | test_svi | - |
 | 2500 | web-l2-vlan | - |
 | 2600 | web-l2-vlan-2 | - |
 | 2601 | l2vlan_with_no_vxlan | - |
@@ -209,6 +215,15 @@ vlan 112
 !
 vlan 113
    name SVI_with_no_vxlan
+!
+vlan 1100
+   name test_svi
+!
+vlan 1101
+   name test_svi
+!
+vlan 1102
+   name test_svi
 !
 vlan 2500
    name web-l2-vlan
@@ -282,6 +297,8 @@ interface Ethernet3
 | --------- | ----------- | --- | ---------- |
 | Loopback0 | EVPN_Overlay_Peering | default | 172.16.120.3/32 |
 | Loopback1 | VTEP_VXLAN_Tunnel_Source | default | 172.18.120.3/32 |
+| Loopback100 | vrf_with_loopbacks_from_overlapping_pool_VTEP_DIAGNOSTICS | vrf_with_loopbacks_from_overlapping_pool | 10.100.0.3/32 |
+| Loopback101 | vrf_with_loopbacks_from_pod_pools_VTEP_DIAGNOSTICS | vrf_with_loopbacks_from_pod_pools | 10.101.102.3/32 |
 
 #### IPv6
 
@@ -289,6 +306,8 @@ interface Ethernet3
 | --------- | ----------- | --- | ------------ |
 | Loopback0 | EVPN_Overlay_Peering | default | - |
 | Loopback1 | VTEP_VXLAN_Tunnel_Source | default | - |
+| Loopback100 | vrf_with_loopbacks_from_overlapping_pool_VTEP_DIAGNOSTICS | vrf_with_loopbacks_from_overlapping_pool | - |
+| Loopback101 | vrf_with_loopbacks_from_pod_pools_VTEP_DIAGNOSTICS | vrf_with_loopbacks_from_pod_pools | - |
 
 
 ### Loopback Interfaces Device Configuration
@@ -304,6 +323,18 @@ interface Loopback1
    description VTEP_VXLAN_Tunnel_Source
    no shutdown
    ip address 172.18.120.3/32
+!
+interface Loopback100
+   description vrf_with_loopbacks_from_overlapping_pool_VTEP_DIAGNOSTICS
+   no shutdown
+   vrf vrf_with_loopbacks_from_overlapping_pool
+   ip address 10.100.0.3/32
+!
+interface Loopback101
+   description vrf_with_loopbacks_from_pod_pools_VTEP_DIAGNOSTICS
+   no shutdown
+   vrf vrf_with_loopbacks_from_pod_pools
+   ip address 10.101.102.3/32
 ```
 
 ## VLAN Interfaces
@@ -316,6 +347,9 @@ interface Loopback1
 | Vlan111 |  Tenant_A_OP_Zone_2  |  Common_VRF  |  -  |  true  |
 | Vlan112 |  Tenant_A_OP_Zone_3  |  Common_VRF  |  -  |  false  |
 | Vlan113 |  SVI_with_no_vxlan  |  Common_VRF  |  -  |  false  |
+| Vlan1100 |  test_svi  |  vrf_with_loopbacks_from_overlapping_pool  |  -  |  false  |
+| Vlan1101 |  test_svi  |  vrf_with_loopbacks_from_pod_pools  |  -  |  false  |
+| Vlan1102 |  test_svi  |  vrf_with_loopbacks_dc1_pod1_only  |  -  |  false  |
 
 #### IPv4
 
@@ -325,6 +359,9 @@ interface Loopback1
 | Vlan111 |  Common_VRF  |  -  |  10.1.11.1/24  |  -  |  -  |  -  |  -  |
 | Vlan112 |  Common_VRF  |  -  |  10.1.12.1/24  |  -  |  -  |  -  |  -  |
 | Vlan113 |  Common_VRF  |  -  |  10.10.13.1/24  |  -  |  -  |  -  |  -  |
+| Vlan1100 |  vrf_with_loopbacks_from_overlapping_pool  |  -  |  10.100.100.1/24  |  -  |  -  |  -  |  -  |
+| Vlan1101 |  vrf_with_loopbacks_from_pod_pools  |  -  |  10.101.100.1/24  |  -  |  -  |  -  |  -  |
+| Vlan1102 |  vrf_with_loopbacks_dc1_pod1_only  |  -  |  10.102.100.1/24  |  -  |  -  |  -  |  -  |
 
 
 ### VLAN Interfaces Device Configuration
@@ -358,6 +395,24 @@ interface Vlan113
    no shutdown
    vrf Common_VRF
    ip address virtual 10.10.13.1/24
+!
+interface Vlan1100
+   description test_svi
+   no shutdown
+   vrf vrf_with_loopbacks_from_overlapping_pool
+   ip address virtual 10.100.100.1/24
+!
+interface Vlan1101
+   description test_svi
+   no shutdown
+   vrf vrf_with_loopbacks_from_pod_pools
+   ip address virtual 10.101.100.1/24
+!
+interface Vlan1102
+   description test_svi
+   no shutdown
+   vrf vrf_with_loopbacks_dc1_pod1_only
+   ip address virtual 10.102.100.1/24
 ```
 
 ## VXLAN Interface
@@ -383,6 +438,9 @@ interface Vlan113
 | VLAN | VNI |
 | ---- | --- |
 | Common_VRF | 1025 |
+| vrf_with_loopbacks_dc1_pod1_only | 1102 |
+| vrf_with_loopbacks_from_overlapping_pool | 1100 |
+| vrf_with_loopbacks_from_pod_pools | 1101 |
 
 ### VXLAN Interface Device Configuration
 
@@ -398,6 +456,9 @@ interface Vxlan1
    vxlan vlan 2500 vni 2500
    vxlan vlan 2600 vni 2600
    vxlan vrf Common_VRF vni 1025
+   vxlan vrf vrf_with_loopbacks_dc1_pod1_only vni 1102
+   vxlan vrf vrf_with_loopbacks_from_overlapping_pool vni 1100
+   vxlan vrf vrf_with_loopbacks_from_pod_pools vni 1101
 ```
 
 # Routing
@@ -431,6 +492,9 @@ ip virtual-router mac-address 00:1c:73:00:dc:01
 | --- | --------------- |
 | default | true|| Common_VRF | true |
 | MGMT | false |
+| vrf_with_loopbacks_dc1_pod1_only | true |
+| vrf_with_loopbacks_from_overlapping_pool | true |
+| vrf_with_loopbacks_from_pod_pools | true |
 
 ### IP Routing Device Configuration
 
@@ -439,6 +503,9 @@ ip virtual-router mac-address 00:1c:73:00:dc:01
 ip routing
 ip routing vrf Common_VRF
 no ip routing vrf MGMT
+ip routing vrf vrf_with_loopbacks_dc1_pod1_only
+ip routing vrf vrf_with_loopbacks_from_overlapping_pool
+ip routing vrf vrf_with_loopbacks_from_pod_pools
 ```
 ## IPv6 Routing
 
@@ -448,6 +515,9 @@ no ip routing vrf MGMT
 | --- | --------------- |
 | default | false || Common_VRF | false |
 | MGMT | false |
+| vrf_with_loopbacks_dc1_pod1_only | false |
+| vrf_with_loopbacks_from_overlapping_pool | false |
+| vrf_with_loopbacks_from_pod_pools | false |
 
 
 ## Static Routes
@@ -533,6 +603,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 | VRF | Route-Distinguisher | Redistribute |
 | --- | ------------------- | ------------ |
 | Common_VRF | 172.16.120.3:1025 | connected |
+| vrf_with_loopbacks_dc1_pod1_only | 172.16.120.3:1102 | connected |
+| vrf_with_loopbacks_from_overlapping_pool | 172.16.120.3:1100 | connected |
+| vrf_with_loopbacks_from_pod_pools | 172.16.120.3:1101 | connected |
 
 ### Router BGP Device Configuration
 
@@ -623,6 +696,27 @@ router bgp 65121
       Comment created from raw_eos_cli under BGP for VRF Common_VRF
       EOF
 
+   !
+   vrf vrf_with_loopbacks_dc1_pod1_only
+      rd 172.16.120.3:1102
+      route-target import evpn 1102:1102
+      route-target export evpn 1102:1102
+      router-id 172.16.120.3
+      redistribute connected
+   !
+   vrf vrf_with_loopbacks_from_overlapping_pool
+      rd 172.16.120.3:1100
+      route-target import evpn 1100:1100
+      route-target export evpn 1100:1100
+      router-id 172.16.120.3
+      redistribute connected
+   !
+   vrf vrf_with_loopbacks_from_pod_pools
+      rd 172.16.120.3:1101
+      route-target import evpn 1101:1101
+      route-target export evpn 1101:1101
+      router-id 172.16.120.3
+      redistribute connected
 ```
 
 # BFD
@@ -718,6 +812,9 @@ route-map RM-EVPN-FILTER-AS65120 permit 20
 | -------- | ---------- |
 | Common_VRF | enabled |
 | MGMT | disabled |
+| vrf_with_loopbacks_dc1_pod1_only | enabled |
+| vrf_with_loopbacks_from_overlapping_pool | enabled |
+| vrf_with_loopbacks_from_pod_pools | enabled |
 
 ## VRF Instances Device Configuration
 
@@ -726,6 +823,29 @@ route-map RM-EVPN-FILTER-AS65120 permit 20
 vrf instance Common_VRF
 !
 vrf instance MGMT
+!
+vrf instance vrf_with_loopbacks_dc1_pod1_only
+!
+vrf instance vrf_with_loopbacks_from_overlapping_pool
+!
+vrf instance vrf_with_loopbacks_from_pod_pools
+```
+
+# Virtual Source NAT
+
+## Virtual Source NAT Summary
+
+| Source NAT VRF | Source NAT IP Address |
+| -------------- | --------------------- |
+| vrf_with_loopbacks_from_overlapping_pool | 10.100.0.3 |
+| vrf_with_loopbacks_from_pod_pools | 10.101.102.3 |
+
+## Virtual Source NAT Configuration
+
+```eos
+!
+ip address virtual source-nat vrf vrf_with_loopbacks_from_overlapping_pool address 10.100.0.3
+ip address virtual source-nat vrf vrf_with_loopbacks_from_pod_pools address 10.101.102.3
 ```
 
 # Quality Of Service

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-L2LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-L2LEAF2A.cfg
@@ -31,6 +31,15 @@ vlan 112
 vlan 113
    name SVI_with_no_vxlan
 !
+vlan 1100
+   name test_svi
+!
+vlan 1101
+   name test_svi
+!
+vlan 1102
+   name test_svi
+!
 vlan 2500
    name web-l2-vlan
 !
@@ -53,7 +62,7 @@ interface Port-Channel1
    description RACK2_MLAG_Po3
    no shutdown
    switchport
-   switchport trunk allowed vlan 110-113,2500,2600-2601,4085
+   switchport trunk allowed vlan 110-113,1100-1102,2500,2600-2601,4085
    switchport mode trunk
    mlag 1
    service-profile QOS-PROFILE

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-L2LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-L2LEAF2B.cfg
@@ -31,6 +31,15 @@ vlan 112
 vlan 113
    name SVI_with_no_vxlan
 !
+vlan 1100
+   name test_svi
+!
+vlan 1101
+   name test_svi
+!
+vlan 1102
+   name test_svi
+!
 vlan 2500
    name web-l2-vlan
 !
@@ -53,7 +62,7 @@ interface Port-Channel1
    description RACK2_MLAG_Po3
    no shutdown
    switchport
-   switchport trunk allowed vlan 110-113,2500,2600-2601,4085
+   switchport trunk allowed vlan 110-113,1100-1102,2500,2600-2601,4085
    switchport mode trunk
    mlag 1
    service-profile QOS-PROFILE

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2A.cfg
@@ -34,6 +34,15 @@ vlan 112
 vlan 113
    name SVI_with_no_vxlan
 !
+vlan 1100
+   name test_svi
+!
+vlan 1101
+   name test_svi
+!
+vlan 1102
+   name test_svi
+!
 vlan 2500
    name web-l2-vlan
 !
@@ -54,11 +63,17 @@ vrf instance Common_VRF
 !
 vrf instance MGMT
 !
+vrf instance vrf_with_loopbacks_dc1_pod1_only
+!
+vrf instance vrf_with_loopbacks_from_overlapping_pool
+!
+vrf instance vrf_with_loopbacks_from_pod_pools
+!
 interface Port-Channel3
    description RACK2_MLAG_Po1
    no shutdown
    switchport
-   switchport trunk allowed vlan 110-113,2500,2600-2601,4085
+   switchport trunk allowed vlan 110-113,1100-1102,2500,2600-2601,4085
    switchport mode trunk
    mlag 3
    service-profile QOS-PROFILE
@@ -222,6 +237,24 @@ interface Loopback1
    no shutdown
    ip address 172.18.110.4/32
 !
+interface Loopback100
+   description vrf_with_loopbacks_from_overlapping_pool_VTEP_DIAGNOSTICS
+   no shutdown
+   vrf vrf_with_loopbacks_from_overlapping_pool
+   ip address 10.100.0.4/32
+!
+interface Loopback101
+   description vrf_with_loopbacks_from_pod_pools_VTEP_DIAGNOSTICS
+   no shutdown
+   vrf vrf_with_loopbacks_from_pod_pools
+   ip address 10.101.101.4/32
+!
+interface Loopback102
+   description vrf_with_loopbacks_dc1_pod1_only_VTEP_DIAGNOSTICS
+   no shutdown
+   vrf vrf_with_loopbacks_dc1_pod1_only
+   ip address 10.102.101.4/32
+!
 interface Vlan110
    description set from structured_config on svi for DC1-POD1-LEAF2A (was Tenant_A_OP_Zone_1)
    no shutdown
@@ -250,6 +283,24 @@ interface Vlan113
    vrf Common_VRF
    ip address virtual 10.10.13.1/24
 !
+interface Vlan1100
+   description test_svi
+   no shutdown
+   vrf vrf_with_loopbacks_from_overlapping_pool
+   ip address virtual 10.100.100.1/24
+!
+interface Vlan1101
+   description test_svi
+   no shutdown
+   vrf vrf_with_loopbacks_from_pod_pools
+   ip address virtual 10.101.100.1/24
+!
+interface Vlan1102
+   description test_svi
+   no shutdown
+   vrf vrf_with_loopbacks_dc1_pod1_only
+   ip address virtual 10.102.100.1/24
+!
 interface Vlan4085
    description L2LEAF_INBAND_MGMT
    no shutdown
@@ -276,12 +327,22 @@ interface Vxlan1
    vxlan vlan 2500 vni 2500
    vxlan vlan 2600 vni 2600
    vxlan vrf Common_VRF vni 1025
+   vxlan vrf vrf_with_loopbacks_dc1_pod1_only vni 1102
+   vxlan vrf vrf_with_loopbacks_from_overlapping_pool vni 1100
+   vxlan vrf vrf_with_loopbacks_from_pod_pools vni 1101
 !
 ip virtual-router mac-address 00:1c:73:00:dc:01
+!
+ip address virtual source-nat vrf vrf_with_loopbacks_dc1_pod1_only address 10.102.101.4
+ip address virtual source-nat vrf vrf_with_loopbacks_from_overlapping_pool address 10.100.0.4
+ip address virtual source-nat vrf vrf_with_loopbacks_from_pod_pools address 10.101.101.4
 !
 ip routing
 ip routing vrf Common_VRF
 no ip routing vrf MGMT
+ip routing vrf vrf_with_loopbacks_dc1_pod1_only
+ip routing vrf vrf_with_loopbacks_from_overlapping_pool
+ip routing vrf vrf_with_loopbacks_from_pod_pools
 !
 ip prefix-list PL-L2LEAF-INBAND-MGMT
    seq 10 permit 172.21.110.0/24
@@ -435,6 +496,27 @@ router bgp 65112.100
       Comment created from raw_eos_cli under BGP for VRF Common_VRF
       EOF
 
+   !
+   vrf vrf_with_loopbacks_dc1_pod1_only
+      rd 172.16.110.4:1102
+      route-target import evpn 1102:1102
+      route-target export evpn 1102:1102
+      router-id 172.16.110.4
+      redistribute connected
+   !
+   vrf vrf_with_loopbacks_from_overlapping_pool
+      rd 172.16.110.4:1100
+      route-target import evpn 1100:1100
+      route-target export evpn 1100:1100
+      router-id 172.16.110.4
+      redistribute connected
+   !
+   vrf vrf_with_loopbacks_from_pod_pools
+      rd 172.16.110.4:1101
+      route-target import evpn 1101:1101
+      route-target export evpn 1101:1101
+      router-id 172.16.110.4
+      redistribute connected
 !
 management api http-commands
    protocol https

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2B.cfg
@@ -33,6 +33,15 @@ vlan 112
 vlan 113
    name SVI_with_no_vxlan
 !
+vlan 1100
+   name test_svi
+!
+vlan 1101
+   name test_svi
+!
+vlan 1102
+   name test_svi
+!
 vlan 2500
    name web-l2-vlan
 !
@@ -53,11 +62,17 @@ vrf instance Common_VRF
 !
 vrf instance MGMT
 !
+vrf instance vrf_with_loopbacks_dc1_pod1_only
+!
+vrf instance vrf_with_loopbacks_from_overlapping_pool
+!
+vrf instance vrf_with_loopbacks_from_pod_pools
+!
 interface Port-Channel3
    description RACK2_MLAG_Po1
    no shutdown
    switchport
-   switchport trunk allowed vlan 110-113,2500,2600-2601,4085
+   switchport trunk allowed vlan 110-113,1100-1102,2500,2600-2601,4085
    switchport mode trunk
    mlag 3
    service-profile QOS-PROFILE
@@ -222,6 +237,24 @@ interface Loopback1
    no shutdown
    ip address 172.18.110.4/32
 !
+interface Loopback100
+   description vrf_with_loopbacks_from_overlapping_pool_VTEP_DIAGNOSTICS
+   no shutdown
+   vrf vrf_with_loopbacks_from_overlapping_pool
+   ip address 10.100.0.5/32
+!
+interface Loopback101
+   description vrf_with_loopbacks_from_pod_pools_VTEP_DIAGNOSTICS
+   no shutdown
+   vrf vrf_with_loopbacks_from_pod_pools
+   ip address 10.101.101.5/32
+!
+interface Loopback102
+   description vrf_with_loopbacks_dc1_pod1_only_VTEP_DIAGNOSTICS
+   no shutdown
+   vrf vrf_with_loopbacks_dc1_pod1_only
+   ip address 10.102.101.5/32
+!
 interface Management1
    description oob_management
    no shutdown
@@ -256,6 +289,24 @@ interface Vlan113
    vrf Common_VRF
    ip address virtual 10.10.13.1/24
 !
+interface Vlan1100
+   description test_svi
+   no shutdown
+   vrf vrf_with_loopbacks_from_overlapping_pool
+   ip address virtual 10.100.100.1/24
+!
+interface Vlan1101
+   description test_svi
+   no shutdown
+   vrf vrf_with_loopbacks_from_pod_pools
+   ip address virtual 10.101.100.1/24
+!
+interface Vlan1102
+   description test_svi
+   no shutdown
+   vrf vrf_with_loopbacks_dc1_pod1_only
+   ip address virtual 10.102.100.1/24
+!
 interface Vlan4085
    description L2LEAF_INBAND_MGMT
    no shutdown
@@ -282,12 +333,22 @@ interface Vxlan1
    vxlan vlan 2500 vni 2500
    vxlan vlan 2600 vni 2600
    vxlan vrf Common_VRF vni 1025
+   vxlan vrf vrf_with_loopbacks_dc1_pod1_only vni 1102
+   vxlan vrf vrf_with_loopbacks_from_overlapping_pool vni 1100
+   vxlan vrf vrf_with_loopbacks_from_pod_pools vni 1101
 !
 ip virtual-router mac-address 00:1c:73:00:dc:01
+!
+ip address virtual source-nat vrf vrf_with_loopbacks_dc1_pod1_only address 10.102.101.5
+ip address virtual source-nat vrf vrf_with_loopbacks_from_overlapping_pool address 10.100.0.5
+ip address virtual source-nat vrf vrf_with_loopbacks_from_pod_pools address 10.101.101.5
 !
 ip routing
 ip routing vrf Common_VRF
 no ip routing vrf MGMT
+ip routing vrf vrf_with_loopbacks_dc1_pod1_only
+ip routing vrf vrf_with_loopbacks_from_overlapping_pool
+ip routing vrf vrf_with_loopbacks_from_pod_pools
 !
 ip prefix-list PL-L2LEAF-INBAND-MGMT
    seq 10 permit 172.21.110.0/24
@@ -441,6 +502,27 @@ router bgp 65112.100
       Comment created from raw_eos_cli under BGP for VRF Common_VRF
       EOF
 
+   !
+   vrf vrf_with_loopbacks_dc1_pod1_only
+      rd 172.16.110.5:1102
+      route-target import evpn 1102:1102
+      route-target export evpn 1102:1102
+      router-id 172.16.110.5
+      redistribute connected
+   !
+   vrf vrf_with_loopbacks_from_overlapping_pool
+      rd 172.16.110.5:1100
+      route-target import evpn 1100:1100
+      route-target export evpn 1100:1100
+      router-id 172.16.110.5
+      redistribute connected
+   !
+   vrf vrf_with_loopbacks_from_pod_pools
+      rd 172.16.110.5:1101
+      route-target import evpn 1101:1101
+      route-target export evpn 1101:1101
+      router-id 172.16.110.5
+      redistribute connected
 !
 management api http-commands
    protocol https

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD2-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD2-LEAF1A.cfg
@@ -31,6 +31,15 @@ vlan 112
 vlan 113
    name SVI_with_no_vxlan
 !
+vlan 1100
+   name test_svi
+!
+vlan 1101
+   name test_svi
+!
+vlan 1102
+   name test_svi
+!
 vlan 2500
    name web-l2-vlan
 !
@@ -43,6 +52,12 @@ vlan 2601
 vrf instance Common_VRF
 !
 vrf instance MGMT
+!
+vrf instance vrf_with_loopbacks_dc1_pod1_only
+!
+vrf instance vrf_with_loopbacks_from_overlapping_pool
+!
+vrf instance vrf_with_loopbacks_from_pod_pools
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-POD2-SPINE1_Ethernet3
@@ -80,6 +95,18 @@ interface Loopback1
    no shutdown
    ip address 172.18.120.3/32
 !
+interface Loopback100
+   description vrf_with_loopbacks_from_overlapping_pool_VTEP_DIAGNOSTICS
+   no shutdown
+   vrf vrf_with_loopbacks_from_overlapping_pool
+   ip address 10.100.0.3/32
+!
+interface Loopback101
+   description vrf_with_loopbacks_from_pod_pools_VTEP_DIAGNOSTICS
+   no shutdown
+   vrf vrf_with_loopbacks_from_pod_pools
+   ip address 10.101.102.3/32
+!
 interface Management1
    description oob_management
    no shutdown
@@ -114,6 +141,24 @@ interface Vlan113
    vrf Common_VRF
    ip address virtual 10.10.13.1/24
 !
+interface Vlan1100
+   description test_svi
+   no shutdown
+   vrf vrf_with_loopbacks_from_overlapping_pool
+   ip address virtual 10.100.100.1/24
+!
+interface Vlan1101
+   description test_svi
+   no shutdown
+   vrf vrf_with_loopbacks_from_pod_pools
+   ip address virtual 10.101.100.1/24
+!
+interface Vlan1102
+   description test_svi
+   no shutdown
+   vrf vrf_with_loopbacks_dc1_pod1_only
+   ip address virtual 10.102.100.1/24
+!
 interface Vxlan1
    description DC1-POD2-LEAF1A_VTEP
    vxlan source-interface Loopback1
@@ -124,12 +169,21 @@ interface Vxlan1
    vxlan vlan 2500 vni 2500
    vxlan vlan 2600 vni 2600
    vxlan vrf Common_VRF vni 1025
+   vxlan vrf vrf_with_loopbacks_dc1_pod1_only vni 1102
+   vxlan vrf vrf_with_loopbacks_from_overlapping_pool vni 1100
+   vxlan vrf vrf_with_loopbacks_from_pod_pools vni 1101
 !
 ip virtual-router mac-address 00:1c:73:00:dc:01
+!
+ip address virtual source-nat vrf vrf_with_loopbacks_from_overlapping_pool address 10.100.0.3
+ip address virtual source-nat vrf vrf_with_loopbacks_from_pod_pools address 10.101.102.3
 !
 ip routing
 ip routing vrf Common_VRF
 no ip routing vrf MGMT
+ip routing vrf vrf_with_loopbacks_dc1_pod1_only
+ip routing vrf vrf_with_loopbacks_from_overlapping_pool
+ip routing vrf vrf_with_loopbacks_from_pod_pools
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 172.16.120.0/24 eq 32
@@ -233,6 +287,27 @@ router bgp 65121
       Comment created from raw_eos_cli under BGP for VRF Common_VRF
       EOF
 
+   !
+   vrf vrf_with_loopbacks_dc1_pod1_only
+      rd 172.16.120.3:1102
+      route-target import evpn 1102:1102
+      route-target export evpn 1102:1102
+      router-id 172.16.120.3
+      redistribute connected
+   !
+   vrf vrf_with_loopbacks_from_overlapping_pool
+      rd 172.16.120.3:1100
+      route-target import evpn 1100:1100
+      route-target export evpn 1100:1100
+      router-id 172.16.120.3
+      redistribute connected
+   !
+   vrf vrf_with_loopbacks_from_pod_pools
+      rd 172.16.120.3:1101
+      route-target import evpn 1101:1101
+      route-target export evpn 1101:1101
+      router-id 172.16.120.3
+      redistribute connected
 !
 management api http-commands
    protocol https

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-LEAF1A.cfg
@@ -27,6 +27,12 @@ vrf instance Common_VRF
 !
 vrf instance MGMT
 !
+vrf instance vrf_with_loopbacks_dc1_pod1_only
+!
+vrf instance vrf_with_loopbacks_from_overlapping_pool
+!
+vrf instance vrf_with_loopbacks_from_pod_pools
+!
 interface Port-Channel3
    description DC2-POD1-L2LEAF1A_Po1
    no shutdown
@@ -83,6 +89,18 @@ interface Loopback1
    no shutdown
    ip address 172.18.210.3/32
 !
+interface Loopback100
+   description vrf_with_loopbacks_from_overlapping_pool_VTEP_DIAGNOSTICS
+   no shutdown
+   vrf vrf_with_loopbacks_from_overlapping_pool
+   ip address 10.100.0.3/32
+!
+interface Loopback101
+   description vrf_with_loopbacks_from_pod_pools_VTEP_DIAGNOSTICS
+   no shutdown
+   vrf vrf_with_loopbacks_from_pod_pools
+   ip address 10.101.201.3/32
+!
 interface Management1
    description oob_management
    no shutdown
@@ -102,12 +120,21 @@ interface Vxlan1
    vxlan source-interface Loopback1
    vxlan udp-port 4789
    vxlan vrf Common_VRF vni 1025
+   vxlan vrf vrf_with_loopbacks_dc1_pod1_only vni 1102
+   vxlan vrf vrf_with_loopbacks_from_overlapping_pool vni 1100
+   vxlan vrf vrf_with_loopbacks_from_pod_pools vni 1101
 !
 ip virtual-router mac-address 00:1c:73:00:dc:01
+!
+ip address virtual source-nat vrf vrf_with_loopbacks_from_overlapping_pool address 10.100.0.3
+ip address virtual source-nat vrf vrf_with_loopbacks_from_pod_pools address 10.101.201.3
 !
 ip routing
 ip routing vrf Common_VRF
 no ip routing vrf MGMT
+ip routing vrf vrf_with_loopbacks_dc1_pod1_only
+ip routing vrf vrf_with_loopbacks_from_overlapping_pool
+ip routing vrf vrf_with_loopbacks_from_pod_pools
 !
 ip prefix-list PL-L2LEAF-INBAND-MGMT
    seq 10 permit 172.21.210.0/24
@@ -194,6 +221,27 @@ router bgp 65211
       Comment created from raw_eos_cli under BGP for VRF Common_VRF
       EOF
 
+   !
+   vrf vrf_with_loopbacks_dc1_pod1_only
+      rd 172.16.210.3:1102
+      route-target import evpn 1102:1102
+      route-target export evpn 1102:1102
+      router-id 172.16.210.3
+      redistribute connected
+   !
+   vrf vrf_with_loopbacks_from_overlapping_pool
+      rd 172.16.210.3:1100
+      route-target import evpn 1100:1100
+      route-target export evpn 1100:1100
+      router-id 172.16.210.3
+      redistribute connected
+   !
+   vrf vrf_with_loopbacks_from_pod_pools
+      rd 172.16.210.3:1101
+      route-target import evpn 1101:1101
+      route-target export evpn 1101:1101
+      router-id 172.16.210.3
+      redistribute connected
 !
 management api http-commands
    protocol https

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF2A.yml
@@ -52,6 +52,15 @@ vlans:
   113:
     tenant: Tenant_A
     name: SVI_with_no_vxlan
+  1102:
+    tenant: Tenant_A
+    name: test_svi
+  1100:
+    tenant: Tenant_A
+    name: test_svi
+  1101:
+    tenant: Tenant_A
+    name: test_svi
   2500:
     tenant: Tenant_A
     name: web-l2-vlan
@@ -85,7 +94,7 @@ port_channel_interfaces:
     description: RACK2_MLAG_Po3
     type: switched
     shutdown: false
-    vlans: 110-113,2500,2600-2601,4085
+    vlans: 110-113,1100-1102,2500,2600-2601,4085
     mode: trunk
     service_profile: QOS-PROFILE
     mlag: 1

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF2B.yml
@@ -67,6 +67,15 @@ vlans:
   113:
     tenant: Tenant_A
     name: SVI_with_no_vxlan
+  1102:
+    tenant: Tenant_A
+    name: test_svi
+  1100:
+    tenant: Tenant_A
+    name: test_svi
+  1101:
+    tenant: Tenant_A
+    name: test_svi
   2500:
     tenant: Tenant_A
     name: web-l2-vlan
@@ -100,7 +109,7 @@ port_channel_interfaces:
     description: RACK2_MLAG_Po3
     type: switched
     shutdown: false
-    vlans: 110-113,2500,2600-2601,4085
+    vlans: 110-113,1100-1102,2500,2600-2601,4085
     mode: trunk
     service_profile: QOS-PROFILE
     mlag: 1

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2A.yml
@@ -110,6 +110,42 @@ router_bgp:
         EOF
 
         '
+    vrf_with_loopbacks_dc1_pod1_only:
+      router_id: 172.16.110.4
+      rd: 172.16.110.4:1102
+      route_targets:
+        import:
+          evpn:
+          - 1102:1102
+        export:
+          evpn:
+          - 1102:1102
+      redistribute_routes:
+      - connected
+    vrf_with_loopbacks_from_overlapping_pool:
+      router_id: 172.16.110.4
+      rd: 172.16.110.4:1100
+      route_targets:
+        import:
+          evpn:
+          - 1100:1100
+        export:
+          evpn:
+          - 1100:1100
+      redistribute_routes:
+      - connected
+    vrf_with_loopbacks_from_pod_pools:
+      router_id: 172.16.110.4
+      rd: 172.16.110.4:1101
+      route_targets:
+        import:
+          evpn:
+          - 1101:1101
+        export:
+          evpn:
+          - 1101:1101
+      redistribute_routes:
+      - connected
   vlans:
     110:
       tenant: Tenant_A
@@ -181,6 +217,15 @@ vrfs:
   Common_VRF:
     tenant: Tenant_A
     ip_routing: true
+  vrf_with_loopbacks_dc1_pod1_only:
+    tenant: Tenant_A
+    ip_routing: true
+  vrf_with_loopbacks_from_overlapping_pool:
+    tenant: Tenant_A
+    ip_routing: true
+  vrf_with_loopbacks_from_pod_pools:
+    tenant: Tenant_A
+    ip_routing: true
 management_api_http:
   enable_vrfs:
     MGMT: {}
@@ -211,6 +256,15 @@ vlans:
   113:
     tenant: Tenant_A
     name: SVI_with_no_vxlan
+  1102:
+    tenant: Tenant_A
+    name: test_svi
+  1100:
+    tenant: Tenant_A
+    name: test_svi
+  1101:
+    tenant: Tenant_A
+    name: test_svi
   2500:
     tenant: Tenant_A
     name: web-l2-vlan
@@ -271,6 +325,33 @@ vlan_interfaces:
     shutdown: false
     vrf: Common_VRF
     ip_address_virtual: 10.10.13.1/24
+  Vlan1102:
+    tenant: Tenant_A
+    tags:
+    - opzone
+    - web
+    description: test_svi
+    shutdown: false
+    vrf: vrf_with_loopbacks_dc1_pod1_only
+    ip_address_virtual: 10.102.100.1/24
+  Vlan1100:
+    tenant: Tenant_A
+    tags:
+    - opzone
+    - web
+    description: test_svi
+    shutdown: false
+    vrf: vrf_with_loopbacks_from_overlapping_pool
+    ip_address_virtual: 10.100.100.1/24
+  Vlan1101:
+    tenant: Tenant_A
+    tags:
+    - opzone
+    - web
+    description: test_svi
+    shutdown: false
+    vrf: vrf_with_loopbacks_from_pod_pools
+    ip_address_virtual: 10.101.100.1/24
   Vlan4085:
     description: L2LEAF_INBAND_MGMT
     shutdown: false
@@ -295,7 +376,7 @@ port_channel_interfaces:
     description: RACK2_MLAG_Po1
     type: switched
     shutdown: false
-    vlans: 110-113,2500,2600-2601,4085
+    vlans: 110-113,1100-1102,2500,2600-2601,4085
     mode: trunk
     service_profile: QOS-PROFILE
     mlag: 3
@@ -590,6 +671,21 @@ loopback_interfaces:
     description: VTEP_VXLAN_Tunnel_Source
     shutdown: false
     ip_address: 172.18.110.4/32
+  Loopback102:
+    description: vrf_with_loopbacks_dc1_pod1_only_VTEP_DIAGNOSTICS
+    shutdown: false
+    vrf: vrf_with_loopbacks_dc1_pod1_only
+    ip_address: 10.102.101.4/32
+  Loopback100:
+    description: vrf_with_loopbacks_from_overlapping_pool_VTEP_DIAGNOSTICS
+    shutdown: false
+    vrf: vrf_with_loopbacks_from_overlapping_pool
+    ip_address: 10.100.0.4/32
+  Loopback101:
+    description: vrf_with_loopbacks_from_pod_pools_VTEP_DIAGNOSTICS
+    shutdown: false
+    vrf: vrf_with_loopbacks_from_pod_pools
+    ip_address: 10.101.101.4/32
 prefix_lists:
   PL-LOOPBACKS-EVPN-OVERLAY:
     sequence_numbers:
@@ -609,6 +705,13 @@ router_bfd:
 ip_igmp_snooping:
   globally_enabled: true
 ip_virtual_router_mac_address: 00:1c:73:00:dc:01
+virtual_source_nat_vrfs:
+  vrf_with_loopbacks_dc1_pod1_only:
+    ip_address: 10.102.101.4
+  vrf_with_loopbacks_from_overlapping_pool:
+    ip_address: 10.100.0.4
+  vrf_with_loopbacks_from_pod_pools:
+    ip_address: 10.101.101.4
 vxlan_interface:
   Vxlan1:
     description: DC1-POD1-LEAF2A_VTEP
@@ -630,6 +733,12 @@ vxlan_interface:
       vrfs:
         Common_VRF:
           vni: 1025
+        vrf_with_loopbacks_dc1_pod1_only:
+          vni: 1102
+        vrf_with_loopbacks_from_overlapping_pool:
+          vni: 1100
+        vrf_with_loopbacks_from_pod_pools:
+          vni: 1101
 domain_list:
 - structured-config.set.on.node
 - structured-config.set.under.vrf.common-vrf

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
@@ -112,6 +112,42 @@ router_bgp:
         EOF
 
         '
+    vrf_with_loopbacks_dc1_pod1_only:
+      router_id: 172.16.110.5
+      rd: 172.16.110.5:1102
+      route_targets:
+        import:
+          evpn:
+          - 1102:1102
+        export:
+          evpn:
+          - 1102:1102
+      redistribute_routes:
+      - connected
+    vrf_with_loopbacks_from_overlapping_pool:
+      router_id: 172.16.110.5
+      rd: 172.16.110.5:1100
+      route_targets:
+        import:
+          evpn:
+          - 1100:1100
+        export:
+          evpn:
+          - 1100:1100
+      redistribute_routes:
+      - connected
+    vrf_with_loopbacks_from_pod_pools:
+      router_id: 172.16.110.5
+      rd: 172.16.110.5:1101
+      route_targets:
+        import:
+          evpn:
+          - 1101:1101
+        export:
+          evpn:
+          - 1101:1101
+      redistribute_routes:
+      - connected
   vlans:
     110:
       tenant: Tenant_A
@@ -183,6 +219,15 @@ vrfs:
   Common_VRF:
     tenant: Tenant_A
     ip_routing: true
+  vrf_with_loopbacks_dc1_pod1_only:
+    tenant: Tenant_A
+    ip_routing: true
+  vrf_with_loopbacks_from_overlapping_pool:
+    tenant: Tenant_A
+    ip_routing: true
+  vrf_with_loopbacks_from_pod_pools:
+    tenant: Tenant_A
+    ip_routing: true
 management_interfaces:
   Management1:
     description: oob_management
@@ -217,6 +262,15 @@ vlans:
   113:
     tenant: Tenant_A
     name: SVI_with_no_vxlan
+  1102:
+    tenant: Tenant_A
+    name: test_svi
+  1100:
+    tenant: Tenant_A
+    name: test_svi
+  1101:
+    tenant: Tenant_A
+    name: test_svi
   2500:
     tenant: Tenant_A
     name: web-l2-vlan
@@ -277,6 +331,33 @@ vlan_interfaces:
     shutdown: false
     vrf: Common_VRF
     ip_address_virtual: 10.10.13.1/24
+  Vlan1102:
+    tenant: Tenant_A
+    tags:
+    - opzone
+    - web
+    description: test_svi
+    shutdown: false
+    vrf: vrf_with_loopbacks_dc1_pod1_only
+    ip_address_virtual: 10.102.100.1/24
+  Vlan1100:
+    tenant: Tenant_A
+    tags:
+    - opzone
+    - web
+    description: test_svi
+    shutdown: false
+    vrf: vrf_with_loopbacks_from_overlapping_pool
+    ip_address_virtual: 10.100.100.1/24
+  Vlan1101:
+    tenant: Tenant_A
+    tags:
+    - opzone
+    - web
+    description: test_svi
+    shutdown: false
+    vrf: vrf_with_loopbacks_from_pod_pools
+    ip_address_virtual: 10.101.100.1/24
   Vlan4085:
     description: L2LEAF_INBAND_MGMT
     shutdown: false
@@ -301,7 +382,7 @@ port_channel_interfaces:
     description: RACK2_MLAG_Po1
     type: switched
     shutdown: false
-    vlans: 110-113,2500,2600-2601,4085
+    vlans: 110-113,1100-1102,2500,2600-2601,4085
     mode: trunk
     service_profile: QOS-PROFILE
     mlag: 3
@@ -594,6 +675,21 @@ loopback_interfaces:
     description: VTEP_VXLAN_Tunnel_Source
     shutdown: false
     ip_address: 172.18.110.4/32
+  Loopback102:
+    description: vrf_with_loopbacks_dc1_pod1_only_VTEP_DIAGNOSTICS
+    shutdown: false
+    vrf: vrf_with_loopbacks_dc1_pod1_only
+    ip_address: 10.102.101.5/32
+  Loopback100:
+    description: vrf_with_loopbacks_from_overlapping_pool_VTEP_DIAGNOSTICS
+    shutdown: false
+    vrf: vrf_with_loopbacks_from_overlapping_pool
+    ip_address: 10.100.0.5/32
+  Loopback101:
+    description: vrf_with_loopbacks_from_pod_pools_VTEP_DIAGNOSTICS
+    shutdown: false
+    vrf: vrf_with_loopbacks_from_pod_pools
+    ip_address: 10.101.101.5/32
 prefix_lists:
   PL-LOOPBACKS-EVPN-OVERLAY:
     sequence_numbers:
@@ -616,6 +712,13 @@ ip_virtual_router_mac_address: 00:1c:73:00:dc:01
 struct_cfg:
   domain_list:
   - structured-config.set.under.vrf.common-vrf
+virtual_source_nat_vrfs:
+  vrf_with_loopbacks_dc1_pod1_only:
+    ip_address: 10.102.101.5
+  vrf_with_loopbacks_from_overlapping_pool:
+    ip_address: 10.100.0.5
+  vrf_with_loopbacks_from_pod_pools:
+    ip_address: 10.101.101.5
 vxlan_interface:
   Vxlan1:
     description: DC1-POD1-LEAF2B_VTEP
@@ -637,5 +740,11 @@ vxlan_interface:
       vrfs:
         Common_VRF:
           vni: 1025
+        vrf_with_loopbacks_dc1_pod1_only:
+          vni: 1102
+        vrf_with_loopbacks_from_overlapping_pool:
+          vni: 1100
+        vrf_with_loopbacks_from_pod_pools:
+          vni: 1101
 domain_list:
 - structured-config.set.under.vrf.common-vrf

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-LEAF1A.yml
@@ -84,6 +84,42 @@ router_bgp:
         EOF
 
         '
+    vrf_with_loopbacks_dc1_pod1_only:
+      router_id: 172.16.120.3
+      rd: 172.16.120.3:1102
+      route_targets:
+        import:
+          evpn:
+          - 1102:1102
+        export:
+          evpn:
+          - 1102:1102
+      redistribute_routes:
+      - connected
+    vrf_with_loopbacks_from_overlapping_pool:
+      router_id: 172.16.120.3
+      rd: 172.16.120.3:1100
+      route_targets:
+        import:
+          evpn:
+          - 1100:1100
+        export:
+          evpn:
+          - 1100:1100
+      redistribute_routes:
+      - connected
+    vrf_with_loopbacks_from_pod_pools:
+      router_id: 172.16.120.3
+      rd: 172.16.120.3:1101
+      route_targets:
+        import:
+          evpn:
+          - 1101:1101
+        export:
+          evpn:
+          - 1101:1101
+      redistribute_routes:
+      - connected
   vlans:
     110:
       tenant: Tenant_A
@@ -151,6 +187,15 @@ vrfs:
   Common_VRF:
     tenant: Tenant_A
     ip_routing: true
+  vrf_with_loopbacks_dc1_pod1_only:
+    tenant: Tenant_A
+    ip_routing: true
+  vrf_with_loopbacks_from_overlapping_pool:
+    tenant: Tenant_A
+    ip_routing: true
+  vrf_with_loopbacks_from_pod_pools:
+    tenant: Tenant_A
+    ip_routing: true
 management_interfaces:
   Management1:
     description: oob_management
@@ -210,6 +255,16 @@ loopback_interfaces:
     description: VTEP_VXLAN_Tunnel_Source
     shutdown: false
     ip_address: 172.18.120.3/32
+  Loopback100:
+    description: vrf_with_loopbacks_from_overlapping_pool_VTEP_DIAGNOSTICS
+    shutdown: false
+    vrf: vrf_with_loopbacks_from_overlapping_pool
+    ip_address: 10.100.0.3/32
+  Loopback101:
+    description: vrf_with_loopbacks_from_pod_pools_VTEP_DIAGNOSTICS
+    shutdown: false
+    vrf: vrf_with_loopbacks_from_pod_pools
+    ip_address: 10.101.102.3/32
 prefix_lists:
   PL-LOOPBACKS-EVPN-OVERLAY:
     sequence_numbers:
@@ -250,6 +305,15 @@ vlans:
   113:
     tenant: Tenant_A
     name: SVI_with_no_vxlan
+  1102:
+    tenant: Tenant_A
+    name: test_svi
+  1100:
+    tenant: Tenant_A
+    name: test_svi
+  1101:
+    tenant: Tenant_A
+    name: test_svi
   2500:
     tenant: Tenant_A
     name: web-l2-vlan
@@ -304,9 +368,41 @@ vlan_interfaces:
     shutdown: false
     vrf: Common_VRF
     ip_address_virtual: 10.10.13.1/24
+  Vlan1102:
+    tenant: Tenant_A
+    tags:
+    - opzone
+    - web
+    description: test_svi
+    shutdown: false
+    vrf: vrf_with_loopbacks_dc1_pod1_only
+    ip_address_virtual: 10.102.100.1/24
+  Vlan1100:
+    tenant: Tenant_A
+    tags:
+    - opzone
+    - web
+    description: test_svi
+    shutdown: false
+    vrf: vrf_with_loopbacks_from_overlapping_pool
+    ip_address_virtual: 10.100.100.1/24
+  Vlan1101:
+    tenant: Tenant_A
+    tags:
+    - opzone
+    - web
+    description: test_svi
+    shutdown: false
+    vrf: vrf_with_loopbacks_from_pod_pools
+    ip_address_virtual: 10.101.100.1/24
 struct_cfg:
   domain_list:
   - structured-config.set.under.vrf.common-vrf
+virtual_source_nat_vrfs:
+  vrf_with_loopbacks_from_overlapping_pool:
+    ip_address: 10.100.0.3
+  vrf_with_loopbacks_from_pod_pools:
+    ip_address: 10.101.102.3
 vxlan_interface:
   Vxlan1:
     description: DC1-POD2-LEAF1A_VTEP
@@ -327,5 +423,11 @@ vxlan_interface:
       vrfs:
         Common_VRF:
           vni: 1025
+        vrf_with_loopbacks_dc1_pod1_only:
+          vni: 1102
+        vrf_with_loopbacks_from_overlapping_pool:
+          vni: 1100
+        vrf_with_loopbacks_from_pod_pools:
+          vni: 1101
 domain_list:
 - structured-config.set.under.vrf.common-vrf

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF1A.yml
@@ -94,6 +94,42 @@ router_bgp:
         EOF
 
         '
+    vrf_with_loopbacks_dc1_pod1_only:
+      router_id: 172.16.210.3
+      rd: 172.16.210.3:1102
+      route_targets:
+        import:
+          evpn:
+          - 1102:1102
+        export:
+          evpn:
+          - 1102:1102
+      redistribute_routes:
+      - connected
+    vrf_with_loopbacks_from_overlapping_pool:
+      router_id: 172.16.210.3
+      rd: 172.16.210.3:1100
+      route_targets:
+        import:
+          evpn:
+          - 1100:1100
+        export:
+          evpn:
+          - 1100:1100
+      redistribute_routes:
+      - connected
+    vrf_with_loopbacks_from_pod_pools:
+      router_id: 172.16.210.3
+      rd: 172.16.210.3:1101
+      route_targets:
+        import:
+          evpn:
+          - 1101:1101
+        export:
+          evpn:
+          - 1101:1101
+      redistribute_routes:
+      - connected
 static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0
@@ -119,6 +155,15 @@ vrfs:
   MGMT:
     ip_routing: false
   Common_VRF:
+    tenant: Tenant_A
+    ip_routing: true
+  vrf_with_loopbacks_dc1_pod1_only:
+    tenant: Tenant_A
+    ip_routing: true
+  vrf_with_loopbacks_from_overlapping_pool:
+    tenant: Tenant_A
+    ip_routing: true
+  vrf_with_loopbacks_from_pod_pools:
     tenant: Tenant_A
     ip_routing: true
 management_interfaces:
@@ -209,6 +254,16 @@ loopback_interfaces:
     description: VTEP_VXLAN_Tunnel_Source
     shutdown: false
     ip_address: 172.18.210.3/32
+  Loopback100:
+    description: vrf_with_loopbacks_from_overlapping_pool_VTEP_DIAGNOSTICS
+    shutdown: false
+    vrf: vrf_with_loopbacks_from_overlapping_pool
+    ip_address: 10.100.0.3/32
+  Loopback101:
+    description: vrf_with_loopbacks_from_pod_pools_VTEP_DIAGNOSTICS
+    shutdown: false
+    vrf: vrf_with_loopbacks_from_pod_pools
+    ip_address: 10.101.201.3/32
 prefix_lists:
   PL-LOOPBACKS-EVPN-OVERLAY:
     sequence_numbers:
@@ -242,6 +297,11 @@ ip_virtual_router_mac_address: 00:1c:73:00:dc:01
 struct_cfg:
   domain_list:
   - structured-config.set.under.vrf.common-vrf
+virtual_source_nat_vrfs:
+  vrf_with_loopbacks_from_overlapping_pool:
+    ip_address: 10.100.0.3
+  vrf_with_loopbacks_from_pod_pools:
+    ip_address: 10.101.201.3
 vxlan_interface:
   Vxlan1:
     description: DC2-POD1-LEAF1A_VTEP
@@ -251,6 +311,12 @@ vxlan_interface:
       vrfs:
         Common_VRF:
           vni: 1025
+        vrf_with_loopbacks_dc1_pod1_only:
+          vni: 1102
+        vrf_with_loopbacks_from_overlapping_pool:
+          vni: 1100
+        vrf_with_loopbacks_from_pod_pools:
+          vni: 1101
 vlans:
   4092:
     tenant: system

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/TENANTS_NETWORKS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/TENANTS_NETWORKS.yml
@@ -59,6 +59,53 @@ tenants:
             comment
             Comment created from raw_eos_cli under BGP for VRF Common_VRF
             EOF
+      vrf_with_loopbacks_from_overlapping_pool:
+        vrf_vni: 1100
+        vtep_diagnostic:
+          loopback: 100
+          loopback_ip_range: 10.100.0.0/24
+          loopback_ip_pools: # This data should not be used since "loopback_ip_range takes precedence"
+            - pod: DC1_POD1
+              ipv4_pool: 10.101.101.0/24
+        svis:
+          1100:
+            name: test_svi
+            tags: [opzone,web]
+            enabled: True
+            ip_address_virtual: 10.100.100.1/24
+            vxlan: False
+      vrf_with_loopbacks_from_pod_pools:
+        vrf_vni: 1101
+        vtep_diagnostic:
+          loopback: 101
+          loopback_ip_pools:
+            - pod: DC1_POD1
+              ipv4_pool: 10.101.101.0/24
+            - pod: DC1_POD2
+              ipv4_pool: 10.101.102.0/24
+            - pod: DC2_POD1
+              ipv4_pool: 10.101.201.0/24
+        svis:
+          1101:
+            name: test_svi
+            tags: [opzone,web]
+            enabled: True
+            ip_address_virtual: 10.101.100.1/24
+            vxlan: False
+      vrf_with_loopbacks_dc1_pod1_only:
+        vrf_vni: 1102
+        vtep_diagnostic:
+          loopback: 102
+          loopback_ip_pools:
+            - pod: DC1_POD1
+              ipv4_pool: 10.102.101.0/24
+        svis:
+          1102:
+            name: test_svi
+            tags: [opzone,web]
+            enabled: True
+            ip_address_virtual: 10.102.100.1/24
+            vxlan: False
 
     # These are pure L2 vlans - so no SVI on l3leafs
     l2vlans:

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/TENANTS_NETWORKS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/TENANTS_NETWORKS.yml
@@ -70,7 +70,7 @@ tenants:
         svis:
           1100:
             name: test_svi
-            tags: [opzone,web]
+            tags: [opzone, web]
             enabled: True
             ip_address_virtual: 10.100.100.1/24
             vxlan: False
@@ -88,7 +88,7 @@ tenants:
         svis:
           1101:
             name: test_svi
-            tags: [opzone,web]
+            tags: [opzone, web]
             enabled: True
             ip_address_virtual: 10.101.100.1/24
             vxlan: False
@@ -102,7 +102,7 @@ tenants:
         svis:
           1102:
             name: test_svi
-            tags: [opzone,web]
+            tags: [opzone, web]
             enabled: True
             ip_address_virtual: 10.102.100.1/24
             vxlan: False

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
@@ -132,6 +132,12 @@ tenants:
           # to each l3 leaf based on it's unique id. | Required (when vtep_diagnotics defined)
           loopback_ip_range: < IPv4_address/Mask >
 
+          # For inventories with multiple PODs a loopback range can be set per POD to avoid overlaps.
+          # This only takes effect when loopback_ip_range is not defined.
+          loopback_ip_pools:
+            - pod: < pod_name >
+              ipv4_pool: < IPv4_address/Mask >
+
         # Dictionary of SVIs | Required.
         # This will create both the L3 SVI and L2 VLAN based on filters applied to l3leaf and l2leaf.
         svis:

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
@@ -129,11 +129,11 @@ tenants:
           loopback: < 2-2100 >
 
           # Loopback ip range, a unique ip is derived from this ranged and assigned
-          # to each l3 leaf based on it's unique id. | Required (when vtep_diagnotics defined)
+          # to each l3 leaf based on it's unique id. | Optional (loopback is not created unless loopback_ip_range or loopback_ip_pools are set)
           loopback_ip_range: < IPv4_address/Mask >
 
           # For inventories with multiple PODs a loopback range can be set per POD to avoid overlaps.
-          # This only takes effect when loopback_ip_range is not defined.
+          # This only takes effect when loopback_ip_range is not defined. | Optional (loopback is not created unless loopback_ip_range or loopback_ip_pools are set)
           loopback_ip_pools:
             - pod: < pod_name >
               ipv4_pool: < IPv4_address/Mask >

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/loopback-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/loopback-interfaces.j2
@@ -5,7 +5,7 @@ loopback_interfaces:
 {%         if tenants[tenant].vrfs[vrf].vtep_diagnostic.loopback is arista.avd.defined %}
 {%             set loopback_description = tenants[tenant].vrfs[vrf].vtep_diagnostic.loopback_description | arista.avd.default(vrf ~ '_VTEP_DIAGNOSTICS') %}
 {%             set loopback_ipv4_pool = tenants[tenant].vrfs[vrf].vtep_diagnostic.loopback_ip_range | arista.avd.default(
-                   tenants[tenant].vrfs[vrf].vtep_diagnostic.loopback_ip_pools | arista.avd.default([]) | selectattr('pod', 'arista.avd.defined', pod_name) | map(attribute='ipv4_pool') | first | arista.avd.default) %}
+                   tenants[tenant].vrfs[vrf].vtep_diagnostic.loopback_ip_pools | arista.avd.default([]) | selectattr('pod', 'arista.avd.defined', pod_name) | map(attribute='ipv4_pool') | first) %}
 {%             if loopback_ipv4_pool is arista.avd.defined %}
   Loopback{{ tenants[tenant].vrfs[vrf].vtep_diagnostic.loopback }}:
     description: {{ loopback_description }}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/loopback-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/loopback-interfaces.j2
@@ -2,13 +2,17 @@
 loopback_interfaces:
 {% for tenant in switch.tenants | arista.avd.natural_sort %}
 {%     for vrf in switch.tenants[tenant].vrfs %}
-{%         if tenants[tenant].vrfs[vrf].vtep_diagnostic is defined %}
-  Loopback{{ tenants[tenant].vrfs[vrf].vtep_diagnostic.loopback }}:
+{%         if tenants[tenant].vrfs[vrf].vtep_diagnostic.loopback is arista.avd.defined %}
 {%             set loopback_description = tenants[tenant].vrfs[vrf].vtep_diagnostic.loopback_description | arista.avd.default(vrf ~ '_VTEP_DIAGNOSTICS') %}
+{%             set loopback_ipv4_pool = tenants[tenant].vrfs[vrf].vtep_diagnostic.loopback_ip_range | arista.avd.default(
+                   tenants[tenant].vrfs[vrf].vtep_diagnostic.loopback_ip_pools | arista.avd.default([]) | selectattr('pod', 'arista.avd.defined', pod_name) | map(attribute='ipv4_pool') | first | arista.avd.default) %}
+{%             if loopback_ipv4_pool is arista.avd.defined %}
+  Loopback{{ tenants[tenant].vrfs[vrf].vtep_diagnostic.loopback }}:
     description: {{ loopback_description }}
     shutdown: false
     vrf: {{ vrf }}
-    ip_address: {{ tenants[tenant].vrfs[vrf].vtep_diagnostic.loopback_ip_range | ansible.netcommon.ipaddr('network') | ansible.netcommon.ipmath(switch.id + switch.loopback_ipv4_offset) }}/32
+    ip_address: {{ loopback_ipv4_pool | ansible.netcommon.ipaddr('network') | ansible.netcommon.ipmath(switch.id + switch.loopback_ipv4_offset) }}/32
+{%             endif %}
 {%         endif %}
 {%     endfor %}
 {% endfor %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/virtual-source-nat-vrfs.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/virtual-source-nat-vrfs.j2
@@ -2,9 +2,14 @@
 virtual_source_nat_vrfs:
 {% for tenant in switch.tenants | arista.avd.natural_sort %}
 {%     for vrf in switch.tenants[tenant].vrfs | arista.avd.natural_sort %}
-{%         if tenants[tenant].vrfs[vrf].vtep_diagnostic is defined %}
+{%         if tenants[tenant].vrfs[vrf].vtep_diagnostic.loopback is arista.avd.defined %}
+{%             set loopback_description = tenants[tenant].vrfs[vrf].vtep_diagnostic.loopback_description | arista.avd.default(vrf ~ '_VTEP_DIAGNOSTICS') %}
+{%             set loopback_ipv4_pool = tenants[tenant].vrfs[vrf].vtep_diagnostic.loopback_ip_range | arista.avd.default(
+                   tenants[tenant].vrfs[vrf].vtep_diagnostic.loopback_ip_pools | arista.avd.default([]) | selectattr('pod', 'arista.avd.defined', pod_name) | map(attribute='ipv4_pool') | first | arista.avd.default) %}
+{%             if loopback_ipv4_pool is arista.avd.defined %}
   {{ vrf }}:
-    ip_address: {{ tenants[tenant].vrfs[vrf].vtep_diagnostic.loopback_ip_range | ansible.netcommon.ipaddr('network') | ansible.netcommon.ipmath(switch.id + switch.loopback_ipv4_offset) }}
+    ip_address: {{ loopback_ipv4_pool | ansible.netcommon.ipaddr('network') | ansible.netcommon.ipmath(switch.id + switch.loopback_ipv4_offset) }}
+{%             endif %}
 {%         endif %}
 {%     endfor %}
 {% endfor %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/virtual-source-nat-vrfs.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/virtual-source-nat-vrfs.j2
@@ -5,7 +5,7 @@ virtual_source_nat_vrfs:
 {%         if tenants[tenant].vrfs[vrf].vtep_diagnostic.loopback is arista.avd.defined %}
 {%             set loopback_description = tenants[tenant].vrfs[vrf].vtep_diagnostic.loopback_description | arista.avd.default(vrf ~ '_VTEP_DIAGNOSTICS') %}
 {%             set loopback_ipv4_pool = tenants[tenant].vrfs[vrf].vtep_diagnostic.loopback_ip_range | arista.avd.default(
-                   tenants[tenant].vrfs[vrf].vtep_diagnostic.loopback_ip_pools | arista.avd.default([]) | selectattr('pod', 'arista.avd.defined', pod_name) | map(attribute='ipv4_pool') | first | arista.avd.default) %}
+                   tenants[tenant].vrfs[vrf].vtep_diagnostic.loopback_ip_pools | arista.avd.default([]) | selectattr('pod', 'arista.avd.defined', pod_name) | map(attribute='ipv4_pool') | first) %}
 {%             if loopback_ipv4_pool is arista.avd.defined %}
   {{ vrf }}:
     ip_address: {{ loopback_ipv4_pool | ansible.netcommon.ipaddr('network') | ansible.netcommon.ipmath(switch.id + switch.loopback_ipv4_offset) }}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Support configuration of vtep_diagnostic loopback pool per POD

## Related Issue(s)

Fixes #1252 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- Add `new loopback_ip_pools` key.
- Clean up logic to make it skip the loopback in case of missing variables instead of failing
- Update documentation
- Add molecule scenario for multi-pod for the different combinations showing precedence to old variable and skipping gracefully if `pod_name` is not defined in the list.
```yaml
tenants:
  <tenant>
    vrfs:
      <vrf>:
        # Enable VTEP Network diagnostics | Optional.
        # This will create a loopback with virtual source-nat enable to perform diagnostics from the switch.
        vtep_diagnostic:

          # Loopback interface number | Required (when vtep_diagnotics defined)
          loopback: < 2-2100 >

          # Loopback ip range, a unique ip is derived from this ranged and assigned
          # to each l3 leaf based on it's unique id. | Optional (loopback is not created unless loopback_ip_range or loopback_ip_pools are set)
          loopback_ip_range: < IPv4_address/Mask >

          # For inventories with multiple PODs a loopback range can be set per POD to avoid overlaps.
          # This only takes effect when loopback_ip_range is not defined. | Optional (loopback is not created unless loopback_ip_range or loopback_ip_pools are set)
          loopback_ip_pools:
            - pod: < pod_name >
              ipv4_pool: < IPv4_address/Mask >
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
added molecule coverage of various combinations.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
