### PR TITLE
Doc(eos_cli_config_gen): OSPF network prefixes

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
@@ -269,6 +269,8 @@ router ospf 100
    no passive-interface Ethernet1
    no passive-interface Ethernet2
    no passive-interface Vlan4093
+   network 198.51.100.0/24 area 0.0.0.1
+   network 203.0.113.0/24 area 0.0.0.2
    bfd default
    max-lsa 12000
    default-information originate

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-ospf.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-ospf.cfg
@@ -44,6 +44,8 @@ router ospf 100
    no passive-interface Ethernet1
    no passive-interface Ethernet2
    no passive-interface Vlan4093
+   network 198.51.100.0/24 area 0.0.0.1
+   network 203.0.113.0/24 area 0.0.0.2
    bfd default
    max-lsa 12000
    default-information originate

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-ospf.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-ospf.yml
@@ -8,6 +8,11 @@ router_ospf:
         - Ethernet1
         - Ethernet2
         - Vlan4093
+      network_prefixes:
+        198.51.100.0/24:
+          area: 0.0.0.1
+        203.0.113.0/24:
+          area: 0.0.0.2
       bfd_enable: true
       max_lsa: 12000
       default_information_originate:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -2601,6 +2601,11 @@ router_ospf:
       passive_interface_default: < true | false >
       router_id: < IPv4_address >
       log_adjacency_changes_detail: < true | false >
+      network_prefixes:
+        < IPv4 subnet / netmask >:
+          area: < area >
+        < IPv4 subnet / netmask >:
+          area: < area >
       bfd_enable: < true | false >
       no_passive_interfaces:
         - < interface_1 >


### PR DESCRIPTION
## Change Summary

Add missing documentation and test coverage for OSPF network prefixes


## Component(s) name

`arista.avd.eos_cli_config_gen`

## Checklist

### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
