### PR TITLE
Feat(eos_designs): Add support for adapter key 'enabled' to admin shutdown interfaces

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3A.md
@@ -427,6 +427,9 @@ vlan 4092
 | Ethernet17 | server10_no_profile_port_channel_lacp_fallback_Eth1 | *trunk | *1-4094 | *- | *- | 17 |
 | Ethernet18 | server11_inherit_profile_port_channel_lacp_fallback_Eth1 | *trunk | *1-4094 | *- | *- | 18 |
 | Ethernet19 | server12_inherit_nested_profile_port_channel_lacp_fallback_Eth1 | *trunk | *1-4094 | *- | *- | 19 |
+| Ethernet20 |  server13_disabled_interfaces_Eth1 | access | 110 | - | - | - |
+| Ethernet21 |  server14_explicitly_enabled_interfaces_Eth1 | access | 110 | - | - | - |
+| Ethernet22 | server15_port_channel_disabled_interfaces_Eth1 | *access | *110 | *- | *- | 22 |
 
 *Inherited from Port-Channel Interface
 
@@ -584,6 +587,25 @@ interface Ethernet19
    no shutdown
    channel-group 19 mode active
    lacp port-priority 8192
+!
+interface Ethernet20
+   description server13_disabled_interfaces_Eth1
+   shutdown
+   switchport
+   switchport access vlan 110
+   switchport mode access
+!
+interface Ethernet21
+   description server14_explicitly_enabled_interfaces_Eth1
+   no shutdown
+   switchport
+   switchport access vlan 110
+   switchport mode access
+!
+interface Ethernet22
+   description server15_port_channel_disabled_interfaces_Eth1
+   shutdown
+   channel-group 22 mode active
 ```
 
 ## Port-Channel Interfaces
@@ -602,6 +624,7 @@ interface Ethernet19
 | Port-Channel17 | server10_no_profile_port_channel_lacp_fallback_server10_no_profile_port_channel_lacp_fallback | switched | trunk | 1-4094 | - | - | 90 | static | 17 | - |
 | Port-Channel18 | server11_inherit_profile_port_channel_lacp_fallback_ALL_WITH_SECURITY_PORT_CHANNEL | switched | trunk | 1-4094 | - | - | 10 | static | 18 | - |
 | Port-Channel19 | server12_inherit_nested_profile_port_channel_lacp_fallback_NESTED_ALL_WITH_SECURITY_PORT_CHANNEL | switched | trunk | 1-4094 | - | - | 10 | static | 19 | - |
+| Port-Channel22 | server15_port_channel_disabled_interfaces_ | switched | access | 110 | - | - | - | - | 22 | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -707,6 +730,13 @@ interface Port-Channel19
    storm-control broadcast level pps 100
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+!
+interface Port-Channel22
+   description server15_port_channel_disabled_interfaces_
+   no shutdown
+   switchport
+   switchport access vlan 110
+   mlag 22
 ```
 
 ## Loopback Interfaces

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3A.md
@@ -429,7 +429,9 @@ vlan 4092
 | Ethernet19 | server12_inherit_nested_profile_port_channel_lacp_fallback_Eth1 | *trunk | *1-4094 | *- | *- | 19 |
 | Ethernet20 |  server13_disabled_interfaces_Eth1 | access | 110 | - | - | - |
 | Ethernet21 |  server14_explicitly_enabled_interfaces_Eth1 | access | 110 | - | - | - |
-| Ethernet22 | server15_port_channel_disabled_interfaces_Eth1 | *access | *110 | *- | *- | 22 |
+| Ethernet22 | server15_port_channel_with_disabled_phy_interfaces_Eth1 | *access | *110 | *- | *- | 22 |
+| Ethernet23 | server16_port_channel_with_disabled_port_channel_Eth1 | *access | *110 | *- | *- | 23 |
+| Ethernet24 | server17_port_channel_with_disabled_phy+po_interfaces_Eth1 | *access | *110 | *- | *- | 24 |
 
 *Inherited from Port-Channel Interface
 
@@ -603,9 +605,19 @@ interface Ethernet21
    switchport mode access
 !
 interface Ethernet22
-   description server15_port_channel_disabled_interfaces_Eth1
+   description server15_port_channel_with_disabled_phy_interfaces_Eth1
    shutdown
    channel-group 22 mode active
+!
+interface Ethernet23
+   description server16_port_channel_with_disabled_port_channel_Eth1
+   no shutdown
+   channel-group 23 mode active
+!
+interface Ethernet24
+   description server17_port_channel_with_disabled_phy+po_interfaces_Eth1
+   shutdown
+   channel-group 24 mode active
 ```
 
 ## Port-Channel Interfaces
@@ -624,7 +636,9 @@ interface Ethernet22
 | Port-Channel17 | server10_no_profile_port_channel_lacp_fallback_server10_no_profile_port_channel_lacp_fallback | switched | trunk | 1-4094 | - | - | 90 | static | 17 | - |
 | Port-Channel18 | server11_inherit_profile_port_channel_lacp_fallback_ALL_WITH_SECURITY_PORT_CHANNEL | switched | trunk | 1-4094 | - | - | 10 | static | 18 | - |
 | Port-Channel19 | server12_inherit_nested_profile_port_channel_lacp_fallback_NESTED_ALL_WITH_SECURITY_PORT_CHANNEL | switched | trunk | 1-4094 | - | - | 10 | static | 19 | - |
-| Port-Channel22 | server15_port_channel_disabled_interfaces_ | switched | access | 110 | - | - | - | - | 22 | - |
+| Port-Channel22 | server15_port_channel_with_disabled_phy_interfaces_ | switched | access | 110 | - | - | - | - | 22 | - |
+| Port-Channel23 | server16_port_channel_with_disabled_port_channel_ | switched | access | 110 | - | - | - | - | 23 | - |
+| Port-Channel24 | server17_port_channel_with_disabled_phy+po_interfaces_ | switched | access | 110 | - | - | - | - | 24 | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -732,11 +746,25 @@ interface Port-Channel19
    storm-control unknown-unicast level 2
 !
 interface Port-Channel22
-   description server15_port_channel_disabled_interfaces_
+   description server15_port_channel_with_disabled_phy_interfaces_
    no shutdown
    switchport
    switchport access vlan 110
    mlag 22
+!
+interface Port-Channel23
+   description server16_port_channel_with_disabled_port_channel_
+   shutdown
+   switchport
+   switchport access vlan 110
+   mlag 23
+!
+interface Port-Channel24
+   description server17_port_channel_with_disabled_phy+po_interfaces_
+   shutdown
+   switchport
+   switchport access vlan 110
+   mlag 24
 ```
 
 ## Loopback Interfaces

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3A.md
@@ -431,7 +431,7 @@ vlan 4092
 | Ethernet21 |  server14_explicitly_enabled_interfaces_Eth1 | access | 110 | - | - | - |
 | Ethernet22 | server15_port_channel_with_disabled_phy_interfaces_Eth1 | *access | *110 | *- | *- | 22 |
 | Ethernet23 | server16_port_channel_with_disabled_port_channel_Eth1 | *access | *110 | *- | *- | 23 |
-| Ethernet24 | server17_port_channel_with_disabled_phy+po_interfaces_Eth1 | *access | *110 | *- | *- | 24 |
+| Ethernet24 | server17_port_channel_with_disabled_phy_and_po_interfaces_Eth1 | *access | *110 | *- | *- | 24 |
 
 *Inherited from Port-Channel Interface
 
@@ -615,7 +615,7 @@ interface Ethernet23
    channel-group 23 mode active
 !
 interface Ethernet24
-   description server17_port_channel_with_disabled_phy+po_interfaces_Eth1
+   description server17_port_channel_with_disabled_phy_and_po_interfaces_Eth1
    shutdown
    channel-group 24 mode active
 ```
@@ -636,9 +636,9 @@ interface Ethernet24
 | Port-Channel17 | server10_no_profile_port_channel_lacp_fallback_server10_no_profile_port_channel_lacp_fallback | switched | trunk | 1-4094 | - | - | 90 | static | 17 | - |
 | Port-Channel18 | server11_inherit_profile_port_channel_lacp_fallback_ALL_WITH_SECURITY_PORT_CHANNEL | switched | trunk | 1-4094 | - | - | 10 | static | 18 | - |
 | Port-Channel19 | server12_inherit_nested_profile_port_channel_lacp_fallback_NESTED_ALL_WITH_SECURITY_PORT_CHANNEL | switched | trunk | 1-4094 | - | - | 10 | static | 19 | - |
-| Port-Channel22 | server15_port_channel_with_disabled_phy_interfaces_ | switched | access | 110 | - | - | - | - | 22 | - |
-| Port-Channel23 | server16_port_channel_with_disabled_port_channel_ | switched | access | 110 | - | - | - | - | 23 | - |
-| Port-Channel24 | server17_port_channel_with_disabled_phy+po_interfaces_ | switched | access | 110 | - | - | - | - | 24 | - |
+| Port-Channel22 | server15_port_channel_with_disabled_phy_interfaces_server15_port_channel_with_disabled_phy_interfaces | switched | access | 110 | - | - | - | - | 22 | - |
+| Port-Channel23 | server16_port_channel_with_disabled_port_channel_server16_port_channel_with_disabled_port_channel | switched | access | 110 | - | - | - | - | 23 | - |
+| Port-Channel24 | server17_port_channel_with_disabled_phy_and_po_interfaces_server17_port_channel_with_disabled_phy_and_po_interfaces | switched | access | 110 | - | - | - | - | 24 | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -746,21 +746,21 @@ interface Port-Channel19
    storm-control unknown-unicast level 2
 !
 interface Port-Channel22
-   description server15_port_channel_with_disabled_phy_interfaces_
+   description server15_port_channel_with_disabled_phy_interfaces_server15_port_channel_with_disabled_phy_interfaces
    no shutdown
    switchport
    switchport access vlan 110
    mlag 22
 !
 interface Port-Channel23
-   description server16_port_channel_with_disabled_port_channel_
+   description server16_port_channel_with_disabled_port_channel_server16_port_channel_with_disabled_port_channel
    shutdown
    switchport
    switchport access vlan 110
    mlag 23
 !
 interface Port-Channel24
-   description server17_port_channel_with_disabled_phy+po_interfaces_
+   description server17_port_channel_with_disabled_phy_and_po_interfaces_server17_port_channel_with_disabled_phy_and_po_interfaces
    shutdown
    switchport
    switchport access vlan 110

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3B.md
@@ -430,7 +430,7 @@ vlan 4092
 | Ethernet21 |  server14_explicitly_enabled_interfaces_Eth2 | access | 110 | - | - | - |
 | Ethernet22 | server15_port_channel_with_disabled_phy_interfaces_Eth2 | *access | *110 | *- | *- | 22 |
 | Ethernet23 | server16_port_channel_with_disabled_port_channel_Eth2 | *access | *110 | *- | *- | 23 |
-| Ethernet24 | server17_port_channel_with_disabled_phy+po_interfaces_Eth2 | *access | *110 | *- | *- | 24 |
+| Ethernet24 | server17_port_channel_with_disabled_phy_and_po_interfaces_Eth2 | *access | *110 | *- | *- | 24 |
 
 *Inherited from Port-Channel Interface
 
@@ -609,7 +609,7 @@ interface Ethernet23
    channel-group 23 mode active
 !
 interface Ethernet24
-   description server17_port_channel_with_disabled_phy+po_interfaces_Eth2
+   description server17_port_channel_with_disabled_phy_and_po_interfaces_Eth2
    shutdown
    channel-group 24 mode active
 ```
@@ -629,9 +629,9 @@ interface Ethernet24
 | Port-Channel17 | server10_no_profile_port_channel_lacp_fallback_server10_no_profile_port_channel_lacp_fallback | switched | trunk | 1-4094 | - | - | 90 | static | 17 | - |
 | Port-Channel18 | server11_inherit_profile_port_channel_lacp_fallback_ALL_WITH_SECURITY_PORT_CHANNEL | switched | trunk | 1-4094 | - | - | 10 | static | 18 | - |
 | Port-Channel19 | server12_inherit_nested_profile_port_channel_lacp_fallback_NESTED_ALL_WITH_SECURITY_PORT_CHANNEL | switched | trunk | 1-4094 | - | - | 10 | static | 19 | - |
-| Port-Channel22 | server15_port_channel_with_disabled_phy_interfaces_ | switched | access | 110 | - | - | - | - | 22 | - |
-| Port-Channel23 | server16_port_channel_with_disabled_port_channel_ | switched | access | 110 | - | - | - | - | 23 | - |
-| Port-Channel24 | server17_port_channel_with_disabled_phy+po_interfaces_ | switched | access | 110 | - | - | - | - | 24 | - |
+| Port-Channel22 | server15_port_channel_with_disabled_phy_interfaces_server15_port_channel_with_disabled_phy_interfaces | switched | access | 110 | - | - | - | - | 22 | - |
+| Port-Channel23 | server16_port_channel_with_disabled_port_channel_server16_port_channel_with_disabled_port_channel | switched | access | 110 | - | - | - | - | 23 | - |
+| Port-Channel24 | server17_port_channel_with_disabled_phy_and_po_interfaces_server17_port_channel_with_disabled_phy_and_po_interfaces | switched | access | 110 | - | - | - | - | 24 | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -731,21 +731,21 @@ interface Port-Channel19
    storm-control unknown-unicast level 2
 !
 interface Port-Channel22
-   description server15_port_channel_with_disabled_phy_interfaces_
+   description server15_port_channel_with_disabled_phy_interfaces_server15_port_channel_with_disabled_phy_interfaces
    no shutdown
    switchport
    switchport access vlan 110
    mlag 22
 !
 interface Port-Channel23
-   description server16_port_channel_with_disabled_port_channel_
+   description server16_port_channel_with_disabled_port_channel_server16_port_channel_with_disabled_port_channel
    shutdown
    switchport
    switchport access vlan 110
    mlag 23
 !
 interface Port-Channel24
-   description server17_port_channel_with_disabled_phy+po_interfaces_
+   description server17_port_channel_with_disabled_phy_and_po_interfaces_server17_port_channel_with_disabled_phy_and_po_interfaces
    shutdown
    switchport
    switchport access vlan 110

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3B.md
@@ -426,6 +426,9 @@ vlan 4092
 | Ethernet17 | server10_no_profile_port_channel_lacp_fallback_Eth2 | *trunk | *1-4094 | *- | *- | 17 |
 | Ethernet18 | server11_inherit_profile_port_channel_lacp_fallback_Eth2 | *trunk | *1-4094 | *- | *- | 18 |
 | Ethernet19 | server12_inherit_nested_profile_port_channel_lacp_fallback_Eth2 | *trunk | *1-4094 | *- | *- | 19 |
+| Ethernet20 |  server13_disabled_interfaces_Eth2 | access | 110 | - | - | - |
+| Ethernet21 |  server14_explicitly_enabled_interfaces_Eth2 | access | 110 | - | - | - |
+| Ethernet22 | server15_port_channel_disabled_interfaces_Eth2 | *access | *110 | *- | *- | 22 |
 
 *Inherited from Port-Channel Interface
 
@@ -578,6 +581,25 @@ interface Ethernet19
    no shutdown
    channel-group 19 mode active
    lacp port-priority 32768
+!
+interface Ethernet20
+   description server13_disabled_interfaces_Eth2
+   shutdown
+   switchport
+   switchport access vlan 110
+   switchport mode access
+!
+interface Ethernet21
+   description server14_explicitly_enabled_interfaces_Eth2
+   no shutdown
+   switchport
+   switchport access vlan 110
+   switchport mode access
+!
+interface Ethernet22
+   description server15_port_channel_disabled_interfaces_Eth2
+   shutdown
+   channel-group 22 mode active
 ```
 
 ## Port-Channel Interfaces
@@ -595,6 +617,7 @@ interface Ethernet19
 | Port-Channel17 | server10_no_profile_port_channel_lacp_fallback_server10_no_profile_port_channel_lacp_fallback | switched | trunk | 1-4094 | - | - | 90 | static | 17 | - |
 | Port-Channel18 | server11_inherit_profile_port_channel_lacp_fallback_ALL_WITH_SECURITY_PORT_CHANNEL | switched | trunk | 1-4094 | - | - | 10 | static | 18 | - |
 | Port-Channel19 | server12_inherit_nested_profile_port_channel_lacp_fallback_NESTED_ALL_WITH_SECURITY_PORT_CHANNEL | switched | trunk | 1-4094 | - | - | 10 | static | 19 | - |
+| Port-Channel22 | server15_port_channel_disabled_interfaces_ | switched | access | 110 | - | - | - | - | 22 | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -692,6 +715,13 @@ interface Port-Channel19
    storm-control broadcast level pps 100
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+!
+interface Port-Channel22
+   description server15_port_channel_disabled_interfaces_
+   no shutdown
+   switchport
+   switchport access vlan 110
+   mlag 22
 ```
 
 ## Loopback Interfaces

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3B.md
@@ -428,7 +428,9 @@ vlan 4092
 | Ethernet19 | server12_inherit_nested_profile_port_channel_lacp_fallback_Eth2 | *trunk | *1-4094 | *- | *- | 19 |
 | Ethernet20 |  server13_disabled_interfaces_Eth2 | access | 110 | - | - | - |
 | Ethernet21 |  server14_explicitly_enabled_interfaces_Eth2 | access | 110 | - | - | - |
-| Ethernet22 | server15_port_channel_disabled_interfaces_Eth2 | *access | *110 | *- | *- | 22 |
+| Ethernet22 | server15_port_channel_with_disabled_phy_interfaces_Eth2 | *access | *110 | *- | *- | 22 |
+| Ethernet23 | server16_port_channel_with_disabled_port_channel_Eth2 | *access | *110 | *- | *- | 23 |
+| Ethernet24 | server17_port_channel_with_disabled_phy+po_interfaces_Eth2 | *access | *110 | *- | *- | 24 |
 
 *Inherited from Port-Channel Interface
 
@@ -597,9 +599,19 @@ interface Ethernet21
    switchport mode access
 !
 interface Ethernet22
-   description server15_port_channel_disabled_interfaces_Eth2
+   description server15_port_channel_with_disabled_phy_interfaces_Eth2
    shutdown
    channel-group 22 mode active
+!
+interface Ethernet23
+   description server16_port_channel_with_disabled_port_channel_Eth2
+   no shutdown
+   channel-group 23 mode active
+!
+interface Ethernet24
+   description server17_port_channel_with_disabled_phy+po_interfaces_Eth2
+   shutdown
+   channel-group 24 mode active
 ```
 
 ## Port-Channel Interfaces
@@ -617,7 +629,9 @@ interface Ethernet22
 | Port-Channel17 | server10_no_profile_port_channel_lacp_fallback_server10_no_profile_port_channel_lacp_fallback | switched | trunk | 1-4094 | - | - | 90 | static | 17 | - |
 | Port-Channel18 | server11_inherit_profile_port_channel_lacp_fallback_ALL_WITH_SECURITY_PORT_CHANNEL | switched | trunk | 1-4094 | - | - | 10 | static | 18 | - |
 | Port-Channel19 | server12_inherit_nested_profile_port_channel_lacp_fallback_NESTED_ALL_WITH_SECURITY_PORT_CHANNEL | switched | trunk | 1-4094 | - | - | 10 | static | 19 | - |
-| Port-Channel22 | server15_port_channel_disabled_interfaces_ | switched | access | 110 | - | - | - | - | 22 | - |
+| Port-Channel22 | server15_port_channel_with_disabled_phy_interfaces_ | switched | access | 110 | - | - | - | - | 22 | - |
+| Port-Channel23 | server16_port_channel_with_disabled_port_channel_ | switched | access | 110 | - | - | - | - | 23 | - |
+| Port-Channel24 | server17_port_channel_with_disabled_phy+po_interfaces_ | switched | access | 110 | - | - | - | - | 24 | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -717,11 +731,25 @@ interface Port-Channel19
    storm-control unknown-unicast level 2
 !
 interface Port-Channel22
-   description server15_port_channel_disabled_interfaces_
+   description server15_port_channel_with_disabled_phy_interfaces_
    no shutdown
    switchport
    switchport access vlan 110
    mlag 22
+!
+interface Port-Channel23
+   description server16_port_channel_with_disabled_port_channel_
+   shutdown
+   switchport
+   switchport access vlan 110
+   mlag 23
+!
+interface Port-Channel24
+   description server17_port_channel_with_disabled_phy+po_interfaces_
+   shutdown
+   switchport
+   switchport access vlan 110
+   mlag 24
 ```
 
 ## Loopback Interfaces

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/fabric/DC1_FABRIC-topology.csv
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/fabric/DC1_FABRIC-topology.csv
@@ -129,7 +129,7 @@ l3leaf,DC1-SVC3A,Ethernet20,server,server13_disabled_interfaces,Eth1
 l3leaf,DC1-SVC3A,Ethernet21,server,server14_explicitly_enabled_interfaces,Eth1
 l3leaf,DC1-SVC3A,Ethernet22,server,server15_port_channel_with_disabled_phy_interfaces,Eth1
 l3leaf,DC1-SVC3A,Ethernet23,server,server16_port_channel_with_disabled_port_channel,Eth1
-l3leaf,DC1-SVC3A,Ethernet24,server,server17_port_channel_with_disabled_phy+po_interfaces,Eth1
+l3leaf,DC1-SVC3A,Ethernet24,server,server17_port_channel_with_disabled_phy_and_po_interfaces,Eth1
 l3leaf,DC1-SVC3B,Ethernet1,spine,DC1-SPINE1,Ethernet5
 l3leaf,DC1-SVC3B,Ethernet2,spine,DC1-SPINE2,Ethernet5
 l3leaf,DC1-SVC3B,Ethernet3,spine,DC1-SPINE3,Ethernet5
@@ -151,4 +151,4 @@ l3leaf,DC1-SVC3B,Ethernet20,server,server13_disabled_interfaces,Eth2
 l3leaf,DC1-SVC3B,Ethernet21,server,server14_explicitly_enabled_interfaces,Eth2
 l3leaf,DC1-SVC3B,Ethernet22,server,server15_port_channel_with_disabled_phy_interfaces,Eth2
 l3leaf,DC1-SVC3B,Ethernet23,server,server16_port_channel_with_disabled_port_channel,Eth2
-l3leaf,DC1-SVC3B,Ethernet24,server,server17_port_channel_with_disabled_phy+po_interfaces,Eth2
+l3leaf,DC1-SVC3B,Ethernet24,server,server17_port_channel_with_disabled_phy_and_po_interfaces,Eth2

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/fabric/DC1_FABRIC-topology.csv
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/fabric/DC1_FABRIC-topology.csv
@@ -127,7 +127,9 @@ l3leaf,DC1-SVC3A,Ethernet18,server,server11_inherit_profile_port_channel_lacp_fa
 l3leaf,DC1-SVC3A,Ethernet19,server,server12_inherit_nested_profile_port_channel_lacp_fallback,Eth1
 l3leaf,DC1-SVC3A,Ethernet20,server,server13_disabled_interfaces,Eth1
 l3leaf,DC1-SVC3A,Ethernet21,server,server14_explicitly_enabled_interfaces,Eth1
-l3leaf,DC1-SVC3A,Ethernet22,server,server15_port_channel_disabled_interfaces,Eth1
+l3leaf,DC1-SVC3A,Ethernet22,server,server15_port_channel_with_disabled_phy_interfaces,Eth1
+l3leaf,DC1-SVC3A,Ethernet23,server,server16_port_channel_with_disabled_port_channel,Eth1
+l3leaf,DC1-SVC3A,Ethernet24,server,server17_port_channel_with_disabled_phy+po_interfaces,Eth1
 l3leaf,DC1-SVC3B,Ethernet1,spine,DC1-SPINE1,Ethernet5
 l3leaf,DC1-SVC3B,Ethernet2,spine,DC1-SPINE2,Ethernet5
 l3leaf,DC1-SVC3B,Ethernet3,spine,DC1-SPINE3,Ethernet5
@@ -147,4 +149,6 @@ l3leaf,DC1-SVC3B,Ethernet18,server,server11_inherit_profile_port_channel_lacp_fa
 l3leaf,DC1-SVC3B,Ethernet19,server,server12_inherit_nested_profile_port_channel_lacp_fallback,Eth2
 l3leaf,DC1-SVC3B,Ethernet20,server,server13_disabled_interfaces,Eth2
 l3leaf,DC1-SVC3B,Ethernet21,server,server14_explicitly_enabled_interfaces,Eth2
-l3leaf,DC1-SVC3B,Ethernet22,server,server15_port_channel_disabled_interfaces,Eth2
+l3leaf,DC1-SVC3B,Ethernet22,server,server15_port_channel_with_disabled_phy_interfaces,Eth2
+l3leaf,DC1-SVC3B,Ethernet23,server,server16_port_channel_with_disabled_port_channel,Eth2
+l3leaf,DC1-SVC3B,Ethernet24,server,server17_port_channel_with_disabled_phy+po_interfaces,Eth2

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/fabric/DC1_FABRIC-topology.csv
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/fabric/DC1_FABRIC-topology.csv
@@ -125,6 +125,9 @@ l3leaf,DC1-SVC3A,Ethernet16,server,server09_override_profile_no_port_channel,Eth
 l3leaf,DC1-SVC3A,Ethernet17,server,server10_no_profile_port_channel_lacp_fallback,Eth1
 l3leaf,DC1-SVC3A,Ethernet18,server,server11_inherit_profile_port_channel_lacp_fallback,Eth1
 l3leaf,DC1-SVC3A,Ethernet19,server,server12_inherit_nested_profile_port_channel_lacp_fallback,Eth1
+l3leaf,DC1-SVC3A,Ethernet20,server,server13_disabled_interfaces,Eth1
+l3leaf,DC1-SVC3A,Ethernet21,server,server14_explicitly_enabled_interfaces,Eth1
+l3leaf,DC1-SVC3A,Ethernet22,server,server15_port_channel_disabled_interfaces,Eth1
 l3leaf,DC1-SVC3B,Ethernet1,spine,DC1-SPINE1,Ethernet5
 l3leaf,DC1-SVC3B,Ethernet2,spine,DC1-SPINE2,Ethernet5
 l3leaf,DC1-SVC3B,Ethernet3,spine,DC1-SPINE3,Ethernet5
@@ -142,3 +145,6 @@ l3leaf,DC1-SVC3B,Ethernet16,server,server09_override_profile_no_port_channel,Eth
 l3leaf,DC1-SVC3B,Ethernet17,server,server10_no_profile_port_channel_lacp_fallback,Eth2
 l3leaf,DC1-SVC3B,Ethernet18,server,server11_inherit_profile_port_channel_lacp_fallback,Eth2
 l3leaf,DC1-SVC3B,Ethernet19,server,server12_inherit_nested_profile_port_channel_lacp_fallback,Eth2
+l3leaf,DC1-SVC3B,Ethernet20,server,server13_disabled_interfaces,Eth2
+l3leaf,DC1-SVC3B,Ethernet21,server,server14_explicitly_enabled_interfaces,Eth2
+l3leaf,DC1-SVC3B,Ethernet22,server,server15_port_channel_disabled_interfaces,Eth2

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3A.cfg
@@ -250,21 +250,21 @@ interface Port-Channel19
    storm-control unknown-unicast level 2
 !
 interface Port-Channel22
-   description server15_port_channel_with_disabled_phy_interfaces_
+   description server15_port_channel_with_disabled_phy_interfaces_server15_port_channel_with_disabled_phy_interfaces
    no shutdown
    switchport
    switchport access vlan 110
    mlag 22
 !
 interface Port-Channel23
-   description server16_port_channel_with_disabled_port_channel_
+   description server16_port_channel_with_disabled_port_channel_server16_port_channel_with_disabled_port_channel
    shutdown
    switchport
    switchport access vlan 110
    mlag 23
 !
 interface Port-Channel24
-   description server17_port_channel_with_disabled_phy+po_interfaces_
+   description server17_port_channel_with_disabled_phy_and_po_interfaces_server17_port_channel_with_disabled_phy_and_po_interfaces
    shutdown
    switchport
    switchport access vlan 110
@@ -437,7 +437,7 @@ interface Ethernet23
    channel-group 23 mode active
 !
 interface Ethernet24
-   description server17_port_channel_with_disabled_phy+po_interfaces_Eth1
+   description server17_port_channel_with_disabled_phy_and_po_interfaces_Eth1
    shutdown
    channel-group 24 mode active
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3A.cfg
@@ -250,11 +250,25 @@ interface Port-Channel19
    storm-control unknown-unicast level 2
 !
 interface Port-Channel22
-   description server15_port_channel_disabled_interfaces_
+   description server15_port_channel_with_disabled_phy_interfaces_
    no shutdown
    switchport
    switchport access vlan 110
    mlag 22
+!
+interface Port-Channel23
+   description server16_port_channel_with_disabled_port_channel_
+   shutdown
+   switchport
+   switchport access vlan 110
+   mlag 23
+!
+interface Port-Channel24
+   description server17_port_channel_with_disabled_phy+po_interfaces_
+   shutdown
+   switchport
+   switchport access vlan 110
+   mlag 24
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet4
@@ -413,9 +427,19 @@ interface Ethernet21
    switchport mode access
 !
 interface Ethernet22
-   description server15_port_channel_disabled_interfaces_Eth1
+   description server15_port_channel_with_disabled_phy_interfaces_Eth1
    shutdown
    channel-group 22 mode active
+!
+interface Ethernet23
+   description server16_port_channel_with_disabled_port_channel_Eth1
+   no shutdown
+   channel-group 23 mode active
+!
+interface Ethernet24
+   description server17_port_channel_with_disabled_phy+po_interfaces_Eth1
+   shutdown
+   channel-group 24 mode active
 !
 interface Loopback0
    description EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3A.cfg
@@ -249,6 +249,13 @@ interface Port-Channel19
    storm-control multicast level 1
    storm-control unknown-unicast level 2
 !
+interface Port-Channel22
+   description server15_port_channel_disabled_interfaces_
+   no shutdown
+   switchport
+   switchport access vlan 110
+   mlag 22
+!
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet4
    no shutdown
@@ -390,6 +397,25 @@ interface Ethernet19
    no shutdown
    channel-group 19 mode active
    lacp port-priority 8192
+!
+interface Ethernet20
+   description server13_disabled_interfaces_Eth1
+   shutdown
+   switchport
+   switchport access vlan 110
+   switchport mode access
+!
+interface Ethernet21
+   description server14_explicitly_enabled_interfaces_Eth1
+   no shutdown
+   switchport
+   switchport access vlan 110
+   switchport mode access
+!
+interface Ethernet22
+   description server15_port_channel_disabled_interfaces_Eth1
+   shutdown
+   channel-group 22 mode active
 !
 interface Loopback0
    description EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3B.cfg
@@ -241,6 +241,13 @@ interface Port-Channel19
    storm-control multicast level 1
    storm-control unknown-unicast level 2
 !
+interface Port-Channel22
+   description server15_port_channel_disabled_interfaces_
+   no shutdown
+   switchport
+   switchport access vlan 110
+   mlag 22
+!
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet5
    no shutdown
@@ -377,6 +384,25 @@ interface Ethernet19
    no shutdown
    channel-group 19 mode active
    lacp port-priority 32768
+!
+interface Ethernet20
+   description server13_disabled_interfaces_Eth2
+   shutdown
+   switchport
+   switchport access vlan 110
+   switchport mode access
+!
+interface Ethernet21
+   description server14_explicitly_enabled_interfaces_Eth2
+   no shutdown
+   switchport
+   switchport access vlan 110
+   switchport mode access
+!
+interface Ethernet22
+   description server15_port_channel_disabled_interfaces_Eth2
+   shutdown
+   channel-group 22 mode active
 !
 interface Loopback0
    description EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3B.cfg
@@ -242,21 +242,21 @@ interface Port-Channel19
    storm-control unknown-unicast level 2
 !
 interface Port-Channel22
-   description server15_port_channel_with_disabled_phy_interfaces_
+   description server15_port_channel_with_disabled_phy_interfaces_server15_port_channel_with_disabled_phy_interfaces
    no shutdown
    switchport
    switchport access vlan 110
    mlag 22
 !
 interface Port-Channel23
-   description server16_port_channel_with_disabled_port_channel_
+   description server16_port_channel_with_disabled_port_channel_server16_port_channel_with_disabled_port_channel
    shutdown
    switchport
    switchport access vlan 110
    mlag 23
 !
 interface Port-Channel24
-   description server17_port_channel_with_disabled_phy+po_interfaces_
+   description server17_port_channel_with_disabled_phy_and_po_interfaces_server17_port_channel_with_disabled_phy_and_po_interfaces
    shutdown
    switchport
    switchport access vlan 110
@@ -424,7 +424,7 @@ interface Ethernet23
    channel-group 23 mode active
 !
 interface Ethernet24
-   description server17_port_channel_with_disabled_phy+po_interfaces_Eth2
+   description server17_port_channel_with_disabled_phy_and_po_interfaces_Eth2
    shutdown
    channel-group 24 mode active
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3B.cfg
@@ -242,11 +242,25 @@ interface Port-Channel19
    storm-control unknown-unicast level 2
 !
 interface Port-Channel22
-   description server15_port_channel_disabled_interfaces_
+   description server15_port_channel_with_disabled_phy_interfaces_
    no shutdown
    switchport
    switchport access vlan 110
    mlag 22
+!
+interface Port-Channel23
+   description server16_port_channel_with_disabled_port_channel_
+   shutdown
+   switchport
+   switchport access vlan 110
+   mlag 23
+!
+interface Port-Channel24
+   description server17_port_channel_with_disabled_phy+po_interfaces_
+   shutdown
+   switchport
+   switchport access vlan 110
+   mlag 24
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet5
@@ -400,9 +414,19 @@ interface Ethernet21
    switchport mode access
 !
 interface Ethernet22
-   description server15_port_channel_disabled_interfaces_Eth2
+   description server15_port_channel_with_disabled_phy_interfaces_Eth2
    shutdown
    channel-group 22 mode active
+!
+interface Ethernet23
+   description server16_port_channel_with_disabled_port_channel_Eth2
+   no shutdown
+   channel-group 23 mode active
+!
+interface Ethernet24
+   description server17_port_channel_with_disabled_phy+po_interfaces_Eth2
+   shutdown
+   channel-group 24 mode active
 !
 interface Loopback0
    description EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
@@ -870,12 +870,26 @@ port_channel_interfaces:
     lacp_fallback_mode: static
     lacp_fallback_timeout: 10
   Port-Channel22:
-    description: server15_port_channel_disabled_interfaces_
+    description: server15_port_channel_with_disabled_phy_interfaces_
     type: switched
     shutdown: false
     mode: access
     vlans: 110
     mlag: 22
+  Port-Channel23:
+    description: server16_port_channel_with_disabled_port_channel_
+    type: switched
+    shutdown: true
+    mode: access
+    vlans: 110
+    mlag: 23
+  Port-Channel24:
+    description: server17_port_channel_with_disabled_phy+po_interfaces_
+    type: switched
+    shutdown: true
+    mode: access
+    vlans: 110
+    mlag: 24
 ethernet_interfaces:
   Ethernet5:
     peer: DC1-SVC3B
@@ -1239,16 +1253,40 @@ ethernet_interfaces:
     mode: access
     vlans: 110
   Ethernet22:
-    peer: server15_port_channel_disabled_interfaces
+    peer: server15_port_channel_with_disabled_phy_interfaces
     peer_interface: Eth1
     peer_type: server
-    description: server15_port_channel_disabled_interfaces_Eth1
+    description: server15_port_channel_with_disabled_phy_interfaces_Eth1
     type: switched
     shutdown: true
     mode: access
     vlans: 110
     channel_group:
       id: 22
+      mode: active
+  Ethernet23:
+    peer: server16_port_channel_with_disabled_port_channel
+    peer_interface: Eth1
+    peer_type: server
+    description: server16_port_channel_with_disabled_port_channel_Eth1
+    type: switched
+    shutdown: false
+    mode: access
+    vlans: 110
+    channel_group:
+      id: 23
+      mode: active
+  Ethernet24:
+    peer: server17_port_channel_with_disabled_phy+po_interfaces
+    peer_interface: Eth1
+    peer_type: server
+    description: server17_port_channel_with_disabled_phy+po_interfaces_Eth1
+    type: switched
+    shutdown: true
+    mode: access
+    vlans: 110
+    channel_group:
+      id: 24
       mode: active
 mlag_configuration:
   domain_id: DC1_SVC3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
@@ -870,21 +870,21 @@ port_channel_interfaces:
     lacp_fallback_mode: static
     lacp_fallback_timeout: 10
   Port-Channel22:
-    description: server15_port_channel_with_disabled_phy_interfaces_
+    description: server15_port_channel_with_disabled_phy_interfaces_server15_port_channel_with_disabled_phy_interfaces
     type: switched
     shutdown: false
     mode: access
     vlans: 110
     mlag: 22
   Port-Channel23:
-    description: server16_port_channel_with_disabled_port_channel_
+    description: server16_port_channel_with_disabled_port_channel_server16_port_channel_with_disabled_port_channel
     type: switched
     shutdown: true
     mode: access
     vlans: 110
     mlag: 23
   Port-Channel24:
-    description: server17_port_channel_with_disabled_phy+po_interfaces_
+    description: server17_port_channel_with_disabled_phy_and_po_interfaces_server17_port_channel_with_disabled_phy_and_po_interfaces
     type: switched
     shutdown: true
     mode: access
@@ -1277,10 +1277,10 @@ ethernet_interfaces:
       id: 23
       mode: active
   Ethernet24:
-    peer: server17_port_channel_with_disabled_phy+po_interfaces
+    peer: server17_port_channel_with_disabled_phy_and_po_interfaces
     peer_interface: Eth1
     peer_type: server
-    description: server17_port_channel_with_disabled_phy+po_interfaces_Eth1
+    description: server17_port_channel_with_disabled_phy_and_po_interfaces_Eth1
     type: switched
     shutdown: true
     mode: access

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
@@ -869,6 +869,13 @@ port_channel_interfaces:
     mlag: 19
     lacp_fallback_mode: static
     lacp_fallback_timeout: 10
+  Port-Channel22:
+    description: server15_port_channel_disabled_interfaces_
+    type: switched
+    shutdown: false
+    mode: access
+    vlans: 110
+    mlag: 22
 ethernet_interfaces:
   Ethernet5:
     peer: DC1-SVC3B
@@ -1213,6 +1220,36 @@ ethernet_interfaces:
       id: 19
       mode: active
     lacp_port_priority: 8192
+  Ethernet20:
+    peer: server13_disabled_interfaces
+    peer_interface: Eth1
+    peer_type: server
+    description: server13_disabled_interfaces_Eth1
+    type: switched
+    shutdown: true
+    mode: access
+    vlans: 110
+  Ethernet21:
+    peer: server14_explicitly_enabled_interfaces
+    peer_interface: Eth1
+    peer_type: server
+    description: server14_explicitly_enabled_interfaces_Eth1
+    type: switched
+    shutdown: false
+    mode: access
+    vlans: 110
+  Ethernet22:
+    peer: server15_port_channel_disabled_interfaces
+    peer_interface: Eth1
+    peer_type: server
+    description: server15_port_channel_disabled_interfaces_Eth1
+    type: switched
+    shutdown: true
+    mode: access
+    vlans: 110
+    channel_group:
+      id: 22
+      mode: active
 mlag_configuration:
   domain_id: DC1_SVC3
   local_interface: Vlan4092

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
@@ -863,21 +863,21 @@ port_channel_interfaces:
     lacp_fallback_mode: static
     lacp_fallback_timeout: 10
   Port-Channel22:
-    description: server15_port_channel_with_disabled_phy_interfaces_
+    description: server15_port_channel_with_disabled_phy_interfaces_server15_port_channel_with_disabled_phy_interfaces
     type: switched
     shutdown: false
     mode: access
     vlans: 110
     mlag: 22
   Port-Channel23:
-    description: server16_port_channel_with_disabled_port_channel_
+    description: server16_port_channel_with_disabled_port_channel_server16_port_channel_with_disabled_port_channel
     type: switched
     shutdown: true
     mode: access
     vlans: 110
     mlag: 23
   Port-Channel24:
-    description: server17_port_channel_with_disabled_phy+po_interfaces_
+    description: server17_port_channel_with_disabled_phy_and_po_interfaces_server17_port_channel_with_disabled_phy_and_po_interfaces
     type: switched
     shutdown: true
     mode: access
@@ -1258,10 +1258,10 @@ ethernet_interfaces:
       id: 23
       mode: active
   Ethernet24:
-    peer: server17_port_channel_with_disabled_phy+po_interfaces
+    peer: server17_port_channel_with_disabled_phy_and_po_interfaces
     peer_interface: Eth2
     peer_type: server
-    description: server17_port_channel_with_disabled_phy+po_interfaces_Eth2
+    description: server17_port_channel_with_disabled_phy_and_po_interfaces_Eth2
     type: switched
     shutdown: true
     mode: access

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
@@ -862,6 +862,13 @@ port_channel_interfaces:
     mlag: 19
     lacp_fallback_mode: static
     lacp_fallback_timeout: 10
+  Port-Channel22:
+    description: server15_port_channel_disabled_interfaces_
+    type: switched
+    shutdown: false
+    mode: access
+    vlans: 110
+    mlag: 22
 ethernet_interfaces:
   Ethernet5:
     peer: DC1-SVC3A
@@ -1194,6 +1201,36 @@ ethernet_interfaces:
       id: 19
       mode: active
     lacp_port_priority: 32768
+  Ethernet20:
+    peer: server13_disabled_interfaces
+    peer_interface: Eth2
+    peer_type: server
+    description: server13_disabled_interfaces_Eth2
+    type: switched
+    shutdown: true
+    mode: access
+    vlans: 110
+  Ethernet21:
+    peer: server14_explicitly_enabled_interfaces
+    peer_interface: Eth2
+    peer_type: server
+    description: server14_explicitly_enabled_interfaces_Eth2
+    type: switched
+    shutdown: false
+    mode: access
+    vlans: 110
+  Ethernet22:
+    peer: server15_port_channel_disabled_interfaces
+    peer_interface: Eth2
+    peer_type: server
+    description: server15_port_channel_disabled_interfaces_Eth2
+    type: switched
+    shutdown: true
+    mode: access
+    vlans: 110
+    channel_group:
+      id: 22
+      mode: active
 mlag_configuration:
   domain_id: DC1_SVC3
   local_interface: Vlan4092

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
@@ -863,12 +863,26 @@ port_channel_interfaces:
     lacp_fallback_mode: static
     lacp_fallback_timeout: 10
   Port-Channel22:
-    description: server15_port_channel_disabled_interfaces_
+    description: server15_port_channel_with_disabled_phy_interfaces_
     type: switched
     shutdown: false
     mode: access
     vlans: 110
     mlag: 22
+  Port-Channel23:
+    description: server16_port_channel_with_disabled_port_channel_
+    type: switched
+    shutdown: true
+    mode: access
+    vlans: 110
+    mlag: 23
+  Port-Channel24:
+    description: server17_port_channel_with_disabled_phy+po_interfaces_
+    type: switched
+    shutdown: true
+    mode: access
+    vlans: 110
+    mlag: 24
 ethernet_interfaces:
   Ethernet5:
     peer: DC1-SVC3A
@@ -1220,16 +1234,40 @@ ethernet_interfaces:
     mode: access
     vlans: 110
   Ethernet22:
-    peer: server15_port_channel_disabled_interfaces
+    peer: server15_port_channel_with_disabled_phy_interfaces
     peer_interface: Eth2
     peer_type: server
-    description: server15_port_channel_disabled_interfaces_Eth2
+    description: server15_port_channel_with_disabled_phy_interfaces_Eth2
     type: switched
     shutdown: true
     mode: access
     vlans: 110
     channel_group:
       id: 22
+      mode: active
+  Ethernet23:
+    peer: server16_port_channel_with_disabled_port_channel
+    peer_interface: Eth2
+    peer_type: server
+    description: server16_port_channel_with_disabled_port_channel_Eth2
+    type: switched
+    shutdown: false
+    mode: access
+    vlans: 110
+    channel_group:
+      id: 23
+      mode: active
+  Ethernet24:
+    peer: server17_port_channel_with_disabled_phy+po_interfaces
+    peer_interface: Eth2
+    peer_type: server
+    description: server17_port_channel_with_disabled_phy+po_interfaces_Eth2
+    type: switched
+    shutdown: true
+    mode: access
+    vlans: 110
+    channel_group:
+      id: 24
       mode: active
 mlag_configuration:
   domain_id: DC1_SVC3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_SERVERS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_SERVERS.yml
@@ -325,6 +325,35 @@ servers:
         switches: [ DC1-SVC3A, DC1-SVC3B ]
         profile: NESTED_PORT_PROFILE
 
+  server13_disabled_interfaces:
+    rack: RackC
+    adapters:
+      - server_ports: [ Eth1, Eth2 ]
+        switch_ports: [ Ethernet20, Ethernet20 ]
+        switches: [ DC1-SVC3A, DC1-SVC3B ]
+        profile: TENANT_A
+        enabled: false
+
+  server14_explicitly_enabled_interfaces:
+    rack: RackC
+    adapters:
+      - server_ports: [ Eth1, Eth2 ]
+        switch_ports: [ Ethernet21, Ethernet21 ]
+        switches: [ DC1-SVC3A, DC1-SVC3B ]
+        profile: TENANT_A
+        enabled: true
+
+  server15_port_channel_disabled_interfaces:
+    rack: RackC
+    adapters:
+      - server_ports: [ Eth1, Eth2 ]
+        switch_ports: [ Ethernet22, Ethernet22 ]
+        switches: [ DC1-SVC3A, DC1-SVC3B ]
+        profile: TENANT_A
+        enabled: false
+        port_channel:
+          mode: active
+
 firewalls:
   FIREWALL01:
     rack: RackB

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_SERVERS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_SERVERS.yml
@@ -343,7 +343,7 @@ servers:
         profile: TENANT_A
         enabled: true
 
-  server15_port_channel_disabled_interfaces:
+  server15_port_channel_with_disabled_phy_interfaces:
     rack: RackC
     adapters:
       - server_ports: [ Eth1, Eth2 ]
@@ -353,6 +353,31 @@ servers:
         enabled: false
         port_channel:
           mode: active
+          enabled: true
+
+  server16_port_channel_with_disabled_port_channel:
+    rack: RackC
+    adapters:
+      - server_ports: [ Eth1, Eth2 ]
+        switch_ports: [ Ethernet23, Ethernet23 ]
+        switches: [ DC1-SVC3A, DC1-SVC3B ]
+        profile: TENANT_A
+        port_channel:
+          mode: active
+          enabled: false
+
+
+  server17_port_channel_with_disabled_phy+po_interfaces:
+    rack: RackC
+    adapters:
+      - server_ports: [ Eth1, Eth2 ]
+        switch_ports: [ Ethernet24, Ethernet24 ]
+        switches: [ DC1-SVC3A, DC1-SVC3B ]
+        profile: TENANT_A
+        enabled: false
+        port_channel:
+          mode: active
+          enabled: false
 
 firewalls:
   FIREWALL01:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_SERVERS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_SERVERS.yml
@@ -352,6 +352,7 @@ servers:
         profile: TENANT_A
         enabled: false
         port_channel:
+          description: server15_port_channel_with_disabled_phy_interfaces
           mode: active
           enabled: true
 
@@ -363,11 +364,11 @@ servers:
         switches: [ DC1-SVC3A, DC1-SVC3B ]
         profile: TENANT_A
         port_channel:
+          description: server16_port_channel_with_disabled_port_channel
           mode: active
           enabled: false
 
-
-  server17_port_channel_with_disabled_phy+po_interfaces:
+  server17_port_channel_with_disabled_phy_and_po_interfaces:
     rack: RackC
     adapters:
       - server_ports: [ Eth1, Eth2 ]
@@ -376,6 +377,7 @@ servers:
         profile: TENANT_A
         enabled: false
         port_channel:
+          description: server17_port_channel_with_disabled_phy_and_po_interfaces
           mode: active
           enabled: false
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -438,6 +438,9 @@ vlan 4092
 | Ethernet17 | CUSTOM_server10_no_profile_port_channel_lacp_fallback_Eth1 | *trunk | *1-4094 | *- | *- | 17 |
 | Ethernet18 | CUSTOM_server11_inherit_profile_port_channel_lacp_fallback_Eth1 | *trunk | *1-4094 | *- | *- | 18 |
 | Ethernet19 | CUSTOM_server12_inherit_nested_profile_port_channel_lacp_fallback_Eth1 | *trunk | *1-4094 | *- | *- | 19 |
+| Ethernet20 |  CUSTOM_server13_disabled_interfaces_Eth1 | access | 110 | - | - | - |
+| Ethernet21 |  CUSTOM_server14_explicitly_enabled_interfaces_Eth1 | access | 110 | - | - | - |
+| Ethernet22 | CUSTOM_server15_port_channel_disabled_interfaces_Eth1 | *access | *110 | *- | *- | 22 |
 
 *Inherited from Port-Channel Interface
 
@@ -562,6 +565,25 @@ interface Ethernet19
    channel-group 19 mode active
    lacp port-priority 8192
 !
+interface Ethernet20
+   description CUSTOM_server13_disabled_interfaces_Eth1
+   shutdown
+   switchport
+   switchport access vlan 110
+   switchport mode access
+!
+interface Ethernet21
+   description CUSTOM_server14_explicitly_enabled_interfaces_Eth1
+   no shutdown
+   switchport
+   switchport access vlan 110
+   switchport mode access
+!
+interface Ethernet22
+   description CUSTOM_server15_port_channel_disabled_interfaces_Eth1
+   shutdown
+   channel-group 22 mode active
+!
 interface Ethernet41
    description CUSTOM_P2P_LINK_TO_DC1-SPINE1_Ethernet4
    no shutdown
@@ -611,6 +633,7 @@ interface Ethernet44
 | Port-Channel17 | CUSTOM_server10_no_profile_port_channel_lacp_fallback_server10_no_profile_port_channel_lacp_fallback | switched | trunk | 1-4094 | - | - | 90 | static | 17 | - |
 | Port-Channel18 | CUSTOM_server11_inherit_profile_port_channel_lacp_fallback_ALL_WITH_SECURITY_PORT_CHANNEL | switched | trunk | 1-4094 | - | - | 10 | static | 18 | - |
 | Port-Channel19 | CUSTOM_server12_inherit_nested_profile_port_channel_lacp_fallback_NESTED_ALL_WITH_SECURITY_PORT_CHANNEL | switched | trunk | 1-4094 | - | - | 10 | static | 19 | - |
+| Port-Channel22 | CUSTOM_server15_port_channel_disabled_interfaces_ | switched | access | 110 | - | - | - | - | 22 | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -719,6 +742,13 @@ interface Port-Channel19
    storm-control broadcast level pps 100
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+!
+interface Port-Channel22
+   description CUSTOM_server15_port_channel_disabled_interfaces_
+   no shutdown
+   switchport
+   switchport access vlan 110
+   mlag 22
 ```
 
 ## Loopback Interfaces

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -438,6 +438,9 @@ vlan 4092
 | Ethernet17 | CUSTOM_server10_no_profile_port_channel_lacp_fallback_Eth2 | *trunk | *1-4094 | *- | *- | 17 |
 | Ethernet18 | CUSTOM_server11_inherit_profile_port_channel_lacp_fallback_Eth2 | *trunk | *1-4094 | *- | *- | 18 |
 | Ethernet19 | CUSTOM_server12_inherit_nested_profile_port_channel_lacp_fallback_Eth2 | *trunk | *1-4094 | *- | *- | 19 |
+| Ethernet20 |  CUSTOM_server13_disabled_interfaces_Eth2 | access | 110 | - | - | - |
+| Ethernet21 |  CUSTOM_server14_explicitly_enabled_interfaces_Eth2 | access | 110 | - | - | - |
+| Ethernet22 | CUSTOM_server15_port_channel_disabled_interfaces_Eth2 | *access | *110 | *- | *- | 22 |
 
 *Inherited from Port-Channel Interface
 
@@ -562,6 +565,25 @@ interface Ethernet19
    channel-group 19 mode active
    lacp port-priority 32768
 !
+interface Ethernet20
+   description CUSTOM_server13_disabled_interfaces_Eth2
+   shutdown
+   switchport
+   switchport access vlan 110
+   switchport mode access
+!
+interface Ethernet21
+   description CUSTOM_server14_explicitly_enabled_interfaces_Eth2
+   no shutdown
+   switchport
+   switchport access vlan 110
+   switchport mode access
+!
+interface Ethernet22
+   description CUSTOM_server15_port_channel_disabled_interfaces_Eth2
+   shutdown
+   channel-group 22 mode active
+!
 interface Ethernet41
    description CUSTOM_P2P_LINK_TO_DC1-SPINE1_Ethernet5
    no shutdown
@@ -611,6 +633,7 @@ interface Ethernet44
 | Port-Channel17 | CUSTOM_server10_no_profile_port_channel_lacp_fallback_server10_no_profile_port_channel_lacp_fallback | switched | trunk | 1-4094 | - | - | 90 | static | 17 | - |
 | Port-Channel18 | CUSTOM_server11_inherit_profile_port_channel_lacp_fallback_ALL_WITH_SECURITY_PORT_CHANNEL | switched | trunk | 1-4094 | - | - | 10 | static | 18 | - |
 | Port-Channel19 | CUSTOM_server12_inherit_nested_profile_port_channel_lacp_fallback_NESTED_ALL_WITH_SECURITY_PORT_CHANNEL | switched | trunk | 1-4094 | - | - | 10 | static | 19 | - |
+| Port-Channel22 | CUSTOM_server15_port_channel_disabled_interfaces_ | switched | access | 110 | - | - | - | - | 22 | - |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -719,6 +742,13 @@ interface Port-Channel19
    storm-control broadcast level pps 100
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+!
+interface Port-Channel22
+   description CUSTOM_server15_port_channel_disabled_interfaces_
+   no shutdown
+   switchport
+   switchport access vlan 110
+   mlag 22
 ```
 
 ## Loopback Interfaces

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/fabric/DC1_FABRIC-topology.csv
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/fabric/DC1_FABRIC-topology.csv
@@ -113,6 +113,9 @@ l3leaf,DC1-SVC3A,Ethernet16,server,server09_override_profile_no_port_channel,Eth
 l3leaf,DC1-SVC3A,Ethernet17,server,server10_no_profile_port_channel_lacp_fallback,Eth1
 l3leaf,DC1-SVC3A,Ethernet18,server,server11_inherit_profile_port_channel_lacp_fallback,Eth1
 l3leaf,DC1-SVC3A,Ethernet19,server,server12_inherit_nested_profile_port_channel_lacp_fallback,Eth1
+l3leaf,DC1-SVC3A,Ethernet20,server,server13_disabled_interfaces,Eth1
+l3leaf,DC1-SVC3A,Ethernet21,server,server14_explicitly_enabled_interfaces,Eth1
+l3leaf,DC1-SVC3A,Ethernet22,server,server15_port_channel_disabled_interfaces,Eth1
 l3leaf,DC1-SVC3A,Ethernet41,spine,DC1-SPINE1,Ethernet4
 l3leaf,DC1-SVC3A,Ethernet42,spine,DC1-SPINE2,Ethernet4
 l3leaf,DC1-SVC3A,Ethernet43,spine,DC1-SPINE3,Ethernet4
@@ -131,6 +134,9 @@ l3leaf,DC1-SVC3B,Ethernet16,server,server09_override_profile_no_port_channel,Eth
 l3leaf,DC1-SVC3B,Ethernet17,server,server10_no_profile_port_channel_lacp_fallback,Eth2
 l3leaf,DC1-SVC3B,Ethernet18,server,server11_inherit_profile_port_channel_lacp_fallback,Eth2
 l3leaf,DC1-SVC3B,Ethernet19,server,server12_inherit_nested_profile_port_channel_lacp_fallback,Eth2
+l3leaf,DC1-SVC3B,Ethernet20,server,server13_disabled_interfaces,Eth2
+l3leaf,DC1-SVC3B,Ethernet21,server,server14_explicitly_enabled_interfaces,Eth2
+l3leaf,DC1-SVC3B,Ethernet22,server,server15_port_channel_disabled_interfaces,Eth2
 l3leaf,DC1-SVC3B,Ethernet41,spine,DC1-SPINE1,Ethernet5
 l3leaf,DC1-SVC3B,Ethernet42,spine,DC1-SPINE2,Ethernet5
 l3leaf,DC1-SVC3B,Ethernet43,spine,DC1-SPINE3,Ethernet5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
@@ -264,6 +264,13 @@ interface Port-Channel19
    storm-control multicast level 1
    storm-control unknown-unicast level 2
 !
+interface Port-Channel22
+   description CUSTOM_server15_port_channel_disabled_interfaces_
+   no shutdown
+   switchport
+   switchport access vlan 110
+   mlag 22
+!
 interface Ethernet5
    description MLAG_PEER_DC1-SVC3B_Ethernet5
    no shutdown
@@ -371,6 +378,25 @@ interface Ethernet19
    no shutdown
    channel-group 19 mode active
    lacp port-priority 8192
+!
+interface Ethernet20
+   description CUSTOM_server13_disabled_interfaces_Eth1
+   shutdown
+   switchport
+   switchport access vlan 110
+   switchport mode access
+!
+interface Ethernet21
+   description CUSTOM_server14_explicitly_enabled_interfaces_Eth1
+   no shutdown
+   switchport
+   switchport access vlan 110
+   switchport mode access
+!
+interface Ethernet22
+   description CUSTOM_server15_port_channel_disabled_interfaces_Eth1
+   shutdown
+   channel-group 22 mode active
 !
 interface Ethernet41
    description CUSTOM_P2P_LINK_TO_DC1-SPINE1_Ethernet4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
@@ -264,6 +264,13 @@ interface Port-Channel19
    storm-control multicast level 1
    storm-control unknown-unicast level 2
 !
+interface Port-Channel22
+   description CUSTOM_server15_port_channel_disabled_interfaces_
+   no shutdown
+   switchport
+   switchport access vlan 110
+   mlag 22
+!
 interface Ethernet5
    description MLAG_PEER_DC1-SVC3A_Ethernet5
    no shutdown
@@ -371,6 +378,25 @@ interface Ethernet19
    no shutdown
    channel-group 19 mode active
    lacp port-priority 32768
+!
+interface Ethernet20
+   description CUSTOM_server13_disabled_interfaces_Eth2
+   shutdown
+   switchport
+   switchport access vlan 110
+   switchport mode access
+!
+interface Ethernet21
+   description CUSTOM_server14_explicitly_enabled_interfaces_Eth2
+   no shutdown
+   switchport
+   switchport access vlan 110
+   switchport mode access
+!
+interface Ethernet22
+   description CUSTOM_server15_port_channel_disabled_interfaces_Eth2
+   shutdown
+   channel-group 22 mode active
 !
 interface Ethernet41
    description CUSTOM_P2P_LINK_TO_DC1-SPINE1_Ethernet5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -914,6 +914,13 @@ port_channel_interfaces:
     mlag: 19
     lacp_fallback_mode: static
     lacp_fallback_timeout: 10
+  Port-Channel22:
+    description: CUSTOM_server15_port_channel_disabled_interfaces_
+    type: switched
+    shutdown: false
+    mode: access
+    vlans: 110
+    mlag: 22
 ethernet_interfaces:
   Ethernet5:
     peer: DC1-SVC3B
@@ -1256,6 +1263,36 @@ ethernet_interfaces:
       id: 19
       mode: active
     lacp_port_priority: 8192
+  Ethernet20:
+    peer: server13_disabled_interfaces
+    peer_interface: Eth1
+    peer_type: server
+    description: CUSTOM_server13_disabled_interfaces_Eth1
+    type: switched
+    shutdown: true
+    mode: access
+    vlans: 110
+  Ethernet21:
+    peer: server14_explicitly_enabled_interfaces
+    peer_interface: Eth1
+    peer_type: server
+    description: CUSTOM_server14_explicitly_enabled_interfaces_Eth1
+    type: switched
+    shutdown: false
+    mode: access
+    vlans: 110
+  Ethernet22:
+    peer: server15_port_channel_disabled_interfaces
+    peer_interface: Eth1
+    peer_type: server
+    description: CUSTOM_server15_port_channel_disabled_interfaces_Eth1
+    type: switched
+    shutdown: true
+    mode: access
+    vlans: 110
+    channel_group:
+      id: 22
+      mode: active
 mlag_configuration:
   domain_id: DC1_SVC3
   local_interface: Vlan4092

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -914,6 +914,13 @@ port_channel_interfaces:
     mlag: 19
     lacp_fallback_mode: static
     lacp_fallback_timeout: 10
+  Port-Channel22:
+    description: CUSTOM_server15_port_channel_disabled_interfaces_
+    type: switched
+    shutdown: false
+    mode: access
+    vlans: 110
+    mlag: 22
 ethernet_interfaces:
   Ethernet5:
     peer: DC1-SVC3A
@@ -1256,6 +1263,36 @@ ethernet_interfaces:
       id: 19
       mode: active
     lacp_port_priority: 32768
+  Ethernet20:
+    peer: server13_disabled_interfaces
+    peer_interface: Eth2
+    peer_type: server
+    description: CUSTOM_server13_disabled_interfaces_Eth2
+    type: switched
+    shutdown: true
+    mode: access
+    vlans: 110
+  Ethernet21:
+    peer: server14_explicitly_enabled_interfaces
+    peer_interface: Eth2
+    peer_type: server
+    description: CUSTOM_server14_explicitly_enabled_interfaces_Eth2
+    type: switched
+    shutdown: false
+    mode: access
+    vlans: 110
+  Ethernet22:
+    peer: server15_port_channel_disabled_interfaces
+    peer_interface: Eth2
+    peer_type: server
+    description: CUSTOM_server15_port_channel_disabled_interfaces_Eth2
+    type: switched
+    shutdown: true
+    mode: access
+    vlans: 110
+    channel_group:
+      id: 22
+      mode: active
 mlag_configuration:
   domain_id: DC1_SVC3
   local_interface: Vlan4092

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_SERVERS.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_SERVERS.yml
@@ -325,6 +325,35 @@ servers:
         switches: [ DC1-SVC3A, DC1-SVC3B ]
         profile: NESTED_PORT_PROFILE
 
+  server13_disabled_interfaces:
+    rack: RackC
+    adapters:
+      - server_ports: [ Eth1, Eth2 ]
+        switch_ports: [ Ethernet20, Ethernet20 ]
+        switches: [ DC1-SVC3A, DC1-SVC3B ]
+        profile: TENANT_A
+        enabled: false
+
+  server14_explicitly_enabled_interfaces:
+    rack: RackC
+    adapters:
+      - server_ports: [ Eth1, Eth2 ]
+        switch_ports: [ Ethernet21, Ethernet21 ]
+        switches: [ DC1-SVC3A, DC1-SVC3B ]
+        profile: TENANT_A
+        enabled: true
+
+  server15_port_channel_disabled_interfaces:
+    rack: RackC
+    adapters:
+      - server_ports: [ Eth1, Eth2 ]
+        switch_ports: [ Ethernet22, Ethernet22 ]
+        switches: [ DC1-SVC3A, DC1-SVC3B ]
+        profile: TENANT_A
+        enabled: false
+        port_channel:
+          mode: active
+
 firewalls:
   FIREWALL01:
     rack: RackB

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/connected-endpoints.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/connected-endpoints.md
@@ -108,6 +108,10 @@ port_profiles:
         # Port-profile name, to inherit configuration.
         profile: < port_profile_name >
 
+        # Administrative state | optional - default is true
+        # setting to false will set port to 'shutdown' in intended configuration
+	enabled: < true | false >
+
         # Interface mode | required
         mode: < access | dot1q-tunnel | trunk >
 

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/connected-endpoints.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/connected-endpoints.md
@@ -176,6 +176,10 @@ port_profiles:
           # Port-Channel Description.
           description: < port_channel_description >
 
+          # Port-Channel administrative state | optional - default is true
+          # setting to false will set port to 'shutdown' in intended configuration
+          enabled: < true | false >
+
           # Port-Channel Mode.
           mode: < "active" | "passive" | "on" >
 

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/connected-endpoints.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/connected-endpoints.md
@@ -110,7 +110,7 @@ port_profiles:
 
         # Administrative state | optional - default is true
         # setting to false will set port to 'shutdown' in intended configuration
-	enabled: < true | false >
+        enabled: < true | false >
 
         # Interface mode | required
         mode: < access | dot1q-tunnel | trunk >

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/ethernet-interfaces.j2
@@ -34,9 +34,10 @@ ethernet_interfaces:
     l2_mtu: {{ adapter_settings.l2_mtu }}
 {%                     endif %}
     type: switched
+{%                     if adapter_settings.enabled is arista.avd.defined(false) %}
+    shutdown: true
+{%                     else %}
     shutdown: false
-{%                     if adapter_settings.enabled is arista.avd.defined %}
-    shutdown: {{ not adapter_settings.enabled }}
 {%                     endif %}
     mode: {{ adapter_settings.mode | arista.avd.default }}
     vlans: {{ adapter_settings.vlans | arista.avd.default }}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/ethernet-interfaces.j2
@@ -35,6 +35,9 @@ ethernet_interfaces:
 {%                     endif %}
     type: switched
     shutdown: false
+{%                     if adapter_settings.enabled is arista.avd.defined %}
+    shutdown: {{ not adapter_settings.enabled }}
+{%                     endif %}
     mode: {{ adapter_settings.mode | arista.avd.default }}
     vlans: {{ adapter_settings.vlans | arista.avd.default }}
 {%                     if adapter_settings.native_vlan is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/port-channel-interfaces.j2
@@ -21,7 +21,11 @@ port_channel_interfaces:
 {%                         set peer = connected_endpoint %}
     description: "{% include switch.interface_descriptions.connected_endpoints_port_channel_interfaces %}"
     type: switched
+{%                         if adapter_settings.port_channel.enabled is arista.avd.defined(false) %}
+    shutdown: true
+{%                         else %}
     shutdown: false
+{%                         endif %}
     mode: {{ adapter_settings.mode | arista.avd.default }}
 {%                         if adapter_settings.mtu is arista.avd.defined %}
     mtu: {{ adapter_settings.mtu }}


### PR DESCRIPTION
## Change Summary
Role 'eos_designs': Implementing 'enabled' key in adapter settings

## Related Issue(s)

Fixes #1266

## Component(s) name

`arista.avd.eos_design`

## Proposed changes
- /roles/eos_designs/templates/connected_endpoints/ethernet-interfaces.j2:
  - respect 'enabled' adapter key, if specified in 'servers' group vars
- molecule/eos_designs_unit_tests/inventory/group_vars/DC1_SERVERS.yml
  - added tests for 'enabled' key

Data model (same as in feature request):

```
servers:
  server01:
    rack: RackB
    adapters:
      - endpoint_ports: [ E0 ]
        switch_ports: [ Ethernet5 ]
        switches: [ DC1-LEAF1A ]
        profile: MGMT
        enabled: true | false
```

## How to test
`molecule test --scenario-name eos_designs_unit_tests`
'enabled: false' leads to 'shutdown' in intented interface config

## Checklist

### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)