### PR TITLE
Feat(eos_cli_config_gen): Support EVPN ethernet segment options on ethernet-interfaces

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -90,6 +90,8 @@ interface Management1
 | Ethernet23 |  Error-correction encoding | access | - | - | - | - |
 | Ethernet24 |  Disable error-correction encoding | access | - | - | - | - |
 | Ethernet25 |  Molecule MAC | access | - | - | - | - |
+| Ethernet27 |  EVPN-Vxlan single-active redundancy | access | - | - | - | - |
+| Ethernet28 |  EVPN-MPLS multihoming | access | - | - | - | - |
 
 *Inherited from Port-Channel Interface
 
@@ -154,6 +156,27 @@ interface Management1
 | Interface | Channel Group | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type |
 | --------- | ------------- | ------------- | ----------- | ---- | ----------------- |
 | Ethernet5 | - | ISIS_TEST | 99 | point-to-point | level-2 |
+
+#### EVPN Multihoming
+
+##### EVPN Multihoming Summary
+
+| Interface | Ethernet Segment Identifier | Multihoming Redundancy Mode | Route Target |
+| --------- | --------------------------- | --------------------------- | ------------ |
+| Ethernet27 | 0000:0000:0000:0102:0304 | single-active | 00:00:01:02:03:04 |
+| Ethernet28 | 0000:0000:0000:0102:0305 | all-active | 00:00:01:02:03:05 |
+
+##### Designated Forwarder Election Summary
+
+| Interface | Algorithm | Preference Value | Dont Preempt | Hold time | Subsequent Hold Time | Candidate Reachability Required |
+| --------- | --------- | ---------------- | ------------ | --------- | -------------------- | ------------------------------- |
+| Ethernet27 | preference | 100 | True | 10 | - | True |
+
+##### EVPN-MPLS summary
+
+| Interface | Shared Index | Tunnel Flood Filter Time |
+| --------- | ------------ | ------------------------ |
+| Ethernet28 | 100 | 100 |
 
 #### Error Correction Encoding Interfaces
 
@@ -439,6 +462,26 @@ interface Ethernet26.500
    description TENANT_A pseudowire 3 interface
    encapsulation vlan
       client dot1q outer 500 inner 50
+!
+interface Ethernet27
+   description EVPN-Vxlan single-active redundancy
+   switchport
+   evpn ethernet-segment
+      identifier 0000:0000:0000:0102:0304
+      redundancy single-active
+      designated-forwarder election algorithm preference 100 dont-preempt
+      designated-forwarder election hold-time 10
+      designated-forwarder election candidate reachability required
+      route-target import 00:00:01:02:03:04
+!
+interface Ethernet28
+   description EVPN-MPLS multihoming
+   switchport
+   evpn ethernet-segment
+      identifier 0000:0000:0000:0102:0305
+      mpls tunnel flood filter time 100
+      mpls shared index 100
+      route-target import 00:00:01:02:03:05
 ```
 
 # Routing

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
@@ -273,6 +273,26 @@ interface Ethernet26.500
    encapsulation vlan
       client dot1q outer 500 inner 50
 !
+interface Ethernet27
+   description EVPN-Vxlan single-active redundancy
+   switchport
+   evpn ethernet-segment
+      identifier 0000:0000:0000:0102:0304
+      redundancy single-active
+      designated-forwarder election algorithm preference 100 dont-preempt
+      designated-forwarder election hold-time 10
+      designated-forwarder election candidate reachability required
+      route-target import 00:00:01:02:03:04
+!
+interface Ethernet28
+   description EVPN-MPLS multihoming
+   switchport
+   evpn ethernet-segment
+      identifier 0000:0000:0000:0102:0305
+      mpls tunnel flood filter time 100
+      mpls shared index 100
+      route-target import 00:00:01:02:03:05
+!
 interface Management1
    description oob_management
    vrf MGMT

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
@@ -372,3 +372,25 @@ ethernet_interfaces:
           inner: 50
       network:
         client: true
+
+  Ethernet27:
+    description: EVPN-Vxlan single-active redundancy
+    evpn_ethernet_segment:
+      identifier: "0000:0000:0000:0102:0304"
+      route_target: "00:00:01:02:03:04"
+      redundancy: single-active
+      designated_forwarder_election:
+        algorithm: preference
+        preference_value: 100
+        dont_preempt: true
+        hold_time: 10
+        candidate_reachability_required: true
+
+  Ethernet28:
+    description: EVPN-MPLS multihoming
+    evpn_ethernet_segment:
+      identifier: "0000:0000:0000:0102:0305"
+      route_target: "00:00:01:02:03:05"
+      mpls:
+        shared_index: 100
+        tunnel_flood_filter_time: 100

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -982,6 +982,21 @@ ethernet_interfaces:
     link_tracking_groups:
       - name: < group_name >
         direction: < upstream | downstream >
+    evpn_ethernet_segment:
+      identifier: < EVPN Ethernet Segment Identifier (Type 1 format) >
+      redundancy: < all-active | single-active >
+      designated_forwarder_election:
+        algorithm: < modulus | preference >
+        # preference_value and dont_preempt are set for preference algorithm and are optional
+        preference_value: < 0-65535 >
+        dont_preempt: < true | false | default -> false >
+        hold_time: < 1-1800 Seconds >
+        subsequent_hold_time: < 10-10000 milliseconds >
+        candidate_reachability_required: < true | false >
+      mpls:
+        shared_index: < 1-1024 >
+        tunnel_flood_filter_time: < 10-10000 milliseconds >
+      route_target: < EVPN Route Target for ESI with format xx:xx:xx:xx:xx:xx >
     flowcontrol:
       received: < "received" | "send" | "on" >
     mac_security:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ethernet-interfaces.j2
@@ -357,6 +357,65 @@
 {%     if port_channel_interfaces_isis | length > 0 %}
  *Inherited from Port-Channel Interface
 {%     endif %}
+{# EVPN Multihoming #}
+{%     set evpn_es_ethernet_interfaces = [] %}
+{%     set evpn_dfe_ethernet_interfaces = [] %}
+{%     set evpn_mpls_ethernet_interfaces = [] %}
+{%     for ethernet_interface in ethernet_interfaces %}
+{%         if ethernet_interfaces[ethernet_interface].evpn_ethernet_segment is arista.avd.defined %}
+{%             do evpn_es_ethernet_interfaces.append(ethernet_interface) %}
+{%             if ethernet_interfaces[ethernet_interface].evpn_ethernet_segment.designated_forwarder_election is arista.avd.defined %}
+{%                 do evpn_dfe_ethernet_interfaces.append(ethernet_interface) %}
+{%             endif %}
+{%             if ethernet_interfaces[ethernet_interface].evpn_ethernet_segment.mpls is arista.avd.defined %}
+{%                 do evpn_mpls_ethernet_interfaces.append(ethernet_interface) %}
+{%             endif %}
+{%         endif %}
+{%     endfor %}
+{%     if evpn_es_ethernet_interfaces | length > 0 %}
+
+#### EVPN Multihoming
+
+##### EVPN Multihoming Summary
+
+| Interface | Ethernet Segment Identifier | Multihoming Redundancy Mode | Route Target |
+| --------- | --------------------------- | --------------------------- | ------------ |
+{%         for evpn_es_ethernet_interface in evpn_es_ethernet_interfaces | arista.avd.natural_sort %}
+{%             set esi = ethernet_interfaces[evpn_es_ethernet_interface].evpn_ethernet_segment.identifier | arista.avd.default("-") %}
+{%             set redundancy = ethernet_interfaces[evpn_es_ethernet_interface].evpn_ethernet_segment.redundancy | arista.avd.default("all-active") %}
+{%             set rt = ethernet_interfaces[evpn_es_ethernet_interface].evpn_ethernet_segment.route_target | arista.avd.default("-") %}
+| {{ evpn_es_ethernet_interface }} | {{ esi }} | {{ redundancy }} | {{ rt }} |
+{%         endfor %}
+{%         if evpn_dfe_ethernet_interfaces | length > 0 %}
+
+##### Designated Forwarder Election Summary
+
+| Interface | Algorithm | Preference Value | Dont Preempt | Hold time | Subsequent Hold Time | Candidate Reachability Required |
+| --------- | --------- | ---------------- | ------------ | --------- | -------------------- | ------------------------------- |
+{%             for evpn_dfe_ethernet_interface in evpn_dfe_ethernet_interfaces | arista.avd.natural_sort %}
+{%                 set df_eth_settings = ethernet_interfaces[evpn_dfe_ethernet_interface].evpn_ethernet_segment.designated_forwarder_election %}
+{%                 set algorithm = df_eth_settings.algorithm | arista.avd.default("modulus") %}
+{%                 set pref_value = df_eth_settings.preference_value | arista.avd.default("-") %}
+{%                 set dont_preempt = df_eth_settings.dont_preempt | arista.avd.default(false) %}
+{%                 set hold_time = df_eth_settings.hold_time | arista.avd.default("-") %}
+{%                 set subsequent_hold_time = df_eth_settings.subsequent_hold_time | arista.avd.default("-") %}
+{%                 set candidate_reachability = df_eth_settings.candidate_reachability_required | arista.avd.default(false) %}
+| {{ evpn_dfe_ethernet_interface }} | {{ algorithm }} | {{ pref_value }} | {{ dont_preempt }} | {{ hold_time }} | {{ subsequent_hold_time }} | {{ candidate_reachability }} |
+{%             endfor %}
+{%         endif %}
+{%         if evpn_mpls_ethernet_interfaces | length > 0 %}
+
+##### EVPN-MPLS summary
+
+| Interface | Shared Index | Tunnel Flood Filter Time |
+| --------- | ------------ | ------------------------ |
+{%             for evpn_mpls_ethernet_interface in evpn_mpls_ethernet_interfaces | arista.avd.natural_sort %}
+{%                 set shared_index = ethernet_interfaces[evpn_mpls_ethernet_interface].evpn_ethernet_segment.mpls.shared_index | arista.avd.default("-") %}
+{%                 set tff_time = ethernet_interfaces[evpn_mpls_ethernet_interface].evpn_ethernet_segment.mpls.tunnel_flood_filter_time | arista.avd.default("-") %}
+| {{ evpn_mpls_ethernet_interface }} | {{ shared_index }} | {{ tff_time }} |
+{%             endfor %}
+{%         endif %}
+{%     endif %}
 {%     set err_cor_enc_intfs = [] %}
 {%     for ethernet_interface in ethernet_interfaces %}
 {%         if ethernet_interfaces[ethernet_interface].error_correction_encoding is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -145,6 +145,47 @@ interface {{ ethernet_interface }}
 {%         if ethernet_interfaces[ethernet_interface].l2_protocol.encapsulation_dot1q_vlan is arista.avd.defined %}
    l2-protocol encapsulation dot1q vlan {{ ethernet_interfaces[ethernet_interface].l2_protocol.encapsulation_dot1q_vlan }}
 {%         endif %}
+{%         if ethernet_interfaces[ethernet_interface].evpn_ethernet_segment is arista.avd.defined %}
+   evpn ethernet-segment
+{%             if ethernet_interfaces[ethernet_interface].evpn_ethernet_segment.identifier is arista.avd.defined %}
+      identifier {{ ethernet_interfaces[ethernet_interface].evpn_ethernet_segment.identifier }}
+{%             endif %}
+{%             if ethernet_interfaces[ethernet_interface].evpn_ethernet_segment.redundancy is arista.avd.defined %}
+      redundancy {{ ethernet_interfaces[ethernet_interface].evpn_ethernet_segment.redundancy }}
+{%             endif %}
+{%             if ethernet_interfaces[ethernet_interface].evpn_ethernet_segment.designated_forwarder_election is arista.avd.defined %}
+{%                 if ethernet_interfaces[ethernet_interface].evpn_ethernet_segment.designated_forwarder_election.algorithm is arista.avd.defined("modulus") %}
+      designated-forwarder election algorithm modulus
+{%                 elif ethernet_interfaces[ethernet_interface].evpn_ethernet_segment.designated_forwarder_election.algorithm is arista.avd.defined("preference") and ethernet_interfaces[ethernet_interface].evpn_ethernet_segment.designated_forwarder_election.preference_value is arista.avd.defined %}
+{%                     set dfe_algo_cli = "designated-forwarder election algorithm preference " ~ ethernet_interfaces[ethernet_interface].evpn_ethernet_segment.designated_forwarder_election.preference_value %}
+{%                     if ethernet_interfaces[ethernet_interface].evpn_ethernet_segment.designated_forwarder_election.dont_preempt is arista.avd.defined(true) %}
+{%                         set dfe_algo_cli = dfe_algo_cli ~ " dont-preempt" %}
+{%                     endif %}
+      {{ dfe_algo_cli }}
+{%                 endif %}
+{%                 if ethernet_interfaces[ethernet_interface].evpn_ethernet_segment.designated_forwarder_election.hold_time is arista.avd.defined %}
+{%                     set dfe_hold_time_cli = "designated-forwarder election hold-time " ~ ethernet_interfaces[ethernet_interface].evpn_ethernet_segment.designated_forwarder_election.hold_time %}
+{%                     if ethernet_interfaces[ethernet_interface].evpn_ethernet_segment.designated_forwarder_election.subsequent_hold_time is arista.avd.defined %}
+{%                         set dfe_hold_time_cli = dfe_hold_time_cli ~ " subsequent-hold-time " ~ ethernet_interfaces[ethernet_interface].evpn_ethernet_segment.designated_forwarder_election.subsequent_hold_time %}
+{%                     endif %}
+      {{ dfe_hold_time_cli }}
+{%                 endif %}
+{%                 if ethernet_interfaces[ethernet_interface].evpn_ethernet_segment.designated_forwarder_election.candidate_reachability_required is arista.avd.defined(true) %}
+      designated-forwarder election candidate reachability required
+{%                 elif ethernet_interfaces[ethernet_interface].evpn_ethernet_segment.designated_forwarder_election.candidate_reachability_required is arista.avd.defined(false) %}
+      no designated-forwarder election candidate reachability required
+{%                 endif %}
+{%             endif %}
+{%             if ethernet_interfaces[ethernet_interface].evpn_ethernet_segment.mpls.tunnel_flood_filter_time is arista.avd.defined %}
+      mpls tunnel flood filter time {{ ethernet_interfaces[ethernet_interface].evpn_ethernet_segment.mpls.tunnel_flood_filter_time }}
+{%             endif %}
+{%             if ethernet_interfaces[ethernet_interface].evpn_ethernet_segment.mpls.shared_index is arista.avd.defined %}
+      mpls shared index {{ ethernet_interfaces[ethernet_interface].evpn_ethernet_segment.mpls.shared_index }}
+{%             endif %}
+{%             if ethernet_interfaces[ethernet_interface].evpn_ethernet_segment.route_target is arista.avd.defined %}
+      route-target import {{ ethernet_interfaces[ethernet_interface].evpn_ethernet_segment.route_target }}
+{%             endif %}
+{%         endif %}
 {%         if ethernet_interfaces[ethernet_interface].qos.trust is arista.avd.defined %}
 {%             if ethernet_interfaces[ethernet_interface].qos.trust == 'disabled' %}
    no qos trust


### PR DESCRIPTION
## Change Summary

EVPN ethernet-segment commands are supported only under port-channel interfaces. This PR will add feature to support similar features under ethernet-interfaces. This is required for non-mlag interfaces.

## Related Issue(s)

Closely related #1163 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Added the new knob as below:

```
evpn_ethernet_segment:
  identifier: < EVPN Ethernet Segment Identifier (Type 1 format) >
  redundancy: < all-active | single-active >
  designated_forwarder_election:
    algorithm: < modulus | preference >
    # preference_value and dont_preempt are set for preference algorithm and are optional
    preference_value: < 0-65535 >
    dont_preempt: < true | false | default -> false >
    hold_time: < 1-1800 Seconds >
    subsequent_hold_time: < 10-10000 milliseconds >
    candidate_reachability_required: < true | false >
  mpls:
    shared_index: < 1-1024 >
    tunnel_flood_filter_time: < 10-10000 milliseconds >
  route_target: < EVPN Route Target for ESI with format xx:xx:xx:xx:xx:xx >
```
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test
molecule test cases updated
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code has been rebased from devel before I start
- [ x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ x] My change requires a change to the documentation and documentation have been updated accordingly.
- [ x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
