### PR TITLE
Fix(eos_designs): Fix ip_helpers when defined under tenant vrf

### DIFF
--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -618,6 +618,7 @@ interface Vlan110
    no shutdown
    vrf Tenant_A_OP_Zone
    ip address virtual 10.1.10.1/24
+   ip helper-address 1.2.3.4
 !
 interface Vlan111
    description SVI 111 CUSTOM DESCRIPTION

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -618,6 +618,7 @@ interface Vlan110
    no shutdown
    vrf Tenant_A_OP_Zone
    ip address virtual 10.1.10.1/24
+   ip helper-address 1.2.3.4
 !
 interface Vlan111
    description SVI 111 CUSTOM DESCRIPTION

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -877,6 +877,7 @@ interface Vlan110
    no shutdown
    vrf Tenant_A_OP_Zone
    ip address virtual 10.1.10.1/24
+   ip helper-address 1.2.3.4
 !
 interface Vlan111
    description SVI 111 CUSTOM DESCRIPTION

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -877,6 +877,7 @@ interface Vlan110
    no shutdown
    vrf Tenant_A_OP_Zone
    ip address virtual 10.1.10.1/24
+   ip helper-address 1.2.3.4
 !
 interface Vlan111
    description SVI 111 CUSTOM DESCRIPTION

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
@@ -267,6 +267,7 @@ interface Vlan110
    no shutdown
    vrf Tenant_A_OP_Zone
    ip address virtual 10.1.10.1/24
+   ip helper-address 1.2.3.4
 !
 interface Vlan111
    description SVI 111 CUSTOM DESCRIPTION

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
@@ -267,6 +267,7 @@ interface Vlan110
    no shutdown
    vrf Tenant_A_OP_Zone
    ip address virtual 10.1.10.1/24
+   ip helper-address 1.2.3.4
 !
 interface Vlan111
    description SVI 111 CUSTOM DESCRIPTION

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
@@ -464,6 +464,7 @@ interface Vlan110
    no shutdown
    vrf Tenant_A_OP_Zone
    ip address virtual 10.1.10.1/24
+   ip helper-address 1.2.3.4
 !
 interface Vlan111
    description SVI 111 CUSTOM DESCRIPTION

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
@@ -464,6 +464,7 @@ interface Vlan110
    no shutdown
    vrf Tenant_A_OP_Zone
    ip address virtual 10.1.10.1/24
+   ip helper-address 1.2.3.4
 !
 interface Vlan111
    description SVI 111 CUSTOM DESCRIPTION

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -639,6 +639,8 @@ vlan_interfaces:
     shutdown: false
     vrf: Tenant_A_OP_Zone
     ip_address_virtual: 10.1.10.1/24
+    ip_helpers:
+      1.2.3.4: {}
   Vlan111:
     tenant: Tenant_A
     tags:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -639,6 +639,8 @@ vlan_interfaces:
     shutdown: false
     vrf: Tenant_A_OP_Zone
     ip_address_virtual: 10.1.10.1/24
+    ip_helpers:
+      1.2.3.4: {}
   Vlan111:
     tenant: Tenant_A
     tags:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -586,6 +586,8 @@ vlan_interfaces:
     shutdown: false
     vrf: Tenant_A_OP_Zone
     ip_address_virtual: 10.1.10.1/24
+    ip_helpers:
+      1.2.3.4: {}
   Vlan111:
     tenant: Tenant_A
     tags:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -586,6 +586,8 @@ vlan_interfaces:
     shutdown: false
     vrf: Tenant_A_OP_Zone
     ip_address_virtual: 10.1.10.1/24
+    ip_helpers:
+      1.2.3.4: {}
   Vlan111:
     tenant: Tenant_A
     tags:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_TENANTS_NETWORKS.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_TENANTS_NETWORKS.yml
@@ -39,6 +39,8 @@ tenants:
           loopback: 100
           loopback_ip_range: 10.255.1.0/24
           loopback_description: CUSTOM_VTEP_DIAGNOSTICS_LOOPBACK_DESC
+        ip_helpers: # IP Helper set on VRF level should inherit only to vlan 110.
+          1.2.3.4:
         svis:
           # SVI as string
           '110':

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vlan-interfaces.j2
@@ -26,7 +26,7 @@ vlan_interfaces:
 {%             set svi_mtu = svi.mtu | arista.avd.default(
                              svi_profile.mtu) %}
 {%             set svi_ip_helpers = svi.ip_helpers | arista.avd.default(
-                                    tenants[tenant].vrfs[vrf].ip_helpers,
+                                    vrf.ip_helpers,
                                     svi_profile.ip_helpers) %}
 {%             set svi_raw_eos_cli = svi.nodes[inventory_hostname].raw_eos_cli | arista.avd.default(
                                      svi_profile.nodes[inventory_hostname].raw_eos_cli,


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Fix ip_helpers when defined under tenant vrf

## Related Issue(s)

After AVD 3.2.0 we did not generate config for `ip_helpers` defined under `tenants.<tenant>.vrfs.<vrf>.ip_helpers`

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->
This was missed during refactoring of the tenants templates.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Added molecule coverage so we will not miss this again.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
