### PR TITLE
Feat(eos_cli_config_gen): Support shape rate in qos profiles

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/qos.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/qos.md
@@ -222,34 +222,34 @@ QOS Profile: **experiment**
 
 **Settings**
 
-| Default COS | Default DSCP | Trust |
-| ----------- | ------------ | ----- |
-| 2 | - | cos |
+| Default COS | Default DSCP | Trust | Shape Rate |
+| ----------- | ------------ | ----- | ---------- |
+| 2 | - | cos | - |
 
 **Tx-queues**
 
-| Tx-queue | Bandwidth | Priority |
-| -------- | --------- | -------- |
-| 3 | 30 | no priority |
-| 4 | 10 | - |
-| 5 | 40 | - |
-| 7 | 30 | - |
+| Tx-queue | Bandwidth | Priority | Shape Rate |
+| -------- | --------- | -------- | ---------- |
+| 3 | 30 | no priority | - |
+| 4 | 10 | - | - |
+| 5 | 40 | - | - |
+| 7 | 30 | - | 40 percent |
 
 QOS Profile: **test**
 
 **Settings**
 
-| Default COS | Default DSCP | Trust |
-| ----------- | ------------ | ----- |
-| - | 46 | dscp |
+| Default COS | Default DSCP | Trust | Shape Rate |
+| ----------- | ------------ | ----- | ---------- |
+| - | 46 | dscp | 80 percent |
 
 **Tx-queues**
 
-| Tx-queue | Bandwidth | Priority |
-| -------- | --------- | -------- |
-| 1 | 50 | no priority |
-| 2 | 10 | priority strict |
-| 4 | 10 | - |
+| Tx-queue | Bandwidth | Priority | Shape Rate |
+| -------- | --------- | -------- | ---------- |
+| 1 | 50 | no priority | - |
+| 2 | 10 | priority strict | - |
+| 4 | 10 | - | - |
 
 ### QOS Profile Device Configuration
 
@@ -271,10 +271,12 @@ qos profile experiment
    !
    tx-queue 7
       bandwidth percent 30
+      shape rate 40 percent
 !
 qos profile test
    qos trust dscp
    qos dscp 46
+   shape rate 80 percent
    !
    tx-queue 1
       bandwidth percent 50

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/qos.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/qos.cfg
@@ -20,10 +20,12 @@ qos profile experiment
    !
    tx-queue 7
       bandwidth percent 30
+      shape rate 40 percent
 !
 qos profile test
    qos trust dscp
    qos dscp 46
+   shape rate 80 percent
    !
    tx-queue 1
       bandwidth percent 50

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/qos.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/qos.yml
@@ -18,6 +18,8 @@ qos_profiles:
   test:
     trust: dscp
     dscp: 46
+    shape:
+      rate: 80 percent
     tx_queues:
       1:
         bandwidth_percent: 50
@@ -40,6 +42,8 @@ qos_profiles:
         bandwidth_guaranteed_percent: 10
       7:
         bandwidth_percent: 30
+        shape:
+          rate: 40 percent
 
 ### Port-Channel Interfaces ###
 ethernet_interfaces:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -654,10 +654,10 @@ generate_device_documentation: < true | false | default -> true >
 
 ### Generate Default Config
 
-The `generate_default_config` knob allows to ommit default EOS configuration.
+The `generate_default_config` knob allows to omit default EOS configuration.
 This can be useful when leveraging `eos_cli_config_gen` to generate configlets with CloudVision.
 
-The following commands will be ommited when `generate_default_config` is set to `false`:
+The following commands will be omitted when `generate_default_config` is set to `false`:
 
 - RANCID Content Type
 - Hostname
@@ -2110,18 +2110,24 @@ qos_profiles:
     trust: < dscp | cos >
     cos: < cos-value >
     dscp: < dscp-value >
-    tx-queues:
+    shape:
+      rate: < "< rate > kbps" | "1-100 percent" | "< rate > pps" , supported options are platform dependent >
+    tx_queues:
       < tx-queue-id >:
         bandwidth_percent: < value >
         priority: < string >
+        shape:
+          rate: < "< rate > kbps" | "1-100 percent" | "< rate > pps" , supported options are platform dependent >
       < tx-queue-id >:
         bandwidth_percent: < value >
         priority: < string >
+        shape:
+          rate: < "< rate > kbps" | "1-100 percent" | "< rate > pps" , supported options are platform dependent >
   < profile-2 >:
     trust: < dscp | cos >
     cos: < cos-value >
     dscp: < dscp-value >
-    tx-queues:
+    tx_queues:
       < tx-queue-id >:
         bandwidth_percent: < value >
         priority: < string >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/qos-profiles.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/qos-profiles.j2
@@ -10,25 +10,27 @@ QOS Profile: **{{ profile }}**
 
 **Settings**
 
-| Default COS | Default DSCP | Trust |
-| ----------- | ------------ | ----- |
+| Default COS | Default DSCP | Trust | Shape Rate |
+| ----------- | ------------ | ----- | ---------- |
 {%         set cos = qos_profiles[profile].cos | arista.avd.default('-') %}
 {%         set dscp = qos_profiles[profile].dscp | arista.avd.default('-') %}
 {%         set trust = qos_profiles[profile].trust | arista.avd.default('-') %}
-| {{ cos }} | {{ dscp }} | {{ trust }} |
+{%         set shape_rate = qos_profiles[profile].shape.rate | arista.avd.default('-') %}
+| {{ cos }} | {{ dscp }} | {{ trust }} | {{ shape_rate }} |
 
 **Tx-queues**
 
 {%         if qos_profiles[profile].tx_queues is arista.avd.defined %}
-| Tx-queue | Bandwidth | Priority |
-| -------- | --------- | -------- |
+| Tx-queue | Bandwidth | Priority | Shape Rate |
+| -------- | --------- | -------- | ---------- |
 {%             for tx_queue in qos_profiles[profile].tx_queues | arista.avd.natural_sort %}
-{%                  set queue = qos_profiles[profile].tx_queues[tx_queue] | arista.avd.default('-') %}
-{%                  set bw_percent = qos_profiles[profile].tx_queues[tx_queue].bandwidth_percent | arista.avd.default(
-                                     qos_profiles[profile].tx_queues[tx_queue].bandwidth_guaranteed_percent,
-                                     '-') %}
-{%                  set priority = qos_profiles[profile].tx_queues[tx_queue].priority | arista.avd.default('-') %}
-| {{ tx_queue }} | {{ bw_percent }} | {{ priority }} |
+{%                 set queue = qos_profiles[profile].tx_queues[tx_queue] | arista.avd.default('-') %}
+{%                 set bw_percent = qos_profiles[profile].tx_queues[tx_queue].bandwidth_percent | arista.avd.default(
+                                    qos_profiles[profile].tx_queues[tx_queue].bandwidth_guaranteed_percent,
+                                    '-') %}
+{%                 set priority = qos_profiles[profile].tx_queues[tx_queue].priority | arista.avd.default('-') %}
+{%                 set shape_rate = qos_profiles[profile].tx_queues[tx_queue].shape.rate | arista.avd.default('-') %}
+| {{ tx_queue }} | {{ bw_percent }} | {{ priority }} | {{ shape_rate }} |
 {%             endfor %}
 {%         endif %}
 {%     endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/qos-profiles.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/qos-profiles.j2
@@ -11,6 +11,9 @@ qos profile {{ profile }}
 {%     if qos_profiles[profile].dscp is arista.avd.defined %}
    qos dscp {{ qos_profiles[profile].dscp }}
 {%     endif %}
+{%     if qos_profiles[profile].shape.rate is arista.avd.defined %}
+   shape rate {{ qos_profiles[profile].shape.rate }}
+{%     endif %}
 {%     for tx_queue in qos_profiles[profile].tx_queues | arista.avd.natural_sort %}
    !
    tx-queue {{ tx_queue }}
@@ -21,6 +24,9 @@ qos profile {{ profile }}
 {%         endif %}
 {%         if qos_profiles[profile].tx_queues[tx_queue].priority is arista.avd.defined %}
       {{ qos_profiles[profile].tx_queues[tx_queue].priority }}
+{%         endif %}
+{%         if qos_profiles[profile].tx_queues[tx_queue].shape.rate is arista.avd.defined %}
+      shape rate {{ qos_profiles[profile].tx_queues[tx_queue].shape.rate }}
 {%         endif %}
 {%     endfor %}
 {% endfor %}


### PR DESCRIPTION
## Change Summary

- Support shape rate commands in qos_profiles similar to the shape rate definition under Ethernet and Port-channel interfaces
- Fix tx-queue documentation

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Data Model

- Fixed the README.md typo, the knob, tx-queues changed to tx_queues

- New knob shape.rate is added at both profile and tx_queue:
```yaml
qos_profiles:
  < profile-1 >:
    trust: < dscp | cos >
    cos: < cos-value >
    dscp: < dscp-value >
    shape:
      rate: < "< rate > kbps" | "1-100 percent" | "< rate > pps" , supported options are platform dependent >
    tx_queues:
      < tx-queue-id >:
        bandwidth_percent: < value >
        priority: < string >
        shape:
          rate: < "< rate > kbps" | "1-100 percent" | "< rate > pps" , supported options are platform dependent >
``` 

## How to test
Molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
