### PR TITLE
Fix: Linting errors with upper-case variables

### DIFF
--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -363,4 +363,4 @@ jobs:
       - name: Run J2lint
         timeout-minutes: 2
         run: |
-          j2lint $GITHUB_WORKSPACE --ignore S7 S6 V1
+          j2lint $GITHUB_WORKSPACE --ignore S7 S6

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/patch-panel.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/patch-panel.j2
@@ -12,14 +12,14 @@
 {%             set patch_panel_patch.enabled = patch.enabled | arista.avd.default(true) %}
 {%             for connector in patch.connectors | arista.avd.default([]) %}
 {%                 if loop.first %}
-{%                     set patch_panel_patch.connector_A_type = connector.type | capitalize %}
-{%                     set patch_panel_patch.connector_A_endpoint = connector.endpoint %}
+{%                     set patch_panel_patch.connector_a_type = connector.type | capitalize %}
+{%                     set patch_panel_patch.connector_a_endpoint = connector.endpoint %}
 {%                 else %}
-{%                     set patch_panel_patch.connector_B_type = connector.type | capitalize %}
-{%                     set patch_panel_patch.connector_B_endpoint = connector.endpoint %}
+{%                     set patch_panel_patch.connector_b_type = connector.type | capitalize %}
+{%                     set patch_panel_patch.connector_b_endpoint = connector.endpoint %}
 {%                 endif %}
 {%             endfor %}
-| {{ patch.name }} | {{ patch_panel_patch.enabled }} | {{ patch_panel_patch.connector_A_type }} | {{ patch_panel_patch.connector_A_endpoint }} | {{ patch_panel_patch.connector_B_type }} | {{ patch_panel_patch.connector_B_endpoint }} |
+| {{ patch.name }} | {{ patch_panel_patch.enabled }} | {{ patch_panel_patch.connector_a_type }} | {{ patch_panel_patch.connector_a_endpoint }} | {{ patch_panel_patch.connector_b_type }} | {{ patch_panel_patch.connector_b_endpoint }} |
 {%         endif %}
 {%     endfor %}
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vxlan-interface.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vxlan-interface.j2
@@ -1,3 +1,4 @@
+{# j2lint: disable=V1 #}
 {% if vxlan_interface.Vxlan1 is arista.avd.defined %}
 
 ## VXLAN Interface

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-access-lists.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-access-lists.j2
@@ -119,6 +119,7 @@ ip access-list {{ acl.name }}
 {%                 if ip_access_lists_max_entries is arista.avd.defined %}
 {%                     set counter.acle_number = counter.acle_number + 1 %}
 {%                     if counter.acle_number > ip_access_lists_max_entries %}
+{#                     j2lint: disable=V1 #}
    {{ a_non_existing_var | mandatory('The number of ACL entries is above defined maximum!') }}
 {%                     endif %}
 {%                 endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vxlan-interface.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vxlan-interface.j2
@@ -1,3 +1,4 @@
+{# j2lint: disable=V1 #}
 {# eos- VxLAN Interface #}
 {% if vxlan_interface.Vxlan1 is arista.avd.defined %}
 !

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/upgrade/upgrade-2.x-to-3.0/vxlan_interface.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/upgrade/upgrade-2.x-to-3.0/vxlan_interface.j2
@@ -1,3 +1,4 @@
+{# j2lint: disable=V1 #}
 {% if vxlan_tunnel_interface.Vxlan1 is arista.avd.defined %}
 # Change from vxlan_tunnel_interface to vxlan_interface data model
 vxlan_interface:

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/mlag/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/mlag/router-bgp.j2
@@ -1,3 +1,4 @@
+{# j2lint: disable=V1 #}
 {# MLAG iBGP peering #}
 {% if switch.mlag_l3 is arista.avd.defined(true) and switch.underlay_routing_protocol == "ebgp" %}
 router_bgp:

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-vrfs.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-vrfs.j2
@@ -1,3 +1,4 @@
+{# j2lint: disable=V1 #}
 {# tenant router bgp evpn VRFs #}
 {% if switch.network_services_l3 is arista.avd.defined(true) %}
 {%     set bgp_vrf = namespace() %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/ebgp/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/ebgp/router-bgp.j2
@@ -1,3 +1,4 @@
+{# j2lint: disable=V1 #}
 router_bgp:
 
   peer_groups:

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/ibgp/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/ibgp/router-bgp.j2
@@ -1,3 +1,4 @@
+{# j2lint: disable=V1 #}
 router_bgp:
 
 {% if switch.evpn_role == "server" %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/underlay/ebgp/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/underlay/ebgp/router-bgp.j2
@@ -1,3 +1,4 @@
+{# j2lint: disable=V1 #}
 {# EBGP #}
 {## Underlay network peerings #}
 router_bgp:

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/upgrade/upgrade-2.x-to-3.0/l3leaf.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/upgrade/upgrade-2.x-to-3.0/l3leaf.j2
@@ -1,3 +1,4 @@
+{# j2lint: disable=V1 #}
 {% if l3leaf is arista.avd.defined %}
 {####### l3leaf #######}
 l3leaf:

--- a/ansible_collections/arista/avd/roles/eos_validate_state/templates/validate_state_report-csv.j2
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/templates/validate_state_report-csv.j2
@@ -1,3 +1,4 @@
+{# j2lint: disable=V1 #}
 {# AVD State Validation Report - CSV #}
 test_id,node,test_category,test_description,test,result,failure_reason
 {% set test_id = namespace(value=0) %}


### PR DESCRIPTION
## Change Summary

Fixes patch panel doc template to not use capital letters in j2 variables.

## Component(s) name

`arista.avd.eos_cli_config_gen`

### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
