### PR TITLE
Doc(eos_designs): Minor documentation fixes

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -2325,36 +2325,19 @@ policy_maps:
 
 ```yaml
 qos_profiles:
-  < profile-1 >:
+  < profile-name >:
     trust: < dscp | cos | disabled >
     cos: < cos-value >
     dscp: < dscp-value >
     shape:
-      rate: < "< rate > kbps" | "1-100 percent" | "< rate > pps" , supported options are platform dependent >
+      rate: < "< rate > kbps" | "< 1-100 > percent" | "< rate > pps" , supported options are platform dependent >
     tx_queues:
       < tx-queue-id >:
-        bandwidth_percent: < value >
-        # The below knob is platform dependent
-        bandwidth_guaranteed_percent: < value >
-        priority: < string >
+        bandwidth_percent: < 1-100 >
+        bandwidth_guaranteed_percent: < value, feature is platform depedent>
+        priority: < "priority strict" | "no priority" >
         shape:
-          rate: < "< rate > kbps" | "1-100 percent" | "< rate > pps" , supported options are platform dependent >
-      < tx-queue-id >:
-        bandwidth_percent: < value >
-        priority: < string >
-        shape:
-          rate: < "< rate > kbps" | "1-100 percent" | "< rate > pps" , supported options are platform dependent >
-  < profile-2 >:
-    trust: < dscp | cos | disabled >
-    cos: < cos-value >
-    dscp: < dscp-value >
-    tx_queues:
-      < tx-queue-id >:
-        bandwidth_percent: < value >
-        priority: < string >
-      < tx-queue-id >:
-        bandwidth_percent: < value >
-        priority: < string >
+          rate: < "< rate > kbps" | "< 1-100 > percent" | "< rate > pps" , supported options are platform dependent >
 ```
 
 #### Queue Monitor Length

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/connected-endpoints.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/connected-endpoints.md
@@ -46,7 +46,9 @@ port_profiles:
   < port_profile_1 >:
     parent_profile: < port_profile_name >
     speed: < interface_speed | forced interface_speed | auto interface_speed >
+    enabled: < true | false >
     mode: < access | dot1q-tunnel | trunk >
+    mtu: < L3 MTU >
     l2_mtu: < l2_mtu - if defined this profile should only be used for platforms supporting the "l2 mtu" CLI >
     native_vlan: <native vlan number>
     vlans: < vlans as string >
@@ -71,12 +73,18 @@ port_profiles:
       unknown_unicast:
         level: < Configure maximum storm-control level >
         unit: < percent | pps > | Optional var and is hardware dependant - default is percent)
+    raw_eos_cli: |
+      < multiline eos cli >
+    structured_config: < dictionary >
     port_channel:
       description: < port_channel_description >
       mode: < "active" | "passive" | "on" >
       lacp_fallback:
         mode: < static > | Currently only static mode is supported
         timeout: < timeout in seconds > | Optional - default is 90 seconds
+      raw_eos_cli: |
+        < multiline eos cli >
+      structured_config: < dictionary >
 
 # Dictionary key of connected endpoint as defined in connected_endpoints_keys
 # This should be applied to group_vars or host_vars where endpoints are connecting.
@@ -121,10 +129,25 @@ port_profiles:
         # Interface vlans | required
         vlans: < vlans as string >
 
-        # Spanning Tree
+        # Spanning Tree | optional
         spanning_tree_portfast: < edge | network >
         spanning_tree_bpdufilter: < "enabled" | true | "disabled" >
         spanning_tree_bpduguard: < "enabled" | true | "disabled" >
+
+        # Storm control per each different category of BUM traffic | optional
+        storm_control:
+          all:
+            level: < Configure maximum storm-control level >
+            unit: < percent | pps > | Optional var and is hardware dependant - default is percent)
+          broadcast:
+            level: < Configure maximum storm-control level >
+            unit: < percent | pps > | Optional var and is hardware dependant - default is percent)
+          multicast:
+            level: < Configure maximum storm-control level >
+            unit: < percent | pps > | Optional var and is hardware dependant - default is percent)
+          unknown_unicast:
+            level: < Configure maximum storm-control level >
+            unit: < percent | pps > | Optional var and is hardware dependant - default is percent)
 
         # Flow control | Optional
         flowcontrol:


### PR DESCRIPTION
## Change Summary

A few doc fixes I've collected while reading things.

Only behavior change is the removal of peer_interface being a required connected endpoint parameter, since this *really* isn't playing nice with my use case.

## Component(s) name

`arista.avd.eos_designs`
`arista.avd.eos_cli_config_gen`

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
