### PR TITLE
Feat(eos_cli_config_gen): Support setting OSPF distance

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
@@ -198,6 +198,12 @@ interface Vlan24
 | 500 | - | disabled |- | disabled | default | disabled | disabled | - | - | - |
 | 600 | - | disabled |- | disabled | default | disabled | disabled | - | - | - |
 
+### Router OSPF Distance
+
+| Process ID | Intra Area | Inter Area | External |
+| ---------- | ---------- | ---------- | -------- |
+| 100 | 50 | 70 | 60 |
+
 ### Router OSPF Router Redistribution
 
 | Process ID | Source Protocol | Route Map |
@@ -264,6 +270,9 @@ interface Vlan24
 !
 router ospf 100
    router-id 192.168.255.3
+   distance ospf intra-area 50
+​   distance ospf external 60
+   distance ospf inter-area 70
    passive-interface default
    no passive-interface Ethernet1
    no passive-interface Ethernet2

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-ospf.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-ospf.cfg
@@ -40,6 +40,9 @@ interface Vlan24
 !
 router ospf 100
    router-id 192.168.255.3
+   distance ospf intra-area 50
+​   distance ospf external 60
+   distance ospf inter-area 70
    passive-interface default
    no passive-interface Ethernet1
    no passive-interface Ethernet2

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-ospf.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-ospf.yml
@@ -23,6 +23,10 @@ router_ospf:
       auto_cost_reference_bandwidth: 100
       maximum_paths: 10
       mpls_ldp_sync_default: true
+      distance:
+        intra_area: 50
+        external: 60
+        inter_area: 70
     101:
       vrf: CUSTOMER01
       passive_interface_default: true

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -2683,6 +2683,10 @@ router_ospf:
       vrf: < vrf_name_for_process_id >
       passive_interface_default: < true | false >
       router_id: < IPv4_address >
+      distance:
+        external: < 1-255 >
+        inter_area: < 1-255 >
+        intra_area: < 1-255 >
       log_adjacency_changes_detail: < true | false >
       network_prefixes:
         < IPv4 subnet / netmask >:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-ospf.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-ospf.j2
@@ -47,6 +47,26 @@
 {%         set mpls_ldp_sync_default = router_ospf.process_ids[process_id].mpls_ldp_sync_default | arista.avd.default('-') %}
 | {{ process_id }} | {{ router_id }} | {{ passive_interface_default }} |{{ no_passive_interfaces.list }} | {{ bgp_enable }} | {{ max_lsa }} | {{ default_information_originate }} | {{ log_adjacency_changes_detail }} | {{ auto_cost_reference_bandwidth }} | {{ maximum_paths }} | {{ mpls_ldp_sync_default }} |
 {%     endfor %}
+{# OSPF Distance #}
+{%     set ospf_distance_process_ids = [] %}
+{%     for process_id in router_ospf.process_ids %}
+{%         if router_ospf.process_ids[process_id].distance is arista.avd.defined %}
+{%             do ospf_distance_process_ids.append(process_id) %}
+{%         endif %}
+{%     endfor %}
+{%     if ospf_distance_process_ids | length > 0 %}
+
+### Router OSPF Distance
+
+| Process ID | Intra Area | Inter Area | External |
+| ---------- | ---------- | ---------- | -------- |
+{%         for process_id in ospf_distance_process_ids %}
+{%             set distance_intra_area = router_ospf.process_ids[process_id].distance.intra_area | arista.avd.default('-') %}
+{%             set distance_inter_area = router_ospf.process_ids[process_id].distance.inter_area | arista.avd.default('-') %}
+{%             set distance_external = router_ospf.process_ids[process_id].distance.external | arista.avd.default('-') %}
+| {{ process_id }} | {{ distance_intra_area }} | {{ distance_inter_area }} | {{ distance_external }} |
+{%         endfor %}
+{%     endif %}
 {# Router Redistribution #}
 {%     set has = namespace() %}
 {%     set has.found = false %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-ospf.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-ospf.j2
@@ -12,6 +12,17 @@ router ospf {{ process_id }}
 {%     if router_ospf.process_ids[process_id].router_id is arista.avd.defined %}
    router-id {{ router_ospf.process_ids[process_id].router_id }}
 {%     endif %}
+{%     if router_ospf.process_ids[process_id].distance is arista.avd.defined %}
+{%         if router_ospf.process_ids[process_id].distance.intra_area is arista.avd.defined %}
+   distance ospf intra-area {{ router_ospf.process_ids[process_id].distance.intra_area }}
+{%         endif %}
+​{%         if router_ospf.process_ids[process_id].distance.external is arista.avd.defined %}
+   distance ospf external {{ router_ospf.process_ids[process_id].distance.external }}
+{%         endif %}
+{%         if router_ospf.process_ids[process_id].distance.inter_area is arista.avd.defined %}
+   distance ospf inter-area {{ router_ospf.process_ids[process_id].distance.inter_area }}
+{%         endif %}
+{%     endif %}
 {%     if router_ospf.process_ids[process_id].passive_interface_default is arista.avd.defined(true) %}
    passive-interface default
 {%     endif %}


### PR DESCRIPTION
## Change Summary

Support setting OSPF distance
<!-- Enter short PR description -->

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->
```yaml
router_ospf:
  process_ids:
    < process_id >:
      distance:
        external: < 1-255 >
        inter_area: < 1-255 >
        intra_area: < 1-255 >
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Added molecule coverage

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
