### PR TITLE
Doc(eos_cli_config_gen): Add no autostate to readme

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/monitor-connectivity.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/monitor-connectivity.md
@@ -1,6 +1,5 @@
 # monitor-connectivity
 # Table of Contents
-<!-- toc -->
 
 - [Management](#management)
   - [Management Interfaces](#management-interfaces)
@@ -21,7 +20,6 @@
 - [ACL](#acl)
 - [Quality Of Service](#quality-of-service)
 
-<!-- toc -->
 # Management
 
 ## Management Interfaces

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
@@ -271,6 +271,7 @@ interface Vlan2001
 !
 interface Vlan2002
    description SVI Description
+   no autostate
    vrf Tenant_B
    ip address virtual 10.2.2.1/24
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
@@ -146,6 +146,7 @@ interface Vlan2001
 !
 interface Vlan2002
    description SVI Description
+   no autostate
    vrf Tenant_B
    ip address virtual 10.2.2.1/24
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
@@ -14,6 +14,7 @@ vlan_interfaces:
     description: SVI Description
     vrf: Tenant_B
     ip_address_virtual: 10.2.2.1/24
+    no_autostate: true
 
   Vlan83:
     description: SVI Description

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1165,6 +1165,7 @@ vlan_interfaces:
     isis_metric: < integer >
     isis_network_point_to_point: < boolean >
     mtu: < mtu >
+    no_autostate: < true | false >
     vrrp:
       virtual_router: < virtual_router_id >
       priority: < instance_priority >


### PR DESCRIPTION
## Change Summary

Add "no_autostate" option to readme. Its currently mising.

## Related Issue(s)

Fixes #1371

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
add: no_autostate: <true | false > to readme and add it to molecule scenario

```
vlan_interfaces:
  < vlan_id >:
    no_autostate: < true | false >
```

## How to test


## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
