### PR TITLE
Refactor(eos_designs): Optimize fabric documentation for speed

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_designs/templates/documentation/fabric-documentation.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/documentation/fabric-documentation.j2
@@ -6,61 +6,63 @@
 {% set assigned_ip_addresses = [] %}
 {% set interfaces_done = [] %}
 {% for node in groups[fabric_name] | arista.avd.natural_sort %}
-{%     if hostvars[node].type | arista.avd.default('undefined') in node_type_keys | dict2items | map(attribute='value.type') | list %}
+{%     set node_hostvars = hostvars[node] %}
+{%     if node_hostvars.type | arista.avd.default('undefined') in node_type_keys | dict2items | map(attribute='value.type') | list %}
 {# Populate network summaries #}
-{%         do uplink_ipv4_pools.append(hostvars[node].switch.uplink_ipv4_pool | arista.avd.default()) %}
-{%         do loopback_ipv4_pools.append(hostvars[node].switch.loopback_ipv4_pool | arista.avd.default()) %}
-{%         do vtep_loopback_ipv4_pools.append(hostvars[node].switch.vtep_loopback_ipv4_pool | arista.avd.default()) %}
+{%         do uplink_ipv4_pools.append(node_hostvars.switch.uplink_ipv4_pool | arista.avd.default()) %}
+{%         do loopback_ipv4_pools.append(node_hostvars.switch.loopback_ipv4_pool | arista.avd.default()) %}
+{%         do vtep_loopback_ipv4_pools.append(node_hostvars.switch.vtep_loopback_ipv4_pool | arista.avd.default()) %}
 {# Populate fabric_switch #}
 {%         set fabric_switch = namespace() %}
-{%         set fabric_switch.pod = hostvars[node].pod_name | arista.avd.default(hostvars[node].dc_name, fabric_name) %}
-{%         set fabric_switch.type = hostvars[node].type %}
+{%         set fabric_switch.pod = node_hostvars.pod_name | arista.avd.default(node_hostvars.dc_name, fabric_name) %}
+{%         set fabric_switch.type = node_hostvars.type %}
 {%         set fabric_switch.node = node %}
-{%         set fabric_switch.mgmt_ip = hostvars[node].switch.mgmt_ip | arista.avd.default('-') %}
-{%         do assigned_ip_addresses.append(hostvars[node].switch.mgmt_ip) if hostvars[node].switch.mgmt_ip is arista.avd.defined %}
-{%         set fabric_switch.inband_management_interface = hostvars[node].switch.inband_management_interface | arista.avd.default(none) %}
-{%         set fabric_switch.inband_management_ip = hostvars[node].switch.inband_management_ip | arista.avd.default(none) %}
-{%         set fabric_switch.platform = hostvars[node].switch.platform | arista.avd.default('-') %}
-{%         set fabric_switch.provisioned = 'Not Available' if hostvars[node].is_deployed is arista.avd.defined(false) else 'Provisioned' %}
-{%         if hostvars[node].loopback_interfaces is arista.avd.defined and hostvars[node].loopback_interfaces.Loopback0 is arista.avd.defined %}
-{%             if hostvars[node].loopback_interfaces.Loopback0.ip_address is arista.avd.defined %}
-{%                 set fabric_switch.loopback0_ip_address = hostvars[node].loopback_interfaces.Loopback0.ip_address %}
+{%         set fabric_switch.mgmt_ip = node_hostvars.switch.mgmt_ip | arista.avd.default('-') %}
+{%         do assigned_ip_addresses.append(node_hostvars.switch.mgmt_ip) if node_hostvars.switch.mgmt_ip is arista.avd.defined %}
+{%         set fabric_switch.inband_management_interface = node_hostvars.switch.inband_management_interface | arista.avd.default(none) %}
+{%         set fabric_switch.inband_management_ip = node_hostvars.switch.inband_management_ip | arista.avd.default(none) %}
+{%         set fabric_switch.platform = node_hostvars.switch.platform | arista.avd.default('-') %}
+{%         set fabric_switch.provisioned = 'Not Available' if node_hostvars.is_deployed is arista.avd.defined(false) else 'Provisioned' %}
+{%         if node_hostvars.loopback_interfaces is arista.avd.defined and node_hostvars.loopback_interfaces.Loopback0 is arista.avd.defined %}
+{%             if node_hostvars.loopback_interfaces.Loopback0.ip_address is arista.avd.defined %}
+{%                 set fabric_switch.loopback0_ip_address = node_hostvars.loopback_interfaces.Loopback0.ip_address %}
 {%                 do assigned_ip_addresses.append(fabric_switch.loopback0_ip_address) %}
 {%             endif %}
 {%         endif %}
-{%         if hostvars[node].loopback_interfaces is arista.avd.defined and hostvars[node].loopback_interfaces.Loopback1 is arista.avd.defined %}
-{%             if hostvars[node].loopback_interfaces.Loopback1.ip_address is arista.avd.defined %}
-{%                 set fabric_switch.loopback1_ip_address = hostvars[node].loopback_interfaces.Loopback1.ip_address %}
+{%         if node_hostvars.loopback_interfaces is arista.avd.defined and node_hostvars.loopback_interfaces.Loopback1 is arista.avd.defined %}
+{%             if node_hostvars.loopback_interfaces.Loopback1.ip_address is arista.avd.defined %}
+{%                 set fabric_switch.loopback1_ip_address = node_hostvars.loopback_interfaces.Loopback1.ip_address %}
 {%                 do assigned_ip_addresses.append(fabric_switch.loopback1_ip_address) %}
 {%             endif %}
 {%         endif %}
-{%         if hostvars[node].router_isis is arista.avd.defined and hostvars[node].router_isis.net is arista.avd.defined %}
-{%             set fabric_switch.router_isis_net = hostvars[node].router_isis.net %}
+{%         if node_hostvars.router_isis is arista.avd.defined and node_hostvars.router_isis.net is arista.avd.defined %}
+{%             set fabric_switch.router_isis_net = node_hostvars.router_isis.net %}
 {%         endif %}
 {%         do fabric_switches.append(fabric_switch) %}
 {# Populate topology_links #}
-{%         for ethernet_interface in hostvars[node].ethernet_interfaces | arista.avd.natural_sort %}
-{%             if hostvars[node].ethernet_interfaces[ethernet_interface].peer_type | arista.avd.default('undefined') in node_type_keys | dict2items | map(attribute='value.type') | list + ['mlag_peer'] %}
+{%         for ethernet_interface in node_hostvars.ethernet_interfaces | arista.avd.natural_sort %}
+{%             if node_hostvars.ethernet_interfaces[ethernet_interface].peer_type | arista.avd.default('undefined') in node_type_keys | dict2items | map(attribute='value.type') | list + ['mlag_peer'] %}
 {%                 do interfaces_done.append(node ~ "," ~ ethernet_interface) %}
-{%                 set peer = hostvars[node].ethernet_interfaces[ethernet_interface].peer %}
-{%                 set peer_interface = hostvars[node].ethernet_interfaces[ethernet_interface].peer_interface %}
+{%                 set peer = node_hostvars.ethernet_interfaces[ethernet_interface].peer %}
+{%                 set peer_interface = node_hostvars.ethernet_interfaces[ethernet_interface].peer_interface %}
 {%                 if peer is arista.avd.defined and peer_interface is arista.avd.defined and peer ~ "," ~ peer_interface not in interfaces_done %}
 {%                     set topology_link = namespace() %}
-{%                     set topology_link.type = hostvars[node].type %}
+{%                     set topology_link.type = node_hostvars.type %}
 {%                     set topology_link.node = node %}
 {%                     set topology_link.node_interface = ethernet_interface %}
-{%                     set topology_link.node_ip_address = hostvars[node].ethernet_interfaces[ethernet_interface].ip_address %}
+{%                     set topology_link.node_ip_address = node_hostvars.ethernet_interfaces[ethernet_interface].ip_address %}
 {%                     if topology_link.node_ip_address is arista.avd.defined %}
 {%                         do assigned_ip_addresses.append(topology_link.node_ip_address) %}
 {%                     endif %}
-{%                     set topology_link.peer_type = hostvars[node].ethernet_interfaces[ethernet_interface].peer_type %}
+{%                     set topology_link.peer_type = node_hostvars.ethernet_interfaces[ethernet_interface].peer_type %}
 {%                     set topology_link.peer = peer %}
 {%                     set topology_link.peer_interface = peer_interface %}
 {%                     set topology_link.peer_ip_address = none %}
-{%                     if hostvars[peer] is arista.avd.defined and hostvars[peer].ethernet_interfaces is arista.avd.defined %}
-{%                         if hostvars[peer].ethernet_interfaces[peer_interface] is arista.avd.defined %}
-{%                             if hostvars[peer].ethernet_interfaces[peer_interface].ip_address is arista.avd.defined %}
-{%                                 set topology_link.peer_ip_address = hostvars[peer].ethernet_interfaces[peer_interface].ip_address %}
+{%                     set peer_hostvars = hostvars[peer] | arista.avd.default %}
+{%                     if peer_hostvars.ethernet_interfaces is arista.avd.defined %}
+{%                         if peer_hostvars.ethernet_interfaces[peer_interface] is arista.avd.defined %}
+{%                             if peer_hostvars.ethernet_interfaces[peer_interface].ip_address is arista.avd.defined %}
+{%                                 set topology_link.peer_ip_address = peer_hostvars.ethernet_interfaces[peer_interface].ip_address %}
 {%                                 do assigned_ip_addresses.append(topology_link.peer_ip_address) %}
 {%                             endif %}
 {%                         endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/documentation/fabric-p2p-links.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/documentation/fabric-p2p-links.j2
@@ -1,26 +1,28 @@
 Type, Node,Node Interface,Leaf IP Address,Peer Type,Peer Node,Peer Interface,Peer IP Address
 {% set interfaces_done = [] %}
 {% for node in groups[fabric_name] | arista.avd.natural_sort %}
-{%     if hostvars[node].type | arista.avd.default('undefined') in node_type_keys | dict2items | map(attribute='value.type') | list %}
-{%         for ethernet_interface in hostvars[node].ethernet_interfaces | arista.avd.natural_sort %}
-{%             if hostvars[node].ethernet_interfaces[ethernet_interface].type is arista.avd.defined('routed') %}
-{%                 if hostvars[node].ethernet_interfaces[ethernet_interface].peer_type | arista.avd.default('undefined') in node_type_keys | dict2items | map(attribute='value.type') | list %}
+{%     set node_hostvars = hostvars[node] %}
+{%     if node_hostvars.type | arista.avd.default('undefined') in node_type_keys | dict2items | map(attribute='value.type') | list %}
+{%         for ethernet_interface in node_hostvars.ethernet_interfaces | arista.avd.natural_sort %}
+{%             if node_hostvars.ethernet_interfaces[ethernet_interface].type is arista.avd.defined('routed') %}
+{%                 if node_hostvars.ethernet_interfaces[ethernet_interface].peer_type | arista.avd.default('undefined') in node_type_keys | dict2items | map(attribute='value.type') | list %}
 {%                     do interfaces_done.append(node ~ "," ~ ethernet_interface) %}
-{%                     set peer = hostvars[node].ethernet_interfaces[ethernet_interface].peer %}
-{%                     set peer_interface = hostvars[node].ethernet_interfaces[ethernet_interface].peer_interface %}
+{%                     set peer = node_hostvars.ethernet_interfaces[ethernet_interface].peer %}
+{%                     set peer_interface = node_hostvars.ethernet_interfaces[ethernet_interface].peer_interface %}
 {%                     if peer is arista.avd.defined and peer_interface is arista.avd.defined and peer ~ "," ~ peer_interface not in interfaces_done %}
 {%                         set csv_line = [] %}
-{%                         do csv_line.append(hostvars[node].type) %}
+{%                         do csv_line.append(node_hostvars.type) %}
 {%                         do csv_line.append(node) %}
 {%                         do csv_line.append(ethernet_interface) %}
-{%                         do csv_line.append(hostvars[node].ethernet_interfaces[ethernet_interface].ip_address | arista.avd.default("")) %}
-{%                         do csv_line.append(hostvars[node].ethernet_interfaces[ethernet_interface].peer_type) %}
+{%                         do csv_line.append(node_hostvars.ethernet_interfaces[ethernet_interface].ip_address | arista.avd.default("")) %}
+{%                         do csv_line.append(node_hostvars.ethernet_interfaces[ethernet_interface].peer_type) %}
 {%                         do csv_line.append(peer) %}
 {%                         do csv_line.append(peer_interface) %}
 {%                         set peer_ip_address = "" %}
-{%                         if hostvars[peer] is arista.avd.defined and hostvars[peer].ethernet_interfaces is arista.avd.defined %}
-{%                             if hostvars[peer].ethernet_interfaces[peer_interface] is arista.avd.defined %}
-{%                                set peer_ip_address = hostvars[peer].ethernet_interfaces[peer_interface].ip_address | arista.avd.default("") %}
+{%                         set peer_hostvars = hostvars[peer] | arista.avd.default %}
+{%                         if peer_hostvars.ethernet_interfaces is arista.avd.defined %}
+{%                             if peer_hostvars.ethernet_interfaces[peer_interface] is arista.avd.defined %}
+{%                                set peer_ip_address = peer_hostvars.ethernet_interfaces[peer_interface].ip_address | arista.avd.default("") %}
 {%                             endif %}
 {%                         endif %}
 {%                         do csv_line.append(peer_ip_address) %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/documentation/fabric-topology.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/documentation/fabric-topology.j2
@@ -1,14 +1,15 @@
 Node Type,Node,Node Interface,Peer Type,Peer,Peer Interface
 {% for node in groups[fabric_name] | arista.avd.natural_sort %}
-{%     if hostvars[node].type | arista.avd.default('undefined') in node_type_keys | dict2items | map(attribute='value.type') | list %}
-{%         for ethernet_interface in hostvars[node].ethernet_interfaces | arista.avd.natural_sort %}
+{%     set node_hostvars = hostvars[node] %}
+{%     if node_hostvars.type | arista.avd.default('undefined') in node_type_keys | dict2items | map(attribute='value.type') | list %}
+{%         for ethernet_interface in node_hostvars.ethernet_interfaces | arista.avd.natural_sort %}
 {%             set csv_line = [] %}
-{%             do csv_line.append(hostvars[node].type) %}
+{%             do csv_line.append(node_hostvars.type) %}
 {%             do csv_line.append(node) %}
 {%             do csv_line.append(ethernet_interface) %}
-{%             do csv_line.append(hostvars[node].ethernet_interfaces[ethernet_interface].peer_type | arista.avd.default("")) %}
-{%             do csv_line.append(hostvars[node].ethernet_interfaces[ethernet_interface].peer | arista.avd.default("")) %}
-{%             do csv_line.append(hostvars[node].ethernet_interfaces[ethernet_interface].peer_interface | arista.avd.default("")) %}
+{%             do csv_line.append(node_hostvars.ethernet_interfaces[ethernet_interface].peer_type | arista.avd.default("")) %}
+{%             do csv_line.append(node_hostvars.ethernet_interfaces[ethernet_interface].peer | arista.avd.default("")) %}
+{%             do csv_line.append(node_hostvars.ethernet_interfaces[ethernet_interface].peer_interface | arista.avd.default("")) %}
 {{ csv_line | join(",") }}
 {%         endfor %}
 {%     endif %}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Optimize fabric documentation for speed

## Related Issue(s)

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->
Replace references to `hostvars[node]` with a temporary variable set to same contents. This optimizes the amount of data that is processed by jinja and improves the runtime significantly. **We see about 90% improvement!**

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Large test project went from:
```
arista.avd.eos_designs : Generate fabric topology in csv format. ---------------------------------- 227.78s
arista.avd.eos_designs : Generate fabric documentation in Markdown Format. ------------------------ 163.23s
arista.avd.eos_designs : Generate fabric point-to-point links summary in csv format. -------------- 122.74s
```
to
```
arista.avd.eos_designs : Generate fabric documentation in Markdown Format. ------------------------ 14.81s
arista.avd.eos_designs : Generate fabric point-to-point links summary in csv format. -------------- 13.87s
arista.avd.eos_designs : Generate fabric topology in csv format. ---------------------------------- 12.80s
```

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
