### PR TITLE
Doc(eos_cli_config_gen): Add Documentation for Management Console

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/base.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/base.md
@@ -5,6 +5,7 @@
 - [Management](#management)
   - [Management Interfaces](#management-interfaces)
   - [Management SSH](#management-ssh)
+  - [Management Console](#management-console)
   - [Management API HTTP](#management-api-http)
 - [Authentication](#authentication)
 - [Management Security](#management-security)
@@ -106,6 +107,20 @@ management ssh
    no shutdown
    vrf mgt
       no shutdown
+```
+
+## Management Console
+
+### Management Console Timeout
+
+Management Console Timeout is set to **300** minutes.
+
+### Management Console Configuration
+
+```eos
+!
+management console
+   idle-timeout 300
 ```
 
 ## Management API HTTP

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-console.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-console.md
@@ -1,0 +1,107 @@
+# management-console
+# Table of Contents
+<!-- toc -->
+
+- [Management](#management)
+  - [Management Interfaces](#management-interfaces)
+  - [Management Console](#management-console)
+- [Authentication](#authentication)
+- [Monitoring](#monitoring)
+- [Internal VLAN Allocation Policy](#internal-vlan-allocation-policy)
+  - [Internal VLAN Allocation Policy Summary](#internal-vlan-allocation-policy-summary)
+- [Interfaces](#interfaces)
+- [Routing](#routing)
+  - [IP Routing](#ip-routing)
+  - [IPv6 Routing](#ipv6-routing)
+- [Multicast](#multicast)
+- [Filters](#filters)
+- [ACL](#acl)
+- [Quality Of Service](#quality-of-service)
+
+<!-- toc -->
+# Management
+
+## Management Interfaces
+
+### Management Interfaces Summary
+
+#### IPv4
+
+| Management Interface | description | Type | VRF | IP Address | Gateway |
+| -------------------- | ----------- | ---- | --- | ---------- | ------- |
+| Management1 | oob_management | oob | MGMT | 10.73.255.122/24 | 10.73.255.2 |
+
+#### IPv6
+
+| Management Interface | description | Type | VRF | IPv6 Address | IPv6 Gateway |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ |
+| Management1 | oob_management | oob | MGMT | -  | - |
+
+### Management Interfaces Device Configuration
+
+```eos
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+```
+
+## Management Console
+
+### Management Console Timeout
+
+Management Console Timeout is set to **15** minutes.
+
+### Management Console Configuration
+
+```eos
+!
+management console
+   idle-timeout 15
+```
+
+# Authentication
+
+# Monitoring
+
+# Internal VLAN Allocation Policy
+
+## Internal VLAN Allocation Policy Summary
+
+**Default Allocation Policy**
+
+| Policy Allocation | Range Beginning | Range Ending |
+| ------------------| --------------- | ------------ |
+| ascending | 1006 | 4094 |
+
+# Interfaces
+
+# Routing
+
+## IP Routing
+
+### IP Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | false|
+### IP Routing Device Configuration
+
+```eos
+```
+## IPv6 Routing
+
+### IPv6 Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | false |
+
+# Multicast
+
+# Filters
+
+# ACL
+
+# Quality Of Service

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-console.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-console.cfg
@@ -1,0 +1,18 @@
+!RANCID-CONTENT-TYPE: arista
+!
+transceiver qsfp default-mode 4x10G
+!
+hostname management-console
+!
+no aaa root
+no enable password
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+!
+management console
+   idle-timeout 15
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/management-console.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/management-console.yml
@@ -1,0 +1,2 @@
+management_console:
+  idle_timeout: 15

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
@@ -43,6 +43,7 @@ mac-address-table
 maintenance
 management-api-http
 management-gnmi
+management-console
 management-interfaces
 management-ssh
 management-ssh-custom-cipher

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-console.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-console.j2
@@ -1,0 +1,17 @@
+{# Management Console #}
+{% if management_console is arista.avd.defined %}
+
+## Management Console
+{%      if management_console.idle_timeout is arista.avd.defined %}
+
+### Management Console Timeout
+
+Management Console Timeout is set to **{{ management_console.idle_timeout }}** minutes.
+{%      endif %}
+
+### Management Console Configuration
+
+```eos
+{%      include 'eos/management-console.j2' %}
+```
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-console.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-console.j2
@@ -2,16 +2,16 @@
 {% if management_console is arista.avd.defined %}
 
 ## Management Console
-{%      if management_console.idle_timeout is arista.avd.defined %}
+{%     if management_console.idle_timeout is arista.avd.defined %}
 
 ### Management Console Timeout
 
 Management Console Timeout is set to **{{ management_console.idle_timeout }}** minutes.
-{%      endif %}
+{%     endif %}
 
 ### Management Console Configuration
 
 ```eos
-{%      include 'eos/management-console.j2' %}
+{%     include 'eos/management-console.j2' %}
 ```
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-device-documentation.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-device-documentation.j2
@@ -25,6 +25,8 @@
 {% include 'documentation/ip-ssh-client-source-interfaces.j2' %}
 {## Management API GNMI #}
 {% include 'documentation/management-api-gnmi.j2' %}
+{# management Console #}
+{% include 'documentation/management-console.j2' %}
 {## Management API HTTP #}
 {% include 'documentation/management-api-http.j2' %}
 {## IP HTTP Client Source Interfaces #}


### PR DESCRIPTION
## Change Summary

Adding documentation for Management Console

## Related Issue(s)

Fixes #1271

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
If management_console.idle_timeout is defined, render it in the documentation as:
"Management Console Timeout is set to **< management_console.idle_timeout >** minutes."

If required, I can add a case for tranlasting "0" to "disabled" instead of rendering "0 minutes"

## How to test
Molecule run

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
