### PR TITLE
Feat(eos_validate_state): Allowing configurable xcvr manufacturers

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_validate_state/README.md
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/README.md
@@ -92,7 +92,12 @@ eos_validate_state_csv_report_path: '{{ eos_validate_state_dir }}/{{ fabric_name
 # Markdown flavor to support non-text rendering
 # Only support default and github
 validate_state_markdown_flavor: "default"
+
+# Allow different manufacturers
+accepted_xcvr_manufacturers: "{{ validation_role.xcvr_own_manufacturers | arista.avd.default(['Arastra, Inc.', 'Arista Networks']) }}"
 ```
+
+Keep in mind that default accepted manufacturers are "Arastra, Inc." and "Arista Networks". If validation_role.xcvr_own_manufacturers is set, it takes precedence and overrides the defined default variables.
 
 ## Requirements
 
@@ -154,6 +159,11 @@ ansible_become: yes
 ansible_become_method: enable
 
 validation_mode_loose: true
+
+validation_role:
+  xcvr_own_manufacturers:
+    - Manufacturer 1
+    - Manufacturer 2
 ```
 
 ### inventory/intended/structured_configs/switch1.yml

--- a/ansible_collections/arista/avd/roles/eos_validate_state/defaults/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/defaults/main.yml
@@ -23,4 +23,4 @@ structured_dir_name: 'structured_configs'
 structured_dir: '{{ output_dir }}/{{ structured_dir_name }}'
 
 # Allow different manufacturers
-accepted_xcvr_manufacturers: "{{ validation_role.xcvr_own_manufacturers + ['Not Present', 'Arastra, Inc.', 'Arista Networks'] }}"
+accepted_xcvr_manufacturers: "{{ validation_role.xcvr_own_manufacturers | arista.avd.default(['Arastra, Inc.', 'Arista Networks']) }}"

--- a/ansible_collections/arista/avd/roles/eos_validate_state/defaults/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/defaults/main.yml
@@ -13,6 +13,9 @@ eos_validate_state_csv_report_path: '{{ eos_validate_state_dir }}/{{ fabric_name
 # Only support default and github
 validate_state_markdown_flavor: "default"
 
+# Allow different manufacturers
+accepted_xcvr_manufacturers: "{{ validation_role.xcvr_own_manufacturers | arista.avd.default(['Arastra, Inc.', 'Arista Networks']) }}"
+
 # AVD configurations output
 # Main output directory
 output_dir_name: 'intended'
@@ -21,6 +24,3 @@ output_dir: '{{ root_dir }}/{{ output_dir_name }}'
 # Output for structured YAML files:
 structured_dir_name: 'structured_configs'
 structured_dir: '{{ output_dir }}/{{ structured_dir_name }}'
-
-# Allow different manufacturers
-accepted_xcvr_manufacturers: "{{ validation_role.xcvr_own_manufacturers | arista.avd.default(['Arastra, Inc.', 'Arista Networks']) }}"

--- a/ansible_collections/arista/avd/roles/eos_validate_state/defaults/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/defaults/main.yml
@@ -23,4 +23,4 @@ structured_dir_name: 'structured_configs'
 structured_dir: '{{ output_dir }}/{{ structured_dir_name }}'
 
 # Allow different manufacturers
-accepted_xcvr_manufacturers: "{{ validation_role_defaults.xcvr_own_manufacturers + ['Not Present', 'Arastra, Inc.', 'Arista Networks'] }}"
+accepted_xcvr_manufacturers: "{{ validation_role.xcvr_own_manufacturers + ['Not Present', 'Arastra, Inc.', 'Arista Networks'] }}"

--- a/ansible_collections/arista/avd/roles/eos_validate_state/defaults/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/defaults/main.yml
@@ -21,3 +21,6 @@ output_dir: '{{ root_dir }}/{{ output_dir_name }}'
 # Output for structured YAML files:
 structured_dir_name: 'structured_configs'
 structured_dir: '{{ output_dir }}/{{ structured_dir_name }}'
+
+# Allow different manufacturers
+accepted_xcvr_manufacturers: "{{ validation_role_defaults.xcvr_own_manufacturers + ['Not Present', 'Arastra, Inc.', 'Arista Networks'] }}"

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/hardware.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/hardware.yml
@@ -87,7 +87,7 @@
 - name: Validate transceivers manufacturers
   assert:
     that:
-      - "xcvrSlot.value.mfgName in ['Not Present', 'Arastra, Inc.', 'Arista Networks']"
+      - "xcvrSlot.value.mfgName in {{ accepted_xcvr_manufacturers }}"
     fail_msg: transceivers manufacturers is "{{ xcvrSlot.value.mfgName }}"
     quiet: true
   loop: "{{ inventory.stdout_lines.0.xcvrSlots | dict2items }}"

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/hardware.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/hardware.yml
@@ -95,5 +95,6 @@
     loop_var: xcvrSlot
   ignore_errors: "{{ eos_validate_state_validation_mode_loose }}"
   register: transceiver_inventory_results
+  when: "xcvrSlot.value.mfgName != 'Not Present'"
   tags:
     - hardware

--- a/ansible_collections/arista/avd/roles/eos_validate_state/templates/validate_state_report-csv.j2
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/templates/validate_state_report-csv.j2
@@ -42,7 +42,7 @@ test_id,node,test_category,test_description,test,result,failure_reason
 {# Hardware results - transceivers manufacturers #}
 {% for node in groups[fabric_name] | arista.avd.natural_sort %}
 {%     if hostvars[node].transceiver_inventory_results is defined and hostvars[node].transceiver_inventory_results.results is defined %}
-{%         for result in hostvars[node].transceiver_inventory_results.results %}
+{%         for result in hostvars[node].transceiver_inventory_results.results | arista.avd.natural_sort %}
 {%             set test_id.value = test_id.value + 1 %}
 {{ test_id.value }},{{ node }},Hardware,transceivers manufacturers,port {{ result.xcvrSlot.key }},{% if result.failed == false %}PASS{% else %}FAIL,{{ result.msg }}{% endif %}
 

--- a/ansible_collections/arista/avd/roles/eos_validate_state/templates/validate_state_report-csv.j2
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/templates/validate_state_report-csv.j2
@@ -43,9 +43,11 @@ test_id,node,test_category,test_description,test,result,failure_reason
 {% for node in groups[fabric_name] | arista.avd.natural_sort %}
 {%     if hostvars[node].transceiver_inventory_results is defined and hostvars[node].transceiver_inventory_results.results is defined %}
 {%         for result in hostvars[node].transceiver_inventory_results.results | arista.avd.natural_sort %}
-{%             set test_id.value = test_id.value + 1 %}
+{%             if result.failed is arista.avd.defined() %}
+{%                 set test_id.value = test_id.value + 1 %}
 {{ test_id.value }},{{ node }},Hardware,transceivers manufacturers,port {{ result.xcvrSlot.key }},{% if result.failed == false %}PASS{% else %}FAIL,{{ result.msg }}{% endif %}
 
+{%             endif %}
 {%         endfor %}
 {%    endif %}
 {% endfor %}


### PR DESCRIPTION
## Change Summary

Currently, if XCVR manufacturer is not in the following list, the test is failing, while the interface may be working as expected: 
- 'Not Present'
- 'Arastra, Inc.'
- 'Arista Networks'

This PR allows the user to configure a list of accepted XCVR manufacturers to avoid failing these tests.

## Related Issue(s)

Fixes #997 

## Component(s) name

`arista.avd.eos_validate_state`

## Proposed changes
Task in hardware.yml file is modified to validate output of XCVR manufacturer agains a list defined in eos_validate_state/defaults/main.yml. 
This list is either the user-defined list under validation_role.xcvr_own_manufacturers variable OR the defined default (Arastra, Arista Networks). The variable is defined at fabric level: 
```
validation_role:
  xcvr_own_manufacturers:
    - Manufacturer 1
    - Manufacturer 2
```
The ansible task is only validating the manufacturer of the XCVR when it is present, so no need of defining the manufacturer "Not Present". This also eliminates noise in the results file, since we do not consider "Not present" as a successful test, we simply do not consider it and this can be catch in different tests (ie P2P ping test) if it should be installed.

This leads to a validation of the result.failed variable when building the CSV file, as the ansible task is executed but is does not fail.
Also, the report in CSV is piped with `| arista.avd.natural_sort` to print all interfaces in order, making it more "human readable".

## How to test
Generate a playbook with the testing devices included and run the eos_validate_state role against it.

Device should have a XCVR different from the above list.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
