### PR TITLE
Fix(eos_designs): Fixing template errors and invalid config when configuring cloudvision as a service

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/converge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/converge.yml
@@ -5,7 +5,7 @@
   connection: local
   tasks:
 
-    - name: generate intented variables
+    - name: generate intended variables
       delegate_to: 127.0.0.1
       import_role:
         name: arista.avd.eos_designs

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/cvp-instance-ips-cvaas.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/cvp-instance-ips-cvaas.md
@@ -1,0 +1,335 @@
+# cvp-instance-ips-cvaas
+# Table of Contents
+
+- [Management](#management)
+  - [Management API HTTP](#management-api-http)
+- [Authentication](#authentication)
+- [Monitoring](#monitoring)
+  - [TerminAttr Daemon](#terminattr-daemon)
+- [Spanning Tree](#spanning-tree)
+  - [Spanning Tree Summary](#spanning-tree-summary)
+  - [Spanning Tree Device Configuration](#spanning-tree-device-configuration)
+- [Internal VLAN Allocation Policy](#internal-vlan-allocation-policy)
+  - [Internal VLAN Allocation Policy Summary](#internal-vlan-allocation-policy-summary)
+  - [Internal VLAN Allocation Policy Configuration](#internal-vlan-allocation-policy-configuration)
+- [Interfaces](#interfaces)
+  - [Loopback Interfaces](#loopback-interfaces)
+- [Routing](#routing)
+  - [Service Routing Protocols Model](#service-routing-protocols-model)
+  - [IP Routing](#ip-routing)
+  - [IPv6 Routing](#ipv6-routing)
+  - [Static Routes](#static-routes)
+  - [Router BGP](#router-bgp)
+- [BFD](#bfd)
+  - [Router BFD](#router-bfd)
+- [Multicast](#multicast)
+- [Filters](#filters)
+  - [Prefix-lists](#prefix-lists)
+  - [Route-maps](#route-maps)
+- [ACL](#acl)
+- [VRF Instances](#vrf-instances)
+  - [VRF Instances Summary](#vrf-instances-summary)
+  - [VRF Instances Device Configuration](#vrf-instances-device-configuration)
+- [Quality Of Service](#quality-of-service)
+
+# Management
+
+## Management API HTTP
+
+### Management API HTTP Summary
+
+| HTTP | HTTPS |
+| ---- | ----- |
+| False | True |
+
+### Management API VRF Access
+
+| VRF Name | IPv4 ACL | IPv6 ACL |
+| -------- | -------- | -------- |
+| MGMT | - | - |
+
+### Management API HTTP Configuration
+
+```eos
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+```
+
+# Authentication
+
+# Monitoring
+
+## TerminAttr Daemon
+
+### TerminAttr Daemon Summary
+
+| CV Compression | CloudVision Servers | VRF | Authentication | Smash Excludes | Ingest Exclude | Bypass AAA |
+| -------------- | ------------------- | --- | -------------- | -------------- | -------------- | ---------- |
+| gzip | cv-staging.corp.arista.io:443 | MGMT | token-secure,/tmp/cv-onboarding-token | ale,flexCounter,hardware,kni,pulse,strata | /Sysdb/cell/1/agent,/Sysdb/cell/2/agent | False |
+
+### TerminAttr Daemon Device Configuration
+
+```eos
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -cvaddr=cv-staging.corp.arista.io:443 -cvauth=token-secure,/tmp/cv-onboarding-token -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   no shutdown
+```
+
+# Spanning Tree
+
+## Spanning Tree Summary
+
+STP mode: **none**
+
+## Spanning Tree Device Configuration
+
+```eos
+!
+spanning-tree mode none
+```
+
+# Internal VLAN Allocation Policy
+
+## Internal VLAN Allocation Policy Summary
+
+| Policy Allocation | Range Beginning | Range Ending |
+| ------------------| --------------- | ------------ |
+| ascending | 1006 | 1199 |
+
+## Internal VLAN Allocation Policy Configuration
+
+```eos
+!
+vlan internal order ascending range 1006 1199
+```
+
+# Interfaces
+
+## Loopback Interfaces
+
+### Loopback Interfaces Summary
+
+#### IPv4
+
+| Interface | Description | VRF | IP Address |
+| --------- | ----------- | --- | ---------- |
+| Loopback0 | EVPN_Overlay_Peering | default | 1.2.3.1/32 |
+
+#### IPv6
+
+| Interface | Description | VRF | IPv6 Address |
+| --------- | ----------- | --- | ------------ |
+| Loopback0 | EVPN_Overlay_Peering | default | - |
+
+
+### Loopback Interfaces Device Configuration
+
+```eos
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 1.2.3.1/32
+```
+
+# Routing
+## Service Routing Protocols Model
+
+Multi agent routing protocol model enabled
+
+```eos
+!
+service routing protocols model multi-agent
+```
+
+## IP Routing
+
+### IP Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | true |
+| MGMT | false |
+
+### IP Routing Device Configuration
+
+```eos
+!
+ip routing
+no ip routing vrf MGMT
+```
+## IPv6 Routing
+
+### IPv6 Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | false |
+| MGMT | false |
+
+## Static Routes
+
+### Static Routes Summary
+
+| VRF | Destination Prefix | Next Hop IP             | Exit interface      | Administrative Distance       | Tag               | Route Name                    | Metric         |
+| --- | ------------------ | ----------------------- | ------------------- | ----------------------------- | ----------------- | ----------------------------- | -------------- |
+| MGMT  | 0.0.0.0/0 |  192.168.0.1  |  -  |  1  |  -  |  -  |  - |
+
+### Static Routes Device Configuration
+
+```eos
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.0.1
+```
+
+## Router BGP
+
+### Router BGP Summary
+
+| BGP AS | Router ID |
+| ------ | --------- |
+| 1234|  1.2.3.1 |
+
+| BGP Tuning |
+| ---------- |
+| maximum-paths 4 ecmp 4 |
+
+### Router BGP Peer Groups
+
+#### EVPN-OVERLAY-PEERS
+
+| Settings | Value |
+| -------- | ----- |
+| Address Family | evpn |
+| Next-hop unchanged | True |
+| Source | Loopback0 |
+| BFD | true |
+| Ebgp multihop | 3 |
+| Send community | all |
+| Maximum routes | 0 (no limit) |
+
+#### IPv4-UNDERLAY-PEERS
+
+| Settings | Value |
+| -------- | ----- |
+| Address Family | ipv4 |
+| Send community | all |
+| Maximum routes | 12000 |
+
+### Router BGP EVPN Address Family
+
+#### EVPN Peer Groups
+
+| Peer Group | Activate |
+| ---------- | -------- |
+| EVPN-OVERLAY-PEERS | True |
+
+### Router BGP Device Configuration
+
+```eos
+!
+router bgp 1234
+   router-id 1.2.3.1
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor IPv4-UNDERLAY-PEERS activate
+```
+
+# BFD
+
+## Router BFD
+
+### Router BFD Multihop Summary
+
+| Interval | Minimum RX | Multiplier |
+| -------- | ---------- | ---------- |
+| 300 | 300 | 3 |
+
+### Router BFD Device Configuration
+
+```eos
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+```
+
+# Multicast
+
+# Filters
+
+## Prefix-lists
+
+### Prefix-lists Summary
+
+#### PL-LOOPBACKS-EVPN-OVERLAY
+
+| Sequence | Action |
+| -------- | ------ |
+| 10 | permit 1.2.3.4/24 eq 32 |
+
+### Prefix-lists Device Configuration
+
+```eos
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 1.2.3.4/24 eq 32
+```
+
+## Route-maps
+
+### Route-maps Summary
+
+#### RM-CONN-2-BGP
+
+| Sequence | Type | Match and/or Set |
+| -------- | ---- | ---------------- |
+| 10 | permit | match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY |
+
+### Route-maps Device Configuration
+
+```eos
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+```
+
+# ACL
+
+# VRF Instances
+
+## VRF Instances Summary
+
+| VRF Name | IP Routing |
+| -------- | ---------- |
+| MGMT | disabled |
+
+## VRF Instances Device Configuration
+
+```eos
+!
+vrf instance MGMT
+```
+
+# Quality Of Service

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cvp-instance-ips-cvaas.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cvp-instance-ips-cvaas.cfg
@@ -1,0 +1,70 @@
+!RANCID-CONTENT-TYPE: arista
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -cvaddr=cv-staging.corp.arista.io:443 -cvauth=token-secure,/tmp/cv-onboarding-token -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   no shutdown
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname cvp-instance-ips-cvaas
+!
+spanning-tree mode none
+!
+no aaa root
+no enable password
+!
+vrf instance MGMT
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 1.2.3.1/32
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 1.2.3.4/24 eq 32
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.0.1
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 1234
+   router-id 1.2.3.1
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor IPv4-UNDERLAY-PEERS activate
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cvp-instance-ips-cvaas.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cvp-instance-ips-cvaas.yml
@@ -1,0 +1,83 @@
+router_bgp:
+  as: '1234'
+  router_id: 1.2.3.1
+  bgp_defaults:
+  - maximum-paths 4 ecmp 4
+  peer_groups:
+    IPv4-UNDERLAY-PEERS:
+      type: ipv4
+      maximum_routes: 12000
+      send_community: all
+    EVPN-OVERLAY-PEERS:
+      type: evpn
+      update_source: Loopback0
+      bfd: true
+      ebgp_multihop: '3'
+      send_community: all
+      maximum_routes: 0
+      next_hop_unchanged: true
+  address_family_ipv4:
+    peer_groups:
+      IPv4-UNDERLAY-PEERS:
+        activate: true
+      EVPN-OVERLAY-PEERS:
+        activate: false
+  redistribute_routes:
+    connected:
+      route_map: RM-CONN-2-BGP
+  address_family_evpn:
+    peer_groups:
+      EVPN-OVERLAY-PEERS:
+        activate: true
+static_routes:
+- vrf: MGMT
+  destination_address_prefix: 0.0.0.0/0
+  gateway: 192.168.0.1
+service_routing_protocols_model: multi-agent
+ip_routing: true
+daemon_terminattr:
+  cvaddrs:
+  - cv-staging.corp.arista.io:443
+  cvauth:
+    method: token-secure
+    token_file: /tmp/cv-onboarding-token
+  cvvrf: MGMT
+  smashexcludes: ale,flexCounter,hardware,kni,pulse,strata
+  ingestexclude: /Sysdb/cell/1/agent,/Sysdb/cell/2/agent
+  disable_aaa: false
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+spanning_tree:
+  mode: none
+vrfs:
+  MGMT:
+    ip_routing: false
+management_api_http:
+  enable_vrfs:
+    MGMT: {}
+  enable_https: true
+loopback_interfaces:
+  Loopback0:
+    description: EVPN_Overlay_Peering
+    shutdown: false
+    ip_address: 1.2.3.1/32
+prefix_lists:
+  PL-LOOPBACKS-EVPN-OVERLAY:
+    sequence_numbers:
+      10:
+        action: permit 1.2.3.4/24 eq 32
+route_maps:
+  RM-CONN-2-BGP:
+    sequence_numbers:
+      10:
+        type: permit
+        match:
+        - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+router_bfd:
+  multihop:
+    interval: 300
+    min_rx: 300
+    multiplier: 3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/AVD_LAB.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/AVD_LAB.yml
@@ -1,5 +1,4 @@
 # Nashua EVE-NG LAB shared attributes
-root_dir: '{{ playbook_dir }}'
 
 # local users
 local_users:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/all.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/all.yml
@@ -1,0 +1,2 @@
+---
+root_dir: '{{ playbook_dir }}'

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/cvp-instance-ips-cvaas.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/cvp-instance-ips-cvaas.yml
@@ -1,0 +1,12 @@
+type: spine
+spine:
+  nodes:
+    cvp-instance-ips-cvaas:
+      id: 1
+      loopback_ipv4_pool: 1.2.3.4/24
+      bgp_as: 1234
+
+mgmt_gateway: 192.168.0.1
+fabric_name: CLEAN_UNIT_TESTS
+cvp_instance_ips:
+  - cv-staging.corp.arista.io

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
@@ -1,5 +1,8 @@
 all:
   children:
+    CLEAN_UNIT_TESTS:
+      hosts:
+        cvp-instance-ips-cvaas
     AVD_LAB:
       children:
         DC1_FABRIC:

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/management-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/management-settings.md
@@ -43,7 +43,10 @@ cvp_instance_ips:
   - < IPv4 address >
   - < IPv4 address >
   - < CV as a Service hostname >
+# cvp_ingestauth_key is required for on-prem CVP
 cvp_ingestauth_key: < CloudVision Ingest Authentication key >
+# cvp_token_file is only applicable to CV as a Service
+cvp_token_file: < 'path_to_token_file_on_switch' | default -> '/tmp/cv-onboarding-token' >
 terminattr_ingestgrpcurl_port: < port_number | default -> 9910 >
 terminattr_smashexcludes: "< smash excludes | default -> ale,flexCounter,hardware,kni,pulse,strata >"
 terminattr_ingestexclude: "< ingest excludes | default -> /Sysdb/cell/1/agent,/Sysdb/cell/2/agent >"

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/base/daemon-terminattr.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/base/daemon-terminattr.j2
@@ -35,7 +35,7 @@ daemon_terminattr:
 {%         endfor %}
   cvauth:
     method: "token-secure"
-    key: "{{ cvp_ingestauth_key | arista.avd.default('/tmp/cv-onboarding-token') }}"
+    token_file: "{{ cvp_token_file | arista.avd.default('/tmp/cv-onboarding-token') }}"
 {%     endif %}
   cvvrf: {{ mgmt_interface_vrf }}
   smashexcludes: "{{ terminattr_smashexcludes }}"

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/base/daemon-terminattr.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/base/daemon-terminattr.j2
@@ -8,8 +8,8 @@
 {%     if cvp_instance_ip is arista.avd.defined %}
 {%         if "arista.io" not in cvp_instance_ip %}
 {%             do cvp_on_prem.ips.append(cvp_instance_ip) %}
-{%         elif "arista.io" in cvp_ip %}
-{%             do cvaas.ips.append(cvp_ip) %}
+{%         elif "arista.io" in cvp_instance_ip%}
+{%             do cvaas.ips.append(cvp_instance_ip) %}
 {%         endif %}
 {%     elif cvp_instance_ips is arista.avd.defined %}
 {%         for cvp_ip in cvp_instance_ips %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/base/daemon-terminattr.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/base/daemon-terminattr.j2
@@ -26,14 +26,17 @@ daemon_terminattr:
 {%         for cvp_instance_ip in cvp_on_prem.ips %}
     - {{ cvp_instance_ip }}:{{ terminattr_ingestgrpcurl_port }}
 {%         endfor %}
+  cvauth:
+    method: "key"
+    key: "{{ cvp_ingestauth_key }}"
 {%     elif cvaas.ips | length > 0 %}
 {%         for cvp_instance_ip in cvaas.ips %}
     - {{ cvp_instance_ip }}:443
 {%         endfor %}
-{%     endif %}
   cvauth:
-    method: "key"
-    key: "{{ cvp_ingestauth_key }}"
+    method: "token-secure"
+    key: "{{ cvp_ingestauth_key | arista.avd.default('/tmp/cv-onboarding-token') }}"
+{%     endif %}
   cvvrf: {{ mgmt_interface_vrf }}
   smashexcludes: "{{ terminattr_smashexcludes }}"
   ingestexclude: "{{ terminattr_ingestexclude }}"

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/base/daemon-terminattr.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/base/daemon-terminattr.j2
@@ -8,7 +8,7 @@
 {%     if cvp_instance_ip is arista.avd.defined %}
 {%         if "arista.io" not in cvp_instance_ip %}
 {%             do cvp_on_prem.ips.append(cvp_instance_ip) %}
-{%         elif "arista.io" in cvp_instance_ip%}
+{%         elif "arista.io" in cvp_instance_ip %}
 {%             do cvaas.ips.append(cvp_instance_ip) %}
 {%         endif %}
 {%     elif cvp_instance_ips is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/base/daemon-terminattr.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/base/daemon-terminattr.j2
@@ -6,17 +6,17 @@
 {%     set cvaas = namespace() %}
 {%     set cvaas.ips = [] %}
 {%     if cvp_instance_ip is arista.avd.defined %}
-{%         if "arista.io" not in cvp_instance_ip %}
-{%             do cvp_on_prem.ips.append(cvp_instance_ip) %}
-{%         elif "arista.io" in cvp_instance_ip %}
+{%         if "arista.io" in cvp_instance_ip %}
 {%             do cvaas.ips.append(cvp_instance_ip) %}
+{%         else %}
+{%             do cvp_on_prem.ips.append(cvp_instance_ip) %}
 {%         endif %}
 {%     elif cvp_instance_ips is arista.avd.defined %}
 {%         for cvp_ip in cvp_instance_ips %}
-{%             if "arista.io" not in cvp_ip %}
-{%                 do cvp_on_prem.ips.append(cvp_ip) %}
-{%             elif "arista.io" in cvp_ip %}
+{%             if "arista.io" in cvp_ip %}
 {%                 do cvaas.ips.append(cvp_ip) %}
+{%             else %}
+{%                 do cvp_on_prem.ips.append(cvp_ip) %}
 {%             endif %}
 {%         endfor %}
 {%     endif %}


### PR DESCRIPTION
## Change Summary

Fixed bug causing cvp_instance_ip variable value containing "arista.io" to error out the template.

## Component(s) name

`arista.avd.eos_designs`

### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
