### PR TITLE
Feat(eos_cli_config_gen): add support for TACACS AES-256-GCM keys (#1456)

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/aaa.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/aaa.md
@@ -82,6 +82,7 @@ username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC9OuVC4D+ARBrc9s
 |  mgt | 10.10.10.157 | True |
 |  default | 10.10.10.249 | False |
 |  default | 10.10.10.158 | False |
+|  default | 10.10.10.159 | False |
 
 ### TACACS Servers Device Configuration
 
@@ -89,6 +90,7 @@ username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC9OuVC4D+ARBrc9s
 !
 tacacs-server host 10.10.10.157 single-connection vrf mgt key 7 071B245F5A
 tacacs-server host 10.10.10.158 key 7 071B245F5A
+tacacs-server host 10.10.10.159 key 8a $kUVyoj7FVQ//yw9D2lbqjA==$kxxohBiofI46IX3pw18KYQ==$DOOM0l9uU4TrQt2kyA7XCKtjUA==
 tacacs-server host 10.10.10.249 timeout 23 key 7 071B245F5A
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/aaa.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/aaa.cfg
@@ -14,6 +14,7 @@ aaa group server tacacs+ TACACS
 !
 tacacs-server host 10.10.10.157 single-connection vrf mgt key 7 071B245F5A
 tacacs-server host 10.10.10.158 key 7 071B245F5A
+tacacs-server host 10.10.10.159 key 8a $kUVyoj7FVQ//yw9D2lbqjA==$kxxohBiofI46IX3pw18KYQ==$DOOM0l9uU4TrQt2kyA7XCKtjUA==
 tacacs-server host 10.10.10.249 timeout 23 key 7 071B245F5A
 !
 aaa authentication login default group TACACS local

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/aaa.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/aaa.yml
@@ -12,6 +12,11 @@ tacacs_servers:
     - host: 10.10.10.158
       vrf: default
       key: 071B245F5A
+      key_type: 7
+    - host: 10.10.10.159
+      vrf: default
+      key: $kUVyoj7FVQ//yw9D2lbqjA==$kxxohBiofI46IX3pw18KYQ==$DOOM0l9uU4TrQt2kyA7XCKtjUA==
+      key_type: 8a
 
 ### Radius Servers
 radius_servers:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -516,6 +516,7 @@ tacacs_servers:
     - host: < host1_ip_address >
       vrf: < vrf_name >
       key: < encrypted_key >
+      key_type: < 0 | 7 | 8a | default -> 7 >
       single_connection: < true | false >
     - host: < host2_ip_address >
       key: < encrypted_key >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/tacacs-servers.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/tacacs-servers.j2
@@ -17,7 +17,7 @@
 {%             set host_cli = host_cli ~ " timeout " ~ host.timeout %}
 {%         endif %}
 {%         if host.key is arista.avd.defined %}
-{%             set host_cli = host_cli ~ " key 7 " ~ host.key %}
+{%             set host_cli = host_cli ~ " key " ~ host.key_type | arista.avd.default('7') ~ ' ' ~ host.key %}
 {%         endif %}
 {{ host_cli }}
 {%     endfor %}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Currently TACACS keys are stored as password 7 which can be converted back from this pseudo hash to plain text.

Support should be added for AES-256-GCM

```
veos(config)#tacacs-server host 1.2.3.4 vrf MGMT key ?
  0     Indicates that the key string is not encrypted
  7     Specifies that a HIDDEN key will follow
  8a    Specifies that a AES-256-GCM encrypted key will follow
  LINE  Unobfuscated key string
```

## Related Issue(s)

Fixes #1456

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

```yaml
tacacs_servers:
  hosts:
    - host: 1.2.3.4
      vrf: MGMT
      key: '132112111915143E2E200A363030'
      key_type: < 0 | 7 | 8a | default -> 7 >
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
