### PR TITLE
Fix(eos_designs): Honor evpn_services_l2_only setting

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/evpn_services_l2_only_false.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/evpn_services_l2_only_false.md
@@ -1,0 +1,1003 @@
+# evpn_services_l2_only_false
+# Table of Contents
+
+- [Management](#management)
+  - [Name Servers](#name-servers)
+  - [NTP](#ntp)
+  - [Management API HTTP](#management-api-http)
+- [Authentication](#authentication)
+  - [Local Users](#local-users)
+- [Monitoring](#monitoring)
+  - [TerminAttr Daemon](#terminattr-daemon)
+  - [SNMP](#snmp)
+- [Internal VLAN Allocation Policy](#internal-vlan-allocation-policy)
+  - [Internal VLAN Allocation Policy Summary](#internal-vlan-allocation-policy-summary)
+  - [Internal VLAN Allocation Policy Configuration](#internal-vlan-allocation-policy-configuration)
+- [VLANs](#vlans)
+  - [VLANs Summary](#vlans-summary)
+  - [VLANs Device Configuration](#vlans-device-configuration)
+- [Interfaces](#interfaces)
+  - [Loopback Interfaces](#loopback-interfaces)
+  - [VLAN Interfaces](#vlan-interfaces)
+  - [VXLAN Interface](#vxlan-interface)
+- [Routing](#routing)
+  - [Service Routing Protocols Model](#service-routing-protocols-model)
+  - [Virtual Router MAC Address](#virtual-router-mac-address)
+  - [IP Routing](#ip-routing)
+  - [IPv6 Routing](#ipv6-routing)
+  - [Static Routes](#static-routes)
+  - [Router BGP](#router-bgp)
+- [BFD](#bfd)
+  - [Router BFD](#router-bfd)
+- [Multicast](#multicast)
+  - [IP IGMP Snooping](#ip-igmp-snooping)
+- [Filters](#filters)
+  - [Prefix-lists](#prefix-lists)
+  - [Route-maps](#route-maps)
+- [ACL](#acl)
+- [VRF Instances](#vrf-instances)
+  - [VRF Instances Summary](#vrf-instances-summary)
+  - [VRF Instances Device Configuration](#vrf-instances-device-configuration)
+- [Virtual Source NAT](#virtual-source-nat)
+  - [Virtual Source NAT Summary](#virtual-source-nat-summary)
+  - [Virtual Source NAT Configuration](#virtual-source-nat-configuration)
+- [Quality Of Service](#quality-of-service)
+
+# Management
+
+## Name Servers
+
+### Name Servers Summary
+
+| Name Server | Source VRF |
+| ----------- | ---------- |
+| 192.168.200.5 | MGMT |
+| 8.8.8.8 | MGMT |
+
+### Name Servers Device Configuration
+
+```eos
+ip name-server vrf MGMT 8.8.8.8
+ip name-server vrf MGMT 192.168.200.5
+```
+
+## NTP
+
+### NTP Summary
+
+#### NTP Local Interface
+
+| Interface | VRF |
+| --------- | --- |
+| Management1 | MGMT |
+
+#### NTP Servers
+
+| Server | VRF | Preferred | Burst | iBurst | Version | Min Poll | Max Poll | Local-interface | Key |
+| ------ | --- | --------- | ----- | ------ | ------- | -------- | -------- | --------------- | --- |
+| 192.168.200.5 | MGMT | True | - | - | - | - | - | - | - |
+
+### NTP Device Configuration
+
+```eos
+!
+ntp local-interface vrf MGMT Management1
+ntp server vrf MGMT 192.168.200.5 prefer
+```
+
+## Management API HTTP
+
+### Management API HTTP Summary
+
+| HTTP | HTTPS |
+| ---------- | ---------- |
+| default | true |
+
+### Management API VRF Access
+
+| VRF Name | IPv4 ACL | IPv6 ACL |
+| -------- | -------- | -------- |
+| MGMT | - | - |
+
+
+### Management API HTTP Configuration
+
+```eos
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+```
+
+# Authentication
+
+## Local Users
+
+### Local Users Summary
+
+| User | Privilege | Role |
+| ---- | --------- | ---- |
+| admin | 15 | network-admin |
+| cvpadmin | 15 | network-admin |
+
+### Local Users Device Configuration
+
+```eos
+!
+username admin privilege 15 role network-admin nopassword
+username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
+```
+
+# Monitoring
+
+## TerminAttr Daemon
+
+### TerminAttr Daemon Summary
+
+| CV Compression | CloudVision Servers | VRF | Authentication | Smash Excludes | Ingest Exclude | Bypass AAA |
+| -------------- | ------------------- | --- | -------------- | -------------- | -------------- | ---------- |
+| gzip | 192.168.200.11:9910 | MGMT | key,telarista | ale,flexCounter,hardware,kni,pulse,strata | /Sysdb/cell/1/agent,/Sysdb/cell/2/agent | False |
+
+### TerminAttr Daemon Device Configuration
+
+```eos
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   no shutdown
+```
+
+## SNMP
+
+### SNMP Configuration Summary
+
+| Contact | Location | SNMP Traps | State |
+| ------- | -------- | ---------- | ----- |
+| example@example.com | DC1_FABRIC evpn_services_l2_only_false | All | Disabled |
+
+### SNMP Device Configuration
+
+```eos
+!
+snmp-server contact example@example.com
+snmp-server location DC1_FABRIC evpn_services_l2_only_false
+```
+
+# Internal VLAN Allocation Policy
+
+## Internal VLAN Allocation Policy Summary
+
+| Policy Allocation | Range Beginning | Range Ending |
+| ------------------| --------------- | ------------ |
+| ascending | 1006 | 1199 |
+
+## Internal VLAN Allocation Policy Configuration
+
+```eos
+!
+vlan internal order ascending range 1006 1199
+```
+
+# VLANs
+
+## VLANs Summary
+
+| VLAN ID | Name | Trunk Groups |
+| ------- | ---- | ------------ |
+| 110 | Tenant_A_OP_Zone_1 | - |
+| 111 | Tenant_A_OP_Zone_2 | - |
+| 120 | Tenant_A_WEB_Zone_1 | - |
+| 121 | Tenant_A_WEBZone_2 | - |
+| 130 | Tenant_A_APP_Zone_1 | - |
+| 131 | Tenant_A_APP_Zone_2 | - |
+| 132 | Tenant_A_APP_Zone_3 | - |
+| 140 | Tenant_A_DB_BZone_1 | - |
+| 141 | Tenant_A_DB_Zone_2 | - |
+| 150 | Tenant_A_WAN_Zone_1 | - |
+| 160 | Tenant_A_VMOTION | - |
+| 161 | Tenant_A_NFS | - |
+| 210 | Tenant_B_OP_Zone_1 | - |
+| 211 | Tenant_B_OP_Zone_2 | - |
+| 250 | Tenant_B_WAN_Zone_1 | - |
+| 310 | Tenant_C_OP_Zone_1 | - |
+| 311 | Tenant_C_OP_Zone_2 | - |
+| 350 | Tenant_C_WAN_Zone_1 | - |
+
+## VLANs Device Configuration
+
+```eos
+!
+vlan 110
+   name Tenant_A_OP_Zone_1
+!
+vlan 111
+   name Tenant_A_OP_Zone_2
+!
+vlan 120
+   name Tenant_A_WEB_Zone_1
+!
+vlan 121
+   name Tenant_A_WEBZone_2
+!
+vlan 130
+   name Tenant_A_APP_Zone_1
+!
+vlan 131
+   name Tenant_A_APP_Zone_2
+!
+vlan 132
+   name Tenant_A_APP_Zone_3
+!
+vlan 140
+   name Tenant_A_DB_BZone_1
+!
+vlan 141
+   name Tenant_A_DB_Zone_2
+!
+vlan 150
+   name Tenant_A_WAN_Zone_1
+!
+vlan 160
+   name Tenant_A_VMOTION
+!
+vlan 161
+   name Tenant_A_NFS
+!
+vlan 210
+   name Tenant_B_OP_Zone_1
+!
+vlan 211
+   name Tenant_B_OP_Zone_2
+!
+vlan 250
+   name Tenant_B_WAN_Zone_1
+!
+vlan 310
+   name Tenant_C_OP_Zone_1
+!
+vlan 311
+   name Tenant_C_OP_Zone_2
+!
+vlan 350
+   name Tenant_C_WAN_Zone_1
+```
+
+# Interfaces
+
+## Loopback Interfaces
+
+### Loopback Interfaces Summary
+
+#### IPv4
+
+| Interface | Description | VRF | IP Address |
+| --------- | ----------- | --- | ---------- |
+| Loopback0 | EVPN_Overlay_Peering | default | 192.168.255.109/32 |
+| Loopback1 | VTEP_VXLAN_Tunnel_Source | default | 192.168.254.109/32 |
+| Loopback100 | Tenant_A_OP_Zone_VTEP_DIAGNOSTICS | Tenant_A_OP_Zone | 10.255.1.109/32 |
+
+#### IPv6
+
+| Interface | Description | VRF | IPv6 Address |
+| --------- | ----------- | --- | ------------ |
+| Loopback0 | EVPN_Overlay_Peering | default | - |
+| Loopback1 | VTEP_VXLAN_Tunnel_Source | default | - |
+| Loopback100 | Tenant_A_OP_Zone_VTEP_DIAGNOSTICS | Tenant_A_OP_Zone | - |
+
+
+### Loopback Interfaces Device Configuration
+
+```eos
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 192.168.255.109/32
+!
+interface Loopback1
+   description VTEP_VXLAN_Tunnel_Source
+   no shutdown
+   ip address 192.168.254.109/32
+!
+interface Loopback100
+   description Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
+   no shutdown
+   vrf Tenant_A_OP_Zone
+   ip address 10.255.1.109/32
+```
+
+## VLAN Interfaces
+
+### VLAN Interfaces Summary
+
+| Interface | Description | VRF |  MTU | Shutdown |
+| --------- | ----------- | --- | ---- | -------- |
+| Vlan110 |  Tenant_A_OP_Zone_1  |  Tenant_A_OP_Zone  |  -  |  false  |
+| Vlan111 |  Tenant_A_OP_Zone_2  |  Tenant_A_OP_Zone  |  -  |  false  |
+| Vlan120 |  Tenant_A_WEB_Zone_1  |  Tenant_A_WEB_Zone  |  -  |  false  |
+| Vlan121 |  Tenant_A_WEBZone_2  |  Tenant_A_WEB_Zone  |  1560  |  true  |
+| Vlan130 |  Tenant_A_APP_Zone_1  |  Tenant_A_APP_Zone  |  -  |  false  |
+| Vlan131 |  Tenant_A_APP_Zone_2  |  Tenant_A_APP_Zone  |  -  |  false  |
+| Vlan132 |  Tenant_A_APP_Zone_3  |  Tenant_A_APP_Zone  |  -  |  false  |
+| Vlan140 |  Tenant_A_DB_BZone_1  |  Tenant_A_DB_Zone  |  -  |  false  |
+| Vlan141 |  Tenant_A_DB_Zone_2  |  Tenant_A_DB_Zone  |  -  |  false  |
+| Vlan150 |  Tenant_A_WAN_Zone_1  |  Tenant_A_WAN_Zone  |  -  |  false  |
+| Vlan210 |  Tenant_B_OP_Zone_1  |  Tenant_B_OP_Zone  |  -  |  false  |
+| Vlan211 |  Tenant_B_OP_Zone_2  |  Tenant_B_OP_Zone  |  -  |  false  |
+| Vlan250 |  Tenant_B_WAN_Zone_1  |  Tenant_B_WAN_Zone  |  -  |  false  |
+| Vlan310 |  Tenant_C_OP_Zone_1  |  Tenant_C_OP_Zone  |  -  |  false  |
+| Vlan311 |  Tenant_C_OP_Zone_2  |  Tenant_C_OP_Zone  |  -  |  false  |
+| Vlan350 |  Tenant_C_WAN_Zone_1  |  Tenant_C_WAN_Zone  |  -  |  false  |
+
+#### IPv4
+
+| Interface | VRF | IP Address | IP Address Virtual | IP Router Virtual Address | VRRP | ACL In | ACL Out |
+| --------- | --- | ---------- | ------------------ | ------------------------- | ---- | ------ | ------- |
+| Vlan110 |  Tenant_A_OP_Zone  |  -  |  10.1.10.1/24  |  -  |  -  |  -  |  -  |
+| Vlan111 |  Tenant_A_OP_Zone  |  -  |  10.1.11.1/24  |  -  |  -  |  -  |  -  |
+| Vlan120 |  Tenant_A_WEB_Zone  |  -  |  10.1.20.1/24  |  -  |  -  |  -  |  -  |
+| Vlan121 |  Tenant_A_WEB_Zone  |  -  |  10.1.10.254/24  |  -  |  -  |  -  |  -  |
+| Vlan130 |  Tenant_A_APP_Zone  |  -  |  10.1.30.1/24  |  -  |  -  |  -  |  -  |
+| Vlan131 |  Tenant_A_APP_Zone  |  -  |  10.1.31.1/24  |  -  |  -  |  -  |  -  |
+| Vlan132 |  Tenant_A_APP_Zone  |  -  |  -  |  10.1.32.254, 10.2.32.254/24, 10.3.32.254/24  |  -  |  -  |  -  |
+| Vlan140 |  Tenant_A_DB_Zone  |  -  |  10.1.40.1/24  |  -  |  -  |  -  |  -  |
+| Vlan141 |  Tenant_A_DB_Zone  |  -  |  10.1.41.1/24  |  -  |  -  |  -  |  -  |
+| Vlan150 |  Tenant_A_WAN_Zone  |  -  |  10.1.40.1/24  |  -  |  -  |  -  |  -  |
+| Vlan210 |  Tenant_B_OP_Zone  |  -  |  10.2.10.1/24  |  -  |  -  |  -  |  -  |
+| Vlan211 |  Tenant_B_OP_Zone  |  -  |  10.2.11.1/24  |  -  |  -  |  -  |  -  |
+| Vlan250 |  Tenant_B_WAN_Zone  |  -  |  10.2.50.1/24  |  -  |  -  |  -  |  -  |
+| Vlan310 |  Tenant_C_OP_Zone  |  -  |  10.3.10.1/24  |  -  |  -  |  -  |  -  |
+| Vlan311 |  Tenant_C_OP_Zone  |  -  |  10.3.11.1/24  |  -  |  -  |  -  |  -  |
+| Vlan350 |  Tenant_C_WAN_Zone  |  -  |  10.3.50.1/24  |  -  |  -  |  -  |  -  |
+
+
+### VLAN Interfaces Device Configuration
+
+```eos
+!
+interface Vlan110
+   description Tenant_A_OP_Zone_1
+   no shutdown
+   vrf Tenant_A_OP_Zone
+   ip address virtual 10.1.10.1/24
+!
+interface Vlan111
+   description Tenant_A_OP_Zone_2
+   no shutdown
+   vrf Tenant_A_OP_Zone
+   ip address virtual 10.1.11.1/24
+   ip helper-address 1.1.1.1 vrf MGMT source-interface lo100
+!
+interface Vlan120
+   description Tenant_A_WEB_Zone_1
+   no shutdown
+   vrf Tenant_A_WEB_Zone
+   ip address virtual 10.1.20.1/24
+   ip address virtual 10.2.20.1/24 secondary
+   ip address virtual 10.2.21.1/24 secondary
+   ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+!
+interface Vlan121
+   description Tenant_A_WEBZone_2
+   shutdown
+   mtu 1560
+   vrf Tenant_A_WEB_Zone
+   ip address virtual 10.1.10.254/24
+!
+interface Vlan130
+   description Tenant_A_APP_Zone_1
+   no shutdown
+   vrf Tenant_A_APP_Zone
+   ip address virtual 10.1.30.1/24
+!
+interface Vlan131
+   description Tenant_A_APP_Zone_2
+   no shutdown
+   vrf Tenant_A_APP_Zone
+   ip address virtual 10.1.31.1/24
+!
+interface Vlan132
+   description Tenant_A_APP_Zone_3
+   no shutdown
+   vrf Tenant_A_APP_Zone
+   ip virtual-router address 10.1.32.254
+   ip virtual-router address 10.2.32.254/24
+   ip virtual-router address 10.3.32.254/24
+!
+interface Vlan140
+   description Tenant_A_DB_BZone_1
+   no shutdown
+   vrf Tenant_A_DB_Zone
+   ip address virtual 10.1.40.1/24
+!
+interface Vlan141
+   description Tenant_A_DB_Zone_2
+   no shutdown
+   vrf Tenant_A_DB_Zone
+   ip address virtual 10.1.41.1/24
+!
+interface Vlan150
+   description Tenant_A_WAN_Zone_1
+   no shutdown
+   vrf Tenant_A_WAN_Zone
+   ip address virtual 10.1.40.1/24
+!
+interface Vlan210
+   description Tenant_B_OP_Zone_1
+   no shutdown
+   vrf Tenant_B_OP_Zone
+   ip address virtual 10.2.10.1/24
+!
+interface Vlan211
+   description Tenant_B_OP_Zone_2
+   no shutdown
+   vrf Tenant_B_OP_Zone
+   ip address virtual 10.2.11.1/24
+!
+interface Vlan250
+   description Tenant_B_WAN_Zone_1
+   no shutdown
+   vrf Tenant_B_WAN_Zone
+   ip address virtual 10.2.50.1/24
+!
+interface Vlan310
+   description Tenant_C_OP_Zone_1
+   no shutdown
+   vrf Tenant_C_OP_Zone
+   ip address virtual 10.3.10.1/24
+!
+interface Vlan311
+   description Tenant_C_OP_Zone_2
+   no shutdown
+   vrf Tenant_C_OP_Zone
+   ip address virtual 10.3.11.1/24
+!
+interface Vlan350
+   description Tenant_C_WAN_Zone_1
+   no shutdown
+   vrf Tenant_C_WAN_Zone
+   ip address virtual 10.3.50.1/24
+```
+
+## VXLAN Interface
+
+### VXLAN Interface Summary
+
+#### Source Interface: Loopback1
+
+#### UDP port: 4789
+
+#### VLAN to VNI, Flood List and Multicast Group Mappings
+
+| VLAN | VNI | Flood List | Multicast Group |
+| ---- | --- | ---------- | --------------- |
+| 110 | 10110 | - | - |
+| 111 | 50111 | - | - |
+| 120 | 10120 | - | - |
+| 121 | 10121 | - | - |
+| 130 | 10130 | - | - |
+| 131 | 10131 | - | - |
+| 132 | 10132 | - | - |
+| 140 | 10140 | - | - |
+| 141 | 10141 | - | - |
+| 150 | 10150 | - | - |
+| 160 | 10160 | - | - |
+| 161 | 10161 | - | - |
+| 210 | 20210 | - | - |
+| 211 | 20211 | - | - |
+| 250 | 20250 | - | - |
+| 310 | 30310 | - | - |
+| 311 | 30311 | - | - |
+| 350 | 30350 | - | - |
+
+#### VRF to VNI and Multicast Group Mappings
+
+| VRF | VNI | Multicast Group |
+| ---- | --- | --------------- |
+| Tenant_A_APP_Zone | 12 | - |
+| Tenant_A_DB_Zone | 13 | - |
+| Tenant_A_OP_Zone | 10 | - |
+| Tenant_A_WAN_Zone | 14 | - |
+| Tenant_A_WEB_Zone | 11 | - |
+| Tenant_B_OP_Zone | 20 | - |
+| Tenant_B_WAN_Zone | 21 | - |
+| Tenant_C_OP_Zone | 30 | - |
+| Tenant_C_WAN_Zone | 31 | - |
+
+### VXLAN Interface Device Configuration
+
+```eos
+!
+interface Vxlan1
+   description evpn_services_l2_only_false_VTEP
+   vxlan source-interface Loopback1
+   vxlan udp-port 4789
+   vxlan vlan 110 vni 10110
+   vxlan vlan 111 vni 50111
+   vxlan vlan 120 vni 10120
+   vxlan vlan 121 vni 10121
+   vxlan vlan 130 vni 10130
+   vxlan vlan 131 vni 10131
+   vxlan vlan 132 vni 10132
+   vxlan vlan 140 vni 10140
+   vxlan vlan 141 vni 10141
+   vxlan vlan 150 vni 10150
+   vxlan vlan 160 vni 10160
+   vxlan vlan 161 vni 10161
+   vxlan vlan 210 vni 20210
+   vxlan vlan 211 vni 20211
+   vxlan vlan 250 vni 20250
+   vxlan vlan 310 vni 30310
+   vxlan vlan 311 vni 30311
+   vxlan vlan 350 vni 30350
+   vxlan vrf Tenant_A_APP_Zone vni 12
+   vxlan vrf Tenant_A_DB_Zone vni 13
+   vxlan vrf Tenant_A_OP_Zone vni 10
+   vxlan vrf Tenant_A_WAN_Zone vni 14
+   vxlan vrf Tenant_A_WEB_Zone vni 11
+   vxlan vrf Tenant_B_OP_Zone vni 20
+   vxlan vrf Tenant_B_WAN_Zone vni 21
+   vxlan vrf Tenant_C_OP_Zone vni 30
+   vxlan vrf Tenant_C_WAN_Zone vni 31
+```
+
+# Routing
+## Service Routing Protocols Model
+
+Multi agent routing protocol model enabled
+
+```eos
+!
+service routing protocols model multi-agent
+```
+
+## Virtual Router MAC Address
+
+### Virtual Router MAC Address Summary
+
+#### Virtual Router MAC Address: 00:dc:00:00:00:0a
+
+### Virtual Router MAC Address Configuration
+
+```eos
+!
+ip virtual-router mac-address 00:dc:00:00:00:0a
+```
+
+## IP Routing
+
+### IP Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | true|| MGMT | false |
+| Tenant_A_APP_Zone | true |
+| Tenant_A_DB_Zone | true |
+| Tenant_A_OP_Zone | true |
+| Tenant_A_WAN_Zone | true |
+| Tenant_A_WEB_Zone | true |
+| Tenant_B_OP_Zone | true |
+| Tenant_B_WAN_Zone | true |
+| Tenant_C_OP_Zone | true |
+| Tenant_C_WAN_Zone | true |
+
+### IP Routing Device Configuration
+
+```eos
+!
+ip routing
+no ip routing vrf MGMT
+ip routing vrf Tenant_A_APP_Zone
+ip routing vrf Tenant_A_DB_Zone
+ip routing vrf Tenant_A_OP_Zone
+ip routing vrf Tenant_A_WAN_Zone
+ip routing vrf Tenant_A_WEB_Zone
+ip routing vrf Tenant_B_OP_Zone
+ip routing vrf Tenant_B_WAN_Zone
+ip routing vrf Tenant_C_OP_Zone
+ip routing vrf Tenant_C_WAN_Zone
+```
+## IPv6 Routing
+
+### IPv6 Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | false || MGMT | false |
+| Tenant_A_APP_Zone | false |
+| Tenant_A_DB_Zone | false |
+| Tenant_A_OP_Zone | false |
+| Tenant_A_WAN_Zone | false |
+| Tenant_A_WEB_Zone | false |
+| Tenant_B_OP_Zone | false |
+| Tenant_B_WAN_Zone | false |
+| Tenant_C_OP_Zone | false |
+| Tenant_C_WAN_Zone | false |
+
+
+## Static Routes
+
+### Static Routes Summary
+
+| VRF | Destination Prefix | Next Hop IP             | Exit interface      | Administrative Distance       | Tag               | Route Name                    | Metric         |
+| --- | ------------------ | ----------------------- | ------------------- | ----------------------------- | ----------------- | ----------------------------- | -------------- |
+| MGMT  | 0.0.0.0/0 |  192.168.200.5  |  -  |  1  |  -  |  -  |  - |
+| Tenant_A_APP_Zone  | 10.2.32.0/24 |  -  |  Vlan132  |  1  |  -  |  VARP  |  - |
+| Tenant_A_APP_Zone  | 10.3.32.0/24 |  -  |  Vlan132  |  1  |  -  |  VARP  |  - |
+
+### Static Routes Device Configuration
+
+```eos
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.200.5
+ip route vrf Tenant_A_APP_Zone 10.2.32.0/24 Vlan132 name VARP
+ip route vrf Tenant_A_APP_Zone 10.3.32.0/24 Vlan132 name VARP
+```
+
+## Router BGP
+
+### Router BGP Summary
+
+| BGP AS | Router ID |
+| ------ | --------- |
+| 101|  192.168.255.109 |
+
+| BGP Tuning |
+| ---------- |
+| maximum-paths 4 ecmp 4 |
+
+### Router BGP Peer Groups
+
+#### EVPN-OVERLAY-PEERS
+
+| Settings | Value |
+| -------- | ----- |
+| Address Family | evpn |
+| Source | Loopback0 |
+| Bfd | true |
+| Ebgp multihop | 3 |
+| Send community | all |
+| Maximum routes | 0 (no limit) |
+
+#### UNDERLAY-PEERS
+
+| Settings | Value |
+| -------- | ----- |
+| Address Family | ipv4 |
+| Send community | all |
+| Maximum routes | 12000 |
+
+### Router BGP EVPN Address Family
+
+#### Router BGP EVPN MAC-VRFs
+
+##### VLAN aware bundles
+
+| VLAN Aware Bundle | Route-Distinguisher | Both Route-Target | Import Route Target | Export Route-Target | Redistribute | VLANs |
+| ----------------- | ------------------- | ----------------- | ------------------- | ------------------- | ------------ | ----- |
+| Tenant_A_APP_Zone | 192.168.255.109:12 | 12:12 | - | - | learned | 130-132 |
+| Tenant_A_DB_Zone | 192.168.255.109:13 | 13:13 | - | - | learned | 140-141 |
+| Tenant_A_NFS | 192.168.255.109:10161 | 10161:10161 | - | - | learned | 161 |
+| Tenant_A_OP_Zone | 192.168.255.109:10 | 10:10 | - | - | learned | 110-111 |
+| Tenant_A_VMOTION | 192.168.255.109:10160 | 10160:10160 | - | - | learned | 160 |
+| Tenant_A_WAN_Zone | 192.168.255.109:14 | 14:14 | - | - | learned | 150 |
+| Tenant_A_WEB_Zone | 192.168.255.109:11 | 11:11 | - | - | learned | 120-121 |
+| Tenant_B_OP_Zone | 192.168.255.109:20 | 20:20 | - | - | learned | 210-211 |
+| Tenant_B_WAN_Zone | 192.168.255.109:21 | 21:21 | - | - | learned | 250 |
+| Tenant_C_OP_Zone | 192.168.255.109:30 | 30:30 | - | - | learned | 310-311 |
+| Tenant_C_WAN_Zone | 192.168.255.109:31 | 31:31 | - | - | learned | 350 |
+
+#### Router BGP EVPN VRFs
+
+| VRF | Route-Distinguisher | Redistribute |
+| --- | ------------------- | ------------ |
+| Tenant_A_APP_Zone | 192.168.255.109:12 | connected |
+| Tenant_A_DB_Zone | 192.168.255.109:13 | connected |
+| Tenant_A_OP_Zone | 192.168.255.109:10 | connected |
+| Tenant_A_WAN_Zone | 192.168.255.109:14 | connected |
+| Tenant_A_WEB_Zone | 192.168.255.109:11 | connected |
+| Tenant_B_OP_Zone | 192.168.255.109:20 | connected |
+| Tenant_B_WAN_Zone | 192.168.255.109:21 | connected |
+| Tenant_C_OP_Zone | 192.168.255.109:30 | connected |
+| Tenant_C_WAN_Zone | 192.168.255.109:31 | connected |
+
+### Router BGP Device Configuration
+
+```eos
+!
+router bgp 101
+   router-id 192.168.255.109
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor UNDERLAY-PEERS peer group
+   neighbor UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor UNDERLAY-PEERS send-community
+   neighbor UNDERLAY-PEERS maximum-routes 12000
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   vlan-aware-bundle Tenant_A_APP_Zone
+      rd 192.168.255.109:12
+      route-target both 12:12
+      redistribute learned
+      vlan 130-132
+   !
+   vlan-aware-bundle Tenant_A_DB_Zone
+      rd 192.168.255.109:13
+      route-target both 13:13
+      redistribute learned
+      vlan 140-141
+   !
+   vlan-aware-bundle Tenant_A_NFS
+      rd 192.168.255.109:10161
+      route-target both 10161:10161
+      redistribute learned
+      vlan 161
+   !
+   vlan-aware-bundle Tenant_A_OP_Zone
+      rd 192.168.255.109:10
+      route-target both 10:10
+      redistribute learned
+      vlan 110-111
+   !
+   vlan-aware-bundle Tenant_A_VMOTION
+      rd 192.168.255.109:10160
+      route-target both 10160:10160
+      redistribute learned
+      vlan 160
+   !
+   vlan-aware-bundle Tenant_A_WAN_Zone
+      rd 192.168.255.109:14
+      route-target both 14:14
+      redistribute learned
+      vlan 150
+   !
+   vlan-aware-bundle Tenant_A_WEB_Zone
+      rd 192.168.255.109:11
+      route-target both 11:11
+      redistribute learned
+      vlan 120-121
+   !
+   vlan-aware-bundle Tenant_B_OP_Zone
+      rd 192.168.255.109:20
+      route-target both 20:20
+      redistribute learned
+      vlan 210-211
+   !
+   vlan-aware-bundle Tenant_B_WAN_Zone
+      rd 192.168.255.109:21
+      route-target both 21:21
+      redistribute learned
+      vlan 250
+   !
+   vlan-aware-bundle Tenant_C_OP_Zone
+      rd 192.168.255.109:30
+      route-target both 30:30
+      redistribute learned
+      vlan 310-311
+   !
+   vlan-aware-bundle Tenant_C_WAN_Zone
+      rd 192.168.255.109:31
+      route-target both 31:31
+      redistribute learned
+      vlan 350
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor UNDERLAY-PEERS activate
+   !
+   vrf Tenant_A_APP_Zone
+      rd 192.168.255.109:12
+      route-target import evpn 12:12
+      route-target export evpn 12:12
+      router-id 192.168.255.109
+      redistribute connected
+   !
+   vrf Tenant_A_DB_Zone
+      rd 192.168.255.109:13
+      route-target import evpn 13:13
+      route-target export evpn 13:13
+      router-id 192.168.255.109
+      redistribute connected
+   !
+   vrf Tenant_A_OP_Zone
+      rd 192.168.255.109:10
+      route-target import evpn 10:10
+      route-target export evpn 10:10
+      router-id 192.168.255.109
+      redistribute connected
+   !
+   vrf Tenant_A_WAN_Zone
+      rd 192.168.255.109:14
+      route-target import evpn 14:14
+      route-target import evpn 65000:456
+      route-target export evpn 14:14
+      route-target export evpn 65000:789
+      router-id 192.168.255.109
+      redistribute connected
+   !
+   vrf Tenant_A_WEB_Zone
+      rd 192.168.255.109:11
+      route-target import evpn 11:11
+      route-target export evpn 11:11
+      router-id 192.168.255.109
+      redistribute connected
+   !
+   vrf Tenant_B_OP_Zone
+      rd 192.168.255.109:20
+      route-target import evpn 20:20
+      route-target export evpn 20:20
+      router-id 192.168.255.109
+      redistribute connected
+   !
+   vrf Tenant_B_WAN_Zone
+      rd 192.168.255.109:21
+      route-target import evpn 21:21
+      route-target export evpn 21:21
+      router-id 192.168.255.109
+      redistribute connected
+   !
+   vrf Tenant_C_OP_Zone
+      rd 192.168.255.109:30
+      route-target import evpn 30:30
+      route-target export evpn 30:30
+      router-id 192.168.255.109
+      redistribute connected
+   !
+   vrf Tenant_C_WAN_Zone
+      rd 192.168.255.109:31
+      route-target import evpn 31:31
+      route-target export evpn 31:31
+      router-id 192.168.255.109
+      redistribute connected
+```
+
+# BFD
+
+## Router BFD
+
+### Router BFD Multihop Summary
+
+| Interval | Minimum RX | Multiplier |
+| -------- | ---------- | ---------- |
+| 1200 | 1200 | 3 |
+
+### Router BFD Device Configuration
+
+```eos
+!
+router bfd
+   multihop interval 1200 min-rx 1200 multiplier 3
+```
+
+# Multicast
+
+## IP IGMP Snooping
+
+### IP IGMP Snooping Summary
+
+IGMP snooping is globally enabled.
+
+
+| VLAN | IGMP Snooping |
+| --- | --------------- |
+| 120 | disabled |
+
+### IP IGMP Snooping Device Configuration
+
+```eos
+!
+no ip igmp snooping vlan 120
+```
+
+# Filters
+
+## Prefix-lists
+
+### Prefix-lists Summary
+
+#### PL-LOOPBACKS-EVPN-OVERLAY
+
+| Sequence | Action |
+| -------- | ------ |
+| 10 | permit 192.168.255.0/24 eq 32 |
+| 20 | permit 192.168.254.0/24 eq 32 |
+
+### Prefix-lists Device Configuration
+
+```eos
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+   seq 20 permit 192.168.254.0/24 eq 32
+```
+
+## Route-maps
+
+### Route-maps Summary
+
+#### RM-CONN-2-BGP
+
+| Sequence | Type | Match and/or Set |
+| -------- | ---- | ---------------- |
+| 10 | permit | match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY |
+
+### Route-maps Device Configuration
+
+```eos
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+```
+
+# ACL
+
+# VRF Instances
+
+## VRF Instances Summary
+
+| VRF Name | IP Routing |
+| -------- | ---------- |
+| MGMT | disabled |
+| Tenant_A_APP_Zone | enabled |
+| Tenant_A_DB_Zone | enabled |
+| Tenant_A_OP_Zone | enabled |
+| Tenant_A_WAN_Zone | enabled |
+| Tenant_A_WEB_Zone | enabled |
+| Tenant_B_OP_Zone | enabled |
+| Tenant_B_WAN_Zone | enabled |
+| Tenant_C_OP_Zone | enabled |
+| Tenant_C_WAN_Zone | enabled |
+
+## VRF Instances Device Configuration
+
+```eos
+!
+vrf instance MGMT
+!
+vrf instance Tenant_A_APP_Zone
+!
+vrf instance Tenant_A_DB_Zone
+!
+vrf instance Tenant_A_OP_Zone
+!
+vrf instance Tenant_A_WAN_Zone
+!
+vrf instance Tenant_A_WEB_Zone
+!
+vrf instance Tenant_B_OP_Zone
+!
+vrf instance Tenant_B_WAN_Zone
+!
+vrf instance Tenant_C_OP_Zone
+!
+vrf instance Tenant_C_WAN_Zone
+```
+
+# Virtual Source NAT
+
+## Virtual Source NAT Summary
+
+| Source NAT VRF | Source NAT IP Address |
+| -------------- | --------------------- |
+| Tenant_A_OP_Zone | 10.255.1.109 |
+
+## Virtual Source NAT Configuration
+
+```eos
+!
+ip address virtual source-nat vrf Tenant_A_OP_Zone address 10.255.1.109
+```
+
+# Quality Of Service

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/evpn_services_l2_only_true.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/evpn_services_l2_only_true.md
@@ -1,0 +1,669 @@
+# evpn_services_l2_only_true
+# Table of Contents
+
+- [Management](#management)
+  - [Name Servers](#name-servers)
+  - [NTP](#ntp)
+  - [Management API HTTP](#management-api-http)
+- [Authentication](#authentication)
+  - [Local Users](#local-users)
+- [Monitoring](#monitoring)
+  - [TerminAttr Daemon](#terminattr-daemon)
+  - [SNMP](#snmp)
+- [Internal VLAN Allocation Policy](#internal-vlan-allocation-policy)
+  - [Internal VLAN Allocation Policy Summary](#internal-vlan-allocation-policy-summary)
+  - [Internal VLAN Allocation Policy Configuration](#internal-vlan-allocation-policy-configuration)
+- [VLANs](#vlans)
+  - [VLANs Summary](#vlans-summary)
+  - [VLANs Device Configuration](#vlans-device-configuration)
+- [Interfaces](#interfaces)
+  - [Loopback Interfaces](#loopback-interfaces)
+  - [VXLAN Interface](#vxlan-interface)
+- [Routing](#routing)
+  - [Service Routing Protocols Model](#service-routing-protocols-model)
+  - [IP Routing](#ip-routing)
+  - [IPv6 Routing](#ipv6-routing)
+  - [Static Routes](#static-routes)
+  - [Router BGP](#router-bgp)
+- [BFD](#bfd)
+  - [Router BFD](#router-bfd)
+- [Multicast](#multicast)
+  - [IP IGMP Snooping](#ip-igmp-snooping)
+- [Filters](#filters)
+  - [Prefix-lists](#prefix-lists)
+  - [Route-maps](#route-maps)
+- [ACL](#acl)
+- [VRF Instances](#vrf-instances)
+  - [VRF Instances Summary](#vrf-instances-summary)
+  - [VRF Instances Device Configuration](#vrf-instances-device-configuration)
+- [Virtual Source NAT](#virtual-source-nat)
+  - [Virtual Source NAT Summary](#virtual-source-nat-summary)
+  - [Virtual Source NAT Configuration](#virtual-source-nat-configuration)
+- [Quality Of Service](#quality-of-service)
+
+# Management
+
+## Name Servers
+
+### Name Servers Summary
+
+| Name Server | Source VRF |
+| ----------- | ---------- |
+| 192.168.200.5 | MGMT |
+| 8.8.8.8 | MGMT |
+
+### Name Servers Device Configuration
+
+```eos
+ip name-server vrf MGMT 8.8.8.8
+ip name-server vrf MGMT 192.168.200.5
+```
+
+## NTP
+
+### NTP Summary
+
+#### NTP Local Interface
+
+| Interface | VRF |
+| --------- | --- |
+| Management1 | MGMT |
+
+#### NTP Servers
+
+| Server | VRF | Preferred | Burst | iBurst | Version | Min Poll | Max Poll | Local-interface | Key |
+| ------ | --- | --------- | ----- | ------ | ------- | -------- | -------- | --------------- | --- |
+| 192.168.200.5 | MGMT | True | - | - | - | - | - | - | - |
+
+### NTP Device Configuration
+
+```eos
+!
+ntp local-interface vrf MGMT Management1
+ntp server vrf MGMT 192.168.200.5 prefer
+```
+
+## Management API HTTP
+
+### Management API HTTP Summary
+
+| HTTP | HTTPS |
+| ---------- | ---------- |
+| default | true |
+
+### Management API VRF Access
+
+| VRF Name | IPv4 ACL | IPv6 ACL |
+| -------- | -------- | -------- |
+| MGMT | - | - |
+
+
+### Management API HTTP Configuration
+
+```eos
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+```
+
+# Authentication
+
+## Local Users
+
+### Local Users Summary
+
+| User | Privilege | Role |
+| ---- | --------- | ---- |
+| admin | 15 | network-admin |
+| cvpadmin | 15 | network-admin |
+
+### Local Users Device Configuration
+
+```eos
+!
+username admin privilege 15 role network-admin nopassword
+username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
+```
+
+# Monitoring
+
+## TerminAttr Daemon
+
+### TerminAttr Daemon Summary
+
+| CV Compression | CloudVision Servers | VRF | Authentication | Smash Excludes | Ingest Exclude | Bypass AAA |
+| -------------- | ------------------- | --- | -------------- | -------------- | -------------- | ---------- |
+| gzip | 192.168.200.11:9910 | MGMT | key,telarista | ale,flexCounter,hardware,kni,pulse,strata | /Sysdb/cell/1/agent,/Sysdb/cell/2/agent | False |
+
+### TerminAttr Daemon Device Configuration
+
+```eos
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   no shutdown
+```
+
+## SNMP
+
+### SNMP Configuration Summary
+
+| Contact | Location | SNMP Traps | State |
+| ------- | -------- | ---------- | ----- |
+| example@example.com | DC1_FABRIC evpn_services_l2_only_true | All | Disabled |
+
+### SNMP Device Configuration
+
+```eos
+!
+snmp-server contact example@example.com
+snmp-server location DC1_FABRIC evpn_services_l2_only_true
+```
+
+# Internal VLAN Allocation Policy
+
+## Internal VLAN Allocation Policy Summary
+
+| Policy Allocation | Range Beginning | Range Ending |
+| ------------------| --------------- | ------------ |
+| ascending | 1006 | 1199 |
+
+## Internal VLAN Allocation Policy Configuration
+
+```eos
+!
+vlan internal order ascending range 1006 1199
+```
+
+# VLANs
+
+## VLANs Summary
+
+| VLAN ID | Name | Trunk Groups |
+| ------- | ---- | ------------ |
+| 110 | Tenant_A_OP_Zone_1 | - |
+| 111 | Tenant_A_OP_Zone_2 | - |
+| 120 | Tenant_A_WEB_Zone_1 | - |
+| 121 | Tenant_A_WEBZone_2 | - |
+| 130 | Tenant_A_APP_Zone_1 | - |
+| 131 | Tenant_A_APP_Zone_2 | - |
+| 132 | Tenant_A_APP_Zone_3 | - |
+| 140 | Tenant_A_DB_BZone_1 | - |
+| 141 | Tenant_A_DB_Zone_2 | - |
+| 150 | Tenant_A_WAN_Zone_1 | - |
+| 160 | Tenant_A_VMOTION | - |
+| 161 | Tenant_A_NFS | - |
+| 210 | Tenant_B_OP_Zone_1 | - |
+| 211 | Tenant_B_OP_Zone_2 | - |
+| 250 | Tenant_B_WAN_Zone_1 | - |
+| 310 | Tenant_C_OP_Zone_1 | - |
+| 311 | Tenant_C_OP_Zone_2 | - |
+| 350 | Tenant_C_WAN_Zone_1 | - |
+
+## VLANs Device Configuration
+
+```eos
+!
+vlan 110
+   name Tenant_A_OP_Zone_1
+!
+vlan 111
+   name Tenant_A_OP_Zone_2
+!
+vlan 120
+   name Tenant_A_WEB_Zone_1
+!
+vlan 121
+   name Tenant_A_WEBZone_2
+!
+vlan 130
+   name Tenant_A_APP_Zone_1
+!
+vlan 131
+   name Tenant_A_APP_Zone_2
+!
+vlan 132
+   name Tenant_A_APP_Zone_3
+!
+vlan 140
+   name Tenant_A_DB_BZone_1
+!
+vlan 141
+   name Tenant_A_DB_Zone_2
+!
+vlan 150
+   name Tenant_A_WAN_Zone_1
+!
+vlan 160
+   name Tenant_A_VMOTION
+!
+vlan 161
+   name Tenant_A_NFS
+!
+vlan 210
+   name Tenant_B_OP_Zone_1
+!
+vlan 211
+   name Tenant_B_OP_Zone_2
+!
+vlan 250
+   name Tenant_B_WAN_Zone_1
+!
+vlan 310
+   name Tenant_C_OP_Zone_1
+!
+vlan 311
+   name Tenant_C_OP_Zone_2
+!
+vlan 350
+   name Tenant_C_WAN_Zone_1
+```
+
+# Interfaces
+
+## Loopback Interfaces
+
+### Loopback Interfaces Summary
+
+#### IPv4
+
+| Interface | Description | VRF | IP Address |
+| --------- | ----------- | --- | ---------- |
+| Loopback0 | EVPN_Overlay_Peering | default | 192.168.255.109/32 |
+| Loopback1 | VTEP_VXLAN_Tunnel_Source | default | 192.168.254.109/32 |
+
+#### IPv6
+
+| Interface | Description | VRF | IPv6 Address |
+| --------- | ----------- | --- | ------------ |
+| Loopback0 | EVPN_Overlay_Peering | default | - |
+| Loopback1 | VTEP_VXLAN_Tunnel_Source | default | - |
+
+
+### Loopback Interfaces Device Configuration
+
+```eos
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 192.168.255.109/32
+!
+interface Loopback1
+   description VTEP_VXLAN_Tunnel_Source
+   no shutdown
+   ip address 192.168.254.109/32
+```
+
+## VXLAN Interface
+
+### VXLAN Interface Summary
+
+#### Source Interface: Loopback1
+
+#### UDP port: 4789
+
+#### VLAN to VNI, Flood List and Multicast Group Mappings
+
+| VLAN | VNI | Flood List | Multicast Group |
+| ---- | --- | ---------- | --------------- |
+| 110 | 10110 | - | - |
+| 111 | 50111 | - | - |
+| 120 | 10120 | - | - |
+| 121 | 10121 | - | - |
+| 130 | 10130 | - | - |
+| 131 | 10131 | - | - |
+| 132 | 10132 | - | - |
+| 140 | 10140 | - | - |
+| 141 | 10141 | - | - |
+| 150 | 10150 | - | - |
+| 160 | 10160 | - | - |
+| 161 | 10161 | - | - |
+| 210 | 20210 | - | - |
+| 211 | 20211 | - | - |
+| 250 | 20250 | - | - |
+| 310 | 30310 | - | - |
+| 311 | 30311 | - | - |
+| 350 | 30350 | - | - |
+
+### VXLAN Interface Device Configuration
+
+```eos
+!
+interface Vxlan1
+   description evpn_services_l2_only_true_VTEP
+   vxlan source-interface Loopback1
+   vxlan udp-port 4789
+   vxlan vlan 110 vni 10110
+   vxlan vlan 111 vni 50111
+   vxlan vlan 120 vni 10120
+   vxlan vlan 121 vni 10121
+   vxlan vlan 130 vni 10130
+   vxlan vlan 131 vni 10131
+   vxlan vlan 132 vni 10132
+   vxlan vlan 140 vni 10140
+   vxlan vlan 141 vni 10141
+   vxlan vlan 150 vni 10150
+   vxlan vlan 160 vni 10160
+   vxlan vlan 161 vni 10161
+   vxlan vlan 210 vni 20210
+   vxlan vlan 211 vni 20211
+   vxlan vlan 250 vni 20250
+   vxlan vlan 310 vni 30310
+   vxlan vlan 311 vni 30311
+   vxlan vlan 350 vni 30350
+```
+
+# Routing
+## Service Routing Protocols Model
+
+Multi agent routing protocol model enabled
+
+```eos
+!
+service routing protocols model multi-agent
+```
+
+## IP Routing
+
+### IP Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | true|| MGMT | false |
+
+### IP Routing Device Configuration
+
+```eos
+!
+ip routing
+no ip routing vrf MGMT
+```
+## IPv6 Routing
+
+### IPv6 Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | false || MGMT | false |
+
+
+## Static Routes
+
+### Static Routes Summary
+
+| VRF | Destination Prefix | Next Hop IP             | Exit interface      | Administrative Distance       | Tag               | Route Name                    | Metric         |
+| --- | ------------------ | ----------------------- | ------------------- | ----------------------------- | ----------------- | ----------------------------- | -------------- |
+| MGMT  | 0.0.0.0/0 |  192.168.200.5  |  -  |  1  |  -  |  -  |  - |
+
+### Static Routes Device Configuration
+
+```eos
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.200.5
+```
+
+## Router BGP
+
+### Router BGP Summary
+
+| BGP AS | Router ID |
+| ------ | --------- |
+| 101|  192.168.255.109 |
+
+| BGP Tuning |
+| ---------- |
+| maximum-paths 4 ecmp 4 |
+
+### Router BGP Peer Groups
+
+#### EVPN-OVERLAY-PEERS
+
+| Settings | Value |
+| -------- | ----- |
+| Address Family | evpn |
+| Source | Loopback0 |
+| Bfd | true |
+| Ebgp multihop | 3 |
+| Send community | all |
+| Maximum routes | 0 (no limit) |
+
+#### UNDERLAY-PEERS
+
+| Settings | Value |
+| -------- | ----- |
+| Address Family | ipv4 |
+| Send community | all |
+| Maximum routes | 12000 |
+
+### Router BGP EVPN Address Family
+
+#### Router BGP EVPN MAC-VRFs
+
+##### VLAN aware bundles
+
+| VLAN Aware Bundle | Route-Distinguisher | Both Route-Target | Import Route Target | Export Route-Target | Redistribute | VLANs |
+| ----------------- | ------------------- | ----------------- | ------------------- | ------------------- | ------------ | ----- |
+| Tenant_A_APP_Zone | 192.168.255.109:12 | 12:12 | - | - | learned | 130-132 |
+| Tenant_A_DB_Zone | 192.168.255.109:13 | 13:13 | - | - | learned | 140-141 |
+| Tenant_A_NFS | 192.168.255.109:10161 | 10161:10161 | - | - | learned | 161 |
+| Tenant_A_OP_Zone | 192.168.255.109:10 | 10:10 | - | - | learned | 110-111 |
+| Tenant_A_VMOTION | 192.168.255.109:10160 | 10160:10160 | - | - | learned | 160 |
+| Tenant_A_WAN_Zone | 192.168.255.109:14 | 14:14 | - | - | learned | 150 |
+| Tenant_A_WEB_Zone | 192.168.255.109:11 | 11:11 | - | - | learned | 120-121 |
+| Tenant_B_OP_Zone | 192.168.255.109:20 | 20:20 | - | - | learned | 210-211 |
+| Tenant_B_WAN_Zone | 192.168.255.109:21 | 21:21 | - | - | learned | 250 |
+| Tenant_C_OP_Zone | 192.168.255.109:30 | 30:30 | - | - | learned | 310-311 |
+| Tenant_C_WAN_Zone | 192.168.255.109:31 | 31:31 | - | - | learned | 350 |
+
+#### Router BGP EVPN VRFs
+
+### Router BGP Device Configuration
+
+```eos
+!
+router bgp 101
+   router-id 192.168.255.109
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor UNDERLAY-PEERS peer group
+   neighbor UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor UNDERLAY-PEERS send-community
+   neighbor UNDERLAY-PEERS maximum-routes 12000
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   vlan-aware-bundle Tenant_A_APP_Zone
+      rd 192.168.255.109:12
+      route-target both 12:12
+      redistribute learned
+      vlan 130-132
+   !
+   vlan-aware-bundle Tenant_A_DB_Zone
+      rd 192.168.255.109:13
+      route-target both 13:13
+      redistribute learned
+      vlan 140-141
+   !
+   vlan-aware-bundle Tenant_A_NFS
+      rd 192.168.255.109:10161
+      route-target both 10161:10161
+      redistribute learned
+      vlan 161
+   !
+   vlan-aware-bundle Tenant_A_OP_Zone
+      rd 192.168.255.109:10
+      route-target both 10:10
+      redistribute learned
+      vlan 110-111
+   !
+   vlan-aware-bundle Tenant_A_VMOTION
+      rd 192.168.255.109:10160
+      route-target both 10160:10160
+      redistribute learned
+      vlan 160
+   !
+   vlan-aware-bundle Tenant_A_WAN_Zone
+      rd 192.168.255.109:14
+      route-target both 14:14
+      redistribute learned
+      vlan 150
+   !
+   vlan-aware-bundle Tenant_A_WEB_Zone
+      rd 192.168.255.109:11
+      route-target both 11:11
+      redistribute learned
+      vlan 120-121
+   !
+   vlan-aware-bundle Tenant_B_OP_Zone
+      rd 192.168.255.109:20
+      route-target both 20:20
+      redistribute learned
+      vlan 210-211
+   !
+   vlan-aware-bundle Tenant_B_WAN_Zone
+      rd 192.168.255.109:21
+      route-target both 21:21
+      redistribute learned
+      vlan 250
+   !
+   vlan-aware-bundle Tenant_C_OP_Zone
+      rd 192.168.255.109:30
+      route-target both 30:30
+      redistribute learned
+      vlan 310-311
+   !
+   vlan-aware-bundle Tenant_C_WAN_Zone
+      rd 192.168.255.109:31
+      route-target both 31:31
+      redistribute learned
+      vlan 350
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor UNDERLAY-PEERS activate
+```
+
+# BFD
+
+## Router BFD
+
+### Router BFD Multihop Summary
+
+| Interval | Minimum RX | Multiplier |
+| -------- | ---------- | ---------- |
+| 1200 | 1200 | 3 |
+
+### Router BFD Device Configuration
+
+```eos
+!
+router bfd
+   multihop interval 1200 min-rx 1200 multiplier 3
+```
+
+# Multicast
+
+## IP IGMP Snooping
+
+### IP IGMP Snooping Summary
+
+IGMP snooping is globally enabled.
+
+
+| VLAN | IGMP Snooping |
+| --- | --------------- |
+| 120 | disabled |
+
+### IP IGMP Snooping Device Configuration
+
+```eos
+!
+no ip igmp snooping vlan 120
+```
+
+# Filters
+
+## Prefix-lists
+
+### Prefix-lists Summary
+
+#### PL-LOOPBACKS-EVPN-OVERLAY
+
+| Sequence | Action |
+| -------- | ------ |
+| 10 | permit 192.168.255.0/24 eq 32 |
+| 20 | permit 192.168.254.0/24 eq 32 |
+
+### Prefix-lists Device Configuration
+
+```eos
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+   seq 20 permit 192.168.254.0/24 eq 32
+```
+
+## Route-maps
+
+### Route-maps Summary
+
+#### RM-CONN-2-BGP
+
+| Sequence | Type | Match and/or Set |
+| -------- | ---- | ---------------- |
+| 10 | permit | match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY |
+
+### Route-maps Device Configuration
+
+```eos
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+```
+
+# ACL
+
+# VRF Instances
+
+## VRF Instances Summary
+
+| VRF Name | IP Routing |
+| -------- | ---------- |
+| MGMT | disabled |
+
+## VRF Instances Device Configuration
+
+```eos
+!
+vrf instance MGMT
+```
+
+# Virtual Source NAT
+
+## Virtual Source NAT Summary
+
+| Source NAT VRF | Source NAT IP Address |
+| -------------- | --------------------- |
+| Tenant_A_OP_Zone | 10.255.1.109 |
+
+## Virtual Source NAT Configuration
+
+```eos
+!
+ip address virtual source-nat vrf Tenant_A_OP_Zone address 10.255.1.109
+```
+
+# Quality Of Service

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/fabric/DC1_FABRIC-documentation.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/fabric/DC1_FABRIC-documentation.md
@@ -35,6 +35,8 @@
 | DC1_FABRIC | spine | DC1-SPINE4 | 192.168.200.104/24 | 7280R3 | Provisioned |
 | DC1_FABRIC | l3leaf | DC1-SVC3A | 192.168.200.108/24 | 7050SX3 | Provisioned |
 | DC1_FABRIC | l3leaf | DC1-SVC3B | 192.168.200.109/24 | 7050SX3 | Provisioned |
+| DC1_FABRIC | l3leaf | evpn_services_l2_only_false | - | - | Provisioned |
+| DC1_FABRIC | l3leaf | evpn_services_l2_only_true | - | - | Provisioned |
 
 > Provision status is based on Ansible inventory declaration and do not represent real status from CloudVision.
 
@@ -152,7 +154,7 @@
 
 | Loopback Pool | Available Addresses | Assigned addresses | Assigned Address % |
 | ------------- | ------------------- | ------------------ | ------------------ |
-| 192.168.255.0/24 | 256 | 13 | 5.08 % |
+| 192.168.255.0/24 | 256 | 15 | 5.86 % |
 
 ## Loopback0 Interfaces Node Allocation
 
@@ -171,12 +173,14 @@
 | DC1_FABRIC | DC1-SPINE4 | 192.168.255.4/32 |
 | DC1_FABRIC | DC1-SVC3A | 192.168.255.12/32 |
 | DC1_FABRIC | DC1-SVC3B | 192.168.255.13/32 |
+| DC1_FABRIC | evpn_services_l2_only_false | 192.168.255.109/32 |
+| DC1_FABRIC | evpn_services_l2_only_true | 192.168.255.109/32 |
 
 ## VTEP Loopback VXLAN Tunnel Source Interfaces (VTEPs Only)
 
 | VTEP Loopback Pool | Available Addresses | Assigned addresses | Assigned Address % |
 | --------------------- | ------------------- | ------------------ | ------------------ |
-| 192.168.254.0/24 | 256 | 9 | 3.52 % |
+| 192.168.254.0/24 | 256 | 11 | 4.3 % |
 
 ## VTEP Loopback Node allocation
 
@@ -191,3 +195,5 @@
 | DC1_FABRIC | DC1-LEAF2B | 192.168.254.11/32 |
 | DC1_FABRIC | DC1-SVC3A | 192.168.254.12/32 |
 | DC1_FABRIC | DC1-SVC3B | 192.168.254.12/32 |
+| DC1_FABRIC | evpn_services_l2_only_false | 192.168.254.109/32 |
+| DC1_FABRIC | evpn_services_l2_only_true | 192.168.254.109/32 |

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_false.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_false.cfg
@@ -1,0 +1,447 @@
+!RANCID-CONTENT-TYPE: arista
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   no shutdown
+!
+vlan internal order ascending range 1006 1199
+!
+no ip igmp snooping vlan 120
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname evpn_services_l2_only_false
+ip name-server vrf MGMT 8.8.8.8
+ip name-server vrf MGMT 192.168.200.5
+!
+ntp local-interface vrf MGMT Management1
+ntp server vrf MGMT 192.168.200.5 prefer
+!
+snmp-server contact example@example.com
+snmp-server location DC1_FABRIC evpn_services_l2_only_false
+!
+no aaa root
+no enable password
+!
+username admin privilege 15 role network-admin nopassword
+username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
+!
+vlan 110
+   name Tenant_A_OP_Zone_1
+!
+vlan 111
+   name Tenant_A_OP_Zone_2
+!
+vlan 120
+   name Tenant_A_WEB_Zone_1
+!
+vlan 121
+   name Tenant_A_WEBZone_2
+!
+vlan 130
+   name Tenant_A_APP_Zone_1
+!
+vlan 131
+   name Tenant_A_APP_Zone_2
+!
+vlan 132
+   name Tenant_A_APP_Zone_3
+!
+vlan 140
+   name Tenant_A_DB_BZone_1
+!
+vlan 141
+   name Tenant_A_DB_Zone_2
+!
+vlan 150
+   name Tenant_A_WAN_Zone_1
+!
+vlan 160
+   name Tenant_A_VMOTION
+!
+vlan 161
+   name Tenant_A_NFS
+!
+vlan 210
+   name Tenant_B_OP_Zone_1
+!
+vlan 211
+   name Tenant_B_OP_Zone_2
+!
+vlan 250
+   name Tenant_B_WAN_Zone_1
+!
+vlan 310
+   name Tenant_C_OP_Zone_1
+!
+vlan 311
+   name Tenant_C_OP_Zone_2
+!
+vlan 350
+   name Tenant_C_WAN_Zone_1
+!
+vrf instance MGMT
+!
+vrf instance Tenant_A_APP_Zone
+!
+vrf instance Tenant_A_DB_Zone
+!
+vrf instance Tenant_A_OP_Zone
+!
+vrf instance Tenant_A_WAN_Zone
+!
+vrf instance Tenant_A_WEB_Zone
+!
+vrf instance Tenant_B_OP_Zone
+!
+vrf instance Tenant_B_WAN_Zone
+!
+vrf instance Tenant_C_OP_Zone
+!
+vrf instance Tenant_C_WAN_Zone
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 192.168.255.109/32
+!
+interface Loopback1
+   description VTEP_VXLAN_Tunnel_Source
+   no shutdown
+   ip address 192.168.254.109/32
+!
+interface Loopback100
+   description Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
+   no shutdown
+   vrf Tenant_A_OP_Zone
+   ip address 10.255.1.109/32
+!
+interface Vlan110
+   description Tenant_A_OP_Zone_1
+   no shutdown
+   vrf Tenant_A_OP_Zone
+   ip address virtual 10.1.10.1/24
+!
+interface Vlan111
+   description Tenant_A_OP_Zone_2
+   no shutdown
+   vrf Tenant_A_OP_Zone
+   ip address virtual 10.1.11.1/24
+   ip helper-address 1.1.1.1 vrf MGMT source-interface lo100
+!
+interface Vlan120
+   description Tenant_A_WEB_Zone_1
+   no shutdown
+   vrf Tenant_A_WEB_Zone
+   ip address virtual 10.1.20.1/24
+   ip address virtual 10.2.20.1/24 secondary
+   ip address virtual 10.2.21.1/24 secondary
+   ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+!
+interface Vlan121
+   description Tenant_A_WEBZone_2
+   shutdown
+   mtu 1560
+   vrf Tenant_A_WEB_Zone
+   ip address virtual 10.1.10.254/24
+!
+interface Vlan130
+   description Tenant_A_APP_Zone_1
+   no shutdown
+   vrf Tenant_A_APP_Zone
+   ip address virtual 10.1.30.1/24
+!
+interface Vlan131
+   description Tenant_A_APP_Zone_2
+   no shutdown
+   vrf Tenant_A_APP_Zone
+   ip address virtual 10.1.31.1/24
+!
+interface Vlan132
+   description Tenant_A_APP_Zone_3
+   no shutdown
+   vrf Tenant_A_APP_Zone
+   ip virtual-router address 10.1.32.254
+   ip virtual-router address 10.2.32.254/24
+   ip virtual-router address 10.3.32.254/24
+!
+interface Vlan140
+   description Tenant_A_DB_BZone_1
+   no shutdown
+   vrf Tenant_A_DB_Zone
+   ip address virtual 10.1.40.1/24
+!
+interface Vlan141
+   description Tenant_A_DB_Zone_2
+   no shutdown
+   vrf Tenant_A_DB_Zone
+   ip address virtual 10.1.41.1/24
+!
+interface Vlan150
+   description Tenant_A_WAN_Zone_1
+   no shutdown
+   vrf Tenant_A_WAN_Zone
+   ip address virtual 10.1.40.1/24
+!
+interface Vlan210
+   description Tenant_B_OP_Zone_1
+   no shutdown
+   vrf Tenant_B_OP_Zone
+   ip address virtual 10.2.10.1/24
+!
+interface Vlan211
+   description Tenant_B_OP_Zone_2
+   no shutdown
+   vrf Tenant_B_OP_Zone
+   ip address virtual 10.2.11.1/24
+!
+interface Vlan250
+   description Tenant_B_WAN_Zone_1
+   no shutdown
+   vrf Tenant_B_WAN_Zone
+   ip address virtual 10.2.50.1/24
+!
+interface Vlan310
+   description Tenant_C_OP_Zone_1
+   no shutdown
+   vrf Tenant_C_OP_Zone
+   ip address virtual 10.3.10.1/24
+!
+interface Vlan311
+   description Tenant_C_OP_Zone_2
+   no shutdown
+   vrf Tenant_C_OP_Zone
+   ip address virtual 10.3.11.1/24
+!
+interface Vlan350
+   description Tenant_C_WAN_Zone_1
+   no shutdown
+   vrf Tenant_C_WAN_Zone
+   ip address virtual 10.3.50.1/24
+!
+interface Vxlan1
+   description evpn_services_l2_only_false_VTEP
+   vxlan source-interface Loopback1
+   vxlan udp-port 4789
+   vxlan vlan 110 vni 10110
+   vxlan vlan 111 vni 50111
+   vxlan vlan 120 vni 10120
+   vxlan vlan 121 vni 10121
+   vxlan vlan 130 vni 10130
+   vxlan vlan 131 vni 10131
+   vxlan vlan 132 vni 10132
+   vxlan vlan 140 vni 10140
+   vxlan vlan 141 vni 10141
+   vxlan vlan 150 vni 10150
+   vxlan vlan 160 vni 10160
+   vxlan vlan 161 vni 10161
+   vxlan vlan 210 vni 20210
+   vxlan vlan 211 vni 20211
+   vxlan vlan 250 vni 20250
+   vxlan vlan 310 vni 30310
+   vxlan vlan 311 vni 30311
+   vxlan vlan 350 vni 30350
+   vxlan vrf Tenant_A_APP_Zone vni 12
+   vxlan vrf Tenant_A_DB_Zone vni 13
+   vxlan vrf Tenant_A_OP_Zone vni 10
+   vxlan vrf Tenant_A_WAN_Zone vni 14
+   vxlan vrf Tenant_A_WEB_Zone vni 11
+   vxlan vrf Tenant_B_OP_Zone vni 20
+   vxlan vrf Tenant_B_WAN_Zone vni 21
+   vxlan vrf Tenant_C_OP_Zone vni 30
+   vxlan vrf Tenant_C_WAN_Zone vni 31
+!
+ip virtual-router mac-address 00:dc:00:00:00:0a
+!
+ip address virtual source-nat vrf Tenant_A_OP_Zone address 10.255.1.109
+!
+ip routing
+no ip routing vrf MGMT
+ip routing vrf Tenant_A_APP_Zone
+ip routing vrf Tenant_A_DB_Zone
+ip routing vrf Tenant_A_OP_Zone
+ip routing vrf Tenant_A_WAN_Zone
+ip routing vrf Tenant_A_WEB_Zone
+ip routing vrf Tenant_B_OP_Zone
+ip routing vrf Tenant_B_WAN_Zone
+ip routing vrf Tenant_C_OP_Zone
+ip routing vrf Tenant_C_WAN_Zone
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+   seq 20 permit 192.168.254.0/24 eq 32
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.200.5
+ip route vrf Tenant_A_APP_Zone 10.2.32.0/24 Vlan132 name VARP
+ip route vrf Tenant_A_APP_Zone 10.3.32.0/24 Vlan132 name VARP
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+router bfd
+   multihop interval 1200 min-rx 1200 multiplier 3
+!
+router bgp 101
+   router-id 192.168.255.109
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor UNDERLAY-PEERS peer group
+   neighbor UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor UNDERLAY-PEERS send-community
+   neighbor UNDERLAY-PEERS maximum-routes 12000
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   vlan-aware-bundle Tenant_A_APP_Zone
+      rd 192.168.255.109:12
+      route-target both 12:12
+      redistribute learned
+      vlan 130-132
+   !
+   vlan-aware-bundle Tenant_A_DB_Zone
+      rd 192.168.255.109:13
+      route-target both 13:13
+      redistribute learned
+      vlan 140-141
+   !
+   vlan-aware-bundle Tenant_A_NFS
+      rd 192.168.255.109:10161
+      route-target both 10161:10161
+      redistribute learned
+      vlan 161
+   !
+   vlan-aware-bundle Tenant_A_OP_Zone
+      rd 192.168.255.109:10
+      route-target both 10:10
+      redistribute learned
+      vlan 110-111
+   !
+   vlan-aware-bundle Tenant_A_VMOTION
+      rd 192.168.255.109:10160
+      route-target both 10160:10160
+      redistribute learned
+      vlan 160
+   !
+   vlan-aware-bundle Tenant_A_WAN_Zone
+      rd 192.168.255.109:14
+      route-target both 14:14
+      redistribute learned
+      vlan 150
+   !
+   vlan-aware-bundle Tenant_A_WEB_Zone
+      rd 192.168.255.109:11
+      route-target both 11:11
+      redistribute learned
+      vlan 120-121
+   !
+   vlan-aware-bundle Tenant_B_OP_Zone
+      rd 192.168.255.109:20
+      route-target both 20:20
+      redistribute learned
+      vlan 210-211
+   !
+   vlan-aware-bundle Tenant_B_WAN_Zone
+      rd 192.168.255.109:21
+      route-target both 21:21
+      redistribute learned
+      vlan 250
+   !
+   vlan-aware-bundle Tenant_C_OP_Zone
+      rd 192.168.255.109:30
+      route-target both 30:30
+      redistribute learned
+      vlan 310-311
+   !
+   vlan-aware-bundle Tenant_C_WAN_Zone
+      rd 192.168.255.109:31
+      route-target both 31:31
+      redistribute learned
+      vlan 350
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor UNDERLAY-PEERS activate
+   !
+   vrf Tenant_A_APP_Zone
+      rd 192.168.255.109:12
+      route-target import evpn 12:12
+      route-target export evpn 12:12
+      router-id 192.168.255.109
+      redistribute connected
+   !
+   vrf Tenant_A_DB_Zone
+      rd 192.168.255.109:13
+      route-target import evpn 13:13
+      route-target export evpn 13:13
+      router-id 192.168.255.109
+      redistribute connected
+   !
+   vrf Tenant_A_OP_Zone
+      rd 192.168.255.109:10
+      route-target import evpn 10:10
+      route-target export evpn 10:10
+      router-id 192.168.255.109
+      redistribute connected
+   !
+   vrf Tenant_A_WAN_Zone
+      rd 192.168.255.109:14
+      route-target import evpn 14:14
+      route-target import evpn 65000:456
+      route-target export evpn 14:14
+      route-target export evpn 65000:789
+      router-id 192.168.255.109
+      redistribute connected
+   !
+   vrf Tenant_A_WEB_Zone
+      rd 192.168.255.109:11
+      route-target import evpn 11:11
+      route-target export evpn 11:11
+      router-id 192.168.255.109
+      redistribute connected
+   !
+   vrf Tenant_B_OP_Zone
+      rd 192.168.255.109:20
+      route-target import evpn 20:20
+      route-target export evpn 20:20
+      router-id 192.168.255.109
+      redistribute connected
+   !
+   vrf Tenant_B_WAN_Zone
+      rd 192.168.255.109:21
+      route-target import evpn 21:21
+      route-target export evpn 21:21
+      router-id 192.168.255.109
+      redistribute connected
+   !
+   vrf Tenant_C_OP_Zone
+      rd 192.168.255.109:30
+      route-target import evpn 30:30
+      route-target export evpn 30:30
+      router-id 192.168.255.109
+      redistribute connected
+   !
+   vrf Tenant_C_WAN_Zone
+      rd 192.168.255.109:31
+      route-target import evpn 31:31
+      route-target export evpn 31:31
+      router-id 192.168.255.109
+      redistribute connected
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_true.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_true.cfg
@@ -1,0 +1,233 @@
+!RANCID-CONTENT-TYPE: arista
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   no shutdown
+!
+vlan internal order ascending range 1006 1199
+!
+no ip igmp snooping vlan 120
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname evpn_services_l2_only_true
+ip name-server vrf MGMT 8.8.8.8
+ip name-server vrf MGMT 192.168.200.5
+!
+ntp local-interface vrf MGMT Management1
+ntp server vrf MGMT 192.168.200.5 prefer
+!
+snmp-server contact example@example.com
+snmp-server location DC1_FABRIC evpn_services_l2_only_true
+!
+no aaa root
+no enable password
+!
+username admin privilege 15 role network-admin nopassword
+username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
+!
+vlan 110
+   name Tenant_A_OP_Zone_1
+!
+vlan 111
+   name Tenant_A_OP_Zone_2
+!
+vlan 120
+   name Tenant_A_WEB_Zone_1
+!
+vlan 121
+   name Tenant_A_WEBZone_2
+!
+vlan 130
+   name Tenant_A_APP_Zone_1
+!
+vlan 131
+   name Tenant_A_APP_Zone_2
+!
+vlan 132
+   name Tenant_A_APP_Zone_3
+!
+vlan 140
+   name Tenant_A_DB_BZone_1
+!
+vlan 141
+   name Tenant_A_DB_Zone_2
+!
+vlan 150
+   name Tenant_A_WAN_Zone_1
+!
+vlan 160
+   name Tenant_A_VMOTION
+!
+vlan 161
+   name Tenant_A_NFS
+!
+vlan 210
+   name Tenant_B_OP_Zone_1
+!
+vlan 211
+   name Tenant_B_OP_Zone_2
+!
+vlan 250
+   name Tenant_B_WAN_Zone_1
+!
+vlan 310
+   name Tenant_C_OP_Zone_1
+!
+vlan 311
+   name Tenant_C_OP_Zone_2
+!
+vlan 350
+   name Tenant_C_WAN_Zone_1
+!
+vrf instance MGMT
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 192.168.255.109/32
+!
+interface Loopback1
+   description VTEP_VXLAN_Tunnel_Source
+   no shutdown
+   ip address 192.168.254.109/32
+!
+interface Vxlan1
+   description evpn_services_l2_only_true_VTEP
+   vxlan source-interface Loopback1
+   vxlan udp-port 4789
+   vxlan vlan 110 vni 10110
+   vxlan vlan 111 vni 50111
+   vxlan vlan 120 vni 10120
+   vxlan vlan 121 vni 10121
+   vxlan vlan 130 vni 10130
+   vxlan vlan 131 vni 10131
+   vxlan vlan 132 vni 10132
+   vxlan vlan 140 vni 10140
+   vxlan vlan 141 vni 10141
+   vxlan vlan 150 vni 10150
+   vxlan vlan 160 vni 10160
+   vxlan vlan 161 vni 10161
+   vxlan vlan 210 vni 20210
+   vxlan vlan 211 vni 20211
+   vxlan vlan 250 vni 20250
+   vxlan vlan 310 vni 30310
+   vxlan vlan 311 vni 30311
+   vxlan vlan 350 vni 30350
+!
+ip address virtual source-nat vrf Tenant_A_OP_Zone address 10.255.1.109
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+   seq 20 permit 192.168.254.0/24 eq 32
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.200.5
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+router bfd
+   multihop interval 1200 min-rx 1200 multiplier 3
+!
+router bgp 101
+   router-id 192.168.255.109
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor UNDERLAY-PEERS peer group
+   neighbor UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
+   neighbor UNDERLAY-PEERS send-community
+   neighbor UNDERLAY-PEERS maximum-routes 12000
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   vlan-aware-bundle Tenant_A_APP_Zone
+      rd 192.168.255.109:12
+      route-target both 12:12
+      redistribute learned
+      vlan 130-132
+   !
+   vlan-aware-bundle Tenant_A_DB_Zone
+      rd 192.168.255.109:13
+      route-target both 13:13
+      redistribute learned
+      vlan 140-141
+   !
+   vlan-aware-bundle Tenant_A_NFS
+      rd 192.168.255.109:10161
+      route-target both 10161:10161
+      redistribute learned
+      vlan 161
+   !
+   vlan-aware-bundle Tenant_A_OP_Zone
+      rd 192.168.255.109:10
+      route-target both 10:10
+      redistribute learned
+      vlan 110-111
+   !
+   vlan-aware-bundle Tenant_A_VMOTION
+      rd 192.168.255.109:10160
+      route-target both 10160:10160
+      redistribute learned
+      vlan 160
+   !
+   vlan-aware-bundle Tenant_A_WAN_Zone
+      rd 192.168.255.109:14
+      route-target both 14:14
+      redistribute learned
+      vlan 150
+   !
+   vlan-aware-bundle Tenant_A_WEB_Zone
+      rd 192.168.255.109:11
+      route-target both 11:11
+      redistribute learned
+      vlan 120-121
+   !
+   vlan-aware-bundle Tenant_B_OP_Zone
+      rd 192.168.255.109:20
+      route-target both 20:20
+      redistribute learned
+      vlan 210-211
+   !
+   vlan-aware-bundle Tenant_B_WAN_Zone
+      rd 192.168.255.109:21
+      route-target both 21:21
+      redistribute learned
+      vlan 250
+   !
+   vlan-aware-bundle Tenant_C_OP_Zone
+      rd 192.168.255.109:30
+      route-target both 30:30
+      redistribute learned
+      vlan 310-311
+   !
+   vlan-aware-bundle Tenant_C_WAN_Zone
+      rd 192.168.255.109:31
+      route-target both 31:31
+      redistribute learned
+      vlan 350
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor UNDERLAY-PEERS activate
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_false.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_false.yml
@@ -1,0 +1,621 @@
+router_bgp:
+  as: '101'
+  router_id: 192.168.255.109
+  bgp_defaults:
+  - maximum-paths 4 ecmp 4
+  peer_groups:
+    UNDERLAY-PEERS:
+      type: ipv4
+      password: AQQvKeimxJu+uGQ/yYvv9w==
+      maximum_routes: 12000
+      send_community: all
+    EVPN-OVERLAY-PEERS:
+      type: evpn
+      update_source: Loopback0
+      bfd: true
+      ebgp_multihop: '3'
+      password: q+VNViP5i4rVjW1cxFv2wA==
+      send_community: all
+      maximum_routes: 0
+  address_family_ipv4:
+    peer_groups:
+      UNDERLAY-PEERS:
+        activate: true
+      EVPN-OVERLAY-PEERS:
+        activate: false
+  redistribute_routes:
+    connected:
+      route_map: RM-CONN-2-BGP
+  address_family_evpn:
+    peer_groups:
+      EVPN-OVERLAY-PEERS:
+        activate: true
+  vrfs:
+    Tenant_A_APP_Zone:
+      router_id: 192.168.255.109
+      rd: 192.168.255.109:12
+      route_targets:
+        import:
+          evpn:
+          - '12:12'
+        export:
+          evpn:
+          - '12:12'
+      redistribute_routes:
+      - connected
+    Tenant_A_DB_Zone:
+      router_id: 192.168.255.109
+      rd: 192.168.255.109:13
+      route_targets:
+        import:
+          evpn:
+          - '13:13'
+        export:
+          evpn:
+          - '13:13'
+      redistribute_routes:
+      - connected
+    Tenant_A_OP_Zone:
+      router_id: 192.168.255.109
+      rd: 192.168.255.109:10
+      route_targets:
+        import:
+          evpn:
+          - '10:10'
+        export:
+          evpn:
+          - '10:10'
+      redistribute_routes:
+      - connected
+    Tenant_A_WAN_Zone:
+      router_id: 192.168.255.109
+      rd: 192.168.255.109:14
+      route_targets:
+        import:
+          evpn:
+          - '14:14'
+          - 65000:456
+        export:
+          evpn:
+          - '14:14'
+          - 65000:789
+      redistribute_routes:
+      - connected
+    Tenant_A_WEB_Zone:
+      router_id: 192.168.255.109
+      rd: 192.168.255.109:11
+      route_targets:
+        import:
+          evpn:
+          - '11:11'
+        export:
+          evpn:
+          - '11:11'
+      redistribute_routes:
+      - connected
+    Tenant_B_OP_Zone:
+      router_id: 192.168.255.109
+      rd: 192.168.255.109:20
+      route_targets:
+        import:
+          evpn:
+          - '20:20'
+        export:
+          evpn:
+          - '20:20'
+      redistribute_routes:
+      - connected
+    Tenant_B_WAN_Zone:
+      router_id: 192.168.255.109
+      rd: 192.168.255.109:21
+      route_targets:
+        import:
+          evpn:
+          - '21:21'
+        export:
+          evpn:
+          - '21:21'
+      redistribute_routes:
+      - connected
+    Tenant_C_OP_Zone:
+      router_id: 192.168.255.109
+      rd: 192.168.255.109:30
+      route_targets:
+        import:
+          evpn:
+          - '30:30'
+        export:
+          evpn:
+          - '30:30'
+      redistribute_routes:
+      - connected
+    Tenant_C_WAN_Zone:
+      router_id: 192.168.255.109
+      rd: 192.168.255.109:31
+      route_targets:
+        import:
+          evpn:
+          - '31:31'
+        export:
+          evpn:
+          - '31:31'
+      redistribute_routes:
+      - connected
+  vlan_aware_bundles:
+    Tenant_A_APP_Zone:
+      rd: 192.168.255.109:12
+      route_targets:
+        both:
+        - '12:12'
+      redistribute_routes:
+      - learned
+      vlan: 130-132
+    Tenant_A_DB_Zone:
+      rd: 192.168.255.109:13
+      route_targets:
+        both:
+        - '13:13'
+      redistribute_routes:
+      - learned
+      vlan: 140-141
+    Tenant_A_OP_Zone:
+      rd: 192.168.255.109:10
+      route_targets:
+        both:
+        - '10:10'
+      redistribute_routes:
+      - learned
+      vlan: 110-111
+    Tenant_A_WAN_Zone:
+      rd: 192.168.255.109:14
+      route_targets:
+        both:
+        - '14:14'
+      redistribute_routes:
+      - learned
+      vlan: 150
+    Tenant_A_WEB_Zone:
+      rd: 192.168.255.109:11
+      route_targets:
+        both:
+        - '11:11'
+      redistribute_routes:
+      - learned
+      vlan: 120-121
+    Tenant_A_VMOTION:
+      tenant: Tenant_A
+      rd: 192.168.255.109:10160
+      route_targets:
+        both:
+        - 10160:10160
+      redistribute_routes:
+      - learned
+      vlan: 160
+    Tenant_A_NFS:
+      tenant: Tenant_A
+      rd: 192.168.255.109:10161
+      route_targets:
+        both:
+        - 10161:10161
+      redistribute_routes:
+      - learned
+      vlan: 161
+    Tenant_B_OP_Zone:
+      rd: 192.168.255.109:20
+      route_targets:
+        both:
+        - '20:20'
+      redistribute_routes:
+      - learned
+      vlan: 210-211
+    Tenant_B_WAN_Zone:
+      rd: 192.168.255.109:21
+      route_targets:
+        both:
+        - '21:21'
+      redistribute_routes:
+      - learned
+      vlan: 250
+    Tenant_C_OP_Zone:
+      rd: 192.168.255.109:30
+      route_targets:
+        both:
+        - '30:30'
+      redistribute_routes:
+      - learned
+      vlan: 310-311
+    Tenant_C_WAN_Zone:
+      rd: 192.168.255.109:31
+      route_targets:
+        both:
+        - '31:31'
+      redistribute_routes:
+      - learned
+      vlan: 350
+static_routes:
+- vrf: MGMT
+  destination_address_prefix: 0.0.0.0/0
+  gateway: 192.168.200.5
+- destination_address_prefix: 10.2.32.0/24
+  vrf: Tenant_A_APP_Zone
+  name: VARP
+  interface: Vlan132
+- destination_address_prefix: 10.3.32.0/24
+  vrf: Tenant_A_APP_Zone
+  name: VARP
+  interface: Vlan132
+service_routing_protocols_model: multi-agent
+ip_routing: true
+daemon_terminattr:
+  cvaddrs:
+  - 192.168.200.11:9910
+  cvauth:
+    method: key
+    key: telarista
+  cvvrf: MGMT
+  smashexcludes: ale,flexCounter,hardware,kni,pulse,strata
+  ingestexclude: /Sysdb/cell/1/agent,/Sysdb/cell/2/agent
+  disable_aaa: false
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+name_server:
+  source:
+    vrf: MGMT
+  nodes:
+  - 192.168.200.5
+  - 8.8.8.8
+snmp_server:
+  contact: example@example.com
+  location: DC1_FABRIC evpn_services_l2_only_false
+local_users:
+  admin:
+    privilege: 15
+    role: network-admin
+    no_password: true
+  cvpadmin:
+    privilege: 15
+    role: network-admin
+    sha512_password: $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
+vrfs:
+  MGMT:
+    ip_routing: false
+  Tenant_A_APP_Zone:
+    tenant: Tenant_A
+    ip_routing: true
+  Tenant_A_DB_Zone:
+    tenant: Tenant_A
+    ip_routing: true
+  Tenant_A_OP_Zone:
+    tenant: Tenant_A
+    ip_routing: true
+  Tenant_A_WAN_Zone:
+    tenant: Tenant_A
+    ip_routing: true
+  Tenant_A_WEB_Zone:
+    tenant: Tenant_A
+    ip_routing: true
+  Tenant_B_OP_Zone:
+    tenant: Tenant_B
+    ip_routing: true
+  Tenant_B_WAN_Zone:
+    tenant: Tenant_B
+    ip_routing: true
+  Tenant_C_OP_Zone:
+    tenant: Tenant_C
+    ip_routing: true
+  Tenant_C_WAN_Zone:
+    tenant: Tenant_C
+    ip_routing: true
+management_api_http:
+  enable_vrfs:
+    MGMT: {}
+  enable_https: true
+loopback_interfaces:
+  Loopback0:
+    description: EVPN_Overlay_Peering
+    shutdown: false
+    ip_address: 192.168.255.109/32
+  Loopback1:
+    description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
+    ip_address: 192.168.254.109/32
+  Loopback100:
+    description: Tenant_A_OP_Zone_VTEP_DIAGNOSTICS
+    shutdown: false
+    vrf: Tenant_A_OP_Zone
+    ip_address: 10.255.1.109/32
+prefix_lists:
+  PL-LOOPBACKS-EVPN-OVERLAY:
+    sequence_numbers:
+      10:
+        action: permit 192.168.255.0/24 eq 32
+      20:
+        action: permit 192.168.254.0/24 eq 32
+route_maps:
+  RM-CONN-2-BGP:
+    sequence_numbers:
+      10:
+        type: permit
+        match:
+        - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+router_bfd:
+  multihop:
+    interval: 1200
+    min_rx: 1200
+    multiplier: 3
+vlans:
+  130:
+    tenant: Tenant_A
+    name: Tenant_A_APP_Zone_1
+  131:
+    tenant: Tenant_A
+    name: Tenant_A_APP_Zone_2
+  132:
+    tenant: Tenant_A
+    name: Tenant_A_APP_Zone_3
+  140:
+    tenant: Tenant_A
+    name: Tenant_A_DB_BZone_1
+  141:
+    tenant: Tenant_A
+    name: Tenant_A_DB_Zone_2
+  110:
+    tenant: Tenant_A
+    name: Tenant_A_OP_Zone_1
+  111:
+    tenant: Tenant_A
+    name: Tenant_A_OP_Zone_2
+  150:
+    tenant: Tenant_A
+    name: Tenant_A_WAN_Zone_1
+  120:
+    tenant: Tenant_A
+    name: Tenant_A_WEB_Zone_1
+  121:
+    tenant: Tenant_A
+    name: Tenant_A_WEBZone_2
+  160:
+    tenant: Tenant_A
+    name: Tenant_A_VMOTION
+  161:
+    tenant: Tenant_A
+    name: Tenant_A_NFS
+  210:
+    tenant: Tenant_B
+    name: Tenant_B_OP_Zone_1
+  211:
+    tenant: Tenant_B
+    name: Tenant_B_OP_Zone_2
+  250:
+    tenant: Tenant_B
+    name: Tenant_B_WAN_Zone_1
+  310:
+    tenant: Tenant_C
+    name: Tenant_C_OP_Zone_1
+  311:
+    tenant: Tenant_C
+    name: Tenant_C_OP_Zone_2
+  350:
+    tenant: Tenant_C
+    name: Tenant_C_WAN_Zone_1
+ip_igmp_snooping:
+  globally_enabled: true
+  vlans:
+    120:
+      enabled: false
+ip_virtual_router_mac_address: 00:dc:00:00:00:0a
+vlan_interfaces:
+  Vlan130:
+    tenant: Tenant_A
+    tags:
+    - app
+    - erp1
+    description: Tenant_A_APP_Zone_1
+    shutdown: false
+    vrf: Tenant_A_APP_Zone
+    ip_address_virtual: 10.1.30.1/24
+  Vlan131:
+    tenant: Tenant_A
+    tags:
+    - app
+    description: Tenant_A_APP_Zone_2
+    shutdown: false
+    vrf: Tenant_A_APP_Zone
+    ip_address_virtual: 10.1.31.1/24
+  Vlan132:
+    tenant: Tenant_A
+    tags:
+    - erp2
+    description: Tenant_A_APP_Zone_3
+    shutdown: false
+    vrf: Tenant_A_APP_Zone
+    ip_virtual_router_addresses:
+    - 10.1.32.254
+    - 10.2.32.254/24
+    - 10.3.32.254/24
+  Vlan140:
+    tenant: Tenant_A
+    tags:
+    - db
+    - erp1
+    description: Tenant_A_DB_BZone_1
+    shutdown: false
+    vrf: Tenant_A_DB_Zone
+    ip_address_virtual: 10.1.40.1/24
+  Vlan141:
+    tenant: Tenant_A
+    tags:
+    - db
+    description: Tenant_A_DB_Zone_2
+    shutdown: false
+    vrf: Tenant_A_DB_Zone
+    ip_address_virtual: 10.1.41.1/24
+  Vlan110:
+    tenant: Tenant_A
+    tags:
+    - opzone
+    description: Tenant_A_OP_Zone_1
+    shutdown: false
+    vrf: Tenant_A_OP_Zone
+    ip_address_virtual: 10.1.10.1/24
+  Vlan111:
+    tenant: Tenant_A
+    tags:
+    - opzone
+    description: Tenant_A_OP_Zone_2
+    shutdown: false
+    vrf: Tenant_A_OP_Zone
+    ip_address_virtual: 10.1.11.1/24
+    ip_helpers:
+      1.1.1.1:
+        source_interface: lo100
+        vrf: MGMT
+  Vlan150:
+    tenant: Tenant_A
+    tags:
+    - wan
+    description: Tenant_A_WAN_Zone_1
+    shutdown: false
+    vrf: Tenant_A_WAN_Zone
+    ip_address_virtual: 10.1.40.1/24
+  Vlan120:
+    tenant: Tenant_A
+    tags:
+    - web
+    - erp1
+    description: Tenant_A_WEB_Zone_1
+    shutdown: false
+    vrf: Tenant_A_WEB_Zone
+    ip_address_virtual: 10.1.20.1/24
+    ip_address_virtual_secondaries:
+    - 10.2.20.1/24
+    - 10.2.21.1/24
+    ip_helpers:
+      1.1.1.1:
+        source_interface: lo100
+        vrf: TEST
+  Vlan121:
+    tenant: Tenant_A
+    tags:
+    - web
+    description: Tenant_A_WEBZone_2
+    shutdown: true
+    vrf: Tenant_A_WEB_Zone
+    ip_address_virtual: 10.1.10.254/24
+    mtu: 1560
+  Vlan210:
+    tenant: Tenant_B
+    tags:
+    - opzone
+    description: Tenant_B_OP_Zone_1
+    shutdown: false
+    vrf: Tenant_B_OP_Zone
+    ip_address_virtual: 10.2.10.1/24
+  Vlan211:
+    tenant: Tenant_B
+    tags:
+    - opzone
+    description: Tenant_B_OP_Zone_2
+    shutdown: false
+    vrf: Tenant_B_OP_Zone
+    ip_address_virtual: 10.2.11.1/24
+  Vlan250:
+    tenant: Tenant_B
+    tags:
+    - wan
+    description: Tenant_B_WAN_Zone_1
+    shutdown: false
+    vrf: Tenant_B_WAN_Zone
+    ip_address_virtual: 10.2.50.1/24
+  Vlan310:
+    tenant: Tenant_C
+    tags:
+    - opzone
+    description: Tenant_C_OP_Zone_1
+    shutdown: false
+    vrf: Tenant_C_OP_Zone
+    ip_address_virtual: 10.3.10.1/24
+  Vlan311:
+    tenant: Tenant_C
+    tags:
+    - opzone
+    description: Tenant_C_OP_Zone_2
+    shutdown: false
+    vrf: Tenant_C_OP_Zone
+    ip_address_virtual: 10.3.11.1/24
+  Vlan350:
+    tenant: Tenant_C
+    tags:
+    - wan
+    description: Tenant_C_WAN_Zone_1
+    shutdown: false
+    vrf: Tenant_C_WAN_Zone
+    ip_address_virtual: 10.3.50.1/24
+virtual_source_nat_vrfs:
+  Tenant_A_OP_Zone:
+    ip_address: 10.255.1.109
+vxlan_interface:
+  Vxlan1:
+    description: evpn_services_l2_only_false_VTEP
+    vxlan:
+      source_interface: Loopback1
+      udp_port: 4789
+      vlans:
+        130:
+          vni: 10130
+        131:
+          vni: 10131
+        132:
+          vni: 10132
+        140:
+          vni: 10140
+        141:
+          vni: 10141
+        110:
+          vni: 10110
+        111:
+          vni: 50111
+        150:
+          vni: 10150
+        120:
+          vni: 10120
+        121:
+          vni: 10121
+        160:
+          vni: 10160
+        161:
+          vni: 10161
+        210:
+          vni: 20210
+        211:
+          vni: 20211
+        250:
+          vni: 20250
+        310:
+          vni: 30310
+        311:
+          vni: 30311
+        350:
+          vni: 30350
+      vrfs:
+        Tenant_A_APP_Zone:
+          vni: 12
+        Tenant_A_DB_Zone:
+          vni: 13
+        Tenant_A_OP_Zone:
+          vni: 10
+        Tenant_A_WAN_Zone:
+          vni: 14
+        Tenant_A_WEB_Zone:
+          vni: 11
+        Tenant_B_OP_Zone:
+          vni: 20
+        Tenant_B_WAN_Zone:
+          vni: 21
+        Tenant_C_OP_Zone:
+          vni: 30
+        Tenant_C_WAN_Zone:
+          vni: 31

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_true.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_true.yml
@@ -1,0 +1,303 @@
+router_bgp:
+  as: '101'
+  router_id: 192.168.255.109
+  bgp_defaults:
+  - maximum-paths 4 ecmp 4
+  peer_groups:
+    UNDERLAY-PEERS:
+      type: ipv4
+      password: AQQvKeimxJu+uGQ/yYvv9w==
+      maximum_routes: 12000
+      send_community: all
+    EVPN-OVERLAY-PEERS:
+      type: evpn
+      update_source: Loopback0
+      bfd: true
+      ebgp_multihop: '3'
+      password: q+VNViP5i4rVjW1cxFv2wA==
+      send_community: all
+      maximum_routes: 0
+  address_family_ipv4:
+    peer_groups:
+      UNDERLAY-PEERS:
+        activate: true
+      EVPN-OVERLAY-PEERS:
+        activate: false
+  redistribute_routes:
+    connected:
+      route_map: RM-CONN-2-BGP
+  address_family_evpn:
+    peer_groups:
+      EVPN-OVERLAY-PEERS:
+        activate: true
+  vlan_aware_bundles:
+    Tenant_A_APP_Zone:
+      rd: 192.168.255.109:12
+      route_targets:
+        both:
+        - '12:12'
+      redistribute_routes:
+      - learned
+      vlan: 130-132
+    Tenant_A_DB_Zone:
+      rd: 192.168.255.109:13
+      route_targets:
+        both:
+        - '13:13'
+      redistribute_routes:
+      - learned
+      vlan: 140-141
+    Tenant_A_OP_Zone:
+      rd: 192.168.255.109:10
+      route_targets:
+        both:
+        - '10:10'
+      redistribute_routes:
+      - learned
+      vlan: 110-111
+    Tenant_A_WAN_Zone:
+      rd: 192.168.255.109:14
+      route_targets:
+        both:
+        - '14:14'
+      redistribute_routes:
+      - learned
+      vlan: 150
+    Tenant_A_WEB_Zone:
+      rd: 192.168.255.109:11
+      route_targets:
+        both:
+        - '11:11'
+      redistribute_routes:
+      - learned
+      vlan: 120-121
+    Tenant_A_VMOTION:
+      tenant: Tenant_A
+      rd: 192.168.255.109:10160
+      route_targets:
+        both:
+        - 10160:10160
+      redistribute_routes:
+      - learned
+      vlan: 160
+    Tenant_A_NFS:
+      tenant: Tenant_A
+      rd: 192.168.255.109:10161
+      route_targets:
+        both:
+        - 10161:10161
+      redistribute_routes:
+      - learned
+      vlan: 161
+    Tenant_B_OP_Zone:
+      rd: 192.168.255.109:20
+      route_targets:
+        both:
+        - '20:20'
+      redistribute_routes:
+      - learned
+      vlan: 210-211
+    Tenant_B_WAN_Zone:
+      rd: 192.168.255.109:21
+      route_targets:
+        both:
+        - '21:21'
+      redistribute_routes:
+      - learned
+      vlan: 250
+    Tenant_C_OP_Zone:
+      rd: 192.168.255.109:30
+      route_targets:
+        both:
+        - '30:30'
+      redistribute_routes:
+      - learned
+      vlan: 310-311
+    Tenant_C_WAN_Zone:
+      rd: 192.168.255.109:31
+      route_targets:
+        both:
+        - '31:31'
+      redistribute_routes:
+      - learned
+      vlan: 350
+static_routes:
+- vrf: MGMT
+  destination_address_prefix: 0.0.0.0/0
+  gateway: 192.168.200.5
+service_routing_protocols_model: multi-agent
+ip_routing: true
+daemon_terminattr:
+  cvaddrs:
+  - 192.168.200.11:9910
+  cvauth:
+    method: key
+    key: telarista
+  cvvrf: MGMT
+  smashexcludes: ale,flexCounter,hardware,kni,pulse,strata
+  ingestexclude: /Sysdb/cell/1/agent,/Sysdb/cell/2/agent
+  disable_aaa: false
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+name_server:
+  source:
+    vrf: MGMT
+  nodes:
+  - 192.168.200.5
+  - 8.8.8.8
+snmp_server:
+  contact: example@example.com
+  location: DC1_FABRIC evpn_services_l2_only_true
+local_users:
+  admin:
+    privilege: 15
+    role: network-admin
+    no_password: true
+  cvpadmin:
+    privilege: 15
+    role: network-admin
+    sha512_password: $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
+vrfs:
+  MGMT:
+    ip_routing: false
+management_api_http:
+  enable_vrfs:
+    MGMT: {}
+  enable_https: true
+loopback_interfaces:
+  Loopback0:
+    description: EVPN_Overlay_Peering
+    shutdown: false
+    ip_address: 192.168.255.109/32
+  Loopback1:
+    description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
+    ip_address: 192.168.254.109/32
+prefix_lists:
+  PL-LOOPBACKS-EVPN-OVERLAY:
+    sequence_numbers:
+      10:
+        action: permit 192.168.255.0/24 eq 32
+      20:
+        action: permit 192.168.254.0/24 eq 32
+route_maps:
+  RM-CONN-2-BGP:
+    sequence_numbers:
+      10:
+        type: permit
+        match:
+        - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+router_bfd:
+  multihop:
+    interval: 1200
+    min_rx: 1200
+    multiplier: 3
+vlans:
+  130:
+    tenant: Tenant_A
+    name: Tenant_A_APP_Zone_1
+  131:
+    tenant: Tenant_A
+    name: Tenant_A_APP_Zone_2
+  132:
+    tenant: Tenant_A
+    name: Tenant_A_APP_Zone_3
+  140:
+    tenant: Tenant_A
+    name: Tenant_A_DB_BZone_1
+  141:
+    tenant: Tenant_A
+    name: Tenant_A_DB_Zone_2
+  110:
+    tenant: Tenant_A
+    name: Tenant_A_OP_Zone_1
+  111:
+    tenant: Tenant_A
+    name: Tenant_A_OP_Zone_2
+  150:
+    tenant: Tenant_A
+    name: Tenant_A_WAN_Zone_1
+  120:
+    tenant: Tenant_A
+    name: Tenant_A_WEB_Zone_1
+  121:
+    tenant: Tenant_A
+    name: Tenant_A_WEBZone_2
+  160:
+    tenant: Tenant_A
+    name: Tenant_A_VMOTION
+  161:
+    tenant: Tenant_A
+    name: Tenant_A_NFS
+  210:
+    tenant: Tenant_B
+    name: Tenant_B_OP_Zone_1
+  211:
+    tenant: Tenant_B
+    name: Tenant_B_OP_Zone_2
+  250:
+    tenant: Tenant_B
+    name: Tenant_B_WAN_Zone_1
+  310:
+    tenant: Tenant_C
+    name: Tenant_C_OP_Zone_1
+  311:
+    tenant: Tenant_C
+    name: Tenant_C_OP_Zone_2
+  350:
+    tenant: Tenant_C
+    name: Tenant_C_WAN_Zone_1
+ip_igmp_snooping:
+  globally_enabled: true
+  vlans:
+    120:
+      enabled: false
+virtual_source_nat_vrfs:
+  Tenant_A_OP_Zone:
+    ip_address: 10.255.1.109
+vxlan_interface:
+  Vxlan1:
+    description: evpn_services_l2_only_true_VTEP
+    vxlan:
+      source_interface: Loopback1
+      udp_port: 4789
+      vlans:
+        130:
+          vni: 10130
+        131:
+          vni: 10131
+        132:
+          vni: 10132
+        140:
+          vni: 10140
+        141:
+          vni: 10141
+        110:
+          vni: 10110
+        111:
+          vni: 50111
+        150:
+          vni: 10150
+        120:
+          vni: 10120
+        121:
+          vni: 10121
+        160:
+          vni: 10160
+        161:
+          vni: 10161
+        210:
+          vni: 20210
+        211:
+          vni: 20211
+        250:
+          vni: 20250
+        310:
+          vni: 30310
+        311:
+          vni: 30311
+        350:
+          vni: 30350

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/evpn_services_l2_only_false.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/evpn_services_l2_only_false.yml
@@ -1,0 +1,12 @@
+# Minimum config to only test the specific feature.
+l3leaf:
+  defaults:
+    loopback_ipv4_pool: 192.168.255.0/24
+    loopback_ipv4_offset: 8
+    vtep_loopback_ipv4_pool: 192.168.254.0/24
+    virtual_router_mac_address: 00:dc:00:00:00:0a
+  nodes:
+    evpn_services_l2_only_false:
+      id: 101
+      bgp_as: 101
+      evpn_services_l2_only: false

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/evpn_services_l2_only_true.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/evpn_services_l2_only_true.yml
@@ -1,0 +1,11 @@
+# Minimum config to only test the specific feature.
+l3leaf:
+  defaults:
+    loopback_ipv4_pool: 192.168.255.0/24
+    loopback_ipv4_offset: 8
+    vtep_loopback_ipv4_pool: 192.168.254.0/24
+  nodes:
+    evpn_services_l2_only_true:
+      id: 101
+      bgp_as: 101
+      evpn_services_l2_only: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
@@ -44,6 +44,10 @@ all:
                       ansible_host: 192.168.200.117
                     DC1-BL2B:
                       ansible_host: 192.168.200.118
+                UNIT_TESTS:
+                  hosts:
+                    evpn_services_l2_only_true:
+                    evpn_services_l2_only_false:
             DC1_L2LEAFS:
               children:
                 DC1_L2LEAF1:

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-topology.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-topology.md
@@ -254,7 +254,7 @@ defaults <- node_group <- node_group.node <- node
 
   defaults:
     # Possibility to prevent configuration of Tenant VRFs and SVIs
-    # Override role definition from node_type_keys
+    # Override node definition "network_services_l3" from node_type_keys
     # This allows support for centralized routing.
     evpn_services_l2_only: < false | true >
 

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/facts/switch/switch.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/facts/switch/switch.j2
@@ -350,7 +350,7 @@ switch:
 {%             set add_svis = [] %}
 {%             for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort %}
 {%                 for svi_tag in tenants[tenant].vrfs[vrf].svis[svi].tags | arista.avd.natural_sort %}
-{%                     if svi_tag in switch_filter_tags or svi_tag == switch_data.group | arista.avd.default('group_not_set') or "all" in switch_filter_tags %}
+{%                     if svi_tag in switch_filter_tags or switch_data.group is arista.avd.defined(svi_tag) or "all" in switch_filter_tags %}
 {%                         do add_svis.append(svi) %}
 {%                         do leaf.vlans.append(svi | int) %}
 {%                         break %}
@@ -375,7 +375,7 @@ switch:
 {%         set add_l2vlans = [] %}
 {%         for l2vlan in tenants[tenant].l2vlans | arista.avd.natural_sort %}
 {%             for vlan_tag in tenants[tenant].l2vlans[l2vlan].tags | arista.avd.natural_sort %}
-{%                 if vlan_tag in switch_filter_tags or vlan_tag == switch_data.group | arista.avd.default('group_not_set') or "all" in switch_filter_tags %}
+{%                 if vlan_tag in switch_filter_tags or switch_data.group is arista.avd.defined(vlan_tag) or "all" in switch_filter_tags %}
 {%                     do add_l2vlans.append(l2vlan) %}
 {%                     do leaf.vlans.append(l2vlan | int) %}
 {%                     break %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/facts/switch/switch.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/facts/switch/switch.j2
@@ -308,8 +308,10 @@ switch:
   vtep_ip: {% include switch.ip_addressing.vtep_ip %}
 {%     endif %}
 
-{# switch.evpn_services_l2_only #}
-  evpn_services_l2_only: {{ switch_data.combined.evpn_services_l2_only | arista.avd.default(false) }}
+{# switch.network_services_l3 override based on evpn_services_l2_only #}
+{%     if switch_data.combined.evpn_services_l2_only is arista.avd.defined(true) %}
+  network_services_l3: false
+{%     endif %}
 
 {% endif %}
 

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/facts/switch/switch.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/facts/switch/switch.j2
@@ -350,7 +350,7 @@ switch:
 {%             set add_svis = [] %}
 {%             for svi in tenants[tenant].vrfs[vrf].svis | arista.avd.natural_sort %}
 {%                 for svi_tag in tenants[tenant].vrfs[vrf].svis[svi].tags | arista.avd.natural_sort %}
-{%                     if svi_tag in switch_filter_tags or svi_tag == switch_data.group or "all" in switch_filter_tags %}
+{%                     if svi_tag in switch_filter_tags or svi_tag == switch_data.group | arista.avd.default('group_not_set') or "all" in switch_filter_tags %}
 {%                         do add_svis.append(svi) %}
 {%                         do leaf.vlans.append(svi | int) %}
 {%                         break %}
@@ -375,7 +375,7 @@ switch:
 {%         set add_l2vlans = [] %}
 {%         for l2vlan in tenants[tenant].l2vlans | arista.avd.natural_sort %}
 {%             for vlan_tag in tenants[tenant].l2vlans[l2vlan].tags | arista.avd.natural_sort %}
-{%                 if vlan_tag in switch_filter_tags or vlan_tag == switch_data.group or "all" in switch_filter_tags %}
+{%                 if vlan_tag in switch_filter_tags or vlan_tag == switch_data.group | arista.avd.default('group_not_set') or "all" in switch_filter_tags %}
 {%                     do add_l2vlans.append(l2vlan) %}
 {%                     do leaf.vlans.append(l2vlan | int) %}
 {%                     break %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-vrfs.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-vrfs.j2
@@ -1,6 +1,6 @@
 {# tenant router bgp evpn VRFs #}
-{% if switch.evpn_services_l2_only == false %}
-{% set bgp_vrf = namespace() %}
+{% if switch.network_services_l3 is arista.avd.defined(true) %}
+{%     set bgp_vrf = namespace() %}
   vrfs:
 {%     for tenant in network_services_data.tenants %}
 {%         for vrf in tenant.vrfs %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vxlan-interface.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vxlan-interface.j2
@@ -31,7 +31,7 @@ vxlan_interface:
                   tenant.mac_vrf_vni_base + l2vlan_int) }}
 {%     endfor %}
 {% endfor %}
-{% if switch.evpn_services_l2_only == false %}
+{% if switch.network_services_l3 is arista.avd.defined(true) %}
       vrfs:
 {%     for tenant in network_services_data.tenants %}
 {%         for vrf in tenant.vrfs %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/underlay/ebgp/prefix-lists.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/underlay/ebgp/prefix-lists.j2
@@ -7,7 +7,7 @@ prefix_lists:
 {% if switch.vtep_ip is arista.avd.defined and switch.vtep_loopback | lower != 'loopback0' %}
       20:
         action: "permit {{ switch.vtep_loopback_ipv4_pool }} eq 32"
-{%     if vtep_vvtep_ip is arista.avd.defined and switch.evpn_services_l2_only is arista.avd.defined(false) %}
+{%     if vtep_vvtep_ip is arista.avd.defined and switch.network_services_l3 is arista.avd.defined(true) %}
       30:
         action: "permit {{ vtep_vvtep_ip }}"
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/underlay/interfaces/loopback-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/underlay/interfaces/loopback-interfaces.j2
@@ -19,7 +19,7 @@ loopback_interfaces:
     description: "{% include switch.interface_descriptions.vtep_loopback_interface %}"
     shutdown: false
     ip_address: {{ switch.vtep_ip }}/32
-{%     if vtep_vvtep_ip is arista.avd.defined and switch.evpn_services_l2_only is arista.avd.defined(false) %}
+{%     if vtep_vvtep_ip is arista.avd.defined and switch.network_services_l3 is arista.avd.defined(true) %}
     ip_address_secondaries: [{{ vtep_vvtep_ip }}]
 {%     endif %}
 {%     if switch.underlay_routing_protocol == "ospf" %}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Fix evpn_services_l2_only setting which got broken by recent refactoring.

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->
- [x] Fix implementation of evpn_services_l2_only
- [x] Fix issue with not using node_groups for l3leaf (found during molecule implementation for evpn_services_l2_only)
- [x] Add molecule coverage for evpn_services_l2_only

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Added molecule coverage for both true and false to make it simple to compare.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
