### PR TITLE
Feat(eos_designs): Support ignore tcam system profiles

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SPINE2.md
@@ -11,8 +11,6 @@
 - [Monitoring](#monitoring)
   - [TerminAttr Daemon](#terminattr-daemon)
   - [SNMP](#snmp)
-- [Hardware TCAM Profile](#hardware-tcam-profile)
-  - [Hardware TCAM configuration](#hardware-tcam-configuration)
 - [Spanning Tree](#spanning-tree)
   - [Spanning Tree Summary](#spanning-tree-summary)
   - [Spanning Tree Device Configuration](#spanning-tree-device-configuration)
@@ -191,18 +189,6 @@ daemon TerminAttr
 !
 snmp-server contact example@example.com
 snmp-server location DC1_FABRIC DC1-SPINE2
-```
-
-# Hardware TCAM Profile
-
-TCAM profile __`vxlan-routing`__ is active
-
-## Hardware TCAM configuration
-
-```eos
-!
-hardware tcam
-   system profile vxlan-routing
 ```
 
 # Spanning Tree

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SPINE2.cfg
@@ -115,9 +115,6 @@ interface Management1
    vrf MGMT
    ip address 192.168.200.102/24
 !
-hardware tcam
-   system profile vxlan-routing
-!
 ip routing
 no ip routing vrf MGMT
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SPINE2.yml
@@ -158,8 +158,6 @@ management_interfaces:
     ip_address: 192.168.200.102/24
     gateway: 192.168.200.5
     type: oob
-tcam_profile:
-  system: vxlan-routing
 platform:
   sand:
     lag:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_FABRIC.yml
@@ -32,6 +32,8 @@ spine:
       mac_address: '0c:1d:c0:1d:62:01'
     DC1-SPINE2:
       platform: 7500R
+      ignore_tcam_system_profiles:
+        - 'vxlan-routing'
       id: 2
       mgmt_ip: 192.168.200.102/24
       mac_address: '0c:1d:c0:1d:62:01'

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-topology.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-topology.md
@@ -349,6 +349,8 @@ defaults <- node_group <- node_group.node <- node
 
   defaults:
     # Optional
+    # !!! Warning, be careful with this knob as it will block applying all the hardware system TCAM profiles mentioned in this list to a respective < node_type >
+    # !!! Warning, this knob might affect the routing capabilities of the device(s)
     ignore_tcam_system_profiles:
       - < TCAM system profile >
 ```

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-topology.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-topology.md
@@ -341,3 +341,14 @@ defaults <- node_group <- node_group.node <- node
     # VLAN number assigned to Inband Management SVI on l2leafs in default VRF.
     inband_management_vlan: < vlan-id | Default -> 4092 >
 ```
+
+### Ignore TCAM system profiles
+
+```yaml
+< node_type_key >:
+
+  defaults:
+    # Optional
+    ignore_tcam_system_profiles:
+      - < TCAM system profile >
+```

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/base/tcam-profile.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/base/tcam-profile.j2
@@ -1,5 +1,5 @@
 {# tcam-profile #}
-{% if switch.platform_settings.tcam_profile is arista.avd.defined %}
+{% if switch.platform_settings.tcam_profile is arista.avd.defined and switch.platform_settings.tcam_profile is not in switch.ignore_tcam_system_profiles %}
 tcam_profile:
   system: {{ switch.platform_settings.tcam_profile }}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/base/tcam-profile.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/base/tcam-profile.j2
@@ -1,5 +1,5 @@
 {# tcam-profile #}
-{% if switch.platform_settings.tcam_profile is arista.avd.defined and switch.platform_settings.tcam_profile is not in switch.ignore_tcam_system_profiles %}
+{% if switch.platform_settings.tcam_profile is arista.avd.defined and switch.platform_settings.tcam_profile not in switch.ignore_tcam_system_profiles %}
 tcam_profile:
   system: {{ switch.platform_settings.tcam_profile }}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/facts/switch/switch.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/facts/switch/switch.j2
@@ -23,6 +23,9 @@ switch:
   platform_settings: {{ platform_settings | selectattr("platforms", "arista.avd.contains", switch_platform) | first | arista.avd.default(
                         platform_settings | selectattr("platforms", "arista.avd.contains", "default") | first) | to_json() }}
 
+{# switch.ignore_tcam_system_profiles #}
+  ignore_tcam_system_profiles: {{ switch_data.combined.ignore_tcam_system_profiles | arista.avd.default([]) }}
+
 {# switch.underlay_routing_protocol #}
 {% if underlay_routing_protocol is arista.avd.defined and underlay_routing_protocol | lower in ['ibgp', 'isis', 'ospf'] %}
   underlay_routing_protocol: {{ underlay_routing_protocol | lower }}


### PR DESCRIPTION
## Change Summary

ignore_tcam_system_profiles knob is a fabric-topology variable to avoid applying specific TCAM system profiles on a switch or group of switches.

## Related Issue(s)

Fixes #1055 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->
Model implemented, under FABRIC topology variables:

```yaml
< node_type_key >:

  defaults:
    # Optional
    ignore_tcam_system_profiles:
      - < TCAM system profile >
```

## How to test
Molecule, eos_designs_unit_tests was updated

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
