### PR TITLE
Feat(eos_designs): Add support for network_services_keys

### DIFF
--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/inventory/group_vars/DC1_TENANTS_NETWORKS.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/inventory/group_vars/DC1_TENANTS_NETWORKS.yml
@@ -1,7 +1,10 @@
 # DC1 Tenants Networks
 # Documentation of Tenant specific information - Vlans/VRFs
 
-tenants:
+network_services_keys:
+  - name: tenant_group1
+
+tenant_group1:
   fake_tenant:
     mac_vrf_vni_base: 20000
     vrfs:

--- a/ansible_collections/arista/avd/roles/eos_designs/defaults/main/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/defaults/main/main.yml
@@ -131,6 +131,9 @@ platform_settings:
 
 connected_endpoints_keys: "{{ default_connected_endpoints_keys[design.type] }}"
 
+network_services_keys:
+  - name: tenants
+
 #custom_structured_configuration_prefix allows the user to customize the prefix for Custom Structured Configuration variables.
 custom_structured_configuration_prefix: custom_structured_configuration_
 custom_structured_configuration_list_merge: 'replace'

--- a/ansible_collections/arista/avd/roles/eos_designs/defaults/main/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/defaults/main/main.yml
@@ -138,7 +138,6 @@ network_services_keys:
 custom_structured_configuration_prefix: custom_structured_configuration_
 custom_structured_configuration_list_merge: 'replace'
 
-
 node_type_keys: "{{ default_node_type_keys[design.type] }}"
 
 templates: "{{ default_templates[design.type] }}"

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
@@ -9,6 +9,24 @@
 
 ## Variables and Options
 
+### Tenants Keys
+
+```yaml
+# Define network services keys, to define grouping of network services.
+# This provides the ability to define various keys of your choice to better organize/group your data.
+# This should be defined in top level group_var for the fabric.
+network_services_keys:
+  - name: < key_1 >
+  - name: < key_2 >
+```
+
+```yaml
+# Example
+# The below key/pair values are the role defaults.
+network_services_keys:
+  - name: tenants
+```
+
 ```yaml
 # On mlag leafs, an SVI interface is defined per vrf, to establish iBGP peering. | Required (when mlag leafs in topology)
 # The SVI id will be derived from the base vlan defined: mlag_ibgp_peering_vrfs.base_vlan + (vrf_id or vrf_vni) - 1
@@ -75,10 +93,9 @@ svi_profiles:
         source_interface: < interface-name >
         source_vrf: < VRF to originate DHCP relay packets to DHCP server >
 
-# Dictionary of tenants, to define network services: L3 VRFs and L2 VLANS.
-
-tenants:
-
+# Dictionary of network services: L3 VRFs and L2 VLANS.
+# The network service key from network_services_keys
+< network_services_keys.key_1 >:
   # Specify a tenant name. | Required
   # Tenant provide a construct to group L3 VRFs and L2 VLANs.
   # Networks services can be filtered by tenant name.
@@ -436,7 +453,37 @@ tenants:
         # Activate or deactivate IGMP snooping | Optional, default is true
         igmp_snooping_enabled: < true | false >
 
-  < tenant_a >:
+  < tenant_b >:
+    mac_vrf_vni_base: < 10000-16770000 >
+    vrfs:
+      < tenant_b_vrf_1 >:
+        vrf_vni: < 1-1024 >
+        vtep_diagnostic:
+          loopback: < 2-2100 >
+          loopback_ip_range: < IPv4_address/Mask >
+        svis:
+          < 1-4096 >:
+            name: < description >
+            tags: [ < tag_1 >, < tag_2 > ]
+            enabled: < true | false >
+            ip_address_virtual: < IPv4_address/Mask >
+          < 1-4096 >:
+            vni_override: < 1-16777215 >
+            name: < description >
+            tags: [ < tag_1 >, < tag_2 > ]
+            enabled: < true | false >
+            ip_address_virtual: < IPv4_address/Mask >
+    l2vlans:
+      < 1-4096 >:
+        vni_override: < 1-16777215 >
+        name: < description >
+        tags: [ < tag_1 >, < tag_2 > ]
+      < 1-4096 >:
+        name: < description >
+        tags: [ < tag_1 >, < tag_2 > ]
+
+< network_services_keys.key_2 >:
+  < tenant_c >:
     mac_vrf_vni_base: < 10000-16770000 >
     vrfs:
       < tenant_b_vrf_1 >:
@@ -472,7 +519,10 @@ tenants:
 # mlag_ibgp_peering_vrfs:
 #   base_vlan: 3000
 
-tenants:
+network_services_keys:
+  - name: dc1_tenants
+
+dc1_tenants:
   Tenant_A:
     mac_vrf_vni_base: 10000
     vrfs:

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/facts/switch/switch.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/facts/switch/switch.j2
@@ -446,61 +446,64 @@ switch:
 {% if switch.network_services_l2 is arista.avd.defined(true) or
       switch.network_services_l3 is arista.avd.defined(true) or
       switch.network_services_l1 is arista.avd.defined(true) %}
-{%     set tenants = dict() %}
-{%     include 'network_services/logic.j2' %}
 {%     set leaf = namespace() %}
 {%     set leaf.vlans = []  %}
 {%     set leaf.tenants = {} %}
 {%     set leaf.pseudowires = [] %}
-{%     for tenant in tenants | arista.avd.natural_sort if tenant in switch_filter_tenants or "all" in switch_filter_tenants %}
-{%         set add_vrfs = {} %}
-{%         for vrf in tenants[tenant].vrfs | arista.avd.natural_sort %}
-{%             set add_svis = [] %}
-{%             for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort %}
-{%                 for svi_tag in tenants[tenant].vrfs[vrf].svis[svi].tags | arista.avd.natural_sort %}
-{%                     if svi_tag in switch_filter_tags or switch_data.group is arista.avd.defined(svi_tag) or "all" in switch_filter_tags %}
-{%                         do add_svis.append(svi) %}
-{%                         do leaf.vlans.append(svi | int) %}
-{%                         break %}
-{%                     endif %}
-{%                 endfor %}
-{%             endfor %}
+{%     set tmp_hostvars = hostvars[inventory_hostname] %}
+{%     for network_services_key in network_services_keys | arista.avd.natural_sort('name') %}
+{%         if network_services_key.name is arista.avd.defined and tmp_hostvars[network_services_key.name] is arista.avd.defined %}
+{%             for tenant in tmp_hostvars[network_services_key.name] | arista.avd.convert_dicts | arista.avd.natural_sort('name') if tenant.name in switch_filter_tenants or "all" in switch_filter_tenants %}
+{%                 set add_vrfs = {} %}
+{%                 for vrf in tenant.vrfs | arista.avd.convert_dicts | arista.avd.natural_sort('name') %}
+{%                     set add_svis = [] %}
+{%                     for svi in vrf.svis | arista.avd.convert_dicts('id') | arista.avd.natural_sort('id') %}
+{%                         for svi_tag in svi.tags | arista.avd.natural_sort %}
+{%                             if svi_tag in switch_filter_tags or switch_data.group is arista.avd.defined(svi_tag) or "all" in switch_filter_tags %}
+{%                                 do add_svis.append(svi.id) %}
+{%                                 do leaf.vlans.append(svi.id | int) %}
+{%                                 break %}
+{%                             endif %}
+{%                         endfor %}
+{%                     endfor %}
 {# Append VRF if we found SVIs #}
-{%             if add_svis | length > 0 %}
-{%                 do add_vrfs.update({ vrf: {"svis": add_svis} }) %}
+{%                     if add_svis | length > 0 %}
+{%                         do add_vrfs.update({ vrf.name: {"svis": add_svis} }) %}
 {# Or Append VRF for tenants set in "always_include_vrfs_in_tenants" is set #}
-{%             elif switch_always_include_vrfs_in_tenants is arista.avd.contains([tenant, 'all']) %}
-{%                 do add_vrfs.update({ vrf: {} }) %}
-{%             else %}
+{%                     elif switch_always_include_vrfs_in_tenants is arista.avd.contains([tenant.name, 'all']) %}
+{%                         do add_vrfs.update({ vrf.name: {} }) %}
+{%                     else %}
 {# Or Append VRF if there is a BGP neighbor defined under tenants for this switch #}
-{%                 for l3_interface in tenants[tenant].vrfs[vrf].l3_interfaces | arista.avd.natural_sort %}
-{%                     if l3_interface.nodes is arista.avd.defined and l3_interface.ip_addresses is arista.avd.defined and l3_interface.interfaces is arista.avd.defined and inventory_hostname in l3_interface.nodes %}
-{%                         do add_vrfs.update({ vrf: {} }) %}
+{%                         for l3_interface in vrf.l3_interfaces | arista.avd.natural_sort %}
+{%                             if l3_interface.nodes is arista.avd.defined and l3_interface.ip_addresses is arista.avd.defined and l3_interface.interfaces is arista.avd.defined and inventory_hostname in l3_interface.nodes %}
+{%                                 do add_vrfs.update({ vrf.name: {} }) %}
+{%                             endif %}
+{%                         endfor %}
 {%                     endif %}
 {%                 endfor %}
-{%             endif %}
-{%         endfor %}
-{%         set add_l2vlans = [] %}
-{%         for l2vlan in tenants[tenant].l2vlans | arista.avd.natural_sort %}
-{%             for vlan_tag in tenants[tenant].l2vlans[l2vlan].tags | arista.avd.natural_sort %}
-{%                 if vlan_tag in switch_filter_tags or switch_data.group is arista.avd.defined(vlan_tag) or "all" in switch_filter_tags %}
-{%                     do add_l2vlans.append(l2vlan) %}
-{%                     do leaf.vlans.append(l2vlan | int) %}
-{%                     break %}
+{%                 set add_l2vlans = [] %}
+{%                 for l2vlan in tenant.l2vlans | arista.avd.convert_dicts('id') | arista.avd.natural_sort('id') %}
+{%                     for vlan_tag in l2vlan.tags | arista.avd.natural_sort %}
+{%                         if vlan_tag in switch_filter_tags or switch_data.group is arista.avd.defined(vlan_tag) or "all" in switch_filter_tags %}
+{%                             do add_l2vlans.append(l2vlan.id) %}
+{%                             do leaf.vlans.append(l2vlan.id | int) %}
+{%                             break %}
+{%                         endif %}
+{%                     endfor %}
+{%                 endfor %}
+{%                 set add_point_to_point_services = [] %}
+{%                 for point_to_point_service in tenant.point_to_point_services | arista.avd.natural_sort %}
+{%                     for endpoint in point_to_point_service.endpoints | arista.avd.default([]) %}
+{%                         if inventory_hostname in endpoint.nodes | arista.avd.default([]) %}
+{%                             do add_point_to_point_services.append(point_to_point_service) %}
+{%                             break %}
+{%                         endif %}
+{%                     endfor %}
+{%                 endfor %}
+{%                 if add_vrfs | length > 0 or add_l2vlans | length > 0 or add_point_to_point_services | length > 0 %}
+{%                     do leaf.tenants.update({ tenant.name: {"vrfs": add_vrfs, "l2vlans": add_l2vlans, "point_to_point_service": add_point_to_point_services} }) %}
 {%                 endif %}
 {%             endfor %}
-{%         endfor %}
-{%         set add_point_to_point_services = [] %}
-{%         for point_to_point_service in tenants[tenant].point_to_point_services | arista.avd.natural_sort %}
-{%             for endpoint in point_to_point_service.endpoints | arista.avd.default([]) %}
-{%                 if inventory_hostname in endpoint.nodes | arista.avd.default([]) %}
-{%                     do add_point_to_point_services.append(point_to_point_service) %}
-{%                     break %}
-{%                 endif %}
-{%             endfor %}
-{%         endfor %}
-{%         if add_vrfs | length > 0 or add_l2vlans | length > 0 or add_point_to_point_services | length > 0 %}
-{%             do leaf.tenants.update({ tenant: {"vrfs": add_vrfs, "l2vlans": add_l2vlans, "point_to_point_service": add_point_to_point_services} }) %}
 {%         endif %}
 {%     endfor %}
 

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/facts/switch/switch.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/facts/switch/switch.j2
@@ -446,6 +446,8 @@ switch:
 {% if switch.network_services_l2 is arista.avd.defined(true) or
       switch.network_services_l3 is arista.avd.defined(true) or
       switch.network_services_l1 is arista.avd.defined(true) %}
+{%     set tenants = dict() %}
+{%     include 'network_services/logic.j2' %}
 {%     set leaf = namespace() %}
 {%     set leaf.vlans = []  %}
 {%     set leaf.tenants = {} %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/logic.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/logic.j2
@@ -1,55 +1,48 @@
-
 {% set tmp_tenants = [] %}
+{% set tmp_hostvars = hostvars[inventory_hostname] %}
+{% for network_services_key in network_services_keys | arista.avd.natural_sort('name') %}
+{%     if network_services_key.name is arista.avd.defined and tmp_hostvars[network_services_key.name] is arista.avd.defined %}
 {# tenants #}
-{% for tenant in tenants | arista.avd.convert_dicts | arista.avd.natural_sort('name') %}
-{%     if tenant.name in switch.tenants | arista.avd.default([]) %}
-{%         set switch_tenant = switch.tenants[tenant.name] %}
-{#         vrfs #}
-{%         set tmp_vrfs = [] %}
-{%         for vrf in tenant.vrfs | arista.avd.convert_dicts | arista.avd.natural_sort('name') %}
-{%             if vrf.name in switch_tenant.vrfs | arista.avd.default([]) %}
-{%                 set switch_vrf = switch_tenant.vrfs[vrf.name] %}
-{#                 svis & bgp_peers #}
-{%                 set tmp_svis = [] %}
-{%                 for svi in vrf.svis | arista.avd.convert_dicts('id') | arista.avd.natural_sort('id') %}
-{%                     if svi.id in switch_vrf.svis | arista.avd.default([]) %}
-{%                         do tmp_svis.append(svi) %}
+{%         for tenant in tmp_hostvars[network_services_key.name] | arista.avd.convert_dicts | arista.avd.natural_sort('name') %}
+{%             if tenant.name in switch.tenants | arista.avd.default([]) %}
+{%                 set switch_tenant = switch.tenants[tenant.name] %}
+{#                 vrfs #}
+{%                 set tmp_vrfs = [] %}
+{%                 for vrf in tenant.vrfs | arista.avd.convert_dicts | arista.avd.natural_sort('name') %}
+{%                     if vrf.name in switch_tenant.vrfs | arista.avd.default([]) %}
+{%                         set switch_vrf = switch_tenant.vrfs[vrf.name] %}
+{#                         svis & bgp_peers #}
+{%                         set tmp_svis = [] %}
+{%                         for svi in vrf.svis | arista.avd.convert_dicts('id') | arista.avd.natural_sort('id') %}
+{%                             if svi.id in switch_vrf.svis | arista.avd.default([]) %}
+{%                                 do tmp_svis.append(svi) %}
+{%                             endif %}
+{%                         endfor %}
+{%                         do vrf.update({'svis': tmp_svis, 'bgp_peers': vrf.bgp_peers | arista.avd.convert_dicts | arista.avd.natural_sort('name')}) %}
+{%                         do tmp_vrfs.append(vrf) %}
 {%                     endif %}
 {%                 endfor %}
-{%                 do vrf.update({'svis': tmp_svis, 'bgp_peers': vrf.bgp_peers | arista.avd.convert_dicts | arista.avd.natural_sort('name')}) %}
-{%                 do tmp_vrfs.append(vrf) %}
+{#                 l2vlans #}
+{%                 set tmp_l2vlans = [] %}
+{%                 for l2vlan in tenant.l2vlans | arista.avd.convert_dicts('id') | arista.avd.natural_sort('id') %}
+{%                    if l2vlan.id in switch_tenant.l2vlans | arista.avd.default([]) %}
+{%                         do tmp_l2vlans.append(l2vlan) %}
+{%                     endif %}
+{%                 endfor %}
+{#                 point_to_point_services #}
+{%                 set tmp_point_to_point_services = [] %}
+{%                 for point_to_point_service in tenant.point_to_point_services | arista.avd.natural_sort('name') %}
+{%                     for endpoint in point_to_point_service.endpoints | arista.avd.default([]) %}
+{%                         if inventory_hostname in endpoint.nodes | arista.avd.default([]) %}
+{%                             do tmp_point_to_point_services.append(point_to_point_service) %}
+{%                             break %}
+{%                         endif %}
+{%                     endfor %}
+{%                 endfor %}
+{%                 do tenant.update({'vrfs': tmp_vrfs, 'l2vlans': tmp_l2vlans, 'point_to_point_services': tmp_point_to_point_services}) %}
+{%                 do tmp_tenants.append(tenant) %}
 {%             endif %}
 {%         endfor %}
-{#         l2vlans #}
-{%         set tmp_l2vlans = [] %}
-{%         for l2vlan in tenant.l2vlans | arista.avd.convert_dicts('id') | arista.avd.natural_sort('id') %}
-{%             if l2vlan.id in switch_tenant.l2vlans | arista.avd.default([]) %}
-{%                 do tmp_l2vlans.append(l2vlan) %}
-{%             endif %}
-{%         endfor %}
-{#         point_to_point_services #}
-{%         set tmp_point_to_point_services = [] %}
-{%         for point_to_point_service in tenant.point_to_point_services | arista.avd.natural_sort('name') %}
-{%             for endpoint in point_to_point_service.endpoints | arista.avd.default([]) %}
-{%                 if inventory_hostname in endpoint.nodes | arista.avd.default([]) %}
-{%                     do tmp_point_to_point_services.append(point_to_point_service) %}
-{%                     break %}
-{%                 endif %}
-{%             endfor %}
-{%         endfor %}
-{%         do tenant.update({'vrfs': tmp_vrfs, 'l2vlans': tmp_l2vlans, 'point_to_point_services': tmp_point_to_point_services}) %}
-{%         do tmp_tenants.append(tenant) %}
 {%     endif %}
 {% endfor %}
 {% set network_services_data.tenants = tmp_tenants %}
-{% for tenants_key in tenants_keys | arista.avd.natural_sort %}
-{%     if hostvars[inventory_hostname][tenants_key.name] is arista.avd.defined %}
-{%         for tenant in hostvars[inventory_hostname][tenants_key.name] | arista.avd.natural_sort %}
-{%             do tenants.update({tenant: hostvars[inventory_hostname][tenants_key.name][tenant]}) %}
-{% for network_services_key in network_services_keys | arista.avd.natural_sort %}
-{%     if hostvars[inventory_hostname][network_services_key.name] is arista.avd.defined %}
-{%         for tenant in hostvars[inventory_hostname][network_services_key.name] | arista.avd.natural_sort %}
-{%             do tenants.update({tenant: hostvars[inventory_hostname][network_services_key.name][tenant]}) %}
-{%         endfor %}
-{%     endif %}
-{% endfor %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/logic.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/logic.j2
@@ -42,3 +42,14 @@
 {%     endif %}
 {% endfor %}
 {% set network_services_data.tenants = tmp_tenants %}
+{% for tenants_key in tenants_keys | arista.avd.natural_sort %}
+{%     if hostvars[inventory_hostname][tenants_key.name] is arista.avd.defined %}
+{%         for tenant in hostvars[inventory_hostname][tenants_key.name] | arista.avd.natural_sort %}
+{%             do tenants.update({tenant: hostvars[inventory_hostname][tenants_key.name][tenant]}) %}
+{% for network_services_key in network_services_keys | arista.avd.natural_sort %}
+{%     if hostvars[inventory_hostname][network_services_key.name] is arista.avd.defined %}
+{%         for tenant in hostvars[inventory_hostname][network_services_key.name] | arista.avd.natural_sort %}
+{%             do tenants.update({tenant: hostvars[inventory_hostname][network_services_key.name][tenant]}) %}
+{%         endfor %}
+{%     endif %}
+{% endfor %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/logic.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/logic.j2
@@ -25,7 +25,7 @@
 {#                 l2vlans #}
 {%                 set tmp_l2vlans = [] %}
 {%                 for l2vlan in tenant.l2vlans | arista.avd.convert_dicts('id') | arista.avd.natural_sort('id') %}
-{%                    if l2vlan.id in switch_tenant.l2vlans | arista.avd.default([]) %}
+{%                     if l2vlan.id in switch_tenant.l2vlans | arista.avd.default([]) %}
 {%                         do tmp_l2vlans.append(l2vlan) %}
 {%                     endif %}
 {%                 endfor %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/main.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/main.j2
@@ -12,13 +12,6 @@
 
 {% endif %}
 
-{% if switch.vtep is arista.avd.defined(true) or
-      switch.network_services_l2 is arista.avd.defined(true) or
-      switch.network_services_l3 is arista.avd.defined(true) %}
-{%     set tenants = dict() %}
-{%     include 'network_services/logic.j2' %}
-{% endif %}
-
 {# L2 #}
 {% if switch.network_services_l2 is arista.avd.defined(true) %}
 {%     include 'network_services/vlans.j2' %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/main.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/main.j2
@@ -12,6 +12,13 @@
 
 {% endif %}
 
+{% if switch.vtep is arista.avd.defined(true) or
+      switch.network_services_l2 is arista.avd.defined(true) or
+      switch.network_services_l3 is arista.avd.defined(true) %}
+{%     set tenants = dict() %}
+{%     include 'network_services/logic.j2' %}
+{% endif %}
+
 {# L2 #}
 {% if switch.network_services_l2 is arista.avd.defined(true) %}
 {%     include 'network_services/vlans.j2' %}


### PR DESCRIPTION
## Change Summary

Add support for network_services_keys

Switches from using the static `tenants` key for defining network services to a user-defined key name. We keep `tenants` as the default key name.

This makes the behavior of tenants similar to how connected_endpoints can be defined and also allows splitting each tenant into a separate file rather than keeping them all in one.

## Related Issue(s)

Fixes #1021

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->
```yaml
network_services_keys:
  - name: <key_1>
  - name: <key_2>
# default
network_services_keys:
  - name: "tenants"
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been rebased from devel before I start
- [X] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [X] My change requires a change to the documentation and documentation have been updated accordingly.
- [X] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
