### PR TITLE
Fix(eos_cli_config_gen): Block delimers between Extended IPv4 ACLs

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/acl.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/acl.md
@@ -185,11 +185,13 @@ ip access-list ACL-01
    10 remark ACL to restrict access to switch API to CVP and Ansible
    20 deny ip host 192.0.2.1 any
    30 permit ip 192.0.2.0/24 any
+!
 ip access-list ACL-02
    counters per-entry
    10 remark ACL to restrict access RFC1918 addresses
    20 permit ip 10.0.0.0/8 any
    30 permit ip 192.0.2.0/24 any
+!
 ip access-list ACL-03
    10 remark ACL to restrict access RFC1918 addresses
    20 deny ip 10.0.0.0/8 any

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/acl.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/acl.cfg
@@ -16,11 +16,13 @@ ip access-list ACL-01
    10 remark ACL to restrict access to switch API to CVP and Ansible
    20 deny ip host 192.0.2.1 any
    30 permit ip 192.0.2.0/24 any
+!
 ip access-list ACL-02
    counters per-entry
    10 remark ACL to restrict access RFC1918 addresses
    20 permit ip 10.0.0.0/8 any
    30 permit ip 192.0.2.0/24 any
+!
 ip access-list ACL-03
    10 remark ACL to restrict access RFC1918 addresses
    20 deny ip 10.0.0.0/8 any

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/access-lists.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/access-lists.j2
@@ -1,15 +1,13 @@
 {# eos - extended access-lists #}
-{% if access_lists is arista.avd.defined %}
+{% for access_list in access_lists | arista.avd.natural_sort %}
 !
-{%     for access_list in access_lists | arista.avd.natural_sort %}
 ip access-list {{ access_list }}
-{%         if access_lists[access_list].counters_per_entry is arista.avd.defined(true) %}
+{%     if access_lists[access_list].counters_per_entry is arista.avd.defined(true) %}
    counters per-entry
-{%         endif %}
-{%         for sequence in access_lists[access_list].sequence_numbers | arista.avd.natural_sort %}
-{%             if access_lists[access_list].sequence_numbers[sequence].action is arista.avd.defined %}
+{%     endif %}
+{%     for sequence in access_lists[access_list].sequence_numbers | arista.avd.natural_sort %}
+{%         if access_lists[access_list].sequence_numbers[sequence].action is arista.avd.defined %}
    {{ sequence }} {{ access_lists[access_list].sequence_numbers[sequence].action }}
-{%             endif %}
-{%         endfor %}
+{%         endif %}
 {%     endfor %}
-{% endif %}
+{% endfor %}


### PR DESCRIPTION


## Change Summary

It looks like when the exclamation points were refactored in
be813b3381242aefb3620c1b131e361c556aa2ef the new ! was placed one line
off and fell outside the for loop, so only a single ! was generated for all the
IPv4 ACLs.

Also aligning Extended IPv4 ACLs with other blocks to not use an if defined block
and rely on looping over an empty list. Fixing indents accordingly.

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Add ! between IPv4 ACLs to make generated config a little easier to read.


## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
