### PR TITLE
Feat(eos_designs): Support MLAG interfaces speed

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-L2LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-L2LEAF1A.md
@@ -339,11 +339,13 @@ interface Ethernet2
 interface Ethernet3
    description MLAG_PEER_DC1-L2LEAF1B_Ethernet3
    no shutdown
+   speed forced 40gfull
    channel-group 3 mode active
 !
 interface Ethernet4
    description MLAG_PEER_DC1-L2LEAF1B_Ethernet4
    no shutdown
+   speed forced 40gfull
    channel-group 3 mode active
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-L2LEAF1B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-L2LEAF1B.md
@@ -339,11 +339,13 @@ interface Ethernet2
 interface Ethernet3
    description MLAG_PEER_DC1-L2LEAF1A_Ethernet3
    no shutdown
+   speed forced 40gfull
    channel-group 3 mode active
 !
 interface Ethernet4
    description MLAG_PEER_DC1-L2LEAF1A_Ethernet4
    no shutdown
+   speed forced 40gfull
    channel-group 3 mode active
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3A.md
@@ -480,11 +480,13 @@ interface Ethernet4
 interface Ethernet5
    description MLAG_PEER_DC1-SVC3B_Ethernet5
    no shutdown
+   speed 100g
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-SVC3B_Ethernet6
    no shutdown
+   speed 100g
    channel-group 5 mode active
 !
 interface Ethernet7

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3B.md
@@ -479,11 +479,13 @@ interface Ethernet4
 interface Ethernet5
    description MLAG_PEER_DC1-SVC3A_Ethernet5
    no shutdown
+   speed 100g
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-SVC3A_Ethernet6
    no shutdown
+   speed 100g
    channel-group 5 mode active
 !
 interface Ethernet7

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-L2LEAF1A.cfg
@@ -91,11 +91,13 @@ interface Ethernet2
 interface Ethernet3
    description MLAG_PEER_DC1-L2LEAF1B_Ethernet3
    no shutdown
+   speed forced 40gfull
    channel-group 3 mode active
 !
 interface Ethernet4
    description MLAG_PEER_DC1-L2LEAF1B_Ethernet4
    no shutdown
+   speed forced 40gfull
    channel-group 3 mode active
 !
 interface Management1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-L2LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-L2LEAF1B.cfg
@@ -91,11 +91,13 @@ interface Ethernet2
 interface Ethernet3
    description MLAG_PEER_DC1-L2LEAF1A_Ethernet3
    no shutdown
+   speed forced 40gfull
    channel-group 3 mode active
 !
 interface Ethernet4
    description MLAG_PEER_DC1-L2LEAF1A_Ethernet4
    no shutdown
+   speed forced 40gfull
    channel-group 3 mode active
 !
 interface Management1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3A.cfg
@@ -284,11 +284,13 @@ interface Ethernet4
 interface Ethernet5
    description MLAG_PEER_DC1-SVC3B_Ethernet5
    no shutdown
+   speed 100g
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-SVC3B_Ethernet6
    no shutdown
+   speed 100g
    channel-group 5 mode active
 !
 interface Ethernet7

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3B.cfg
@@ -276,11 +276,13 @@ interface Ethernet4
 interface Ethernet5
    description MLAG_PEER_DC1-SVC3A_Ethernet5
    no shutdown
+   speed 100g
    channel-group 5 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-SVC3A_Ethernet6
    no shutdown
+   speed 100g
    channel-group 5 mode active
 !
 interface Ethernet7

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -122,6 +122,7 @@ ethernet_interfaces:
     channel_group:
       id: 3
       mode: active
+    speed: forced 40gfull
   Ethernet4:
     peer: DC1-L2LEAF1B
     peer_interface: Ethernet4
@@ -132,6 +133,7 @@ ethernet_interfaces:
     channel_group:
       id: 3
       mode: active
+    speed: forced 40gfull
   Ethernet1:
     peer: DC1-LEAF2A
     peer_interface: Ethernet7

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF1B.yml
@@ -122,6 +122,7 @@ ethernet_interfaces:
     channel_group:
       id: 3
       mode: active
+    speed: forced 40gfull
   Ethernet4:
     peer: DC1-L2LEAF1A
     peer_interface: Ethernet4
@@ -132,6 +133,7 @@ ethernet_interfaces:
     channel_group:
       id: 3
       mode: active
+    speed: forced 40gfull
   Ethernet1:
     peer: DC1-LEAF2A
     peer_interface: Ethernet8

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
@@ -880,6 +880,7 @@ ethernet_interfaces:
     channel_group:
       id: 5
       mode: active
+    speed: 100g
   Ethernet6:
     peer: DC1-SVC3B
     peer_interface: Ethernet6
@@ -890,6 +891,7 @@ ethernet_interfaces:
     channel_group:
       id: 5
       mode: active
+    speed: 100g
   Ethernet1:
     peer: DC1-SPINE1
     peer_interface: Ethernet4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
@@ -873,6 +873,7 @@ ethernet_interfaces:
     channel_group:
       id: 5
       mode: active
+    speed: 100g
   Ethernet6:
     peer: DC1-SVC3A
     peer_interface: Ethernet6
@@ -883,6 +884,7 @@ ethernet_interfaces:
     channel_group:
       id: 5
       mode: active
+    speed: 100g
   Ethernet1:
     peer: DC1-SPINE1
     peer_interface: Ethernet5

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_FABRIC.yml
@@ -64,6 +64,7 @@ l3leaf:
     platform: 7280R
     bgp_as: 65101
     mlag_interfaces: [ Ethernet5, Ethernet6 ]
+    mlag_interfaces_speed: 100g
     mlag_peer_l3_vlan: 4090
     mlag_peer_vlan: 4092
     spanning_tree_mode: mstp
@@ -175,6 +176,7 @@ l2leaf:
     mlag_peer_ipv4_pool: 10.255.252.0/24
   node_groups:
     DC1_L2LEAF1:
+      mlag_interfaces_speed: forced 40gfull
       uplink_switches: [ DC1-LEAF2A, DC1-LEAF2B ]
       short_esi: 0808:0707:0606
       filter:

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-topology.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-topology.md
@@ -287,6 +287,10 @@ defaults <- node_group <- node_group.node <- node
     # MLAG interfaces (list) | Required when MLAG leafs present in topology.
     mlag_interfaces: [ < ethernet_interface_3 >, < ethernet_interface_4 > ]
 
+    # MLAG interfaces speed | Optional and depends on mlag_interfaces to be defined
+    # Can be defined at multiple levels -> defaults or node_groups or nodes
+    mlag_interfaces_speed: < interface_speed | forced interface_speed | auto interface_speed >
+
     # Underlay L3 peering SVI interface id
     # If set to false or the same vlan as mlag_peer_vlan the mlag_peer_vlan will be used for L3 peering.
     mlag_peer_l3_vlan: < 0-4094 | false | default -> 4093 >

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-topology.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-topology.md
@@ -288,7 +288,6 @@ defaults <- node_group <- node_group.node <- node
     mlag_interfaces: [ < ethernet_interface_3 >, < ethernet_interface_4 > ]
 
     # MLAG interfaces speed | Optional and depends on mlag_interfaces to be defined
-    # Can be defined at multiple levels -> defaults or node_groups or nodes
     mlag_interfaces_speed: < interface_speed | forced interface_speed | auto interface_speed >
 
     # Underlay L3 peering SVI interface id

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/facts/switch/switch.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/facts/switch/switch.j2
@@ -198,8 +198,13 @@ switch:
 {# switch.mlag_dual_primary_detection #}
   mlag_dual_primary_detection: {{ switch_data.combined.mlag_dual_primary_detection | arista.avd.default(false) }}
 
-{# switch.mlag_dual_primary_detection #}
+{# switch.mlag_interfaces #}
   mlag_interfaces: {{ switch_data.combined.mlag_interfaces | arista.avd.default() }}
+
+{# switch.mlag_interfaces_speed #}
+{%     if switch_data.combined.mlag_interfaces_speed is arista.avd.defined %}
+  mlag_interfaces_speed: {{ switch_data.combined.mlag_interfaces_speed }}
+{%     endif %}
 
 {# switch.mlag_l3 #}
 {# switch.mlag_peer_l3_vlan #}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/mlag/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/mlag/ethernet-interfaces.j2
@@ -12,5 +12,8 @@ ethernet_interfaces:
     channel_group:
       id: {{ switch.mlag_interfaces[0] | regex_findall("\d") | join }}
       mode: active
+{%         if switch.mlag_interfaces_speed is arista.avd.defined %}
+    speed: {{ switch.mlag_interfaces_speed }}
+{%         endif %}
 {%     endfor %}
 {% endif %}


### PR DESCRIPTION
## Change Summary

Knob mlag_interfaces_speed is added to support mlag interfaces speed in eos_designs

## Related Issue(s)

Fixes #1328 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->
The knob ```mlag_interfaces_speed: < interface_speed | forced interface_speed | auto interface_speed >``` can be used with in <node_type_keys> at different levels (defaults or node_groups or nodes) with the last one having higher precedence.

## How to test
Molecule

<!--- Please describe in detail how you tested your changes. -->
Molecule eos_designs_unit_tests is updated

<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code has been rebased from devel before I start
- [ x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ x] My change requires a change to the documentation and documentation have been updated accordingly.
- [ x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
