### PR TITLE
Fix(eos_designs): Remove ibgp from underlay_routing_protocol

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_designs/templates/facts/switch/switch.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/facts/switch/switch.j2
@@ -27,7 +27,7 @@ switch:
                         platform_settings | selectattr("platforms", "arista.avd.contains", "default") | first) | to_json() }}
 
 {# switch.underlay_routing_protocol #}
-{% if underlay_routing_protocol is arista.avd.defined and underlay_routing_protocol | lower in ['ibgp', 'isis', 'ospf'] %}
+{% if underlay_routing_protocol is arista.avd.defined and underlay_routing_protocol | lower in ['isis', 'ospf'] %}
   underlay_routing_protocol: {{ underlay_routing_protocol | lower }}
 {% else %}
   underlay_routing_protocol: 'ebgp'

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/l3_edge/logic.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/l3_edge/logic.j2
@@ -67,7 +67,7 @@
 {%         if p2p_link.include_in_underlay_protocol | arista.avd.default(
               p2p_profile.include_in_underlay_protocol) is arista.avd.defined(true) %}
 {# Include in underlay routing. Build routing data #}
-{%             if switch.underlay_routing_protocol in ["ebgp","ibgp"] %}
+{%             if switch.underlay_routing_protocol == "ebgp" %}
 {%                 set as = p2p_link.as | arista.avd.default(
                             p2p_profile.as) %}
 {%                 set p2p_bgp_neighbor = namespace() %}
@@ -76,7 +76,7 @@
 {%                 set p2p_bgp_neighbor.peer_group = bgp_peer_groups.IPv4_UNDERLAY_PEERS.name | arista.avd.default("IPv4-UNDERLAY-PEERS") %}
 {%                 set p2p_bgp_neighbor.bfd = p2p_link.bfd | arista.avd.default(
                                               p2p_profile.bfd) %}
-{%                 if switch.bgp_as is arista.avd.defined and as[node_index] | string != switch.bgp_as %}
+{%                 if switch.bgp_as is arista.avd.defined and as[node_index] | string != switch.bgp_as %}
 {%                     set p2p_bgp_neighbor.local_as = as[node_index] | string %}
 {%                 endif %}
 {%                 do l3_edge_data.bgp_neighbors.update({ p2p_interface.peer_ip: p2p_bgp_neighbor }) %}


### PR DESCRIPTION
## Change Summary

Though ibgp is not supported as an underlay_routing_protocol, the var ```underlay_routing_protocol``` is checked in the eos_designs, which is not required.

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test
```make refresh-facts``` should not generate or update the artifacts. Tested the same locally
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

- [x] No new artifacts should be generated as this is a fix

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
