### PR TITLE
Feat(eos_cli_config_gen): Add options to disable logging

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/logging.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/logging.md
@@ -55,10 +55,10 @@ interface Management1
 
 | Type | Level |
 | -----| ----- |
-| Console | debugging |
-| Buffer | informational |
-| Trap | informational |
-| Synchronous | error |
+| Console | error |
+| Buffer | warnings |
+| Trap | disabled |
+| Synchronous | critical |
 
 | VRF | Source Interface |
 | --- | ---------------- |
@@ -78,10 +78,10 @@ interface Management1
 
 ```eos
 !
-logging console debugging
-logging buffered 1000000 informational
-logging trap informational
-logging synchronous level error
+logging console error
+logging buffered 1000000 warnings
+no logging trap
+logging synchronous level critical
 logging source-interface Loopback0
 logging host 20.20.20.7
 logging host 50.50.50.7 100 200 protocol tcp

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/logging.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/logging.cfg
@@ -2,10 +2,10 @@
 !
 transceiver qsfp default-mode 4x10G
 !
-logging console debugging
-logging buffered 1000000 informational
-logging trap informational
-logging synchronous level error
+logging console error
+logging buffered 1000000 warnings
+no logging trap
+logging synchronous level critical
 logging source-interface Loopback0
 logging host 20.20.20.7
 logging host 50.50.50.7 100 200 protocol tcp

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/logging.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/logging.yml
@@ -1,12 +1,12 @@
 ### Logging ###
 logging:
-  console: debugging
+  console: error
   buffered:
     size: 1000000
-    level: informational
-  trap: informational
+    level: warnings
+  trap: disabled
   synchronous:
-    level: error
+    level:
   source_interface:
   vrfs:
     mgt:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/evpn_services_l2_only_false.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/evpn_services_l2_only_false.md
@@ -672,9 +672,13 @@ ip route vrf Tenant_A_APP_Zone 10.3.32.0/24 Vlan132 name VARP
 
 ### Router BGP EVPN Address Family
 
-#### Router BGP EVPN MAC-VRFs
+#### EVPN Peer Groups
 
-##### VLAN aware bundles
+| Peer Group | Activate |
+| ---------- | -------- |
+| EVPN-OVERLAY-PEERS | True |
+
+### Router BGP VLAN Aware Bundles
 
 | VLAN Aware Bundle | Route-Distinguisher | Both Route-Target | Import Route Target | Export Route-Target | Redistribute | VLANs |
 | ----------------- | ------------------- | ----------------- | ------------------- | ------------------- | ------------ | ----- |
@@ -690,7 +694,7 @@ ip route vrf Tenant_A_APP_Zone 10.3.32.0/24 Vlan132 name VARP
 | Tenant_C_OP_Zone | 192.168.255.109:30 | 30:30 | - | - | learned | 310-311 |
 | Tenant_C_WAN_Zone | 192.168.255.109:31 | 31:31 | - | - | learned | 350 |
 
-#### Router BGP EVPN VRFs
+### Router BGP VRFs
 
 | VRF | Route-Distinguisher | Redistribute |
 | --- | ------------------- | ------------ |

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/evpn_services_l2_only_true.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/evpn_services_l2_only_true.md
@@ -442,9 +442,13 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 ### Router BGP EVPN Address Family
 
-#### Router BGP EVPN MAC-VRFs
+#### EVPN Peer Groups
 
-##### VLAN aware bundles
+| Peer Group | Activate |
+| ---------- | -------- |
+| EVPN-OVERLAY-PEERS | True |
+
+### Router BGP VLAN Aware Bundles
 
 | VLAN Aware Bundle | Route-Distinguisher | Both Route-Target | Import Route Target | Export Route-Target | Redistribute | VLANs |
 | ----------------- | ------------------- | ----------------- | ------------------- | ------------------- | ------------ | ----- |
@@ -459,8 +463,6 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | Tenant_B_WAN_Zone | 192.168.255.109:21 | 21:21 | - | - | learned | 250 |
 | Tenant_C_OP_Zone | 192.168.255.109:30 | 30:30 | - | - | learned | 310-311 |
 | Tenant_C_WAN_Zone | 192.168.255.109:31 | 31:31 | - | - | learned | 350 |
-
-#### Router BGP EVPN VRFs
 
 ### Router BGP Device Configuration
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1823,7 +1823,7 @@ logging:
     level: < "<severity_level>" | "disabled" >
   trap: < "<severity_level>" | "disabled" >
   synchronous:
-    level: < "<severity_level>" | default --> critical | "disabled" >
+    level: < "<severity_level>" | "disabled" | default --> critical >
   format:
     timestamp: < high-resolution | traditional >
     hostname: < fqdn | ipv4 >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1817,14 +1817,14 @@ load_interval:
 
 ```yaml
 logging:
-  console: < severity_level >
-  monitor: < severity_level >
+  console: < "<severity_level>" | "disabled" >
+  monitor: < "<severity_level>" | "disabled" >
   buffered:
     size: < messages_nb (minimum of 10) >
-    level: < severity_level >
-  trap: < severity_level >
+    level: < "<severity_level>" | "disabled" >
+  trap: < "<severity_level>" | "disabled" >
   synchronous:
-    level: < severity_level | default --> critical >
+    level: < "<severity_level>" | default --> critical | "disabled" >
   format:
     timestamp: < high-resolution | traditional >
     hostname: < fqdn | ipv4 >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/logging.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/logging.j2
@@ -14,11 +14,11 @@ logging monitor {{ logging.monitor }}
 {%     if logging.buffered.level is arista.avd.defined('disabled') %}
 no logging buffered
 {%     elif logging.buffered.level is arista.avd.defined %}
-{%         set logging_buffered_cli = "logging buffered "%}
+{%         set logging_buffered_cli = "logging buffered"%}
 {%         if logging.buffered.size is arista.avd.defined %}
-{%             set logging_buffered_cli = logging_buffered_cli ~ logging.buffered.size ~ " " %}
+{%             set logging_buffered_cli = logging_buffered_cli ~ " " ~ logging.buffered.size %}
 {%         endif %}
-{%         set logging_buffered_cli = logging_buffered_cli ~ logging.buffered.level %}
+{%         set logging_buffered_cli = logging_buffered_cli ~ " " ~ logging.buffered.level %}
 {{ logging_buffered_cli }}
 {%     endif %}
 {%     if logging.trap is arista.avd.defined('disabled') %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/logging.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/logging.j2
@@ -1,19 +1,34 @@
 {# eos - logging #}
 {% if logging is arista.avd.defined %}
 !
-{%     if logging.console is arista.avd.defined %}
+{%     if logging.console is arista.avd.defined('disabled') %}
+no logging console
+{%     elif logging.console is arista.avd.defined %}
 logging console {{ logging.console }}
 {%     endif %}
-{%     if logging.monitor is arista.avd.defined %}
+{%     if logging.monitor is arista.avd.defined('disabled') %}
+no logging monitor
+{%     elif logging.monitor is arista.avd.defined %}
 logging monitor {{ logging.monitor }}
 {%     endif %}
-{%     if logging.buffered.size is arista.avd.defined and logging.buffered.level is arista.avd.defined %}
-logging buffered {{ logging.buffered.size }} {{ logging.buffered.level }}
+{%     if logging.buffered.level is arista.avd.defined('disabled') %}
+no logging buffered
+{%     elif logging.buffered.level is arista.avd.defined %}
+{%         set logging_buffered_cli = "logging buffered "%}
+{%         if logging.buffered.size is arista.avd.defined %}
+{%             set logging_buffered_cli = logging_buffered_cli ~ logging.buffered.size ~ " " %}
+{%         endif %}
+{%         set logging_buffered_cli = logging_buffered_cli ~ logging.buffered.level %}
+{{ logging_buffered_cli }}
 {%     endif %}
-{%     if logging.trap is arista.avd.defined %}
+{%     if logging.trap is arista.avd.defined('disabled') %}
+no logging trap
+{%     elif logging.trap is arista.avd.defined %}
 logging trap {{ logging.trap }}
 {%     endif %}
-{%     if logging.synchronous is arista.avd.defined() %}
+{%     if logging.synchronous.level is arista.avd.defined('disabled') %}
+no logging synchronous
+{%     elif logging.synchronous is arista.avd.defined %}
 logging synchronous level {{ logging.synchronous.level | arista.avd.default("critical") }}
 {%     endif %}
 {%     if logging.format.timestamp is arista.avd.defined('high-resolution') %}


### PR DESCRIPTION
## Change Summary

Add options to disable logging types

## Related Issue(s)

Fixes #1347

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Provide option to disable:
logging.console
logging.monitor
logging.buffered
logging.trap
logging.synchronous

logging:
  console: < "<severity_level>" | "disabled" >
  monitor: < "<severity_level>" | "disabled" >
  buffered:
    size: < messages_nb (minimum of 10) >
    level: < "<severity_level>" | "disabled" >
  trap: < "<severity_level>" | "disabled" >
  synchronous:
    level: < "<severity_level>" | default --> critical | "disabled" >

!!!! Keep default value for logging synchronous to ensure backwards compatibility

!!!! I have **not** added a dedicated column for "enabled | disabled" state to the documentation. 

## How to test
Tested with molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
