### PR TITLE
Feat(eos_cli_config_gen): Support error-correction encoding on ethernet interfaces

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -87,6 +87,8 @@ interface Management1
 | Ethernet19 |  Switched port with no LLDP rx/tx | access | 110 | - | - | - |
 | Ethernet21 |  200MBit/s shape | access | - | - | - | - |
 | Ethernet22 |  10% shape | access | - | - | - | - |
+| Ethernet23 |  Error-correction encoding | access | - | - | - | - |
+| Ethernet24 |  Disable error-correction encoding | access | - | - | - | - |
 
 *Inherited from Port-Channel Interface
 
@@ -134,6 +136,13 @@ interface Management1
 | Interface | Channel Group | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type |
 | --------- | ------------- | ------------- | ----------- | ---- | ----------------- |
 | Ethernet5 | - | ISIS_TEST | 99 | point-to-point | level-2 |
+
+#### Error Correction Encoding Interfaces
+
+| Interface | Enabled |
+| --------- | ------- |
+| Ethernet23 | fire-code<br>reed-solomon |
+| Ethernet24 | Disabled |
 
 ### Ethernet Interfaces Device Configuration
 
@@ -343,6 +352,17 @@ interface Ethernet22
    description 10% shape
    switchport
    shape rate 10 percent
+!
+interface Ethernet23
+   description Error-correction encoding
+   error-correction encoding fire-code
+   error-correction encoding reed-solomon
+   switchport
+!
+interface Ethernet24
+   description Disable error-correction encoding
+   no error-correction encoding
+   switchport
 ```
 
 # Routing

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
@@ -212,6 +212,17 @@ interface Ethernet22
    switchport
    shape rate 10 percent
 !
+interface Ethernet23
+   description Error-correction encoding
+   error-correction encoding fire-code
+   error-correction encoding reed-solomon
+   switchport
+!
+interface Ethernet24
+   description Disable error-correction encoding
+   no error-correction encoding
+   switchport
+!
 interface Management1
    description oob_management
    vrf MGMT

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
@@ -275,3 +275,14 @@ ethernet_interfaces:
     description: 10% shape
     shape:
       rate: "10 percent"
+
+  Ethernet23:
+    description: Error-correction encoding
+    error_correction_encoding:
+      fire_code: true
+      reed_solomon: true
+
+  Ethernet24:
+    description: Disable error-correction encoding
+    error_correction_encoding:
+      enabled: false

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -31,6 +31,7 @@
     - [Custom Templates](#custom-templates)
     - [EOS CLI](#eos-cli)
     - [Errdisable](#errdisable)
+    - [Error Correction Encoding](#error-correction-encoding)
     - [Filters](#filters)
       - [Prefix Lists](#prefix-lists)
       - [IPv6 Prefix Lists](#ipv6-prefix-lists)
@@ -514,6 +515,15 @@ errdisable:
       - xcvr-power-unsupported
       - xcvr-unsupported
     interval: < seconds | default = 300 >
+```
+
+### Error Correction Encoding
+
+```yaml
+error_correction_encoding:
+  enabled: < true | false | default -> true >
+  fire_code: < true | false >
+  reed_solomon: < true | false >
 ```
 
 ### Filters

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ethernet-interfaces.j2
@@ -310,10 +310,37 @@
 {%     if port_channel_interfaces_isis | length > 0 %}
  *Inherited from Port-Channel Interface
 {%     endif %}
+{%     set err_cor_enc_intfs = [] %}
+{%     for ethernet_interface in ethernet_interfaces %}
+{%         if ethernet_interfaces[ethernet_interface].error_correction_encoding is arista.avd.defined %}
+{%             do err_cor_enc_intfs.append(ethernet_interface) %}
+{%         endif %}
+{%     endfor %}
+{%     if err_cor_enc_intfs | length > 0 %}
+
+#### Error Correction Encoding Interfaces
+
+| Interface | Enabled |
+| --------- | ------- |
+{%         for ethernet_interface in err_cor_enc_intfs | arista.avd.natural_sort %}
+{%             if ethernet_interfaces[ethernet_interface].error_correction_encoding.enabled is arista.avd.defined(false) %}
+{%                 set enabled = ['Disabled'] %}
+{%             else %}
+{%                 set enabled = [] %}
+{%                 if ethernet_interfaces[ethernet_interface].error_correction_encoding.fire_code is arista.avd.defined(true) %}
+{%                     do enabled.append('fire-code') %}
+{%                 endif %}
+{%                 if ethernet_interfaces[ethernet_interface].error_correction_encoding.reed_solomon is arista.avd.defined(true) %}
+{%                     do enabled.append('reed-solomon') %}
+{%                 endif %}
+{%             endif %}
+| {{ ethernet_interface }} | {{ enabled | join('<br>') }} |
+{%         endfor %}
+{%     endif %}
 
 ### Ethernet Interfaces Device Configuration
 
 ```eos
-{% include 'eos/ethernet-interfaces.j2' %}
+{%     include 'eos/ethernet-interfaces.j2' %}
 ```
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -45,6 +45,20 @@ interface {{ ethernet_interface }}
 {%         if ethernet_interfaces[ethernet_interface].l2_mtu is arista.avd.defined %}
    l2 mtu {{ ethernet_interfaces[ethernet_interface].l2_mtu }}
 {%         endif %}
+{%         if ethernet_interfaces[ethernet_interface].error_correction_encoding.enabled is arista.avd.defined(false) %}
+   no error-correction encoding
+{%         else %}
+{%             if ethernet_interfaces[ethernet_interface].error_correction_encoding.fire_code is arista.avd.defined(true) %}
+   error-correction encoding fire-code
+{%             elif ethernet_interfaces[ethernet_interface].error_correction_encoding.fire_code is arista.avd.defined(false) %}
+   no error-correction encoding fire-code
+{%             endif %}
+{%             if ethernet_interfaces[ethernet_interface].error_correction_encoding.reed_solomon is arista.avd.defined(true) %}
+   error-correction encoding reed-solomon
+{%             elif ethernet_interfaces[ethernet_interface].error_correction_encoding.reed_solomon is arista.avd.defined(false) %}
+   no error-correction encoding reed-solomon
+{%             endif %}
+{%         endif %}
 {%         if ethernet_interfaces[ethernet_interface].type is arista.avd.defined('routed') %}
    no switchport
 {%         elif ethernet_interfaces[ethernet_interface].type is arista.avd.defined('l3dot1q') and ethernet_interfaces[ethernet_interface].encapsulation_dot1q_vlan is arista.avd.defined() %}


### PR DESCRIPTION
## Change Summary

Supports three types of options: 1) error-correction encoding disable 2) enable fire-code 3) reed-solomon or the combination of 2 and 3.

## Related Issue(s)

Fixes #1079 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

New feature:

```yaml
error_correction_encoding:
  enabled: < true | false | default -> true >
  fire_code: < true | false >
  reed_solomon: < true | false >
```

## How to test
Molecule
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
