### PR TITLE
Fix(eos_cli_config_gen): fix issue #1352

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
@@ -88,7 +88,7 @@ interface Management1
 
 | BGP AS | Router ID |
 | ------ | --------- |
-| 65101|  192.168.255.3 |
+| 65101|  - |
 
 | BGP Tuning |
 | ---------- |
@@ -127,7 +127,6 @@ interface Management1
 ```eos
 !
 router bgp 65101
-   router-id 192.168.255.3
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    graceful-restart restart-time 300

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-base.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-base.cfg
@@ -13,7 +13,6 @@ interface Management1
    ip address 10.73.255.122/24
 !
 router bgp 65101
-   router-id 192.168.255.3
    no bgp default ipv4-unicast
    distance bgp 20 200 200
    graceful-restart restart-time 300

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-base.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-base.yml
@@ -1,6 +1,6 @@
 router_bgp:
   as: 65101
-  router_id: 192.168.255.3
+  #router_id: 192.168.255.3 # commented out to test issue 1352
   bgp_defaults:
     - no bgp default ipv4-unicast
     - distance bgp 20 200 200

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
@@ -6,7 +6,7 @@
 
 | BGP AS | Router ID |
 | ------ | --------- |
-| {{ router_bgp.as }}|  {{ router_bgp.router_id }} |
+| {{ router_bgp.as }}|  {{ router_bgp.router_id | arista.avd.default('-') }} |
 {%     if router_bgp.bgp_cluster_id is arista.avd.defined %}
 
 | BGP AS | Cluster ID |


### PR DESCRIPTION

## Change Summary

eos_cli_config_gen won't fail documentation generation when `router_bgp.router_id` is not included.
Includes updates to molecule tests.

## Related Issue(s)

Fixes #1352

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Changed `ansible-avd/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2`: an empty `router_bgp.router_id` will now generate the output `-`
```
| {{ router_bgp.as }}|  {{ router_bgp.router_id | arista.avd.default('-') }} |
```

## How to test
Define a stuctured config where`router_bgp` doesn't include `router_id`.
Run documentation generation job.

## Checklist

### User Checklist

- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
