### PR TITLE
Feat(eos_cli_config_gen): interface vlans add ip igmp

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
@@ -210,6 +210,7 @@ interface Vlan89
    description SVI Description
    no shutdown
    ip address virtual 10.10.144.3/20
+   ip igmp
    ipv6 address 1b11:3a00:22b0:5200::15/64
    ipv6 nd managed-config-flag
    ipv6 nd prefix 1b11:3a00:22b0:5200::/64 infinite infinite no-autoconfig

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
@@ -85,6 +85,7 @@ interface Vlan89
    description SVI Description
    no shutdown
    ip address virtual 10.10.144.3/20
+   ip igmp
    ipv6 address 1b11:3a00:22b0:5200::15/64
    ipv6 nd managed-config-flag
    ipv6 nd prefix 1b11:3a00:22b0:5200::/64 infinite infinite no-autoconfig

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
@@ -178,6 +178,7 @@ vlan_interfaces:
   Vlan89:
     description: SVI Description
     shutdown: false
+    ip_igmp: true
     ip_address_virtual: 10.10.144.3/20
     ipv6_address: 1b11:3a00:22b0:5200::15/64
     ipv6_nd_managed_config_flag: true

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1120,6 +1120,7 @@ vlan_interfaces:
     ip_address_virtual_secondaries:
       - < IPv4_address/Mask >
       - < IPv4_address/Mask >
+    ip_igmp: < true | false >
     ip_helpers:
       < ip_helper_address_1 >:
         source_interface: < source_interface_name >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
@@ -65,6 +65,9 @@ interface {{ vlan_interface }}
 {%         endif %}
    {{ ip_helper_cli }}
 {%     endfor %}
+{%     if vlan_interfaces[vlan_interface].ip_igmp is arista.avd.defined(true) %}
+   ip igmp
+{%     endif %}
 {%     if vlan_interfaces[vlan_interface].ipv6_enable is arista.avd.defined(true) %}
    ipv6 enable
 {%     endif %}


### PR DESCRIPTION
## Change Summary

Add ip igmp command to interface vlans

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

```yaml
vlan_interfaces:
  < Vlan_id_1 >:
    ip_igmp: < true | false >
```

Note I didn't update the documentation template at this time. I proposed a future PR where we can build a table and group Multicast relevant features.

## How to test

See molecule test case.

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
