### PR TITLE
Fix(eos_cli_config_gen): Fix logic in daemon_terminattr

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/daemon-terminattr.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/daemon-terminattr.j2
@@ -43,13 +43,13 @@ daemon TerminAttr
 {%     if daemon_terminattr.cvsourceip is arista.avd.defined %}
 {%         set cvp_config.cli = cvp_config.cli ~ " -cvsourceip=" ~ daemon_terminattr.cvsourceip %}
 {%     endif %}
-{%     if daemon_terminattr.cvgnmi is arista.avd.defined %}
+{%     if daemon_terminattr.cvgnmi is arista.avd.defined(true) %}
 {%         set cvp_config.cli = cvp_config.cli ~ " -cvgnmi" %}
 {%     endif %}
-{%     if daemon_terminattr.cvobscurekeyfile is true %}
+{%     if daemon_terminattr.cvobscurekeyfile is arista.avd.defined(true) %}
 {%         set cvp_config.cli = cvp_config.cli ~ " -cvobscurekeyfile" %}
 {%     endif %}
-{%     if daemon_terminattr.disable_aaa is true %}
+{%     if daemon_terminattr.disable_aaa is arista.avd.defined(true) %}
 {%         set cvp_config.cli = cvp_config.cli ~ " -disableaaa" %}
 {%     endif %}
 {%     if daemon_terminattr.cvproxy is arista.avd.defined %}
@@ -58,7 +58,7 @@ daemon TerminAttr
 {%     if daemon_terminattr.grpcaddr is arista.avd.defined %}
 {%         set cvp_config.cli = cvp_config.cli ~ " -grpcaddr=" ~ daemon_terminattr.grpcaddr %}
 {%     endif %}
-{%     if daemon_terminattr.grpcreadonly is true %}
+{%     if daemon_terminattr.grpcreadonly is arista.avd.defined(true) %}
 {%         set cvp_config.cli = cvp_config.cli ~ " -grpcreadonly" %}
 {%     endif %}
 {%     if daemon_terminattr.smashexcludes is arista.avd.defined %}
@@ -67,28 +67,28 @@ daemon TerminAttr
 {%     if daemon_terminattr.ingestexclude is arista.avd.defined %}
 {%         set cvp_config.cli = cvp_config.cli ~ " -ingestexclude=" ~ daemon_terminattr.ingestexclude %}
 {%     endif %}
-{%     if daemon_terminattr.taillogs is arista.avd.defined  %}
+{%     if daemon_terminattr.taillogs is arista.avd.defined %}
 {%         set cvp_config.cli = cvp_config.cli ~ " -taillogs=" ~ daemon_terminattr.taillogs %}
 {%     else %}
 {%         set cvp_config.cli = cvp_config.cli ~ " -taillogs" %}
 {%     endif %}
-{%     if daemon_terminattr.ecodhcpaddr is true %}
+{%     if daemon_terminattr.ecodhcpaddr is arista.avd.defined %}
 {%         set cvp_config.cli = cvp_config.cli ~ " -ecodhcpaddr=" ~ daemon_terminattr.ecodhcpaddr %}
 {%     endif %}
-{%     if daemon_terminattr.ipfix is true %}
+{%     if daemon_terminattr.ipfix is arista.avd.defined(true) %}
 {%         set cvp_config.cli = cvp_config.cli ~ " -ipfix" %}
-{%     elif daemon_terminattr.ipfix is false %}
+{%     elif daemon_terminattr.ipfix is arista.avd.defined(false) %}
 {%         set cvp_config.cli = cvp_config.cli ~ " -ipfix=false" %}
 {%     endif %}
-{%     if daemon_terminattr.ipfixaddr is true %}
+{%     if daemon_terminattr.ipfixaddr is arista.avd.defined(true) %}
 {%         set cvp_config.cli = cvp_config.cli ~ " -ipfixaddr=" ~ daemon_terminattr.ipfixaddr %}
 {%     endif %}
-{%     if daemon_terminattr.sflow is true %}
+{%     if daemon_terminattr.sflow is arista.avd.defined(true) %}
 {%         set cvp_config.cli = cvp_config.cli ~ " -sflow" %}
-{%     elif daemon_terminattr.sflow is false %}
+{%     elif daemon_terminattr.sflow is arista.avd.defined(false) %}
 {%         set cvp_config.cli = cvp_config.cli ~ " -sflow=false" %}
 {%     endif %}
-{%     if daemon_terminattr.sflowaddr is true %}
+{%     if daemon_terminattr.sflowaddr is arista.avd.defined %}
 {%         set cvp_config.cli = cvp_config.cli ~ " -sflowaddr=" ~ daemon_terminattr.sflowaddr %}
 {%     endif %}
    {{ cvp_config.cli }}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/daemon-terminattr.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/daemon-terminattr.j2
@@ -80,7 +80,7 @@ daemon TerminAttr
 {%     elif daemon_terminattr.ipfix is arista.avd.defined(false) %}
 {%         set cvp_config.cli = cvp_config.cli ~ " -ipfix=false" %}
 {%     endif %}
-{%     if daemon_terminattr.ipfixaddr is arista.avd.defined(true) %}
+{%     if daemon_terminattr.ipfixaddr is arista.avd.defined %}
 {%         set cvp_config.cli = cvp_config.cli ~ " -ipfixaddr=" ~ daemon_terminattr.ipfixaddr %}
 {%     endif %}
 {%     if daemon_terminattr.sflow is arista.avd.defined(true) %}


### PR DESCRIPTION
## Change Summary
 Fix logic in daemon_terminattr

<!-- Enter short PR description -->

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

The template `daemon_terminattr.j2` contained several "is true" tests, which fails on older versions on jinja.
This fix change the logic to look more like all other templates using `arista.avd.defined`.
Also fixed a few other logic errors in the same template.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been rebased from devel before I start
- [ ] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
