### PR TITLE
Feat(plugins): Add var_type 'bool' to arista.avd.defined filter

### DIFF
--- a/ansible_collections/arista/avd/plugins/README.md
+++ b/ansible_collections/arista/avd/plugins/README.md
@@ -186,7 +186,7 @@ Syntax:
 
 ```jinja
 {% <value> is arista.avd.defined(test_value=<test_value>,
-                                 var_type=['float', 'int', 'str', 'list', 'dict', 'tuple'],
+                                 var_type=['float', 'int', 'str', 'list', 'dict', 'tuple', 'bool'],
                                  fail_action=['warning','error'],
                                  var_name=<string representing name of value>) %}
 ```

--- a/ansible_collections/arista/avd/plugins/test/defined.py
+++ b/ansible_collections/arista/avd/plugins/test/defined.py
@@ -57,7 +57,7 @@ def defined(value, test_value=None, var_type=None, fail_action=None, var_name=No
         Value to test from ansible
     test_value : any, optional
         Value to test in addition of defined and not none, by default None
-    var_type : ['float', 'int', 'str', 'list', 'dict', 'tuple'], optional
+    var_type : ['float', 'int', 'str', 'list', 'dict', 'tuple', 'bool'], optional
         Type or Class to test for
     fail_action : ['warning', 'error'], optional
         Optional action if test fails to emit a Warning or Error
@@ -95,7 +95,7 @@ def defined(value, test_value=None, var_type=None, fail_action=None, var_name=No
             else:
                 raise AnsibleError(f"A variable was set to {value} but we expected {test_value}!")
         return False
-    elif str(var_type).lower() in ['float', 'int', 'str', 'list', 'dict', 'tuple'] and str(var_type).lower() != type(value).__name__:
+    elif str(var_type).lower() in ['float', 'int', 'str', 'list', 'dict', 'tuple', 'bool'] and str(var_type).lower() != type(value).__name__:
         # Invalid class - return false
         if str(fail_action).lower() == 'warning':
             if var_name is not None:


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Add var_type 'bool' to arista.avd.defined filter

## Component(s) name

`arista.avd.defined` filter

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->
Adding support for detecting var_type='bool' with arista.avd.defined filter.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
No changes to molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
