### PR TITLE
Fix(eos_designs): `mlag xx` is rendered on port-channels to servers even when switches do not run mlag.

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2A.md
@@ -446,10 +446,10 @@ interface Ethernet21
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
 | Port-Channel7 | DC1_L2LEAF1_Po1 | switched | trunk | 110-111,120-121,130-131,160-161 | - | - | - | - | - | 0000:0000:0808:0707:0606 |
 | Port-Channel9 | DC1-L2LEAF3A_Po1 | switched | trunk | 110-111,120-121,130-131,160-161 | - | - | - | - | - | 0000:0000:0606:0707:0808 |
-| Port-Channel10 | server01_MLAG_PortChanne1 | switched | trunk | 210-211 | - | - | - | - | 10 | - |
-| Port-Channel11 | server01_MTU_PROFILE_MLAG_PortChanne1 | switched | access | 110 | - | - | - | - | 11 | - |
-| Port-Channel12 | server01_MTU_ADAPTOR_MLAG_PortChanne1 | switched | access | - | - | - | - | - | 12 | - |
-| Port-Channel20 | FIREWALL01_PortChanne1 | switched | trunk | 110-111,210-211 | - | - | - | - | 20 | - |
+| Port-Channel10 | server01_MLAG_PortChanne1 | switched | trunk | 210-211 | - | - | - | - | - | - |
+| Port-Channel11 | server01_MTU_PROFILE_MLAG_PortChanne1 | switched | access | 110 | - | - | - | - | - | - |
+| Port-Channel12 | server01_MTU_ADAPTOR_MLAG_PortChanne1 | switched | access | - | - | - | - | - | - | - |
+| Port-Channel20 | FIREWALL01_PortChanne1 | switched | trunk | 110-111,210-211 | - | - | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -483,7 +483,6 @@ interface Port-Channel10
    switchport
    switchport trunk allowed vlan 210-211
    switchport mode trunk
-   mlag 10
 !
 interface Port-Channel11
    description server01_MTU_PROFILE_MLAG_PortChanne1
@@ -491,14 +490,12 @@ interface Port-Channel11
    mtu 1600
    switchport
    switchport access vlan 110
-   mlag 11
 !
 interface Port-Channel12
    description server01_MTU_ADAPTOR_MLAG_PortChanne1
    no shutdown
    mtu 1601
    switchport
-   mlag 12
 !
 interface Port-Channel20
    description FIREWALL01_PortChanne1
@@ -506,7 +503,6 @@ interface Port-Channel20
    switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
-   mlag 20
 ```
 
 ## Loopback Interfaces

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2B.md
@@ -446,10 +446,10 @@ interface Ethernet21
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
 | Port-Channel7 | DC1_L2LEAF1_Po1 | switched | trunk | 110-111,120-121,130-131,160-161 | - | - | - | - | - | 0000:0000:0808:0707:0606 |
 | Port-Channel9 | DC1-L2LEAF3A_Po1 | switched | trunk | 110-111,120-121,130-131,160-161 | - | - | - | - | - | 0000:0000:0606:0707:0808 |
-| Port-Channel10 | server01_MLAG_PortChanne1 | switched | trunk | 210-211 | - | - | - | - | 10 | - |
-| Port-Channel11 | server01_MTU_PROFILE_MLAG_PortChanne1 | switched | access | 110 | - | - | - | - | 11 | - |
-| Port-Channel12 | server01_MTU_ADAPTOR_MLAG_PortChanne1 | switched | access | - | - | - | - | - | 12 | - |
-| Port-Channel20 | FIREWALL01_PortChanne1 | switched | trunk | 110-111,210-211 | - | - | - | - | 20 | - |
+| Port-Channel10 | server01_MLAG_PortChanne1 | switched | trunk | 210-211 | - | - | - | - | - | - |
+| Port-Channel11 | server01_MTU_PROFILE_MLAG_PortChanne1 | switched | access | 110 | - | - | - | - | - | - |
+| Port-Channel12 | server01_MTU_ADAPTOR_MLAG_PortChanne1 | switched | access | - | - | - | - | - | - | - |
+| Port-Channel20 | FIREWALL01_PortChanne1 | switched | trunk | 110-111,210-211 | - | - | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -483,7 +483,6 @@ interface Port-Channel10
    switchport
    switchport trunk allowed vlan 210-211
    switchport mode trunk
-   mlag 10
 !
 interface Port-Channel11
    description server01_MTU_PROFILE_MLAG_PortChanne1
@@ -491,14 +490,12 @@ interface Port-Channel11
    mtu 1600
    switchport
    switchport access vlan 110
-   mlag 11
 !
 interface Port-Channel12
    description server01_MTU_ADAPTOR_MLAG_PortChanne1
    no shutdown
    mtu 1601
    switchport
-   mlag 12
 !
 interface Port-Channel20
    description FIREWALL01_PortChanne1
@@ -506,7 +503,6 @@ interface Port-Channel20
    switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
-   mlag 20
 ```
 
 ## Loopback Interfaces

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
@@ -123,7 +123,6 @@ interface Port-Channel10
    switchport
    switchport trunk allowed vlan 210-211
    switchport mode trunk
-   mlag 10
 !
 interface Port-Channel11
    description server01_MTU_PROFILE_MLAG_PortChanne1
@@ -131,14 +130,12 @@ interface Port-Channel11
    mtu 1600
    switchport
    switchport access vlan 110
-   mlag 11
 !
 interface Port-Channel12
    description server01_MTU_ADAPTOR_MLAG_PortChanne1
    no shutdown
    mtu 1601
    switchport
-   mlag 12
 !
 interface Port-Channel20
    description FIREWALL01_PortChanne1
@@ -146,7 +143,6 @@ interface Port-Channel20
    switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
-   mlag 20
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet2

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
@@ -123,7 +123,6 @@ interface Port-Channel10
    switchport
    switchport trunk allowed vlan 210-211
    switchport mode trunk
-   mlag 10
 !
 interface Port-Channel11
    description server01_MTU_PROFILE_MLAG_PortChanne1
@@ -131,14 +130,12 @@ interface Port-Channel11
    mtu 1600
    switchport
    switchport access vlan 110
-   mlag 11
 !
 interface Port-Channel12
    description server01_MTU_ADAPTOR_MLAG_PortChanne1
    no shutdown
    mtu 1601
    switchport
-   mlag 12
 !
 interface Port-Channel20
    description FIREWALL01_PortChanne1
@@ -146,7 +143,6 @@ interface Port-Channel20
    switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
-   mlag 20
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
@@ -452,20 +452,17 @@ port_channel_interfaces:
     shutdown: false
     mode: trunk
     vlans: 110-111,210-211
-    mlag: 20
   Port-Channel10:
     description: server01_MLAG_PortChanne1
     type: switched
     shutdown: false
     mode: trunk
     vlans: 210-211
-    mlag: 10
   Port-Channel12:
     description: server01_MTU_ADAPTOR_MLAG_PortChanne1
     type: switched
     shutdown: false
     mtu: 1601
-    mlag: 12
   Port-Channel11:
     description: server01_MTU_PROFILE_MLAG_PortChanne1
     type: switched
@@ -473,7 +470,6 @@ port_channel_interfaces:
     mode: access
     mtu: 1600
     vlans: 110
-    mlag: 11
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
@@ -452,20 +452,17 @@ port_channel_interfaces:
     shutdown: false
     mode: trunk
     vlans: 110-111,210-211
-    mlag: 20
   Port-Channel10:
     description: server01_MLAG_PortChanne1
     type: switched
     shutdown: false
     mode: trunk
     vlans: 210-211
-    mlag: 10
   Port-Channel12:
     description: server01_MTU_ADAPTOR_MLAG_PortChanne1
     type: switched
     shutdown: false
     mtu: 1601
-    mlag: 12
   Port-Channel11:
     description: server01_MTU_PROFILE_MLAG_PortChanne1
     type: switched
@@ -473,7 +470,6 @@ port_channel_interfaces:
     mode: access
     mtu: 1600
     vlans: 110
-    mlag: 11
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -468,10 +468,10 @@ interface Ethernet21
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
 | Port-Channel7 | CUSTOM_DC1_L2LEAF1_Po1 | switched | trunk | 110-111,120-124,130-131,160-162 | - | - | - | - | - | 0000:1234:0808:0707:0606 |
 | Port-Channel9 | CUSTOM_DC1-L2LEAF3A_Po1 | switched | trunk | 110-111,120-124,130-131,160-162 | - | - | - | - | - | 0000:1234:0606:0707:0808 |
-| Port-Channel10 | CUSTOM_server01_MLAG_PortChanne1 | switched | trunk | 210-211 | - | - | - | - | 10 | - |
-| Port-Channel11 | CUSTOM_server01_MTU_PROFILE_MLAG_PortChanne1 | switched | access | 110 | - | - | - | - | 11 | - |
-| Port-Channel12 | CUSTOM_server01_MTU_ADAPTOR_MLAG_PortChanne1 | switched | access | - | - | - | - | - | 12 | - |
-| Port-Channel20 | CUSTOM_FIREWALL01_PortChanne1 | switched | trunk | 110-111,210-211 | - | - | - | - | 20 | - |
+| Port-Channel10 | CUSTOM_server01_MLAG_PortChanne1 | switched | trunk | 210-211 | - | - | - | - | - | - |
+| Port-Channel11 | CUSTOM_server01_MTU_PROFILE_MLAG_PortChanne1 | switched | access | 110 | - | - | - | - | - | - |
+| Port-Channel12 | CUSTOM_server01_MTU_ADAPTOR_MLAG_PortChanne1 | switched | access | - | - | - | - | - | - | - |
+| Port-Channel20 | CUSTOM_FIREWALL01_PortChanne1 | switched | trunk | 110-111,210-211 | - | - | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -505,7 +505,6 @@ interface Port-Channel10
    switchport
    switchport trunk allowed vlan 210-211
    switchport mode trunk
-   mlag 10
 !
 interface Port-Channel11
    description CUSTOM_server01_MTU_PROFILE_MLAG_PortChanne1
@@ -513,14 +512,12 @@ interface Port-Channel11
    mtu 1600
    switchport
    switchport access vlan 110
-   mlag 11
 !
 interface Port-Channel12
    description CUSTOM_server01_MTU_ADAPTOR_MLAG_PortChanne1
    no shutdown
    mtu 1601
    switchport
-   mlag 12
 !
 interface Port-Channel20
    description CUSTOM_FIREWALL01_PortChanne1
@@ -528,7 +525,6 @@ interface Port-Channel20
    switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
-   mlag 20
 ```
 
 ## Loopback Interfaces

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -468,10 +468,10 @@ interface Ethernet21
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
 | Port-Channel7 | CUSTOM_DC1_L2LEAF1_Po1 | switched | trunk | 110-111,120-124,130-131,160-162 | - | - | - | - | - | 0000:1234:0808:0707:0606 |
 | Port-Channel9 | CUSTOM_DC1-L2LEAF3A_Po1 | switched | trunk | 110-111,120-124,130-131,160-162 | - | - | - | - | - | 0000:1234:0606:0707:0808 |
-| Port-Channel10 | CUSTOM_server01_MLAG_PortChanne1 | switched | trunk | 210-211 | - | - | - | - | 10 | - |
-| Port-Channel11 | CUSTOM_server01_MTU_PROFILE_MLAG_PortChanne1 | switched | access | 110 | - | - | - | - | 11 | - |
-| Port-Channel12 | CUSTOM_server01_MTU_ADAPTOR_MLAG_PortChanne1 | switched | access | - | - | - | - | - | 12 | - |
-| Port-Channel20 | CUSTOM_FIREWALL01_PortChanne1 | switched | trunk | 110-111,210-211 | - | - | - | - | 20 | - |
+| Port-Channel10 | CUSTOM_server01_MLAG_PortChanne1 | switched | trunk | 210-211 | - | - | - | - | - | - |
+| Port-Channel11 | CUSTOM_server01_MTU_PROFILE_MLAG_PortChanne1 | switched | access | 110 | - | - | - | - | - | - |
+| Port-Channel12 | CUSTOM_server01_MTU_ADAPTOR_MLAG_PortChanne1 | switched | access | - | - | - | - | - | - | - |
+| Port-Channel20 | CUSTOM_FIREWALL01_PortChanne1 | switched | trunk | 110-111,210-211 | - | - | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -505,7 +505,6 @@ interface Port-Channel10
    switchport
    switchport trunk allowed vlan 210-211
    switchport mode trunk
-   mlag 10
 !
 interface Port-Channel11
    description CUSTOM_server01_MTU_PROFILE_MLAG_PortChanne1
@@ -513,14 +512,12 @@ interface Port-Channel11
    mtu 1600
    switchport
    switchport access vlan 110
-   mlag 11
 !
 interface Port-Channel12
    description CUSTOM_server01_MTU_ADAPTOR_MLAG_PortChanne1
    no shutdown
    mtu 1601
    switchport
-   mlag 12
 !
 interface Port-Channel20
    description CUSTOM_FIREWALL01_PortChanne1
@@ -528,7 +525,6 @@ interface Port-Channel20
    switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
-   mlag 20
 ```
 
 ## Loopback Interfaces

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
@@ -140,7 +140,6 @@ interface Port-Channel10
    switchport
    switchport trunk allowed vlan 210-211
    switchport mode trunk
-   mlag 10
 !
 interface Port-Channel11
    description CUSTOM_server01_MTU_PROFILE_MLAG_PortChanne1
@@ -148,14 +147,12 @@ interface Port-Channel11
    mtu 1600
    switchport
    switchport access vlan 110
-   mlag 11
 !
 interface Port-Channel12
    description CUSTOM_server01_MTU_ADAPTOR_MLAG_PortChanne1
    no shutdown
    mtu 1601
    switchport
-   mlag 12
 !
 interface Port-Channel20
    description CUSTOM_FIREWALL01_PortChanne1
@@ -163,7 +160,6 @@ interface Port-Channel20
    switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
-   mlag 20
 !
 interface Ethernet1
    description CUSTOM_P2P_LINK_TO_DC1-SPINE1_Ethernet2

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
@@ -140,7 +140,6 @@ interface Port-Channel10
    switchport
    switchport trunk allowed vlan 210-211
    switchport mode trunk
-   mlag 10
 !
 interface Port-Channel11
    description CUSTOM_server01_MTU_PROFILE_MLAG_PortChanne1
@@ -148,14 +147,12 @@ interface Port-Channel11
    mtu 1600
    switchport
    switchport access vlan 110
-   mlag 11
 !
 interface Port-Channel12
    description CUSTOM_server01_MTU_ADAPTOR_MLAG_PortChanne1
    no shutdown
    mtu 1601
    switchport
-   mlag 12
 !
 interface Port-Channel20
    description CUSTOM_FIREWALL01_PortChanne1
@@ -163,7 +160,6 @@ interface Port-Channel20
    switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
-   mlag 20
 !
 interface Ethernet1
    description CUSTOM_P2P_LINK_TO_DC1-SPINE1_Ethernet3

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -480,20 +480,17 @@ port_channel_interfaces:
     shutdown: false
     mode: trunk
     vlans: 110-111,210-211
-    mlag: 20
   Port-Channel10:
     description: CUSTOM_server01_MLAG_PortChanne1
     type: switched
     shutdown: false
     mode: trunk
     vlans: 210-211
-    mlag: 10
   Port-Channel12:
     description: CUSTOM_server01_MTU_ADAPTOR_MLAG_PortChanne1
     type: switched
     shutdown: false
     mtu: 1601
-    mlag: 12
   Port-Channel11:
     description: CUSTOM_server01_MTU_PROFILE_MLAG_PortChanne1
     type: switched
@@ -501,7 +498,6 @@ port_channel_interfaces:
     mode: access
     mtu: 1600
     vlans: 110
-    mlag: 11
 loopback_interfaces:
   Loopback0:
     description: CUSTOM_EVPN_Overlay_Peering_L3LEAF

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -480,20 +480,17 @@ port_channel_interfaces:
     shutdown: false
     mode: trunk
     vlans: 110-111,210-211
-    mlag: 20
   Port-Channel10:
     description: CUSTOM_server01_MLAG_PortChanne1
     type: switched
     shutdown: false
     mode: trunk
     vlans: 210-211
-    mlag: 10
   Port-Channel12:
     description: CUSTOM_server01_MTU_ADAPTOR_MLAG_PortChanne1
     type: switched
     shutdown: false
     mtu: 1601
-    mlag: 12
   Port-Channel11:
     description: CUSTOM_server01_MTU_PROFILE_MLAG_PortChanne1
     type: switched
@@ -501,7 +498,6 @@ port_channel_interfaces:
     mode: access
     mtu: 1600
     vlans: 110
-    mlag: 11
 loopback_interfaces:
   Loopback0:
     description: CUSTOM_EVPN_Overlay_Peering_L3LEAF

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -452,10 +452,10 @@ interface Ethernet21
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
 | Port-Channel7 | DC1_L2LEAF1_Po1 | switched | trunk | 110-111,120-121,130-131,160-161 | - | - | - | - | - | 0000:1234:0808:0707:0606 |
 | Port-Channel9 | DC1-L2LEAF3A_Po1 | switched | trunk | 110-111,120-121,130-131,160-161 | - | - | - | - | - | 0000:1234:0606:0707:0808 |
-| Port-Channel10 | server01_MLAG_PortChanne1 | switched | trunk | 210-211 | - | - | - | - | 10 | - |
-| Port-Channel11 | server01_MTU_PROFILE_MLAG_PortChanne1 | switched | access | 110 | - | - | - | - | 11 | - |
-| Port-Channel12 | server01_MTU_ADAPTOR_MLAG_PortChanne1 | switched | access | - | - | - | - | - | 12 | - |
-| Port-Channel20 | FIREWALL01_PortChanne1 | switched | trunk | 110-111,210-211 | - | - | - | - | 20 | - |
+| Port-Channel10 | server01_MLAG_PortChanne1 | switched | trunk | 210-211 | - | - | - | - | - | - |
+| Port-Channel11 | server01_MTU_PROFILE_MLAG_PortChanne1 | switched | access | 110 | - | - | - | - | - | - |
+| Port-Channel12 | server01_MTU_ADAPTOR_MLAG_PortChanne1 | switched | access | - | - | - | - | - | - | - |
+| Port-Channel20 | FIREWALL01_PortChanne1 | switched | trunk | 110-111,210-211 | - | - | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -489,7 +489,6 @@ interface Port-Channel10
    switchport
    switchport trunk allowed vlan 210-211
    switchport mode trunk
-   mlag 10
 !
 interface Port-Channel11
    description server01_MTU_PROFILE_MLAG_PortChanne1
@@ -497,14 +496,12 @@ interface Port-Channel11
    mtu 1600
    switchport
    switchport access vlan 110
-   mlag 11
 !
 interface Port-Channel12
    description server01_MTU_ADAPTOR_MLAG_PortChanne1
    no shutdown
    mtu 1601
    switchport
-   mlag 12
 !
 interface Port-Channel20
    description FIREWALL01_PortChanne1
@@ -512,7 +509,6 @@ interface Port-Channel20
    switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
-   mlag 20
 ```
 
 ## Loopback Interfaces

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -452,10 +452,10 @@ interface Ethernet21
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
 | Port-Channel7 | DC1_L2LEAF1_Po1 | switched | trunk | 110-111,120-121,130-131,160-161 | - | - | - | - | - | 0000:1234:0808:0707:0606 |
 | Port-Channel9 | DC1-L2LEAF3A_Po1 | switched | trunk | 110-111,120-121,130-131,160-161 | - | - | - | - | - | 0000:1234:0606:0707:0808 |
-| Port-Channel10 | server01_MLAG_PortChanne1 | switched | trunk | 210-211 | - | - | - | - | 10 | - |
-| Port-Channel11 | server01_MTU_PROFILE_MLAG_PortChanne1 | switched | access | 110 | - | - | - | - | 11 | - |
-| Port-Channel12 | server01_MTU_ADAPTOR_MLAG_PortChanne1 | switched | access | - | - | - | - | - | 12 | - |
-| Port-Channel20 | FIREWALL01_PortChanne1 | switched | trunk | 110-111,210-211 | - | - | - | - | 20 | - |
+| Port-Channel10 | server01_MLAG_PortChanne1 | switched | trunk | 210-211 | - | - | - | - | - | - |
+| Port-Channel11 | server01_MTU_PROFILE_MLAG_PortChanne1 | switched | access | 110 | - | - | - | - | - | - |
+| Port-Channel12 | server01_MTU_ADAPTOR_MLAG_PortChanne1 | switched | access | - | - | - | - | - | - | - |
+| Port-Channel20 | FIREWALL01_PortChanne1 | switched | trunk | 110-111,210-211 | - | - | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -489,7 +489,6 @@ interface Port-Channel10
    switchport
    switchport trunk allowed vlan 210-211
    switchport mode trunk
-   mlag 10
 !
 interface Port-Channel11
    description server01_MTU_PROFILE_MLAG_PortChanne1
@@ -497,14 +496,12 @@ interface Port-Channel11
    mtu 1600
    switchport
    switchport access vlan 110
-   mlag 11
 !
 interface Port-Channel12
    description server01_MTU_ADAPTOR_MLAG_PortChanne1
    no shutdown
    mtu 1601
    switchport
-   mlag 12
 !
 interface Port-Channel20
    description FIREWALL01_PortChanne1
@@ -512,7 +509,6 @@ interface Port-Channel20
    switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
-   mlag 20
 ```
 
 ## Loopback Interfaces

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
@@ -123,7 +123,6 @@ interface Port-Channel10
    switchport
    switchport trunk allowed vlan 210-211
    switchport mode trunk
-   mlag 10
 !
 interface Port-Channel11
    description server01_MTU_PROFILE_MLAG_PortChanne1
@@ -131,14 +130,12 @@ interface Port-Channel11
    mtu 1600
    switchport
    switchport access vlan 110
-   mlag 11
 !
 interface Port-Channel12
    description server01_MTU_ADAPTOR_MLAG_PortChanne1
    no shutdown
    mtu 1601
    switchport
-   mlag 12
 !
 interface Port-Channel20
    description FIREWALL01_PortChanne1
@@ -146,7 +143,6 @@ interface Port-Channel20
    switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
-   mlag 20
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet2

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
@@ -123,7 +123,6 @@ interface Port-Channel10
    switchport
    switchport trunk allowed vlan 210-211
    switchport mode trunk
-   mlag 10
 !
 interface Port-Channel11
    description server01_MTU_PROFILE_MLAG_PortChanne1
@@ -131,14 +130,12 @@ interface Port-Channel11
    mtu 1600
    switchport
    switchport access vlan 110
-   mlag 11
 !
 interface Port-Channel12
    description server01_MTU_ADAPTOR_MLAG_PortChanne1
    no shutdown
    mtu 1601
    switchport
-   mlag 12
 !
 interface Port-Channel20
    description FIREWALL01_PortChanne1
@@ -146,7 +143,6 @@ interface Port-Channel20
    switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
-   mlag 20
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet3

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -476,20 +476,17 @@ port_channel_interfaces:
     shutdown: false
     mode: trunk
     vlans: 110-111,210-211
-    mlag: 20
   Port-Channel10:
     description: server01_MLAG_PortChanne1
     type: switched
     shutdown: false
     mode: trunk
     vlans: 210-211
-    mlag: 10
   Port-Channel12:
     description: server01_MTU_ADAPTOR_MLAG_PortChanne1
     type: switched
     shutdown: false
     mtu: 1601
-    mlag: 12
   Port-Channel11:
     description: server01_MTU_PROFILE_MLAG_PortChanne1
     type: switched
@@ -497,7 +494,6 @@ port_channel_interfaces:
     mode: access
     mtu: 1600
     vlans: 110
-    mlag: 11
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -476,20 +476,17 @@ port_channel_interfaces:
     shutdown: false
     mode: trunk
     vlans: 110-111,210-211
-    mlag: 20
   Port-Channel10:
     description: server01_MLAG_PortChanne1
     type: switched
     shutdown: false
     mode: trunk
     vlans: 210-211
-    mlag: 10
   Port-Channel12:
     description: server01_MTU_ADAPTOR_MLAG_PortChanne1
     type: switched
     shutdown: false
     mtu: 1601
-    mlag: 12
   Port-Channel11:
     description: server01_MTU_PROFILE_MLAG_PortChanne1
     type: switched
@@ -497,7 +494,6 @@ port_channel_interfaces:
     mode: access
     mtu: 1600
     vlans: 110
-    mlag: 11
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/port-channel-interfaces.j2
@@ -62,7 +62,9 @@ port_channel_interfaces:
 {%                                     endif %}
 {%                                 endif %}
 {%                             else %}
+{%                                if switch.mlag is arista.avd.defined(true) %}
     mlag: {{ channel_group_id }}
+{%                                endif %}
 {%                             endif %}
 {%                         endif %}
 {%                         if adapter_settings.port_channel.lacp_fallback.mode is arista.avd.defined('static') %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/port-channel-interfaces.j2
@@ -61,10 +61,8 @@ port_channel_interfaces:
     lacp_id: {{ adapter.port_channel.short_esi | arista.avd.generate_lacp_id }}
 {%                                     endif %}
 {%                                 endif %}
-{%                             else %}
-{%                                if switch.mlag is arista.avd.defined(true) %}
+{%                             elif switch.mlag is arista.avd.defined(true) %}
     mlag: {{ channel_group_id }}
-{%                                endif %}
 {%                             endif %}
 {%                         endif %}
 {%                         if adapter_settings.port_channel.lacp_fallback.mode is arista.avd.defined('static') %}


### PR DESCRIPTION
## Change Summary

Add logic to test for switch.mlag to the connected_endpoint port-channel templates.

## Related Issue(s)

Fixes #1318

## Component(s) name

`arista.avd.eos_designs`

## How to test

See Molecule scenarios results.

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
