### PR TITLE
Fix(eos_designs): Pull endpoint interface information from combined adapter+port profile settings

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_SERVERS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_SERVERS.yml
@@ -18,6 +18,7 @@ port_profiles:
 
   ALL_WITH_SECURITY:
     parent_profile: NON_EXISTING_PROFILE #Test that pointing to a nonexisting profile won't break templates.
+    server_ports: [ Eth1, Eth2 ]
     mode: trunk
     vlans: "1-4094"
     spanning_tree_bpdufilter: disabled
@@ -168,8 +169,7 @@ servers:
   server04_inherit_all_from_profile:
     rack: RackC
     adapters:
-      - server_ports: [ Eth1, Eth2 ]
-        switch_ports: [ Ethernet11, Ethernet11 ]
+      - switch_ports: [ Ethernet11, Ethernet11 ]
         switches: [ DC1-SVC3A, DC1-SVC3B ]
         profile: ALL_WITH_SECURITY
 

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/ethernet-interfaces.j2
@@ -15,11 +15,11 @@ ethernet_interfaces:
 {%             set endpoint_ports = adapter_settings.endpoint_ports | arista.avd.default(adapter_settings.server_ports) %}
 {%             set peer_type = connected_endpoints_keys[endpoint_key].type %}
 {%             set peer = connected_endpoint %}
-{%             for adapter_switch in adapter.switches %}
+{%             for adapter_switch in adapter_settings.switches %}
 {%                 if adapter_switch == inventory_hostname %}
-{%                     set channel_group_id = (adapter.switch_ports[0] | regex_findall("\d") | join) %}
+{%                     set channel_group_id = (adapter_settings.switch_ports[0] | regex_findall("\d") | join) %}
 {%                     set peer_interface = endpoint_ports[loop.index0] %}
-  {{ adapter.switch_ports[loop.index0] }}:
+  {{ adapter_settings.switch_ports[loop.index0] }}:
     peer: {{ peer }}
     peer_interface: {{ peer_interface }}
     peer_type: {{ peer_type }}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/ethernet-interfaces.j2
@@ -12,7 +12,7 @@ ethernet_interfaces:
 {%             set adapter_settings = {} | combine(parent_profile | arista.avd.default({}),
                                                    adapter_profile | arista.avd.default({}),
                                                    adapter, recursive=true, list_merge='replace') %}
-{%             set endpoint_ports = adapter.endpoint_ports | arista.avd.default(adapter.server_ports) %}
+{%             set endpoint_ports = adapter_settings.endpoint_ports | arista.avd.default(adapter_settings.server_ports) %}
 {%             set peer_type = connected_endpoints_keys[endpoint_key].type %}
 {%             set peer = connected_endpoint %}
 {%             for adapter_switch in adapter.switches %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/port-channel-interfaces.j2
@@ -13,9 +13,9 @@ port_channel_interfaces:
                                                    adapter_profile | arista.avd.default({}),
                                                    adapter, recursive=true, list_merge='replace') %}
 {%             if adapter_settings.port_channel.mode is arista.avd.defined %}
-{%                 set channel_group_id = (adapter.switch_ports[0] | regex_findall("\d") | join) %}
+{%                 set channel_group_id = (adapter_settings.switch_ports[0] | regex_findall("\d") | join) %}
 {%                 set adapter_port_channel_description = adapter_settings.port_channel.description | arista.avd.default('') %}
-{%                 for adapter_switch in adapter.switches | arista.avd.natural_sort %}
+{%                 for adapter_switch in adapter_settings.switches | arista.avd.natural_sort %}
 {%                     if adapter_switch == inventory_hostname %}
   Port-Channel{{ channel_group_id }}:
 {%                         set peer = connected_endpoint %}
@@ -56,7 +56,7 @@ port_channel_interfaces:
 {%                                 endif %}
 {%                             endfor %}
 {%                         endif %}
-{%                         if adapter.switches | unique | list | length > 1 %}
+{%                         if adapter_settings.switches | unique | list | length > 1 %}
 {%                             if adapter.port_channel.short_esi is arista.avd.defined %}
 {%                                 if adapter.port_channel.short_esi.split(':') | length == 3 %}
     esi: {{ adapter.port_channel.short_esi | arista.avd.generate_esi(evpn_short_esi_prefix) }}


### PR DESCRIPTION


## Change Summary

endpoint_ports was incorrectly being pulled from the original raw adapter
configuration, which did not allow the endpoint port to be configured in
a port profile and inherited, which would be useful when stamping out a large number of
connected endpoints with the same port configuraiton.

Also makes it much easier to stub out endpoint_ports when they're not
applicable for the user since they can set endpoint_ports: [ 'N/A' ] in
just a parent port profile template.

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

Pull endpoint_ports from the merged dataset instead of the original top level dict

## How to test

Moved one server_ports definition up into a profile.

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
