### PR TITLE
Feat(eos_cli_config_gen): enhance router multicast data model

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-multicast.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-multicast.md
@@ -89,7 +89,7 @@ interface Management1
 ### IP Router Multicast Summary
 
 - Routing for IPv4 multicast is enabled.
-- Multipathing deterministically picking router-id.
+- Multipathing deterministically by selecting the same upstream router.
 - Software forwarding by the Software Forwarding Engine (SFE)
 
 ### IP Router Multicast VRFs
@@ -106,7 +106,6 @@ interface Management1
 router multicast
    ipv4
       routing
-      multipath none
       multipath deterministic router-id
       software-forwarding sfe
       !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-multicast.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-multicast.md
@@ -97,6 +97,16 @@ Routing for IPv4 multicast is enabled.
 router multicast
    ipv4
       routing
+      multipath deterministic router-id
+      software-forwarding sfe
+      !
+      vrf MCAST_VRF1
+         ipv4
+           routing
+      !
+      vrf MCAST_VRF2
+         ipv4
+           routing
 ```
 
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-multicast.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-multicast.md
@@ -88,7 +88,16 @@ interface Management1
 
 ### IP Router Multicast Summary
 
-Routing for IPv4 multicast is enabled.
+- Routing for IPv4 multicast is enabled.
+- Multipathing deterministically picking router-id.
+- Software forwarding by the Software Forwarding Engine (SFE)
+
+### IP Router Multicast VRFs
+
+| VRF Name | Multicast Routing |
+| -------- | ----------------- |
+| MCAST_VRF1 | enabled |
+| MCAST_VRF2 | enabled |
 
 ### Router Multicast Device Configuration
 
@@ -97,16 +106,17 @@ Routing for IPv4 multicast is enabled.
 router multicast
    ipv4
       routing
+      multipath none
       multipath deterministic router-id
       software-forwarding sfe
       !
       vrf MCAST_VRF1
          ipv4
-           routing
+            routing
       !
       vrf MCAST_VRF2
          ipv4
-           routing
+            routing
 ```
 
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-multicast.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-multicast.cfg
@@ -15,7 +15,6 @@ interface Management1
 router multicast
    ipv4
       routing
-      multipath none
       multipath deterministic router-id
       software-forwarding sfe
       !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-multicast.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-multicast.cfg
@@ -15,15 +15,16 @@ interface Management1
 router multicast
    ipv4
       routing
+      multipath none
       multipath deterministic router-id
       software-forwarding sfe
       !
       vrf MCAST_VRF1
          ipv4
-           routing
+            routing
       !
       vrf MCAST_VRF2
          ipv4
-           routing
+            routing
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-multicast.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-multicast.cfg
@@ -15,5 +15,15 @@ interface Management1
 router multicast
    ipv4
       routing
+      multipath deterministic router-id
+      software-forwarding sfe
+      !
+      vrf MCAST_VRF1
+         ipv4
+           routing
+      !
+      vrf MCAST_VRF2
+         ipv4
+           routing
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-multicast.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-multicast.yml
@@ -3,3 +3,12 @@
 router_multicast:
   ipv4:
     routing: true
+    multipath_deterministic: router-id
+    software_forwarding: sfe
+  vrfs:
+    - name: MCAST_VRF1
+      ipv4:
+        routing: true
+    - name: MCAST_VRF2
+      ipv4:
+        routing: true

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-multicast.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-multicast.yml
@@ -3,7 +3,8 @@
 router_multicast:
   ipv4:
     routing: true
-    multipath_deterministic: router-id
+    multipath: none
+    multipath_deterministic_pick: router-id
     software_forwarding: sfe
   vrfs:
     - name: MCAST_VRF1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-multicast.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-multicast.yml
@@ -3,8 +3,7 @@
 router_multicast:
   ipv4:
     routing: true
-    multipath: none
-    multipath_deterministic_pick: router-id
+    multipath: "deterministic router-id"
     software_forwarding: sfe
   vrfs:
     - name: MCAST_VRF1

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1608,7 +1608,8 @@ ip_igmp_snooping:
 router_multicast:
   ipv4:
     routing: < true | false >
-    multipath_deterministic: < color | router-id  >
+    multipath: < none | deterministic >
+    multipath_deterministic_pick:  < color | router-id  >
     software_forwarding: < kernel | sfe >
   vrfs:
     - name: < vrf_name >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1610,8 +1610,7 @@ ip_igmp_snooping:
 router_multicast:
   ipv4:
     routing: < true | false >
-    multipath: < none | deterministic >
-    multipath_deterministic_pick:  < color | router-id  >
+    multipath: < none | deterministic | "deterministic color" | "deterministic router-id" >
     software_forwarding: < kernel | sfe >
   vrfs:
     - name: < vrf_name >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -63,6 +63,7 @@
     - [IP DHCP Relay](#ip-dhcp-relay)
     - [IP ICMP Redirect](#ip-icmp-redirect)
     - [LACP](#lacp)
+    - [Link Tracking Groups](#link-tracking-groups)
     - [LLDP](#lldp)
     - [MACsec](#macsec)
     - [Maintenance Mode](#maintenance-mode)
@@ -1256,6 +1257,7 @@ lacp:
   rate_limit:
     default: < true | false >
   system_priority: < 0-65535 >
+```
 
 ### Link Tracking Groups
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -63,7 +63,6 @@
     - [IP DHCP Relay](#ip-dhcp-relay)
     - [IP ICMP Redirect](#ip-icmp-redirect)
     - [LACP](#lacp)
-    - [Link Tracking Groups](#link-tracking-groups)
     - [LLDP](#lldp)
     - [MACsec](#macsec)
     - [Maintenance Mode](#maintenance-mode)
@@ -1609,6 +1608,12 @@ ip_igmp_snooping:
 router_multicast:
   ipv4:
     routing: < true | false >
+    multipath_deterministic: < color | router-id  >
+    software_forwarding: < kernel | sfe >
+  vrfs:
+    - name: < vrf_name >
+      ipv4:
+        routing: < true | false >
 ```
 
 #### Routing PIM Sparse Mode

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-multicast.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-multicast.j2
@@ -21,11 +21,13 @@
 - Software forwarding by the Software Forwarding Engine (SFE)
 {%     endif %}
 
+### IP Router Multicast VRFs
+
 {%     if router_multicast.vrfs is arista.avd.defined %}
 | VRF Name | Multicast Routing |
 | -------- | ----------------- |
 {%         for vrf in router_multicast.vrfs| arista.avd.natural_sort('name') %}
-| {{ vrf.name }} |{% if vrf.ip_routing is arista.avd.defined(true) %} enabled {% else %} disabled {% endif %}|
+| {{ vrf.name }} |{% if vrf.ipv4.routing is arista.avd.defined(true) %} enabled {% else %} disabled {% endif %}|
 {%         endfor %}
 
 ### Router Multicast Device Configuration

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-multicast.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-multicast.j2
@@ -20,15 +20,21 @@
 {%     elif router_multicast.ipv4.software_forwarding is arista.avd.defined('sfe') %}
 - Software forwarding by the Software Forwarding Engine (SFE)
 {%     endif %}
+{%     if router_multicast.vrfs is arista.avd.defined %}
 
 ### IP Router Multicast VRFs
 
-{%     if router_multicast.vrfs is arista.avd.defined %}
 | VRF Name | Multicast Routing |
 | -------- | ----------------- |
-{%         for vrf in router_multicast.vrfs| arista.avd.natural_sort('name') %}
-| {{ vrf.name }} |{% if vrf.ipv4.routing is arista.avd.defined(true) %} enabled {% else %} disabled {% endif %}|
+{%         for vrf in router_multicast.vrfs | arista.avd.natural_sort('name') %}
+{%             if vrf.ipv4.routing is arista.avd.defined(true) %}
+{%                 set multicast_routing = "enabled" %}
+{%             else %}
+{%                 set multicast_routing = "disabled" %}
+{%             endif %}
+| {{ vrf.name }} | {{ multicast_routing }} |
 {%         endfor %}
+{%     endif %}
 
 ### Router Multicast Device Configuration
 
@@ -36,5 +42,4 @@
 {% include 'eos/router-multicast.j2' %}
 ```
 
-{%     endif %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-multicast.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-multicast.j2
@@ -7,9 +7,10 @@
 {%     if router_multicast.ipv4.routing is arista.avd.defined(true) %}
 - Routing for IPv4 multicast is enabled.
 {%     endif %}
-{# Multipathing deterministically picking would take precedence based on order of commands #}
-{%     if router_multicast.ipv4.multipath_deterministic_pick is arista.avd.defined %}
-- Multipathing deterministically picking {{ router_multicast.ipv4.multipath_deterministic_pick }}.
+{%     if router_multicast.ipv4.multipath is arista.avd.defined('deterministic color') %}
+- Multipathing deterministically by selecting the same-colored upstream routers.
+{%     elif router_multicast.ipv4.multipath is arista.avd.defined('deterministic router-id') %}
+- Multipathing deterministically by selecting the same upstream router.
 {%     elif router_multicast.ipv4.multipath is arista.avd.defined('none') %}
 - Multipathing disabled.
 {%     elif router_multicast.ipv4.multipath is arista.avd.defined('deterministic') %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-multicast.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-multicast.j2
@@ -1,11 +1,32 @@
-{% if router_multicast is defined and router_multicast is not none %}
+{% if router_multicast is arista.avd.defined %}
 
 ## Router Multicast
 
 ### IP Router Multicast Summary
 
-{%   if router_multicast.ipv4.routing is defined and router_multicast.ipv4.routing == true %}
-Routing for IPv4 multicast is enabled.
+{%     if router_multicast.ipv4.routing is arista.avd.defined(true) %}
+- Routing for IPv4 multicast is enabled.
+{%     endif %}
+{# Multipathing deterministically picking would take precedence based on order of commands #}
+{%     if router_multicast.ipv4.multipath_deterministic_pick is arista.avd.defined %}
+- Multipathing deterministically picking {{ router_multicast.ipv4.multipath_deterministic_pick }}.
+{%     elif router_multicast.ipv4.multipath is arista.avd.defined('none') %}
+- Multipathing disabled.
+{%     elif router_multicast.ipv4.multipath is arista.avd.defined('deterministic') %}
+- Multipathing via ECMP.
+{%     endif %}
+{%     if router_multicast.ipv4.software_forwarding is arista.avd.defined('kernel') %}
+- Software forwarding by the Linux kernel
+{%     elif router_multicast.ipv4.software_forwarding is arista.avd.defined('sfe') %}
+- Software forwarding by the Software Forwarding Engine (SFE)
+{%     endif %}
+
+{%     if router_multicast.vrfs is arista.avd.defined %}
+| VRF Name | Multicast Routing |
+| -------- | ----------------- |
+{%         for vrf in router_multicast.vrfs| arista.avd.natural_sort('name') %}
+| {{ vrf.name }} |{% if vrf.ip_routing is arista.avd.defined(true) %} enabled {% else %} disabled {% endif %}|
+{%         endfor %}
 
 ### Router Multicast Device Configuration
 
@@ -13,5 +34,5 @@ Routing for IPv4 multicast is enabled.
 {% include 'eos/router-multicast.j2' %}
 ```
 
-{%   endif %}
+{%     endif %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-multicast.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-multicast.j2
@@ -10,9 +10,6 @@ router multicast
 {%         if router_multicast.ipv4.multipath is arista.avd.defined %}
       multipath {{ router_multicast.ipv4.multipath }}
 {%         endif %}
-{%         if router_multicast.ipv4.multipath_deterministic_pick is arista.avd.defined %}
-      multipath deterministic {{ router_multicast.ipv4.multipath_deterministic_pick }}
-{%         endif %}
 {%         if router_multicast.ipv4.software_forwarding is arista.avd.defined %}
       software-forwarding {{ router_multicast.ipv4.software_forwarding }}
 {%         endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-multicast.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-multicast.j2
@@ -7,8 +7,11 @@ router multicast
 {%         if router_multicast.ipv4.routing is arista.avd.defined(true) %}
       routing
 {%         endif %}
-{%         if router_multicast.ipv4.multipath_deterministic is arista.avd.defined %}
-      multipath deterministic {{ router_multicast.ipv4.multipath_deterministic }}
+{%         if router_multicast.ipv4.multipath is arista.avd.defined %}
+      multipath {{ router_multicast.ipv4.multipath }}
+{%         endif %}
+{%         if router_multicast.ipv4.multipath_deterministic_pick is arista.avd.defined %}
+      multipath deterministic {{ router_multicast.ipv4.multipath_deterministic_pick }}
 {%         endif %}
 {%         if router_multicast.ipv4.software_forwarding is arista.avd.defined %}
       software-forwarding {{ router_multicast.ipv4.software_forwarding }}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-multicast.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-multicast.j2
@@ -7,5 +7,21 @@ router multicast
 {%         if router_multicast.ipv4.routing is arista.avd.defined(true) %}
       routing
 {%         endif %}
+{%         if router_multicast.ipv4.multipath_deterministic is arista.avd.defined %}
+      multipath deterministic {{ router_multicast.ipv4.multipath_deterministic }}
+{%         endif %}
+{%         if router_multicast.ipv4.software_forwarding is arista.avd.defined %}
+      software-forwarding {{ router_multicast.ipv4.software_forwarding }}
+{%         endif %}
 {%     endif %}
+{%     for vrf in router_multicast.vrfs | arista.avd.natural_sort('name') %}
+      !
+      vrf {{ vrf.name }}
+{%         if vrf.ipv4 is arista.avd.defined %}
+         ipv4
+{%         endif %}
+{%         if vrf.ipv4.routing is arista.avd.defined(true) %}
+            routing
+{%         endif%}
+{%     endfor %}
 {% endif %}


### PR DESCRIPTION
## Change Summary

Enhance eos_cli_config_gen router multicast features.

## Related Issue(s)

Fixes #1349 and partial #1358

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Notes from EOS CLI behavior on ipv4/multipath
- `multipath deterministic` (via ECPM) is the default.
- To disable multipath: `multipath none`
- To pick a specific method `multipath deterministic router-id` or `multipath deterministic color`

```yaml
router_multicast:
  ipv4:
    multipath: < none | deterministic >
    multipath_deterministic_pick: < color | router-id  >
    software_forwarding: < kernel | sfe >
  vrfs:
    - name: < vrf_name >
      ipv4:
        routing: < true | false >
```

## How to test

See Molecule test case

## Checklist

### User Checklist

- [x] eos_cli_config_gen configuration template
- [x] eos_cli_config_gen documentation template
- [x] update test case

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
