### PR TITLE
Doc: Adding quotes to keys accepting the string value "on"

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -813,12 +813,12 @@ ethernet_interfaces:
     l2_protocol:
       encapsulation_dot1q_vlan: < vlan number >
     flowcontrol:
-      received: < received | send | on >
+      received: < "received" | "send" | "on" >
     mac_security:
       profile: < profile >
     channel_group:
       id: < Port-Channel_id >
-      mode: < on | active | passive >
+      mode: < "on" | "active" | "passive" >
     qos:
       trust: < dscp | cos >
       dscp: < dscp-value >

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/connected-endpoints.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/connected-endpoints.md
@@ -54,7 +54,7 @@ port_profiles:
     spanning_tree_bpdufilter: < true | false >
     spanning_tree_bpduguard: < true | false >
     flowcontrol:
-      received: < received | send | on >
+      received: < "received" | "send" | "on" >
     qos_profile: < qos_profile_name >
     ptp:
       enable: < true | false >
@@ -73,7 +73,7 @@ port_profiles:
         unit: < percent | pps > | Optional var and is hardware dependant - default is percent)
     port_channel:
       description: < port_channel_description >
-      mode: < active | passive | on >
+      mode: < "active" | "passive" | "on" >
       lacp_fallback:
         mode: < static > | Currently only static mode is supported
         timeout: < timeout in seconds > | Optional - default is 90 seconds
@@ -124,7 +124,7 @@ port_profiles:
 
         # Flow control | Optional
         flowcontrol:
-          received: < received | send | on >
+          received: < "received" | "send" | "on" >
 
         # QOS Profile | Optional
         qos_profile: < qos_profile_name >
@@ -173,7 +173,7 @@ port_profiles:
           description: < port_channel_description >
 
           # Port-Channel Mode.
-          mode: < active | passive | on >
+          mode: < "active" | "passive" | "on" >
 
           # LACP Fallback configuration | Optional
           lacp_fallback:


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Adding quotes to keys accepting the string value "on"

## Related Issue(s)

Fixes #1321 

## Component(s) name

`arista.avd.eos_cli_config_gen`
`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->
Added quotes to the documentation for keys that accept the string `"on"`. If the user enters `on` without quotes, Ansible will convert it to the boolean `True`.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
N/A Only doc change.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
