### PR TITLE
Feat(eos_cli_config_gen): Add support for reversible encryption algorithm #1468

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/base.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/base.md
@@ -155,8 +155,9 @@ management api http-commands
 
 ## Management Security Summary
 
-Management Security password encryption is common.
-
+| Settings | Value |
+| -------- | ----- |
+| Common password encryption key | True |
 
 ## Management Security Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mac-security-eth-po-entropy.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mac-security-eth-po-entropy.md
@@ -6,6 +6,7 @@
 - [Authentication](#authentication)
 - [Management Security](#management-security)
   - [Management Security Summary](#management-security-summary)
+  - [Management Security SSL Profiles](#management-security-ssl-profiles)
   - [Management Security Configuration](#management-security-configuration)
 - [Monitoring](#monitoring)
 - [Internal VLAN Allocation Policy](#internal-vlan-allocation-policy)
@@ -58,12 +59,15 @@ interface Management1
 
 ## Management Security Summary
 
-Management Security entropy source is **hardware**
+| Settings | Value |
+| -------- | ----- |
+| Entropy source | hardware |
+| Common password encryption key | True |
 
-Management Security password encryption is common.
+## Management Security SSL Profiles
 
 | SSL Profile Name | TLS protocol accepted | Certificate filename | Key filename |
-| ------------ | --------------------- | -------------------- | ------------ |
+| ---------------- | --------------------- | -------------------- | ------------ |
 | SSL_PROFILE | 1.1 1.2 | SSL_CERT | SSL_KEY |
 
 ## Management Security Configuration

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-security.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-security.md
@@ -67,6 +67,7 @@ Management Security password minimum lenght is **17** characters.
 management security
    entropy source hardware
    password encryption-key common
+   password encryption reversible aes-256-gcm
    password minimum length 17
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-security.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-security.md
@@ -53,12 +53,12 @@ interface Management1
 
 ## Management Security Summary
 
-Management Security entropy source is **hardware**
-
-Management Security password encryption is common.
-
-Management Security password minimum lenght is **17** characters.
-
+| Settings | Value |
+| -------- | ----- |
+| Entropy source | hardware |
+| Common password encryption key | True |
+| Reversible password encryption | aes-256-gcm |
+| Minimum password length | 17 |
 
 ## Management Security Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-security.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-security.cfg
@@ -15,6 +15,7 @@ interface Management1
 management security
    entropy source hardware
    password encryption-key common
+   password encryption reversible aes-256-gcm
    password minimum length 17
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/management-security.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/management-security.yml
@@ -4,3 +4,4 @@ management_security:
   password:
     minimum_length: 17
     encryption_key_common: true
+    encryption_reversible: aes-256-gcm

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1692,6 +1692,7 @@ management_security:
   password:
     minimum_length: < 1-32 >
     encryption_key_common: < true | false >
+    encryption_reversible: < aes-256-gcm >
   ssl_profiles:
     - name: <ssl_profile_1>
       tls_versions: < list of allowed tls versions as string >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-security.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-security.j2
@@ -4,23 +4,28 @@
 
 ## Management Security Summary
 
+| Settings | Value |
+| -------- | ----- |
 {%     if management_security.entropy_source is arista.avd.defined %}
-Management Security entropy source is **{{ management_security.entropy_source }}**
-
+| Entropy source | {{ management_security.entropy_source }} |
 {%     endif %}
-{%     if management_security.password.encryption_key_common is arista.avd.defined(true) %}
-Management Security password encryption is common.
-
+{%     if management_security.password.encryption_key_common is arista.avd.defined %}
+| Common password encryption key | {{ management_security.password.encryption_key_common }} |
+{%     endif %}
+{%     if management_security.password.encryption_reversible is arista.avd.defined %}
+| Reversible password encryption | {{ management_security.password.encryption_reversible }} |
 {%     endif %}
 {%     if management_security.password.minimum_length is arista.avd.defined %}
-Management Security password minimum lenght is **{{ management_security.password.minimum_length }}** characters.
-
+| Minimum password length | {{ management_security.password.minimum_length }} |
 {%     endif %}
 {%     if management_security.ssl_profiles is arista.avd.defined %}
+
+## Management Security SSL Profiles
+
 | SSL Profile Name | TLS protocol accepted | Certificate filename | Key filename |
-| ------------ | --------------------- | -------------------- | ------------ |
+| ---------------- | --------------------- | -------------------- | ------------ |
 {%         for ssl_profile in management_security.ssl_profiles | arista.avd.natural_sort %}
-| {{ ssl_profile.name }} | {{ ssl_profile.tls_versions | arista.avd.default('-') }} | {{ ssl_profile.certificate.file | arista.avd.default('-') }} | {{ ssl_profile.certificate.key | arista.avd.default('-') }} |
+| {{ ssl_profile.name | arista.avd.default('-') }} | {{ ssl_profile.tls_versions | arista.avd.default('-') }} | {{ ssl_profile.certificate.file | arista.avd.default('-') }} | {{ ssl_profile.certificate.key | arista.avd.default('-') }} |
 {%         endfor %}
 {%     endif %}
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-security.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-security.j2
@@ -8,6 +8,9 @@ management security
 {%     if management_security.password.encryption_key_common is arista.avd.defined(true) %}
    password encryption-key common
 {%     endif %}
+{%     if management_security.password.encryption_reversible is arista.avd.defined() %}
+   password encryption reversible {{ management_security.password.encryption_reversible }}
+{%     endif %}
 {%     if management_security.password.minimum_length is arista.avd.defined %}
    password minimum length {{ management_security.password.minimum_length }}
 {%     endif %}


### PR DESCRIPTION
## Change Summary

Support for AES-GCM has been added as a method for storing symmetric secrets in EOS. This applies to secrets that must be used to remote systems, as found in NTP, TACACS+, and other places. Using this, the configuration can be secured since the secrets cannot be easily reversed or decrypted by copying the configuration out of the box.

See https://eos.arista.com/eos-4-27-0f/aes-gcm-encryption-of-eos-secret-configuration/

## Related Issue(s)

Fixes #1468

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

```yaml
management_security:
  password:
    encryption_reversible: < aes-256-gcm >
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
