### PR TITLE
Fix(eos_cli_config_gen): Fix extra blank lines in upgrade templates

### DIFF
--- a/ansible_collections/arista/avd/molecule/upgrade_eos_cli_config_gen/eos_cli_config_gen_upgrade_2.x_to_3.0/aaa.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_eos_cli_config_gen/eos_cli_config_gen_upgrade_2.x_to_3.0/aaa.yml
@@ -9,4 +9,3 @@ aaa_accounting:
       - commands: 0
         logging: true
         type: start-stop
-

--- a/ansible_collections/arista/avd/molecule/upgrade_eos_cli_config_gen/eos_cli_config_gen_upgrade_2.x_to_3.0/vxlan-interface.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_eos_cli_config_gen/eos_cli_config_gen_upgrade_2.x_to_3.0/vxlan-interface.yml
@@ -11,10 +11,8 @@ vxlan_interface:
           vni: 10110
         111:
           vni: 10111
-
       vrfs:
         Tenant_A_OP_Zone:
           vni: 10
         Tenant_A_WEB_Zone:
           vni: 11
-

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/upgrade/upgrade-2.x-to-3.0/aaa_accounting.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/upgrade/upgrade-2.x-to-3.0/aaa_accounting.j2
@@ -3,5 +3,5 @@
 aaa_accounting:
   commands:
     default:
-      {{ aaa_accounting.commands.commands_default | to_nice_yaml(indent=2) | indent(6, false) }}
+      {{ aaa_accounting.commands.commands_default | to_nice_yaml(indent=2) | indent(6, false) -}}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/upgrade/upgrade-2.x-to-3.0/vxlan_interface.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/upgrade/upgrade-2.x-to-3.0/vxlan_interface.j2
@@ -17,10 +17,10 @@ vxlan_interface:
 {%     endif %}
 {%     if vxlan_tunnel_interface.Vxlan1.vxlan_vni_mappings.vlans is arista.avd.defined %}
       vlans:
-        {{ vxlan_tunnel_interface.Vxlan1.vxlan_vni_mappings.vlans | to_nice_yaml(indent=2) | indent(8, false) }}
+        {{ vxlan_tunnel_interface.Vxlan1.vxlan_vni_mappings.vlans | to_nice_yaml(indent=2) | indent(8, false) -}}
 {%     endif %}
 {%     if vxlan_tunnel_interface.Vxlan1.vxlan_vni_mappings.vrfs is arista.avd.defined %}
       vrfs:
-        {{ vxlan_tunnel_interface.Vxlan1.vxlan_vni_mappings.vrfs | to_nice_yaml(indent=2) | indent(8, false) }}
+        {{ vxlan_tunnel_interface.Vxlan1.vxlan_vni_mappings.vrfs | to_nice_yaml(indent=2) | indent(8, false) -}}
 {%     endif %}
 {% endif %}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Fix extra blank lines in upgrade templates

## Related Issue(s)

## Component(s) name

`arista.avd.eos_cli_config_gen`
