### PR TITLE
Feat(eos_cli_config_gen): Support for Flex Encap and l2dot1q subinterfaces

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -93,6 +93,23 @@ interface Management1
 
 *Inherited from Port-Channel Interface
 
+#### Encapsulation Dot1q Interfaces
+
+| Interface | Description | Type | Vlan ID | Dot1q VLAN Tag |
+| --------- | ----------- | -----| ------- | -------------- |
+| Ethernet8.101 | to WAN-ISP-01 Ethernet2.101 - VRF-C1 | l3dot1q | - | 101 |
+
+#### Flexible Encapsulation Interfaces
+
+| Interface | Description | Type | Vlan ID | Client Unmatched | Client Dot1q VLAN | Client Dot1q Outer Tag | Client Dot1q Inner Tag | Network Retain Client Encapsulation | Network Dot1q VLAN | Network Dot1q Outer Tag | Network Dot1q Inner Tag |
+| --------- | ----------- | ---- | ------- | -----------------| ----------------- | ---------------------- | ---------------------- | ----------------------------------- | ------------------ | ----------------------- | ----------------------- |
+| Ethernet26.1 | TENANT_A pseudowire 1 interface | l2dot1q | - | True | - | - | - | False | - | - | - |
+| Ethernet26.100 | TENANT_A pseudowire 1 interface | l2dot1q | - | False | 100 | - | - | True | - | - | - |
+| Ethernet26.200 | TENANT_A pseudowire 2 interface | l2dot1q | - | False | 200 | - | - | False | - | - | - |
+| Ethernet26.300 | TENANT_A pseudowire 3 interface | l2dot1q | - | False | 300 | - | - | False | 400 | - | - |
+| Ethernet26.400 | TENANT_A pseudowire 3 interface | l2dot1q | - | False | - | 400 | 20 | False | - | 401 | 21 |
+| Ethernet26.500 | TENANT_A pseudowire 3 interface | l2dot1q | - | False | - | 500 | 50 | True | - | - | - |
+
 #### Private VLAN
 
 | Interface | PVLAN Mapping | Secondary Trunk |
@@ -389,6 +406,39 @@ interface Ethernet25
    switchport
    mac access-group MAC_ACL_IN in
    mac access-group MAC_ACL_OUT out
+!
+interface Ethernet26
+   no switchport
+!
+interface Ethernet26.1
+   description TENANT_A pseudowire 1 interface
+   encapsulation vlan
+      client unmatched
+!
+interface Ethernet26.100
+   description TENANT_A pseudowire 1 interface
+   encapsulation vlan
+      client dot1q 100 network client
+!
+interface Ethernet26.200
+   description TENANT_A pseudowire 2 interface
+   encapsulation vlan
+      client dot1q 200
+!
+interface Ethernet26.300
+   description TENANT_A pseudowire 3 interface
+   encapsulation vlan
+      client dot1q 300 network dot1q 400
+!
+interface Ethernet26.400
+   description TENANT_A pseudowire 3 interface
+   encapsulation vlan
+      client dot1q outer 400 inner 20 network dot1q outer 21 inner 401
+!
+interface Ethernet26.500
+   description TENANT_A pseudowire 3 interface
+   encapsulation vlan
+      client dot1q outer 500 inner 50
 ```
 
 # Routing

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
@@ -134,6 +134,10 @@ interface Ethernet10/4
    switchport mode trunk
    spanning-tree portfast
 !
+interface Ethernet11/1
+   description LAG Member
+   channel-group 111 mode active
+!
 interface Ethernet15
    description DC1-AGG03_Ethernet1
    channel-group 15 mode active
@@ -186,6 +190,23 @@ interface Ethernet50
 | Port-Channel107 | bpdu true | switched | access | - | - | - | - | - | - | - |
 | Port-Channel108 | bpdu false | switched | access | - | - | - | - | - | - | - |
 | Port-Channel109 | Molecule ACLs | switched | access | 110 | - | - | - | - | - | - |
+
+#### Encapsulation Dot1q Interfaces
+
+| Interface | Description | Type | Vlan ID | Dot1q VLAN Tag |
+| --------- | ----------- | -----| ------- | -------------- |
+| Port-Channel8.101 | to Dev02 Port-Channel8.101 - VRF-C1 | l3dot1q | - | 101 |
+
+#### Flexible Encapsulation Interfaces
+
+| Interface | Description | Type | Vlan ID | Client Unmatched | Client Dot1q VLAN | Client Dot1q Outer Tag | Client Dot1q Inner Tag | Network Retain Client Encapsulation | Network Dot1q VLAN | Network Dot1q Outer Tag | Network Dot1q Inner Tag |
+| --------- | ----------- | ---- | ------- | -----------------| ----------------- | ---------------------- | ---------------------- | ----------------------------------- | ------------------ | ----------------------- | ----------------------- |
+| Port-Channel111.1 | TENANT_A pseudowire 1 interface | l2dot1q | - | True | - | - | - | False | - | - | - |
+| Port-Channel111.100 | TENANT_A pseudowire 2 interface | l2dot1q | - | False | 100 | - | - | True | - | - | - |
+| Port-Channel111.200 | TENANT_A pseudowire 3 interface | l2dot1q | - | False | 200 | - | - | False | - | - | - |
+| Port-Channel111.300 | TENANT_A pseudowire 4 interface | l2dot1q | - | False | 300 | - | - | False | 400 | - | - |
+| Port-Channel111.400 | TENANT_A pseudowire 3 interface | l2dot1q | - | False | - | 400 | 20 | False | - | 401 | 21 |
+| Port-Channel111.1000 | L2 Subinterface | l2dot1q | 1000 | False | 100 | - | - | True | - | - | - |
 
 #### Private VLAN
 
@@ -398,6 +419,45 @@ interface Port-Channel109
    ipv6 access-group IPV6_ACL_OUT out
    mac access-group MAC_ACL_IN in
    mac access-group MAC_ACL_OUT out
+!
+interface Port-Channel111
+   description Flexencap Port-Channel
+   no switchport
+!
+interface Port-Channel111.1
+   description TENANT_A pseudowire 1 interface
+   encapsulation vlan
+      client unmatched
+!
+interface Port-Channel111.100
+   description TENANT_A pseudowire 2 interface
+   encapsulation vlan
+      client dot1q 100 network client
+!
+interface Port-Channel111.200
+   description TENANT_A pseudowire 3 interface
+   encapsulation vlan
+      client dot1q 200
+!
+interface Port-Channel111.300
+   description TENANT_A pseudowire 4 interface
+   encapsulation vlan
+      client dot1q 300 network dot1q 400
+!
+interface Port-Channel111.400
+   description TENANT_A pseudowire 3 interface
+   encapsulation vlan
+      client dot1q outer 400 inner 20 network dot1q outer 21 inner 401
+!
+interface Port-Channel111.1000
+   description L2 Subinterface
+   vlan id 1000
+   encapsulation vlan
+      client dot1q 100 network client
+   evpn ethernet-segment
+      identifier 0000:0000:0303:0202:0101
+      route-target import 03:03:02:02:01:01
+   lacp system-id 0303.0202.0101
 ```
 
 # Routing

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
@@ -240,6 +240,39 @@ interface Ethernet25
    mac access-group MAC_ACL_IN in
    mac access-group MAC_ACL_OUT out
 !
+interface Ethernet26
+   no switchport
+!
+interface Ethernet26.1
+   description TENANT_A pseudowire 1 interface
+   encapsulation vlan
+      client unmatched
+!
+interface Ethernet26.100
+   description TENANT_A pseudowire 1 interface
+   encapsulation vlan
+      client dot1q 100 network client
+!
+interface Ethernet26.200
+   description TENANT_A pseudowire 2 interface
+   encapsulation vlan
+      client dot1q 200
+!
+interface Ethernet26.300
+   description TENANT_A pseudowire 3 interface
+   encapsulation vlan
+      client dot1q 300 network dot1q 400
+!
+interface Ethernet26.400
+   description TENANT_A pseudowire 3 interface
+   encapsulation vlan
+      client dot1q outer 400 inner 20 network dot1q outer 21 inner 401
+!
+interface Ethernet26.500
+   description TENANT_A pseudowire 3 interface
+   encapsulation vlan
+      client dot1q outer 500 inner 50
+!
 interface Management1
    description oob_management
    vrf MGMT

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
@@ -187,6 +187,45 @@ interface Port-Channel109
    mac access-group MAC_ACL_IN in
    mac access-group MAC_ACL_OUT out
 !
+interface Port-Channel111
+   description Flexencap Port-Channel
+   no switchport
+!
+interface Port-Channel111.1
+   description TENANT_A pseudowire 1 interface
+   encapsulation vlan
+      client unmatched
+!
+interface Port-Channel111.100
+   description TENANT_A pseudowire 2 interface
+   encapsulation vlan
+      client dot1q 100 network client
+!
+interface Port-Channel111.200
+   description TENANT_A pseudowire 3 interface
+   encapsulation vlan
+      client dot1q 200
+!
+interface Port-Channel111.300
+   description TENANT_A pseudowire 4 interface
+   encapsulation vlan
+      client dot1q 300 network dot1q 400
+!
+interface Port-Channel111.400
+   description TENANT_A pseudowire 3 interface
+   encapsulation vlan
+      client dot1q outer 400 inner 20 network dot1q outer 21 inner 401
+!
+interface Port-Channel111.1000
+   description L2 Subinterface
+   vlan id 1000
+   encapsulation vlan
+      client dot1q 100 network client
+   evpn ethernet-segment
+      identifier 0000:0000:0303:0202:0101
+      route-target import 03:03:02:02:01:01
+   lacp system-id 0303.0202.0101
+!
 interface Ethernet3
    description MLAG_PEER_DC1-LEAF1B_Ethernet3
    channel-group 3 mode active
@@ -223,6 +262,10 @@ interface Ethernet10/4
    switchport trunk allowed vlan 100
    switchport mode trunk
    spanning-tree portfast
+!
+interface Ethernet11/1
+   description LAG Member
+   channel-group 111 mode active
 !
 interface Ethernet15
    description DC1-AGG03_Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
@@ -315,3 +315,60 @@ ethernet_interfaces:
     description: Molecule MAC
     mac_access_group_in: MAC_ACL_IN
     mac_access_group_out: MAC_ACL_OUT
+
+  Ethernet26:
+    type: routed
+  Ethernet26.1:
+    type: l2dot1q
+    description: TENANT_A pseudowire 1 interface
+    encapsulation_vlan:
+      client:
+        unmatched: true
+  Ethernet26.100:
+    type: l2dot1q
+    description: TENANT_A pseudowire 1 interface
+    encapsulation_vlan:
+      client:
+        dot1q:
+          vlan: 100
+      network:
+        client: true
+  Ethernet26.200:
+    type: l2dot1q
+    description: TENANT_A pseudowire 2 interface
+    encapsulation_vlan:
+      client:
+        dot1q:
+          vlan: 200
+  Ethernet26.300:
+    type: l2dot1q
+    description: TENANT_A pseudowire 3 interface
+    encapsulation_vlan:
+      client:
+        dot1q:
+          vlan: 300
+      network:
+        dot1q:
+          vlan: 400
+  Ethernet26.400:
+    type: l2dot1q
+    description: TENANT_A pseudowire 3 interface
+    encapsulation_vlan:
+      client:
+        dot1q:
+          outer: 400
+          inner: 20
+      network:
+        dot1q:
+          outer: 401
+          inner: 21
+  Ethernet26.500:
+    type: l2dot1q
+    description: TENANT_A pseudowire 3 interface
+    encapsulation_vlan:
+      client:
+        dot1q:
+          outer: 500
+          inner: 50
+      network:
+        client: true

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
@@ -203,6 +203,66 @@ port_channel_interfaces:
     mac_access_group_in: MAC_ACL_IN
     mac_access_group_out: MAC_ACL_OUT
 
+  Port-Channel111:
+    description: Flexencap Port-Channel
+    type: routed
+  Port-Channel111.1:
+    type: l2dot1q
+    description: TENANT_A pseudowire 1 interface
+    encapsulation_vlan:
+      client:
+        unmatched: true
+  Port-Channel111.100:
+    type: l2dot1q
+    description: TENANT_A pseudowire 2 interface
+    encapsulation_vlan:
+      client:
+        dot1q:
+          vlan: 100
+      network:
+        client: true
+  Port-Channel111.200:
+    type: l2dot1q
+    description: TENANT_A pseudowire 3 interface
+    encapsulation_vlan:
+      client:
+        dot1q:
+          vlan: 200
+  Port-Channel111.300:
+    type: l2dot1q
+    description: TENANT_A pseudowire 4 interface
+    encapsulation_vlan:
+      client:
+        dot1q:
+          vlan: 300
+      network:
+        dot1q:
+          vlan: 400
+  Port-Channel111.400:
+    type: l2dot1q
+    description: TENANT_A pseudowire 3 interface
+    encapsulation_vlan:
+      client:
+        dot1q:
+          outer: 400
+          inner: 20
+      network:
+        dot1q:
+          outer: 401
+          inner: 21
+  Port-Channel111.1000:
+    type: l2dot1q
+    description: L2 Subinterface
+    vlan_id: 1000
+    encapsulation_vlan:
+      client:
+        dot1q:
+          vlan: 100
+      network:
+        client: true
+    esi: 0000:0000:0303:0202:0101
+    rt: 03:03:02:02:01:01
+    lacp_id: 0303.0202.0101
 
 # Children interfaces
 ethernet_interfaces:
@@ -315,4 +375,10 @@ ethernet_interfaces:
     description: LAG Member
     channel_group:
       id: 109
+      mode: active
+
+  Ethernet11/1:
+    description: LAG Member
+    channel_group:
+      id: 111
       mode: active

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -263,6 +263,13 @@ vlan 350
 
 *Inherited from Port-Channel Interface
 
+#### Encapsulation Dot1q Interfaces
+
+| Interface | Description | Type | Vlan ID | Dot1q VLAN Tag |
+| --------- | ----------- | -----| ------- | -------------- |
+| Ethernet10.100 | subinterface test | l3dot1q | - | 100 |
+| Ethernet10.200 | subinterface test with vlan override | l3dot1q | - | 121 |
+
 #### IPv4
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -261,6 +261,13 @@ vlan 350
 
 *Inherited from Port-Channel Interface
 
+#### Encapsulation Dot1q Interfaces
+
+| Interface | Description | Type | Vlan ID | Dot1q VLAN Tag |
+| --------- | ----------- | -----| ------- | -------------- |
+| Ethernet10.100 | subinterface test | l3dot1q | - | 100 |
+| Ethernet10.200 | subinterface test with vlan override | l3dot1q | - | 141 |
+
 #### IPv4
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -263,6 +263,13 @@ vlan 350
 
 *Inherited from Port-Channel Interface
 
+#### Encapsulation Dot1q Interfaces
+
+| Interface | Description | Type | Vlan ID | Dot1q VLAN Tag |
+| --------- | ----------- | -----| ------- | -------------- |
+| Ethernet10.100 | subinterface test | l3dot1q | - | 100 |
+| Ethernet10.200 | subinterface test with vlan override | l3dot1q | - | 121 |
+
 #### IPv4
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -261,6 +261,13 @@ vlan 350
 
 *Inherited from Port-Channel Interface
 
+#### Encapsulation Dot1q Interfaces
+
+| Interface | Description | Type | Vlan ID | Dot1q VLAN Tag |
+| --------- | ----------- | -----| ------- | -------------- |
+| Ethernet10.100 | subinterface test | l3dot1q | - | 100 |
+| Ethernet10.200 | subinterface test with vlan override | l3dot1q | - | 141 |
+
 #### IPv4
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -832,7 +832,9 @@ ethernet_interfaces:
     shutdown: < true | false >
     speed: < interface_speed | forced interface_speed | auto interface_speed >
     mtu: < mtu >
-    type: < routed | switched | l3dot1q >
+    # l3dot1q and l2dot1q are used for sub-interfaces.
+    # The parent interface should be defined as routed.
+    type: < routed | switched | l3dot1q | l2dot1q >
     vrf: < vrf_name >
     error_correction_encoding:
       enabled: < true | false | default -> true >
@@ -842,6 +844,21 @@ ethernet_interfaces:
       - name: < group_name >
         direction: < upstream | downstream >
     encapsulation_dot1q_vlan: < vlan tag to configure on sub-interface >
+    encapsulation_vlan:
+      client:
+        dot1q:
+          vlan: < Client VLAN ID >
+        outer: < Client Outer VLAN ID >
+        inner: < Client Inner VLAN ID >
+        unmatched: < true | false >
+      # network encapsulation is all optional, and skipped if using client unmatched.
+      network:
+        dot1q:
+          vlan: < Network VLAN ID >
+        outer: < Network Outer VLAN ID >
+        inner: < Network Inner VLAN ID >
+        client: < true | false >
+    vlan_id: < 1-4094 >
     ip_address: < IPv4_address/Mask >
     ip_address_secondaries:
       - < IPv4_address/Mask >
@@ -1104,8 +1121,25 @@ port_channel_interfaces:
         link_status: < true | false >
     shutdown: < true | false >
     vlans: "< list of vlans as string >"
-    type: < routed | switched | l3dot1q >
+    # l3dot1q and l2dot1q are used for sub-interfaces.
+    # The parent interface should be defined as routed.
+    type: < routed | switched | l3dot1q | l2dot1q >
     encapsulation_dot1q_vlan: < vlan tag to configure on sub-interface >
+    encapsulation_vlan:
+      client:
+        dot1q:
+          vlan: < Client VLAN ID >
+        outer: < Client Outer VLAN ID >
+        inner: < Client Inner VLAN ID >
+        unmatched: < true | false >
+      # network encapsulation is all optional, and skipped if using client unmatched.
+      network:
+        dot1q:
+          vlan: < Network VLAN ID >
+        outer: < Network Outer VLAN ID >
+        inner: < Network Inner VLAN ID >
+        client: < true | false >
+    vlan_id: < 1-4094 >
     mode: < access | dot1q-tunnel | trunk | "trunk phone" >
     native_vlan: < native vlan number >
     link_tracking_groups:
@@ -1174,7 +1208,7 @@ port_channel_interfaces:
   < Port-Channel_interface_3 >:
     description: < description >
     vlans: "< list of vlans as string >"
-    type: < routed | switched | l3dot1q >
+    type: < routed | switched | l3dot1q | l2dot1q >
     mode: < access | dot1q-tunnel | trunk | "trunk phone" >
     spanning_tree_bpdufilter: < "enabled" | true | "disabled" >
     spanning_tree_bpduguard: < "enabled" | true | "disabled" >
@@ -1195,7 +1229,7 @@ port_channel_interfaces:
   < Port-Channel_interface_4 >:
     description: < description >
     mtu: < mtu >
-    type: < routed | switched | l3dot1q >
+    type: < routed | switched | l3dot1q | l2dot1q >
     ip_address: < IP_address/mask >
     ipv6_enable: < true | false >
     ipv6_address: < IPv6_address/mask >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ethernet-interfaces.j2
@@ -11,7 +11,7 @@
 {%     for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort %}
 {%         if ethernet_interfaces[ethernet_interface].channel_group.id is arista.avd.defined %}
 {%             set port_channel_interface = 'Port-Channel' + ethernet_interfaces[ethernet_interface].channel_group.id | string %}
-{%             if port_channel_interfaces[port_channel_interface].type is not defined or port_channel_interfaces[port_channel_interface].type not in ['routed', 'l3dot1q'] %}
+{%             if port_channel_interfaces[port_channel_interface].type is not defined or port_channel_interfaces[port_channel_interface].type not in ['routed', 'l3dot1q', 'l2dot1q'] %}
 {%                 set description = ethernet_interfaces[ethernet_interface].description | default("-") %}
 {%                 set mode = port_channel_interfaces[port_channel_interface].mode | default("access") %}
 {%                 set vlans = port_channel_interfaces[port_channel_interface].vlans | default ('-') %}
@@ -29,7 +29,7 @@
 {%                 endif %}
 | {{ ethernet_interface }} | {{ description }} | *{{ mode }} | *{{ vlans }} | *{{ native_vlan }} | *{{ l2.trunk_groups }} | {{ channel_group }} |
 {%             endif %}
-{%         elif ethernet_interfaces[ethernet_interface].type is not defined or ethernet_interfaces[ethernet_interface].type not in ['routed', 'l3dot1q'] %}
+{%         elif ethernet_interfaces[ethernet_interface].type is not defined or ethernet_interfaces[ethernet_interface].type not in ['routed', 'l3dot1q', 'l2dot1q'] %}
 {%             set description = ethernet_interfaces[ethernet_interface].description | default("-") %}
 {%             set mode = ethernet_interfaces[ethernet_interface].mode | default("access") %}
 {%             set vlans = ethernet_interfaces[ethernet_interface].vlans | default ('-') %}
@@ -49,6 +49,53 @@
 {%     endfor %}
 
 *Inherited from Port-Channel Interface
+{# Encapsulation #}
+{%     set encapsulation_dot1q_interfaces = [] %}
+{%     set flexencap_interfaces = [] %}
+{%     for ethernet_interface in ethernet_interfaces %}
+{%         if ethernet_interfaces[ethernet_interface].type | arista.avd.default in ['l3dot1q', 'l2dot1q'] %}
+{%             if ethernet_interfaces[ethernet_interface].encapsulation_dot1q_vlan is arista.avd.defined %}
+{%                 do encapsulation_dot1q_interfaces.append(ethernet_interface) %}
+{%             elif ethernet_interfaces[ethernet_interface].encapsulation_vlan is arista.avd.defined %}
+{%                 do flexencap_interfaces.append(ethernet_interface) %}
+{%             endif %}
+{%         endif %}
+{%     endfor %}
+{%     if encapsulation_dot1q_interfaces | length > 0 %}
+
+#### Encapsulation Dot1q Interfaces
+
+| Interface | Description | Type | Vlan ID | Dot1q VLAN Tag |
+| --------- | ----------- | -----| ------- | -------------- |
+{%         for ethernet_interface in encapsulation_dot1q_interfaces | arista.avd.natural_sort %}
+{%             set description = ethernet_interfaces[ethernet_interface].description | arista.avd.default('-') %}
+{%             set type = ethernet_interfaces[ethernet_interface].type %}
+{%             set vlan_id = ethernet_interfaces[ethernet_interface].vlan_id | arista.avd.default('-') %}
+{%             set encapsulation_dot1q_vlan = ethernet_interfaces[ethernet_interface].encapsulation_dot1q_vlan | arista.avd.default('-') %}
+| {{ ethernet_interface }} | {{ description }} | {{ type }} | {{ vlan_id }} | {{ encapsulation_dot1q_vlan }} |
+{%         endfor %}
+{%     endif %}
+{%     if flexencap_interfaces | length > 0 %}
+
+#### Flexible Encapsulation Interfaces
+
+| Interface | Description | Type | Vlan ID | Client Unmatched | Client Dot1q VLAN | Client Dot1q Outer Tag | Client Dot1q Inner Tag | Network Retain Client Encapsulation | Network Dot1q VLAN | Network Dot1q Outer Tag | Network Dot1q Inner Tag |
+| --------- | ----------- | ---- | ------- | -----------------| ----------------- | ---------------------- | ---------------------- | ----------------------------------- | ------------------ | ----------------------- | ----------------------- |
+{%         for ethernet_interface in flexencap_interfaces | arista.avd.natural_sort %}
+{%             set description = ethernet_interfaces[ethernet_interface].description | arista.avd.default("-") %}
+{%             set type = ethernet_interfaces[ethernet_interface].type %}
+{%             set vlan_id = ethernet_interfaces[ethernet_interface].vlan_id | arista.avd.default('-') %}
+{%             set client_unmatched = ethernet_interfaces[ethernet_interface].encapsulation_vlan.client.unmatched | arista.avd.default(false) %}
+{%             set client_dot1q_vlan = ethernet_interfaces[ethernet_interface].encapsulation_vlan.client.dot1q.vlan | arista.avd.default("-") %}
+{%             set client_dot1q_outer = ethernet_interfaces[ethernet_interface].encapsulation_vlan.client.dot1q.outer | arista.avd.default("-") %}
+{%             set client_dot1q_inner = ethernet_interfaces[ethernet_interface].encapsulation_vlan.client.dot1q.inner | arista.avd.default("-") %}
+{%             set network_client = ethernet_interfaces[ethernet_interface].encapsulation_vlan.network.client | arista.avd.default(false) %}
+{%             set network_dot1q_vlan = ethernet_interfaces[ethernet_interface].encapsulation_vlan.network.dot1q.vlan | arista.avd.default("-") %}
+{%             set network_dot1q_outer = ethernet_interfaces[ethernet_interface].encapsulation_vlan.network.dot1q.outer | arista.avd.default("-") %}
+{%             set network_dot1q_inner = ethernet_interfaces[ethernet_interface].encapsulation_vlan.network.dot1q.inner | arista.avd.default("-") %}
+| {{ ethernet_interface }} | {{ description }} | {{ type }} | {{ vlan_id }} | {{ client_unmatched }} | {{ client_dot1q_vlan }} | {{ client_dot1q_outer }} | {{ client_dot1q_inner }} | {{ network_client }} | {{ network_dot1q_vlan }} | {{ network_dot1q_outer }} | {{ network_dot1q_inner }} |
+{%         endfor %}
+{%     endif %}
 {# PVLAN #}
 {%     set ethernet_interface_pvlan = namespace() %}
 {%     set ethernet_interface_pvlan.configured = false %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/port-channel-interfaces.j2
@@ -9,7 +9,7 @@
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
 {%     for port_channel_interface in port_channel_interfaces | arista.avd.natural_sort %}
-{%         if port_channel_interfaces[port_channel_interface].type is not defined or port_channel_interfaces[port_channel_interface].type not in ['routed', 'l3dot1q'] %}
+{%         if port_channel_interfaces[port_channel_interface].type is not defined or port_channel_interfaces[port_channel_interface].type not in ['routed', 'l3dot1q', 'l2dot1q'] %}
 {%             set description = port_channel_interfaces[port_channel_interface].description | default ("-") %}
 {%             set type = port_channel_interfaces[port_channel_interface].type | default ("switched") %}
 {%             set mode = port_channel_interfaces[port_channel_interface].mode | default ("access") %}
@@ -32,6 +32,53 @@
 | {{ port_channel_interface }} | {{ description }} | {{ type }} | {{ mode }} | {{ vlans }} | {{ native_vlan }} | {{ l2.trunk_groups }} | {{ lacp_fallback_timeout }} | {{ lacp_fallback_mode }} | {{ mlag }} | {{ esi }} |
 {%         endif %}
 {%     endfor %}
+{# Encapsulation #}
+{%     set encapsulation_dot1q_interfaces = [] %}
+{%     set flexencap_interfaces = [] %}
+{%     for port_channel_interface in port_channel_interfaces %}
+{%         if port_channel_interfaces[port_channel_interface].type | arista.avd.default in ['l3dot1q', 'l2dot1q'] %}
+{%             if port_channel_interfaces[port_channel_interface].encapsulation_dot1q_vlan is arista.avd.defined %}
+{%                 do encapsulation_dot1q_interfaces.append(port_channel_interface) %}
+{%             elif port_channel_interfaces[port_channel_interface].encapsulation_vlan is arista.avd.defined %}
+{%                 do flexencap_interfaces.append(port_channel_interface) %}
+{%             endif %}
+{%         endif %}
+{%     endfor %}
+{%     if encapsulation_dot1q_interfaces | length > 0 %}
+
+#### Encapsulation Dot1q Interfaces
+
+| Interface | Description | Type | Vlan ID | Dot1q VLAN Tag |
+| --------- | ----------- | -----| ------- | -------------- |
+{%         for port_channel_interface in encapsulation_dot1q_interfaces | arista.avd.natural_sort %}
+{%             set description = port_channel_interfaces[port_channel_interface].description | arista.avd.default('-') %}
+{%             set type = port_channel_interfaces[port_channel_interface].type %}
+{%             set vlan_id = port_channel_interfaces[port_channel_interface].vlan_id | arista.avd.default('-') %}
+{%             set encapsulation_dot1q_vlan = port_channel_interfaces[port_channel_interface].encapsulation_dot1q_vlan | arista.avd.default('-') %}
+| {{ port_channel_interface }} | {{ description }} | {{ type }} | {{ vlan_id }} | {{ encapsulation_dot1q_vlan }} |
+{%         endfor %}
+{%     endif %}
+{%     if flexencap_interfaces | length > 0 %}
+
+#### Flexible Encapsulation Interfaces
+
+| Interface | Description | Type | Vlan ID | Client Unmatched | Client Dot1q VLAN | Client Dot1q Outer Tag | Client Dot1q Inner Tag | Network Retain Client Encapsulation | Network Dot1q VLAN | Network Dot1q Outer Tag | Network Dot1q Inner Tag |
+| --------- | ----------- | ---- | ------- | -----------------| ----------------- | ---------------------- | ---------------------- | ----------------------------------- | ------------------ | ----------------------- | ----------------------- |
+{%         for port_channel_interface in flexencap_interfaces | arista.avd.natural_sort %}
+{%             set description = port_channel_interfaces[port_channel_interface].description | arista.avd.default("-") %}
+{%             set type = port_channel_interfaces[port_channel_interface].type %}
+{%             set vlan_id = port_channel_interfaces[port_channel_interface].vlan_id | arista.avd.default('-') %}
+{%             set client_unmatched = port_channel_interfaces[port_channel_interface].encapsulation_vlan.client.unmatched | arista.avd.default(false) %}
+{%             set client_dot1q_vlan = port_channel_interfaces[port_channel_interface].encapsulation_vlan.client.dot1q.vlan | arista.avd.default("-") %}
+{%             set client_dot1q_outer = port_channel_interfaces[port_channel_interface].encapsulation_vlan.client.dot1q.outer | arista.avd.default("-") %}
+{%             set client_dot1q_inner = port_channel_interfaces[port_channel_interface].encapsulation_vlan.client.dot1q.inner | arista.avd.default("-") %}
+{%             set network_client = port_channel_interfaces[port_channel_interface].encapsulation_vlan.network.client | arista.avd.default(false) %}
+{%             set network_dot1q_vlan = port_channel_interfaces[port_channel_interface].encapsulation_vlan.network.dot1q.vlan | arista.avd.default("-") %}
+{%             set network_dot1q_outer = port_channel_interfaces[port_channel_interface].encapsulation_vlan.network.dot1q.outer | arista.avd.default("-") %}
+{%             set network_dot1q_inner = port_channel_interfaces[port_channel_interface].encapsulation_vlan.network.dot1q.inner | arista.avd.default("-") %}
+| {{ port_channel_interface }} | {{ description }} | {{ type }} | {{ vlan_id }} | {{ client_unmatched }} | {{ client_dot1q_vlan }} | {{ client_dot1q_outer }} | {{ client_dot1q_inner }} | {{ network_client }} | {{ network_dot1q_vlan }} | {{ network_dot1q_outer }} | {{ network_dot1q_inner }} |
+{%         endfor %}
+{%     endif %}
 {# PVLAN #}
 {%     set port_channel_interface_pvlan = namespace() %}
 {%     set port_channel_interface_pvlan.configured = false %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -61,8 +61,34 @@ interface {{ ethernet_interface }}
 {%         endif %}
 {%         if ethernet_interfaces[ethernet_interface].type is arista.avd.defined('routed') %}
    no switchport
-{%         elif ethernet_interfaces[ethernet_interface].type is arista.avd.defined('l3dot1q') and ethernet_interfaces[ethernet_interface].encapsulation_dot1q_vlan is arista.avd.defined() %}
+{%         elif ethernet_interfaces[ethernet_interface].type | arista.avd.default in ['l3dot1q', 'l2dot1q'] %}
+{%             if ethernet_interfaces[ethernet_interface].vlan_id is arista.avd.defined and
+                  ethernet_interfaces[ethernet_interface].type == 'l2dot1q' %}
+   vlan id {{ ethernet_interfaces[ethernet_interface].vlan_id }}
+{%             endif %}
+{%             if ethernet_interfaces[ethernet_interface].encapsulation_dot1q_vlan is arista.avd.defined %}
    encapsulation dot1q vlan {{ ethernet_interfaces[ethernet_interface].encapsulation_dot1q_vlan }}
+{%             elif ethernet_interfaces[ethernet_interface].encapsulation_vlan.client.dot1q.vlan is arista.avd.defined() %}
+{%                 set encapsulation_cli = "client dot1q " ~ ethernet_interfaces[ethernet_interface].encapsulation_vlan.client.dot1q.vlan %}
+{%                 if ethernet_interfaces[ethernet_interface].encapsulation_vlan.network.dot1q.vlan is arista.avd.defined() %}
+{%                     set encapsulation_cli = encapsulation_cli ~ " network dot1q " ~ ethernet_interfaces[ethernet_interface].encapsulation_vlan.network.dot1q.vlan %}
+{%                 elif ethernet_interfaces[ethernet_interface].encapsulation_vlan.network.client is arista.avd.defined(true) %}
+{%                     set encapsulation_cli = encapsulation_cli ~ " network client" %}
+{%                 endif %}
+{%             elif ethernet_interfaces[ethernet_interface].encapsulation_vlan.client.dot1q.inner is arista.avd.defined and ethernet_interfaces[ethernet_interface].encapsulation_vlan.client.dot1q.outer is arista.avd.defined %}
+{%                 set encapsulation_cli = "client dot1q outer " ~ ethernet_interfaces[ethernet_interface].encapsulation_vlan.client.dot1q.outer ~ " inner " ~ ethernet_interfaces[ethernet_interface].encapsulation_vlan.client.dot1q.inner %}
+{%                 if ethernet_interfaces[ethernet_interface].encapsulation_vlan.network.dot1q.inner is arista.avd.defined and ethernet_interfaces[ethernet_interface].encapsulation_vlan.network.dot1q.outer is arista.avd.defined %}
+{%                     set encapsulation_cli = encapsulation_cli ~ " network dot1q outer " ~ ethernet_interfaces[ethernet_interface].encapsulation_vlan.network.dot1q.inner ~ " inner " ~ ethernet_interfaces[ethernet_interface].encapsulation_vlan.network.dot1q.outer %}
+{%                 elif ethernet_interfaces[ethernet_interface].encapsulation_vlan.network.dot1q.client is arista.avd.defined(true) %}
+{%                     set encapsulation_cli = encapsulation_cli ~ " network client" %}
+{%                 endif %}
+{%             elif ethernet_interfaces[ethernet_interface].encapsulation_vlan.client.unmatched is arista.avd.defined(true) %}
+{%                 set encapsulation_cli = "client unmatched" %}
+{%             endif %}
+{%             if encapsulation_cli is arista.avd.defined %}
+   encapsulation vlan
+      {{ encapsulation_cli }}
+{%             endif %}
 {%         else %}
    switchport
 {%         endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
@@ -20,8 +20,34 @@ interface {{ port_channel_interface }}
 {%     endif %}
 {%     if port_channel_interfaces[port_channel_interface].type is arista.avd.defined("routed") %}
    no switchport
-{%     elif port_channel_interfaces[port_channel_interface].type is arista.avd.defined('l3dot1q') and port_channel_interfaces[port_channel_interface].encapsulation_dot1q_vlan is arista.avd.defined() %}
+{%     elif port_channel_interfaces[port_channel_interface].type | arista.avd.default in ['l3dot1q', 'l2dot1q'] %}
+{%         if port_channel_interfaces[port_channel_interface].vlan_id is arista.avd.defined and
+              port_channel_interfaces[port_channel_interface].type == 'l2dot1q' %}
+   vlan id {{ port_channel_interfaces[port_channel_interface].vlan_id }}
+{%         endif %}
+{%         if port_channel_interfaces[port_channel_interface].encapsulation_dot1q_vlan is arista.avd.defined %}
    encapsulation dot1q vlan {{ port_channel_interfaces[port_channel_interface].encapsulation_dot1q_vlan }}
+{%         elif port_channel_interfaces[port_channel_interface].encapsulation_vlan.client.dot1q.vlan is arista.avd.defined() %}
+{%             set encapsulation_cli = "client dot1q " ~ port_channel_interfaces[port_channel_interface].encapsulation_vlan.client.dot1q.vlan %}
+{%             if port_channel_interfaces[port_channel_interface].encapsulation_vlan.network.dot1q.vlan is arista.avd.defined() %}
+{%                 set encapsulation_cli = encapsulation_cli ~ " network dot1q " ~ port_channel_interfaces[port_channel_interface].encapsulation_vlan.network.dot1q.vlan %}
+{%             elif port_channel_interfaces[port_channel_interface].encapsulation_vlan.network.client is arista.avd.defined(true) %}
+{%                 set encapsulation_cli = encapsulation_cli ~ " network client" %}
+{%             endif %}
+{%         elif port_channel_interfaces[port_channel_interface].encapsulation_vlan.client.dot1q.inner is arista.avd.defined and port_channel_interfaces[port_channel_interface].encapsulation_vlan.client.dot1q.outer is arista.avd.defined %}
+{%             set encapsulation_cli = "client dot1q outer " ~ port_channel_interfaces[port_channel_interface].encapsulation_vlan.client.dot1q.outer ~ " inner " ~ port_channel_interfaces[port_channel_interface].encapsulation_vlan.client.dot1q.inner %}
+{%             if port_channel_interfaces[port_channel_interface].encapsulation_vlan.network.dot1q.inner is arista.avd.defined and port_channel_interfaces[port_channel_interface].encapsulation_vlan.network.dot1q.outer is arista.avd.defined %}
+{%                 set encapsulation_cli = encapsulation_cli ~ " network dot1q outer " ~ port_channel_interfaces[port_channel_interface].encapsulation_vlan.network.dot1q.inner ~ " inner " ~ port_channel_interfaces[port_channel_interface].encapsulation_vlan.network.dot1q.outer %}
+{%             elif port_channel_interfaces[port_channel_interface].encapsulation_vlan.network.dot1q.client is arista.avd.defined(true) %}
+{%                 set encapsulation_cli = encapsulation_cli ~ " network client" %}
+{%             endif %}
+{%         elif port_channel_interfaces[port_channel_interface].encapsulation_vlan.client.unmatched is arista.avd.defined(true) %}
+{%             set encapsulation_cli = "client unmatched" %}
+{%         endif %}
+{%         if encapsulation_cli is arista.avd.defined %}
+   encapsulation vlan
+      {{ encapsulation_cli }}
+{%         endif %}
 {%     else %}
    switchport
 {%     endif %}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Support for Flex Encap and l2dot1q subinterfaces

## Related Issue(s)

Needed for PR #1418 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->
Under ethernet_interfaces and port_channel_interfaces:
```yaml
    # l3dot1q and l2dot1q are used for sub-interfaces.
    # The parent interface should be defined as routed.
    type: < routed | switched | l3dot1q | l2dot1q >

    encapsulation_vlan:
      client:
        dot1q:
          vlan: < Client VLAN ID >
        outer: < Client Outer VLAN ID >
        inner: < Client Inner VLAN ID >
        unmatched: < true | false >
      # network encapsulation is all optional, and skipped if using client unmatched.
      network:
        dot1q:
          vlan: < Network VLAN ID >
        outer: < Network Outer VLAN ID >
        inner: < Network Inner VLAN ID >
        client: < true | false >

    vlan_id: < 1-4094 >
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
