### PR TITLE
Feat(eos_cli_config_gen): extend vxlan interface data model to support multicast configuration

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vxlan-interface.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vxlan-interface.md
@@ -65,7 +65,7 @@ interface Management1
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
+#### Source Interface: Loopback0
 
 #### UDP port: 4789
 
@@ -99,7 +99,7 @@ interface Management1
 !
 interface Vxlan1
    description DC1-LEAF2A_VTEP
-   vxlan source-interface Loopback1
+   vxlan source-interface Loopback0
    vxlan virtual-router encapsulation mac-address mlag-system-id
    vxlan udp-port 4789
    vxlan flood vtep learned data-plane
@@ -108,7 +108,10 @@ interface Vxlan1
    vxlan vlan 111 flood vtep 10.1.1.10 10.1.1.11
    vxlan vrf Tenant_A_OP_Zone vni 10
    vxlan vrf Tenant_A_WEB_Zone vni 11
+   vxlan mlag source-interface Loopback1
    vxlan flood vtep 10.1.0.10 10.1.0.11
+   vxlan vlan 110 multicast group 239.9.1.4
+   vxlan vrf Tenant_A_OP_Zone multicast group 232.0.0.10
    vxlan encapsulation ipv4
 
 ```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vxlan-interface.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vxlan-interface.md
@@ -82,7 +82,7 @@ interface Management1
 
 #### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI | Multicast Group |
+| VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Tenant_A_OP_Zone | 10 | 232.0.0.10 |
 | Tenant_A_WEB_Zone | 11 | - |

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vxlan-interface.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vxlan-interface.md
@@ -67,23 +67,25 @@ interface Management1
 
 #### Source Interface: Loopback0
 
+#### MLAG Source Interface: Loopback1
+
 #### UDP port: 4789
 
 #### EVPN MLAG Shared Router MAC : mlag-system-id
 
-#### VLAN to VNI and Flood List Mappings
+#### VLAN to VNI, Flood List and Multicast Group Mappings
 
-| VLAN | VNI | Flood List |
-| ---- | --- | ---------- |
-| 110 | 10110 | - |
-| 111 | 10111 | 10.1.1.10<br/>10.1.1.11 |
+| VLAN | VNI | Flood List | Multicast Group |
+| ---- | --- | ---------- | --------------- |
+| 110 | 10110 | - | 239.9.1.4 |
+| 111 | 10111 | 10.1.1.10<br/>10.1.1.11 | - |
 
-#### VRF to VNI Mappings
+#### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI |
-| ---- | --- |
-| Tenant_A_OP_Zone | 10 |
-| Tenant_A_WEB_Zone | 11 |
+| VLAN | VNI | Multicast Group |
+| ---- | --- | --------------- |
+| Tenant_A_OP_Zone | 10 | 232.0.0.10 |
+| Tenant_A_WEB_Zone | 11 | - |
 
 #### Default Flood List
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vxlan-interface.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vxlan-interface.cfg
@@ -14,7 +14,7 @@ interface Management1
 !
 interface Vxlan1
    description DC1-LEAF2A_VTEP
-   vxlan source-interface Loopback1
+   vxlan source-interface Loopback0
    vxlan virtual-router encapsulation mac-address mlag-system-id
    vxlan udp-port 4789
    vxlan flood vtep learned data-plane
@@ -23,7 +23,10 @@ interface Vxlan1
    vxlan vlan 111 flood vtep 10.1.1.10 10.1.1.11
    vxlan vrf Tenant_A_OP_Zone vni 10
    vxlan vrf Tenant_A_WEB_Zone vni 11
+   vxlan mlag source-interface Loopback1
    vxlan flood vtep 10.1.0.10 10.1.0.11
+   vxlan vlan 110 multicast group 239.9.1.4
+   vxlan vrf Tenant_A_OP_Zone multicast group 232.0.0.10
    vxlan encapsulation ipv4
 
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vxlan-interface.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vxlan-interface.yml
@@ -4,12 +4,14 @@ vxlan_interface:
   Vxlan1:
     description: DC1-LEAF2A_VTEP
     vxlan:
-      source_interface: Loopback1
+      source_interface: Loopback0
+      mlag_source_interface: Loopback1
       udp_port: 4789
       virtual_router_encapsulation_mac_address: mlag-system-id
       vlans:
         110:
           vni: 10110
+          multicast_group: 239.9.1.4
         111:
           vni: 10111
           flood_vteps:
@@ -18,6 +20,7 @@ vxlan_interface:
       vrfs:
         Tenant_A_OP_Zone:
           vni: 10
+          multicast_group: 232.0.0.10
         Tenant_A_WEB_Zone:
           vni: 11
       flood_vteps:

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1A.md
@@ -525,7 +525,7 @@ interface Vlan4094
 
 #### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI | Multicast Group |
+| VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Tenant_A_WAN_Zone | 14 | - |
 | Tenant_B_WAN_Zone | 21 | - |

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1A.md
@@ -515,21 +515,21 @@ interface Vlan4094
 
 #### EVPN MLAG Shared Router MAC : mlag-system-id
 
-#### VLAN to VNI and Flood List Mappings
+#### VLAN to VNI, Flood List and Multicast Group Mappings
 
-| VLAN | VNI | Flood List |
-| ---- | --- | ---------- |
-| 150 | 10150 | - |
-| 250 | 20250 | - |
-| 350 | 30350 | - |
+| VLAN | VNI | Flood List | Multicast Group |
+| ---- | --- | ---------- | --------------- |
+| 150 | 10150 | - | - |
+| 250 | 20250 | - | - |
+| 350 | 30350 | - | - |
 
-#### VRF to VNI Mappings
+#### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI |
-| ---- | --- |
-| Tenant_A_WAN_Zone | 14 |
-| Tenant_B_WAN_Zone | 21 |
-| Tenant_C_WAN_Zone | 31 |
+| VLAN | VNI | Multicast Group |
+| ---- | --- | --------------- |
+| Tenant_A_WAN_Zone | 14 | - |
+| Tenant_B_WAN_Zone | 21 | - |
+| Tenant_C_WAN_Zone | 31 | - |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1B.md
@@ -525,7 +525,7 @@ interface Vlan4094
 
 #### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI | Multicast Group |
+| VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Tenant_A_WAN_Zone | 14 | - |
 | Tenant_B_WAN_Zone | 21 | - |

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1B.md
@@ -515,21 +515,21 @@ interface Vlan4094
 
 #### EVPN MLAG Shared Router MAC : mlag-system-id
 
-#### VLAN to VNI and Flood List Mappings
+#### VLAN to VNI, Flood List and Multicast Group Mappings
 
-| VLAN | VNI | Flood List |
-| ---- | --- | ---------- |
-| 150 | 10150 | - |
-| 250 | 20250 | - |
-| 350 | 30350 | - |
+| VLAN | VNI | Flood List | Multicast Group |
+| ---- | --- | ---------- | --------------- |
+| 150 | 10150 | - | - |
+| 250 | 20250 | - | - |
+| 350 | 30350 | - | - |
 
-#### VRF to VNI Mappings
+#### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI |
-| ---- | --- |
-| Tenant_A_WAN_Zone | 14 |
-| Tenant_B_WAN_Zone | 21 |
-| Tenant_C_WAN_Zone | 31 |
+| VLAN | VNI | Multicast Group |
+| ---- | --- | --------------- |
+| Tenant_A_WAN_Zone | 14 | - |
+| Tenant_B_WAN_Zone | 21 | - |
+| Tenant_C_WAN_Zone | 31 | - |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF1A.md
@@ -409,21 +409,21 @@ interface Vlan131
 
 #### UDP port: 4789
 
-#### VLAN to VNI and Flood List Mappings
+#### VLAN to VNI, Flood List and Multicast Group Mappings
 
-| VLAN | VNI | Flood List |
-| ---- | --- | ---------- |
-| 120 | 10120 | - |
-| 121 | 10121 | - |
-| 130 | 10130 | - |
-| 131 | 10131 | - |
+| VLAN | VNI | Flood List | Multicast Group |
+| ---- | --- | ---------- | --------------- |
+| 120 | 10120 | - | - |
+| 121 | 10121 | - | - |
+| 130 | 10130 | - | - |
+| 131 | 10131 | - | - |
 
-#### VRF to VNI Mappings
+#### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI |
-| ---- | --- |
-| Tenant_A_APP_Zone | 12 |
-| Tenant_A_WEB_Zone | 11 |
+| VLAN | VNI | Multicast Group |
+| ---- | --- | --------------- |
+| Tenant_A_APP_Zone | 12 | - |
+| Tenant_A_WEB_Zone | 11 | - |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF1A.md
@@ -420,7 +420,7 @@ interface Vlan131
 
 #### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI | Multicast Group |
+| VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Tenant_A_APP_Zone | 12 | - |
 | Tenant_A_WEB_Zone | 11 | - |

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2A.md
@@ -709,33 +709,33 @@ interface Vlan4094
 
 #### EVPN MLAG Shared Router MAC : mlag-system-id
 
-#### VLAN to VNI and Flood List Mappings
+#### VLAN to VNI, Flood List and Multicast Group Mappings
 
-| VLAN | VNI | Flood List |
-| ---- | --- | ---------- |
-| 110 | 10110 | - |
-| 111 | 50111 | - |
-| 120 | 10120 | - |
-| 121 | 10121 | - |
-| 130 | 10130 | - |
-| 131 | 10131 | - |
-| 140 | 10140 | - |
-| 141 | 10141 | - |
-| 210 | 20210 | - |
-| 211 | 20211 | - |
-| 310 | 30310 | - |
-| 311 | 30311 | - |
+| VLAN | VNI | Flood List | Multicast Group |
+| ---- | --- | ---------- | --------------- |
+| 110 | 10110 | - | - |
+| 111 | 50111 | - | - |
+| 120 | 10120 | - | - |
+| 121 | 10121 | - | - |
+| 130 | 10130 | - | - |
+| 131 | 10131 | - | - |
+| 140 | 10140 | - | - |
+| 141 | 10141 | - | - |
+| 210 | 20210 | - | - |
+| 211 | 20211 | - | - |
+| 310 | 30310 | - | - |
+| 311 | 30311 | - | - |
 
-#### VRF to VNI Mappings
+#### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI |
-| ---- | --- |
-| Tenant_A_APP_Zone | 12 |
-| Tenant_A_DB_Zone | 13 |
-| Tenant_A_OP_Zone | 10 |
-| Tenant_A_WEB_Zone | 11 |
-| Tenant_B_OP_Zone | 20 |
-| Tenant_C_OP_Zone | 30 |
+| VLAN | VNI | Multicast Group |
+| ---- | --- | --------------- |
+| Tenant_A_APP_Zone | 12 | - |
+| Tenant_A_DB_Zone | 13 | - |
+| Tenant_A_OP_Zone | 10 | - |
+| Tenant_A_WEB_Zone | 11 | - |
+| Tenant_B_OP_Zone | 20 | - |
+| Tenant_C_OP_Zone | 30 | - |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2A.md
@@ -728,7 +728,7 @@ interface Vlan4094
 
 #### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI | Multicast Group |
+| VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Tenant_A_APP_Zone | 12 | - |
 | Tenant_A_DB_Zone | 13 | - |

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2B.md
@@ -709,33 +709,33 @@ interface Vlan4094
 
 #### EVPN MLAG Shared Router MAC : mlag-system-id
 
-#### VLAN to VNI and Flood List Mappings
+#### VLAN to VNI, Flood List and Multicast Group Mappings
 
-| VLAN | VNI | Flood List |
-| ---- | --- | ---------- |
-| 110 | 10110 | - |
-| 111 | 50111 | - |
-| 120 | 10120 | - |
-| 121 | 10121 | - |
-| 130 | 10130 | - |
-| 131 | 10131 | - |
-| 140 | 10140 | - |
-| 141 | 10141 | - |
-| 210 | 20210 | - |
-| 211 | 20211 | - |
-| 310 | 30310 | - |
-| 311 | 30311 | - |
+| VLAN | VNI | Flood List | Multicast Group |
+| ---- | --- | ---------- | --------------- |
+| 110 | 10110 | - | - |
+| 111 | 50111 | - | - |
+| 120 | 10120 | - | - |
+| 121 | 10121 | - | - |
+| 130 | 10130 | - | - |
+| 131 | 10131 | - | - |
+| 140 | 10140 | - | - |
+| 141 | 10141 | - | - |
+| 210 | 20210 | - | - |
+| 211 | 20211 | - | - |
+| 310 | 30310 | - | - |
+| 311 | 30311 | - | - |
 
-#### VRF to VNI Mappings
+#### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI |
-| ---- | --- |
-| Tenant_A_APP_Zone | 12 |
-| Tenant_A_DB_Zone | 13 |
-| Tenant_A_OP_Zone | 10 |
-| Tenant_A_WEB_Zone | 11 |
-| Tenant_B_OP_Zone | 20 |
-| Tenant_C_OP_Zone | 30 |
+| VLAN | VNI | Multicast Group |
+| ---- | --- | --------------- |
+| Tenant_A_APP_Zone | 12 | - |
+| Tenant_A_DB_Zone | 13 | - |
+| Tenant_A_OP_Zone | 10 | - |
+| Tenant_A_WEB_Zone | 11 | - |
+| Tenant_B_OP_Zone | 20 | - |
+| Tenant_C_OP_Zone | 30 | - |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2B.md
@@ -728,7 +728,7 @@ interface Vlan4094
 
 #### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI | Multicast Group |
+| VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Tenant_A_APP_Zone | 12 | - |
 | Tenant_A_DB_Zone | 13 | - |

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3A.md
@@ -793,39 +793,39 @@ interface Vlan4094
 
 #### EVPN MLAG Shared Router MAC : mlag-system-id
 
-#### VLAN to VNI and Flood List Mappings
+#### VLAN to VNI, Flood List and Multicast Group Mappings
 
-| VLAN | VNI | Flood List |
-| ---- | --- | ---------- |
-| 110 | 10110 | - |
-| 111 | 50111 | - |
-| 120 | 10120 | - |
-| 121 | 10121 | - |
-| 130 | 10130 | - |
-| 131 | 10131 | - |
-| 140 | 10140 | - |
-| 141 | 10141 | - |
-| 150 | 10150 | - |
-| 210 | 20210 | - |
-| 211 | 20211 | - |
-| 250 | 20250 | - |
-| 310 | 30310 | - |
-| 311 | 30311 | - |
-| 350 | 30350 | - |
+| VLAN | VNI | Flood List | Multicast Group |
+| ---- | --- | ---------- | --------------- |
+| 110 | 10110 | - | - |
+| 111 | 50111 | - | - |
+| 120 | 10120 | - | - |
+| 121 | 10121 | - | - |
+| 130 | 10130 | - | - |
+| 131 | 10131 | - | - |
+| 140 | 10140 | - | - |
+| 141 | 10141 | - | - |
+| 150 | 10150 | - | - |
+| 210 | 20210 | - | - |
+| 211 | 20211 | - | - |
+| 250 | 20250 | - | - |
+| 310 | 30310 | - | - |
+| 311 | 30311 | - | - |
+| 350 | 30350 | - | - |
 
-#### VRF to VNI Mappings
+#### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI |
-| ---- | --- |
-| Tenant_A_APP_Zone | 12 |
-| Tenant_A_DB_Zone | 13 |
-| Tenant_A_OP_Zone | 10 |
-| Tenant_A_WAN_Zone | 14 |
-| Tenant_A_WEB_Zone | 11 |
-| Tenant_B_OP_Zone | 20 |
-| Tenant_B_WAN_Zone | 21 |
-| Tenant_C_OP_Zone | 30 |
-| Tenant_C_WAN_Zone | 31 |
+| VLAN | VNI | Multicast Group |
+| ---- | --- | --------------- |
+| Tenant_A_APP_Zone | 12 | - |
+| Tenant_A_DB_Zone | 13 | - |
+| Tenant_A_OP_Zone | 10 | - |
+| Tenant_A_WAN_Zone | 14 | - |
+| Tenant_A_WEB_Zone | 11 | - |
+| Tenant_B_OP_Zone | 20 | - |
+| Tenant_B_WAN_Zone | 21 | - |
+| Tenant_C_OP_Zone | 30 | - |
+| Tenant_C_WAN_Zone | 31 | - |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3A.md
@@ -815,7 +815,7 @@ interface Vlan4094
 
 #### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI | Multicast Group |
+| VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Tenant_A_APP_Zone | 12 | - |
 | Tenant_A_DB_Zone | 13 | - |

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3B.md
@@ -778,39 +778,39 @@ interface Vlan4094
 
 #### EVPN MLAG Shared Router MAC : mlag-system-id
 
-#### VLAN to VNI and Flood List Mappings
+#### VLAN to VNI, Flood List and Multicast Group Mappings
 
-| VLAN | VNI | Flood List |
-| ---- | --- | ---------- |
-| 110 | 10110 | - |
-| 111 | 50111 | - |
-| 120 | 10120 | - |
-| 121 | 10121 | - |
-| 130 | 10130 | - |
-| 131 | 10131 | - |
-| 140 | 10140 | - |
-| 141 | 10141 | - |
-| 150 | 10150 | - |
-| 210 | 20210 | - |
-| 211 | 20211 | - |
-| 250 | 20250 | - |
-| 310 | 30310 | - |
-| 311 | 30311 | - |
-| 350 | 30350 | - |
+| VLAN | VNI | Flood List | Multicast Group |
+| ---- | --- | ---------- | --------------- |
+| 110 | 10110 | - | - |
+| 111 | 50111 | - | - |
+| 120 | 10120 | - | - |
+| 121 | 10121 | - | - |
+| 130 | 10130 | - | - |
+| 131 | 10131 | - | - |
+| 140 | 10140 | - | - |
+| 141 | 10141 | - | - |
+| 150 | 10150 | - | - |
+| 210 | 20210 | - | - |
+| 211 | 20211 | - | - |
+| 250 | 20250 | - | - |
+| 310 | 30310 | - | - |
+| 311 | 30311 | - | - |
+| 350 | 30350 | - | - |
 
-#### VRF to VNI Mappings
+#### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI |
-| ---- | --- |
-| Tenant_A_APP_Zone | 12 |
-| Tenant_A_DB_Zone | 13 |
-| Tenant_A_OP_Zone | 10 |
-| Tenant_A_WAN_Zone | 14 |
-| Tenant_A_WEB_Zone | 11 |
-| Tenant_B_OP_Zone | 20 |
-| Tenant_B_WAN_Zone | 21 |
-| Tenant_C_OP_Zone | 30 |
-| Tenant_C_WAN_Zone | 31 |
+| VLAN | VNI | Multicast Group |
+| ---- | --- | --------------- |
+| Tenant_A_APP_Zone | 12 | - |
+| Tenant_A_DB_Zone | 13 | - |
+| Tenant_A_OP_Zone | 10 | - |
+| Tenant_A_WAN_Zone | 14 | - |
+| Tenant_A_WEB_Zone | 11 | - |
+| Tenant_B_OP_Zone | 20 | - |
+| Tenant_B_WAN_Zone | 21 | - |
+| Tenant_C_OP_Zone | 30 | - |
+| Tenant_C_WAN_Zone | 31 | - |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3B.md
@@ -800,7 +800,7 @@ interface Vlan4094
 
 #### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI | Multicast Group |
+| VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Tenant_A_APP_Zone | 12 | - |
 | Tenant_A_DB_Zone | 13 | - |

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2A.md
@@ -645,7 +645,7 @@ interface Vlan4094
 
 #### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI | Multicast Group |
+| VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Common_VRF | 1025 | - |
 | vrf_with_loopbacks_dc1_pod1_only | 1102 | - |

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2A.md
@@ -633,24 +633,24 @@ interface Vlan4094
 
 #### EVPN MLAG Shared Router MAC : mlag-system-id
 
-#### VLAN to VNI and Flood List Mappings
+#### VLAN to VNI, Flood List and Multicast Group Mappings
 
-| VLAN | VNI | Flood List |
-| ---- | --- | ---------- |
-| 110 | 10110 | - |
-| 111 | 50111 | - |
-| 112 | 50112 | - |
-| 2500 | 2500 | - |
-| 2600 | 2600 | - |
+| VLAN | VNI | Flood List | Multicast Group |
+| ---- | --- | ---------- | --------------- |
+| 110 | 10110 | - | - |
+| 111 | 50111 | - | - |
+| 112 | 50112 | - | - |
+| 2500 | 2500 | - | - |
+| 2600 | 2600 | - | - |
 
-#### VRF to VNI Mappings
+#### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI |
-| ---- | --- |
-| Common_VRF | 1025 |
-| vrf_with_loopbacks_dc1_pod1_only | 1102 |
-| vrf_with_loopbacks_from_overlapping_pool | 1100 |
-| vrf_with_loopbacks_from_pod_pools | 1101 |
+| VLAN | VNI | Multicast Group |
+| ---- | --- | --------------- |
+| Common_VRF | 1025 | - |
+| vrf_with_loopbacks_dc1_pod1_only | 1102 | - |
+| vrf_with_loopbacks_from_overlapping_pool | 1100 | - |
+| vrf_with_loopbacks_from_pod_pools | 1101 | - |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
@@ -658,24 +658,24 @@ interface Vlan4094
 
 #### EVPN MLAG Shared Router MAC : mlag-system-id
 
-#### VLAN to VNI and Flood List Mappings
+#### VLAN to VNI, Flood List and Multicast Group Mappings
 
-| VLAN | VNI | Flood List |
-| ---- | --- | ---------- |
-| 110 | 10110 | - |
-| 111 | 50111 | - |
-| 112 | 50112 | - |
-| 2500 | 2500 | - |
-| 2600 | 2600 | - |
+| VLAN | VNI | Flood List | Multicast Group |
+| ---- | --- | ---------- | --------------- |
+| 110 | 10110 | - | - |
+| 111 | 50111 | - | - |
+| 112 | 50112 | - | - |
+| 2500 | 2500 | - | - |
+| 2600 | 2600 | - | - |
 
-#### VRF to VNI Mappings
+#### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI |
-| ---- | --- |
-| Common_VRF | 1025 |
-| vrf_with_loopbacks_dc1_pod1_only | 1102 |
-| vrf_with_loopbacks_from_overlapping_pool | 1100 |
-| vrf_with_loopbacks_from_pod_pools | 1101 |
+| VLAN | VNI | Multicast Group |
+| ---- | --- | --------------- |
+| Common_VRF | 1025 | - |
+| vrf_with_loopbacks_dc1_pod1_only | 1102 | - |
+| vrf_with_loopbacks_from_overlapping_pool | 1100 | - |
+| vrf_with_loopbacks_from_pod_pools | 1101 | - |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
@@ -670,7 +670,7 @@ interface Vlan4094
 
 #### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI | Multicast Group |
+| VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Common_VRF | 1025 | - |
 | vrf_with_loopbacks_dc1_pod1_only | 1102 | - |

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-LEAF1A.md
@@ -421,24 +421,24 @@ interface Vlan1102
 
 #### UDP port: 4789
 
-#### VLAN to VNI and Flood List Mappings
+#### VLAN to VNI, Flood List and Multicast Group Mappings
 
-| VLAN | VNI | Flood List |
-| ---- | --- | ---------- |
-| 110 | 10110 | - |
-| 111 | 50111 | - |
-| 112 | 50112 | - |
-| 2500 | 2500 | - |
-| 2600 | 2600 | - |
+| VLAN | VNI | Flood List | Multicast Group |
+| ---- | --- | ---------- | --------------- |
+| 110 | 10110 | - | - |
+| 111 | 50111 | - | - |
+| 112 | 50112 | - | - |
+| 2500 | 2500 | - | - |
+| 2600 | 2600 | - | - |
 
-#### VRF to VNI Mappings
+#### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI |
-| ---- | --- |
-| Common_VRF | 1025 |
-| vrf_with_loopbacks_dc1_pod1_only | 1102 |
-| vrf_with_loopbacks_from_overlapping_pool | 1100 |
-| vrf_with_loopbacks_from_pod_pools | 1101 |
+| VLAN | VNI | Multicast Group |
+| ---- | --- | --------------- |
+| Common_VRF | 1025 | - |
+| vrf_with_loopbacks_dc1_pod1_only | 1102 | - |
+| vrf_with_loopbacks_from_overlapping_pool | 1100 | - |
+| vrf_with_loopbacks_from_pod_pools | 1101 | - |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-LEAF1A.md
@@ -433,7 +433,7 @@ interface Vlan1102
 
 #### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI | Multicast Group |
+| VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Common_VRF | 1025 | - |
 | vrf_with_loopbacks_dc1_pod1_only | 1102 | - |

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-LEAF1A.md
@@ -375,14 +375,14 @@ interface Vlan4092
 
 #### UDP port: 4789
 
-#### VRF to VNI Mappings
+#### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI |
-| ---- | --- |
-| Common_VRF | 1025 |
-| vrf_with_loopbacks_dc1_pod1_only | 1102 |
-| vrf_with_loopbacks_from_overlapping_pool | 1100 |
-| vrf_with_loopbacks_from_pod_pools | 1101 |
+| VLAN | VNI | Multicast Group |
+| ---- | --- | --------------- |
+| Common_VRF | 1025 | - |
+| vrf_with_loopbacks_dc1_pod1_only | 1102 | - |
+| vrf_with_loopbacks_from_overlapping_pool | 1100 | - |
+| vrf_with_loopbacks_from_pod_pools | 1101 | - |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-LEAF1A.md
@@ -377,7 +377,7 @@ interface Vlan4092
 
 #### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI | Multicast Group |
+| VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Common_VRF | 1025 | - |
 | vrf_with_loopbacks_dc1_pod1_only | 1102 | - |

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL1A.md
@@ -442,7 +442,7 @@ interface Vlan350
 
 #### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI | Multicast Group |
+| VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Tenant_A_WAN_Zone | 14 | - |
 | Tenant_B_OP_Zone | 20 | - |

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL1A.md
@@ -432,23 +432,23 @@ interface Vlan350
 
 #### UDP port: 4789
 
-#### VLAN to VNI and Flood List Mappings
+#### VLAN to VNI, Flood List and Multicast Group Mappings
 
-| VLAN | VNI | Flood List |
-| ---- | --- | ---------- |
-| 150 | 10150 | - |
-| 250 | 20250 | - |
-| 350 | 30350 | - |
+| VLAN | VNI | Flood List | Multicast Group |
+| ---- | --- | ---------- | --------------- |
+| 150 | 10150 | - | - |
+| 250 | 20250 | - | - |
+| 350 | 30350 | - | - |
 
-#### VRF to VNI Mappings
+#### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI |
-| ---- | --- |
-| Tenant_A_WAN_Zone | 14 |
-| Tenant_B_OP_Zone | 20 |
-| Tenant_B_WAN_Zone | 21 |
-| Tenant_C_WAN_Zone | 31 |
-| Tenant_L3_VRF_Zone | 15 |
+| VLAN | VNI | Multicast Group |
+| ---- | --- | --------------- |
+| Tenant_A_WAN_Zone | 14 | - |
+| Tenant_B_OP_Zone | 20 | - |
+| Tenant_B_WAN_Zone | 21 | - |
+| Tenant_C_WAN_Zone | 31 | - |
+| Tenant_L3_VRF_Zone | 15 | - |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL1B.md
@@ -430,23 +430,23 @@ interface Vlan350
 
 #### UDP port: 4789
 
-#### VLAN to VNI and Flood List Mappings
+#### VLAN to VNI, Flood List and Multicast Group Mappings
 
-| VLAN | VNI | Flood List |
-| ---- | --- | ---------- |
-| 150 | 10150 | - |
-| 250 | 20250 | - |
-| 350 | 30350 | - |
+| VLAN | VNI | Flood List | Multicast Group |
+| ---- | --- | ---------- | --------------- |
+| 150 | 10150 | - | - |
+| 250 | 20250 | - | - |
+| 350 | 30350 | - | - |
 
-#### VRF to VNI Mappings
+#### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI |
-| ---- | --- |
-| Tenant_A_WAN_Zone | 14 |
-| Tenant_B_OP_Zone | 20 |
-| Tenant_B_WAN_Zone | 21 |
-| Tenant_C_WAN_Zone | 31 |
-| Tenant_L3_VRF_Zone | 15 |
+| VLAN | VNI | Multicast Group |
+| ---- | --- | --------------- |
+| Tenant_A_WAN_Zone | 14 | - |
+| Tenant_B_OP_Zone | 20 | - |
+| Tenant_B_WAN_Zone | 21 | - |
+| Tenant_C_WAN_Zone | 31 | - |
+| Tenant_L3_VRF_Zone | 15 | - |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL1B.md
@@ -440,7 +440,7 @@ interface Vlan350
 
 #### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI | Multicast Group |
+| VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Tenant_A_WAN_Zone | 14 | - |
 | Tenant_B_OP_Zone | 20 | - |

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL2A.md
@@ -430,7 +430,7 @@ interface Vlan350
 
 #### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI | Multicast Group |
+| VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Tenant_A_WAN_Zone | 14 | - |
 | Tenant_B_OP_Zone | 20 | - |

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL2A.md
@@ -420,22 +420,22 @@ interface Vlan350
 
 #### UDP port: 4789
 
-#### VLAN to VNI and Flood List Mappings
+#### VLAN to VNI, Flood List and Multicast Group Mappings
 
-| VLAN | VNI | Flood List |
-| ---- | --- | ---------- |
-| 150 | 10150 | - |
-| 250 | 20250 | - |
-| 350 | 30350 | - |
+| VLAN | VNI | Flood List | Multicast Group |
+| ---- | --- | ---------- | --------------- |
+| 150 | 10150 | - | - |
+| 250 | 20250 | - | - |
+| 350 | 30350 | - | - |
 
-#### VRF to VNI Mappings
+#### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI |
-| ---- | --- |
-| Tenant_A_WAN_Zone | 14 |
-| Tenant_B_OP_Zone | 20 |
-| Tenant_B_WAN_Zone | 21 |
-| Tenant_C_WAN_Zone | 31 |
+| VLAN | VNI | Multicast Group |
+| ---- | --- | --------------- |
+| Tenant_A_WAN_Zone | 14 | - |
+| Tenant_B_OP_Zone | 20 | - |
+| Tenant_B_WAN_Zone | 21 | - |
+| Tenant_C_WAN_Zone | 31 | - |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL2B.md
@@ -413,7 +413,7 @@ interface Vlan350
 
 #### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI | Multicast Group |
+| VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Tenant_A_WAN_Zone | 14 | - |
 | Tenant_B_OP_Zone | 20 | - |

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL2B.md
@@ -403,22 +403,22 @@ interface Vlan350
 
 #### UDP port: 4789
 
-#### VLAN to VNI and Flood List Mappings
+#### VLAN to VNI, Flood List and Multicast Group Mappings
 
-| VLAN | VNI | Flood List |
-| ---- | --- | ---------- |
-| 150 | 10150 | - |
-| 250 | 20250 | - |
-| 350 | 30350 | - |
+| VLAN | VNI | Flood List | Multicast Group |
+| ---- | --- | ---------- | --------------- |
+| 150 | 10150 | - | - |
+| 250 | 20250 | - | - |
+| 350 | 30350 | - | - |
 
-#### VRF to VNI Mappings
+#### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI |
-| ---- | --- |
-| Tenant_A_WAN_Zone | 14 |
-| Tenant_B_OP_Zone | 20 |
-| Tenant_B_WAN_Zone | 21 |
-| Tenant_C_WAN_Zone | 31 |
+| VLAN | VNI | Multicast Group |
+| ---- | --- | --------------- |
+| Tenant_A_WAN_Zone | 14 | - |
+| Tenant_B_OP_Zone | 20 | - |
+| Tenant_B_WAN_Zone | 21 | - |
+| Tenant_C_WAN_Zone | 31 | - |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF1A.md
@@ -457,22 +457,22 @@ interface Vlan132
 
 #### UDP port: 4789
 
-#### VLAN to VNI and Flood List Mappings
+#### VLAN to VNI, Flood List and Multicast Group Mappings
 
-| VLAN | VNI | Flood List |
-| ---- | --- | ---------- |
-| 120 | 10120 | - |
-| 121 | 10121 | - |
-| 130 | 10130 | - |
-| 131 | 10131 | - |
-| 132 | 10132 | - |
+| VLAN | VNI | Flood List | Multicast Group |
+| ---- | --- | ---------- | --------------- |
+| 120 | 10120 | - | - |
+| 121 | 10121 | - | - |
+| 130 | 10130 | - | - |
+| 131 | 10131 | - | - |
+| 132 | 10132 | - | - |
 
-#### VRF to VNI Mappings
+#### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI |
-| ---- | --- |
-| Tenant_A_APP_Zone | 12 |
-| Tenant_A_WEB_Zone | 11 |
+| VLAN | VNI | Multicast Group |
+| ---- | --- | --------------- |
+| Tenant_A_APP_Zone | 12 | - |
+| Tenant_A_WEB_Zone | 11 | - |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF1A.md
@@ -469,7 +469,7 @@ interface Vlan132
 
 #### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI | Multicast Group |
+| VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Tenant_A_APP_Zone | 12 | - |
 | Tenant_A_WEB_Zone | 11 | - |

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2A.md
@@ -693,7 +693,7 @@ interface Vlan311
 
 #### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI | Multicast Group |
+| VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Tenant_A_APP_Zone | 12 | - |
 | Tenant_A_DB_Zone | 13 | - |

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2A.md
@@ -672,35 +672,35 @@ interface Vlan311
 
 #### UDP port: 4789
 
-#### VLAN to VNI and Flood List Mappings
+#### VLAN to VNI, Flood List and Multicast Group Mappings
 
-| VLAN | VNI | Flood List |
-| ---- | --- | ---------- |
-| 110 | 10110 | - |
-| 111 | 50111 | - |
-| 120 | 10120 | - |
-| 121 | 10121 | - |
-| 130 | 10130 | - |
-| 131 | 10131 | - |
-| 140 | 10140 | - |
-| 141 | 10141 | - |
-| 160 | 10160 | - |
-| 161 | 10161 | - |
-| 210 | 20210 | - |
-| 211 | 20211 | - |
-| 310 | 30310 | - |
-| 311 | 30311 | - |
+| VLAN | VNI | Flood List | Multicast Group |
+| ---- | --- | ---------- | --------------- |
+| 110 | 10110 | - | - |
+| 111 | 50111 | - | - |
+| 120 | 10120 | - | - |
+| 121 | 10121 | - | - |
+| 130 | 10130 | - | - |
+| 131 | 10131 | - | - |
+| 140 | 10140 | - | - |
+| 141 | 10141 | - | - |
+| 160 | 10160 | - | - |
+| 161 | 10161 | - | - |
+| 210 | 20210 | - | - |
+| 211 | 20211 | - | - |
+| 310 | 30310 | - | - |
+| 311 | 30311 | - | - |
 
-#### VRF to VNI Mappings
+#### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI |
-| ---- | --- |
-| Tenant_A_APP_Zone | 12 |
-| Tenant_A_DB_Zone | 13 |
-| Tenant_A_OP_Zone | 10 |
-| Tenant_A_WEB_Zone | 11 |
-| Tenant_B_OP_Zone | 20 |
-| Tenant_C_OP_Zone | 30 |
+| VLAN | VNI | Multicast Group |
+| ---- | --- | --------------- |
+| Tenant_A_APP_Zone | 12 | - |
+| Tenant_A_DB_Zone | 13 | - |
+| Tenant_A_OP_Zone | 10 | - |
+| Tenant_A_WEB_Zone | 11 | - |
+| Tenant_B_OP_Zone | 20 | - |
+| Tenant_C_OP_Zone | 30 | - |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2B.md
@@ -693,7 +693,7 @@ interface Vlan311
 
 #### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI | Multicast Group |
+| VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Tenant_A_APP_Zone | 12 | - |
 | Tenant_A_DB_Zone | 13 | - |

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2B.md
@@ -672,35 +672,35 @@ interface Vlan311
 
 #### UDP port: 4789
 
-#### VLAN to VNI and Flood List Mappings
+#### VLAN to VNI, Flood List and Multicast Group Mappings
 
-| VLAN | VNI | Flood List |
-| ---- | --- | ---------- |
-| 110 | 10110 | - |
-| 111 | 50111 | - |
-| 120 | 10120 | - |
-| 121 | 10121 | - |
-| 130 | 10130 | - |
-| 131 | 10131 | - |
-| 140 | 10140 | - |
-| 141 | 10141 | - |
-| 160 | 10160 | - |
-| 161 | 10161 | - |
-| 210 | 20210 | - |
-| 211 | 20211 | - |
-| 310 | 30310 | - |
-| 311 | 30311 | - |
+| VLAN | VNI | Flood List | Multicast Group |
+| ---- | --- | ---------- | --------------- |
+| 110 | 10110 | - | - |
+| 111 | 50111 | - | - |
+| 120 | 10120 | - | - |
+| 121 | 10121 | - | - |
+| 130 | 10130 | - | - |
+| 131 | 10131 | - | - |
+| 140 | 10140 | - | - |
+| 141 | 10141 | - | - |
+| 160 | 10160 | - | - |
+| 161 | 10161 | - | - |
+| 210 | 20210 | - | - |
+| 211 | 20211 | - | - |
+| 310 | 30310 | - | - |
+| 311 | 30311 | - | - |
 
-#### VRF to VNI Mappings
+#### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI |
-| ---- | --- |
-| Tenant_A_APP_Zone | 12 |
-| Tenant_A_DB_Zone | 13 |
-| Tenant_A_OP_Zone | 10 |
-| Tenant_A_WEB_Zone | 11 |
-| Tenant_B_OP_Zone | 20 |
-| Tenant_C_OP_Zone | 30 |
+| VLAN | VNI | Multicast Group |
+| ---- | --- | --------------- |
+| Tenant_A_APP_Zone | 12 | - |
+| Tenant_A_DB_Zone | 13 | - |
+| Tenant_A_OP_Zone | 10 | - |
+| Tenant_A_WEB_Zone | 11 | - |
+| Tenant_B_OP_Zone | 20 | - |
+| Tenant_C_OP_Zone | 30 | - |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3A.md
@@ -1002,41 +1002,41 @@ interface Vlan4092
 
 #### EVPN MLAG Shared Router MAC : mlag-system-id
 
-#### VLAN to VNI and Flood List Mappings
+#### VLAN to VNI, Flood List and Multicast Group Mappings
 
-| VLAN | VNI | Flood List |
-| ---- | --- | ---------- |
-| 110 | 10110 | - |
-| 111 | 50111 | - |
-| 120 | 10120 | - |
-| 121 | 10121 | - |
-| 130 | 10130 | - |
-| 131 | 10131 | - |
-| 140 | 10140 | - |
-| 141 | 10141 | - |
-| 150 | 10150 | - |
-| 160 | 10160 | - |
-| 161 | 10161 | - |
-| 210 | 20210 | - |
-| 211 | 20211 | - |
-| 250 | 20250 | - |
-| 310 | 30310 | - |
-| 311 | 30311 | - |
-| 350 | 30350 | - |
+| VLAN | VNI | Flood List | Multicast Group |
+| ---- | --- | ---------- | --------------- |
+| 110 | 10110 | - | - |
+| 111 | 50111 | - | - |
+| 120 | 10120 | - | - |
+| 121 | 10121 | - | - |
+| 130 | 10130 | - | - |
+| 131 | 10131 | - | - |
+| 140 | 10140 | - | - |
+| 141 | 10141 | - | - |
+| 150 | 10150 | - | - |
+| 160 | 10160 | - | - |
+| 161 | 10161 | - | - |
+| 210 | 20210 | - | - |
+| 211 | 20211 | - | - |
+| 250 | 20250 | - | - |
+| 310 | 30310 | - | - |
+| 311 | 30311 | - | - |
+| 350 | 30350 | - | - |
 
-#### VRF to VNI Mappings
+#### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI |
-| ---- | --- |
-| Tenant_A_APP_Zone | 12 |
-| Tenant_A_DB_Zone | 13 |
-| Tenant_A_OP_Zone | 10 |
-| Tenant_A_WAN_Zone | 14 |
-| Tenant_A_WEB_Zone | 11 |
-| Tenant_B_OP_Zone | 20 |
-| Tenant_B_WAN_Zone | 21 |
-| Tenant_C_OP_Zone | 30 |
-| Tenant_C_WAN_Zone | 31 |
+| VLAN | VNI | Multicast Group |
+| ---- | --- | --------------- |
+| Tenant_A_APP_Zone | 12 | - |
+| Tenant_A_DB_Zone | 13 | - |
+| Tenant_A_OP_Zone | 10 | - |
+| Tenant_A_WAN_Zone | 14 | - |
+| Tenant_A_WEB_Zone | 11 | - |
+| Tenant_B_OP_Zone | 20 | - |
+| Tenant_B_WAN_Zone | 21 | - |
+| Tenant_C_OP_Zone | 30 | - |
+| Tenant_C_WAN_Zone | 31 | - |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3A.md
@@ -1026,7 +1026,7 @@ interface Vlan4092
 
 #### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI | Multicast Group |
+| VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Tenant_A_APP_Zone | 12 | - |
 | Tenant_A_DB_Zone | 13 | - |

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3B.md
@@ -1011,7 +1011,7 @@ interface Vlan4092
 
 #### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI | Multicast Group |
+| VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Tenant_A_APP_Zone | 12 | - |
 | Tenant_A_DB_Zone | 13 | - |

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3B.md
@@ -987,41 +987,41 @@ interface Vlan4092
 
 #### EVPN MLAG Shared Router MAC : mlag-system-id
 
-#### VLAN to VNI and Flood List Mappings
+#### VLAN to VNI, Flood List and Multicast Group Mappings
 
-| VLAN | VNI | Flood List |
-| ---- | --- | ---------- |
-| 110 | 10110 | - |
-| 111 | 50111 | - |
-| 120 | 10120 | - |
-| 121 | 10121 | - |
-| 130 | 10130 | - |
-| 131 | 10131 | - |
-| 140 | 10140 | - |
-| 141 | 10141 | - |
-| 150 | 10150 | - |
-| 160 | 10160 | - |
-| 161 | 10161 | - |
-| 210 | 20210 | - |
-| 211 | 20211 | - |
-| 250 | 20250 | - |
-| 310 | 30310 | - |
-| 311 | 30311 | - |
-| 350 | 30350 | - |
+| VLAN | VNI | Flood List | Multicast Group |
+| ---- | --- | ---------- | --------------- |
+| 110 | 10110 | - | - |
+| 111 | 50111 | - | - |
+| 120 | 10120 | - | - |
+| 121 | 10121 | - | - |
+| 130 | 10130 | - | - |
+| 131 | 10131 | - | - |
+| 140 | 10140 | - | - |
+| 141 | 10141 | - | - |
+| 150 | 10150 | - | - |
+| 160 | 10160 | - | - |
+| 161 | 10161 | - | - |
+| 210 | 20210 | - | - |
+| 211 | 20211 | - | - |
+| 250 | 20250 | - | - |
+| 310 | 30310 | - | - |
+| 311 | 30311 | - | - |
+| 350 | 30350 | - | - |
 
-#### VRF to VNI Mappings
+#### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI |
-| ---- | --- |
-| Tenant_A_APP_Zone | 12 |
-| Tenant_A_DB_Zone | 13 |
-| Tenant_A_OP_Zone | 10 |
-| Tenant_A_WAN_Zone | 14 |
-| Tenant_A_WEB_Zone | 11 |
-| Tenant_B_OP_Zone | 20 |
-| Tenant_B_WAN_Zone | 21 |
-| Tenant_C_OP_Zone | 30 |
-| Tenant_C_WAN_Zone | 31 |
+| VLAN | VNI | Multicast Group |
+| ---- | --- | --------------- |
+| Tenant_A_APP_Zone | 12 | - |
+| Tenant_A_DB_Zone | 13 | - |
+| Tenant_A_OP_Zone | 10 | - |
+| Tenant_A_WAN_Zone | 14 | - |
+| Tenant_A_WEB_Zone | 11 | - |
+| Tenant_B_OP_Zone | 20 | - |
+| Tenant_B_WAN_Zone | 21 | - |
+| Tenant_C_OP_Zone | 30 | - |
+| Tenant_C_WAN_Zone | 31 | - |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -463,7 +463,7 @@ interface Vlan350
 
 #### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI | Multicast Group |
+| VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Tenant_A_WAN_Zone | 14 | - |
 | Tenant_B_OP_Zone | 20 | - |

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -454,22 +454,22 @@ interface Vlan350
 
 #### UDP port: 4789
 
-#### VLAN to VNI and Flood List Mappings
+#### VLAN to VNI, Flood List and Multicast Group Mappings
 
-| VLAN | VNI | Flood List |
-| ---- | --- | ---------- |
-| 150 | 10150 | - |
-| 250 | 20250 | - |
+| VLAN | VNI | Flood List | Multicast Group |
+| ---- | --- | ---------- | --------------- |
+| 150 | 10150 | - | - |
+| 250 | 20250 | - | - |
 
-#### VRF to VNI Mappings
+#### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI |
-| ---- | --- |
-| Tenant_A_WAN_Zone | 14 |
-| Tenant_B_OP_Zone | 20 |
-| Tenant_B_WAN_Zone | 21 |
-| Tenant_C_WAN_Zone | 31 |
-| Tenant_L3_VRF_Zone | 15 |
+| VLAN | VNI | Multicast Group |
+| ---- | --- | --------------- |
+| Tenant_A_WAN_Zone | 14 | - |
+| Tenant_B_OP_Zone | 20 | - |
+| Tenant_B_WAN_Zone | 21 | - |
+| Tenant_C_WAN_Zone | 31 | - |
+| Tenant_L3_VRF_Zone | 15 | - |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -461,7 +461,7 @@ interface Vlan350
 
 #### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI | Multicast Group |
+| VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Tenant_A_WAN_Zone | 14 | - |
 | Tenant_B_OP_Zone | 20 | - |

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -452,22 +452,22 @@ interface Vlan350
 
 #### UDP port: 4789
 
-#### VLAN to VNI and Flood List Mappings
+#### VLAN to VNI, Flood List and Multicast Group Mappings
 
-| VLAN | VNI | Flood List |
-| ---- | --- | ---------- |
-| 150 | 10150 | - |
-| 250 | 20250 | - |
+| VLAN | VNI | Flood List | Multicast Group |
+| ---- | --- | ---------- | --------------- |
+| 150 | 10150 | - | - |
+| 250 | 20250 | - | - |
 
-#### VRF to VNI Mappings
+#### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI |
-| ---- | --- |
-| Tenant_A_WAN_Zone | 14 |
-| Tenant_B_OP_Zone | 20 |
-| Tenant_B_WAN_Zone | 21 |
-| Tenant_C_WAN_Zone | 31 |
-| Tenant_L3_VRF_Zone | 15 |
+| VLAN | VNI | Multicast Group |
+| ---- | --- | --------------- |
+| Tenant_A_WAN_Zone | 14 | - |
+| Tenant_B_OP_Zone | 20 | - |
+| Tenant_B_WAN_Zone | 21 | - |
+| Tenant_C_WAN_Zone | 31 | - |
+| Tenant_L3_VRF_Zone | 15 | - |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -472,23 +472,23 @@ interface Vlan131
 
 #### UDP port: 4789
 
-#### VLAN to VNI and Flood List Mappings
+#### VLAN to VNI, Flood List and Multicast Group Mappings
 
-| VLAN | VNI | Flood List |
-| ---- | --- | ---------- |
-| 120 | 10120 | - |
-| 121 | 10121 | - |
-| 122 | 10122 | - |
-| 123 | 10123 | - |
-| 124 | 10124 | - |
-| 130 | 10130 | - |
+| VLAN | VNI | Flood List | Multicast Group |
+| ---- | --- | ---------- | --------------- |
+| 120 | 10120 | - | - |
+| 121 | 10121 | - | - |
+| 122 | 10122 | - | - |
+| 123 | 10123 | - | - |
+| 124 | 10124 | - | - |
+| 130 | 10130 | - | - |
 
-#### VRF to VNI Mappings
+#### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI |
-| ---- | --- |
-| Tenant_A_APP_Zone | 12 |
-| Tenant_A_WEB_Zone | 11 |
+| VLAN | VNI | Multicast Group |
+| ---- | --- | --------------- |
+| Tenant_A_APP_Zone | 12 | - |
+| Tenant_A_WEB_Zone | 11 | - |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -485,7 +485,7 @@ interface Vlan131
 
 #### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI | Multicast Group |
+| VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Tenant_A_APP_Zone | 12 | - |
 | Tenant_A_WEB_Zone | 11 | - |

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -743,7 +743,7 @@ interface Vlan311
 
 #### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI | Multicast Group |
+| VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Tenant_A_APP_Zone | 12 | - |
 | Tenant_A_DB_Zone | 13 | - |

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -719,38 +719,38 @@ interface Vlan311
 
 #### UDP port: 4789
 
-#### VLAN to VNI and Flood List Mappings
+#### VLAN to VNI, Flood List and Multicast Group Mappings
 
-| VLAN | VNI | Flood List |
-| ---- | --- | ---------- |
-| 110 | 10110 | - |
-| 111 | 50111 | - |
-| 120 | 10120 | - |
-| 121 | 10121 | - |
-| 122 | 10122 | - |
-| 123 | 10123 | - |
-| 124 | 10124 | - |
-| 130 | 10130 | - |
-| 140 | 10140 | - |
-| 141 | 10141 | - |
-| 160 | 10160 | - |
-| 161 | 10161 | - |
-| 162 | 10162 | - |
-| 210 | 20210 | - |
-| 211 | 20211 | - |
-| 310 | 30310 | - |
-| 311 | 30311 | - |
+| VLAN | VNI | Flood List | Multicast Group |
+| ---- | --- | ---------- | --------------- |
+| 110 | 10110 | - | - |
+| 111 | 50111 | - | - |
+| 120 | 10120 | - | - |
+| 121 | 10121 | - | - |
+| 122 | 10122 | - | - |
+| 123 | 10123 | - | - |
+| 124 | 10124 | - | - |
+| 130 | 10130 | - | - |
+| 140 | 10140 | - | - |
+| 141 | 10141 | - | - |
+| 160 | 10160 | - | - |
+| 161 | 10161 | - | - |
+| 162 | 10162 | - | - |
+| 210 | 20210 | - | - |
+| 211 | 20211 | - | - |
+| 310 | 30310 | - | - |
+| 311 | 30311 | - | - |
 
-#### VRF to VNI Mappings
+#### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI |
-| ---- | --- |
-| Tenant_A_APP_Zone | 12 |
-| Tenant_A_DB_Zone | 13 |
-| Tenant_A_OP_Zone | 10 |
-| Tenant_A_WEB_Zone | 11 |
-| Tenant_B_OP_Zone | 20 |
-| Tenant_C_OP_Zone | 30 |
+| VLAN | VNI | Multicast Group |
+| ---- | --- | --------------- |
+| Tenant_A_APP_Zone | 12 | - |
+| Tenant_A_DB_Zone | 13 | - |
+| Tenant_A_OP_Zone | 10 | - |
+| Tenant_A_WEB_Zone | 11 | - |
+| Tenant_B_OP_Zone | 20 | - |
+| Tenant_C_OP_Zone | 30 | - |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -743,7 +743,7 @@ interface Vlan311
 
 #### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI | Multicast Group |
+| VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Tenant_A_APP_Zone | 12 | - |
 | Tenant_A_DB_Zone | 13 | - |

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -719,38 +719,38 @@ interface Vlan311
 
 #### UDP port: 4789
 
-#### VLAN to VNI and Flood List Mappings
+#### VLAN to VNI, Flood List and Multicast Group Mappings
 
-| VLAN | VNI | Flood List |
-| ---- | --- | ---------- |
-| 110 | 10110 | - |
-| 111 | 50111 | - |
-| 120 | 10120 | - |
-| 121 | 10121 | - |
-| 122 | 10122 | - |
-| 123 | 10123 | - |
-| 124 | 10124 | - |
-| 130 | 10130 | - |
-| 140 | 10140 | - |
-| 141 | 10141 | - |
-| 160 | 10160 | - |
-| 161 | 10161 | - |
-| 162 | 10162 | - |
-| 210 | 20210 | - |
-| 211 | 20211 | - |
-| 310 | 30310 | - |
-| 311 | 30311 | - |
+| VLAN | VNI | Flood List | Multicast Group |
+| ---- | --- | ---------- | --------------- |
+| 110 | 10110 | - | - |
+| 111 | 50111 | - | - |
+| 120 | 10120 | - | - |
+| 121 | 10121 | - | - |
+| 122 | 10122 | - | - |
+| 123 | 10123 | - | - |
+| 124 | 10124 | - | - |
+| 130 | 10130 | - | - |
+| 140 | 10140 | - | - |
+| 141 | 10141 | - | - |
+| 160 | 10160 | - | - |
+| 161 | 10161 | - | - |
+| 162 | 10162 | - | - |
+| 210 | 20210 | - | - |
+| 211 | 20211 | - | - |
+| 310 | 30310 | - | - |
+| 311 | 30311 | - | - |
 
-#### VRF to VNI Mappings
+#### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI |
-| ---- | --- |
-| Tenant_A_APP_Zone | 12 |
-| Tenant_A_DB_Zone | 13 |
-| Tenant_A_OP_Zone | 10 |
-| Tenant_A_WEB_Zone | 11 |
-| Tenant_B_OP_Zone | 20 |
-| Tenant_C_OP_Zone | 30 |
+| VLAN | VNI | Multicast Group |
+| ---- | --- | --------------- |
+| Tenant_A_APP_Zone | 12 | - |
+| Tenant_A_DB_Zone | 13 | - |
+| Tenant_A_OP_Zone | 10 | - |
+| Tenant_A_WEB_Zone | 11 | - |
+| Tenant_B_OP_Zone | 20 | - |
+| Tenant_C_OP_Zone | 30 | - |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -1031,43 +1031,43 @@ interface Vlan4092
 
 #### EVPN MLAG Shared Router MAC : mlag-system-id
 
-#### VLAN to VNI and Flood List Mappings
+#### VLAN to VNI, Flood List and Multicast Group Mappings
 
-| VLAN | VNI | Flood List |
-| ---- | --- | ---------- |
-| 110 | 10110 | - |
-| 111 | 50111 | - |
-| 120 | 10120 | - |
-| 121 | 10121 | - |
-| 122 | 10122 | - |
-| 123 | 10123 | - |
-| 124 | 10124 | - |
-| 130 | 10130 | - |
-| 140 | 10140 | - |
-| 141 | 10141 | - |
-| 150 | 10150 | - |
-| 160 | 10160 | - |
-| 161 | 10161 | - |
-| 162 | 10162 | - |
-| 210 | 20210 | - |
-| 211 | 20211 | - |
-| 250 | 20250 | - |
-| 310 | 30310 | - |
-| 311 | 30311 | - |
+| VLAN | VNI | Flood List | Multicast Group |
+| ---- | --- | ---------- | --------------- |
+| 110 | 10110 | - | - |
+| 111 | 50111 | - | - |
+| 120 | 10120 | - | - |
+| 121 | 10121 | - | - |
+| 122 | 10122 | - | - |
+| 123 | 10123 | - | - |
+| 124 | 10124 | - | - |
+| 130 | 10130 | - | - |
+| 140 | 10140 | - | - |
+| 141 | 10141 | - | - |
+| 150 | 10150 | - | - |
+| 160 | 10160 | - | - |
+| 161 | 10161 | - | - |
+| 162 | 10162 | - | - |
+| 210 | 20210 | - | - |
+| 211 | 20211 | - | - |
+| 250 | 20250 | - | - |
+| 310 | 30310 | - | - |
+| 311 | 30311 | - | - |
 
-#### VRF to VNI Mappings
+#### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI |
-| ---- | --- |
-| Tenant_A_APP_Zone | 12 |
-| Tenant_A_DB_Zone | 13 |
-| Tenant_A_OP_Zone | 10 |
-| Tenant_A_WAN_Zone | 14 |
-| Tenant_A_WEB_Zone | 11 |
-| Tenant_B_OP_Zone | 20 |
-| Tenant_B_WAN_Zone | 21 |
-| Tenant_C_OP_Zone | 30 |
-| Tenant_C_WAN_Zone | 31 |
+| VLAN | VNI | Multicast Group |
+| ---- | --- | --------------- |
+| Tenant_A_APP_Zone | 12 | - |
+| Tenant_A_DB_Zone | 13 | - |
+| Tenant_A_OP_Zone | 10 | - |
+| Tenant_A_WAN_Zone | 14 | - |
+| Tenant_A_WEB_Zone | 11 | - |
+| Tenant_B_OP_Zone | 20 | - |
+| Tenant_B_WAN_Zone | 21 | - |
+| Tenant_C_OP_Zone | 30 | - |
+| Tenant_C_WAN_Zone | 31 | - |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -1057,7 +1057,7 @@ interface Vlan4092
 
 #### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI | Multicast Group |
+| VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Tenant_A_APP_Zone | 12 | - |
 | Tenant_A_DB_Zone | 13 | - |

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -1031,43 +1031,43 @@ interface Vlan4092
 
 #### EVPN MLAG Shared Router MAC : mlag-system-id
 
-#### VLAN to VNI and Flood List Mappings
+#### VLAN to VNI, Flood List and Multicast Group Mappings
 
-| VLAN | VNI | Flood List |
-| ---- | --- | ---------- |
-| 110 | 10110 | - |
-| 111 | 50111 | - |
-| 120 | 10120 | - |
-| 121 | 10121 | - |
-| 122 | 10122 | - |
-| 123 | 10123 | - |
-| 124 | 10124 | - |
-| 130 | 10130 | - |
-| 140 | 10140 | - |
-| 141 | 10141 | - |
-| 150 | 10150 | - |
-| 160 | 10160 | - |
-| 161 | 10161 | - |
-| 162 | 10162 | - |
-| 210 | 20210 | - |
-| 211 | 20211 | - |
-| 250 | 20250 | - |
-| 310 | 30310 | - |
-| 311 | 30311 | - |
+| VLAN | VNI | Flood List | Multicast Group |
+| ---- | --- | ---------- | --------------- |
+| 110 | 10110 | - | - |
+| 111 | 50111 | - | - |
+| 120 | 10120 | - | - |
+| 121 | 10121 | - | - |
+| 122 | 10122 | - | - |
+| 123 | 10123 | - | - |
+| 124 | 10124 | - | - |
+| 130 | 10130 | - | - |
+| 140 | 10140 | - | - |
+| 141 | 10141 | - | - |
+| 150 | 10150 | - | - |
+| 160 | 10160 | - | - |
+| 161 | 10161 | - | - |
+| 162 | 10162 | - | - |
+| 210 | 20210 | - | - |
+| 211 | 20211 | - | - |
+| 250 | 20250 | - | - |
+| 310 | 30310 | - | - |
+| 311 | 30311 | - | - |
 
-#### VRF to VNI Mappings
+#### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI |
-| ---- | --- |
-| Tenant_A_APP_Zone | 12 |
-| Tenant_A_DB_Zone | 13 |
-| Tenant_A_OP_Zone | 10 |
-| Tenant_A_WAN_Zone | 14 |
-| Tenant_A_WEB_Zone | 11 |
-| Tenant_B_OP_Zone | 20 |
-| Tenant_B_WAN_Zone | 21 |
-| Tenant_C_OP_Zone | 30 |
-| Tenant_C_WAN_Zone | 31 |
+| VLAN | VNI | Multicast Group |
+| ---- | --- | --------------- |
+| Tenant_A_APP_Zone | 12 | - |
+| Tenant_A_DB_Zone | 13 | - |
+| Tenant_A_OP_Zone | 10 | - |
+| Tenant_A_WAN_Zone | 14 | - |
+| Tenant_A_WEB_Zone | 11 | - |
+| Tenant_B_OP_Zone | 20 | - |
+| Tenant_B_WAN_Zone | 21 | - |
+| Tenant_C_OP_Zone | 30 | - |
+| Tenant_C_WAN_Zone | 31 | - |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -1057,7 +1057,7 @@ interface Vlan4092
 
 #### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI | Multicast Group |
+| VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Tenant_A_APP_Zone | 12 | - |
 | Tenant_A_DB_Zone | 13 | - |

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -410,21 +410,21 @@ interface Vlan350
 
 #### UDP port: 4789
 
-#### VLAN to VNI and Flood List Mappings
+#### VLAN to VNI, Flood List and Multicast Group Mappings
 
-| VLAN | VNI | Flood List |
-| ---- | --- | ---------- |
-| 150 | 10150 | - |
-| 250 | 20250 | - |
-| 350 | 30350 | - |
+| VLAN | VNI | Flood List | Multicast Group |
+| ---- | --- | ---------- | --------------- |
+| 150 | 10150 | - | - |
+| 250 | 20250 | - | - |
+| 350 | 30350 | - | - |
 
-#### VRF to VNI Mappings
+#### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI |
-| ---- | --- |
-| Tenant_A_WAN_Zone | 14 |
-| Tenant_B_WAN_Zone | 21 |
-| Tenant_C_WAN_Zone | 31 |
+| VLAN | VNI | Multicast Group |
+| ---- | --- | --------------- |
+| Tenant_A_WAN_Zone | 14 | - |
+| Tenant_B_WAN_Zone | 21 | - |
+| Tenant_C_WAN_Zone | 31 | - |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -420,7 +420,7 @@ interface Vlan350
 
 #### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI | Multicast Group |
+| VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Tenant_A_WAN_Zone | 14 | - |
 | Tenant_B_WAN_Zone | 21 | - |

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -409,21 +409,21 @@ interface Vlan350
 
 #### UDP port: 4789
 
-#### VLAN to VNI and Flood List Mappings
+#### VLAN to VNI, Flood List and Multicast Group Mappings
 
-| VLAN | VNI | Flood List |
-| ---- | --- | ---------- |
-| 150 | 10150 | - |
-| 250 | 20250 | - |
-| 350 | 30350 | - |
+| VLAN | VNI | Flood List | Multicast Group |
+| ---- | --- | ---------- | --------------- |
+| 150 | 10150 | - | - |
+| 250 | 20250 | - | - |
+| 350 | 30350 | - | - |
 
-#### VRF to VNI Mappings
+#### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI |
-| ---- | --- |
-| Tenant_A_WAN_Zone | 14 |
-| Tenant_B_WAN_Zone | 21 |
-| Tenant_C_WAN_Zone | 31 |
+| VLAN | VNI | Multicast Group |
+| ---- | --- | --------------- |
+| Tenant_A_WAN_Zone | 14 | - |
+| Tenant_B_WAN_Zone | 21 | - |
+| Tenant_C_WAN_Zone | 31 | - |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -419,7 +419,7 @@ interface Vlan350
 
 #### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI | Multicast Group |
+| VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Tenant_A_WAN_Zone | 14 | - |
 | Tenant_B_WAN_Zone | 21 | - |

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -432,21 +432,21 @@ interface Vlan131
 
 #### UDP port: 4789
 
-#### VLAN to VNI and Flood List Mappings
+#### VLAN to VNI, Flood List and Multicast Group Mappings
 
-| VLAN | VNI | Flood List |
-| ---- | --- | ---------- |
-| 120 | 10120 | - |
-| 121 | 10121 | - |
-| 130 | 10130 | - |
-| 131 | 10131 | - |
+| VLAN | VNI | Flood List | Multicast Group |
+| ---- | --- | ---------- | --------------- |
+| 120 | 10120 | - | - |
+| 121 | 10121 | - | - |
+| 130 | 10130 | - | - |
+| 131 | 10131 | - | - |
 
-#### VRF to VNI Mappings
+#### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI |
-| ---- | --- |
-| Tenant_A_APP_Zone | 12 |
-| Tenant_A_WEB_Zone | 11 |
+| VLAN | VNI | Multicast Group |
+| ---- | --- | --------------- |
+| Tenant_A_APP_Zone | 12 | - |
+| Tenant_A_WEB_Zone | 11 | - |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -443,7 +443,7 @@ interface Vlan131
 
 #### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI | Multicast Group |
+| VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Tenant_A_APP_Zone | 12 | - |
 | Tenant_A_WEB_Zone | 11 | - |

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -763,35 +763,35 @@ interface Vlan4094
 
 #### EVPN MLAG Shared Router MAC : mlag-system-id
 
-#### VLAN to VNI and Flood List Mappings
+#### VLAN to VNI, Flood List and Multicast Group Mappings
 
-| VLAN | VNI | Flood List |
-| ---- | --- | ---------- |
-| 110 | 10110 | - |
-| 111 | 50111 | - |
-| 120 | 10120 | - |
-| 121 | 10121 | - |
-| 130 | 10130 | - |
-| 131 | 10131 | - |
-| 140 | 10140 | - |
-| 141 | 10141 | - |
-| 160 | 10160 | - |
-| 161 | 10161 | - |
-| 210 | 20210 | - |
-| 211 | 20211 | - |
-| 310 | 30310 | - |
-| 311 | 30311 | - |
+| VLAN | VNI | Flood List | Multicast Group |
+| ---- | --- | ---------- | --------------- |
+| 110 | 10110 | - | - |
+| 111 | 50111 | - | - |
+| 120 | 10120 | - | - |
+| 121 | 10121 | - | - |
+| 130 | 10130 | - | - |
+| 131 | 10131 | - | - |
+| 140 | 10140 | - | - |
+| 141 | 10141 | - | - |
+| 160 | 10160 | - | - |
+| 161 | 10161 | - | - |
+| 210 | 20210 | - | - |
+| 211 | 20211 | - | - |
+| 310 | 30310 | - | - |
+| 311 | 30311 | - | - |
 
-#### VRF to VNI Mappings
+#### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI |
-| ---- | --- |
-| Tenant_A_APP_Zone | 12 |
-| Tenant_A_DB_Zone | 13 |
-| Tenant_A_OP_Zone | 10 |
-| Tenant_A_WEB_Zone | 11 |
-| Tenant_B_OP_Zone | 20 |
-| Tenant_C_OP_Zone | 30 |
+| VLAN | VNI | Multicast Group |
+| ---- | --- | --------------- |
+| Tenant_A_APP_Zone | 12 | - |
+| Tenant_A_DB_Zone | 13 | - |
+| Tenant_A_OP_Zone | 10 | - |
+| Tenant_A_WEB_Zone | 11 | - |
+| Tenant_B_OP_Zone | 20 | - |
+| Tenant_C_OP_Zone | 30 | - |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -784,7 +784,7 @@ interface Vlan4094
 
 #### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI | Multicast Group |
+| VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Tenant_A_APP_Zone | 12 | - |
 | Tenant_A_DB_Zone | 13 | - |

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -763,35 +763,35 @@ interface Vlan4094
 
 #### EVPN MLAG Shared Router MAC : mlag-system-id
 
-#### VLAN to VNI and Flood List Mappings
+#### VLAN to VNI, Flood List and Multicast Group Mappings
 
-| VLAN | VNI | Flood List |
-| ---- | --- | ---------- |
-| 110 | 10110 | - |
-| 111 | 50111 | - |
-| 120 | 10120 | - |
-| 121 | 10121 | - |
-| 130 | 10130 | - |
-| 131 | 10131 | - |
-| 140 | 10140 | - |
-| 141 | 10141 | - |
-| 160 | 10160 | - |
-| 161 | 10161 | - |
-| 210 | 20210 | - |
-| 211 | 20211 | - |
-| 310 | 30310 | - |
-| 311 | 30311 | - |
+| VLAN | VNI | Flood List | Multicast Group |
+| ---- | --- | ---------- | --------------- |
+| 110 | 10110 | - | - |
+| 111 | 50111 | - | - |
+| 120 | 10120 | - | - |
+| 121 | 10121 | - | - |
+| 130 | 10130 | - | - |
+| 131 | 10131 | - | - |
+| 140 | 10140 | - | - |
+| 141 | 10141 | - | - |
+| 160 | 10160 | - | - |
+| 161 | 10161 | - | - |
+| 210 | 20210 | - | - |
+| 211 | 20211 | - | - |
+| 310 | 30310 | - | - |
+| 311 | 30311 | - | - |
 
-#### VRF to VNI Mappings
+#### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI |
-| ---- | --- |
-| Tenant_A_APP_Zone | 12 |
-| Tenant_A_DB_Zone | 13 |
-| Tenant_A_OP_Zone | 10 |
-| Tenant_A_WEB_Zone | 11 |
-| Tenant_B_OP_Zone | 20 |
-| Tenant_C_OP_Zone | 30 |
+| VLAN | VNI | Multicast Group |
+| ---- | --- | --------------- |
+| Tenant_A_APP_Zone | 12 | - |
+| Tenant_A_DB_Zone | 13 | - |
+| Tenant_A_OP_Zone | 10 | - |
+| Tenant_A_WEB_Zone | 11 | - |
+| Tenant_B_OP_Zone | 20 | - |
+| Tenant_C_OP_Zone | 30 | - |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -784,7 +784,7 @@ interface Vlan4094
 
 #### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI | Multicast Group |
+| VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Tenant_A_APP_Zone | 12 | - |
 | Tenant_A_DB_Zone | 13 | - |

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -916,41 +916,41 @@ interface Vlan4094
 
 #### EVPN MLAG Shared Router MAC : mlag-system-id
 
-#### VLAN to VNI and Flood List Mappings
+#### VLAN to VNI, Flood List and Multicast Group Mappings
 
-| VLAN | VNI | Flood List |
-| ---- | --- | ---------- |
-| 110 | 10110 | - |
-| 111 | 50111 | - |
-| 120 | 10120 | - |
-| 121 | 10121 | - |
-| 130 | 10130 | - |
-| 131 | 10131 | - |
-| 140 | 10140 | - |
-| 141 | 10141 | - |
-| 150 | 10150 | - |
-| 160 | 10160 | - |
-| 161 | 10161 | - |
-| 210 | 20210 | - |
-| 211 | 20211 | - |
-| 250 | 20250 | - |
-| 310 | 30310 | - |
-| 311 | 30311 | - |
-| 350 | 30350 | - |
+| VLAN | VNI | Flood List | Multicast Group |
+| ---- | --- | ---------- | --------------- |
+| 110 | 10110 | - | - |
+| 111 | 50111 | - | - |
+| 120 | 10120 | - | - |
+| 121 | 10121 | - | - |
+| 130 | 10130 | - | - |
+| 131 | 10131 | - | - |
+| 140 | 10140 | - | - |
+| 141 | 10141 | - | - |
+| 150 | 10150 | - | - |
+| 160 | 10160 | - | - |
+| 161 | 10161 | - | - |
+| 210 | 20210 | - | - |
+| 211 | 20211 | - | - |
+| 250 | 20250 | - | - |
+| 310 | 30310 | - | - |
+| 311 | 30311 | - | - |
+| 350 | 30350 | - | - |
 
-#### VRF to VNI Mappings
+#### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI |
-| ---- | --- |
-| Tenant_A_APP_Zone | 12 |
-| Tenant_A_DB_Zone | 13 |
-| Tenant_A_OP_Zone | 10 |
-| Tenant_A_WAN_Zone | 14 |
-| Tenant_A_WEB_Zone | 11 |
-| Tenant_B_OP_Zone | 20 |
-| Tenant_B_WAN_Zone | 21 |
-| Tenant_C_OP_Zone | 30 |
-| Tenant_C_WAN_Zone | 31 |
+| VLAN | VNI | Multicast Group |
+| ---- | --- | --------------- |
+| Tenant_A_APP_Zone | 12 | - |
+| Tenant_A_DB_Zone | 13 | - |
+| Tenant_A_OP_Zone | 10 | - |
+| Tenant_A_WAN_Zone | 14 | - |
+| Tenant_A_WEB_Zone | 11 | - |
+| Tenant_B_OP_Zone | 20 | - |
+| Tenant_B_WAN_Zone | 21 | - |
+| Tenant_C_OP_Zone | 30 | - |
+| Tenant_C_WAN_Zone | 31 | - |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -940,7 +940,7 @@ interface Vlan4094
 
 #### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI | Multicast Group |
+| VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Tenant_A_APP_Zone | 12 | - |
 | Tenant_A_DB_Zone | 13 | - |

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -925,7 +925,7 @@ interface Vlan4094
 
 #### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI | Multicast Group |
+| VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Tenant_A_APP_Zone | 12 | - |
 | Tenant_A_DB_Zone | 13 | - |

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -901,41 +901,41 @@ interface Vlan4094
 
 #### EVPN MLAG Shared Router MAC : mlag-system-id
 
-#### VLAN to VNI and Flood List Mappings
+#### VLAN to VNI, Flood List and Multicast Group Mappings
 
-| VLAN | VNI | Flood List |
-| ---- | --- | ---------- |
-| 110 | 10110 | - |
-| 111 | 50111 | - |
-| 120 | 10120 | - |
-| 121 | 10121 | - |
-| 130 | 10130 | - |
-| 131 | 10131 | - |
-| 140 | 10140 | - |
-| 141 | 10141 | - |
-| 150 | 10150 | - |
-| 160 | 10160 | - |
-| 161 | 10161 | - |
-| 210 | 20210 | - |
-| 211 | 20211 | - |
-| 250 | 20250 | - |
-| 310 | 30310 | - |
-| 311 | 30311 | - |
-| 350 | 30350 | - |
+| VLAN | VNI | Flood List | Multicast Group |
+| ---- | --- | ---------- | --------------- |
+| 110 | 10110 | - | - |
+| 111 | 50111 | - | - |
+| 120 | 10120 | - | - |
+| 121 | 10121 | - | - |
+| 130 | 10130 | - | - |
+| 131 | 10131 | - | - |
+| 140 | 10140 | - | - |
+| 141 | 10141 | - | - |
+| 150 | 10150 | - | - |
+| 160 | 10160 | - | - |
+| 161 | 10161 | - | - |
+| 210 | 20210 | - | - |
+| 211 | 20211 | - | - |
+| 250 | 20250 | - | - |
+| 310 | 30310 | - | - |
+| 311 | 30311 | - | - |
+| 350 | 30350 | - | - |
 
-#### VRF to VNI Mappings
+#### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI |
-| ---- | --- |
-| Tenant_A_APP_Zone | 12 |
-| Tenant_A_DB_Zone | 13 |
-| Tenant_A_OP_Zone | 10 |
-| Tenant_A_WAN_Zone | 14 |
-| Tenant_A_WEB_Zone | 11 |
-| Tenant_B_OP_Zone | 20 |
-| Tenant_B_WAN_Zone | 21 |
-| Tenant_C_OP_Zone | 30 |
-| Tenant_C_WAN_Zone | 31 |
+| VLAN | VNI | Multicast Group |
+| ---- | --- | --------------- |
+| Tenant_A_APP_Zone | 12 | - |
+| Tenant_A_DB_Zone | 13 | - |
+| Tenant_A_OP_Zone | 10 | - |
+| Tenant_A_WAN_Zone | 14 | - |
+| Tenant_A_WEB_Zone | 11 | - |
+| Tenant_B_OP_Zone | 20 | - |
+| Tenant_B_WAN_Zone | 21 | - |
+| Tenant_C_OP_Zone | 30 | - |
+| Tenant_C_WAN_Zone | 31 | - |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_eos_cli_config_gen/documentation/devices/vxlan-interface.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_eos_cli_config_gen/documentation/devices/vxlan-interface.md
@@ -71,19 +71,19 @@ interface Management1
 
 #### EVPN MLAG Shared Router MAC : mlag-system-id
 
-#### VLAN to VNI and Flood List Mappings
+#### VLAN to VNI, Flood List and Multicast Group Mappings
 
-| VLAN | VNI | Flood List |
-| ---- | --- | ---------- |
-| 110 | 10110 | - |
-| 111 | 10111 | - |
+| VLAN | VNI | Flood List | Multicast Group |
+| ---- | --- | ---------- | --------------- |
+| 110 | 10110 | - | - |
+| 111 | 10111 | - | - |
 
-#### VRF to VNI Mappings
+#### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI |
-| ---- | --- |
-| Tenant_A_OP_Zone | 10 |
-| Tenant_A_WEB_Zone | 11 |
+| VLAN | VNI | Multicast Group |
+| ---- | --- | --------------- |
+| Tenant_A_OP_Zone | 10 | - |
+| Tenant_A_WEB_Zone | 11 | - |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_eos_cli_config_gen/documentation/devices/vxlan-interface.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_eos_cli_config_gen/documentation/devices/vxlan-interface.md
@@ -80,7 +80,7 @@ interface Management1
 
 #### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI | Multicast Group |
+| VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Tenant_A_OP_Zone | 10 | - |
 | Tenant_A_WEB_Zone | 11 | - |

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2A.md
@@ -531,21 +531,21 @@ interface Vlan4094
 
 #### EVPN MLAG Shared Router MAC : mlag-system-id
 
-#### VLAN to VNI and Flood List Mappings
+#### VLAN to VNI, Flood List and Multicast Group Mappings
 
-| VLAN | VNI | Flood List |
-| ---- | --- | ---------- |
-| 110 | 10110 | - |
-| 111 | 50111 | - |
-| 112 | 50112 | - |
-| 2500 | 2500 | - |
-| 2600 | 2600 | - |
+| VLAN | VNI | Flood List | Multicast Group |
+| ---- | --- | ---------- | --------------- |
+| 110 | 10110 | - | - |
+| 111 | 50111 | - | - |
+| 112 | 50112 | - | - |
+| 2500 | 2500 | - | - |
+| 2600 | 2600 | - | - |
 
-#### VRF to VNI Mappings
+#### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI |
-| ---- | --- |
-| Common_VRF | 1025 |
+| VLAN | VNI | Multicast Group |
+| ---- | --- | --------------- |
+| Common_VRF | 1025 | - |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2A.md
@@ -543,7 +543,7 @@ interface Vlan4094
 
 #### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI | Multicast Group |
+| VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Common_VRF | 1025 | - |
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
@@ -570,7 +570,7 @@ interface Vlan4094
 
 #### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI | Multicast Group |
+| VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Common_VRF | 1025 | - |
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
@@ -558,21 +558,21 @@ interface Vlan4094
 
 #### EVPN MLAG Shared Router MAC : mlag-system-id
 
-#### VLAN to VNI and Flood List Mappings
+#### VLAN to VNI, Flood List and Multicast Group Mappings
 
-| VLAN | VNI | Flood List |
-| ---- | --- | ---------- |
-| 110 | 10110 | - |
-| 111 | 50111 | - |
-| 112 | 50112 | - |
-| 2500 | 2500 | - |
-| 2600 | 2600 | - |
+| VLAN | VNI | Flood List | Multicast Group |
+| ---- | --- | ---------- | --------------- |
+| 110 | 10110 | - | - |
+| 111 | 50111 | - | - |
+| 112 | 50112 | - | - |
+| 2500 | 2500 | - | - |
+| 2600 | 2600 | - | - |
 
-#### VRF to VNI Mappings
+#### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI |
-| ---- | --- |
-| Common_VRF | 1025 |
+| VLAN | VNI | Multicast Group |
+| ---- | --- | --------------- |
+| Common_VRF | 1025 | - |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-LEAF1A.md
@@ -348,7 +348,7 @@ interface Vlan112
 
 #### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI | Multicast Group |
+| VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Common_VRF | 1025 | - |
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-LEAF1A.md
@@ -336,21 +336,21 @@ interface Vlan112
 
 #### UDP port: 4789
 
-#### VLAN to VNI and Flood List Mappings
+#### VLAN to VNI, Flood List and Multicast Group Mappings
 
-| VLAN | VNI | Flood List |
-| ---- | --- | ---------- |
-| 110 | 10110 | - |
-| 111 | 50111 | - |
-| 112 | 50112 | - |
-| 2500 | 2500 | - |
-| 2600 | 2600 | - |
+| VLAN | VNI | Flood List | Multicast Group |
+| ---- | --- | ---------- | --------------- |
+| 110 | 10110 | - | - |
+| 111 | 50111 | - | - |
+| 112 | 50112 | - | - |
+| 2500 | 2500 | - | - |
+| 2600 | 2600 | - | - |
 
-#### VRF to VNI Mappings
+#### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI |
-| ---- | --- |
-| Common_VRF | 1025 |
+| VLAN | VNI | Multicast Group |
+| ---- | --- | --------------- |
+| Common_VRF | 1025 | - |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-LEAF1A.md
@@ -342,11 +342,11 @@ interface Vlan4092
 
 #### UDP port: 4789
 
-#### VRF to VNI Mappings
+#### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI |
-| ---- | --- |
-| Common_VRF | 1025 |
+| VLAN | VNI | Multicast Group |
+| ---- | --- | --------------- |
+| Common_VRF | 1025 | - |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-LEAF1A.md
@@ -344,7 +344,7 @@ interface Vlan4092
 
 #### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI | Multicast Group |
+| VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Common_VRF | 1025 | - |
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -454,23 +454,23 @@ interface Vlan350
 
 #### UDP port: 4789
 
-#### VLAN to VNI and Flood List Mappings
+#### VLAN to VNI, Flood List and Multicast Group Mappings
 
-| VLAN | VNI | Flood List |
-| ---- | --- | ---------- |
-| 150 | 10150 | - |
-| 250 | 20250 | - |
-| 350 | 30350 | - |
+| VLAN | VNI | Flood List | Multicast Group |
+| ---- | --- | ---------- | --------------- |
+| 150 | 10150 | - | - |
+| 250 | 20250 | - | - |
+| 350 | 30350 | - | - |
 
-#### VRF to VNI Mappings
+#### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI |
-| ---- | --- |
-| Tenant_A_WAN_Zone | 14 |
-| Tenant_B_OP_Zone | 20 |
-| Tenant_B_WAN_Zone | 21 |
-| Tenant_C_WAN_Zone | 31 |
-| Tenant_L3_VRF_Zone | 15 |
+| VLAN | VNI | Multicast Group |
+| ---- | --- | --------------- |
+| Tenant_A_WAN_Zone | 14 | - |
+| Tenant_B_OP_Zone | 20 | - |
+| Tenant_B_WAN_Zone | 21 | - |
+| Tenant_C_WAN_Zone | 31 | - |
+| Tenant_L3_VRF_Zone | 15 | - |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -464,7 +464,7 @@ interface Vlan350
 
 #### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI | Multicast Group |
+| VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Tenant_A_WAN_Zone | 14 | - |
 | Tenant_B_OP_Zone | 20 | - |

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -462,7 +462,7 @@ interface Vlan350
 
 #### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI | Multicast Group |
+| VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Tenant_A_WAN_Zone | 14 | - |
 | Tenant_B_OP_Zone | 20 | - |

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -452,23 +452,23 @@ interface Vlan350
 
 #### UDP port: 4789
 
-#### VLAN to VNI and Flood List Mappings
+#### VLAN to VNI, Flood List and Multicast Group Mappings
 
-| VLAN | VNI | Flood List |
-| ---- | --- | ---------- |
-| 150 | 10150 | - |
-| 250 | 20250 | - |
-| 350 | 30350 | - |
+| VLAN | VNI | Flood List | Multicast Group |
+| ---- | --- | ---------- | --------------- |
+| 150 | 10150 | - | - |
+| 250 | 20250 | - | - |
+| 350 | 30350 | - | - |
 
-#### VRF to VNI Mappings
+#### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI |
-| ---- | --- |
-| Tenant_A_WAN_Zone | 14 |
-| Tenant_B_OP_Zone | 20 |
-| Tenant_B_WAN_Zone | 21 |
-| Tenant_C_WAN_Zone | 31 |
-| Tenant_L3_VRF_Zone | 15 |
+| VLAN | VNI | Multicast Group |
+| ---- | --- | --------------- |
+| Tenant_A_WAN_Zone | 14 | - |
+| Tenant_B_OP_Zone | 20 | - |
+| Tenant_B_WAN_Zone | 21 | - |
+| Tenant_C_WAN_Zone | 31 | - |
+| Tenant_L3_VRF_Zone | 15 | - |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -440,21 +440,21 @@ interface Vlan131
 
 #### UDP port: 4789
 
-#### VLAN to VNI and Flood List Mappings
+#### VLAN to VNI, Flood List and Multicast Group Mappings
 
-| VLAN | VNI | Flood List |
-| ---- | --- | ---------- |
-| 120 | 10120 | - |
-| 121 | 10121 | - |
-| 130 | 10130 | - |
-| 131 | 10131 | - |
+| VLAN | VNI | Flood List | Multicast Group |
+| ---- | --- | ---------- | --------------- |
+| 120 | 10120 | - | - |
+| 121 | 10121 | - | - |
+| 130 | 10130 | - | - |
+| 131 | 10131 | - | - |
 
-#### VRF to VNI Mappings
+#### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI |
-| ---- | --- |
-| Tenant_A_APP_Zone | 12 |
-| Tenant_A_WEB_Zone | 11 |
+| VLAN | VNI | Multicast Group |
+| ---- | --- | --------------- |
+| Tenant_A_APP_Zone | 12 | - |
+| Tenant_A_WEB_Zone | 11 | - |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -451,7 +451,7 @@ interface Vlan131
 
 #### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI | Multicast Group |
+| VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Tenant_A_APP_Zone | 12 | - |
 | Tenant_A_WEB_Zone | 11 | - |

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -676,35 +676,35 @@ interface Vlan311
 
 #### UDP port: 4789
 
-#### VLAN to VNI and Flood List Mappings
+#### VLAN to VNI, Flood List and Multicast Group Mappings
 
-| VLAN | VNI | Flood List |
-| ---- | --- | ---------- |
-| 110 | 10110 | - |
-| 111 | 50111 | - |
-| 120 | 10120 | - |
-| 121 | 10121 | - |
-| 130 | 10130 | - |
-| 131 | 10131 | - |
-| 140 | 10140 | - |
-| 141 | 10141 | - |
-| 160 | 10160 | - |
-| 161 | 10161 | - |
-| 210 | 20210 | - |
-| 211 | 20211 | - |
-| 310 | 30310 | - |
-| 311 | 30311 | - |
+| VLAN | VNI | Flood List | Multicast Group |
+| ---- | --- | ---------- | --------------- |
+| 110 | 10110 | - | - |
+| 111 | 50111 | - | - |
+| 120 | 10120 | - | - |
+| 121 | 10121 | - | - |
+| 130 | 10130 | - | - |
+| 131 | 10131 | - | - |
+| 140 | 10140 | - | - |
+| 141 | 10141 | - | - |
+| 160 | 10160 | - | - |
+| 161 | 10161 | - | - |
+| 210 | 20210 | - | - |
+| 211 | 20211 | - | - |
+| 310 | 30310 | - | - |
+| 311 | 30311 | - | - |
 
-#### VRF to VNI Mappings
+#### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI |
-| ---- | --- |
-| Tenant_A_APP_Zone | 12 |
-| Tenant_A_DB_Zone | 13 |
-| Tenant_A_OP_Zone | 10 |
-| Tenant_A_WEB_Zone | 11 |
-| Tenant_B_OP_Zone | 20 |
-| Tenant_C_OP_Zone | 30 |
+| VLAN | VNI | Multicast Group |
+| ---- | --- | --------------- |
+| Tenant_A_APP_Zone | 12 | - |
+| Tenant_A_DB_Zone | 13 | - |
+| Tenant_A_OP_Zone | 10 | - |
+| Tenant_A_WEB_Zone | 11 | - |
+| Tenant_B_OP_Zone | 20 | - |
+| Tenant_C_OP_Zone | 30 | - |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -697,7 +697,7 @@ interface Vlan311
 
 #### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI | Multicast Group |
+| VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Tenant_A_APP_Zone | 12 | - |
 | Tenant_A_DB_Zone | 13 | - |

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -676,35 +676,35 @@ interface Vlan311
 
 #### UDP port: 4789
 
-#### VLAN to VNI and Flood List Mappings
+#### VLAN to VNI, Flood List and Multicast Group Mappings
 
-| VLAN | VNI | Flood List |
-| ---- | --- | ---------- |
-| 110 | 10110 | - |
-| 111 | 50111 | - |
-| 120 | 10120 | - |
-| 121 | 10121 | - |
-| 130 | 10130 | - |
-| 131 | 10131 | - |
-| 140 | 10140 | - |
-| 141 | 10141 | - |
-| 160 | 10160 | - |
-| 161 | 10161 | - |
-| 210 | 20210 | - |
-| 211 | 20211 | - |
-| 310 | 30310 | - |
-| 311 | 30311 | - |
+| VLAN | VNI | Flood List | Multicast Group |
+| ---- | --- | ---------- | --------------- |
+| 110 | 10110 | - | - |
+| 111 | 50111 | - | - |
+| 120 | 10120 | - | - |
+| 121 | 10121 | - | - |
+| 130 | 10130 | - | - |
+| 131 | 10131 | - | - |
+| 140 | 10140 | - | - |
+| 141 | 10141 | - | - |
+| 160 | 10160 | - | - |
+| 161 | 10161 | - | - |
+| 210 | 20210 | - | - |
+| 211 | 20211 | - | - |
+| 310 | 30310 | - | - |
+| 311 | 30311 | - | - |
 
-#### VRF to VNI Mappings
+#### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI |
-| ---- | --- |
-| Tenant_A_APP_Zone | 12 |
-| Tenant_A_DB_Zone | 13 |
-| Tenant_A_OP_Zone | 10 |
-| Tenant_A_WEB_Zone | 11 |
-| Tenant_B_OP_Zone | 20 |
-| Tenant_C_OP_Zone | 30 |
+| VLAN | VNI | Multicast Group |
+| ---- | --- | --------------- |
+| Tenant_A_APP_Zone | 12 | - |
+| Tenant_A_DB_Zone | 13 | - |
+| Tenant_A_OP_Zone | 10 | - |
+| Tenant_A_WEB_Zone | 11 | - |
+| Tenant_B_OP_Zone | 20 | - |
+| Tenant_C_OP_Zone | 30 | - |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -697,7 +697,7 @@ interface Vlan311
 
 #### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI | Multicast Group |
+| VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Tenant_A_APP_Zone | 12 | - |
 | Tenant_A_DB_Zone | 13 | - |

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -1001,41 +1001,41 @@ interface Vlan4092
 
 #### EVPN MLAG Shared Router MAC : mlag-system-id
 
-#### VLAN to VNI and Flood List Mappings
+#### VLAN to VNI, Flood List and Multicast Group Mappings
 
-| VLAN | VNI | Flood List |
-| ---- | --- | ---------- |
-| 110 | 10110 | - |
-| 111 | 50111 | - |
-| 120 | 10120 | - |
-| 121 | 10121 | - |
-| 130 | 10130 | - |
-| 131 | 10131 | - |
-| 140 | 10140 | - |
-| 141 | 10141 | - |
-| 150 | 10150 | - |
-| 160 | 10160 | - |
-| 161 | 10161 | - |
-| 210 | 20210 | - |
-| 211 | 20211 | - |
-| 250 | 20250 | - |
-| 310 | 30310 | - |
-| 311 | 30311 | - |
-| 350 | 30350 | - |
+| VLAN | VNI | Flood List | Multicast Group |
+| ---- | --- | ---------- | --------------- |
+| 110 | 10110 | - | - |
+| 111 | 50111 | - | - |
+| 120 | 10120 | - | - |
+| 121 | 10121 | - | - |
+| 130 | 10130 | - | - |
+| 131 | 10131 | - | - |
+| 140 | 10140 | - | - |
+| 141 | 10141 | - | - |
+| 150 | 10150 | - | - |
+| 160 | 10160 | - | - |
+| 161 | 10161 | - | - |
+| 210 | 20210 | - | - |
+| 211 | 20211 | - | - |
+| 250 | 20250 | - | - |
+| 310 | 30310 | - | - |
+| 311 | 30311 | - | - |
+| 350 | 30350 | - | - |
 
-#### VRF to VNI Mappings
+#### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI |
-| ---- | --- |
-| Tenant_A_APP_Zone | 12 |
-| Tenant_A_DB_Zone | 13 |
-| Tenant_A_OP_Zone | 10 |
-| Tenant_A_WAN_Zone | 14 |
-| Tenant_A_WEB_Zone | 11 |
-| Tenant_B_OP_Zone | 20 |
-| Tenant_B_WAN_Zone | 21 |
-| Tenant_C_OP_Zone | 30 |
-| Tenant_C_WAN_Zone | 31 |
+| VLAN | VNI | Multicast Group |
+| ---- | --- | --------------- |
+| Tenant_A_APP_Zone | 12 | - |
+| Tenant_A_DB_Zone | 13 | - |
+| Tenant_A_OP_Zone | 10 | - |
+| Tenant_A_WAN_Zone | 14 | - |
+| Tenant_A_WEB_Zone | 11 | - |
+| Tenant_B_OP_Zone | 20 | - |
+| Tenant_B_WAN_Zone | 21 | - |
+| Tenant_C_OP_Zone | 30 | - |
+| Tenant_C_WAN_Zone | 31 | - |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -1025,7 +1025,7 @@ interface Vlan4092
 
 #### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI | Multicast Group |
+| VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Tenant_A_APP_Zone | 12 | - |
 | Tenant_A_DB_Zone | 13 | - |

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -1001,41 +1001,41 @@ interface Vlan4092
 
 #### EVPN MLAG Shared Router MAC : mlag-system-id
 
-#### VLAN to VNI and Flood List Mappings
+#### VLAN to VNI, Flood List and Multicast Group Mappings
 
-| VLAN | VNI | Flood List |
-| ---- | --- | ---------- |
-| 110 | 10110 | - |
-| 111 | 50111 | - |
-| 120 | 10120 | - |
-| 121 | 10121 | - |
-| 130 | 10130 | - |
-| 131 | 10131 | - |
-| 140 | 10140 | - |
-| 141 | 10141 | - |
-| 150 | 10150 | - |
-| 160 | 10160 | - |
-| 161 | 10161 | - |
-| 210 | 20210 | - |
-| 211 | 20211 | - |
-| 250 | 20250 | - |
-| 310 | 30310 | - |
-| 311 | 30311 | - |
-| 350 | 30350 | - |
+| VLAN | VNI | Flood List | Multicast Group |
+| ---- | --- | ---------- | --------------- |
+| 110 | 10110 | - | - |
+| 111 | 50111 | - | - |
+| 120 | 10120 | - | - |
+| 121 | 10121 | - | - |
+| 130 | 10130 | - | - |
+| 131 | 10131 | - | - |
+| 140 | 10140 | - | - |
+| 141 | 10141 | - | - |
+| 150 | 10150 | - | - |
+| 160 | 10160 | - | - |
+| 161 | 10161 | - | - |
+| 210 | 20210 | - | - |
+| 211 | 20211 | - | - |
+| 250 | 20250 | - | - |
+| 310 | 30310 | - | - |
+| 311 | 30311 | - | - |
+| 350 | 30350 | - | - |
 
-#### VRF to VNI Mappings
+#### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI |
-| ---- | --- |
-| Tenant_A_APP_Zone | 12 |
-| Tenant_A_DB_Zone | 13 |
-| Tenant_A_OP_Zone | 10 |
-| Tenant_A_WAN_Zone | 14 |
-| Tenant_A_WEB_Zone | 11 |
-| Tenant_B_OP_Zone | 20 |
-| Tenant_B_WAN_Zone | 21 |
-| Tenant_C_OP_Zone | 30 |
-| Tenant_C_WAN_Zone | 31 |
+| VLAN | VNI | Multicast Group |
+| ---- | --- | --------------- |
+| Tenant_A_APP_Zone | 12 | - |
+| Tenant_A_DB_Zone | 13 | - |
+| Tenant_A_OP_Zone | 10 | - |
+| Tenant_A_WAN_Zone | 14 | - |
+| Tenant_A_WEB_Zone | 11 | - |
+| Tenant_B_OP_Zone | 20 | - |
+| Tenant_B_WAN_Zone | 21 | - |
+| Tenant_C_OP_Zone | 30 | - |
+| Tenant_C_WAN_Zone | 31 | - |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -1025,7 +1025,7 @@ interface Vlan4092
 
 #### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI | Multicast Group |
+| VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Tenant_A_APP_Zone | 12 | - |
 | Tenant_A_DB_Zone | 13 | - |

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -410,21 +410,21 @@ interface Vlan350
 
 #### UDP port: 4789
 
-#### VLAN to VNI and Flood List Mappings
+#### VLAN to VNI, Flood List and Multicast Group Mappings
 
-| VLAN | VNI | Flood List |
-| ---- | --- | ---------- |
-| 150 | 10150 | - |
-| 250 | 20250 | - |
-| 350 | 30350 | - |
+| VLAN | VNI | Flood List | Multicast Group |
+| ---- | --- | ---------- | --------------- |
+| 150 | 10150 | - | - |
+| 250 | 20250 | - | - |
+| 350 | 30350 | - | - |
 
-#### VRF to VNI Mappings
+#### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI |
-| ---- | --- |
-| Tenant_A_WAN_Zone | 14 |
-| Tenant_B_WAN_Zone | 21 |
-| Tenant_C_WAN_Zone | 31 |
+| VLAN | VNI | Multicast Group |
+| ---- | --- | --------------- |
+| Tenant_A_WAN_Zone | 14 | - |
+| Tenant_B_WAN_Zone | 21 | - |
+| Tenant_C_WAN_Zone | 31 | - |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -420,7 +420,7 @@ interface Vlan350
 
 #### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI | Multicast Group |
+| VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Tenant_A_WAN_Zone | 14 | - |
 | Tenant_B_WAN_Zone | 21 | - |

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -409,21 +409,21 @@ interface Vlan350
 
 #### UDP port: 4789
 
-#### VLAN to VNI and Flood List Mappings
+#### VLAN to VNI, Flood List and Multicast Group Mappings
 
-| VLAN | VNI | Flood List |
-| ---- | --- | ---------- |
-| 150 | 10150 | - |
-| 250 | 20250 | - |
-| 350 | 30350 | - |
+| VLAN | VNI | Flood List | Multicast Group |
+| ---- | --- | ---------- | --------------- |
+| 150 | 10150 | - | - |
+| 250 | 20250 | - | - |
+| 350 | 30350 | - | - |
 
-#### VRF to VNI Mappings
+#### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI |
-| ---- | --- |
-| Tenant_A_WAN_Zone | 14 |
-| Tenant_B_WAN_Zone | 21 |
-| Tenant_C_WAN_Zone | 31 |
+| VLAN | VNI | Multicast Group |
+| ---- | --- | --------------- |
+| Tenant_A_WAN_Zone | 14 | - |
+| Tenant_B_WAN_Zone | 21 | - |
+| Tenant_C_WAN_Zone | 31 | - |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -419,7 +419,7 @@ interface Vlan350
 
 #### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI | Multicast Group |
+| VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Tenant_A_WAN_Zone | 14 | - |
 | Tenant_B_WAN_Zone | 21 | - |

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -432,21 +432,21 @@ interface Vlan131
 
 #### UDP port: 4789
 
-#### VLAN to VNI and Flood List Mappings
+#### VLAN to VNI, Flood List and Multicast Group Mappings
 
-| VLAN | VNI | Flood List |
-| ---- | --- | ---------- |
-| 120 | 10120 | - |
-| 121 | 10121 | - |
-| 130 | 10130 | - |
-| 131 | 10131 | - |
+| VLAN | VNI | Flood List | Multicast Group |
+| ---- | --- | ---------- | --------------- |
+| 120 | 10120 | - | - |
+| 121 | 10121 | - | - |
+| 130 | 10130 | - | - |
+| 131 | 10131 | - | - |
 
-#### VRF to VNI Mappings
+#### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI |
-| ---- | --- |
-| Tenant_A_APP_Zone | 12 |
-| Tenant_A_WEB_Zone | 11 |
+| VLAN | VNI | Multicast Group |
+| ---- | --- | --------------- |
+| Tenant_A_APP_Zone | 12 | - |
+| Tenant_A_WEB_Zone | 11 | - |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -443,7 +443,7 @@ interface Vlan131
 
 #### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI | Multicast Group |
+| VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Tenant_A_APP_Zone | 12 | - |
 | Tenant_A_WEB_Zone | 11 | - |

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -763,35 +763,35 @@ interface Vlan4094
 
 #### EVPN MLAG Shared Router MAC : mlag-system-id
 
-#### VLAN to VNI and Flood List Mappings
+#### VLAN to VNI, Flood List and Multicast Group Mappings
 
-| VLAN | VNI | Flood List |
-| ---- | --- | ---------- |
-| 110 | 10110 | - |
-| 111 | 50111 | - |
-| 120 | 10120 | - |
-| 121 | 10121 | - |
-| 130 | 10130 | - |
-| 131 | 10131 | - |
-| 140 | 10140 | - |
-| 141 | 10141 | - |
-| 160 | 10160 | - |
-| 161 | 10161 | - |
-| 210 | 20210 | - |
-| 211 | 20211 | - |
-| 310 | 30310 | - |
-| 311 | 30311 | - |
+| VLAN | VNI | Flood List | Multicast Group |
+| ---- | --- | ---------- | --------------- |
+| 110 | 10110 | - | - |
+| 111 | 50111 | - | - |
+| 120 | 10120 | - | - |
+| 121 | 10121 | - | - |
+| 130 | 10130 | - | - |
+| 131 | 10131 | - | - |
+| 140 | 10140 | - | - |
+| 141 | 10141 | - | - |
+| 160 | 10160 | - | - |
+| 161 | 10161 | - | - |
+| 210 | 20210 | - | - |
+| 211 | 20211 | - | - |
+| 310 | 30310 | - | - |
+| 311 | 30311 | - | - |
 
-#### VRF to VNI Mappings
+#### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI |
-| ---- | --- |
-| Tenant_A_APP_Zone | 12 |
-| Tenant_A_DB_Zone | 13 |
-| Tenant_A_OP_Zone | 10 |
-| Tenant_A_WEB_Zone | 11 |
-| Tenant_B_OP_Zone | 20 |
-| Tenant_C_OP_Zone | 30 |
+| VLAN | VNI | Multicast Group |
+| ---- | --- | --------------- |
+| Tenant_A_APP_Zone | 12 | - |
+| Tenant_A_DB_Zone | 13 | - |
+| Tenant_A_OP_Zone | 10 | - |
+| Tenant_A_WEB_Zone | 11 | - |
+| Tenant_B_OP_Zone | 20 | - |
+| Tenant_C_OP_Zone | 30 | - |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -784,7 +784,7 @@ interface Vlan4094
 
 #### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI | Multicast Group |
+| VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Tenant_A_APP_Zone | 12 | - |
 | Tenant_A_DB_Zone | 13 | - |

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -763,35 +763,35 @@ interface Vlan4094
 
 #### EVPN MLAG Shared Router MAC : mlag-system-id
 
-#### VLAN to VNI and Flood List Mappings
+#### VLAN to VNI, Flood List and Multicast Group Mappings
 
-| VLAN | VNI | Flood List |
-| ---- | --- | ---------- |
-| 110 | 10110 | - |
-| 111 | 50111 | - |
-| 120 | 10120 | - |
-| 121 | 10121 | - |
-| 130 | 10130 | - |
-| 131 | 10131 | - |
-| 140 | 10140 | - |
-| 141 | 10141 | - |
-| 160 | 10160 | - |
-| 161 | 10161 | - |
-| 210 | 20210 | - |
-| 211 | 20211 | - |
-| 310 | 30310 | - |
-| 311 | 30311 | - |
+| VLAN | VNI | Flood List | Multicast Group |
+| ---- | --- | ---------- | --------------- |
+| 110 | 10110 | - | - |
+| 111 | 50111 | - | - |
+| 120 | 10120 | - | - |
+| 121 | 10121 | - | - |
+| 130 | 10130 | - | - |
+| 131 | 10131 | - | - |
+| 140 | 10140 | - | - |
+| 141 | 10141 | - | - |
+| 160 | 10160 | - | - |
+| 161 | 10161 | - | - |
+| 210 | 20210 | - | - |
+| 211 | 20211 | - | - |
+| 310 | 30310 | - | - |
+| 311 | 30311 | - | - |
 
-#### VRF to VNI Mappings
+#### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI |
-| ---- | --- |
-| Tenant_A_APP_Zone | 12 |
-| Tenant_A_DB_Zone | 13 |
-| Tenant_A_OP_Zone | 10 |
-| Tenant_A_WEB_Zone | 11 |
-| Tenant_B_OP_Zone | 20 |
-| Tenant_C_OP_Zone | 30 |
+| VLAN | VNI | Multicast Group |
+| ---- | --- | --------------- |
+| Tenant_A_APP_Zone | 12 | - |
+| Tenant_A_DB_Zone | 13 | - |
+| Tenant_A_OP_Zone | 10 | - |
+| Tenant_A_WEB_Zone | 11 | - |
+| Tenant_B_OP_Zone | 20 | - |
+| Tenant_C_OP_Zone | 30 | - |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -784,7 +784,7 @@ interface Vlan4094
 
 #### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI | Multicast Group |
+| VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Tenant_A_APP_Zone | 12 | - |
 | Tenant_A_DB_Zone | 13 | - |

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -916,41 +916,41 @@ interface Vlan4094
 
 #### EVPN MLAG Shared Router MAC : mlag-system-id
 
-#### VLAN to VNI and Flood List Mappings
+#### VLAN to VNI, Flood List and Multicast Group Mappings
 
-| VLAN | VNI | Flood List |
-| ---- | --- | ---------- |
-| 110 | 10110 | - |
-| 111 | 50111 | - |
-| 120 | 10120 | - |
-| 121 | 10121 | - |
-| 130 | 10130 | - |
-| 131 | 10131 | - |
-| 140 | 10140 | - |
-| 141 | 10141 | - |
-| 150 | 10150 | - |
-| 160 | 10160 | - |
-| 161 | 10161 | - |
-| 210 | 20210 | - |
-| 211 | 20211 | - |
-| 250 | 20250 | - |
-| 310 | 30310 | - |
-| 311 | 30311 | - |
-| 350 | 30350 | - |
+| VLAN | VNI | Flood List | Multicast Group |
+| ---- | --- | ---------- | --------------- |
+| 110 | 10110 | - | - |
+| 111 | 50111 | - | - |
+| 120 | 10120 | - | - |
+| 121 | 10121 | - | - |
+| 130 | 10130 | - | - |
+| 131 | 10131 | - | - |
+| 140 | 10140 | - | - |
+| 141 | 10141 | - | - |
+| 150 | 10150 | - | - |
+| 160 | 10160 | - | - |
+| 161 | 10161 | - | - |
+| 210 | 20210 | - | - |
+| 211 | 20211 | - | - |
+| 250 | 20250 | - | - |
+| 310 | 30310 | - | - |
+| 311 | 30311 | - | - |
+| 350 | 30350 | - | - |
 
-#### VRF to VNI Mappings
+#### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI |
-| ---- | --- |
-| Tenant_A_APP_Zone | 12 |
-| Tenant_A_DB_Zone | 13 |
-| Tenant_A_OP_Zone | 10 |
-| Tenant_A_WAN_Zone | 14 |
-| Tenant_A_WEB_Zone | 11 |
-| Tenant_B_OP_Zone | 20 |
-| Tenant_B_WAN_Zone | 21 |
-| Tenant_C_OP_Zone | 30 |
-| Tenant_C_WAN_Zone | 31 |
+| VLAN | VNI | Multicast Group |
+| ---- | --- | --------------- |
+| Tenant_A_APP_Zone | 12 | - |
+| Tenant_A_DB_Zone | 13 | - |
+| Tenant_A_OP_Zone | 10 | - |
+| Tenant_A_WAN_Zone | 14 | - |
+| Tenant_A_WEB_Zone | 11 | - |
+| Tenant_B_OP_Zone | 20 | - |
+| Tenant_B_WAN_Zone | 21 | - |
+| Tenant_C_OP_Zone | 30 | - |
+| Tenant_C_WAN_Zone | 31 | - |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -940,7 +940,7 @@ interface Vlan4094
 
 #### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI | Multicast Group |
+| VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Tenant_A_APP_Zone | 12 | - |
 | Tenant_A_DB_Zone | 13 | - |

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -925,7 +925,7 @@ interface Vlan4094
 
 #### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI | Multicast Group |
+| VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 | Tenant_A_APP_Zone | 12 | - |
 | Tenant_A_DB_Zone | 13 | - |

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -901,41 +901,41 @@ interface Vlan4094
 
 #### EVPN MLAG Shared Router MAC : mlag-system-id
 
-#### VLAN to VNI and Flood List Mappings
+#### VLAN to VNI, Flood List and Multicast Group Mappings
 
-| VLAN | VNI | Flood List |
-| ---- | --- | ---------- |
-| 110 | 10110 | - |
-| 111 | 50111 | - |
-| 120 | 10120 | - |
-| 121 | 10121 | - |
-| 130 | 10130 | - |
-| 131 | 10131 | - |
-| 140 | 10140 | - |
-| 141 | 10141 | - |
-| 150 | 10150 | - |
-| 160 | 10160 | - |
-| 161 | 10161 | - |
-| 210 | 20210 | - |
-| 211 | 20211 | - |
-| 250 | 20250 | - |
-| 310 | 30310 | - |
-| 311 | 30311 | - |
-| 350 | 30350 | - |
+| VLAN | VNI | Flood List | Multicast Group |
+| ---- | --- | ---------- | --------------- |
+| 110 | 10110 | - | - |
+| 111 | 50111 | - | - |
+| 120 | 10120 | - | - |
+| 121 | 10121 | - | - |
+| 130 | 10130 | - | - |
+| 131 | 10131 | - | - |
+| 140 | 10140 | - | - |
+| 141 | 10141 | - | - |
+| 150 | 10150 | - | - |
+| 160 | 10160 | - | - |
+| 161 | 10161 | - | - |
+| 210 | 20210 | - | - |
+| 211 | 20211 | - | - |
+| 250 | 20250 | - | - |
+| 310 | 30310 | - | - |
+| 311 | 30311 | - | - |
+| 350 | 30350 | - | - |
 
-#### VRF to VNI Mappings
+#### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI |
-| ---- | --- |
-| Tenant_A_APP_Zone | 12 |
-| Tenant_A_DB_Zone | 13 |
-| Tenant_A_OP_Zone | 10 |
-| Tenant_A_WAN_Zone | 14 |
-| Tenant_A_WEB_Zone | 11 |
-| Tenant_B_OP_Zone | 20 |
-| Tenant_B_WAN_Zone | 21 |
-| Tenant_C_OP_Zone | 30 |
-| Tenant_C_WAN_Zone | 31 |
+| VLAN | VNI | Multicast Group |
+| ---- | --- | --------------- |
+| Tenant_A_APP_Zone | 12 | - |
+| Tenant_A_DB_Zone | 13 | - |
+| Tenant_A_OP_Zone | 10 | - |
+| Tenant_A_WAN_Zone | 14 | - |
+| Tenant_A_WEB_Zone | 11 | - |
+| Tenant_B_OP_Zone | 20 | - |
+| Tenant_B_WAN_Zone | 21 | - |
+| Tenant_C_OP_Zone | 30 | - |
+| Tenant_C_WAN_Zone | 31 | - |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -63,6 +63,7 @@
     - [IP DHCP Relay](#ip-dhcp-relay)
     - [IP ICMP Redirect](#ip-icmp-redirect)
     - [LACP](#lacp)
+    - [Link Tracking Groups](#link-tracking-groups)
     - [LLDP](#lldp)
     - [MACsec](#macsec)
     - [Maintenance Mode](#maintenance-mode)
@@ -1261,6 +1262,7 @@ lacp:
   rate_limit:
     default: < true | false >
   system_priority: < 0-65535 >
+```
 
 ### Link Tracking Groups
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -63,7 +63,6 @@
     - [IP DHCP Relay](#ip-dhcp-relay)
     - [IP ICMP Redirect](#ip-icmp-redirect)
     - [LACP](#lacp)
-    - [Link Tracking Groups](#link-tracking-groups)
     - [LLDP](#lldp)
     - [MACsec](#macsec)
     - [Maintenance Mode](#maintenance-mode)
@@ -1194,24 +1193,29 @@ vxlan_interface:
     description: < description >
     vxlan:
       source_interface: < source_interface_name >
+      mlag_source_interface: < source_interface_name >
       udp_port: < udp_port >
       virtual_router_encapsulation_mac_address: < mlag-system-id | ethernet_address (H.H.H) >
       vlans:
         < vlan_id_1 >:
           vni: < vni_id_1 >
+          multicast_group: < ip_multicast_group_address >
           flood_vteps:
             - < remote_vtep_1_ip_address >
             - < remote_vtep_2_ip_address >
         < vlan_id_2 >:
           vni: < vni_id_2 >
+          multicast_group: < ip_multicast_group_address >
           flood_vteps:
             - < remote_vtep_1_ip_address >
             - < remote_vtep_2_ip_address >
       vrfs:
         < vrf_name_1 >:
           vni: < vni_id_3 >
+          multicast_group: < ip_multicast_group_address >
         < vrf_name_2 >:
           vni: < vni_id_4 >
+          multicast_group: < ip_multicast_group_address >
       flood_vteps:
         - < remote_vtep_1_ip_address >
         - < remote_vtep_2_ip_address >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vxlan-interface.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vxlan-interface.j2
@@ -38,7 +38,7 @@
 
 #### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI | Multicast Group |
+| VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
 {%         for vrf in vxlan_interface.Vxlan1.vxlan.vrfs | arista.avd.natural_sort %}
 {%             set vrf_vni = vxlan_interface.Vxlan1.vxlan.vrfs[vrf].vni | arista.avd.default('-') %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vxlan-interface.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vxlan-interface.j2
@@ -3,8 +3,14 @@
 ## VXLAN Interface
 
 ### VXLAN Interface Summary
+{%     if vxlan_interface.Vxlan1.vxlan.source_interface is arista.avd.defined %}
 
 #### Source Interface: {{ vxlan_interface.Vxlan1.vxlan.source_interface }}
+{%     endif %}
+{%     if vxlan_interface.Vxlan1.vxlan.mlag_source_interface is arista.avd.defined %}
+
+#### MLAG Source Interface: {{ vxlan_interface.Vxlan1.vxlan.mlag_source_interface }}
+{%     endif %}
 
 #### UDP port: {{ vxlan_interface.Vxlan1.vxlan.udp_port | arista.avd.default('4789') }}
 {%     if vxlan_interface.Vxlan1.vxlan.virtual_router_encapsulation_mac_address is arista.avd.defined %}
@@ -13,30 +19,31 @@
 {%     endif %}
 {%     if vxlan_interface.Vxlan1.vxlan.vlans is arista.avd.defined %}
 
-#### VLAN to VNI and Flood List Mappings
+#### VLAN to VNI, Flood List and Multicast Group Mappings
 
-| VLAN | VNI | Flood List |
-| ---- | --- | ---------- |
+| VLAN | VNI | Flood List | Multicast Group |
+| ---- | --- | ---------- | --------------- |
 {%         for vlan in vxlan_interface.Vxlan1.vxlan.vlans | arista.avd.natural_sort %}
-{%             set vni = vxlan_interface.Vxlan1.vxlan.vlans[vlan].vni %}
+{%             set vlan_vni = vxlan_interface.Vxlan1.vxlan.vlans[vlan].vni | arista.avd.default('-') %}
+{%             set multicast_group = vxlan_interface.Vxlan1.vxlan.vlans[vlan].multicast_group | arista.avd.default('-') %}
 {%             if vxlan_interface.Vxlan1.vxlan.vlans[vlan].flood_vteps is arista.avd.defined %}
 {%                 set flood_list = vxlan_interface.Vxlan1.vxlan.vlans[vlan].flood_vteps | join('<br/>')  %}
 {%             else %}
 {%                 set flood_list = '-' %}
 {%             endif %}
-| {{ vlan }} | {{ vni }} | {{  flood_list }} |
+| {{ vlan }} | {{ vlan_vni }} | {{  flood_list }} | {{ multicast_group }} |
 {%         endfor %}
 {%     endif %}
 {%     if vxlan_interface.Vxlan1.vxlan.vrfs is arista.avd.defined %}
 
-#### VRF to VNI Mappings
+#### VRF to VNI and Multicast Group Mappings
 
-| VLAN | VNI |
-| ---- | --- |
+| VLAN | VNI | Multicast Group |
+| ---- | --- | --------------- |
 {%         for vrf in vxlan_interface.Vxlan1.vxlan.vrfs | arista.avd.natural_sort %}
-{%             if vxlan_interface.Vxlan1.vxlan.vrfs[vrf].vni is arista.avd.defined %}
-| {{ vrf }} | {{ vxlan_interface.Vxlan1.vxlan.vrfs[vrf].vni }} |
-{%             endif %}
+{%             set vrf_vni = vxlan_interface.Vxlan1.vxlan.vrfs[vrf].vni | arista.avd.default('-') %}
+{%             set multicast_group = vxlan_interface.Vxlan1.vxlan.vrfs[vrf].multicast_group | arista.avd.default('-') %}
+| {{ vrf }} | {{ vrf_vni }} | {{ multicast_group }} |
 {%         endfor %}
 {%     endif %}
 {%     if vxlan_interface.Vxlan1.vxlan.flood_vteps is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vxlan-interface.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vxlan-interface.j2
@@ -28,9 +28,18 @@ interface Vxlan1
    vxlan vrf {{ vrf }} vni {{ vxlan_interface.Vxlan1.vxlan.vrfs[vrf].vni }}
 {%         endif %}
 {%     endfor %}
+{%     if vxlan_interface.Vxlan1.vxlan.mlag_source_interface is arista.avd.defined %}
+   vxlan mlag source-interface {{ vxlan_interface.Vxlan1.vxlan.mlag_source_interface }}
+{%     endif %}
 {%     if vxlan_interface.Vxlan1.vxlan.flood_vteps is arista.avd.defined %}
    vxlan flood vtep {{ vxlan_interface.Vxlan1.vxlan.flood_vteps | join(' ') }}
 {%     endif %}
+{%     for vlan in vxlan_interface.Vxlan1.vxlan.vlans | arista.avd.natural_sort if vxlan_interface.Vxlan1.vxlan.vlans[vlan].multicast_group is arista.avd.defined %}
+   vxlan vlan {{ vlan }} multicast group {{ vxlan_interface.Vxlan1.vxlan.vlans[vlan].multicast_group }}
+{%     endfor %}
+{%     for vrf in vxlan_interface.Vxlan1.vxlan.vrfs | arista.avd.natural_sort if vxlan_interface.Vxlan1.vxlan.vrfs[vrf].multicast_group is arista.avd.defined %}
+   vxlan vrf {{ vrf }} multicast group {{ vxlan_interface.Vxlan1.vxlan.vrfs[vrf].multicast_group }}
+{%     endfor %}
 {%     if  vxlan_interface.Vxlan1.eos_cli is arista.avd.defined %}
    {{ vxlan_interface.Vxlan1.eos_cli | indent(3, false) }}
 {%     endif %}


### PR DESCRIPTION
## Change Summary

Extend vxlan interface data model for multicast support.

## Related Issue(s)

Fixes #1363

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

```yaml
vxlan_interface:
  Vxlan1:
    vxlan:
      mlag_source_interface: < source_interface_name >
      vlans:
        < vlan_id_1 >:
          multicast_group: < ip_multicast_group_address >
        < vlan_id_2 >:
          vni: < vni_id_2 >
          multicast_group: < ip_multicast_group_address >
      vrfs:
        < vrf_name_1 >:
          multicast_group: < ip_multicast_group_address >
        < vrf_name_2 >:
          multicast_group: < ip_multicast_group_address >
```

## How to test

See Molecule Scenario

## Checklist

### User Checklist

- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
