### PR TITLE
Fix(eos_cli_config_gen): BGP IPv6 AF redistribute_route_cli bug

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
@@ -163,6 +163,7 @@ router bgp 65101
       neighbor baz prefix-list PL-BAR-v6-OUT out
       neighbor 2001:db8::1 prefix-list PL-FOO-v6-IN in
       neighbor 2001:db8::1 prefix-list PL-FOO-v6-OUT out
+      redistribute static route-map RM-IPV6-STATIC-TO-BGP
 ```
 
 # Multicast

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-base.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-base.cfg
@@ -52,5 +52,6 @@ router bgp 65101
       neighbor baz prefix-list PL-BAR-v6-OUT out
       neighbor 2001:db8::1 prefix-list PL-FOO-v6-IN in
       neighbor 2001:db8::1 prefix-list PL-FOO-v6-OUT out
+      redistribute static route-map RM-IPV6-STATIC-TO-BGP
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-base.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-base.yml
@@ -58,6 +58,9 @@ router_bgp:
       2001:db8::1:
         prefix_list_in: PL-FOO-v6-IN
         prefix_list_out: PL-FOO-v6-OUT
+    redistribute_routes:
+      static:
+        route_map: RM-IPV6-STATIC-TO-BGP
   neighbors:
     192.0.3.1:
       remote_as: 65432

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -538,7 +538,7 @@ router bgp {{ router_bgp.as }}
 {%         for redistribute_route in router_bgp.address_family_ipv6.redistribute_routes | arista.avd.natural_sort %}
 {%             set redistribute_route_cli = "redistribute " ~ redistribute_route %}
 {%             if router_bgp.address_family_ipv6.redistribute_routes[redistribute_route].route_map is arista.avd.defined %}
-{%                 set redistribute_route_cli = redistribute_route_cl ~ " route-map " ~ router_bgp.address_family_ipv6.redistribute_routes[redistribute_route].route_map %}
+{%                 set redistribute_route_cli = redistribute_route_cli ~ " route-map " ~ router_bgp.address_family_ipv6.redistribute_routes[redistribute_route].route_map %}
 {%             endif %}
       {{ redistribute_route_cli }}
 {%         endfor %}


### PR DESCRIPTION
## Change Summary

Fix small bug, missing "i" in set redistribute_route_cli = redistribute_route_cli in BGP IPv6 AF.

## Component(s) name

`arista.avd.eos_cli_config_gen`

### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
