### PR TITLE
CI: Fixing the j2lint CI stall issue

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/dhcp-relay.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/dhcp-relay.md
@@ -91,7 +91,8 @@ dhcp relay
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | false|
+| default | false |
+
 ### IP Routing Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
@@ -272,7 +272,7 @@ interface Vlan24
 router ospf 100
    router-id 192.168.255.3
    distance ospf intra-area 50
-​   distance ospf external 60
+   distance ospf external 60
    distance ospf inter-area 70
    passive-interface default
    no passive-interface Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-ospf.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-ospf.cfg
@@ -41,7 +41,7 @@ interface Vlan24
 router ospf 100
    router-id 192.168.255.3
    distance ospf intra-area 50
-​   distance ospf external 60
+   distance ospf external 60
    distance ospf inter-area 70
    passive-interface default
    no passive-interface Ethernet1

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/patch-panel.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/patch-panel.j2
@@ -10,9 +10,9 @@ patch panel
 {%             for connector in patch.connectors | arista.avd.natural_sort %}
 {%                 if connector.id is arista.avd.defined %}
 {%                     if connector.type is arista.avd.defined("interface") %}
-{%                         set connector_cli = "connector " ~ connector.id ~ " interface " ~ connector.endpoint %}
+{%                         set connector_cli = "connector " ~ connector.id ~ " interface " ~ connector.endpoint %}
 {%                     elif connector.type is arista.avd.defined("pseudowire") %}
-{%                         set connector_cli = "connector " ~ connector.id ~ " pseudowire " ~ connector.endpoint %}
+{%                         set connector_cli = "connector " ~ connector.id ~ " pseudowire " ~ connector.endpoint %}
 {%                     endif %}
       {{ connector_cli }}
 {%                 endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-ospf.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-ospf.j2
@@ -16,7 +16,7 @@ router ospf {{ process_id }}
 {%         if router_ospf.process_ids[process_id].distance.intra_area is arista.avd.defined %}
    distance ospf intra-area {{ router_ospf.process_ids[process_id].distance.intra_area }}
 {%         endif %}
-​{%         if router_ospf.process_ids[process_id].distance.external is arista.avd.defined %}
+{%         if router_ospf.process_ids[process_id].distance.external is arista.avd.defined %}
    distance ospf external {{ router_ospf.process_ids[process_id].distance.external }}
 {%         endif %}
 {%         if router_ospf.process_ids[process_id].distance.inter_area is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
@@ -142,7 +142,7 @@ tenants:
             - pod: < pod_name >
               ipv4_pool: < IPv4_address/Mask >
 
-        # Dictionary for router OSPF configuration | Optional.
+        # Dictionary for router OSPF configuration | Optional.
         # This will create an ospf routing instance in the tenant VRF. If there is no nodes definition, the ospf instance will be
         # created on all leafs where the vrf is deployed. This will also cause automatic ospf redistribution into bgp unless
         # explicitly turned off with "redistribute_ospf: false".
@@ -159,7 +159,7 @@ tenants:
             - < hostname1 >
             - < hostname2 >
 
-        # Non-selectively enabling or disabling redistribute ospf inside the VRF | Optional.
+        # Non-selectively enabling or disabling redistribute ospf inside the VRF | Optional.
         redistribute_ospf: < true | false, Default -> true >
 
         # Dictionary of SVIs | Required.
@@ -315,10 +315,10 @@ tenants:
             interface: < interface >
             nodes: [ < node_1 >, < node_2 >]
 
-        # Non-selectively enabling or disabling redistribute static inside the VRF | Optional.
+        # Non-selectively enabling or disabling redistribute static inside the VRF | Optional.
         redistribute_static: < true | false >
 
-        # Dictionary of BGP peer definitions | Optional.
+        # Dictionary of BGP peer definitions | Optional.
         # This will configure BGP neighbors inside the tenant VRF for peering with external devices.
         # The configured peer will automatically be activated for ipv4 or ipv6 address family based on the ip address.
         # Note, only ipv4 and ipv6 address families are currently supported in eos_designs.
@@ -328,7 +328,7 @@ tenants:
             remote_as: < remote ASN >
             description: < description >
             password: < encrypted password >
-            send_community: < standard | extended | large | all >
+            send_community: < standard | extended | large | all >
             next_hop_self: < true | false >
             maximum_routes: < 0-4294967294 >
             default_originate:


### PR DESCRIPTION
## Change Summary

j2lint job hangs in the pipeline. This is due to j2lint not being able to process a j2 template with special character.

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
1. Removed a special character from ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-ospf.j2
2. This special character was stalling the jinja2 linter

## How to test
I have checked that the j2lint command works correctly on latest devel branch

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
