### PR TITLE
Feat(eos_cli_config_gen): Add support for Vxlan DSCP mapping

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vxlan-interface.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vxlan-interface.md
@@ -65,8 +65,8 @@ interface Management1
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback0 |
 | MLAG Source Interface | Loopback1 |
 | UDP port | 4789 |

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vxlan-interface.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vxlan-interface.md
@@ -65,13 +65,15 @@ interface Management1
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback0
-
-#### MLAG Source Interface: Loopback1
-
-#### UDP port: 4789
-
-#### EVPN MLAG Shared Router MAC : mlag-system-id
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback0 |
+| MLAG Source Interface | Loopback1 |
+| UDP port | 4789 |
+| EVPN MLAG Shared Router MAC | mlag-system-id |
+| VXLAN flood-lists learning from data-plane | Enabled |
+| Qos dscp propagation encapsulation | Enabled |
+| Qos map dscp to traffic-class decapsulation | Enabled |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 
@@ -90,10 +92,8 @@ interface Management1
 #### Default Flood List
 
 | Default Flood List |
-| ---------- |
+| ------------------ |
 | 10.1.0.10<br/>10.1.0.11 |
-
-#### VXLAN flood-lists learning from data-plane: Enabled
 
 ### VXLAN Interface Device Configuration
 
@@ -112,6 +112,8 @@ interface Vxlan1
    vxlan vrf Tenant_A_WEB_Zone vni 11
    vxlan mlag source-interface Loopback1
    vxlan flood vtep 10.1.0.10 10.1.0.11
+   vxlan qos dscp propagation encapsulation
+   vxlan qos map dscp to traffic-class decapsulation
    vxlan vlan 110 multicast group 239.9.1.4
    vxlan vrf Tenant_A_OP_Zone multicast group 232.0.0.10
    vxlan encapsulation ipv4

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vxlan-interface.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vxlan-interface.cfg
@@ -25,6 +25,8 @@ interface Vxlan1
    vxlan vrf Tenant_A_WEB_Zone vni 11
    vxlan mlag source-interface Loopback1
    vxlan flood vtep 10.1.0.10 10.1.0.11
+   vxlan qos dscp propagation encapsulation
+   vxlan qos map dscp to traffic-class decapsulation
    vxlan vlan 110 multicast group 239.9.1.4
    vxlan vrf Tenant_A_OP_Zone multicast group 232.0.0.10
    vxlan encapsulation ipv4

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vxlan-interface.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vxlan-interface.yml
@@ -8,6 +8,9 @@ vxlan_interface:
       mlag_source_interface: Loopback1
       udp_port: 4789
       virtual_router_encapsulation_mac_address: mlag-system-id
+      qos:
+        dscp_propagation_encapsulation: true
+        map_dscp_to_traffic_class_decapsulation: true
       vlans:
         110:
           vni: 10110

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1A.md
@@ -508,11 +508,11 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
-
-#### EVPN MLAG Shared Router MAC : mlag-system-id
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
+| EVPN MLAG Shared Router MAC | mlag-system-id |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1A.md
@@ -508,8 +508,8 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 | EVPN MLAG Shared Router MAC | mlag-system-id |

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1B.md
@@ -508,11 +508,11 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
-
-#### EVPN MLAG Shared Router MAC : mlag-system-id
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
+| EVPN MLAG Shared Router MAC | mlag-system-id |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1B.md
@@ -508,8 +508,8 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 | EVPN MLAG Shared Router MAC | mlag-system-id |

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF1A.md
@@ -401,8 +401,8 @@ interface Vlan131
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF1A.md
@@ -401,9 +401,10 @@ interface Vlan131
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2A.md
@@ -702,11 +702,11 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
-
-#### EVPN MLAG Shared Router MAC : mlag-system-id
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
+| EVPN MLAG Shared Router MAC | mlag-system-id |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2A.md
@@ -702,8 +702,8 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 | EVPN MLAG Shared Router MAC | mlag-system-id |

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2B.md
@@ -702,11 +702,11 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
-
-#### EVPN MLAG Shared Router MAC : mlag-system-id
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
+| EVPN MLAG Shared Router MAC | mlag-system-id |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2B.md
@@ -702,8 +702,8 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 | EVPN MLAG Shared Router MAC | mlag-system-id |

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3A.md
@@ -786,8 +786,8 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 | EVPN MLAG Shared Router MAC | mlag-system-id |

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3A.md
@@ -786,11 +786,11 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
-
-#### EVPN MLAG Shared Router MAC : mlag-system-id
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
+| EVPN MLAG Shared Router MAC | mlag-system-id |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3B.md
@@ -771,8 +771,8 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 | EVPN MLAG Shared Router MAC | mlag-system-id |

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3B.md
@@ -771,11 +771,11 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
-
-#### EVPN MLAG Shared Router MAC : mlag-system-id
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
+| EVPN MLAG Shared Router MAC | mlag-system-id |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF1A.md
@@ -296,8 +296,8 @@ interface Vlan4085
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF1A.md
@@ -296,9 +296,10 @@ interface Vlan4085
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2A.md
@@ -626,11 +626,11 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
-
-#### EVPN MLAG Shared Router MAC : mlag-system-id
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
+| EVPN MLAG Shared Router MAC | mlag-system-id |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2A.md
@@ -626,8 +626,8 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 | EVPN MLAG Shared Router MAC | mlag-system-id |

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
@@ -651,11 +651,11 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
-
-#### EVPN MLAG Shared Router MAC : mlag-system-id
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
+| EVPN MLAG Shared Router MAC | mlag-system-id |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
@@ -651,8 +651,8 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 | EVPN MLAG Shared Router MAC | mlag-system-id |

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-LEAF1A.md
@@ -413,9 +413,10 @@ interface Vlan1102
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-LEAF1A.md
@@ -413,8 +413,8 @@ interface Vlan1102
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-LEAF1A.md
@@ -370,8 +370,8 @@ interface Vlan4092
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-LEAF1A.md
@@ -370,9 +370,10 @@ interface Vlan4092
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
 
 #### VRF to VNI and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL1A.md
@@ -436,9 +436,10 @@ interface Vlan350
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL1A.md
@@ -436,8 +436,8 @@ interface Vlan350
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL1B.md
@@ -428,8 +428,8 @@ interface Vlan350
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL1B.md
@@ -428,9 +428,10 @@ interface Vlan350
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL2A.md
@@ -417,8 +417,8 @@ interface Vlan350
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL2A.md
@@ -417,9 +417,10 @@ interface Vlan350
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL2B.md
@@ -400,9 +400,10 @@ interface Vlan350
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL2B.md
@@ -400,8 +400,8 @@ interface Vlan350
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF1A.md
@@ -449,8 +449,8 @@ interface Vlan132
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF1A.md
@@ -449,9 +449,10 @@ interface Vlan132
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2A.md
@@ -671,8 +671,8 @@ interface Vlan311
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2A.md
@@ -671,9 +671,10 @@ interface Vlan311
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2B.md
@@ -671,8 +671,8 @@ interface Vlan311
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2B.md
@@ -671,9 +671,10 @@ interface Vlan311
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3A.md
@@ -1067,11 +1067,11 @@ interface Vlan4092
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
-
-#### EVPN MLAG Shared Router MAC : mlag-system-id
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
+| EVPN MLAG Shared Router MAC | mlag-system-id |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3A.md
@@ -1067,8 +1067,8 @@ interface Vlan4092
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 | EVPN MLAG Shared Router MAC | mlag-system-id |

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3B.md
@@ -1052,8 +1052,8 @@ interface Vlan4092
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 | EVPN MLAG Shared Router MAC | mlag-system-id |

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3B.md
@@ -1052,11 +1052,11 @@ interface Vlan4092
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
-
-#### EVPN MLAG Shared Router MAC : mlag-system-id
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
+| EVPN MLAG Shared Router MAC | mlag-system-id |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/MH-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/MH-LEAF1A.md
@@ -410,9 +410,10 @@ interface Vlan310
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
+| Setting | Value |
+| ------- | ----- |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/MH-LEAF1B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/MH-LEAF1B.md
@@ -410,9 +410,10 @@ interface Vlan310
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
+| Setting | Value |
+| ------- | ----- |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/MH-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/MH-LEAF2A.md
@@ -410,9 +410,10 @@ interface Vlan310
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
+| Setting | Value |
+| ------- | ----- |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/evpn_services_l2_only_false.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/evpn_services_l2_only_false.md
@@ -470,8 +470,8 @@ interface Vlan350
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/evpn_services_l2_only_false.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/evpn_services_l2_only_false.md
@@ -470,9 +470,10 @@ interface Vlan350
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/evpn_services_l2_only_true.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/evpn_services_l2_only_true.md
@@ -303,9 +303,10 @@ interface Loopback1
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/evpn_services_l2_only_true.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/evpn_services_l2_only_true.md
@@ -303,8 +303,8 @@ interface Loopback1
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -453,8 +453,8 @@ interface Vlan350
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -453,9 +453,10 @@ interface Vlan350
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -451,9 +451,10 @@ interface Vlan350
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -451,8 +451,8 @@ interface Vlan350
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -464,9 +464,10 @@ interface Vlan131
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback0
-
-#### UDP port: 4789
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback0 |
+| UDP port | 4789 |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -464,8 +464,8 @@ interface Vlan131
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback0 |
 | UDP port | 4789 |
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -712,9 +712,10 @@ interface Vlan311
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback10
-
-#### UDP port: 4789
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback10 |
+| UDP port | 4789 |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -712,8 +712,8 @@ interface Vlan311
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback10 |
 | UDP port | 4789 |
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -712,9 +712,10 @@ interface Vlan311
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback10
-
-#### UDP port: 4789
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback10 |
+| UDP port | 4789 |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -712,8 +712,8 @@ interface Vlan311
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback10 |
 | UDP port | 4789 |
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -1055,11 +1055,11 @@ interface Vlan4092
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
-
-#### EVPN MLAG Shared Router MAC : mlag-system-id
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
+| EVPN MLAG Shared Router MAC | mlag-system-id |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -1055,8 +1055,8 @@ interface Vlan4092
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 | EVPN MLAG Shared Router MAC | mlag-system-id |

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -1055,11 +1055,11 @@ interface Vlan4092
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
-
-#### EVPN MLAG Shared Router MAC : mlag-system-id
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
+| EVPN MLAG Shared Router MAC | mlag-system-id |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -1055,8 +1055,8 @@ interface Vlan4092
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 | EVPN MLAG Shared Router MAC | mlag-system-id |

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1A.md
@@ -471,11 +471,11 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
-
-#### EVPN MLAG Shared Router MAC : mlag-system-id
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
+| EVPN MLAG Shared Router MAC | mlag-system-id |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1A.md
@@ -471,8 +471,8 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 | EVPN MLAG Shared Router MAC | mlag-system-id |

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1B.md
@@ -471,11 +471,11 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
-
-#### EVPN MLAG Shared Router MAC : mlag-system-id
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
+| EVPN MLAG Shared Router MAC | mlag-system-id |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1B.md
@@ -471,8 +471,8 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 | EVPN MLAG Shared Router MAC | mlag-system-id |

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF1A.md
@@ -323,8 +323,8 @@ interface Loopback0
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback0 |
 | UDP port | 4789 |
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF1A.md
@@ -323,9 +323,10 @@ interface Loopback0
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback0
-
-#### UDP port: 4789
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback0 |
+| UDP port | 4789 |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2A.md
@@ -485,11 +485,11 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback10
-
-#### UDP port: 4789
-
-#### EVPN MLAG Shared Router MAC : mlag-system-id
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback10 |
+| UDP port | 4789 |
+| EVPN MLAG Shared Router MAC | mlag-system-id |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2A.md
@@ -485,8 +485,8 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback10 |
 | UDP port | 4789 |
 | EVPN MLAG Shared Router MAC | mlag-system-id |

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2B.md
@@ -485,11 +485,11 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback10
-
-#### UDP port: 4789
-
-#### EVPN MLAG Shared Router MAC : mlag-system-id
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback10 |
+| UDP port | 4789 |
+| EVPN MLAG Shared Router MAC | mlag-system-id |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2B.md
@@ -485,8 +485,8 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback10 |
 | UDP port | 4789 |
 | EVPN MLAG Shared Router MAC | mlag-system-id |

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3A.md
@@ -491,8 +491,8 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 | EVPN MLAG Shared Router MAC | mlag-system-id |

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3A.md
@@ -491,11 +491,11 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
-
-#### EVPN MLAG Shared Router MAC : mlag-system-id
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
+| EVPN MLAG Shared Router MAC | mlag-system-id |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3B.md
@@ -491,8 +491,8 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 | EVPN MLAG Shared Router MAC | mlag-system-id |

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3B.md
@@ -491,11 +491,11 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
-
-#### EVPN MLAG Shared Router MAC : mlag-system-id
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
+| EVPN MLAG Shared Router MAC | mlag-system-id |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -441,11 +441,11 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
-
-#### EVPN MLAG Shared Router MAC : mlag-system-id
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
+| EVPN MLAG Shared Router MAC | mlag-system-id |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -441,8 +441,8 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 | EVPN MLAG Shared Router MAC | mlag-system-id |

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -441,11 +441,11 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
-
-#### EVPN MLAG Shared Router MAC : mlag-system-id
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
+| EVPN MLAG Shared Router MAC | mlag-system-id |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -441,8 +441,8 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 | EVPN MLAG Shared Router MAC | mlag-system-id |

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -310,8 +310,8 @@ interface Loopback1
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -310,9 +310,10 @@ interface Loopback1
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -455,11 +455,11 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
-
-#### EVPN MLAG Shared Router MAC : mlag-system-id
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
+| EVPN MLAG Shared Router MAC | mlag-system-id |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -455,8 +455,8 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 | EVPN MLAG Shared Router MAC | mlag-system-id |

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -455,11 +455,11 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
-
-#### EVPN MLAG Shared Router MAC : mlag-system-id
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
+| EVPN MLAG Shared Router MAC | mlag-system-id |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -455,8 +455,8 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 | EVPN MLAG Shared Router MAC | mlag-system-id |

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -461,8 +461,8 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 | EVPN MLAG Shared Router MAC | mlag-system-id |

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -461,11 +461,11 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
-
-#### EVPN MLAG Shared Router MAC : mlag-system-id
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
+| EVPN MLAG Shared Router MAC | mlag-system-id |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -461,8 +461,8 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 | EVPN MLAG Shared Router MAC | mlag-system-id |

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -461,11 +461,11 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
-
-#### EVPN MLAG Shared Router MAC : mlag-system-id
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
+| EVPN MLAG Shared Router MAC | mlag-system-id |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -402,9 +402,10 @@ interface Vlan350
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -402,8 +402,8 @@ interface Vlan350
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -401,9 +401,10 @@ interface Vlan350
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -401,8 +401,8 @@ interface Vlan350
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -424,9 +424,10 @@ interface Vlan131
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -424,8 +424,8 @@ interface Vlan131
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -756,8 +756,8 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 | EVPN MLAG Shared Router MAC | mlag-system-id |

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -756,11 +756,11 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
-
-#### EVPN MLAG Shared Router MAC : mlag-system-id
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
+| EVPN MLAG Shared Router MAC | mlag-system-id |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -756,8 +756,8 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 | EVPN MLAG Shared Router MAC | mlag-system-id |

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -756,11 +756,11 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
-
-#### EVPN MLAG Shared Router MAC : mlag-system-id
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
+| EVPN MLAG Shared Router MAC | mlag-system-id |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -909,8 +909,8 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 | EVPN MLAG Shared Router MAC | mlag-system-id |

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -909,11 +909,11 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
-
-#### EVPN MLAG Shared Router MAC : mlag-system-id
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
+| EVPN MLAG Shared Router MAC | mlag-system-id |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -894,11 +894,11 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
-
-#### EVPN MLAG Shared Router MAC : mlag-system-id
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
+| EVPN MLAG Shared Router MAC | mlag-system-id |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -894,8 +894,8 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 | EVPN MLAG Shared Router MAC | mlag-system-id |

--- a/ansible_collections/arista/avd/molecule/upgrade_eos_cli_config_gen/documentation/devices/vxlan-interface.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_eos_cli_config_gen/documentation/devices/vxlan-interface.md
@@ -65,8 +65,8 @@ interface Management1
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 | EVPN MLAG Shared Router MAC | mlag-system-id |

--- a/ansible_collections/arista/avd/molecule/upgrade_eos_cli_config_gen/documentation/devices/vxlan-interface.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_eos_cli_config_gen/documentation/devices/vxlan-interface.md
@@ -65,11 +65,11 @@ interface Management1
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
-
-#### EVPN MLAG Shared Router MAC : mlag-system-id
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
+| EVPN MLAG Shared Router MAC | mlag-system-id |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF1A.md
@@ -296,8 +296,8 @@ interface Vlan4085
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF1A.md
@@ -296,9 +296,10 @@ interface Vlan4085
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2A.md
@@ -524,8 +524,8 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 | EVPN MLAG Shared Router MAC | mlag-system-id |

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2A.md
@@ -524,11 +524,11 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
-
-#### EVPN MLAG Shared Router MAC : mlag-system-id
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
+| EVPN MLAG Shared Router MAC | mlag-system-id |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
@@ -551,8 +551,8 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 | EVPN MLAG Shared Router MAC | mlag-system-id |

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
@@ -551,11 +551,11 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
-
-#### EVPN MLAG Shared Router MAC : mlag-system-id
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
+| EVPN MLAG Shared Router MAC | mlag-system-id |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-LEAF1A.md
@@ -328,9 +328,10 @@ interface Vlan112
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-LEAF1A.md
@@ -328,8 +328,8 @@ interface Vlan112
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-LEAF1A.md
@@ -337,8 +337,8 @@ interface Vlan4092
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-LEAF1A.md
@@ -337,9 +337,10 @@ interface Vlan4092
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
 
 #### VRF to VNI and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -453,8 +453,8 @@ interface Vlan350
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -453,9 +453,10 @@ interface Vlan350
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -451,9 +451,10 @@ interface Vlan350
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -451,8 +451,8 @@ interface Vlan350
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -432,9 +432,10 @@ interface Vlan131
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -432,8 +432,8 @@ interface Vlan131
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -668,9 +668,10 @@ interface Vlan311
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -668,8 +668,8 @@ interface Vlan311
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -668,9 +668,10 @@ interface Vlan311
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -668,8 +668,8 @@ interface Vlan311
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -994,11 +994,11 @@ interface Vlan4092
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
-
-#### EVPN MLAG Shared Router MAC : mlag-system-id
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
+| EVPN MLAG Shared Router MAC | mlag-system-id |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -994,8 +994,8 @@ interface Vlan4092
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 | EVPN MLAG Shared Router MAC | mlag-system-id |

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -994,11 +994,11 @@ interface Vlan4092
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
-
-#### EVPN MLAG Shared Router MAC : mlag-system-id
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
+| EVPN MLAG Shared Router MAC | mlag-system-id |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -994,8 +994,8 @@ interface Vlan4092
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 | EVPN MLAG Shared Router MAC | mlag-system-id |

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1A.md
@@ -471,11 +471,11 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
-
-#### EVPN MLAG Shared Router MAC : mlag-system-id
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
+| EVPN MLAG Shared Router MAC | mlag-system-id |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1A.md
@@ -471,8 +471,8 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 | EVPN MLAG Shared Router MAC | mlag-system-id |

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1B.md
@@ -471,11 +471,11 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
-
-#### EVPN MLAG Shared Router MAC : mlag-system-id
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
+| EVPN MLAG Shared Router MAC | mlag-system-id |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1B.md
@@ -471,8 +471,8 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 | EVPN MLAG Shared Router MAC | mlag-system-id |

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF1A.md
@@ -333,9 +333,10 @@ interface Loopback1
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF1A.md
@@ -333,8 +333,8 @@ interface Loopback1
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2A.md
@@ -485,11 +485,11 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
-
-#### EVPN MLAG Shared Router MAC : mlag-system-id
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
+| EVPN MLAG Shared Router MAC | mlag-system-id |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2A.md
@@ -485,8 +485,8 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 | EVPN MLAG Shared Router MAC | mlag-system-id |

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2B.md
@@ -485,11 +485,11 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
-
-#### EVPN MLAG Shared Router MAC : mlag-system-id
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
+| EVPN MLAG Shared Router MAC | mlag-system-id |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2B.md
@@ -485,8 +485,8 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 | EVPN MLAG Shared Router MAC | mlag-system-id |

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3A.md
@@ -491,8 +491,8 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 | EVPN MLAG Shared Router MAC | mlag-system-id |

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3A.md
@@ -491,11 +491,11 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
-
-#### EVPN MLAG Shared Router MAC : mlag-system-id
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
+| EVPN MLAG Shared Router MAC | mlag-system-id |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3B.md
@@ -491,8 +491,8 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 | EVPN MLAG Shared Router MAC | mlag-system-id |

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3B.md
@@ -491,11 +491,11 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
-
-#### EVPN MLAG Shared Router MAC : mlag-system-id
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
+| EVPN MLAG Shared Router MAC | mlag-system-id |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -441,11 +441,11 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
-
-#### EVPN MLAG Shared Router MAC : mlag-system-id
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
+| EVPN MLAG Shared Router MAC | mlag-system-id |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -441,8 +441,8 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 | EVPN MLAG Shared Router MAC | mlag-system-id |

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -441,11 +441,11 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
-
-#### EVPN MLAG Shared Router MAC : mlag-system-id
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
+| EVPN MLAG Shared Router MAC | mlag-system-id |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -441,8 +441,8 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 | EVPN MLAG Shared Router MAC | mlag-system-id |

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -310,8 +310,8 @@ interface Loopback1
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -310,9 +310,10 @@ interface Loopback1
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -455,11 +455,11 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
-
-#### EVPN MLAG Shared Router MAC : mlag-system-id
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
+| EVPN MLAG Shared Router MAC | mlag-system-id |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -455,8 +455,8 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 | EVPN MLAG Shared Router MAC | mlag-system-id |

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -455,11 +455,11 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
-
-#### EVPN MLAG Shared Router MAC : mlag-system-id
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
+| EVPN MLAG Shared Router MAC | mlag-system-id |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -455,8 +455,8 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 | EVPN MLAG Shared Router MAC | mlag-system-id |

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -461,8 +461,8 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 | EVPN MLAG Shared Router MAC | mlag-system-id |

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -461,11 +461,11 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
-
-#### EVPN MLAG Shared Router MAC : mlag-system-id
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
+| EVPN MLAG Shared Router MAC | mlag-system-id |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -461,8 +461,8 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 | EVPN MLAG Shared Router MAC | mlag-system-id |

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -461,11 +461,11 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
-
-#### EVPN MLAG Shared Router MAC : mlag-system-id
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
+| EVPN MLAG Shared Router MAC | mlag-system-id |
 
 ### VXLAN Interface Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -402,9 +402,10 @@ interface Vlan350
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -402,8 +402,8 @@ interface Vlan350
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -401,9 +401,10 @@ interface Vlan350
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -401,8 +401,8 @@ interface Vlan350
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -424,9 +424,10 @@ interface Vlan131
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -424,8 +424,8 @@ interface Vlan131
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -756,8 +756,8 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 | EVPN MLAG Shared Router MAC | mlag-system-id |

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -756,11 +756,11 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
-
-#### EVPN MLAG Shared Router MAC : mlag-system-id
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
+| EVPN MLAG Shared Router MAC | mlag-system-id |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -756,8 +756,8 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 | EVPN MLAG Shared Router MAC | mlag-system-id |

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -756,11 +756,11 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
-
-#### EVPN MLAG Shared Router MAC : mlag-system-id
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
+| EVPN MLAG Shared Router MAC | mlag-system-id |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -909,8 +909,8 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 | EVPN MLAG Shared Router MAC | mlag-system-id |

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -909,11 +909,11 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
-
-#### EVPN MLAG Shared Router MAC : mlag-system-id
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
+| EVPN MLAG Shared Router MAC | mlag-system-id |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -894,11 +894,11 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-#### Source Interface: Loopback1
-
-#### UDP port: 4789
-
-#### EVPN MLAG Shared Router MAC : mlag-system-id
+| Settings | Values |
+| -------- | ------ |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
+| EVPN MLAG Shared Router MAC | mlag-system-id |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -894,8 +894,8 @@ interface Vlan4094
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 | Source Interface | Loopback1 |
 | UDP port | 4789 |
 | EVPN MLAG Shared Router MAC | mlag-system-id |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1401,6 +1401,11 @@ vxlan_interface:
       mlag_source_interface: < source_interface_name >
       udp_port: < udp_port >
       virtual_router_encapsulation_mac_address: < mlag-system-id | ethernet_address (H.H.H) >
+      qos:
+        # !!!Warning, only few hardware types with software version >= 4.26.0 support the below knobs to configure Vxlan DSCP mapping.
+        # For the Traffic Class to be derived based on the outer DSCP field of the incoming VxLan packet, the core ports must be in “DSCP Trust” mode.
+        dscp_propagation_encapsulation: < true | false >
+        map_dscp_to_traffic_class_decapsulation: < true | false >
       vlans:
         < vlan_id_1 >:
           vni: < vni_id_1 >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vxlan-interface.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vxlan-interface.j2
@@ -4,19 +4,27 @@
 ## VXLAN Interface
 
 ### VXLAN Interface Summary
-{%     if vxlan_interface.Vxlan1.vxlan.source_interface is arista.avd.defined %}
 
-#### Source Interface: {{ vxlan_interface.Vxlan1.vxlan.source_interface }}
+| Settings | Values |
+| -------- | ------ |
+{%     if vxlan_interface.Vxlan1.vxlan.source_interface is arista.avd.defined %}
+| Source Interface | {{ vxlan_interface.Vxlan1.vxlan.source_interface }} |
 {%     endif %}
 {%     if vxlan_interface.Vxlan1.vxlan.mlag_source_interface is arista.avd.defined %}
-
-#### MLAG Source Interface: {{ vxlan_interface.Vxlan1.vxlan.mlag_source_interface }}
+| MLAG Source Interface | {{ vxlan_interface.Vxlan1.vxlan.mlag_source_interface }} |
 {%     endif %}
-
-#### UDP port: {{ vxlan_interface.Vxlan1.vxlan.udp_port | arista.avd.default('4789') }}
+| UDP port | {{ vxlan_interface.Vxlan1.vxlan.udp_port | arista.avd.default('4789') }} |
 {%     if vxlan_interface.Vxlan1.vxlan.virtual_router_encapsulation_mac_address is arista.avd.defined %}
-
-#### EVPN MLAG Shared Router MAC : {{ vxlan_interface.Vxlan1.vxlan.virtual_router_encapsulation_mac_address }}
+| EVPN MLAG Shared Router MAC | {{ vxlan_interface.Vxlan1.vxlan.virtual_router_encapsulation_mac_address }} |
+{%     endif %}
+{%     if vxlan_interface.Vxlan1.vxlan.flood_vtep_learned_data_plane is arista.avd.defined(var_type='bool') %}
+| VXLAN flood-lists learning from data-plane | {{ vxlan_interface.Vxlan1.vxlan.flood_vtep_learned_data_plane | ternary('Enabled', 'Disabled') }} |
+{%     endif %}
+{%     if vxlan_interface.Vxlan1.vxlan.qos.dscp_propagation_encapsulation is arista.avd.defined(var_type='bool') %}
+| Qos dscp propagation encapsulation | {{ vxlan_interface.Vxlan1.vxlan.qos.dscp_propagation_encapsulation | ternary('Enabled', 'Disabled') }} |
+{%     endif %}
+{%     if vxlan_interface.Vxlan1.vxlan.qos.map_dscp_to_traffic_class_decapsulation is arista.avd.defined(var_type='bool') %}
+| Qos map dscp to traffic-class decapsulation | {{ vxlan_interface.Vxlan1.vxlan.qos.map_dscp_to_traffic_class_decapsulation | ternary('Enabled', 'Disabled') }} |
 {%     endif %}
 {%     if vxlan_interface.Vxlan1.vxlan.vlans is arista.avd.defined %}
 
@@ -52,12 +60,8 @@
 #### Default Flood List
 
 | Default Flood List |
-| ---------- |
+| ------------------ |
 | {{ vxlan_interface.Vxlan1.vxlan.flood_vteps | join('<br/>') }} |
-{%     endif %}
-{%     if vxlan_interface.Vxlan1.vxlan.flood_vtep_learned_data_plane is arista.avd.defined(true) %}
-
-#### VXLAN flood-lists learning from data-plane: Enabled
 {%     endif %}
 
 ### VXLAN Interface Device Configuration

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vxlan-interface.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vxlan-interface.j2
@@ -5,8 +5,8 @@
 
 ### VXLAN Interface Summary
 
-| Settings | Values |
-| -------- | ------ |
+| Setting | Value |
+| ------- | ----- |
 {%     if vxlan_interface.Vxlan1.vxlan.source_interface is arista.avd.defined %}
 | Source Interface | {{ vxlan_interface.Vxlan1.vxlan.source_interface }} |
 {%     endif %}
@@ -17,14 +17,20 @@
 {%     if vxlan_interface.Vxlan1.vxlan.virtual_router_encapsulation_mac_address is arista.avd.defined %}
 | EVPN MLAG Shared Router MAC | {{ vxlan_interface.Vxlan1.vxlan.virtual_router_encapsulation_mac_address }} |
 {%     endif %}
-{%     if vxlan_interface.Vxlan1.vxlan.flood_vtep_learned_data_plane is arista.avd.defined(var_type='bool') %}
-| VXLAN flood-lists learning from data-plane | {{ vxlan_interface.Vxlan1.vxlan.flood_vtep_learned_data_plane | ternary('Enabled', 'Disabled') }} |
+{%     if vxlan_interface.Vxlan1.vxlan.flood_vtep_learned_data_plane is arista.avd.defined(true) %}
+| VXLAN flood-lists learning from data-plane | Enabled |
+{%     elif vxlan_interface.Vxlan1.vxlan.flood_vtep_learned_data_plane is arista.avd.defined(false) %}
+| VXLAN flood-lists learning from data-plane | Disabled |
 {%     endif %}
-{%     if vxlan_interface.Vxlan1.vxlan.qos.dscp_propagation_encapsulation is arista.avd.defined(var_type='bool') %}
-| Qos dscp propagation encapsulation | {{ vxlan_interface.Vxlan1.vxlan.qos.dscp_propagation_encapsulation | ternary('Enabled', 'Disabled') }} |
+{%     if vxlan_interface.Vxlan1.vxlan.qos.dscp_propagation_encapsulation is arista.avd.defined(true) %}
+| Qos dscp propagation encapsulation | Enabled |
+{%     elif vxlan_interface.Vxlan1.vxlan.qos.dscp_propagation_encapsulation is arista.avd.defined(false) %}
+| Qos dscp propagation encapsulation | Disabled |
 {%     endif %}
-{%     if vxlan_interface.Vxlan1.vxlan.qos.map_dscp_to_traffic_class_decapsulation is arista.avd.defined(var_type='bool') %}
-| Qos map dscp to traffic-class decapsulation | {{ vxlan_interface.Vxlan1.vxlan.qos.map_dscp_to_traffic_class_decapsulation | ternary('Enabled', 'Disabled') }} |
+{%     if vxlan_interface.Vxlan1.vxlan.qos.map_dscp_to_traffic_class_decapsulation is arista.avd.defined(true) %}
+| Qos map dscp to traffic-class decapsulation | Enabled |
+{%     elif vxlan_interface.Vxlan1.vxlan.qos.map_dscp_to_traffic_class_decapsulation is arista.avd.defined(false) %}
+| Qos map dscp to traffic-class decapsulation | Disabled |
 {%     endif %}
 {%     if vxlan_interface.Vxlan1.vxlan.vlans is arista.avd.defined %}
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vxlan-interface.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vxlan-interface.j2
@@ -35,6 +35,16 @@ interface Vxlan1
 {%     if vxlan_interface.Vxlan1.vxlan.flood_vteps is arista.avd.defined %}
    vxlan flood vtep {{ vxlan_interface.Vxlan1.vxlan.flood_vteps | join(' ') }}
 {%     endif %}
+{%     if vxlan_interface.Vxlan1.vxlan.qos.dscp_propagation_encapsulation is arista.avd.defined(true) %}
+   vxlan qos dscp propagation encapsulation
+{%     elif vxlan_interface.Vxlan1.vxlan.qos.dscp_propagation_encapsulation is arista.avd.defined(false) %}
+   no vxlan qos dscp propagation encapsulation
+{%     endif %}
+{%     if vxlan_interface.Vxlan1.vxlan.qos.map_dscp_to_traffic_class_decapsulation is arista.avd.defined(true) %}
+   vxlan qos map dscp to traffic-class decapsulation
+{%     elif vxlan_interface.Vxlan1.vxlan.qos.map_dscp_to_traffic_class_decapsulation is arista.avd.defined(false) %}
+   no vxlan qos map dscp to traffic-class decapsulation
+{%     endif %}
 {%     for vlan in vxlan_interface.Vxlan1.vxlan.vlans | arista.avd.natural_sort if vxlan_interface.Vxlan1.vxlan.vlans[vlan].multicast_group is arista.avd.defined %}
    vxlan vlan {{ vlan }} multicast group {{ vxlan_interface.Vxlan1.vxlan.vlans[vlan].multicast_group }}
 {%     endfor %}


### PR DESCRIPTION
## Change Summary

Added DSCP encapsulation and decapsulation commands in Vxlan interface. Also refactored Vxlan documentation template to support further scaling.

https://eos.arista.com/eos-4-26-0f/vxlan-dscp-mapping/

## Related Issue(s)

Fixes #1455 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
New knobs added:

```yaml
vxlan_interface:
  Vxlan1:
    description: < description >
    vxlan:
      qos:
        # !!!Warning, only few hardware types with software version >= 4.26.0 support the below knobs to configure Vxlan DSCP mapping.
        # For the Traffic Class to be derived based on the outer DSCP field of the incoming VxLan packet, the core ports must be in “DSCP Trust” mode.
        dscp_propagation_encapsulation: < true | false >
        map_dscp_to_traffic_class_decapsulation: < true | false >
```
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test
Molecule
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
