### PR TITLE
Feat(eos_cli_config_gen): Add support for MPLS and LDP on port-channel interfaces

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
@@ -15,6 +15,8 @@
   - [IPv6 Routing](#ipv6-routing)
 - [BFD](#bfd)
   - [BFD Interfaces](#bfd-interfaces)
+- [MPLS](#mpls)
+  - [MPLS Interfaces](#mpls-interfaces)
 - [Multicast](#multicast)
 - [Filters](#filters)
 - [ACL](#acl)
@@ -257,6 +259,8 @@ interface Ethernet50
 | Port-Channel8.101 | to Dev02 Port-Channel8.101 - VRF-C1 | routed | - | 10.1.2.3/31 | default | - | - | - | - |
 | Port-Channel9 | - | routed | - | 10.9.2.3/31 | default | - | - | - | - |
 | Port-Channel17 | PBR Description | routed | - | 192.0.2.3/31 | default | - | - | - | - |
+| Port-Channel113 | interface_with_mpls_enabled | routed | - | 172.31.128.9/31 | default | - | - | - | - |
+| Port-Channel114 | interface_with_mpls_disabled | routed | - | 172.31.128.10/31 | default | - | - | - | - |
 
 #### ISIS
 
@@ -508,6 +512,21 @@ interface Port-Channel112
    switchport mode trunk
    port-channel lacp fallback timeout 5
    port-channel lacp fallback individual
+!
+interface Port-Channel113
+   description interface_with_mpls_enabled
+   no switchport
+   ip address 172.31.128.9/31
+   mpls ip
+   mpls ldp interface
+   mpls ldp igp sync
+!
+interface Port-Channel114
+   description interface_with_mpls_disabled
+   no switchport
+   ip address 172.31.128.10/31
+   no mpls ip
+   no mpls ldp interface
 ```
 
 # Routing
@@ -539,6 +558,15 @@ interface Port-Channel112
 | Interface | Interval | Minimum RX | Multiplier |
 | --------- | -------- | ---------- | ---------- |
 | Port-Channel9 | 500 | 500 | 5 |
+
+# MPLS
+
+## MPLS Interfaces
+
+| Interface | MPLS IP Enabled | LDP Enabled | IGP Sync |
+| --------- | --------------- | ----------- | -------- |
+| Port-Channel113 | True | True | True |
+| Port-Channel114 | False | False | - |
 
 # Multicast
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
@@ -248,6 +248,21 @@ interface Port-Channel112
    port-channel lacp fallback timeout 5
    port-channel lacp fallback individual
 !
+interface Port-Channel113
+   description interface_with_mpls_enabled
+   no switchport
+   ip address 172.31.128.9/31
+   mpls ip
+   mpls ldp interface
+   mpls ldp igp sync
+!
+interface Port-Channel114
+   description interface_with_mpls_disabled
+   no switchport
+   ip address 172.31.128.10/31
+   no mpls ip
+   no mpls ldp interface
+!
 interface Ethernet3
    description MLAG_PEER_DC1-LEAF1B_Ethernet3
    channel-group 3 mode active

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
@@ -286,6 +286,25 @@ port_channel_interfaces:
     lacp_fallback_timeout: 5
     lacp_fallback_mode: individual
 
+  Port-Channel113:
+    description: interface_with_mpls_enabled
+    type: routed
+    ip_address: 172.31.128.9/31
+    mpls:
+      ip: true
+      ldp:
+        interface: true
+        igp_sync: true
+
+  Port-Channel114:
+    description: interface_with_mpls_disabled
+    type: routed
+    ip_address: 172.31.128.10/31
+    mpls:
+      ip: false
+      ldp:
+        interface: false
+
 # Children interfaces
 ethernet_interfaces:
   Ethernet5:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1189,6 +1189,11 @@ port_channel_interfaces:
     service_policy:
       pbr:
         input: < policy-map name >
+    mpls:
+      ip: < true | false >
+      ldp:
+        interface: < true | false >
+        igp_sync: < true | false >
     trunk_private_vlan_secondary: < true | false >
     pvlan_mapping: "< list of vlans as string >"
     vlan_translations:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/mpls-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/mpls-interfaces.j2
@@ -1,5 +1,5 @@
 {# Interfaces #}
-{% if mpls_configured.ethernet_interfaces or mpls_configured.loopback_interfaces %}
+{% if mpls_configured.ethernet_interfaces or mpls_configured.loopback_interfaces or mpls_configured.port_channel_interfaces %}
 
 ## MPLS Interfaces
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/mpls-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/mpls-interfaces.j2
@@ -19,4 +19,12 @@
 | {{ loopback_interface }} | - | {{ row_ldp_interface }} | - |
 {%         endif %}
 {%     endfor %}
+{%     for port_channel_interface in port_channel_interfaces | arista.avd.natural_sort %}
+{%         if port_channel_interfaces[port_channel_interface].mpls is arista.avd.defined %}
+{%             set row_mpls_ip = port_channel_interfaces[port_channel_interface].mpls.ip | arista.avd.default('-') %}
+{%             set row_ldp_interface = port_channel_interfaces[port_channel_interface].mpls.ldp.interface | arista.avd.default('-') %}
+{%             set row_ldp_igp_sync = port_channel_interfaces[port_channel_interface].mpls.ldp.igp_sync | arista.avd.default('-') %}
+| {{ port_channel_interface }} | {{ row_mpls_ip }} | {{ row_ldp_interface }} | {{ row_ldp_igp_sync }} |
+{%         endif %}
+{%     endfor %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/mpls.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/mpls.j2
@@ -1,5 +1,5 @@
 {# MPLS #}
-{% set mpls_configured = namespace(ethernet_interfaces=false, loopback_interfaces=false) %}
+{% set mpls_configured = namespace(ethernet_interfaces=false, loopback_interfaces=false, port_channel_interfaces=false) %}
 {% for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort %}
 {%     if ethernet_interfaces[ethernet_interface].mpls is arista.avd.defined %}
 {%         set mpls_configured.ethernet_interfaces = true %}
@@ -10,7 +10,12 @@
 {%         set mpls_configured.loopback_interfaces = true %}
 {%     endif %}
 {% endfor %}
-{% if mpls is arista.avd.defined or mpls_configured.ethernet_interfaces or mpls_configured.loopback_interfaces %}
+{% for port_channel_interface in port_channel_interfaces | arista.avd.natural_sort %}
+{%     if port_channel_interface[port_channel_interfaces].mpls is arista.avd.defined %}
+{%         set mpls_configured.port_channel_interfaces = true %}
+{%     endif %}
+{% endfor %}
+{% if mpls is arista.avd.defined or mpls_configured.ethernet_interfaces or mpls_configured.loopback_interfaces or mpls_configured.port_channel_interfaces %}
 
 # MPLS
 {## MPLS and LDP #}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/mpls.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/mpls.j2
@@ -11,7 +11,7 @@
 {%     endif %}
 {% endfor %}
 {% for port_channel_interface in port_channel_interfaces | arista.avd.natural_sort %}
-{%     if port_channel_interface[port_channel_interfaces].mpls is arista.avd.defined %}
+{%     if port_channel_interfaces[port_channel_interface].mpls is arista.avd.defined %}
 {%         set mpls_configured.port_channel_interfaces = true %}
 {%     endif %}
 {% endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
@@ -289,6 +289,19 @@ interface {{ port_channel_interface }}
 {%     if port_channel_interfaces[port_channel_interface].service_policy.pbr.input is arista.avd.defined %}
    service-policy type pbr input {{ port_channel_interfaces[port_channel_interface].service_policy.pbr.input }}
 {%     endif %}
+{%     if port_channel_interfaces[port_channel_interface].mpls.ip is arista.avd.defined(true) %}
+   mpls ip
+{%     elif port_channel_interfaces[port_channel_interface].mpls.ip is arista.avd.defined(false) %}
+   no mpls ip
+{%     endif %}
+{%     if port_channel_interfaces[port_channel_interface].mpls.ldp.interface is arista.avd.defined(true) %}
+   mpls ldp interface
+{%     elif port_channel_interfaces[port_channel_interface].mpls.ldp.interface is arista.avd.defined(false) %}
+   no mpls ldp interface
+{%     endif %}
+{%     if port_channel_interfaces[port_channel_interface].mpls.ldp.igp_sync is arista.avd.defined(true) %}
+   mpls ldp igp sync
+{%     endif %}
 {%     if port_channel_interfaces[port_channel_interface].isis_enable is arista.avd.defined %}
    isis enable {{ port_channel_interfaces[port_channel_interface].isis_enable }}
 {%     endif %}


### PR DESCRIPTION
Co-authored-by: emilarista <73955263+emilarista@users.noreply.github.com>

## Change Summary

<!-- Enter short PR description -->
Add support for MPLS and LDP on port-channel interfaces

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->
```yaml
port_channel_interfaces:
  < Port-Channel_interface_1 >:
    mpls:
      ip: < true | false >
      ldp:
        interface: < true | false >
        igp_sync: < true | false >
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
