### PR TITLE
Feat(eos_cli_config_gen): added false condition for bpdu guard

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -118,6 +118,8 @@ interface {{ ethernet_interface }}
 {%         endif %}
 {%         if ethernet_interfaces[ethernet_interface].spanning_tree_bpduguard is arista.avd.defined(true) %}
    spanning-tree bpduguard enable
+{%         elif ethernet_interfaces[ethernet_interface].spanning_tree_bpduguard is arista.avd.defined(false) %}
+   spanning-tree bpduguard disable
 {%         endif %}
 {%         if ethernet_interfaces[ethernet_interface].vrf is arista.avd.defined %}
    vrf {{ ethernet_interfaces[ethernet_interface].vrf }}


### PR DESCRIPTION
## Change Summary

Add False value for bpdu guard, to be able to disable it.

## Related Issue(s)

Fixes #1377

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
bpdu guard should support True or False values as per documentation; yet it only supported True values on the template.

## How to test
set bpdu guard to False should set "disabled" to the bpdu command on EOS.

## Checklist

### User Checklist
- N/A

### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
