### PR TITLE
CI: Leverage CODEOWNERS file instead of workflow action for assigning reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+---
+# Add all members of the group ansible-avd-developers as reviewers on all PRs
+*   @aristanetworks/ansible-avd-developers

--- a/.github/workflows/pull-request-triage.yml
+++ b/.github/workflows/pull-request-triage.yml
@@ -31,16 +31,7 @@ jobs:
       - uses: toshimaru/auto-author-assign@v1.2.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
-  pr_reviewvers:
-    name: "Assign PR reviewer"
-    # https://github.com/shufo/auto-assign-reviewer-by-files
-    runs-on: ubuntu-latest
-    steps:
-      - name: Request review based on files changes and/or groups the author belongs to
-        uses: shufo/auto-assign-reviewer-by-files@v1.1.1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          config: .github/reviewers.yml
+
   ###################################################
   # Check Conventional Commit Syntax
   ###################################################


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Leverage CODEOWNERS file instead of workflow action for assigning reviewers

Code owners file is pointing all changes to the group ansible-avd-developers, who will be requested to review all PRs.