### PR TITLE
Feat(eos_cli_config_gen): port-channel-interfaces enhancement

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
@@ -197,6 +197,8 @@ interface Ethernet50
 | Port-Channel5 | DC1_L2LEAF1_Po1 | switched | trunk | 110,201 | - | - | - | - | 5 | - |
 | Port-Channel10 | SRV01_bond0 | switched | trunk | 2-3000 | - | - | - | - | - | 0000:0000:0404:0404:0303 |
 | Port-Channel12 | interface_in_mode_access_with_voice | switched | trunk phone | - | 100 | - | - | - | - | - |
+| Port-Channel13 | EVPN-Vxlan single-active redundancy | switched | access | - | - | - | - | - | - | 0000:0000:0000:0102:0304 |
+| Port-Channel14 | EVPN-MPLS multihoming | switched | access | - | - | - | - | - | - | 0000:0000:0000:0102:0305 |
 | Port-Channel15 | DC1_L2LEAF3_Po1 | switched | trunk | 110,201 | - | - | - | - | 15 | - |
 | Port-Channel16 | DC1_L2LEAF4_Po1 | switched | trunk | 110,201 | - | - | - | - | 16 | - |
 | Port-Channel20 | Po_in_mode_access_accepting_tagged_LACP_frames | switched | access | 200 | - | - | - | - | - | - |
@@ -244,6 +246,27 @@ interface Ethernet50
 | Interface | From VLAN ID(s) | To VLAN ID | Direction |
 | --------- | --------------- | -----------| --------- |
 | Port-Channel102 | 111-112 | 110 | out
+
+#### EVPN Multihoming
+
+##### EVPN Multihoming Summary
+
+| Interface | Ethernet Segment Identifier | Multihoming Redundancy Mode | Route Target |
+| --------- | --------------------------- | --------------------------- | ------------ |
+| Port-Channel13 | 0000:0000:0000:0102:0304 | single-active | 00:00:01:02:03:04 |
+| Port-Channel14 | 0000:0000:0000:0102:0305 | all-active | 00:00:01:02:03:05 |
+
+##### Designated Forwarder Election Summary
+
+| Interface | Algorithm | Preference Value | Dont Preempt | Hold time | Subsequent Hold Time | Candidate Reachability Required |
+| --------- | --------- | ---------------- | ------------ | --------- | -------------------- | ------------------------------- |
+| Port-Channel13 | preference | 100 | True | 10 | - | True |
+
+##### EVPN-MPLS summary
+
+| Interface | Shared Index | Tunnel Flood Filter Time |
+| --------- | ------------ | ------------------------ |
+| Port-Channel14 | 100 | 100 |
 
 #### Link Tracking Groups
 
@@ -327,6 +350,26 @@ interface Port-Channel12
    switchport trunk native vlan 100
    switchport phone vlan 70
    switchport phone trunk untagged
+!
+interface Port-Channel13
+   description EVPN-Vxlan single-active redundancy
+   switchport
+   evpn ethernet-segment
+      identifier 0000:0000:0000:0102:0304
+      redundancy single-active
+      designated-forwarder election algorithm preference 100 dont-preempt
+      designated-forwarder election hold-time 10
+      designated-forwarder election candidate reachability required
+      route-target import 00:00:01:02:03:04
+!
+interface Port-Channel14
+   description EVPN-MPLS multihoming
+   switchport
+   evpn ethernet-segment
+      identifier 0000:0000:0000:0102:0305
+      mpls tunnel flood filter time 100
+      mpls shared index 100
+      route-target import 00:00:01:02:03:05
 !
 interface Port-Channel15
    description DC1_L2LEAF3_Po1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
@@ -63,6 +63,26 @@ interface Port-Channel12
    switchport phone vlan 70
    switchport phone trunk untagged
 !
+interface Port-Channel13
+   description EVPN-Vxlan single-active redundancy
+   switchport
+   evpn ethernet-segment
+      identifier 0000:0000:0000:0102:0304
+      redundancy single-active
+      designated-forwarder election algorithm preference 100 dont-preempt
+      designated-forwarder election hold-time 10
+      designated-forwarder election candidate reachability required
+      route-target import 00:00:01:02:03:04
+!
+interface Port-Channel14
+   description EVPN-MPLS multihoming
+   switchport
+   evpn ethernet-segment
+      identifier 0000:0000:0000:0102:0305
+      mpls tunnel flood filter time 100
+      mpls shared index 100
+      route-target import 00:00:01:02:03:05
+!
 interface Port-Channel15
    description DC1_L2LEAF3_Po1
    switchport

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
@@ -137,6 +137,28 @@ port_channel_interfaces:
       trunk: untagged
       vlan: 70
 
+  Port-Channel13:
+    description: EVPN-Vxlan single-active redundancy
+    esi: "0000:0000:0000:0102:0304"
+    rt: "00:00:01:02:03:04"
+    evpn_ethernet_segment:
+      redundancy: single-active
+      designated_forwarder_election:
+        algorithm: preference
+        preference_value: 100
+        dont_preempt: true
+        hold_time: 10
+        candidate_reachability_required: true
+
+  Port-Channel14:
+    description: EVPN-MPLS multihoming
+    esi: "0000:0000:0000:0102:0305"
+    rt: "00:00:01:02:03:05"
+    evpn_ethernet_segment:
+      mpls:
+        shared_index: 100
+        tunnel_flood_filter_time: 100
+
   Port-Channel17:
     description: PBR Description
     type: routed

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -994,12 +994,12 @@ ethernet_interfaces:
         # preference_value and dont_preempt are set for preference algorithm and are optional
         preference_value: < 0-65535 >
         dont_preempt: < true | false | default -> false >
-        hold_time: < 1-1800 Seconds >
-        subsequent_hold_time: < 10-10000 milliseconds >
+        hold_time: < integer >
+        subsequent_hold_time: < integer >
         candidate_reachability_required: < true | false >
       mpls:
         shared_index: < 1-1024 >
-        tunnel_flood_filter_time: < 10-10000 milliseconds >
+        tunnel_flood_filter_time: < integer >
       route_target: < EVPN Route Target for ESI with format xx:xx:xx:xx:xx:xx >
     flowcontrol:
       received: < "received" | "send" | "on" >
@@ -1231,6 +1231,19 @@ port_channel_interfaces:
     description: < description >
     vlans: "< list of vlans as string >"
     mode: < access | dot1q-tunnel | trunk | "trunk phone" >
+    evpn_ethernet_segment:
+      redundancy: < all-active | single-active >
+      designated_forwarder_election:
+        algorithm: < modulus | preference >
+        # preference_value and dont_preempt are set for preference algorithm and are optional
+        preference_value: < 0-65535 >
+        dont_preempt: < true | false | default -> false >
+        hold_time: < integer >
+        subsequent_hold_time: < integer >
+        candidate_reachability_required: < true | false >
+      mpls:
+        shared_index: < 1-1024 >
+        tunnel_flood_filter_time: < integer >
     esi: < EVPN Ethernet Segment Identifier (Type 1 format) >
     rt: < EVPN Route Target for ESI with format xx:xx:xx:xx:xx:xx >
     lacp_id: < LACP ID with format xxxx.xxxx.xxxx >
@@ -2192,7 +2205,7 @@ monitor_sessions:
       name: < acl_name >
     rate_limit_per_ingress_chip: < "<int> bps" | "<int> kbps" | "<int> mbps" >
     rate_limit_per_egress_chip: < "<int> bps" | "<int> kbps" | "<int> mbps" >
-    sample: < int >
+    sample: < integer >
     truncate:
       enabled: < true | false >
       size: < bytes >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/port-channel-interfaces.j2
@@ -1,4 +1,4 @@
-{% if port_channel_interfaces is defined and port_channel_interfaces is not none %}
+{% if port_channel_interfaces is arista.avd.defined %}
 
 ## Port-Channel Interfaces
 
@@ -10,11 +10,11 @@
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
 {%     for port_channel_interface in port_channel_interfaces | arista.avd.natural_sort %}
 {%         if port_channel_interfaces[port_channel_interface].type is not defined or port_channel_interfaces[port_channel_interface].type not in ['routed', 'l3dot1q', 'l2dot1q'] %}
-{%             set description = port_channel_interfaces[port_channel_interface].description | default ("-") %}
-{%             set type = port_channel_interfaces[port_channel_interface].type | default ("switched") %}
-{%             set mode = port_channel_interfaces[port_channel_interface].mode | default ("access") %}
-{%             set vlans = port_channel_interfaces[port_channel_interface].vlans | default ("-") %}
-{%             set native_vlan = port_channel_interfaces[port_channel_interface].native_vlan | default ("-") %}
+{%             set description = port_channel_interfaces[port_channel_interface].description | arista.avd.default("-") %}
+{%             set type = port_channel_interfaces[port_channel_interface].type | arista.avd.default("switched") %}
+{%             set mode = port_channel_interfaces[port_channel_interface].mode | arista.avd.default("access") %}
+{%             set vlans = port_channel_interfaces[port_channel_interface].vlans | arista.avd.default("-") %}
+{%             set native_vlan = port_channel_interfaces[port_channel_interface].native_vlan | arista.avd.default("-") %}
 {%             if port_channel_interfaces[port_channel_interface].trunk_groups is defined %}
 {%                 set l2 = namespace() %}
 {%                 set l2.trunk_groups = [] %}
@@ -25,10 +25,10 @@
 {%                 set l2 = namespace() %}
 {%                 set l2.trunk_groups = "-" %}
 {%             endif %}
-{%             set lacp_fallback_timeout = port_channel_interfaces[port_channel_interface].lacp_fallback_timeout | default ("-") %}
-{%             set lacp_fallback_mode = port_channel_interfaces[port_channel_interface].lacp_fallback_mode | default ("-") %}
-{%             set mlag = port_channel_interfaces[port_channel_interface].mlag | default ("-") %}
-{%             set esi = port_channel_interfaces[port_channel_interface].esi | default ("-") %}
+{%             set lacp_fallback_timeout = port_channel_interfaces[port_channel_interface].lacp_fallback_timeout | arista.avd.default("-") %}
+{%             set lacp_fallback_mode = port_channel_interfaces[port_channel_interface].lacp_fallback_mode | arista.avd.default("-") %}
+{%             set mlag = port_channel_interfaces[port_channel_interface].mlag | arista.avd.default("-") %}
+{%             set esi = port_channel_interfaces[port_channel_interface].esi | arista.avd.default("-") %}
 | {{ port_channel_interface }} | {{ description }} | {{ type }} | {{ mode }} | {{ vlans }} | {{ native_vlan }} | {{ l2.trunk_groups }} | {{ lacp_fallback_timeout }} | {{ lacp_fallback_mode }} | {{ mlag }} | {{ esi }} |
 {%         endif %}
 {%     endfor %}
@@ -89,7 +89,7 @@
 {%             break %}
 {%         endif %}
 {%     endfor %}
-{%     if port_channel_interface_pvlan.configured == true %}
+{%     if port_channel_interface_pvlan.configured %}
 
 #### Private VLAN
 
@@ -113,7 +113,7 @@
 {%             break %}
 {%         endif %}
 {%     endfor %}
-{%     if port_channel_interface_vlan_xlate.configured == true %}
+{%     if port_channel_interface_vlan_xlate.configured %}
 
 #### VLAN Translations
 
@@ -130,20 +130,78 @@
 {%             endif %}
 {%         endfor %}
 {%     endif %}
-{# Link Tracking Groups #}
+{#     Fecth EVPN multihoming and Link Tracking variables #}
+{%     set evpn_es_po_interfaces = [] %}
+{%     set evpn_dfe_po_interfaces = [] %}
+{%     set evpn_mpls_po_interfaces = [] %}
 {%     set link_tracking_interfaces = [] %}
-{%     for port_channel_interface in port_channel_interfaces | arista.avd.natural_sort %}
+{%     for port_channel_interface in port_channel_interfaces %}
+{%         if port_channel_interfaces[port_channel_interface].evpn_ethernet_segment is arista.avd.defined %}
+{%             do evpn_es_po_interfaces.append(port_channel_interface) %}
+{%             if port_channel_interfaces[port_channel_interface].evpn_ethernet_segment.designated_forwarder_election is arista.avd.defined %}
+{%                 do evpn_dfe_po_interfaces.append(port_channel_interface) %}
+{%             endif %}
+{%             if port_channel_interfaces[port_channel_interface].evpn_ethernet_segment.mpls is arista.avd.defined %}
+{%                 do evpn_mpls_po_interfaces.append(port_channel_interface) %}
+{%             endif %}
+{%         endif %}
 {%         if port_channel_interfaces[port_channel_interface].link_tracking_groups is arista.avd.defined %}
 {%             do link_tracking_interfaces.append(port_channel_interface) %}
 {%         endif %}
 {%     endfor %}
+{#     EVPN Multihoming #}
+{%     if evpn_es_po_interfaces | length > 0 %}
+
+#### EVPN Multihoming
+
+##### EVPN Multihoming Summary
+
+| Interface | Ethernet Segment Identifier | Multihoming Redundancy Mode | Route Target |
+| --------- | --------------------------- | --------------------------- | ------------ |
+{%         for evpn_es_po_interface in evpn_es_po_interfaces | arista.avd.natural_sort %}
+{%             set esi = port_channel_interfaces[evpn_es_po_interface].esi | arista.avd.default("-") %}
+{%             set redundancy = port_channel_interfaces[evpn_es_po_interface].evpn_ethernet_segment.redundancy | arista.avd.default("all-active") %}
+{%             set rt = port_channel_interfaces[evpn_es_po_interface].rt | arista.avd.default("-") %}
+| {{ evpn_es_po_interface }} | {{ esi }} | {{ redundancy }} | {{ rt }} |
+{%         endfor %}
+{%         if evpn_dfe_po_interfaces | length > 0 %}
+
+##### Designated Forwarder Election Summary
+
+| Interface | Algorithm | Preference Value | Dont Preempt | Hold time | Subsequent Hold Time | Candidate Reachability Required |
+| --------- | --------- | ---------------- | ------------ | --------- | -------------------- | ------------------------------- |
+{%             for evpn_dfe_po_interface in evpn_dfe_po_interfaces | arista.avd.natural_sort %}
+{%                 set df_po_settings = port_channel_interfaces[evpn_dfe_po_interface].evpn_ethernet_segment.designated_forwarder_election %}
+{%                 set algorithm = df_po_settings.algorithm | arista.avd.default("modulus") %}
+{%                 set pref_value = df_po_settings.preference_value | arista.avd.default("-") %}
+{%                 set dont_preempt = df_po_settings.dont_preempt | arista.avd.default(false) %}
+{%                 set hold_time = df_po_settings.hold_time | arista.avd.default("-") %}
+{%                 set subsequent_hold_time = df_po_settings.subsequent_hold_time | arista.avd.default("-") %}
+{%                 set candidate_reachability = df_po_settings.candidate_reachability_required | arista.avd.default(false) %}
+| {{ evpn_dfe_po_interface }} | {{ algorithm }} | {{ pref_value }} | {{ dont_preempt }} | {{ hold_time }} | {{ subsequent_hold_time }} | {{ candidate_reachability }} |
+{%             endfor %}
+{%         endif %}
+{%         if evpn_mpls_po_interfaces | length > 0 %}
+
+##### EVPN-MPLS summary
+
+| Interface | Shared Index | Tunnel Flood Filter Time |
+| --------- | ------------ | ------------------------ |
+{%             for evpn_mpls_po_interface in evpn_mpls_po_interfaces | arista.avd.natural_sort %}
+{%                 set shared_index = port_channel_interfaces[evpn_mpls_po_interface].evpn_ethernet_segment.mpls.shared_index | arista.avd.default("-") %}
+{%                 set tff_time = port_channel_interfaces[evpn_mpls_po_interface].evpn_ethernet_segment.mpls.tunnel_flood_filter_time | arista.avd.default("-") %}
+| {{ evpn_mpls_po_interface }} | {{ shared_index }} | {{ tff_time }} |
+{%             endfor %}
+{%         endif %}
+{%     endif %}
+{#     Link Tracking Groups #}
 {%     if link_tracking_interfaces | length > 0 %}
 
 #### Link Tracking Groups
 
 | Interface | Group Name | Direction |
 | --------- | ---------- | --------- |
-{%         for link_tracking_interface in link_tracking_interfaces %}
+{%         for link_tracking_interface in link_tracking_interfaces | arista.avd.natural_sort %}
 {%             for link_tracking_group in port_channel_interfaces[link_tracking_interface].link_tracking_groups | arista.avd.natural_sort('name') %}
 {%                 if link_tracking_group.name is arista.avd.defined and link_tracking_group.direction is arista.avd.defined %}
 | {{ link_tracking_interface }} | {{ link_tracking_group.name }} | {{ link_tracking_group.direction }} |
@@ -154,30 +212,28 @@
 {# IPv4 #}
 {%     set port_channel_interface_ipv4 = namespace() %}
 {%     set port_channel_interface_ipv4.configured = false %}
-{%     if port_channel_interfaces is defined and port_channel_interfaces is not none %}
-{%         for port_channel_interface in port_channel_interfaces | arista.avd.natural_sort %}
-{%             if port_channel_interfaces[port_channel_interface].type is defined and port_channel_interfaces[port_channel_interface].type in ['routed', 'l3dot1q'] and port_channel_interfaces[port_channel_interface].ip_address is defined %}
-{%                 set port_channel_interface_ipv4.configured = true %}
-{%             endif %}
-{%         endfor %}
-{%     endif %}
-{%     if port_channel_interface_ipv4.configured == true %}
+{%     for port_channel_interface in port_channel_interfaces | arista.avd.natural_sort %}
+{%         if port_channel_interfaces[port_channel_interface].type is defined and port_channel_interfaces[port_channel_interface].type in ['routed', 'l3dot1q'] and port_channel_interfaces[port_channel_interface].ip_address is defined %}
+{%             set port_channel_interface_ipv4.configured = true %}
+{%         endif %}
+{%     endfor %}
+{%     if port_channel_interface_ipv4.configured %}
 
 #### IPv4
 
 | Interface | Description | Type | MLAG ID | IP Address | VRF | MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | ---- | ------- | ---------- | --- | --- | -------- | ------ | ------- |
 {%         for port_channel_interface in port_channel_interfaces | arista.avd.natural_sort %}
-{%             if port_channel_interfaces[port_channel_interface].type is defined and port_channel_interfaces[port_channel_interface].type in ['routed', 'l3dot1q'] and port_channel_interfaces[port_channel_interface].ip_address is defined and port_channel_interfaces[port_channel_interface].ip_address is not none %}
-{%                 set description = port_channel_interfaces[port_channel_interface].description | default ("-") %}
+{%             if port_channel_interfaces[port_channel_interface].type is defined and port_channel_interfaces[port_channel_interface].type in ['routed', 'l3dot1q'] and port_channel_interfaces[port_channel_interface].ip_address is arista.avd.defined %}
+{%                 set description = port_channel_interfaces[port_channel_interface].description | arista.avd.default("-") %}
 {%                 set type = "routed" %}
-{%                 set mlag = port_channel_interfaces[port_channel_interface].mlag | default ("-") %}
-{%                 set ip_address = port_channel_interfaces[port_channel_interface].ip_address | default ("-") %}
-{%                 set vrf = port_channel_interfaces[port_channel_interface].vrf | default ("default") %}
-{%                 set mtu = port_channel_interfaces[port_channel_interface].mtu | default ("-") %}
-{%                 set shutdown = port_channel_interfaces[port_channel_interface].shutdown | default ("-") %}
-{%                 set acl_in = port_channel_interfaces[port_channel_interface].access_group_in | default ("-") %}
-{%                 set acl_out = port_channel_interfaces[port_channel_interface].access_group_out | default ("-") %}
+{%                 set mlag = port_channel_interfaces[port_channel_interface].mlag | arista.avd.default("-") %}
+{%                 set ip_address = port_channel_interfaces[port_channel_interface].ip_address | arista.avd.default("-") %}
+{%                 set vrf = port_channel_interfaces[port_channel_interface].vrf | arista.avd.default("default") %}
+{%                 set mtu = port_channel_interfaces[port_channel_interface].mtu | arista.avd.default("-") %}
+{%                 set shutdown = port_channel_interfaces[port_channel_interface].shutdown | arista.avd.default("-") %}
+{%                 set acl_in = port_channel_interfaces[port_channel_interface].access_group_in | arista.avd.default("-") %}
+{%                 set acl_out = port_channel_interfaces[port_channel_interface].access_group_out | arista.avd.default("-") %}
 | {{ port_channel_interface }} | {{ description }} | {{ type }} | {{ mlag }} | {{ ip_address }} | {{ vrf }} | {{ mtu }} | {{ shutdown | lower }} | {{ acl_in }} | {{ acl_out }} |
 {%             endif %}
 {%         endfor %}
@@ -185,36 +241,34 @@
 {# IPv6 #}
 {%     set port_channel_interface_ipv6 = namespace() %}
 {%     set port_channel_interface_ipv6.configured = false %}
-{%     if port_channel_interfaces is defined and port_channel_interfaces is not none %}
-{%         for port_channel_interface in port_channel_interfaces | arista.avd.natural_sort %}
-{%             if port_channel_interfaces[port_channel_interface].type is defined and port_channel_interfaces[port_channel_interface].type in ['routed', 'l3dot1q'] and port_channel_interfaces[port_channel_interface].ipv6_address is defined %}
-{%                 set port_channel_interface_ipv6.configured = true %}
-{%             endif %}
-{%         endfor %}
-{%     endif %}
-{%     if port_channel_interface_ipv6.configured == true %}
+{%     for port_channel_interface in port_channel_interfaces | arista.avd.natural_sort %}
+{%         if port_channel_interfaces[port_channel_interface].type is defined and port_channel_interfaces[port_channel_interface].type in ['routed', 'l3dot1q'] and port_channel_interfaces[port_channel_interface].ipv6_address is defined %}
+{%             set port_channel_interface_ipv6.configured = true %}
+{%         endif %}
+{%     endfor %}
+{%     if port_channel_interface_ipv6.configured %}
 
 #### IPv6
 
 | Interface | Description | Type | MLAG ID | IPv6 Address | VRF | MTU | Shutdown | ND RA Disabled | Managed Config Flag | IPv6 ACL In | IPv6 ACL Out |
 | --------- | ----------- | ---- | ------- | -------------| --- | --- | -------- | -------------- | ------------------- | ----------- | ------------ |
 {%         for port_channel_interface in port_channel_interfaces | arista.avd.natural_sort %}
-{%             if port_channel_interfaces[port_channel_interface].type is defined and port_channel_interfaces[port_channel_interface].type in ['routed', 'l3dot1q'] and port_channel_interfaces[port_channel_interface].ipv6_address is defined and port_channel_interfaces[port_channel_interface].ipv6_address is not none %}
-{%                 set description = port_channel_interfaces[port_channel_interface].description | default ("-") %}
+{%             if port_channel_interfaces[port_channel_interface].type is defined and port_channel_interfaces[port_channel_interface].type in ['routed', 'l3dot1q'] and port_channel_interfaces[port_channel_interface].ipv6_address is arista.avd.defined %}
+{%                 set description = port_channel_interfaces[port_channel_interface].description | arista.avd.default("-") %}
 {%                 set type = "routed" %}
-{%                 set mlag = port_channel_interfaces[port_channel_interface].mlag | default ("-") %}
-{%                 set ipv6_address = port_channel_interfaces[port_channel_interface].ipv6_address | default ("-") %}
-{%                 set vrf = port_channel_interfaces[port_channel_interface].vrf | default ("default") %}
-{%                 set mtu = port_channel_interfaces[port_channel_interface].mtu | default ("-") %}
-{%                 set shutdown = port_channel_interfaces[port_channel_interface].shutdown | default ("-") %}
-{%                 set ipv6_nd_ra_disabled = port_channel_interfaces[port_channel_interface].ipv6_nd_ra_disabled | default ("-") %}
-{%                 if port_channel_interfaces[port_channel_interface].ipv6_nd_managed_config_flag is defined and port_channel_interfaces[port_channel_interface].ipv6_nd_managed_config_flag is not none %}
+{%                 set mlag = port_channel_interfaces[port_channel_interface].mlag | arista.avd.default("-") %}
+{%                 set ipv6_address = port_channel_interfaces[port_channel_interface].ipv6_address | arista.avd.default("-") %}
+{%                 set vrf = port_channel_interfaces[port_channel_interface].vrf | arista.avd.default("default") %}
+{%                 set mtu = port_channel_interfaces[port_channel_interface].mtu | arista.avd.default("-") %}
+{%                 set shutdown = port_channel_interfaces[port_channel_interface].shutdown | arista.avd.default("-") %}
+{%                 set ipv6_nd_ra_disabled = port_channel_interfaces[port_channel_interface].ipv6_nd_ra_disabled | arista.avd.default("-") %}
+{%                 if port_channel_interfaces[port_channel_interface].ipv6_nd_managed_config_flag is arista.avd.defined %}
 {%                     set ipv6_nd_managed_config_flag = port_channel_interfaces[port_channel_interface].ipv6_nd_managed_config_flag | lower %}
 {%                 else %}
 {%                     set ipv6_nd_managed_config_flag = '-' %}
 {%                 endif %}
-{%                 set ipv6_acl_in = port_channel_interfaces[port_channel_interface].ipv6_access_group_in | default ("-") %}
-{%                 set ipv6_acl_out = port_channel_interfaces[port_channel_interface].ipv6_access_group_out | default ("-") %}
+{%                 set ipv6_acl_in = port_channel_interfaces[port_channel_interface].ipv6_access_group_in | arista.avd.default("-") %}
+{%                 set ipv6_acl_out = port_channel_interfaces[port_channel_interface].ipv6_access_group_out | arista.avd.default("-") %}
 | {{ port_channel_interface }} | {{ description }} | {{ type }} | {{ mlag }} | {{ ipv6_address }} | {{ vrf }} | {{ mtu }} | {{ shutdown | lower }} | {{ ipv6_nd_ra_disabled | lower }} | {{ ipv6_nd_managed_config_flag | lower }} | {{ ipv6_acl_in }} | {{ ipv6_acl_out }} |
 {%             endif %}
 {%         endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
@@ -100,9 +100,43 @@ interface {{ port_channel_interface }}
 {%     if port_channel_interfaces[port_channel_interface].mlag is arista.avd.defined %}
    mlag {{ port_channel_interfaces[port_channel_interface].mlag }}
 {%     endif %}
-{%     if port_channel_interfaces[port_channel_interface].esi is arista.avd.defined %}
+{%     if port_channel_interfaces[port_channel_interface].esi is arista.avd.defined or port_channel_interfaces[port_channel_interface].evpn_ethernet_segment is arista.avd.defined %}
    evpn ethernet-segment
+{%         if port_channel_interfaces[port_channel_interface].esi is arista.avd.defined %}
       identifier {{ port_channel_interfaces[port_channel_interface].esi }}
+{%         endif %}
+{%         if port_channel_interfaces[port_channel_interface].evpn_ethernet_segment.redundancy is arista.avd.defined %}
+      redundancy {{ port_channel_interfaces[port_channel_interface].evpn_ethernet_segment.redundancy }}
+{%         endif %}
+{%         if port_channel_interfaces[port_channel_interface].evpn_ethernet_segment.designated_forwarder_election is arista.avd.defined %}
+{%             if port_channel_interfaces[port_channel_interface].evpn_ethernet_segment.designated_forwarder_election.algorithm is arista.avd.defined("modulus") %}
+      designated-forwarder election algorithm modulus
+{%             elif port_channel_interfaces[port_channel_interface].evpn_ethernet_segment.designated_forwarder_election.algorithm is arista.avd.defined("preference") and port_channel_interfaces[port_channel_interface].evpn_ethernet_segment.designated_forwarder_election.preference_value is arista.avd.defined %}
+{%                 set dfe_algo_cli = "designated-forwarder election algorithm preference " ~ port_channel_interfaces[port_channel_interface].evpn_ethernet_segment.designated_forwarder_election.preference_value %}
+{%                 if port_channel_interfaces[port_channel_interface].evpn_ethernet_segment.designated_forwarder_election.dont_preempt is arista.avd.defined(true) %}
+{%                     set dfe_algo_cli = dfe_algo_cli ~ " dont-preempt" %}
+{%                 endif %}
+      {{ dfe_algo_cli }}
+{%             endif %}
+{%             if port_channel_interfaces[port_channel_interface].evpn_ethernet_segment.designated_forwarder_election.hold_time is arista.avd.defined %}
+{%                 set dfe_hold_time_cli = "designated-forwarder election hold-time " ~ port_channel_interfaces[port_channel_interface].evpn_ethernet_segment.designated_forwarder_election.hold_time %}
+{%                 if port_channel_interfaces[port_channel_interface].evpn_ethernet_segment.designated_forwarder_election.subsequent_hold_time is arista.avd.defined %}
+{%                     set dfe_hold_time_cli = dfe_hold_time_cli ~ " subsequent-hold-time " ~ port_channel_interfaces[port_channel_interface].evpn_ethernet_segment.designated_forwarder_election.subsequent_hold_time %}
+{%                 endif %}
+      {{ dfe_hold_time_cli }}
+{%             endif %}
+{%             if port_channel_interfaces[port_channel_interface].evpn_ethernet_segment.designated_forwarder_election.candidate_reachability_required is arista.avd.defined(true) %}
+      designated-forwarder election candidate reachability required
+{%             elif port_channel_interfaces[port_channel_interface].evpn_ethernet_segment.designated_forwarder_election.candidate_reachability_required is arista.avd.defined(false) %}
+      no designated-forwarder election candidate reachability required
+{%             endif %}
+{%         endif %}
+{%         if port_channel_interfaces[port_channel_interface].evpn_ethernet_segment.mpls.tunnel_flood_filter_time is arista.avd.defined %}
+      mpls tunnel flood filter time {{ port_channel_interfaces[port_channel_interface].evpn_ethernet_segment.mpls.tunnel_flood_filter_time }}
+{%         endif %}
+{%         if port_channel_interfaces[port_channel_interface].evpn_ethernet_segment.mpls.shared_index is arista.avd.defined %}
+      mpls shared index {{ port_channel_interfaces[port_channel_interface].evpn_ethernet_segment.mpls.shared_index }}
+{%         endif %}
 {%         if port_channel_interfaces[port_channel_interface].rt is arista.avd.defined %}
       route-target import {{ port_channel_interfaces[port_channel_interface].rt }}
 {%         endif %}


### PR DESCRIPTION
## Change Summary

PR to add support for:
- single-active multi-homing redundancy mode
- designated-forwarder election algorithm 

Reference [article](https://eos.arista.com/eos-4-26-0f/evpn-single-active-multihoming-preference-based-df-election/)

## Related Issue(s)

Fixes #1163

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Added following changes to the port-channel-interfaces.yml

```shell
  < Port-Channel_interface_2 >:
    <snipped>
    redundancy: < Multihoming redundancy mode (all-active | single-active | default --> all-active) >
    designated_forwarder_election:
      algorithm: < modulus | preference | default --> modulus >
      preference_value: < Preference value (0-65535) >
      dont_preempt: < non-revertive DF election mode ( true | false | default --> false ) >
```

YAML

```shell
  Port-Channel60:
    description: server01_PortChannel3
    vlans: 1-4000
    mode: trunk
    esi: 0000:0000:0101:0102:0033
    rt: 01:01:01:02:00:33
    lacp_id: 0101.0102.0033
    redundancy: single-active
    designated_forwarder_election:
      algorithm: preference
      preference_value: 1000
      dont_preempt: true
```

CLI
```shell
interface Port-Channel60
   description server01_PortChannel3
   switchport
   switchport trunk allowed vlan 1-4000
   switchport mode trunk
   evpn ethernet-segment
      identifier 0000:0000:0101:0102:0033
      route-target import 01:01:01:02:00:33
      redundancy single-active
      designated-forwarder election algorithm preference 1000 dont-preempt
   lacp system-id 0101.0102.0033
```
<!--- Describe data model implemented for new features -->

## How to test
Ran molecule test which resulted in generation of TOC documentation and intended configuration

`molecule test --scenario-name eos_cli_config_gen`

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
