### PR TITLE
Feat(eos_cli_config_gen): Support connectivity monitor configuration

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/monitor-connectivity.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/monitor-connectivity.md
@@ -1,0 +1,172 @@
+# monitor-connectivity
+# Table of Contents
+<!-- toc -->
+
+- [Management](#management)
+  - [Management Interfaces](#management-interfaces)
+- [Authentication](#authentication)
+- [Monitoring](#monitoring)
+- [Monitor Connectivity](#monitor-connectivity)
+  - [Global Configuration](#global-configuration)
+  - [Vrf Configuration](#vrf-configuration)
+  - [Monitor Connectivity Device Configuration](#monitor-connectivity-device-configuration)
+- [Internal VLAN Allocation Policy](#internal-vlan-allocation-policy)
+  - [Internal VLAN Allocation Policy Summary](#internal-vlan-allocation-policy-summary)
+- [Interfaces](#interfaces)
+- [Routing](#routing)
+  - [IP Routing](#ip-routing)
+  - [IPv6 Routing](#ipv6-routing)
+- [Multicast](#multicast)
+- [Filters](#filters)
+- [ACL](#acl)
+- [Quality Of Service](#quality-of-service)
+
+<!-- toc -->
+# Management
+
+## Management Interfaces
+
+### Management Interfaces Summary
+
+#### IPv4
+
+| Management Interface | description | Type | VRF | IP Address | Gateway |
+| -------------------- | ----------- | ---- | --- | ---------- | ------- |
+| Management1 | oob_management | oob | MGMT | 10.73.255.122/24 | 10.73.255.2 |
+
+#### IPv6
+
+| Management Interface | description | Type | VRF | IPv6 Address | IPv6 Gateway |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ |
+| Management1 | oob_management | oob | MGMT | -  | - |
+
+### Management Interfaces Device Configuration
+
+```eos
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+```
+
+# Authentication
+
+# Monitoring
+
+# Monitor Connectivity
+
+## Global Configuration
+
+### Interface Sets
+
+| Name | Interfaces |
+| ---- | ---------- |
+| GLOBAL_SET | Ethernet1-4 |
+| HOST_SET | Loopback2-4, Loopback10-12 |
+
+### Probing Configuration
+
+| Enabled | Interval | Default Interface Set |
+| ------- | -------- | --------------------- |
+| True | 5 | GLOBAL_SET |
+
+### Host Parameters
+
+| Host Name | Description | IPv4 Address | Probing Interface Set | URL |
+| --------- | ----------- | ------------ | --------------------- | --- |
+| server1 | server1_connectivity_monitor | 10.10.10.1 | HOST_SET | https://server1.local.com |
+
+## Vrf Configuration
+
+| Name | Description | Default Interface Set |
+| ---- | ----------- | --------------------- |
+| red | vrf_connectivity_monitor | VRF_GLOBAL_SET |
+
+### Vrf red Configuration
+
+#### Interface Sets
+
+| Name | Interfaces |
+| ---- | ---------- |
+| VRF_GLOBAL_SET | Vlan21-24, Vlan29-32 |
+| VRF_HOST_SET | Loopback12-14, 19-23 |
+
+#### Host Parameters
+
+| Host Name | Description | IPv4 Address | Probing Interface Set | URL |
+| --------- | ----------- | ------------ | --------------------- | --- |
+| server2 | server2_connectivity_monitor | 10.10.20.1 | VRF_HOST_SET | https://server2.local.com |
+
+## Monitor Connectivity Device Configuration
+
+```eos
+!
+monitor connectivity
+   interval 5
+   no shutdown
+   interface set GLOBAL_SET Ethernet1-4
+   interface set HOST_SET Loopback2-4, Loopback10-12
+   local-interfaces GLOBAL_SET address-only default
+   !
+   host server1
+      description
+      server1_connectivity_monitor
+      local-interfaces HOST_SET address-only
+      ip 10.10.10.1
+      url https://server1.local.com
+   vrf red
+      interface set VRF_GLOBAL_SET Vlan21-24, Vlan29-32
+      interface set VRF_HOST_SET Loopback12-14, 19-23
+      local-interfaces VRF_GLOBAL_SET address-only default
+      description
+      vrf_connectivity_monitor
+      !
+      host server2
+         description
+         server2_connectivity_monitor
+         local-interfaces VRF_HOST_SET address-only
+         ip 10.10.20.1
+         url https://server2.local.com
+```
+
+# Internal VLAN Allocation Policy
+
+## Internal VLAN Allocation Policy Summary
+
+**Default Allocation Policy**
+
+| Policy Allocation | Range Beginning | Range Ending |
+| ------------------| --------------- | ------------ |
+| ascending | 1006 | 4094 |
+
+# Interfaces
+
+# Routing
+
+## IP Routing
+
+### IP Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | false|
+### IP Routing Device Configuration
+
+```eos
+```
+## IPv6 Routing
+
+### IPv6 Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | false |
+
+# Multicast
+
+# Filters
+
+# ACL
+
+# Quality Of Service

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/monitor-connectivity.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/monitor-connectivity.cfg
@@ -1,0 +1,42 @@
+!RANCID-CONTENT-TYPE: arista
+!
+transceiver qsfp default-mode 4x10G
+!
+hostname monitor-connectivity
+!
+no aaa root
+no enable password
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+!
+monitor connectivity
+   interval 5
+   no shutdown
+   interface set GLOBAL_SET Ethernet1-4
+   interface set HOST_SET Loopback2-4, Loopback10-12
+   local-interfaces GLOBAL_SET address-only default
+   !
+   host server1
+      description
+      server1_connectivity_monitor
+      local-interfaces HOST_SET address-only
+      ip 10.10.10.1
+      url https://server1.local.com
+   vrf red
+      interface set VRF_GLOBAL_SET Vlan21-24, Vlan29-32
+      interface set VRF_HOST_SET Loopback12-14, 19-23
+      local-interfaces VRF_GLOBAL_SET address-only default
+      description
+      vrf_connectivity_monitor
+      !
+      host server2
+         description
+         server2_connectivity_monitor
+         local-interfaces VRF_HOST_SET address-only
+         ip 10.10.20.1
+         url https://server2.local.com
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/monitor-connectivity.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/monitor-connectivity.yml
@@ -1,31 +1,31 @@
 ---
 monitor_connectivity:
-    shutdown: false
-    interval: 5
-    interface_sets:
-        - name: GLOBAL_SET
-          interfaces: Ethernet1-4
-        - name: HOST_SET
-          interfaces: Loopback2-4, Loopback10-12
-    local_interfaces: GLOBAL_SET
-    hosts:
-        - name: server1
-          description: server1_connectivity_monitor
-          ip: 10.10.10.1
-          local_interfaces: HOST_SET
-          url: https://server1.local.com
-    vrfs:
-        - name: red
-          description: vrf_connectivity_monitor
-          interface_sets:
-              - name: VRF_GLOBAL_SET
-                interfaces: Vlan21-24, Vlan29-32
-              - name: VRF_HOST_SET
-                interfaces: Loopback12-14, 19-23
-          local_interfaces: VRF_GLOBAL_SET
-          hosts:
-              - name: server2
-                description: server2_connectivity_monitor
-                ip: 10.10.20.1
-                local_interfaces: VRF_HOST_SET
-                url: https://server2.local.com
+  shutdown: false
+  interval: 5
+  interface_sets:
+    - name: GLOBAL_SET
+      interfaces: Ethernet1-4
+    - name: HOST_SET
+      interfaces: Loopback2-4, Loopback10-12
+  local_interfaces: GLOBAL_SET
+  hosts:
+    - name: server1
+      description: server1_connectivity_monitor
+      ip: 10.10.10.1
+      local_interfaces: HOST_SET
+      url: https://server1.local.com
+  vrfs:
+    - name: red
+      description: vrf_connectivity_monitor
+      interface_sets:
+        - name: VRF_GLOBAL_SET
+          interfaces: Vlan21-24, Vlan29-32
+        - name: VRF_HOST_SET
+          interfaces: Loopback12-14, 19-23
+      local_interfaces: VRF_GLOBAL_SET
+      hosts:
+        - name: server2
+          description: server2_connectivity_monitor
+          ip: 10.10.20.1
+          local_interfaces: VRF_HOST_SET
+          url: https://server2.local.com

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/monitor-connectivity.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/monitor-connectivity.yml
@@ -1,0 +1,31 @@
+---
+monitor_connectivity:
+    shutdown: false
+    interval: 5
+    interface_sets:
+        - name: GLOBAL_SET
+          interfaces: Ethernet1-4
+        - name: HOST_SET
+          interfaces: Loopback2-4, Loopback10-12
+    local_interfaces: GLOBAL_SET
+    hosts:
+        - name: server1
+          description: server1_connectivity_monitor
+          ip: 10.10.10.1
+          local_interfaces: HOST_SET
+          url: https://server1.local.com
+    vrfs:
+        - name: red
+          description: vrf_connectivity_monitor
+          interface_sets:
+              - name: VRF_GLOBAL_SET
+                interfaces: Vlan21-24, Vlan29-32
+              - name: VRF_HOST_SET
+                interfaces: Loopback12-14, 19-23
+          local_interfaces: VRF_GLOBAL_SET
+          hosts:
+              - name: server2
+                description: server2_connectivity_monitor
+                ip: 10.10.20.1
+                local_interfaces: VRF_HOST_SET
+                url: https://server2.local.com

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
@@ -53,6 +53,7 @@ management-ssh-custom-cipher
 mac-security-eth-po-entropy
 match-lists
 mlag-configuration
+monitor-connectivity
 mpls
 none_configuration
 ntp

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1690,40 +1690,40 @@ daemons:
     enabled: "< true | false | default -> true >"
 ```
 
-This will add a dameon to the eos configuration that is most useful when trying to run OpenConfig clients like ocprometheus
-
 #### Connectivity Monitor
 
 ```yaml
 monitor_connectivity:
-    shutdown: < true | false >
-    interval: < probing_interval >
-    interface_sets:
-      - name: < interface_set >
-        # Interface range(s) should be of same type, Ethernet, Loopback, Management etc.
-        # Multiple interface ranges can be specified separated by ","
-        interfaces: < interface_or_interface_range(s) >
-    local_interfaces: < interface_set_name >
-    hosts:
-      - name: < host_name >
-        description: < description >
-        ip: < ipv4 >
-        local_interfaces: < interface_set_name >
-        url: < url >
-    vrfs:
-      - name: < vrf_name >
-        description: < description >
-        interface_sets:
-          - name: < interface_set >
-            interfaces: < interface_or_interface_range(s) >
-        local_interfaces: < interface_set_name >
-        hosts:
-          - name: < host_name >
-            description: < description >
-            ip: < ipv4 >
-            local_interfaces: < interface_set_name >
-            url: < url >
+  shutdown: < true | false >
+  interval: < probing_interval >
+  interface_sets:
+    - name: < interface_set >
+      # Interface range(s) should be of same type, Ethernet, Loopback, Management etc.
+      # Multiple interface ranges can be specified separated by ","
+      interfaces: < interface_or_interface_range(s) >
+  local_interfaces: < interface_set_name >
+  hosts:
+    - name: < host_name >
+      description: < description >
+      ip: < ipv4 >
+      local_interfaces: < interface_set_name >
+      url: < url >
+  vrfs:
+    - name: < vrf_name >
+      description: < description >
+      interface_sets:
+        - name: < interface_set >
+          interfaces: < interface_or_interface_range(s) >
+      local_interfaces: < interface_set_name >
+      hosts:
+        - name: < host_name >
+          description: < description >
+          ip: < ipv4 >
+          local_interfaces: < interface_set_name >
+          url: < url >
 ```
+
+This will add a daemon to the eos configuration that is most useful when trying to run OpenConfig clients like ocprometheus
 
 #### Event Handler
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -93,6 +93,7 @@
     - [Monitoring](#monitoring)
       - [Daemon TerminAttr](#daemon-terminattr)
       - [Custom Daemons](#custom-daemons)
+      - [Connectivity Monitor](#connectivity-monitor)
       - [Event Handler](#event-handler)
       - [Event Monitor](#event-monitor)
       - [Load Interval](#load-interval)
@@ -1690,6 +1691,39 @@ daemons:
 ```
 
 This will add a dameon to the eos configuration that is most useful when trying to run OpenConfig clients like ocprometheus
+
+#### Connectivity Monitor
+
+```yaml
+monitor_connectivity:
+    shutdown: < true | false >
+    interval: < probing_interval >
+    interface_sets:
+      - name: < interface_set >
+        # Interface range(s) should be of same type, Ethernet, Loopback, Management etc.
+        # Multiple interface ranges can be specified separated by ","
+        interfaces: < interface_or_interface_range(s) >
+    local_interfaces: < interface_set_name >
+    hosts:
+      - name: < host_name >
+        description: < description >
+        ip: < ipv4 >
+        local_interfaces: < interface_set_name >
+        url: < url >
+    vrfs:
+      - name: < vrf_name >
+        description: < description >
+        interface_sets:
+          - name: < interface_set >
+            interfaces: < interface_or_interface_range(s) >
+        local_interfaces: < interface_set_name >
+        hosts:
+          - name: < host_name >
+            description: < description >
+            ip: < ipv4 >
+            local_interfaces: < interface_set_name >
+            url: < url >
+```
 
 #### Event Handler
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1690,6 +1690,8 @@ daemons:
     enabled: "< true | false | default -> true >"
 ```
 
+This will add a daemon to the eos configuration that is most useful when trying to run OpenConfig clients like ocprometheus
+
 #### Connectivity Monitor
 
 ```yaml
@@ -1722,8 +1724,6 @@ monitor_connectivity:
           local_interfaces: < interface_set_name >
           url: < url >
 ```
-
-This will add a daemon to the eos configuration that is most useful when trying to run OpenConfig clients like ocprometheus
 
 #### Event Handler
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/monitor-connectivity.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/monitor-connectivity.j2
@@ -1,0 +1,84 @@
+{% if monitor_connectivity is arista.avd.defined %}
+
+# Monitor Connectivity
+
+## Global Configuration
+{%     if monitor_connectivity.interface_sets is arista.avd.defined %}
+
+### Interface Sets
+
+| Name | Interfaces |
+| ---- | ---------- |
+{%         for interface_set in monitor_connectivity.interface_sets | arista.avd.natural_sort('name') %}
+{%             if interface_set.name is arista.avd.defined and interface_set.interfaces is arista.avd.defined %}
+| {{ interface_set.name }} | {{ interface_set.interfaces }} |
+{%             endif %}
+{%         endfor %}
+{%     endif %}
+
+### Probing Configuration
+
+| Enabled | Interval | Default Interface Set |
+| ------- | -------- | --------------------- |
+| {{ not monitor_connectivity.shutdown | arista.avd.default(true) }} | {{ monitor_connectivity.interval | arista.avd.default('-') }} | {{ monitor_connectivity.local_interfaces | arista.avd.default('-') }} |
+{%     if monitor_connectivity.hosts is arista.avd.defined %}
+
+### Host Parameters
+
+| Host Name | Description | IPv4 Address | Probing Interface Set | URL |
+| --------- | ----------- | ------------ | --------------------- | --- |
+{%         for host in monitor_connectivity.hosts | arista.avd.natural_sort('name') %}
+{%             if host.name is arista.avd.defined %}
+| {{ host.name }} | {{ host.description | arista.avd.default('-') }} | {{ host.ip | arista.avd.default('-') }} | {{ host.local_interfaces | arista.avd.default('-') }} | {{ host.url | arista.avd.default('-') }} |
+{%             endif %}
+{%         endfor %}
+{%     endif %}
+{%     if monitor_connectivity.vrfs is arista.avd.defined %}
+
+## Vrf Configuration
+
+| Name | Description | Default Interface Set |
+| ---- | ----------- | --------------------- |
+{%         for vrf in monitor_connectivity.vrfs | arista.avd.natural_sort('name') %}
+{%             if vrf.name is arista.avd.defined %}
+| {{ vrf.name }} | {{ vrf.description | arista.avd.default('-') }} | {{ vrf.local_interfaces | arista.avd.default('-') }} |
+{%             endif %}
+{%         endfor %}
+{%         for vrf in monitor_connectivity.vrfs | arista.avd.natural_sort('name') %}
+{%             if vrf.name is arista.avd.defined %}
+
+### Vrf {{ vrf.name }} Configuration
+{%                 if vrf.interface_sets is arista.avd.defined %}
+
+#### Interface Sets
+
+| Name | Interfaces |
+| ---- | ---------- |
+{%                     for interface_set in vrf.interface_sets | arista.avd.natural_sort('name') %}
+{%                         if interface_set.name is arista.avd.defined and interface_set.interfaces is arista.avd.defined %}
+| {{ interface_set.name }} | {{ interface_set.interfaces }} |
+{%                         endif %}
+{%                     endfor %}
+{%                 endif %}
+{%                 if vrf.hosts is arista.avd.defined %}
+
+#### Host Parameters
+
+| Host Name | Description | IPv4 Address | Probing Interface Set | URL |
+| --------- | ----------- | ------------ | --------------------- | --- |
+{%                     for host in vrf.hosts | arista.avd.natural_sort('name') %}
+{%                         if host.name is arista.avd.defined %}
+| {{ host.name }} | {{ host.description | arista.avd.default('-') }} | {{ host.ip | arista.avd.default('-') }} | {{ host.local_interfaces | arista.avd.default('-') }} | {{ host.url | arista.avd.default('-') }} |
+{%                         endif %}
+{%                     endfor %}
+{%                 endif %}
+{%             endif %}
+{%         endfor %}
+{%     endif %}
+
+## Monitor Connectivity Device Configuration
+
+```eos
+{%     include 'eos/monitor-connectivity.j2' %}
+```
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-device-documentation.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-device-documentation.j2
@@ -79,6 +79,8 @@
 {% include 'documentation/vmtracer-sessions.j2' %}
 {## Event Handler #}
 {% include 'documentation/event-handler.j2' %}
+{# Monitor Connectivity #}
+{% include 'documentation/monitor-connectivity.j2' %}
 {# Hardware TCAM Profile #}
 {% include 'documentation/tcam-profile.j2' %}
 {# Link Tracking Groups #}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
@@ -120,6 +120,8 @@
 {% include 'eos/vxlan-interface.j2' %}
 {# Hardware TCAM Profiles #}
 {% include 'eos/tcam-profile.j2' %}
+{# Connectivity monitor configuration #}
+{% include 'eos/monitor-connectivity.j2' %}
 {# MAC address-table#}
 {% include 'eos/mac-address-table.j2' %}
 {# Router virtual mac address #}
@@ -132,7 +134,6 @@
 {% include 'eos/bgp-groups.j2' %}
 {# Interface Groups configuration #}
 {% include 'eos/interface-groups.j2' %}
-{# IPv6 Standard access-lists #}
 {# IPv6 Extended Access-lists #}
 {% include 'eos/ipv6-access-lists.j2' %}
 {# IPv6 Standard Access-lists #}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/monitor-connectivity.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/monitor-connectivity.j2
@@ -1,0 +1,76 @@
+{# eos - monitor connectivity configuration #}
+{% if monitor_connectivity is arista.avd.defined %}
+!
+monitor connectivity
+{%     if monitor_connectivity.interval is arista.avd.defined %}
+   interval {{ monitor_connectivity.interval }}
+{%     endif %}
+{%     if monitor_connectivity.shutdown is arista.avd.defined(false) %}
+   no shutdown
+{%     elif monitor_connectivity.shutdown is arista.avd.defined(true) %}
+   shutdown
+{%     endif %}
+{%     for interface_set in monitor_connectivity.interface_sets | arista.avd.natural_sort('name') %}
+{%         if interface_set.name is arista.avd.defined and interface_set.interfaces is arista.avd.defined %}
+   interface set {{ interface_set.name }} {{ interface_set.interfaces }}
+{%         endif %}
+{%     endfor %}
+{%     if monitor_connectivity.local_interfaces is arista.avd.defined %}
+   local-interfaces {{ monitor_connectivity.local_interfaces }} address-only default
+{%     endif %}
+{%     for host in monitor_connectivity.hosts | arista.avd.natural_sort('name') %}
+{%         if host.name is arista.avd.defined %}
+   !
+   host {{ host.name }}
+{%             if host.description is arista.avd.defined %}
+      description
+      {{ host.description }}
+{%             endif %}
+{%             if host.local_interfaces is arista.avd.defined %}
+      local-interfaces {{ host.local_interfaces }} address-only
+{%             endif %}
+{%             if host.ip is arista.avd.defined %}
+      ip {{ host.ip }}
+{%             endif %}
+{%             if host.url is arista.avd.defined %}
+      url {{ host.url }}
+{%             endif %}
+{%         endif %}
+{%     endfor %}
+{%     for vrf in monitor_connectivity.vrfs | arista.avd.natural_sort('name') %}
+{%         if vrf.name is arista.avd.defined %}
+   vrf {{ vrf.name }}
+{%             for interface_set in vrf.interface_sets | arista.avd.natural_sort('name') %}
+{%                 if interface_set.name is arista.avd.defined and interface_set.interfaces is arista.avd.defined %}
+      interface set {{ interface_set.name }} {{ interface_set.interfaces }}
+{%                 endif %}
+{%             endfor %}
+{%             if vrf.local_interfaces is arista.avd.defined %}
+      local-interfaces {{ vrf.local_interfaces }} address-only default
+{%             endif %}
+{%             if vrf.description is arista.avd.defined %}
+      description
+      {{ vrf.description }}
+{%             endif %}
+{%             for host in vrf.hosts | arista.avd.natural_sort('name') %}
+{%                 if host.name is arista.avd.defined %}
+      !
+      host {{ host.name }}
+{%                     if host.description is arista.avd.defined %}
+         description
+         {{ host.description }}
+{%                     endif %}
+{%                     if host.local_interfaces is arista.avd.defined %}
+         local-interfaces {{ host.local_interfaces }} address-only
+{%                     endif %}
+{%                     if host.ip is arista.avd.defined %}
+         ip {{ host.ip }}
+{%                     endif %}
+{%                     if host.url is arista.avd.defined %}
+         url {{ host.url }}
+{%                     endif %}
+{%                 endif %}
+{%             endfor %}
+{%         endif %}
+{%     endfor %}
+{% endif %}


### PR DESCRIPTION
## Change Summary

Support for Monitor connectivity cli commands, both global and vrf configuration.

## Related Issue(s)

Fixes #1094 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Proposed model:

```yaml
monitor_connectivity:
  shutdown: < true | false >
  interval: < probing_interval >
  interface_sets:
    - name: < interface_set >
      interfaces:
        - < interface_or_interface_range >
        - < interface_or_interface_range >
  local_interfaces: < interface_set_name >
  hosts:
    - name: < host_name >
      description: < description >
      ip: < ipv4 >
      local_interfaces: < interface_set_name >
      url: < url >
  vrfs:
    - name: < vrf_name >
      description: < description >
      interface_sets:
        - name: < interface_set >
          interfaces:
            - < interface_or_interface_range >
      local_interfaces: < interface_set_name >
      hosts:
        - name: < host_name >
          description: < description >
          ip: < ipv4 >
          local_interfaces: < interface_set_name >
          url: < url >
```   
        

## How to test
Molecule scenario monitor-connectivity is added for reference.

## Checklist
- [x] Added documentation
- [x] Added molecule scenario
- [x] Self documentation, jinja template added
- [x] Tested locally for bugs   

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
