### PR TITLE
Doc(eos_designs): Minor documentation fixes

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_designs/doc/connected-endpoints.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/connected-endpoints.md
@@ -96,13 +96,13 @@ port_profiles:
         # Adapter speed - if not specified will be auto.
       - speed: < interface_speed | forced interface_speed | auto interface_speed >
 
-        # Local endpoint port(s)
+        # Local endpoint port(s) | required
         endpoint_ports: [ < interface_name > ]
 
-        # List of port(s) connected to switches
+        # List of port(s) connected to switches | required
         switch_ports: [ < switchport_interface > ]
 
-        # List of switche(s)
+        # List of switche(s) | required
         switches: [ < device > ]
 
         # Port-profile name, to inherit configuration.

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/node-types.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/node-types.md
@@ -53,7 +53,7 @@ node_type_keys:
 
     # Optional | Override interface_descriptions templates
     # If description templates use Jinja2, they have to strip whitespaces using {%- -%} on any code blocks
-    interface descriptions:
+    interface_descriptions:
       underlay_ethernet_interfaces: <path to J2 template - default inherited from templates.interface_descriptions.underlay_ethernet_interfaces >
       underlay_port_channel_interfaces: <path to J2 template - default inherited from templates.interface_descriptions.underlay_port_channel_interfaces >
       connected_endpoints_ethernet_interfaces: <path to J2 template - default inherited from templates.interface_descriptions.connected_endpoints_ethernet_interfaces >


### PR DESCRIPTION
## Change Summary

Fix two typos in the eos_designs documentation:
* interface_descriptions variable is spelled incorrectly in node_types.md
* endpoint_ports is required to be defined in connected_endpoints.md

## Related Issue(s)

## Component(s) name

`arista.avd.eos_designs`


## Checklist


### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
