### PR TITLE
Refactor(eos_designs): Network-services templates to use lists internally

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/monitor-connectivity.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/monitor-connectivity.md
@@ -1,6 +1,5 @@
 # monitor-connectivity
 # Table of Contents
-<!-- toc -->
 
 - [Management](#management)
   - [Management Interfaces](#management-interfaces)
@@ -21,7 +20,6 @@
 - [ACL](#acl)
 - [Quality Of Service](#quality-of-service)
 
-<!-- toc -->
 # Management
 
 ## Management Interfaces

--- a/ansible_collections/arista/avd/plugins/README.md
+++ b/ansible_collections/arista/avd/plugins/README.md
@@ -73,10 +73,8 @@ To use this filter:
 
 ### convert_dicts filter
 
-convert_dicts will convert dictionary to list.
-
-The `arista.avd.convert_dicts` filter will convert nested dictionaries to lists of dictionaries
-and insert the outer dictionary keys into each list item using the primary_key `name`.
+The `arista.avd.convert_dicts` filter will convert a dictionary containing nested dictionaries to a list of dictionaries
+and insert the outer dictionary keys into each list item using the primary_key `name` (key name is configurable).
 
 This filter is intended for:
 
@@ -88,13 +86,16 @@ Note: If the variable is already a list, it will pass through untouched
 To use this filter:
 
 ```jinja
-{# convert list of dictionnary with default `name:` as the primary key #}
-{% for example_list in example_lists | arista.avd.convert_dicts %}
-{{ example_list }}
+{# convert list of dictionary with default `name:` as the primary key #}
+{% set example_list = example_dictionary | arista.avd.convert_dicts %}
+{% for example_item in example_list %}
+item primary key is {{ example_item.name }}
 {% endfor %}
-{# convert list of dictionnary with `id:` set as the primary key #}
-{% for example_list in example_lists | arista.avd.convert_dicts('id') %}
-{{ example_list }}
+
+{# convert list of dictionary with `id:` set as the primary key #}
+{% set example_list = example_dictionary | arista.avd.convert_dicts('id') %}
+{% for example_item in example_list %}
+item primary key is {{ example_item.id }}
 {% endfor %}
 ```
 

--- a/ansible_collections/arista/avd/plugins/README.md
+++ b/ansible_collections/arista/avd/plugins/README.md
@@ -7,6 +7,7 @@
     - [list_compress filter](#list_compress-filter)
     - [natural_sort filter](#natural_sort-filter)
     - [default filter](#default-filter)
+    - [convert_dicts filter](#convert_dicts-filter)
     - [ethernet segment identifiers management filter](#ethernet-segment-identifiers-management-filter)
       - [generate_esi filter](#generate_esi-filter)
       - [generate_lacp_id filter](#generate_lacp_id-filter)
@@ -68,6 +69,33 @@ To use this filter:
 
 ```jinja
 {{ variable | arista.avd.default( default_value_1 , default_value_2 ... ) }}
+```
+
+### convert_dicts filter
+
+convert_dicts will convert dictionary to list.
+
+The `arista.avd.convert_dicts` filter will convert nested dictionaries to lists of dictionaries
+and insert the outer dictionary keys into each list item using the primary_key `name`.
+
+This filter is intended for:
+
+- Seemless data model migration from dictionaries to lists.
+- Improve Ansible's processing performance when dealing with large dictionaries by converting them to lists of dictionaries.
+
+Note: If the variable is already a list, it will pass through untouched
+
+To use this filter:
+
+```jinja
+{# convert list of dictionnary with default `name:` as the primary key #}
+{% for example_list in example_lists | arista.avd.convert_dicts %}
+{{ example_list }}
+{% endfor %}
+{# convert list of dictionnary with `id:` set as the primary key #}
+{% for example_list in example_lists | arista.avd.convert_dicts('id') %}
+{{ example_list }}
+{% endfor %}
 ```
 
 ### ethernet segment identifiers management filter

--- a/ansible_collections/arista/avd/plugins/filter/convert_dicts.py
+++ b/ansible_collections/arista/avd/plugins/filter/convert_dicts.py
@@ -1,5 +1,5 @@
 #
-# def arista.avd.migrate_dicts
+# def arista.avd.convert_dicts
 #
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
@@ -7,23 +7,27 @@ __metaclass__ = type
 from jinja2.runtime import Undefined
 
 
-def migrate_dicts(dictionary, primary_key="name"):
+def convert_dicts(dictionary, primary_key="name"):
     """
-    migrate_dicts will convert dictionary to list.
+    convert_dicts will convert dictionary to list.
 
-    Arista.avd.migrate_dicts will convert nested dictionaries to list of dictionaries
+    The `arista.avd.convert_dicts` filter will convert nested dictionaries to lists of dictionaries
     and insert the outer dictionary keys into each list item using the primary_key name.
 
-    This filter is intended for seemless data model migration.
-    If variable is already converted to list, it will pass through untouched
+    This filter is intended for:
+
+    - Seemless data model migration from dictionaries to lists.
+    - Improve Ansible's processing performance when dealing with large dictionaries by converting them to lists of dictionaries.
+
+    Note: If the variable is already a list, it will pass through untouched
 
     Example
     -------
     {# Migrate access_lists data model from dict to list #}
-    {% set access_lists = access_lists | arista.avd.migrate_dicts %}
+    {% set access_lists = access_lists | arista.avd.convert_dicts %}
     {% for access_list in access_lists %}
     {#     Migrate access-lists.sequence_numbers data model from dict to list #}
-    {%     do access_lists[loop.index0].update({'sequence_numbers': access_list.sequence_numbers | arista.avd.migrate_dicts('sequence')}) %}
+    {%     do access_lists[loop.index0].update({'sequence_numbers': access_list.sequence_numbers | arista.avd.convert_dicts('sequence')}) %}
     {% endfor %}
     access_lists: {{ access_lists }}
 
@@ -58,5 +62,5 @@ def migrate_dicts(dictionary, primary_key="name"):
 class FilterModule(object):
     def filters(self):
         return {
-            'migrate_dicts': migrate_dicts,
+            'convert_dicts': convert_dicts,
         }

--- a/ansible_collections/arista/avd/plugins/filter/convert_dicts.py
+++ b/ansible_collections/arista/avd/plugins/filter/convert_dicts.py
@@ -9,10 +9,8 @@ from jinja2.runtime import Undefined
 
 def convert_dicts(dictionary, primary_key="name"):
     """
-    convert_dicts will convert dictionary to list.
-
-    The `arista.avd.convert_dicts` filter will convert nested dictionaries to lists of dictionaries
-    and insert the outer dictionary keys into each list item using the primary_key `name`.
+    The `arista.avd.convert_dicts` filter will convert a dictionary containing nested dictionaries to a list of dictionaries
+    and insert the outer dictionary keys into each list item using the primary_key `name` (key name is configurable).
 
     This filter is intended for:
 
@@ -24,13 +22,16 @@ def convert_dicts(dictionary, primary_key="name"):
     To use this filter:
 
     ```jinja
-    {# convert list of dictionnary with default `name:` as the primary key #}
-    {% for example_list in example_lists | arista.avd.convert_dicts %}
-    {{ example_list }}
+    {# convert list of dictionary with default `name:` as the primary key #}
+    {% set example_list = example_dictionary | arista.avd.convert_dicts %}
+    {% for example_item in example_list %}
+    item primary key is {{ example_item.name }}
     {% endfor %}
-    {# convert list of dictionnary with `id:` set as the primary key #}
-    {% for example_list in example_lists | arista.avd.convert_dicts('id') %}
-    {{ example_list }}
+
+    {# convert list of dictionary with `id:` set as the primary key #}
+    {% set example_list = example_dictionary | arista.avd.convert_dicts('id') %}
+    {% for example_item in example_list %}
+    item primary key is {{ example_item.id }}
     {% endfor %}
     ```
 

--- a/ansible_collections/arista/avd/plugins/filter/convert_dicts.py
+++ b/ansible_collections/arista/avd/plugins/filter/convert_dicts.py
@@ -12,7 +12,7 @@ def convert_dicts(dictionary, primary_key="name"):
     convert_dicts will convert dictionary to list.
 
     The `arista.avd.convert_dicts` filter will convert nested dictionaries to lists of dictionaries
-    and insert the outer dictionary keys into each list item using the primary_key name.
+    and insert the outer dictionary keys into each list item using the primary_key `name`.
 
     This filter is intended for:
 
@@ -21,15 +21,18 @@ def convert_dicts(dictionary, primary_key="name"):
 
     Note: If the variable is already a list, it will pass through untouched
 
-    Example
-    -------
-    {# Migrate access_lists data model from dict to list #}
-    {% set access_lists = access_lists | arista.avd.convert_dicts %}
-    {% for access_list in access_lists %}
-    {#     Migrate access-lists.sequence_numbers data model from dict to list #}
-    {%     do access_lists[loop.index0].update({'sequence_numbers': access_list.sequence_numbers | arista.avd.convert_dicts('sequence')}) %}
+    To use this filter:
+
+    ```jinja
+    {# convert list of dictionnary with default `name:` as the primary key #}
+    {% for example_list in example_lists | arista.avd.convert_dicts %}
+    {{ example_list }}
     {% endfor %}
-    access_lists: {{ access_lists }}
+    {# convert list of dictionnary with `id:` set as the primary key #}
+    {% for example_list in example_lists | arista.avd.convert_dicts('id') %}
+    {{ example_list }}
+    {% endfor %}
+    ```
 
     Parameters
     ----------

--- a/ansible_collections/arista/avd/plugins/filter/migrate_dicts.py
+++ b/ansible_collections/arista/avd/plugins/filter/migrate_dicts.py
@@ -1,0 +1,62 @@
+#
+# def arista.avd.migrate_dicts
+#
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from jinja2.runtime import Undefined
+
+
+def migrate_dicts(dictionary, primary_key="name"):
+    """
+    migrate_dicts will convert dictionary to list.
+
+    Arista.avd.migrate_dicts will convert nested dictionaries to list of dictionaries
+    and insert the outer dictionary keys into each list item using the primary_key name.
+
+    This filter is intended for seemless data model migration.
+    If variable is already converted to list, it will pass through untouched
+
+    Example
+    -------
+    {# Migrate access_lists data model from dict to list #}
+    {% set access_lists = access_lists | arista.avd.migrate_dicts %}
+    {% for access_list in access_lists %}
+    {#     Migrate access-lists.sequence_numbers data model from dict to list #}
+    {%     do access_lists[loop.index0].update({'sequence_numbers': access_list.sequence_numbers | arista.avd.migrate_dicts('sequence')}) %}
+    {% endfor %}
+    access_lists: {{ access_lists }}
+
+    Parameters
+    ----------
+    dictionary : any
+        Nested Dictionary to convert - returned untouched if not a nested dictionary
+    primary_key : str, optional
+        Name of primary key used when inserting outer dictionary keys into items.
+
+    Returns
+    -------
+    any
+        Returns list of dictionaries or input variable untouched if not a nested dictionary
+    """
+    if not isinstance(dictionary, dict):
+        # Not a dictionary, return the original
+        return dictionary
+    else:
+        output = []
+        for key in dictionary.keys():
+            if not isinstance(dictionary[key], dict):
+                # Not a nested dictionary, return the original
+                return dictionary
+            else:
+                item = dictionary[key]
+                item.update({primary_key: key})
+                output.append(item)
+        return output
+
+
+class FilterModule(object):
+    def filters(self):
+        return {
+            'migrate_dicts': migrate_dicts,
+        }

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/eos-cli-vrfs.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/eos-cli-vrfs.j2
@@ -3,10 +3,10 @@
 {% if structured_config.eos_cli is arista.avd.defined %}
 {%     do tmp_eos_clis.append(structured_config.eos_cli) %}
 {% endif %}
-{% for tenant in switch.tenants | arista.avd.natural_sort %}
-{%     for vrf in switch.tenants[tenant].vrfs | arista.avd.natural_sort %}
-{%         if tenants[tenant].vrfs[vrf].raw_eos_cli is arista.avd.defined %}
-{%             do tmp_eos_clis.append(tenants[tenant].vrfs[vrf].raw_eos_cli) %}
+{% for tenant in network_services_data.tenants %}
+{%     for vrf in tenant.vrfs %}
+{%         if vrf.raw_eos_cli is arista.avd.defined %}
+{%             do tmp_eos_clis.append(vrf.raw_eos_cli) %}
 {%         endif %}
 {%     endfor %}
 {% endfor %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/ethernet-interfaces.j2
@@ -1,9 +1,9 @@
 {# Tenant l3 interfaces #}
 {% set l3_interface_subif_parents = [] %}
 ethernet_interfaces:
-{% for tenant in switch.tenants | arista.avd.natural_sort %}
-{%     for vrf in switch.tenants[tenant].vrfs | arista.avd.natural_sort %}
-{%         for l3_interface in tenants[tenant].vrfs[vrf].l3_interfaces | arista.avd.default([]) %}
+{% for tenant in network_services_data.tenants %}
+{%     for vrf in tenant.vrfs %}
+{%         for l3_interface in vrf.l3_interfaces | arista.avd.default([]) %}
 {%             if l3_interface.nodes is arista.avd.defined and inventory_hostname in l3_interface.nodes and l3_interface.ip_addresses is arista.avd.defined and l3_interface.interfaces is arista.avd.defined %}
 {%                 for node in l3_interface.nodes %}
 {%                     if node == inventory_hostname %}
@@ -20,7 +20,7 @@ ethernet_interfaces:
     type: routed
 {%                         endif %}
     peer_type: l3_interface
-    vrf: {{ vrf }}
+    vrf: {{ vrf.name }}
     ip_address: {{ l3_interface.ip_addresses[loop.index0] }}
 {%                         if l3_interface.mtu is arista.avd.defined %}
     mtu: {{ l3_interface.mtu }}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/ip-igmp-snooping.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/ip-igmp-snooping.j2
@@ -6,20 +6,19 @@ ip_igmp_snooping:
 {# ---------------------------- #}
 {# SVI & L3VLANs services       #}
 {# ---------------------------- #}
-{%     for tenant in switch.tenants | arista.avd.natural_sort %}
-{%         for vrf in switch.tenants[tenant].vrfs | arista.avd.natural_sort %}
+{%     for tenant in network_services_data.tenants %}
+{%         for vrf in tenant.vrfs %}
 {# Tenant VLANs w/SVIs #}
-{%             for svi in switch.tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort %}
-{%                 set svi_config = tenants[tenant].vrfs[vrf].svis[svi] %}
+{%             for svi in vrf.svis %}
 {# Detect if a svi_profile exists #}
 {# If exists, create a shortpath to access profile data #}
-{%                 if svi_config.profile is arista.avd.defined %}
-{%                     set svi_profile = svi_profiles[svi_config.profile] | arista.avd.default() %}
+{%                 if svi.profile is arista.avd.defined %}
+{%                     set svi_profile = svi_profiles[svi.profile] | arista.avd.default() %}
 {%                 endif %}
-{%                 set svi_igmp_snooping_enabled = svi_config.igmp_snooping_enabled | arista.avd.default(
+{%                 set svi_igmp_snooping_enabled = svi.igmp_snooping_enabled | arista.avd.default(
                                                    svi_profile.igmp_snooping_enabled) %}
 {%                 if svi_igmp_snooping_enabled is arista.avd.defined %}
-    {{ svi | int }}:
+    {{ svi.id | int }}:
       enabled: {{ svi_igmp_snooping_enabled }}
 {%                 endif %}
 {%             endfor %}
@@ -27,11 +26,10 @@ ip_igmp_snooping:
 {# ---------------------------- #}
 {# L2VLANs services             #}
 {# ---------------------------- #}
-{%         for l2vlan in switch.tenants[tenant].l2vlans | arista.avd.natural_sort %}
-{%             set l2vlan_igmp_snooping_enabled = tenants[tenant].l2vlans[l2vlan].igmp_snooping_enabled | arista.avd.default() %}
-{%             if l2vlan_igmp_snooping_enabled is arista.avd.defined %}
-    {{ l2vlan | int }}:
-      enabled: {{ l2vlan_igmp_snooping_enabled }}
+{%         for l2vlan in tenant.l2vlans %}
+{%             if l2vlan.igmp_snooping_enabled is arista.avd.defined %}
+    {{ l2vlan.id | int }}:
+      enabled: {{ l2vlan.igmp_snooping_enabled }}
 {%             endif %}
 {%         endfor %}
 {%     endfor %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/logic.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/logic.j2
@@ -1,28 +1,28 @@
 
 {% set tmp_tenants = [] %}
 {# tenants #}
-{% for tenant in tenants | arista.avd.migrate_dicts | arista.avd.natural_sort('name') %}
+{% for tenant in tenants | arista.avd.convert_dicts | arista.avd.natural_sort('name') %}
 {%     if tenant.name in switch.tenants | arista.avd.default([]) %}
 {%         set switch_tenant = switch.tenants[tenant.name] %}
 {#         vrfs #}
 {%         set tmp_vrfs = [] %}
-{%         for vrf in tenant.vrfs | arista.avd.migrate_dicts | arista.avd.natural_sort('name') %}
+{%         for vrf in tenant.vrfs | arista.avd.convert_dicts | arista.avd.natural_sort('name') %}
 {%             if vrf.name in switch_tenant.vrfs | arista.avd.default([]) %}
 {%                 set switch_vrf = switch_tenant.vrfs[vrf.name] %}
 {#                 svis & bgp_peers #}
 {%                 set tmp_svis = [] %}
-{%                 for svi in vrf.svis | arista.avd.migrate_dicts('id') | arista.avd.natural_sort('id') %}
+{%                 for svi in vrf.svis | arista.avd.convert_dicts('id') | arista.avd.natural_sort('id') %}
 {%                     if svi.id in switch_vrf.svis | arista.avd.default([]) %}
 {%                         do tmp_svis.append(svi) %}
 {%                     endif %}
 {%                 endfor %}
-{%                 do vrf.update({'svis': tmp_svis, 'bgp_peers': vrf.bgp_peers | arista.avd.migrate_dicts | arista.avd.natural_sort('name')}) %}
+{%                 do vrf.update({'svis': tmp_svis, 'bgp_peers': vrf.bgp_peers | arista.avd.convert_dicts | arista.avd.natural_sort('name')}) %}
 {%                 do tmp_vrfs.append(vrf) %}
 {%             endif %}
 {%         endfor %}
 {#         l2vlans #}
 {%         set tmp_l2vlans = [] %}
-{%         for l2vlan in tenant.l2vlans | arista.avd.migrate_dicts('id') | arista.avd.natural_sort('id') %}
+{%         for l2vlan in tenant.l2vlans | arista.avd.convert_dicts('id') | arista.avd.natural_sort('id') %}
 {%             if l2vlan.id in switch_tenant.l2vlans | arista.avd.default([]) %}
 {%                 do tmp_l2vlans.append(l2vlan) %}
 {%             endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/logic.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/logic.j2
@@ -1,0 +1,34 @@
+
+{% set tmp_tenants = [] %}
+{# tenants #}
+{% for tenant in tenants | arista.avd.migrate_dicts | arista.avd.natural_sort('name') %}
+{%     if tenant.name in switch.tenants | arista.avd.default([]) %}
+{%         set switch_tenant = switch.tenants[tenant.name] %}
+{#         vrfs #}
+{%         set tmp_vrfs = [] %}
+{%         for vrf in tenant.vrfs | arista.avd.migrate_dicts | arista.avd.natural_sort('name') %}
+{%             if vrf.name in switch_tenant.vrfs | arista.avd.default([]) %}
+{%                 set switch_vrf = switch_tenant.vrfs[vrf.name] %}
+{#                 svis & bgp_peers #}
+{%                 set tmp_svis = [] %}
+{%                 for svi in vrf.svis | arista.avd.migrate_dicts('id') | arista.avd.natural_sort('id') %}
+{%                     if svi.id in switch_vrf.svis | arista.avd.default([]) %}
+{%                         do tmp_svis.append(svi) %}
+{%                     endif %}
+{%                 endfor %}
+{%                 do vrf.update({'svis': tmp_svis, 'bgp_peers': vrf.bgp_peers | arista.avd.migrate_dicts | arista.avd.natural_sort('name')}) %}
+{%                 do tmp_vrfs.append(vrf) %}
+{%             endif %}
+{%         endfor %}
+{#         l2vlans #}
+{%         set tmp_l2vlans = [] %}
+{%         for l2vlan in tenant.l2vlans | arista.avd.migrate_dicts('id') | arista.avd.natural_sort('id') %}
+{%             if l2vlan.id in switch_tenant.l2vlans | arista.avd.default([]) %}
+{%                 do tmp_l2vlans.append(l2vlan) %}
+{%             endif %}
+{%         endfor %}
+{%         do tenant.update({'vrfs': tmp_vrfs, 'l2vlans': tmp_l2vlans}) %}
+{%         do tmp_tenants.append(tenant) %}
+{%     endif %}
+{% endfor %}
+{% set network_services_data.tenants = tmp_tenants %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/loopback-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/loopback-interfaces.j2
@@ -1,16 +1,16 @@
 {# Tenant vrf loopback interfaces for VTEP diagnostic #}
 loopback_interfaces:
-{% for tenant in switch.tenants | arista.avd.natural_sort %}
-{%     for vrf in switch.tenants[tenant].vrfs %}
-{%         if tenants[tenant].vrfs[vrf].vtep_diagnostic.loopback is arista.avd.defined %}
-{%             set loopback_description = tenants[tenant].vrfs[vrf].vtep_diagnostic.loopback_description | arista.avd.default(vrf ~ '_VTEP_DIAGNOSTICS') %}
-{%             set loopback_ipv4_pool = tenants[tenant].vrfs[vrf].vtep_diagnostic.loopback_ip_range | arista.avd.default(
-                   tenants[tenant].vrfs[vrf].vtep_diagnostic.loopback_ip_pools | arista.avd.default([]) | selectattr('pod', 'arista.avd.defined', pod_name) | map(attribute='ipv4_pool') | first) %}
+{% for tenant in network_services_data.tenants %}
+{%     for vrf in tenant.vrfs %}
+{%         if vrf.vtep_diagnostic.loopback is arista.avd.defined %}
+{%             set loopback_description = vrf.vtep_diagnostic.loopback_description | arista.avd.default(vrf.name ~ '_VTEP_DIAGNOSTICS') %}
+{%             set loopback_ipv4_pool = vrf.vtep_diagnostic.loopback_ip_range | arista.avd.default(
+                   vrf.vtep_diagnostic.loopback_ip_pools | arista.avd.default([]) | selectattr('pod', 'arista.avd.defined', pod_name) | map(attribute='ipv4_pool') | first) %}
 {%             if loopback_ipv4_pool is arista.avd.defined %}
-  Loopback{{ tenants[tenant].vrfs[vrf].vtep_diagnostic.loopback }}:
+  Loopback{{ vrf.vtep_diagnostic.loopback }}:
     description: {{ loopback_description }}
     shutdown: false
-    vrf: {{ vrf }}
+    vrf: {{ vrf.name }}
     ip_address: {{ loopback_ipv4_pool | ansible.netcommon.ipaddr('network') | ansible.netcommon.ipmath(switch.id + switch.loopback_ipv4_offset) }}/32
 {%             endif %}
 {%         endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/main.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/main.j2
@@ -1,4 +1,9 @@
 {# Add one blank line after each included template #}
+{% if switch.network_services_l2 is arista.avd.defined(true) or switch.network_services_l3 is arista.avd.defined(true) %}
+{%     set network_services_data = namespace() %}
+{%     include 'network_services/logic.j2' %}
+
+{% endif %}
 
 {# L2 #}
 {% if switch.network_services_l2 is arista.avd.defined(true) %}
@@ -38,7 +43,6 @@
 {% if switch.vtep is arista.avd.defined(true) and
       (switch.network_services_l2 is arista.avd.defined(true) or
       switch.network_services_l3 is arista.avd.defined(true)) %}
-{%     set tenants_data = namespace() %}
 {%     include 'network_services/vtep-logic.j2' %}
 
 {%     include 'network_services/router-bgp.j2' %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/route-maps.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/route-maps.j2
@@ -1,19 +1,19 @@
 {# Route-maps for tenant bgp peers set_ipv4_next_hop parameter #}
 route_maps:
-{% for tenant in switch.tenants | arista.avd.natural_sort %}
-{%     for vrf in switch.tenants[tenant].vrfs | arista.avd.natural_sort %}
-{%         for bgp_peer in tenants[tenant].vrfs[vrf].bgp_peers | arista.avd.natural_sort %}
-{%             if inventory_hostname in tenants[tenant].vrfs[vrf].bgp_peers[bgp_peer].nodes | arista.avd.natural_sort %}
-{%                 if tenants[tenant].vrfs[vrf].bgp_peers[bgp_peer].set_ipv4_next_hop is arista.avd.defined or tenants[tenant].vrfs[vrf].bgp_peers[bgp_peer].set_ipv6_next_hop is arista.avd.defined %}
-  RM-{{ vrf }}-{{ bgp_peer }}-SET-NEXT-HOP-OUT:
+{% for tenant in network_services_data.tenants %}
+{%     for vrf in tenant.vrfs %}
+{%         for bgp_peer in vrf.bgp_peers %}
+{%             if inventory_hostname in bgp_peer.nodes | arista.avd.default([]) %}
+{%                 if bgp_peer.set_ipv4_next_hop is arista.avd.defined or bgp_peer.set_ipv6_next_hop is arista.avd.defined %}
+  RM-{{ vrf.name }}-{{ bgp_peer.name }}-SET-NEXT-HOP-OUT:
     sequence_numbers:
       10:
         type: permit
         set:
-{%                     if tenants[tenant].vrfs[vrf].bgp_peers[bgp_peer].set_ipv4_next_hop is arista.avd.defined %}
-          - "ip next-hop {{ tenants[tenant].vrfs[vrf].bgp_peers[bgp_peer].set_ipv4_next_hop }}"
-{%                     elif tenants[tenant].vrfs[vrf].bgp_peers[bgp_peer].set_ipv6_next_hop is arista.avd.defined %}
-          - "ipv6 next-hop {{ tenants[tenant].vrfs[vrf].bgp_peers[bgp_peer].set_ipv6_next_hop }}"
+{%                     if bgp_peer.set_ipv4_next_hop is arista.avd.defined %}
+          - "ip next-hop {{ bgp_peer.set_ipv4_next_hop }}"
+{%                     elif bgp_peer.set_ipv6_next_hop is arista.avd.defined %}
+          - "ipv6 next-hop {{ bgp_peer.set_ipv6_next_hop }}"
 {%                     endif %}
 {%                 endif %}
 {%             endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-vlan-aware-bundles.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-vlan-aware-bundles.j2
@@ -1,44 +1,44 @@
 {# tenant router bgp evpn configuration - MAC-VRF VLAN Aware bundles #}
   vlan_aware_bundles:
 {% if vxlan_vlan_aware_bundles is arista.avd.defined(true) %}
-{%     for tenant in switch.tenants | arista.avd.natural_sort %}
-{%         for vrf in switch.tenants[tenant].vrfs | arista.avd.natural_sort %}
-{%             if switch.tenants[tenant].vrfs[vrf].svis | arista.avd.default([]) | length > 0 %}
+{%     for tenant in network_services_data.tenants %}
+{%         for vrf in tenant.vrfs %}
+{%             if vrf.svis | length > 0 %}
 {%                 set svi_int_list = [] %}
-{%                 for svi in switch.tenants[tenant].vrfs[vrf].svis %}
-{%                     if tenants[tenant].vrfs[vrf].svis[svi].vxlan is arista.avd.defined(false) %}
+{%                 for svi in vrf.svis %}
+{%                     if svi.vxlan is arista.avd.defined(false) %}
 {%                         continue %}
 {%                     endif %}
-{%                     do svi_int_list.append(svi | int) %}
+{%                     do svi_int_list.append(svi.id | int) %}
 {%                 endfor %}
 {%                 if svi_int_list | length == 0 %}
 {%                     continue %}
 {%                 endif %}
-{%                 set vrf_vni_int = tenants[tenant].vrfs[vrf].vrf_vni | int %}
-{%                 set bundle_number =  vrf_vni_int + tenants[tenant].vlan_aware_bundle_number_base | arista.avd.default(0) %}
-    {{ vrf }}:
-      rd: "{{ tenants_data.evpn_rd_admin_subfield }}:{{ bundle_number }}"
+{%                 set vrf_vni_int = vrf.vrf_vni | int %}
+{%                 set bundle_number =  vrf_vni_int + tenant.vlan_aware_bundle_number_base | arista.avd.default(0) %}
+    {{ vrf.name }}:
+      rd: "{{ network_services_data.evpn_rd_admin_subfield }}:{{ bundle_number }}"
       route_targets:
         both:
-          - "{{ tenants_data.evpn_rt_admin_subfield or bundle_number }}:{{ bundle_number }}"
+          - "{{ network_services_data.evpn_rt_admin_subfield or bundle_number }}:{{ bundle_number }}"
       redistribute_routes:
         - learned
       vlan: {{ svi_int_list | map('int') | arista.avd.list_compress }}
 {%             endif %}
 {%         endfor %}
-{%         for l2vlan in switch.tenants[tenant].l2vlans | arista.avd.natural_sort %}
-{%             if tenants[tenant].l2vlans[l2vlan].vxlan is arista.avd.defined(false) %}
+{%         for l2vlan in tenant.l2vlans %}
+{%             if l2vlan.vxlan is arista.avd.defined(false) %}
 {%                 continue %}
 {%             endif %}
-{%             set l2vlan_int = l2vlan | int %}
-{%             set vni = tenants[tenant].l2vlans[l2vlan].vni_override | arista.avd.default(
-                         tenants[tenant].mac_vrf_vni_base + l2vlan_int) %}
-    {{ tenants[tenant].l2vlans[l2vlan].name }}:
-      tenant: {{ tenant }}
-      rd: "{{ tenants_data.evpn_rd_admin_subfield }}:{{ vni }}"
+{%             set l2vlan_int = l2vlan.id | int %}
+{%             set vni = l2vlan.vni_override | arista.avd.default(
+                         tenant.mac_vrf_vni_base + l2vlan_int) %}
+    {{ l2vlan.name }}:
+      tenant: {{ tenant.name }}
+      rd: "{{ network_services_data.evpn_rd_admin_subfield }}:{{ vni }}"
       route_targets:
         both:
-          - "{{ tenants_data.evpn_rt_admin_subfield or vni }}:{{ vni }}"
+          - "{{ network_services_data.evpn_rt_admin_subfield or vni }}:{{ vni }}"
       redistribute_routes:
         - learned
       vlan: {{ l2vlan_int }}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-vlans.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-vlans.j2
@@ -1,38 +1,38 @@
 {# tenant router bgp evpn configuration- MAC-VRF VLAN-Based #}
   vlans:
 {% if vxlan_vlan_aware_bundles == false %}
-{%     for tenant in switch.tenants | arista.avd.natural_sort %}
-{%         for vrf in switch.tenants[tenant].vrfs | arista.avd.natural_sort %}
-{%             for svi in switch.tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort %}
-{%                 if tenants[tenant].vrfs[vrf].svis[svi].vxlan is arista.avd.defined(false) %}
+{%     for tenant in network_services_data.tenants %}
+{%         for vrf in tenant.vrfs %}
+{%             for svi in vrf.svis %}
+{%                 if svi.vxlan is arista.avd.defined(false) %}
 {%                     continue %}
 {%                 endif %}
-{%                 set svi_int = svi | int %}
-{%                 set vni = tenants[tenant].vrfs[vrf].svis[svi].vni_override | arista.avd.default(
-                             tenants[tenant].mac_vrf_vni_base + svi_int) %}
-    {{ svi }}:
-      tenant: {{ tenant }}
-      rd: "{{ tenants_data.evpn_rd_admin_subfield }}:{{ vni }}"
+{%                 set svi_int = svi.id | int %}
+{%                 set vni = svi.vni_override | arista.avd.default(
+                             tenant.mac_vrf_vni_base + svi_int) %}
+    {{ svi.id }}:
+      tenant: {{ tenant.name }}
+      rd: "{{ network_services_data.evpn_rd_admin_subfield }}:{{ vni }}"
       route_targets:
         both:
-          - "{{ tenants_data.evpn_rt_admin_subfield or vni }}:{{ vni }}"
+          - "{{ network_services_data.evpn_rt_admin_subfield or vni }}:{{ vni }}"
       redistribute_routes:
         - learned
 {%             endfor %}
 {%         endfor %}
-{%         for l2vlan in switch.tenants[tenant].l2vlans | arista.avd.natural_sort %}
-{%             if tenants[tenant].l2vlans[l2vlan].vxlan is arista.avd.defined(false) %}
+{%         for l2vlan in tenant.l2vlans %}
+{%             if l2vlan.vxlan is arista.avd.defined(false) %}
 {%                 continue %}
 {%             endif %}
-{%             set l2vlan_int = l2vlan | int %}
-{%             set vni = tenants[tenant].l2vlans[l2vlan].vni_override | arista.avd.default(
-                         tenants[tenant].mac_vrf_vni_base + l2vlan_int) %}
-    {{ l2vlan }}:
-      tenant: {{ tenant }}
-      rd: "{{ tenants_data.evpn_rd_admin_subfield }}:{{ vni }}"
+{%             set l2vlan_int = l2vlan.id | int %}
+{%             set vni = l2vlan.vni_override | arista.avd.default(
+                         tenant.mac_vrf_vni_base + l2vlan_int) %}
+    {{ l2vlan.id }}:
+      tenant: {{ tenant.name }}
+      rd: "{{ network_services_data.evpn_rd_admin_subfield }}:{{ vni }}"
       route_targets:
         both:
-          - "{{ tenants_data.evpn_rt_admin_subfield or vni }}:{{ vni }}"
+          - "{{ network_services_data.evpn_rt_admin_subfield or vni }}:{{ vni }}"
       redistribute_routes:
         - learned
 {%         endfor %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-vrfs.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-vrfs.j2
@@ -2,13 +2,13 @@
 {% if switch.evpn_services_l2_only == false %}
 {% set bgp_vrf = namespace() %}
   vrfs:
-{%     for tenant in switch.tenants | arista.avd.natural_sort %}
-{%         for vrf in switch.tenants[tenant].vrfs | arista.avd.natural_sort %}
+{%     for tenant in network_services_data.tenants %}
+{%         for vrf in tenant.vrfs %}
 {%             set bgp_vrf.address_family_ipv4_neighbors = [] %}
 {%             set bgp_vrf.address_family_ipv6_neighbors = [] %}
-{%             set leaf_evpn_rt = (tenants_data.evpn_rt_admin_subfield or tenants[tenant].vrfs[vrf].vrf_vni) ~ ':' ~ tenants[tenant].vrfs[vrf].vrf_vni %}
+{%             set leaf_evpn_rt = (network_services_data.evpn_rt_admin_subfield or vrf.vrf_vni) ~ ':' ~ vrf.vrf_vni %}
 {%             set route_targets = namespace(import={'evpn': [leaf_evpn_rt]}, export={'evpn': [leaf_evpn_rt]}) %}
-{%             for additional_route_target in tenants[tenant].vrfs[vrf].additional_route_targets | arista.avd.natural_sort %}
+{%             for additional_route_target in vrf.additional_route_targets | arista.avd.natural_sort %}
 {%                 if inventory_hostname in additional_route_target.nodes | arista.avd.default([inventory_hostname]) %}
 {%                     if additional_route_target.address_family is arista.avd.defined and additional_route_target.route_target is arista.avd.defined and additional_route_target.type is arista.avd.defined %}
 {%                         if additional_route_target.type in ['import', 'export'] %}
@@ -21,68 +21,61 @@
 {%                     endif %}
 {%                 endif %}
 {%             endfor %}
-    {{ vrf }}:
+    {{ vrf.name }}:
       router_id: {{ switch.router_id }}
-      rd: "{{ tenants_data.evpn_rd_admin_subfield }}:{{ tenants[tenant].vrfs[vrf].vrf_vni }}"
+      rd: "{{ network_services_data.evpn_rd_admin_subfield }}:{{ vrf.vrf_vni }}"
       route_targets:
         import: {{ route_targets.import | to_json }}
         export: {{ route_targets.export | to_json }}
       neighbors:
 {%             if switch.mlag_l3 is arista.avd.defined(true) %}
-{%                 set configure_mlag_ibgp_peering = tenants[tenant].vrfs[vrf].enable_mlag_ibgp_peering_vrfs | arista.avd.default(
-                                                     tenants[tenant].enable_mlag_ibgp_peering_vrfs,
+{%                 set configure_mlag_ibgp_peering = vrf.enable_mlag_ibgp_peering_vrfs | arista.avd.default(
+                                                     tenant.enable_mlag_ibgp_peering_vrfs,
                                                      true) %}
 {%                 if configure_mlag_ibgp_peering %}
         {{ switch.mlag_peer_l3_ip | arista.avd.default(switch.mlag_peer_ip) }}:
           peer_group: {{ bgp_peer_groups.MLAG_IPv4_UNDERLAY_PEER.name | arista.avd.default("MLAG-IPv4-UNDERLAY-PEER") }}
 {%                 endif %}
 {%             endif %}
-{%             if tenants[tenant].vrfs[vrf].bgp_peers is arista.avd.defined %}
-{%                 for bgp_peer in tenants[tenant].vrfs[vrf].bgp_peers %}
-{%                     if tenants[tenant].vrfs[vrf].bgp_peers[bgp_peer].nodes is arista.avd.defined %}
-{%                         if inventory_hostname in tenants[tenant].vrfs[vrf].bgp_peers[bgp_peer].nodes %}
-{%                             set neighbor_params = tenants[tenant].vrfs[vrf].bgp_peers[bgp_peer] %}
-{%                             if bgp_peer | ansible.netcommon.ipv4 %}
-{%                                 do bgp_vrf.address_family_ipv4_neighbors.append(bgp_peer) %}
+{%             for bgp_peer in vrf.bgp_peers %}
+{%                 if inventory_hostname in bgp_peer.nodes | arista.avd.default([]) %}
+{%                     if bgp_peer.name | ansible.netcommon.ipv4 %}
+{%                         do bgp_vrf.address_family_ipv4_neighbors.append(bgp_peer.name) %}
+{%                     endif %}
+{%                     if bgp_peer.name | ansible.netcommon.ipv6 %}
+{%                         do bgp_vrf.address_family_ipv6_neighbors.append(bgp_peer.name) %}
+{%                     endif %}
+{%                     if bgp_peer.set_ipv4_next_hop is arista.avd.defined or bgp_peer.set_ipv6_next_hop is arista.avd.defined %}
+{%                         do bgp_peer.update({ 'route_map_out':'RM-' ~ vrf.name ~ '-' ~ bgp_peer.name ~ '-SET-NEXT-HOP-OUT' }) %}
+{%                         if bgp_peer.default_originate is arista.avd.defined %}
+{%                             if bgp_peer.default_originate.route_map is not arista.avd.defined %}
+{%                                 do bgp_peer.default_originate.update({ 'route_map_out':'RM-' ~ vrf.name ~ '-' ~ bgp_peer.name ~ '-SET-NEXT-HOP-OUT' }) %}
 {%                             endif %}
-{%                             if bgp_peer | ansible.netcommon.ipv6 %}
-{%                                 do bgp_vrf.address_family_ipv6_neighbors.append(bgp_peer) %}
-{%                             endif %}
-{%                             if neighbor_params.set_ipv4_next_hop is arista.avd.defined or neighbor_params.set_ipv6_next_hop is arista.avd.defined %}
-{%                                 do neighbor_params.update({ 'route_map_out':'RM-' ~ vrf ~ '-' ~ bgp_peer ~ '-SET-NEXT-HOP-OUT' }) %}
-{%                                 if neighbor_params.default_originate is arista.avd.defined %}
-{%                                     if neighbor_params.default_originate.route_map is not arista.avd.defined %}
-{%                                         do neighbor_params.default_originate.update({ 'route_map_out':'RM-' ~ vrf ~ '-' ~ bgp_peer ~ '-SET-NEXT-HOP-OUT' }) %}
-{%                                     endif %}
-{%                                 endif %}
-{%                                 if neighbor_params.set_ipv4_next_hop is arista.avd.defined %}
-{%                                     do neighbor_params.pop('set_ipv4_next_hop') %}
-{%                                 endif %}
-{%                                 if neighbor_params.set_ipv6_next_hop is arista.avd.defined %}
-{%                                     do neighbor_params.pop('set_ipv6_next_hop') %}
-{%                                 endif %}
-{%                             endif %}
-{%                             do neighbor_params.pop('nodes') %}
-        {{ bgp_peer }}:
-          {{ neighbor_params }}
+{%                         endif %}
+{%                         if bgp_peer.set_ipv4_next_hop is arista.avd.defined %}
+{%                             do bgp_peer.pop('set_ipv4_next_hop') %}
+{%                         endif %}
+{%                         if bgp_peer.set_ipv6_next_hop is arista.avd.defined %}
+{%                             do bgp_peer.pop('set_ipv6_next_hop') %}
 {%                         endif %}
 {%                     endif %}
-{%                 endfor %}
-{%             endif %}
+{%                     do bgp_peer.pop('nodes') %}
+        {{ bgp_peer.name }}:
+{%                     do bgp_peer.pop('name') %}
+          {{ bgp_peer }}
+{%                 endif %}
+{%             endfor %}
       redistribute_routes:
         - connected
-{%             if tenants[tenant].vrfs[vrf].static_routes is arista.avd.defined %}
-{%                 if tenants[tenant].vrfs[vrf].redistribute_static is not arista.avd.defined %}
-{%                     for static_route in tenants[tenant].vrfs[vrf].static_routes %}
-{%                         if static_route.nodes is not arista.avd.defined %}
-        - static
-{%                             break %}
-{%                         elif inventory_hostname in static_route.nodes %}
+{%             if vrf.static_routes is arista.avd.defined %}
+{%                 if vrf.redistribute_static is not arista.avd.defined %}
+{%                     for static_route in vrf.static_routes %}
+{%                         if inventory_hostname in static_route.nodes | arista.avd.default([inventory_hostname]) %}
         - static
 {%                             break %}
 {%                         endif %}
 {%                     endfor %}
-{%                 elif tenants[tenant].vrfs[vrf].redistribute_static == true %}
+{%                 elif vrf.redistribute_static == true %}
         - static
 {%                 endif %}
 {%             endif %}
@@ -103,12 +96,12 @@
               activate: true
 {%                 endfor %}
 {%             endif %}
-{%             if tenants[tenant].vrfs[vrf].bgp.raw_eos_cli is arista.avd.defined %}
+{%             if vrf.bgp.raw_eos_cli is arista.avd.defined %}
       eos_cli: |
-        {{ tenants[tenant].vrfs[vrf].bgp.raw_eos_cli | indent(8,false) }}
+        {{ vrf.bgp.raw_eos_cli | indent(8,false) }}
 {%             endif %}
-{%             if tenants[tenant].vrfs[vrf].bgp.structured_config is arista.avd.defined %}
-      struct_cfg: {{ tenants[tenant].vrfs[vrf].bgp.structured_config }}
+{%             if vrf.bgp.structured_config is arista.avd.defined %}
+      struct_cfg: {{ vrf.bgp.structured_config }}
 {%             endif %}
 {%         endfor %}
 {%     endfor %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/static-routes.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/static-routes.j2
@@ -1,11 +1,11 @@
 static_routes:
-{% for tenant in switch.tenants | arista.avd.natural_sort %}
-{%     for vrf in switch.tenants[tenant].vrfs | arista.avd.natural_sort %}
-{%         if tenants[tenant].vrfs[vrf].static_routes is arista.avd.defined %}
-{%             for static_route in tenants[tenant].vrfs[vrf].static_routes %}
-{%                 if static_route.nodes is not arista.avd.defined or inventory_hostname in static_route.nodes %}
+{% for tenant in network_services_data.tenants %}
+{%     for vrf in tenant.vrfs %}
+{%         if vrf.static_routes is arista.avd.defined %}
+{%             for static_route in vrf.static_routes %}
+{%                 if inventory_hostname in static_route.nodes | arista.avd.default([inventory_hostname]) %}
   - destination_address_prefix: {{ static_route.destination_address_prefix }}
-    vrf: {{ vrf }}
+    vrf: {{ vrf.name }}
 {%                     if static_route.gateway is arista.avd.defined %}
     gateway: {{ static_route.gateway }}
 {%                     endif %}
@@ -27,23 +27,22 @@ static_routes:
 {%                 endif %}
 {%             endfor %}
 {%         endif %}
-{%         for svi in switch.tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort %}
-{%             set svi_config = tenants[tenant].vrfs[vrf].svis[svi] %}
+{%         for svi in vrf.svis %}
 {# Detect if a svi_profile exists #}
 {# If exists, create a shortpath to access profile data #}
-{%             if svi_config.profile is arista.avd.defined %}
-{%                 set svi_profile = svi_profiles[svi_config.profile] | arista.avd.default() %}
+{%             if svi.profile is arista.avd.defined %}
+{%                 set svi_profile = svi_profiles[svi.profile] | arista.avd.default() %}
 {%             endif %}
-{%             set svi_varp = svi_config.ip_virtual_router_addresses | arista.avd.default(
+{%             set svi_varp = svi.ip_virtual_router_addresses | arista.avd.default(
                               svi_profile.ip_virtual_router_addresses) %}
 {%             if svi_varp is arista.avd.defined %}
 {# Detect if VARP addresses with prefixes exist and loop through the ip_address/prefix #}
 {# If the VARP address with prefix doesn't exist then it will loop through empty_list [], so config is not generated in this scenario #}
 {%                 for dest_addr_prefix in svi_varp | ansible.netcommon.ipaddr(0) | ansible.netcommon.ipaddr('net') %}
   - destination_address_prefix: {{ dest_addr_prefix }}
-    vrf: {{ vrf }}
+    vrf: {{ vrf.name }}
     name: "VARP"
-    interface: Vlan{{ svi | int }}
+    interface: Vlan{{ svi.id | int }}
 {%                 endfor %}
 {%             endif %}
 {%         endfor %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/structured-config-vrfs.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/structured-config-vrfs.j2
@@ -1,9 +1,9 @@
 {# Read any global set structured_config and combine per tenant-vrf structured_config #}
 {% set ns = namespace(struct_cfg = struct_cfg | arista.avd.default({})) %}
-{% for tenant in switch.tenants | arista.avd.natural_sort %}
-{%     for vrf in switch.tenants[tenant].vrfs | arista.avd.natural_sort %}
-{%         if tenants[tenant].vrfs[vrf].structured_config is arista.avd.defined %}
-{%             set ns.struct_cfg = ns.struct_cfg | combine(tenants[tenant].vrfs[vrf].structured_config, recursive=true, list_merge=custom_structured_configuration_list_merge) %}
+{% for tenant in network_services_data.tenants %}
+{%     for vrf in tenant.vrfs %}
+{%         if vrf.structured_config is arista.avd.defined %}
+{%             set ns.struct_cfg = ns.struct_cfg | combine(vrf.structured_config, recursive=true, list_merge=custom_structured_configuration_list_merge) %}
 {%         endif %}
 {%     endfor %}
 {% endfor %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/virtual-source-nat-vrfs.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/virtual-source-nat-vrfs.j2
@@ -1,13 +1,13 @@
 {# Tenant virtual source NAT vrfs #}
 virtual_source_nat_vrfs:
-{% for tenant in switch.tenants | arista.avd.natural_sort %}
-{%     for vrf in switch.tenants[tenant].vrfs | arista.avd.natural_sort %}
-{%         if tenants[tenant].vrfs[vrf].vtep_diagnostic.loopback is arista.avd.defined %}
-{%             set loopback_description = tenants[tenant].vrfs[vrf].vtep_diagnostic.loopback_description | arista.avd.default(vrf ~ '_VTEP_DIAGNOSTICS') %}
-{%             set loopback_ipv4_pool = tenants[tenant].vrfs[vrf].vtep_diagnostic.loopback_ip_range | arista.avd.default(
-                   tenants[tenant].vrfs[vrf].vtep_diagnostic.loopback_ip_pools | arista.avd.default([]) | selectattr('pod', 'arista.avd.defined', pod_name) | map(attribute='ipv4_pool') | first) %}
+{% for tenant in network_services_data.tenants %}
+{%     for vrf in tenant.vrfs %}
+{%         if vrf.vtep_diagnostic.loopback is arista.avd.defined %}
+{%             set loopback_description = vrf.vtep_diagnostic.loopback_description | arista.avd.default(vrf ~ '_VTEP_DIAGNOSTICS') %}
+{%             set loopback_ipv4_pool = vrf.vtep_diagnostic.loopback_ip_range | arista.avd.default(
+                                        vrf.vtep_diagnostic.loopback_ip_pools | arista.avd.default([]) | selectattr('pod', 'arista.avd.defined', pod_name) | map(attribute='ipv4_pool') | first) %}
 {%             if loopback_ipv4_pool is arista.avd.defined %}
-  {{ vrf }}:
+  {{ vrf.name }}:
     ip_address: {{ loopback_ipv4_pool | ansible.netcommon.ipaddr('network') | ansible.netcommon.ipmath(switch.id + switch.loopback_ipv4_offset) }}
 {%             endif %}
 {%         endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vlan-interfaces.j2
@@ -1,44 +1,43 @@
 {# tenant vlan interfaces #}
 vlan_interfaces:
-{% for tenant in switch.tenants | arista.avd.natural_sort %}
-{%     for vrf in switch.tenants[tenant].vrfs | arista.avd.natural_sort %}
-{%         for svi in switch.tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort %}
-{%             set svi_config = tenants[tenant].vrfs[vrf].svis[svi] %}
+{% for tenant in network_services_data.tenants %}
+{%     for vrf in tenant.vrfs %}
+{%         for svi in vrf.svis %}
 {# Detect if a svi_profile exists #}
 {# If exists, create a shortpath to access profile data #}
-{%             if svi_config.profile is arista.avd.defined %}
-{%                 set svi_profile = svi_profiles[svi_config.profile] | arista.avd.default() %}
+{%             if svi.profile is arista.avd.defined %}
+{%                 set svi_profile = svi_profiles[svi.profile] | arista.avd.default() %}
 {%             endif %}
-{%             set svi_tags = svi_config.tags | arista.avd.default(
+{%             set svi_tags = svi.tags | arista.avd.default(
                               svi_profile.tags) %}
-{%             set svi_name = svi_config.name | arista.avd.default(
+{%             set svi_name = svi.name | arista.avd.default(
                               svi_profile.name) %}
-{%             set svi_description = svi_config.description | arista.avd.default(
+{%             set svi_description = svi.description | arista.avd.default(
                                      svi_profile.description,
                                      svi_name) %}
-{%             set svi_enabled = svi_config.enabled | arista.avd.default(
+{%             set svi_enabled = svi.enabled | arista.avd.default(
                                  svi_profile.enabled) %}
-{%             set svi_ip_virtual_router_addresses = svi_config.ip_virtual_router_addresses | arista.avd.default(
+{%             set svi_ip_virtual_router_addresses = svi.ip_virtual_router_addresses | arista.avd.default(
                                                      svi_profile.ip_virtual_router_addresses) %}
-{%             set svi_ip_address_virtual = svi_config.ip_address_virtual | arista.avd.default(
+{%             set svi_ip_address_virtual = svi.ip_address_virtual | arista.avd.default(
                                             svi_profile.ip_address_virtual) %}
-{%             set svi_ip_address_virtual_secondaries = svi_config.ip_address_virtual_secondaries | arista.avd.default(
+{%             set svi_ip_address_virtual_secondaries = svi.ip_address_virtual_secondaries | arista.avd.default(
                                                       svi_profile.ip_address_virtual_secondaries) %}
-{%             set svi_mtu = svi_config.mtu | arista.avd.default(
+{%             set svi_mtu = svi.mtu | arista.avd.default(
                              svi_profile.mtu) %}
-{%             set svi_ip_helpers = svi_config.ip_helpers | arista.avd.default(
+{%             set svi_ip_helpers = svi.ip_helpers | arista.avd.default(
                                     tenants[tenant].vrfs[vrf].ip_helpers,
                                     svi_profile.ip_helpers) %}
-{%             set svi_raw_eos_cli = svi_config.nodes[inventory_hostname].raw_eos_cli | arista.avd.default(
+{%             set svi_raw_eos_cli = svi.nodes[inventory_hostname].raw_eos_cli | arista.avd.default(
                                      svi_profile.nodes[inventory_hostname].raw_eos_cli,
-                                     svi_config.raw_eos_cli,
+                                     svi.raw_eos_cli,
                                      svi_profile.raw_eos_cli) %}
-{%             set svi_structured_config = svi_config.nodes[inventory_hostname].structured_config | arista.avd.default(
+{%             set svi_structured_config = svi.nodes[inventory_hostname].structured_config | arista.avd.default(
                                            svi_profile.nodes[inventory_hostname].structured_config,
-                                           svi_config.structured_config,
+                                           svi.structured_config,
                                            svi_profile.structured_config) %}
-  Vlan{{ svi | int }}:
-    tenant: {{ tenant }}
+  Vlan{{ svi.id | int }}:
+    tenant: {{ tenant.name }}
     tags: {{ svi_tags }}
     description: {{ svi_description }}
 {%             if svi_enabled is arista.avd.defined(true) %}
@@ -46,10 +45,10 @@ vlan_interfaces:
 {%             else %}
     shutdown: true
 {%             endif %}
-    vrf: {{ vrf }}
+    vrf: {{ vrf.name }}
 {# IP address configuration #}
-{%             if tenants[tenant].vrfs[vrf].svis[svi].nodes[inventory_hostname].ip_address is arista.avd.defined %}
-    ip_address: {{ tenants[tenant].vrfs[vrf].svis[svi].nodes[inventory_hostname].ip_address }}
+{%             if svi.nodes[inventory_hostname].ip_address is arista.avd.defined %}
+    ip_address: {{ svi.nodes[inventory_hostname].ip_address }}
 {%             endif %}
 {# Virtual Router IP Address #}
 {%             if svi_ip_virtual_router_addresses is arista.avd.defined %}
@@ -86,16 +85,16 @@ vlan_interfaces:
 {%         endfor %}
 {# VLAN interface for iBGP peering in overlay VRFs #}
 {%         if switch.mlag_l3 is arista.avd.defined(true) %}
-{%             set configure_mlag_ibgp_peering = tenants[tenant].vrfs[vrf].enable_mlag_ibgp_peering_vrfs | arista.avd.default(
-                                                 tenants[tenant].enable_mlag_ibgp_peering_vrfs,
+{%             set configure_mlag_ibgp_peering = vrf.enable_mlag_ibgp_peering_vrfs | arista.avd.default(
+                                                 tenant.enable_mlag_ibgp_peering_vrfs,
                                                  true) %}
 {%             if configure_mlag_ibgp_peering %}
-  Vlan{{ tenants[tenant].vrfs[vrf].mlag_ibgp_peering_vlan | arista.avd.default (mlag_ibgp_peering_vrfs.base_vlan + (tenants[tenant].vrfs[vrf].vrf_vni - 1)) }}:
-    tenant: {{ tenant }}
+  Vlan{{ vrf.mlag_ibgp_peering_vlan | arista.avd.default (mlag_ibgp_peering_vrfs.base_vlan + (vrf.vrf_vni - 1)) }}:
+    tenant: {{ tenant.name }}
     type: underlay_peering
     shutdown: false
-    description: "MLAG_PEER_L3_iBGP: vrf {{ vrf }}"
-    vrf: {{ vrf }}
+    description: "MLAG_PEER_L3_iBGP: vrf {{ vrf.name }}"
+    vrf: {{ vrf.name }}
     ip_address: {{ switch.mlag_l3_ip | arista.avd.default(switch.mlag_ip) }}/31
     mtu: {{ p2p_uplinks_mtu }}
 {%             endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vlans.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vlans.j2
@@ -1,35 +1,35 @@
 {# tenant vlans #}
 vlans:
-{% for tenant in switch.tenants | arista.avd.natural_sort %}
-{%     for vrf in switch.tenants[tenant].vrfs | arista.avd.natural_sort %}
+{% for tenant in network_services_data.tenants %}
+{%     for vrf in tenant.vrfs %}
 {# Tenant VLANs w/SVIs #}
-{%         for svi in switch.tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort %}
-{%             if svi | int in topology.vlans %}
-  {{ svi | int }}:
-    tenant: {{ tenant }}
-    name: {{ tenants[tenant].vrfs[vrf].svis[svi].name }}
+{%         for svi in vrf.svis %}
+{%             if svi.id | int in topology.vlans %}
+  {{ svi.id | int }}:
+    tenant: {{ tenant.name }}
+    name: {{ svi.name }}
 {%             endif %}
 {%         endfor %}
 {# VLAN for iBGP peering in overlay VRFs #}
 {%         if switch.mlag_l3 is arista.avd.defined(true) %}
-{%             set configure_mlag_ibgp_peering = tenants[tenant].vrfs[vrf].enable_mlag_ibgp_peering_vrfs | arista.avd.default(
-                                                 tenants[tenant].enable_mlag_ibgp_peering_vrfs,
+{%             set configure_mlag_ibgp_peering = vrf.enable_mlag_ibgp_peering_vrfs | arista.avd.default(
+                                                 tenant.enable_mlag_ibgp_peering_vrfs,
                                                  true) %}
 {%             if configure_mlag_ibgp_peering %}
-  {{ tenants[tenant].vrfs[vrf].mlag_ibgp_peering_vlan | arista.avd.default(mlag_ibgp_peering_vrfs.base_vlan + (tenants[tenant].vrfs[vrf].vrf_vni - 1)) }}:
-    tenant: {{ tenant }}
-    name: MLAG_iBGP_{{ vrf }}
+  {{ vrf.mlag_ibgp_peering_vlan | arista.avd.default(mlag_ibgp_peering_vrfs.base_vlan + (vrf.vrf_vni - 1)) }}:
+    tenant: {{ tenant.name }}
+    name: MLAG_iBGP_{{ vrf.name }}
     trunk_groups:
       - LEAF_PEER_L3
 {%             endif %}
 {%         endif %}
 {%     endfor %}
 {# Tenant L2 VLANs #}
-{%     for l2vlan in switch.tenants[tenant].l2vlans | arista.avd.natural_sort %}
-{%         if l2vlan | int in topology.vlans %}
-  {{ l2vlan | int }}:
-    tenant: {{ tenant }}
-    name: {{ tenants[tenant].l2vlans[l2vlan].name }}
+{%     for l2vlan in tenant.l2vlans %}
+{%         if l2vlan.id | int in topology.vlans %}
+  {{ l2vlan.id | int }}:
+    tenant: {{ tenant.name }}
+    name: {{ l2vlan.name }}
 {%         endif %}
 {%     endfor %}
 {% endfor %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vrfs.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vrfs.j2
@@ -1,9 +1,9 @@
 {# tenant vrfs #}
 vrfs:
-{% for tenant in switch.tenants | arista.avd.natural_sort %}
-{%     for vrf in switch.tenants[tenant].vrfs | arista.avd.natural_sort %}
-  {{ vrf }}:
-    tenant: {{ tenant }}
+{% for tenant in network_services_data.tenants %}
+{%     for vrf in tenant.vrfs %}
+  {{ vrf.name }}:
+    tenant: {{ tenant.name }}
     ip_routing: true
 {%     endfor %}
 {% endfor %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vtep-logic.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vtep-logic.j2
@@ -1,30 +1,30 @@
 {# Setting evpn_rd_admin_subfield #}
-{% set tenants_data.evpn_rd_admin_subfield = switch.router_id %}
+{% set network_services_data.evpn_rd_admin_subfield = switch.router_id %}
 {% if evpn_rd_type is defined and evpn_rd_type is not none %}
 {%     if evpn_rd_type.admin_subfield is arista.avd.defined %}
 {%         if evpn_rd_type.admin_subfield == "vtep_loopback" %}
-{%             set tenants_data.evpn_rd_admin_subfield = switch.vtep_ip %}
+{%             set network_services_data.evpn_rd_admin_subfield = switch.vtep_ip %}
 {%         elif evpn_rd_type.admin_subfield == "bgp_as" %}
-{%             set tenants_data.evpn_rd_admin_subfield = switch.bgp_as %}
+{%             set network_services_data.evpn_rd_admin_subfield = switch.bgp_as %}
 {%         elif evpn_rd_type.admin_subfield | ansible.netcommon.ipaddr %}
-{%             set tenants_data.evpn_rd_admin_subfield = evpn_rd_type.admin_subfield %}
+{%             set network_services_data.evpn_rd_admin_subfield = evpn_rd_type.admin_subfield %}
 {%         elif evpn_rd_type.admin_subfield is number and
                 evpn_rd_type.admin_subfield >= 0 and
                 evpn_rd_type.admin_subfield <= 4294967295 %}
-{%             set tenants_data.evpn_rd_admin_subfield = evpn_rd_type.admin_subfield %}
+{%             set network_services_data.evpn_rd_admin_subfield = evpn_rd_type.admin_subfield %}
 {%         endif %}
 {%     endif %}
 {% endif %}
 {# Setting evpn_rt_admin_subfield #}
-{% set tenants_data.evpn_rt_admin_subfield = false %}
+{% set network_services_data.evpn_rt_admin_subfield = false %}
 {% if evpn_rt_type is defined and evpn_rt_type is not none %}
 {%     if evpn_rt_type.admin_subfield is arista.avd.defined %}
 {%         if evpn_rt_type.admin_subfield == "bgp_as" %}
-{%             set tenants_data.evpn_rt_admin_subfield = switch.bgp_as %}
+{%             set network_services_data.evpn_rt_admin_subfield = switch.bgp_as %}
 {%         elif evpn_rt_type.admin_subfield is number and
                 evpn_rt_type.admin_subfield >= 0 and
                 evpn_rt_type.admin_subfield <= 4294967295 %}
-{%             set tenants_data.evpn_rt_admin_subfield = evpn_rt_type.admin_subfield %}
+{%             set network_services_data.evpn_rt_admin_subfield = evpn_rt_type.admin_subfield %}
 {%         endif %}
 {%     endif %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vxlan-interface.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vxlan-interface.j2
@@ -9,34 +9,34 @@ vxlan_interface:
 {% endif %}
       udp_port: 4789
       vlans:
-{% for tenant in switch.tenants | arista.avd.natural_sort %}
-{%     for vrf in switch.tenants[tenant].vrfs | arista.avd.natural_sort %}
-{%         for svi in switch.tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort %}
-{%             if tenants[tenant].vrfs[vrf].svis[svi].vxlan is arista.avd.defined(false) %}
+{% for tenant in network_services_data.tenants %}
+{%     for vrf in tenant.vrfs %}
+{%         for svi in vrf.svis %}
+{%             if svi.vxlan is arista.avd.defined(false) %}
 {%                 continue %}
 {%             endif %}
-{%             set svi_int = svi | int %}
+{%             set svi_int = svi.id | int %}
         {{ svi_int }}:
-          vni: {{ tenants[tenant].vrfs[vrf].svis[svi].vni_override | arista.avd.default(
-                  tenants[tenant].mac_vrf_vni_base + svi_int) }}
+          vni: {{ svi.vni_override | arista.avd.default(
+                  tenant.mac_vrf_vni_base + svi_int) }}
 {%         endfor %}
 {%     endfor %}
-{%     for l2vlan in switch.tenants[tenant].l2vlans | arista.avd.natural_sort %}
-{%         if tenants[tenant].l2vlans[l2vlan].vxlan is arista.avd.defined(false) %}
+{%     for l2vlan in tenant.l2vlans %}
+{%         if l2vlan.vxlan is arista.avd.defined(false) %}
 {%             continue %}
 {%         endif %}
-{%         set l2vlan_int = l2vlan | int %}
+{%         set l2vlan_int = l2vlan.id | int %}
         {{ l2vlan_int }}:
-          vni: {{ tenants[tenant].l2vlans[l2vlan].vni_override | arista.avd.default(
-                  tenants[tenant].mac_vrf_vni_base + l2vlan_int) }}
+          vni: {{ l2vlan.vni_override | arista.avd.default(
+                  tenant.mac_vrf_vni_base + l2vlan_int) }}
 {%     endfor %}
 {% endfor %}
 {% if switch.evpn_services_l2_only == false %}
       vrfs:
-{%     for tenant in switch.tenants | arista.avd.natural_sort %}
-{%         for vrf in switch.tenants[tenant].vrfs | arista.avd.natural_sort %}
-        {{ vrf }}:
-          vni: {{ tenants[tenant].vrfs[vrf].vrf_vni }}
+{%     for tenant in network_services_data.tenants %}
+{%         for vrf in tenant.vrfs %}
+        {{ vrf.name }}:
+          vni: {{ vrf.vrf_vni }}
 {%         endfor %}
 {%     endfor %}
 {% endif %}


### PR DESCRIPTION
## Change Summary

Refactor eos_designs Network Services to improve performance by converting dictionaries to lists of dictionaries

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

- Introduce new filter plugin to convert_dict_to_list
- refactor network_services to use this method on for loops to address performance issues.

## How to test
- No change reported in Molecule
- Run test scenario with large data set

## Checklist

### User Checklist

- [x] Create new filter plugin - convert_dict_to_list
- [x] Upldate filter plugin documentation 
- [x] Refactor tenant network services template
- [x] Test with large data set for performance

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
