### PR TITLE
Feat(eos_cli_config_gen): AAA: add option for group access per privilege level 

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/aaa.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/aaa.md
@@ -180,6 +180,7 @@ Authorization for serial console is enabled.
 aaa authorization exec default group CUST local
 aaa authorization serial-console
 aaa authorization commands all default group aaaAuth
+aaa authorization commands 10,15 group tacacs+ local
 !
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/aaa.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/aaa.md
@@ -178,8 +178,8 @@ Authorization for serial console is enabled.
 | Privilege Level | Group |
 | --------------- | ----- |
 | all | group aaaAuth |
-| 5 | radius |
-| 10,15 | tacacs+ local |
+| 5 | group radius |
+| 10,15 | group tacacs+ local |
 
 ### AAA Authorization Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/aaa.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/aaa.md
@@ -180,7 +180,7 @@ Authorization for serial console is enabled.
 aaa authorization exec default group CUST local
 aaa authorization serial-console
 aaa authorization commands all default group aaaAuth
-aaa authorization commands 10,15 group tacacs+ local
+aaa authorization commands 10,15 default group tacacs+ local
 !
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/aaa.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/aaa.md
@@ -168,10 +168,7 @@ aaa authentication policy lockout failure 3 window 900 duration 300
 | Type | User Stores |
 | ---- | ----------- |
 | Exec | group CUST local |
-
-
 Authorization for configuration commands is enabled.
-
 
 ### AAA Authorization Privilege Levels Summary
 
@@ -180,9 +177,7 @@ Authorization for configuration commands is enabled.
 | all | group aaaAuth |
 | 5 | radius |
 | 10,15 | tacacs+ local |
-
 Authorization for serial console is enabled.
-
 
 ### AAA Authorization Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/aaa.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/aaa.md
@@ -178,9 +178,8 @@ Authorization for serial console is enabled.
 | Privilege Level | Group |
 | --------------  | ----- |
 | all | group aaaAuth |
- | 5 | radius |
+| 5 | radius |
 | 10,15 | tacacs+ local |
-
 
 ### AAA Authorization Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/aaa.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/aaa.md
@@ -170,6 +170,11 @@ aaa authentication policy lockout failure 3 window 900 duration 300
 | Exec | group CUST local |
 
 Authorization for configuration commands is enabled.
+| Type | User Stores |
+| ---- | ----------- |
+| all  | group aaaAuth |
+| 10,15 | group tacacs+ local |
+| 5 | group RADIUS |
 
 Authorization for serial console is enabled.
 
@@ -181,6 +186,7 @@ aaa authorization exec default group CUST local
 aaa authorization serial-console
 aaa authorization commands all default group aaaAuth
 aaa authorization commands 10,15 default group tacacs+ local
+aaa authorization commands 5 default group RADIUS
 !
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/aaa.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/aaa.md
@@ -168,6 +168,7 @@ aaa authentication policy lockout failure 3 window 900 duration 300
 | Type | User Stores |
 | ---- | ----------- |
 | Exec | group CUST local |
+
 Authorization for configuration commands is enabled.
 
 ### AAA Authorization Privilege Levels Summary
@@ -175,8 +176,9 @@ Authorization for configuration commands is enabled.
 | Privilege Level | Group |
 | --------------  | ----- |
 | all | group aaaAuth |
-| 5 | radius |
+ | 5 | radius |
 | 10,15 | tacacs+ local |
+
 Authorization for serial console is enabled.
 
 ### AAA Authorization Device Configuration

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/aaa.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/aaa.md
@@ -169,17 +169,20 @@ aaa authentication policy lockout failure 3 window 900 duration 300
 | ---- | ----------- |
 | Exec | group CUST local |
 
+
 Authorization for configuration commands is enabled.
+
 
 ### AAA Authorization Privilege Levels Summary
 
 | Privilege Level | Group |
 | --------------  | ----- |
 | all | group aaaAuth |
-| 5 | group radius |
-| 10,15 | group tacacs+ local |
+| 5 | radius |
+| 10,15 | tacacs+ local |
 
 Authorization for serial console is enabled.
+
 
 ### AAA Authorization Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/aaa.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/aaa.md
@@ -171,6 +171,8 @@ aaa authentication policy lockout failure 3 window 900 duration 300
 
 Authorization for configuration commands is enabled.
 
+Authorization for serial console is enabled.
+
 ### AAA Authorization Privilege Levels Summary
 
 | Privilege Level | Group |
@@ -179,7 +181,6 @@ Authorization for configuration commands is enabled.
  | 5 | radius |
 | 10,15 | tacacs+ local |
 
-Authorization for serial console is enabled.
 
 ### AAA Authorization Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/aaa.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/aaa.md
@@ -176,7 +176,7 @@ Authorization for serial console is enabled.
 ### AAA Authorization Privilege Levels Summary
 
 | Privilege Level | Group |
-| --------------  | ----- |
+| --------------- | ----- |
 | all | group aaaAuth |
 | 5 | radius |
 | 10,15 | tacacs+ local |

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/aaa.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/aaa.md
@@ -170,11 +170,14 @@ aaa authentication policy lockout failure 3 window 900 duration 300
 | Exec | group CUST local |
 
 Authorization for configuration commands is enabled.
-| Type | User Stores |
-| ---- | ----------- |
-| all  | group aaaAuth |
+
+### AAA Authorization Privilege Levels Summary
+
+| Privilege Level | Group |
+| --------------  | ----- |
+| all | group aaaAuth |
+| 5 | group radius |
 | 10,15 | group tacacs+ local |
-| 5 | group RADIUS |
 
 Authorization for serial console is enabled.
 
@@ -185,8 +188,8 @@ Authorization for serial console is enabled.
 aaa authorization exec default group CUST local
 aaa authorization serial-console
 aaa authorization commands all default group aaaAuth
+aaa authorization commands 5 default group radius
 aaa authorization commands 10,15 default group tacacs+ local
-aaa authorization commands 5 default group RADIUS
 !
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/aaa.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/aaa.md
@@ -175,8 +175,8 @@ Authorization for serial console is enabled.
 
 ### AAA Authorization Privilege Levels Summary
 
-| Privilege Level | Group |
-| --------------- | ----- |
+| Privilege Level | User Stores |
+| --------------- | ----------- |
 | all | group aaaAuth |
 | 5 | group radius |
 | 10,15 | group tacacs+ local |

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/aaa.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/aaa.cfg
@@ -29,6 +29,7 @@ aaa authorization exec default group CUST local
 aaa authorization serial-console
 aaa authorization commands all default group aaaAuth
 aaa authorization commands 10,15 default group tacacs+ local
+aaa authorization commands 5 default group RADIUS
 !
 aaa accounting exec console start-stop group TACACS
 aaa accounting commands all console start-stop group TACACS logging

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/aaa.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/aaa.cfg
@@ -28,7 +28,7 @@ aaa authentication policy lockout failure 3 window 900 duration 300
 aaa authorization exec default group CUST local
 aaa authorization serial-console
 aaa authorization commands all default group aaaAuth
-aaa authorization commands 10,15 group tacacs+ local
+aaa authorization commands 10,15 default group tacacs+ local
 !
 aaa accounting exec console start-stop group TACACS
 aaa accounting commands all console start-stop group TACACS logging

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/aaa.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/aaa.cfg
@@ -28,6 +28,7 @@ aaa authentication policy lockout failure 3 window 900 duration 300
 aaa authorization exec default group CUST local
 aaa authorization serial-console
 aaa authorization commands all default group aaaAuth
+aaa authorization commands 10,15 group tacacs+ local
 !
 aaa accounting exec console start-stop group TACACS
 aaa accounting commands all console start-stop group TACACS logging

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/aaa.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/aaa.cfg
@@ -28,8 +28,8 @@ aaa authentication policy lockout failure 3 window 900 duration 300
 aaa authorization exec default group CUST local
 aaa authorization serial-console
 aaa authorization commands all default group aaaAuth
+aaa authorization commands 5 default group radius
 aaa authorization commands 10,15 default group tacacs+ local
-aaa authorization commands 5 default group RADIUS
 !
 aaa accounting exec console start-stop group TACACS
 aaa accounting commands all console start-stop group TACACS logging

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/aaa.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/aaa.yml
@@ -65,6 +65,7 @@ aaa_authorization:
         group: "tacacs+ local"
       - level: "5"
         group: "radius"
+        
 ## AAA Accounting
 aaa_accounting:
   exec:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/aaa.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/aaa.yml
@@ -61,9 +61,10 @@ aaa_authorization:
   commands:
     all_default: group aaaAuth
     privilege:
-      level: "10,15"
-      group: "tacacs+ local"
-
+      - level: "10,15"
+        group: "tacacs+ local"
+      - level: "5"
+        group: "RADIUS"
 ## AAA Accounting
 aaa_accounting:
   exec:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/aaa.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/aaa.yml
@@ -62,9 +62,9 @@ aaa_authorization:
     all_default: group aaaAuth
     privilege:
       - level: "10,15"
-        group: "group tacacs+ local"
+        default: "group tacacs+ local"
       - level: "5"
-        group: "group radius"
+        default: "group radius"
 
 ## AAA Accounting
 aaa_accounting:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/aaa.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/aaa.yml
@@ -60,6 +60,9 @@ aaa_authorization:
   serial_console: true
   commands:
     all_default: group aaaAuth
+    privilege:
+      level: "10,15"
+      group: "tacacs+ local"
 
 ## AAA Accounting
 aaa_accounting:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/aaa.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/aaa.yml
@@ -62,10 +62,10 @@ aaa_authorization:
     all_default: group aaaAuth
     privilege:
       - level: "10,15"
-        group: "tacacs+ local"
+        group: "group tacacs+ local"
       - level: "5"
-        group: "radius"
-        
+        group: "group radius"
+
 ## AAA Accounting
 aaa_accounting:
   exec:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/aaa.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/aaa.yml
@@ -64,7 +64,7 @@ aaa_authorization:
       - level: "10,15"
         group: "tacacs+ local"
       - level: "5"
-        group: "RADIUS"
+        group: "radius"
 ## AAA Accounting
 aaa_accounting:
   exec:

--- a/ansible_collections/arista/avd/molecule/upgrade_eos_cli_config_gen/documentation/devices/aaa.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_eos_cli_config_gen/documentation/devices/aaa.md
@@ -167,9 +167,12 @@ aaa authentication policy local allow-nopassword-remote-login
 | Exec | group CUST local |
 
 Authorization for configuration commands is enabled.
-| Type | User Stores |
-| ---- | ----------- |
-| all  | group aaaAuth |
+
+### AAA Authorization Privilege Levels Summary
+
+| Privilege Level | Group |
+| --------------  | ----- |
+| all | group aaaAuth |
 
 Authorization for serial console is enabled.
 

--- a/ansible_collections/arista/avd/molecule/upgrade_eos_cli_config_gen/documentation/devices/aaa.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_eos_cli_config_gen/documentation/devices/aaa.md
@@ -165,19 +165,14 @@ aaa authentication policy local allow-nopassword-remote-login
 | Type | User Stores |
 | ---- | ----------- |
 | Exec | group CUST local |
-
-
 Authorization for configuration commands is enabled.
-
 
 ### AAA Authorization Privilege Levels Summary
 
 | Privilege Level | Group |
 | --------------  | ----- |
 | all | group aaaAuth |
-
 Authorization for serial console is enabled.
-
 
 ### AAA Authorization Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_eos_cli_config_gen/documentation/devices/aaa.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_eos_cli_config_gen/documentation/devices/aaa.md
@@ -175,7 +175,6 @@ Authorization for serial console is enabled.
 | Privilege Level | Group |
 | --------------  | ----- |
 | all | group aaaAuth |
- 
 
 ### AAA Authorization Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_eos_cli_config_gen/documentation/devices/aaa.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_eos_cli_config_gen/documentation/devices/aaa.md
@@ -166,7 +166,9 @@ aaa authentication policy local allow-nopassword-remote-login
 | ---- | ----------- |
 | Exec | group CUST local |
 
+
 Authorization for configuration commands is enabled.
+
 
 ### AAA Authorization Privilege Levels Summary
 
@@ -175,6 +177,7 @@ Authorization for configuration commands is enabled.
 | all | group aaaAuth |
 
 Authorization for serial console is enabled.
+
 
 ### AAA Authorization Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_eos_cli_config_gen/documentation/devices/aaa.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_eos_cli_config_gen/documentation/devices/aaa.md
@@ -172,8 +172,8 @@ Authorization for serial console is enabled.
 
 ### AAA Authorization Privilege Levels Summary
 
-| Privilege Level | Group |
-| --------------- | ----- |
+| Privilege Level | User Stores |
+| --------------- | ----------- |
 | all | group aaaAuth |
 
 ### AAA Authorization Device Configuration

--- a/ansible_collections/arista/avd/molecule/upgrade_eos_cli_config_gen/documentation/devices/aaa.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_eos_cli_config_gen/documentation/devices/aaa.md
@@ -173,7 +173,7 @@ Authorization for serial console is enabled.
 ### AAA Authorization Privilege Levels Summary
 
 | Privilege Level | Group |
-| --------------  | ----- |
+| --------------- | ----- |
 | all | group aaaAuth |
 
 ### AAA Authorization Device Configuration

--- a/ansible_collections/arista/avd/molecule/upgrade_eos_cli_config_gen/documentation/devices/aaa.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_eos_cli_config_gen/documentation/devices/aaa.md
@@ -168,13 +168,14 @@ aaa authentication policy local allow-nopassword-remote-login
 
 Authorization for configuration commands is enabled.
 
+Authorization for serial console is enabled.
+
 ### AAA Authorization Privilege Levels Summary
 
 | Privilege Level | Group |
 | --------------  | ----- |
 | all | group aaaAuth |
  
-Authorization for serial console is enabled.
 
 ### AAA Authorization Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_eos_cli_config_gen/documentation/devices/aaa.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_eos_cli_config_gen/documentation/devices/aaa.md
@@ -167,6 +167,9 @@ aaa authentication policy local allow-nopassword-remote-login
 | Exec | group CUST local |
 
 Authorization for configuration commands is enabled.
+| Type | User Stores |
+| ---- | ----------- |
+| all  | group aaaAuth |
 
 Authorization for serial console is enabled.
 

--- a/ansible_collections/arista/avd/molecule/upgrade_eos_cli_config_gen/documentation/devices/aaa.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_eos_cli_config_gen/documentation/devices/aaa.md
@@ -165,6 +165,7 @@ aaa authentication policy local allow-nopassword-remote-login
 | Type | User Stores |
 | ---- | ----------- |
 | Exec | group CUST local |
+
 Authorization for configuration commands is enabled.
 
 ### AAA Authorization Privilege Levels Summary
@@ -172,6 +173,7 @@ Authorization for configuration commands is enabled.
 | Privilege Level | Group |
 | --------------  | ----- |
 | all | group aaaAuth |
+ 
 Authorization for serial console is enabled.
 
 ### AAA Authorization Device Configuration

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -296,8 +296,8 @@ aaa_authorization:
   commands:
     all_default: < group group_name | local | none > < group group_name | local | none >
     privilege:
-      level: < privilege level(s) as csv string >
-      group: < group_name(s) | tacacs+ local >
+      - level: < privilege level(s) 0-15 as string >
+        group: < group_name(s) | tacacs+ | radius | local | none >
 ```
 
 #### AAA Accounting

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -297,7 +297,7 @@ aaa_authorization:
     all_default: < group group_name | local | none > < group group_name | local | none >
     privilege:
       - level: < privilege level(s) 0-15 >
-        group: < group group_name | local | none > < group group_name | local | none >
+        default: < group group_name | local | none > < group group_name | local | none >
 ```
 
 #### AAA Accounting

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -296,8 +296,8 @@ aaa_authorization:
   commands:
     all_default: < group group_name | local | none > < group group_name | local | none >
     privilege:
-      - level: < privilege level(s) 0-15 as string >
-        group: < group_name(s) | tacacs+ | radius | local | none >
+      - level: < privilege level(s) 0-15 >
+        group: < group_name | tacacs+ | radius | local | none >
 ```
 
 #### AAA Accounting

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -295,6 +295,9 @@ aaa_authorization:
   serial_console: < true | false >
   commands:
     all_default: < group group_name | local | none > < group group_name | local | none >
+    privilege:
+      level: < privilege level(s) as csv string >
+      group: < group_name(s) | tacacs+ local >
 ```
 
 #### AAA Accounting

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -297,7 +297,7 @@ aaa_authorization:
     all_default: < group group_name | local | none > < group group_name | local | none >
     privilege:
       - level: < privilege level(s) 0-15 >
-        group: < group_name | tacacs+ | radius | local | none >
+        group: < group group_name | local | none > < group group_name | local | none >
 ```
 
 #### AAA Accounting

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/aaa-authorization.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/aaa-authorization.j2
@@ -12,6 +12,16 @@
 
 {%     if aaa_authorization.config_commands is defined and aaa_authorization.config_commands == true %}
 Authorization for configuration commands is enabled.
+| Type | User Stores |
+| ---- | ----------- |
+{%         if aaa_authorization.commands.all_default is defined %}
+| all  | {{ aaa_authorization.commands.all_default }} |
+{%         endif %}
+{%         if aaa_authorization.commands.privilege is defined %}
+{%             for command_level in aaa_authorization.commands.privilege %}
+| {{ command_level.level }} | group {{ command_level.group }} |
+{%             endfor %}
+{%         endif %}
 {%     else %}
 Authorization for configuration commands is disabled.
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/aaa-authorization.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/aaa-authorization.j2
@@ -10,8 +10,10 @@
 | Exec | {{ aaa_authorization.exec.default }} |
 {%     endif %}
 {%     if aaa_authorization.config_commands is arista.avd.defined(true) %}
+
 Authorization for configuration commands is enabled.
 {%     else %}
+
 Authorization for configuration commands is disabled.
 {%     endif %}
 {%     if aaa_authorization.commands.privilege is arista.avd.defined or aaa_authorization.commands.all_default is arista.avd.defined %}
@@ -23,13 +25,14 @@ Authorization for configuration commands is disabled.
 {%         if aaa_authorization.commands.all_default is arista.avd.defined %}
 | all | {{ aaa_authorization.commands.all_default }} |
 {%         endif %}
-{%         if aaa_authorization.commands.privilege is arista.avd.defined %}
-{%             for command_levels in aaa_authorization.commands.privilege | arista.avd.natural_sort %}
-| {{ command_levels.level }} | {{ command_levels.group }} |
-{%             endfor %}
-{%         endif %}
+ {%        for command_level in aaa_authorization.commands.privilege | arista.avd.natural_sort %}
+{%             if command_level.level is arista.avd.defined and command_level.group is arista.avd.defined %}
+| {{ command_level.level }} | {{ command_level.group }} |
+{%             endif %}
+{%         endfor %}
 {%     endif %}
 {%     if aaa_authorization.serial_console is arista.avd.defined(true) %}
+
 Authorization for serial console is enabled.
 {%     endif %}
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/aaa-authorization.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/aaa-authorization.j2
@@ -29,13 +29,12 @@ Authorization for serial console is enabled.
 {%         if aaa_authorization.commands.all_default is arista.avd.defined %}
 | all | {{ aaa_authorization.commands.all_default }} |
 {%         endif %}
- {%        for command_level in aaa_authorization.commands.privilege | arista.avd.natural_sort %}
+{%        for command_level in aaa_authorization.commands.privilege | arista.avd.natural_sort %}
 {%             if command_level.level is arista.avd.defined and command_level.group is arista.avd.defined %}
 | {{ command_level.level }} | {{ command_level.group }} |
 {%             endif %}
 {%         endfor %}
 {%     endif %}
-
 
 ### AAA Authorization Device Configuration
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/aaa-authorization.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/aaa-authorization.j2
@@ -25,11 +25,11 @@ Authorization for serial console is enabled.
 ### AAA Authorization Privilege Levels Summary
 
 | Privilege Level | Group |
-| --------------  | ----- |
+| --------------- | ----- |
 {%         if aaa_authorization.commands.all_default is arista.avd.defined %}
 | all | {{ aaa_authorization.commands.all_default }} |
 {%         endif %}
-{%        for command_level in aaa_authorization.commands.privilege | arista.avd.natural_sort %}
+{%         for command_level in aaa_authorization.commands.privilege | arista.avd.natural_sort %}
 {%             if command_level.level is arista.avd.defined and command_level.group is arista.avd.defined %}
 | {{ command_level.level }} | {{ command_level.group }} |
 {%             endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/aaa-authorization.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/aaa-authorization.j2
@@ -1,4 +1,4 @@
-{% if aaa_authorization is defined and aaa_authorization is not none %}
+{% if aaa_authorization is arista.avd.defined %}
 
 ## AAA Authorization
 
@@ -6,27 +6,32 @@
 
 | Type | User Stores |
 | ---- | ----------- |
-{%     if aaa_authorization.exec.default is defined %}
+{%     if aaa_authorization.exec.default is arista.avd.defined %}
 | Exec | {{ aaa_authorization.exec.default }} |
 {%     endif %}
 
-{%     if aaa_authorization.config_commands is defined and aaa_authorization.config_commands == true %}
+{%     if aaa_authorization.config_commands is arista.avd.defined(true) %}
 Authorization for configuration commands is enabled.
-| Type | User Stores |
-| ---- | ----------- |
-{%         if aaa_authorization.commands.all_default is defined %}
-| all  | {{ aaa_authorization.commands.all_default }} |
-{%         endif %}
-{%         if aaa_authorization.commands.privilege is defined %}
-{%             for command_level in aaa_authorization.commands.privilege %}
-| {{ command_level.level }} | group {{ command_level.group }} |
-{%             endfor %}
-{%         endif %}
 {%     else %}
 Authorization for configuration commands is disabled.
 {%     endif %}
 
-{%     if aaa_authorization.serial_console is defined and aaa_authorization.serial_console == true %}
+### AAA Authorization Privilege Levels Summary
+
+{%     if aaa_authorization.privilege is arista.avd.defined or aaa_authorization.commands.all_default is arista.avd.defined %}
+| Privilege Level | Group |
+| --------------  | ----- |
+{%         if aaa_authorization.commands.all_default is arista.avd.defined %}
+| all | {{ aaa_authorization.commands.all_default }} |
+{%         endif %}
+{%         if aaa_authorization.commands.privilege is arista.avd.defined %}
+{%             for command_levels in aaa_authorization.commands.privilege | arista.avd.natural_sort %}
+| {{ command_levels.level }} | group {{ command_levels.group }} |
+{%             endfor %}
+{%         endif %}
+{%     endif %}
+
+{%     if aaa_authorization.serial_console is arista.avd.defined(true) %}
 Authorization for serial console is enabled.
 
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/aaa-authorization.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/aaa-authorization.j2
@@ -9,15 +9,11 @@
 {%     if aaa_authorization.exec.default is arista.avd.defined %}
 | Exec | {{ aaa_authorization.exec.default }} |
 {%     endif %}
-
 {%     if aaa_authorization.config_commands is arista.avd.defined(true) %}
-
 Authorization for configuration commands is enabled.
 {%     else %}
-
 Authorization for configuration commands is disabled.
 {%     endif %}
-
 {%     if aaa_authorization.commands.privilege is arista.avd.defined or aaa_authorization.commands.all_default is arista.avd.defined %}
 
 ### AAA Authorization Privilege Levels Summary
@@ -34,9 +30,7 @@ Authorization for configuration commands is disabled.
 {%         endif %}
 {%     endif %}
 {%     if aaa_authorization.serial_console is arista.avd.defined(true) %}
-
 Authorization for serial console is enabled.
-
 {%     endif %}
 
 ### AAA Authorization Device Configuration

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/aaa-authorization.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/aaa-authorization.j2
@@ -24,14 +24,14 @@ Authorization for serial console is enabled.
 
 ### AAA Authorization Privilege Levels Summary
 
-| Privilege Level | Group |
-| --------------- | ----- |
+| Privilege Level | User Stores |
+| --------------- | ----------- |
 {%         if aaa_authorization.commands.all_default is arista.avd.defined %}
 | all | {{ aaa_authorization.commands.all_default }} |
 {%         endif %}
 {%         for command_level in aaa_authorization.commands.privilege | arista.avd.natural_sort %}
-{%             if command_level.level is arista.avd.defined and command_level.group is arista.avd.defined %}
-| {{ command_level.level }} | {{ command_level.group }} |
+{%             if command_level.level is arista.avd.defined and command_level.default is arista.avd.defined %}
+| {{ command_level.level }} | {{ command_level.default }} |
 {%             endif %}
 {%         endfor %}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/aaa-authorization.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/aaa-authorization.j2
@@ -11,14 +11,17 @@
 {%     endif %}
 
 {%     if aaa_authorization.config_commands is arista.avd.defined(true) %}
+
 Authorization for configuration commands is enabled.
 {%     else %}
+
 Authorization for configuration commands is disabled.
 {%     endif %}
 
+{%     if aaa_authorization.commands.privilege is arista.avd.defined or aaa_authorization.commands.all_default is arista.avd.defined %}
+
 ### AAA Authorization Privilege Levels Summary
 
-{%     if aaa_authorization.privilege is arista.avd.defined or aaa_authorization.commands.all_default is arista.avd.defined %}
 | Privilege Level | Group |
 | --------------  | ----- |
 {%         if aaa_authorization.commands.all_default is arista.avd.defined %}
@@ -26,15 +29,16 @@ Authorization for configuration commands is disabled.
 {%         endif %}
 {%         if aaa_authorization.commands.privilege is arista.avd.defined %}
 {%             for command_levels in aaa_authorization.commands.privilege | arista.avd.natural_sort %}
-| {{ command_levels.level }} | group {{ command_levels.group }} |
+| {{ command_levels.level }} | {{ command_levels.group }} |
 {%             endfor %}
 {%         endif %}
 {%     endif %}
-
 {%     if aaa_authorization.serial_console is arista.avd.defined(true) %}
+
 Authorization for serial console is enabled.
 
 {%     endif %}
+
 ### AAA Authorization Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/aaa-authorization.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/aaa-authorization.j2
@@ -16,6 +16,10 @@ Authorization for configuration commands is enabled.
 
 Authorization for configuration commands is disabled.
 {%     endif %}
+{%     if aaa_authorization.serial_console is arista.avd.defined(true) %}
+
+Authorization for serial console is enabled.
+{%     endif %}
 {%     if aaa_authorization.commands.privilege is arista.avd.defined or aaa_authorization.commands.all_default is arista.avd.defined %}
 
 ### AAA Authorization Privilege Levels Summary
@@ -31,10 +35,7 @@ Authorization for configuration commands is disabled.
 {%             endif %}
 {%         endfor %}
 {%     endif %}
-{%     if aaa_authorization.serial_console is arista.avd.defined(true) %}
 
-Authorization for serial console is enabled.
-{%     endif %}
 
 ### AAA Authorization Device Configuration
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/aaa-authorization.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/aaa-authorization.j2
@@ -14,9 +14,9 @@ no aaa authorization config-commands
 aaa authorization commands all default {{ aaa_authorization.commands.all_default }}
 {%     endif %}
 {%     if aaa_authorization.commands.privilege is arista.avd.defined %}
-{%         for command_level in aaa_authorization.commands.privilege %}
-{%             set aaa_authorization_commands_privilege_cli = "aaa authorization commands " ~ command_level.level ~ " default group " ~ command_level.group %}
-{{aaa_authorization_commands_privilege_cli }}
+{%         for command_levels in aaa_authorization.commands.privilege | arista.avd.natural_sort %}
+{%             set aaa_authorization_commands_privilege_cli = "aaa authorization commands " ~ command_levels.level ~ " default group " ~ command_levels.group %}
+{{ aaa_authorization_commands_privilege_cli }}
 {%         endfor %}
 {%     endif %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/aaa-authorization.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/aaa-authorization.j2
@@ -15,8 +15,8 @@ aaa authorization commands all default {{ aaa_authorization.commands.all_default
 {%     endif %}
 {%     if aaa_authorization.commands.privilege is arista.avd.defined %}
 {%         for command_levels in aaa_authorization.commands.privilege | arista.avd.natural_sort %}
-{%             set aaa_authorization_commands_privilege_cli = "aaa authorization commands " ~ command_levels.level ~ " default group " ~ command_levels.group %}
-{{ aaa_authorization_commands_privilege_cli }}
+{%             set commands_privilege_cli = "aaa authorization commands " ~ command_levels.level ~ " default group " ~ command_levels.group %}
+{{ commands_privilege_cli }}
 {%         endfor %}
 {%     endif %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/aaa-authorization.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/aaa-authorization.j2
@@ -14,7 +14,9 @@ no aaa authorization config-commands
 aaa authorization commands all default {{ aaa_authorization.commands.all_default }}
 {%     endif %}
 {%     if aaa_authorization.commands.privilege is arista.avd.defined %}
-{%         set aaa_authorization_commands_commands_console_cli = "aaa authorization commands " ~ aaa_authorization.commands.privilege.level ~ " default group " ~ aaa_authorization.commands.privilege.group %}
-{{ aaa_authorization_commands_commands_console_cli }}
+{%         for command_level in aaa_authorization.commands.privilege %}
+{%             set aaa_authorization_commands_privilege_cli = "aaa authorization commands " ~ command_level.level ~ " default group " ~ command_level.group %}
+{{aaa_authorization_commands_privilege_cli }}
+{%         endfor %}
 {%     endif %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/aaa-authorization.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/aaa-authorization.j2
@@ -13,4 +13,8 @@ no aaa authorization config-commands
 {%     if aaa_authorization.commands.all_default is arista.avd.defined %}
 aaa authorization commands all default {{ aaa_authorization.commands.all_default }}
 {%     endif %}
+{%     if aaa_authorization.commands.privilege is arista.avd.defined %}
+{%         set aaa_authorization_commands_commands_console_cli = "aaa authorization commands " ~ aaa_authorization.commands.privilege.level ~ " group " ~ aaa_authorization.commands.privilege.group %}
+{%     endif %}
+{{ aaa_authorization_commands_commands_console_cli }}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/aaa-authorization.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/aaa-authorization.j2
@@ -13,10 +13,10 @@ no aaa authorization config-commands
 {%     if aaa_authorization.commands.all_default is arista.avd.defined %}
 aaa authorization commands all default {{ aaa_authorization.commands.all_default }}
 {%     endif %}
-{%     if aaa_authorization.commands.privilege is arista.avd.defined %}
-{%         for command_levels in aaa_authorization.commands.privilege | arista.avd.natural_sort %}
-{%             set commands_privilege_cli = "aaa authorization commands " ~ command_levels.level ~ " default group " ~ command_levels.group %}
+{%     for command_level in aaa_authorization.commands.privilege | arista.avd.natural_sort %}
+{%         if command_level.level is arista.avd.defined and command_level.group is arista.avd.defined %}
+{%             set commands_privilege_cli = "aaa authorization commands " ~ command_level.level ~ " default group " ~ command_level.group %}
 {{ commands_privilege_cli }}
-{%         endfor %}
-{%     endif %}
+{%         endif %}
+{%     endfor %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/aaa-authorization.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/aaa-authorization.j2
@@ -15,6 +15,6 @@ aaa authorization commands all default {{ aaa_authorization.commands.all_default
 {%     endif %}
 {%     if aaa_authorization.commands.privilege is arista.avd.defined %}
 {%         set aaa_authorization_commands_commands_console_cli = "aaa authorization commands " ~ aaa_authorization.commands.privilege.level ~ " default group " ~ aaa_authorization.commands.privilege.group %}
-{%     endif %}
 {{ aaa_authorization_commands_commands_console_cli }}
+{%     endif %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/aaa-authorization.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/aaa-authorization.j2
@@ -15,7 +15,7 @@ aaa authorization commands all default {{ aaa_authorization.commands.all_default
 {%     endif %}
 {%     for command_level in aaa_authorization.commands.privilege | arista.avd.natural_sort %}
 {%         if command_level.level is arista.avd.defined and command_level.group is arista.avd.defined %}
-{%             set commands_privilege_cli = "aaa authorization commands " ~ command_level.level ~ " default group " ~ command_level.group %}
+{%             set commands_privilege_cli = "aaa authorization commands " ~ command_level.level ~ " default " ~ command_level.group %}
 {{ commands_privilege_cli }}
 {%         endif %}
 {%     endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/aaa-authorization.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/aaa-authorization.j2
@@ -14,8 +14,8 @@ no aaa authorization config-commands
 aaa authorization commands all default {{ aaa_authorization.commands.all_default }}
 {%     endif %}
 {%     for command_level in aaa_authorization.commands.privilege | arista.avd.natural_sort %}
-{%         if command_level.level is arista.avd.defined and command_level.group is arista.avd.defined %}
-{%             set commands_privilege_cli = "aaa authorization commands " ~ command_level.level ~ " default " ~ command_level.group %}
+{%         if command_level.level is arista.avd.defined and command_level.default is arista.avd.defined %}
+{%             set commands_privilege_cli = "aaa authorization commands " ~ command_level.level ~ " default " ~ command_level.default %}
 {{ commands_privilege_cli }}
 {%         endif %}
 {%     endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/aaa-authorization.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/aaa-authorization.j2
@@ -14,7 +14,7 @@ no aaa authorization config-commands
 aaa authorization commands all default {{ aaa_authorization.commands.all_default }}
 {%     endif %}
 {%     if aaa_authorization.commands.privilege is arista.avd.defined %}
-{%         set aaa_authorization_commands_commands_console_cli = "aaa authorization commands " ~ aaa_authorization.commands.privilege.level ~ " group " ~ aaa_authorization.commands.privilege.group %}
+{%         set aaa_authorization_commands_commands_console_cli = "aaa authorization commands " ~ aaa_authorization.commands.privilege.level ~ " default group " ~ aaa_authorization.commands.privilege.group %}
 {%     endif %}
 {{ aaa_authorization_commands_commands_console_cli }}
 {% endif %}


### PR DESCRIPTION
## Change Summary

Extend existing AAA options from all to add option to use per privilege level group access for AAA

From Switch CLI:
(config)#aaa authorization commands ?
  all     All privilege levels
  $       list end
  <0-15>  privilege level(s) or range(s) of privilege levels

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
aaa_authorization:
  commands:
    privilege:
      level: < privilege level(s) as a string >
      group: <group names as a string >

## How to test
See molecule test case.

## Checklist

### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
