### PR TITLE
Feat(eos_cli_config_gen): Add AAA Authentication Policy Lockout

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/aaa.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/aaa.md
@@ -146,6 +146,8 @@ AAA Authentication on-success log has been enabled
 
 Policy local allow-nopassword-remote-login has been enabled.
 
+Policy lockout has been enabled. After **3** failed login attempts within **900** minutes, you'll be locked out for **300** minutes.
+
 ### AAA Authentication Device Configuration
 
 ```eos
@@ -157,6 +159,7 @@ aaa authentication dot1x default DOT1X default group
 aaa authentication policy on-failure log
 aaa authentication policy on-success log
 aaa authentication policy local allow-nopassword-remote-login
+aaa authentication policy lockout failure 3 window 900 duration 300
 !
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/aaa.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/aaa.cfg
@@ -23,6 +23,7 @@ aaa authentication dot1x default DOT1X default group
 aaa authentication policy on-failure log
 aaa authentication policy on-success log
 aaa authentication policy local allow-nopassword-remote-login
+aaa authentication policy lockout failure 3 window 900 duration 300
 !
 aaa authorization exec default group CUST local
 aaa authorization serial-console

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/aaa.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/aaa.yml
@@ -47,6 +47,10 @@ aaa_authentication:
     on_success_log: true
     local:
       allow_nopassword: true
+    lockout:
+      failure: 3
+      duration: 300
+      window: 900
 
 ## AAA Authorization
 aaa_authorization:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -276,6 +276,10 @@ aaa_authentication:
     on_success_log: < true | false >
     local:
       allow_nopassword: < false | true >
+    lockout:
+      failure: < 1-255 >
+      duration: < 1-4294967295 >
+      window: < 1-4294967295 >
 ```
 
 #### AAA Authorization

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/aaa-authentication.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/aaa-authentication.j2
@@ -27,6 +27,10 @@ AAA Authentication on-success log has been enabled
 Policy local allow-nopassword-remote-login has been enabled.
 {%             endif %}
 {%         endif %}
+{%         if aaa_authentication.policies.lockout.failure is arista.avd.defined and aaa_authentication.policies.lockout.duration is arista.avd.defined %}
+
+Policy lockout has been enabled. After **{{ aaa_authentication.policies.lockout.failure }}** failed login attempts within **{{ aaa_authentication.policies.lockout.window | arista.avd.default('1440') }}** minutes, you'll be locked out for **{{ aaa_authentication.policies.lockout.duration }}** minutes.
+{%         endif %}
 {%     endif %}
 
 ### AAA Authentication Device Configuration

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/aaa-authentication.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/aaa-authentication.j2
@@ -23,10 +23,11 @@ aaa authentication policy on-success log
 aaa authentication policy local allow-nopassword-remote-login
 {%     endif %}
 {%     if aaa_authentication.policies.lockout.failure is arista.avd.defined and aaa_authentication.policies.lockout.duration is arista.avd.defined %}
-{%         set lockout_cli = "aaa authentication policy lockout failure " ~ aaa_authentication.policies.lockout.failure ~ " duration " ~ aaa_authentication.policies.lockout.duration %}
+{%         set lockout_cli = "aaa authentication policy lockout failure " ~ aaa_authentication.policies.lockout.failure %}
 {%         if aaa_authentication.policies.lockout.window is arista.avd.defined %}
-{%             set lockout_cli = "aaa authentication policy lockout failure " ~ aaa_authentication.policies.lockout.failure ~ " window " ~ aaa_authentication.policies.lockout.window ~ " duration " ~ aaa_authentication.policies.lockout.duration %}
+{%             set lockout_cli = lockout_cli ~ " window " ~ aaa_authentication.policies.lockout.window %}
 {%         endif %}
+{%         set lockout_cli = lockout_cli ~ " duration " ~ aaa_authentication.policies.lockout.duration %}
 {{ lockout_cli }}
 {%     endif %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/aaa-authentication.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/aaa-authentication.j2
@@ -22,4 +22,11 @@ aaa authentication policy on-success log
 {%     if aaa_authentication.policies.local.allow_nopassword is arista.avd.defined(true) %}
 aaa authentication policy local allow-nopassword-remote-login
 {%     endif %}
+{%     if aaa_authentication.policies.lockout.failure is arista.avd.defined and aaa_authentication.policies.lockout.duration is arista.avd.defined %}
+{%         set lockout_cli = "aaa authentication policy lockout failure " ~ aaa_authentication.policies.lockout.failure ~ " duration " ~ aaa_authentication.policies.lockout.duration %}
+{%         if aaa_authentication.policies.lockout.window is arista.avd.defined %}
+{%             set lockout_cli = "aaa authentication policy lockout failure " ~ aaa_authentication.policies.lockout.failure ~ " window " ~ aaa_authentication.policies.lockout.window ~ " duration " ~ aaa_authentication.policies.lockout.duration %}
+{%         endif %}
+{{ lockout_cli }}
+{%     endif %}
 {% endif %}


### PR DESCRIPTION
## Change Summary

Added AAA Auth Policy Lockout option

## Related Issue(s)

Fixes #1345

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
added policy lockout options

```
aaa_authentication:
  login:
    default: < group group_name | local | none > < group group_name | local | none >
    console: < group group_name | local | none > < group group_name | local | none >
  enable:
    default: < group group_name | local | none > < group group_name | local | none >
  dot1x:
    default: < group group_name >
  policies:
    on_failure_log: < true | false >
    on_success_log: < true | false >
    local:
      allow_nopassword: < false | true >
    lockout:
      failure: < 1-255 >
      duration: < 1-4294967295 >
      window: < 1-4294967295 >
```

## How to test
molecule run

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
