### PR TITLE
Feat(eos_cli_config_gen): Support no qos trust

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -346,6 +346,7 @@ interface Ethernet20
 interface Ethernet21
    description 200MBit/s shape
    switchport
+   no qos trust
    shape rate 200000 kbps
 !
 interface Ethernet22
@@ -416,5 +417,5 @@ interface Ethernet24
 | Interface | Trust | Default DSCP | Default COS | Shape rate |
 | --------- | ----- | ------------ | ----------- | ---------- |
 | Ethernet7 | cos | - | 5 | - |
-| Ethernet21 | - | - | - | 200000 kbps |
+| Ethernet21 | disabled | - | - | 200000 kbps |
 | Ethernet22 | - | - | - | 10 percent |

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
@@ -332,6 +332,7 @@ interface Port-Channel101
    switchport
    switchport access vlan 110
    switchport pvlan mapping 111
+   no qos trust
 !
 interface Port-Channel102
    description PVLAN Promiscuous Trunk - vlan translation out
@@ -399,3 +400,4 @@ interface Port-Channel104
 | --------- | ----- | ------------ | ----------- | ---------- |
 | Port-Channel3 | - | - | - | 200000 kbps |
 | Port-Channel10 | - | - | - | 50 percent |
+| Port-Channel101 | disabled | - | - | - |

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/qos.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/qos.md
@@ -235,6 +235,14 @@ QOS Profile: **experiment**
 | 5 | 40 | - | - |
 | 7 | 30 | - | 40 percent |
 
+QOS Profile: **no_qos_trust**
+
+**Settings**
+
+| Default COS | Default DSCP | Trust | Shape Rate |
+| ----------- | ------------ | ----- | ---------- |
+| 3 | 4 | disabled | - |
+
 QOS Profile: **test**
 
 **Settings**
@@ -272,6 +280,11 @@ qos profile experiment
    tx-queue 7
       bandwidth percent 30
       shape rate 40 percent
+!
+qos profile no_qos_trust
+   no qos trust
+   qos cos 3
+   qos dscp 4
 !
 qos profile test
    qos trust dscp

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
@@ -205,6 +205,7 @@ interface Ethernet20
 interface Ethernet21
    description 200MBit/s shape
    switchport
+   no qos trust
    shape rate 200000 kbps
 !
 interface Ethernet22

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
@@ -130,6 +130,7 @@ interface Port-Channel101
    switchport
    switchport access vlan 110
    switchport pvlan mapping 111
+   no qos trust
 !
 interface Port-Channel102
    description PVLAN Promiscuous Trunk - vlan translation out

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/qos.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/qos.cfg
@@ -22,6 +22,11 @@ qos profile experiment
       bandwidth percent 30
       shape rate 40 percent
 !
+qos profile no_qos_trust
+   no qos trust
+   qos cos 3
+   qos dscp 4
+!
 qos profile test
    qos trust dscp
    qos dscp 46

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
@@ -268,6 +268,8 @@ ethernet_interfaces:
 
   Ethernet21:
     description: 200MBit/s shape
+    qos:
+      trust: disabled
     shape:
       rate: "200000 kbps"
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
@@ -147,6 +147,8 @@ port_channel_interfaces:
     mode: access
     vlans: 110
     pvlan_mapping: 111
+    qos:
+      trust: disabled
 
   Port-Channel102:
     description: PVLAN Promiscuous Trunk - vlan translation out

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/qos.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/qos.yml
@@ -44,6 +44,10 @@ qos_profiles:
         bandwidth_percent: 30
         shape:
           rate: 40 percent
+  no_qos_trust:
+    trust: disabled
+    cos: 3
+    dscp: 4
 
 ### Port-Channel Interfaces ###
 ethernet_interfaces:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -802,7 +802,7 @@ ethernet_interfaces:
     shape:
       rate: < "< rate > kbps" | "1-100 percent" | "< rate > pps" , supported options are platform dependent >
     qos:
-      trust: < dscp | cos >
+      trust: < dscp | cos | disabled >
       dscp: < dscp-value >
       cos: < cos-value >
     bfd:
@@ -858,7 +858,7 @@ ethernet_interfaces:
       id: < Port-Channel_id >
       mode: < "on" | "active" | "passive" >
     qos:
-      trust: < dscp | cos >
+      trust: < dscp | cos | disabled >
       dscp: < dscp-value >
       cos: < cos-value >
     spanning_tree_bpdufilter: < true | false >
@@ -1004,7 +1004,7 @@ port_channel_interfaces:
     lacp_fallback_timeout: <timeout in seconds, 0-300 (default 90) >
     lacp_fallback_mode: < individual | static >
     qos:
-      trust: < dscp | cos >
+      trust: < dscp | cos | disabled >
       dscp: < dscp-value >
       cos: < cos-value >
     bfd:
@@ -2107,7 +2107,7 @@ policy_maps:
 ```yaml
 qos_profiles:
   < profile-1 >:
-    trust: < dscp | cos >
+    trust: < dscp | cos | disabled >
     cos: < cos-value >
     dscp: < dscp-value >
     shape:
@@ -2124,7 +2124,7 @@ qos_profiles:
         shape:
           rate: < "< rate > kbps" | "1-100 percent" | "< rate > pps" , supported options are platform dependent >
   < profile-2 >:
-    trust: < dscp | cos >
+    trust: < dscp | cos | disabled >
     cos: < cos-value >
     dscp: < dscp-value >
     tx_queues:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/qos-profiles.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/qos-profiles.j2
@@ -17,10 +17,10 @@ QOS Profile: **{{ profile }}**
 {%         set trust = qos_profiles[profile].trust | arista.avd.default('-') %}
 {%         set shape_rate = qos_profiles[profile].shape.rate | arista.avd.default('-') %}
 | {{ cos }} | {{ dscp }} | {{ trust }} | {{ shape_rate }} |
+{%         if qos_profiles[profile].tx_queues is arista.avd.defined %}
 
 **Tx-queues**
 
-{%         if qos_profiles[profile].tx_queues is arista.avd.defined %}
 | Tx-queue | Bandwidth | Priority | Shape Rate |
 | -------- | --------- | -------- | ---------- |
 {%             for tx_queue in qos_profiles[profile].tx_queues | arista.avd.natural_sort %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -120,7 +120,11 @@ interface {{ ethernet_interface }}
    l2-protocol encapsulation dot1q vlan {{ ethernet_interfaces[ethernet_interface].l2_protocol.encapsulation_dot1q_vlan }}
 {%         endif %}
 {%         if ethernet_interfaces[ethernet_interface].qos.trust is arista.avd.defined %}
+{%             if ethernet_interfaces[ethernet_interface].qos.trust == 'disabled' %}
+   no qos trust
+{%             else %}
    qos trust {{ ethernet_interfaces[ethernet_interface].qos.trust }}
+{%             endif %}
 {%         endif %}
 {%         if ethernet_interfaces[ethernet_interface].qos.dscp is arista.avd.defined %}
    qos dscp {{ ethernet_interfaces[ethernet_interface].qos.dscp }}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
@@ -40,7 +40,7 @@ interface {{ port_channel_interface }}
 {%     if port_channel_interfaces[port_channel_interface].phone.vlan is arista.avd.defined %}
    switchport phone vlan {{ port_channel_interfaces[port_channel_interface].phone.vlan }}
 {%     endif %}
-{%     if port_channel_interfaces[port_channel_interface].phone.trunk is arista.avd.defined%}
+{%     if port_channel_interfaces[port_channel_interface].phone.trunk is arista.avd.defined %}
    switchport phone trunk {{ port_channel_interfaces[port_channel_interface].phone.trunk }}
 {%     endif %}
 {%     if port_channel_interfaces[port_channel_interface].mode is arista.avd.defined("trunk") %}
@@ -91,7 +91,11 @@ interface {{ port_channel_interface }}
    port-channel lacp fallback {{ port_channel_interfaces[port_channel_interface].lacp_fallback_mode }}
 {%     endif %}
 {%     if port_channel_interfaces[port_channel_interface].qos.trust is arista.avd.defined %}
+{%         if port_channel_interfaces[port_channel_interface].qos.trust == 'disabled' %}
+   no qos trust
+{%         else %}
    qos trust {{ port_channel_interfaces[port_channel_interface].qos.trust }}
+{%         endif %}
 {%     endif %}
 {%     if port_channel_interfaces[port_channel_interface].qos.dscp is arista.avd.defined %}
    qos dscp {{ port_channel_interfaces[port_channel_interface].qos.dscp }}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/qos-profiles.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/qos-profiles.j2
@@ -3,7 +3,11 @@
 !
 qos profile {{ profile }}
 {%     if qos_profiles[profile].trust is arista.avd.defined %}
+{%         if qos_profiles[profile].trust == 'disabled' %}
+   no qos trust
+{%         else %}
    qos trust {{ qos_profiles[profile].trust }}
+{%         endif %}
 {%     endif %}
 {%     if qos_profiles[profile].cos is arista.avd.defined %}
    qos cos {{ qos_profiles[profile].cos }}


### PR DESCRIPTION
## Change Summary

Modified jinja templates to support ```no qos trust``` with the existing knob. Supported in ```qos_profiles```, ```ethernet-interfaces```, ```portchannel-interfaces``` Refactored documentation.

## Related Issue(s)

Fixes #1387 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Old:
```yaml
qos_profiles:
  trust: < dscp | cos >
```

New:
```yaml
qos_profiles:
  trust: < dscp | cos | disabled >
```

Similar changes were done in ethernet-interfaces and port-channel interfaces.
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test
molecule
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
