### PR TITLE
Fix(eos_cli_config_gen): Fix name-servers jinja templates to allow non-vrf nameservers

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/name-servers.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/name-servers.j2
@@ -7,7 +7,7 @@
 | Name Server | Source VRF |
 | ----------- | ---------- |
 {%     for node in name_server.nodes %}
-| {{ node }} | {{ name_server.source.vrf }} |
+| {{ node }} | {{ name_server.source.vrf | arista.avd.default('-') }} |
 {%     endfor %}
 
 ### Name Servers Device Configuration

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/name-servers.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/name-servers.j2
@@ -2,5 +2,7 @@
 {% for node in name_server.nodes | arista.avd.natural_sort %}
 {%     if name_server.source.vrf is arista.avd.defined %}
 ip name-server vrf {{ name_server.source.vrf }} {{ node }}
+{%     else %}
+ip name-server {{ node }}
 {%     endif %}
 {% endfor %}


### PR DESCRIPTION
## Change Summary

name-servers.j2 is missing a condition to handle non-vrf (vrf default) name servers.

In previous versions the code existed (inline) and I think it was accidently removed during refactoring.

## Related Issue(s)

Fixes #N/A

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
add condition to also cover output rendering of no vrf is defined

<!--- Describe data model implemented for new features -->
model unchanged

## How to test
molecule test only covers scenario with vrf, so maybe this is why we didn't catch the issue?

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been rebased from devel before I start
- [X] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [X] My change requires a change to the documentation and documentation have been updated accordingly.
- [O] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
