### PR TITLE
Feat(eos_designs): Add extra ID options to network services and rename rd/rt vars

### DIFF
--- a/ansible_collections/arista/avd/docs/release-notes/3.x.x.md
+++ b/ansible_collections/arista/avd/docs/release-notes/3.x.x.md
@@ -2,6 +2,23 @@
 
 Documentation for AVD version `3.x.x` [available here](https://www.avd.sh/en/releases-v3.x.x/)
 
+## Release 3.3.0
+
+### Data model modifications (non-breaking)
+
+This section provides an overview of only the data model that have ***changed*** from the previous release, but which are backwards compatible.
+
+No changes are required for existing deployments.
+
+See the release notes and role documentation for all new additions.
+
+#### Changes to eos_designs role
+
+- __Network Services variables:__
+
+  - `evpn_rt_type` has been renamed to `overlay_rt_type` as part of preparations for MPLS design. The old key is still supported.
+  - `evpn_rd_type` has been renamed to `overlay_rd_type` as part of preparations for MPLS design. The old key is still supported.
+
 ## Release 3.2.1
 
 ### Fixed isses

--- a/ansible_collections/arista/avd/docs/release-notes/3.x.x.md
+++ b/ansible_collections/arista/avd/docs/release-notes/3.x.x.md
@@ -18,6 +18,7 @@ See the release notes and role documentation for all new additions.
 
   - `evpn_rt_type` has been renamed to `overlay_rt_type` as part of preparations for MPLS design. The old key is still supported.
   - `evpn_rd_type` has been renamed to `overlay_rd_type` as part of preparations for MPLS design. The old key is still supported.
+  - `vxlan_vlan_aware_bundles` has been renamed to `evpn_vlan_aware_bundles` as part of preparations for MPLS design. The old key is still supported.
 
 ## Release 3.2.1
 

--- a/ansible_collections/arista/avd/molecule/dhcp_configuration/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/dhcp_configuration/inventory/group_vars/DC1_FABRIC.yml
@@ -21,7 +21,7 @@ mlag_ips:
   leaf_peer_l3: 10.255.251.0/24
   mlag_peer: 10.255.252.0/24
 
-# Enable vlan aware bundles
+# Enable vlan aware bundles using the old name of the setting (backwards compatible)
 vxlan_vlan_aware_bundles: true
 
 # bgp peer groups passwords

--- a/ansible_collections/arista/avd/molecule/dhcp_provisionning/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/dhcp_provisionning/inventory/group_vars/DC1_FABRIC.yml
@@ -21,7 +21,7 @@ mlag_ips:
   leaf_peer_l3: 10.255.251.0/24
   mlag_peer: 10.255.252.0/24
 
-# Enable vlan aware bundles
+# Enable vlan aware bundles using the old name of the setting (backwards compatible)
 vxlan_vlan_aware_bundles: true
 
 # bgp peer groups passwords

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/inventory/group_vars/DC1_FABRIC.yml
@@ -4,7 +4,7 @@
 
 fabric_name: DC1_FABRIC
 
-# Enable vlan aware bundles
+# Enable vlan aware bundles using the old name of the setting (backwards compatible)
 vxlan_vlan_aware_bundles: true
 
 # bgp peer groups passwords

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2A.md
@@ -638,9 +638,9 @@ interface Vlan4094
 | ---- | --- | ---------- | --------------- |
 | 110 | 10110 | - | - |
 | 111 | 50111 | - | - |
-| 112 | 50112 | - | - |
+| 112 | 10112 | - | - |
 | 2500 | 2500 | - | - |
-| 2600 | 2600 | - | - |
+| 2600 | 12600 | - | - |
 
 #### VRF to VNI and Multicast Group Mappings
 
@@ -662,9 +662,9 @@ interface Vxlan1
    vxlan udp-port 4789
    vxlan vlan 110 vni 10110
    vxlan vlan 111 vni 50111
-   vxlan vlan 112 vni 50112
+   vxlan vlan 112 vni 10112
    vxlan vlan 2500 vni 2500
-   vxlan vlan 2600 vni 2600
+   vxlan vlan 2600 vni 12600
    vxlan vrf Common_VRF vni 1025
    vxlan vrf vrf_with_loopbacks_dc1_pod1_only vni 1102
    vxlan vrf vrf_with_loopbacks_from_overlapping_pool vni 1100
@@ -821,11 +821,11 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 
 | VLAN | Route-Distinguisher | Both Route-Target | Import Route Target | Export Route-Target | Redistribute |
 | ---- | ------------------- | ----------------- | ------------------- | ------------------- | ------------ |
-| 110 | 172.16.110.4:10110 | 10110:10110 | - | - | learned |
+| 110 | 172.16.110.4:99110 | 99110:99110 | - | - | learned |
 | 111 | 172.16.110.4:50111 | 50111:50111 | - | - | learned |
-| 112 | 172.16.110.4:50112 | 50112:50112 | - | - | learned |
+| 112 | 172.16.110.4:20112 | 20112:20112 | - | - | learned |
 | 2500 | 172.16.110.4:2500 | 2500:2500 | - | - | learned |
-| 2600 | 172.16.110.4:2600 | 2600:2600 | - | - | learned |
+| 2600 | 172.16.110.4:32600 | 32600:32600 | - | - | learned |
 
 ### Router BGP VRFs
 
@@ -898,8 +898,8 @@ router bgp 65112.100
    redistribute connected route-map RM-CONN-2-BGP
    !
    vlan 110
-      rd 172.16.110.4:10110
-      route-target both 10110:10110
+      rd 172.16.110.4:99110
+      route-target both 99110:99110
       redistribute learned
    !
    vlan 111
@@ -908,8 +908,8 @@ router bgp 65112.100
       redistribute learned
    !
    vlan 112
-      rd 172.16.110.4:50112
-      route-target both 50112:50112
+      rd 172.16.110.4:20112
+      route-target both 20112:20112
       redistribute learned
    !
    vlan 2500
@@ -918,8 +918,8 @@ router bgp 65112.100
       redistribute learned
    !
    vlan 2600
-      rd 172.16.110.4:2600
-      route-target both 2600:2600
+      rd 172.16.110.4:32600
+      route-target both 32600:32600
       redistribute learned
    !
    address-family evpn

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
@@ -663,9 +663,9 @@ interface Vlan4094
 | ---- | --- | ---------- | --------------- |
 | 110 | 10110 | - | - |
 | 111 | 50111 | - | - |
-| 112 | 50112 | - | - |
+| 112 | 10112 | - | - |
 | 2500 | 2500 | - | - |
-| 2600 | 2600 | - | - |
+| 2600 | 12600 | - | - |
 
 #### VRF to VNI and Multicast Group Mappings
 
@@ -687,9 +687,9 @@ interface Vxlan1
    vxlan udp-port 4789
    vxlan vlan 110 vni 10110
    vxlan vlan 111 vni 50111
-   vxlan vlan 112 vni 50112
+   vxlan vlan 112 vni 10112
    vxlan vlan 2500 vni 2500
-   vxlan vlan 2600 vni 2600
+   vxlan vlan 2600 vni 12600
    vxlan vrf Common_VRF vni 1025
    vxlan vrf vrf_with_loopbacks_dc1_pod1_only vni 1102
    vxlan vrf vrf_with_loopbacks_from_overlapping_pool vni 1100
@@ -846,11 +846,11 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 
 | VLAN | Route-Distinguisher | Both Route-Target | Import Route Target | Export Route-Target | Redistribute |
 | ---- | ------------------- | ----------------- | ------------------- | ------------------- | ------------ |
-| 110 | 172.16.110.5:10110 | 10110:10110 | - | - | learned |
+| 110 | 172.16.110.5:99110 | 99110:99110 | - | - | learned |
 | 111 | 172.16.110.5:50111 | 50111:50111 | - | - | learned |
-| 112 | 172.16.110.5:50112 | 50112:50112 | - | - | learned |
+| 112 | 172.16.110.5:20112 | 20112:20112 | - | - | learned |
 | 2500 | 172.16.110.5:2500 | 2500:2500 | - | - | learned |
-| 2600 | 172.16.110.5:2600 | 2600:2600 | - | - | learned |
+| 2600 | 172.16.110.5:32600 | 32600:32600 | - | - | learned |
 
 ### Router BGP VRFs
 
@@ -925,8 +925,8 @@ router bgp 65112.100
    redistribute connected route-map RM-CONN-2-BGP
    !
    vlan 110
-      rd 172.16.110.5:10110
-      route-target both 10110:10110
+      rd 172.16.110.5:99110
+      route-target both 99110:99110
       redistribute learned
    !
    vlan 111
@@ -935,8 +935,8 @@ router bgp 65112.100
       redistribute learned
    !
    vlan 112
-      rd 172.16.110.5:50112
-      route-target both 50112:50112
+      rd 172.16.110.5:20112
+      route-target both 20112:20112
       redistribute learned
    !
    vlan 2500
@@ -945,8 +945,8 @@ router bgp 65112.100
       redistribute learned
    !
    vlan 2600
-      rd 172.16.110.5:2600
-      route-target both 2600:2600
+      rd 172.16.110.5:32600
+      route-target both 32600:32600
       redistribute learned
    !
    address-family evpn

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-LEAF1A.md
@@ -423,9 +423,9 @@ interface Vlan1102
 | ---- | --- | ---------- | --------------- |
 | 110 | 10110 | - | - |
 | 111 | 50111 | - | - |
-| 112 | 50112 | - | - |
+| 112 | 10112 | - | - |
 | 2500 | 2500 | - | - |
-| 2600 | 2600 | - | - |
+| 2600 | 12600 | - | - |
 
 #### VRF to VNI and Multicast Group Mappings
 
@@ -446,9 +446,9 @@ interface Vxlan1
    vxlan udp-port 4789
    vxlan vlan 110 vni 10110
    vxlan vlan 111 vni 50111
-   vxlan vlan 112 vni 50112
+   vxlan vlan 112 vni 10112
    vxlan vlan 2500 vni 2500
-   vxlan vlan 2600 vni 2600
+   vxlan vlan 2600 vni 12600
    vxlan vrf Common_VRF vni 1025
    vxlan vrf vrf_with_loopbacks_dc1_pod1_only vni 1102
    vxlan vrf vrf_with_loopbacks_from_overlapping_pool vni 1100
@@ -591,11 +591,11 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 
 | VLAN | Route-Distinguisher | Both Route-Target | Import Route Target | Export Route-Target | Redistribute |
 | ---- | ------------------- | ----------------- | ------------------- | ------------------- | ------------ |
-| 110 | 172.16.120.3:10110 | 10110:10110 | - | - | learned |
+| 110 | 172.16.120.3:99110 | 99110:99110 | - | - | learned |
 | 111 | 172.16.120.3:50111 | 50111:50111 | - | - | learned |
-| 112 | 172.16.120.3:50112 | 50112:50112 | - | - | learned |
+| 112 | 172.16.120.3:20112 | 20112:20112 | - | - | learned |
 | 2500 | 172.16.120.3:2500 | 2500:2500 | - | - | learned |
-| 2600 | 172.16.120.3:2600 | 2600:2600 | - | - | learned |
+| 2600 | 172.16.120.3:32600 | 32600:32600 | - | - | learned |
 
 ### Router BGP VRFs
 
@@ -649,8 +649,8 @@ router bgp 65121
    redistribute connected route-map RM-CONN-2-BGP
    !
    vlan 110
-      rd 172.16.120.3:10110
-      route-target both 10110:10110
+      rd 172.16.120.3:99110
+      route-target both 99110:99110
       redistribute learned
    !
    vlan 111
@@ -659,8 +659,8 @@ router bgp 65121
       redistribute learned
    !
    vlan 112
-      rd 172.16.120.3:50112
-      route-target both 50112:50112
+      rd 172.16.120.3:20112
+      route-target both 20112:20112
       redistribute learned
    !
    vlan 2500
@@ -669,8 +669,8 @@ router bgp 65121
       redistribute learned
    !
    vlan 2600
-      rd 172.16.120.3:2600
-      route-target both 2600:2600
+      rd 172.16.120.3:32600
+      route-target both 32600:32600
       redistribute learned
    !
    address-family evpn

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2A.cfg
@@ -323,9 +323,9 @@ interface Vxlan1
    vxlan udp-port 4789
    vxlan vlan 110 vni 10110
    vxlan vlan 111 vni 50111
-   vxlan vlan 112 vni 50112
+   vxlan vlan 112 vni 10112
    vxlan vlan 2500 vni 2500
-   vxlan vlan 2600 vni 2600
+   vxlan vlan 2600 vni 12600
    vxlan vrf Common_VRF vni 1025
    vxlan vrf vrf_with_loopbacks_dc1_pod1_only vni 1102
    vxlan vrf vrf_with_loopbacks_from_overlapping_pool vni 1100
@@ -449,8 +449,8 @@ router bgp 65112.100
    redistribute connected route-map RM-CONN-2-BGP
    !
    vlan 110
-      rd 172.16.110.4:10110
-      route-target both 10110:10110
+      rd 172.16.110.4:99110
+      route-target both 99110:99110
       redistribute learned
    !
    vlan 111
@@ -459,8 +459,8 @@ router bgp 65112.100
       redistribute learned
    !
    vlan 112
-      rd 172.16.110.4:50112
-      route-target both 50112:50112
+      rd 172.16.110.4:20112
+      route-target both 20112:20112
       redistribute learned
    !
    vlan 2500
@@ -469,8 +469,8 @@ router bgp 65112.100
       redistribute learned
    !
    vlan 2600
-      rd 172.16.110.4:2600
-      route-target both 2600:2600
+      rd 172.16.110.4:32600
+      route-target both 32600:32600
       redistribute learned
    !
    address-family evpn

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2B.cfg
@@ -329,9 +329,9 @@ interface Vxlan1
    vxlan udp-port 4789
    vxlan vlan 110 vni 10110
    vxlan vlan 111 vni 50111
-   vxlan vlan 112 vni 50112
+   vxlan vlan 112 vni 10112
    vxlan vlan 2500 vni 2500
-   vxlan vlan 2600 vni 2600
+   vxlan vlan 2600 vni 12600
    vxlan vrf Common_VRF vni 1025
    vxlan vrf vrf_with_loopbacks_dc1_pod1_only vni 1102
    vxlan vrf vrf_with_loopbacks_from_overlapping_pool vni 1100
@@ -455,8 +455,8 @@ router bgp 65112.100
    redistribute connected route-map RM-CONN-2-BGP
    !
    vlan 110
-      rd 172.16.110.5:10110
-      route-target both 10110:10110
+      rd 172.16.110.5:99110
+      route-target both 99110:99110
       redistribute learned
    !
    vlan 111
@@ -465,8 +465,8 @@ router bgp 65112.100
       redistribute learned
    !
    vlan 112
-      rd 172.16.110.5:50112
-      route-target both 50112:50112
+      rd 172.16.110.5:20112
+      route-target both 20112:20112
       redistribute learned
    !
    vlan 2500
@@ -475,8 +475,8 @@ router bgp 65112.100
       redistribute learned
    !
    vlan 2600
-      rd 172.16.110.5:2600
-      route-target both 2600:2600
+      rd 172.16.110.5:32600
+      route-target both 32600:32600
       redistribute learned
    !
    address-family evpn

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD2-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD2-LEAF1A.cfg
@@ -165,9 +165,9 @@ interface Vxlan1
    vxlan udp-port 4789
    vxlan vlan 110 vni 10110
    vxlan vlan 111 vni 50111
-   vxlan vlan 112 vni 50112
+   vxlan vlan 112 vni 10112
    vxlan vlan 2500 vni 2500
-   vxlan vlan 2600 vni 2600
+   vxlan vlan 2600 vni 12600
    vxlan vrf Common_VRF vni 1025
    vxlan vrf vrf_with_loopbacks_dc1_pod1_only vni 1102
    vxlan vrf vrf_with_loopbacks_from_overlapping_pool vni 1100
@@ -241,8 +241,8 @@ router bgp 65121
    redistribute connected route-map RM-CONN-2-BGP
    !
    vlan 110
-      rd 172.16.120.3:10110
-      route-target both 10110:10110
+      rd 172.16.120.3:99110
+      route-target both 99110:99110
       redistribute learned
    !
    vlan 111
@@ -251,8 +251,8 @@ router bgp 65121
       redistribute learned
    !
    vlan 112
-      rd 172.16.120.3:50112
-      route-target both 50112:50112
+      rd 172.16.120.3:20112
+      route-target both 20112:20112
       redistribute learned
    !
    vlan 2500
@@ -261,8 +261,8 @@ router bgp 65121
       redistribute learned
    !
    vlan 2600
-      rd 172.16.120.3:2600
-      route-target both 2600:2600
+      rd 172.16.120.3:32600
+      route-target both 32600:32600
       redistribute learned
    !
    address-family evpn

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2A.yml
@@ -149,10 +149,10 @@ router_bgp:
   vlans:
     110:
       tenant: Tenant_A
-      rd: 172.16.110.4:10110
+      rd: 172.16.110.4:99110
       route_targets:
         both:
-        - 10110:10110
+        - 99110:99110
       redistribute_routes:
       - learned
     111:
@@ -165,10 +165,10 @@ router_bgp:
       - learned
     112:
       tenant: Tenant_A
-      rd: 172.16.110.4:50112
+      rd: 172.16.110.4:20112
       route_targets:
         both:
-        - 50112:50112
+        - 20112:20112
       redistribute_routes:
       - learned
     2500:
@@ -181,10 +181,10 @@ router_bgp:
       - learned
     2600:
       tenant: Tenant_A
-      rd: 172.16.110.4:2600
+      rd: 172.16.110.4:32600
       route_targets:
         both:
-        - 2600:2600
+        - 32600:32600
       redistribute_routes:
       - learned
 static_routes:
@@ -723,11 +723,11 @@ vxlan_interface:
         111:
           vni: 50111
         112:
-          vni: 50112
+          vni: 10112
         2500:
           vni: 2500
         2600:
-          vni: 2600
+          vni: 12600
       vrfs:
         Common_VRF:
           vni: 1025

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
@@ -151,10 +151,10 @@ router_bgp:
   vlans:
     110:
       tenant: Tenant_A
-      rd: 172.16.110.5:10110
+      rd: 172.16.110.5:99110
       route_targets:
         both:
-        - 10110:10110
+        - 99110:99110
       redistribute_routes:
       - learned
     111:
@@ -167,10 +167,10 @@ router_bgp:
       - learned
     112:
       tenant: Tenant_A
-      rd: 172.16.110.5:50112
+      rd: 172.16.110.5:20112
       route_targets:
         both:
-        - 50112:50112
+        - 20112:20112
       redistribute_routes:
       - learned
     2500:
@@ -183,10 +183,10 @@ router_bgp:
       - learned
     2600:
       tenant: Tenant_A
-      rd: 172.16.110.5:2600
+      rd: 172.16.110.5:32600
       route_targets:
         both:
-        - 2600:2600
+        - 32600:32600
       redistribute_routes:
       - learned
 static_routes:
@@ -730,11 +730,11 @@ vxlan_interface:
         111:
           vni: 50111
         112:
-          vni: 50112
+          vni: 10112
         2500:
           vni: 2500
         2600:
-          vni: 2600
+          vni: 12600
       vrfs:
         Common_VRF:
           vni: 1025

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-LEAF1A.yml
@@ -123,10 +123,10 @@ router_bgp:
   vlans:
     110:
       tenant: Tenant_A
-      rd: 172.16.120.3:10110
+      rd: 172.16.120.3:99110
       route_targets:
         both:
-        - 10110:10110
+        - 99110:99110
       redistribute_routes:
       - learned
     111:
@@ -139,10 +139,10 @@ router_bgp:
       - learned
     112:
       tenant: Tenant_A
-      rd: 172.16.120.3:50112
+      rd: 172.16.120.3:20112
       route_targets:
         both:
-        - 50112:50112
+        - 20112:20112
       redistribute_routes:
       - learned
     2500:
@@ -155,10 +155,10 @@ router_bgp:
       - learned
     2600:
       tenant: Tenant_A
-      rd: 172.16.120.3:2600
+      rd: 172.16.120.3:32600
       route_targets:
         both:
-        - 2600:2600
+        - 32600:32600
       redistribute_routes:
       - learned
 static_routes:
@@ -414,11 +414,11 @@ vxlan_interface:
         111:
           vni: 50111
         112:
-          vni: 50112
+          vni: 10112
         2500:
           vni: 2500
         2600:
-          vni: 2600
+          vni: 12600
       vrfs:
         Common_VRF:
           vni: 1025

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/TENANTS_NETWORKS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/TENANTS_NETWORKS.yml
@@ -5,6 +5,7 @@ tenants:
   # Tenant A Specific Information - VRFs / VLANs
   Tenant_A:
     mac_vrf_vni_base: 10000
+    mac_vrf_id_base: 20000
     enable_mlag_ibgp_peering_vrfs: false
     vrfs:
       Common_VRF:
@@ -14,6 +15,7 @@ tenants:
             name: Tenant_A_OP_Zone_1
             tags: [opzone]
             enabled: true
+            rt_override: 99110 # RT would have been 20000 + 110.
             ip_address_virtual: 10.1.10.1/24
             structured_config:
               description: set from structured_config on svi (was Tenant_A_OP_Zone_1)
@@ -27,7 +29,6 @@ tenants:
             tags: [opzone]
             ip_address_virtual: 10.1.11.1/24
           "112":
-            vni_override: 50112
             name: Tenant_A_OP_Zone_3
             tags: [opzone]
             enabled: true
@@ -114,7 +115,7 @@ tenants:
         name: web-l2-vlan
         tags: [web]
       "2600":
-        vni_override: 2600
+        rt_override: 32600
         name: web-l2-vlan-2
         tags: [web]
       2601:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL1A.md
@@ -654,9 +654,9 @@ router ospf 14 vrf Tenant_A_WAN_Zone
 
 | VLAN Aware Bundle | Route-Distinguisher | Both Route-Target | Import Route Target | Export Route-Target | Redistribute | VLANs |
 | ----------------- | ------------------- | ----------------- | ------------------- | ------------------- | ------------ | ----- |
-| Tenant_A_WAN_Zone | 192.168.254.14:14 | 14:14 | - | - | learned | 150 |
-| Tenant_B_WAN_Zone | 192.168.254.14:21 | 21:21 | - | - | learned | 250 |
-| Tenant_C_WAN_Zone | 192.168.254.14:31 | 31:31 | - | - | learned | 350 |
+| Tenant_A_WAN_Zone | 192.168.254.14:14 | 65104:14 | - | - | learned | 150 |
+| Tenant_B_WAN_Zone | 192.168.254.14:21 | 65104:21 | - | - | learned | 250 |
+| Tenant_C_WAN_Zone | 192.168.254.14:31 | 65104:31 | - | - | learned | 350 |
 
 ### Router BGP VRFs
 
@@ -716,19 +716,19 @@ router bgp 65104
    !
    vlan-aware-bundle Tenant_A_WAN_Zone
       rd 192.168.254.14:14
-      route-target both 14:14
+      route-target both 65104:14
       redistribute learned
       vlan 150
    !
    vlan-aware-bundle Tenant_B_WAN_Zone
       rd 192.168.254.14:21
-      route-target both 21:21
+      route-target both 65104:21
       redistribute learned
       vlan 250
    !
    vlan-aware-bundle Tenant_C_WAN_Zone
       rd 192.168.254.14:31
-      route-target both 31:31
+      route-target both 65104:31
       redistribute learned
       vlan 350
    !
@@ -741,10 +741,10 @@ router bgp 65104
    !
    vrf Tenant_A_WAN_Zone
       rd 192.168.254.14:14
-      route-target import evpn 14:14
+      route-target import evpn 65104:14
       route-target import evpn 65000:456
       route-target import vpn-ipv4 65000:123
-      route-target export evpn 14:14
+      route-target export evpn 65104:14
       route-target export evpn 65000:789
       route-target export vpn-ipv4 65000:123
       router-id 192.168.255.14
@@ -789,29 +789,29 @@ router bgp 65104
    !
    vrf Tenant_B_OP_Zone
       rd 192.168.254.14:20
-      route-target import evpn 20:20
-      route-target export evpn 20:20
+      route-target import evpn 65104:20
+      route-target export evpn 65104:20
       router-id 192.168.255.14
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
       rd 192.168.254.14:21
-      route-target import evpn 21:21
-      route-target export evpn 21:21
+      route-target import evpn 65104:21
+      route-target export evpn 65104:21
       router-id 192.168.255.14
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
       rd 192.168.254.14:31
-      route-target import evpn 31:31
-      route-target export evpn 31:31
+      route-target import evpn 65104:31
+      route-target export evpn 65104:31
       router-id 192.168.255.14
       redistribute connected
    !
    vrf Tenant_L3_VRF_Zone
       rd 192.168.254.14:15
-      route-target import evpn 15:15
-      route-target export evpn 15:15
+      route-target import evpn 65104:15
+      route-target export evpn 65104:15
       router-id 192.168.255.14
       redistribute connected
 ```

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL1B.md
@@ -644,9 +644,9 @@ router ospf 14 vrf Tenant_A_WAN_Zone
 
 | VLAN Aware Bundle | Route-Distinguisher | Both Route-Target | Import Route Target | Export Route-Target | Redistribute | VLANs |
 | ----------------- | ------------------- | ----------------- | ------------------- | ------------------- | ------------ | ----- |
-| Tenant_A_WAN_Zone | 192.168.254.15:14 | 14:14 | - | - | learned | 150 |
-| Tenant_B_WAN_Zone | 192.168.254.15:21 | 21:21 | - | - | learned | 250 |
-| Tenant_C_WAN_Zone | 192.168.254.15:31 | 31:31 | - | - | learned | 350 |
+| Tenant_A_WAN_Zone | 192.168.254.15:14 | 65105:14 | - | - | learned | 150 |
+| Tenant_B_WAN_Zone | 192.168.254.15:21 | 65105:21 | - | - | learned | 250 |
+| Tenant_C_WAN_Zone | 192.168.254.15:31 | 65105:31 | - | - | learned | 350 |
 
 ### Router BGP VRFs
 
@@ -706,19 +706,19 @@ router bgp 65105
    !
    vlan-aware-bundle Tenant_A_WAN_Zone
       rd 192.168.254.15:14
-      route-target both 14:14
+      route-target both 65105:14
       redistribute learned
       vlan 150
    !
    vlan-aware-bundle Tenant_B_WAN_Zone
       rd 192.168.254.15:21
-      route-target both 21:21
+      route-target both 65105:21
       redistribute learned
       vlan 250
    !
    vlan-aware-bundle Tenant_C_WAN_Zone
       rd 192.168.254.15:31
-      route-target both 31:31
+      route-target both 65105:31
       redistribute learned
       vlan 350
    !
@@ -731,10 +731,10 @@ router bgp 65105
    !
    vrf Tenant_A_WAN_Zone
       rd 192.168.254.15:14
-      route-target import evpn 14:14
+      route-target import evpn 65105:14
       route-target import evpn 65000:456
       route-target import vpn-ipv4 65000:123
-      route-target export evpn 14:14
+      route-target export evpn 65105:14
       route-target export evpn 65000:789
       route-target export vpn-ipv4 65000:123
       router-id 192.168.255.15
@@ -779,29 +779,29 @@ router bgp 65105
    !
    vrf Tenant_B_OP_Zone
       rd 192.168.254.15:20
-      route-target import evpn 20:20
-      route-target export evpn 20:20
+      route-target import evpn 65105:20
+      route-target export evpn 65105:20
       router-id 192.168.255.15
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
       rd 192.168.254.15:21
-      route-target import evpn 21:21
-      route-target export evpn 21:21
+      route-target import evpn 65105:21
+      route-target export evpn 65105:21
       router-id 192.168.255.15
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
       rd 192.168.254.15:31
-      route-target import evpn 31:31
-      route-target export evpn 31:31
+      route-target import evpn 65105:31
+      route-target export evpn 65105:31
       router-id 192.168.255.15
       redistribute connected
    !
    vrf Tenant_L3_VRF_Zone
       rd 192.168.254.15:15
-      route-target import evpn 15:15
-      route-target export evpn 15:15
+      route-target import evpn 65105:15
+      route-target export evpn 65105:15
       router-id 192.168.255.15
       redistribute connected
 ```

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF1A.md
@@ -620,8 +620,8 @@ ip route vrf Tenant_A_APP_Zone 10.3.32.0/24 Vlan132 name VARP
 
 | VLAN Aware Bundle | Route-Distinguisher | Both Route-Target | Import Route Target | Export Route-Target | Redistribute | VLANs |
 | ----------------- | ------------------- | ----------------- | ------------------- | ------------------- | ------------ | ----- |
-| Tenant_A_APP_Zone | 1.1.1.1:12 | 12:12 | - | - | learned | 130-132 |
-| Tenant_A_WEB_Zone | 1.1.1.1:11 | 11:11 | - | - | learned | 120-121 |
+| Tenant_A_APP_Zone | 1.1.1.1:12 | 1234:12 | - | - | learned | 130-132 |
+| Tenant_A_WEB_Zone | 1.1.1.1:11 | 1234:11 | - | - | learned | 120-121 |
 
 ### Router BGP VRFs
 
@@ -678,13 +678,13 @@ router bgp 65101
    !
    vlan-aware-bundle Tenant_A_APP_Zone
       rd 1.1.1.1:12
-      route-target both 12:12
+      route-target both 1234:12
       redistribute learned
       vlan 130-132
    !
    vlan-aware-bundle Tenant_A_WEB_Zone
       rd 1.1.1.1:11
-      route-target both 11:11
+      route-target both 1234:11
       redistribute learned
       vlan 120-121
    !
@@ -697,15 +697,15 @@ router bgp 65101
    !
    vrf Tenant_A_APP_Zone
       rd 1.1.1.1:12
-      route-target import evpn 12:12
-      route-target export evpn 12:12
+      route-target import evpn 1234:12
+      route-target export evpn 1234:12
       router-id 192.168.255.9
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
       rd 1.1.1.1:11
-      route-target import evpn 11:11
-      route-target export evpn 11:11
+      route-target import evpn 1234:11
+      route-target export evpn 1234:11
       router-id 192.168.255.9
       redistribute connected
 ```

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2A.md
@@ -879,7 +879,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | Tenant_A_APP_Zone | 65001:12 | 100000:12 | - | - | learned | 130-131 |
 | Tenant_A_DB_Zone | 65001:13 | 100000:13 | - | - | learned | 140-141 |
 | Tenant_A_NFS | 65001:10161 | 100000:10161 | - | - | learned | 161 |
-| Tenant_A_OP_Zone | 65001:10 | 100000:10 | - | - | learned | 110-111 |
+| Tenant_A_OP_Zone | 65001:9 | 100000:9 | - | - | learned | 110-111 |
 | Tenant_A_VMOTION | 65001:10160 | 100000:10160 | - | - | learned | 160 |
 | Tenant_A_WEB_Zone | 65001:11 | 100000:11 | - | - | learned | 120-121 |
 | Tenant_B_OP_Zone | 65001:20 | 100000:20 | - | - | learned | 210-211 |
@@ -891,7 +891,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | --- | ------------------- | ------------ |
 | Tenant_A_APP_Zone | 65001:12 | connected |
 | Tenant_A_DB_Zone | 65001:13 | connected |
-| Tenant_A_OP_Zone | 65001:10 | connected |
+| Tenant_A_OP_Zone | 65001:9 | connected |
 | Tenant_A_WEB_Zone | 65001:11 | connected |
 | Tenant_B_OP_Zone | 65001:20 | connected |
 | Tenant_C_OP_Zone | 65001:30 | connected |
@@ -961,8 +961,8 @@ router bgp 65102
       vlan 161
    !
    vlan-aware-bundle Tenant_A_OP_Zone
-      rd 65001:10
-      route-target both 100000:10
+      rd 65001:9
+      route-target both 100000:9
       redistribute learned
       vlan 110-111
    !
@@ -1012,9 +1012,9 @@ router bgp 65102
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
-      rd 65001:10
-      route-target import evpn 100000:10
-      route-target export evpn 100000:10
+      rd 65001:9
+      route-target import evpn 100000:9
+      route-target export evpn 100000:9
       router-id 192.168.255.10
       redistribute connected
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2A.md
@@ -876,14 +876,14 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | VLAN Aware Bundle | Route-Distinguisher | Both Route-Target | Import Route Target | Export Route-Target | Redistribute | VLANs |
 | ----------------- | ------------------- | ----------------- | ------------------- | ------------------- | ------------ | ----- |
-| Tenant_A_APP_Zone | 65001:12 | 12:12 | - | - | learned | 130-131 |
-| Tenant_A_DB_Zone | 65001:13 | 13:13 | - | - | learned | 140-141 |
-| Tenant_A_NFS | 65001:10161 | 10161:10161 | - | - | learned | 161 |
-| Tenant_A_OP_Zone | 65001:10 | 10:10 | - | - | learned | 110-111 |
-| Tenant_A_VMOTION | 65001:10160 | 10160:10160 | - | - | learned | 160 |
-| Tenant_A_WEB_Zone | 65001:11 | 11:11 | - | - | learned | 120-121 |
-| Tenant_B_OP_Zone | 65001:20 | 20:20 | - | - | learned | 210-211 |
-| Tenant_C_OP_Zone | 65001:30 | 30:30 | - | - | learned | 310-311 |
+| Tenant_A_APP_Zone | 65001:12 | 100000:12 | - | - | learned | 130-131 |
+| Tenant_A_DB_Zone | 65001:13 | 100000:13 | - | - | learned | 140-141 |
+| Tenant_A_NFS | 65001:10161 | 100000:10161 | - | - | learned | 161 |
+| Tenant_A_OP_Zone | 65001:10 | 100000:10 | - | - | learned | 110-111 |
+| Tenant_A_VMOTION | 65001:10160 | 100000:10160 | - | - | learned | 160 |
+| Tenant_A_WEB_Zone | 65001:11 | 100000:11 | - | - | learned | 120-121 |
+| Tenant_B_OP_Zone | 65001:20 | 100000:20 | - | - | learned | 210-211 |
+| Tenant_C_OP_Zone | 65001:30 | 100000:30 | - | - | learned | 310-311 |
 
 ### Router BGP VRFs
 
@@ -944,49 +944,49 @@ router bgp 65102
    !
    vlan-aware-bundle Tenant_A_APP_Zone
       rd 65001:12
-      route-target both 12:12
+      route-target both 100000:12
       redistribute learned
       vlan 130-131
    !
    vlan-aware-bundle Tenant_A_DB_Zone
       rd 65001:13
-      route-target both 13:13
+      route-target both 100000:13
       redistribute learned
       vlan 140-141
    !
    vlan-aware-bundle Tenant_A_NFS
       rd 65001:10161
-      route-target both 10161:10161
+      route-target both 100000:10161
       redistribute learned
       vlan 161
    !
    vlan-aware-bundle Tenant_A_OP_Zone
       rd 65001:10
-      route-target both 10:10
+      route-target both 100000:10
       redistribute learned
       vlan 110-111
    !
    vlan-aware-bundle Tenant_A_VMOTION
       rd 65001:10160
-      route-target both 10160:10160
+      route-target both 100000:10160
       redistribute learned
       vlan 160
    !
    vlan-aware-bundle Tenant_A_WEB_Zone
       rd 65001:11
-      route-target both 11:11
+      route-target both 100000:11
       redistribute learned
       vlan 120-121
    !
    vlan-aware-bundle Tenant_B_OP_Zone
       rd 65001:20
-      route-target both 20:20
+      route-target both 100000:20
       redistribute learned
       vlan 210-211
    !
    vlan-aware-bundle Tenant_C_OP_Zone
       rd 65001:30
-      route-target both 30:30
+      route-target both 100000:30
       redistribute learned
       vlan 310-311
    !
@@ -999,43 +999,43 @@ router bgp 65102
    !
    vrf Tenant_A_APP_Zone
       rd 65001:12
-      route-target import evpn 12:12
-      route-target export evpn 12:12
+      route-target import evpn 100000:12
+      route-target export evpn 100000:12
       router-id 192.168.255.10
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
       rd 65001:13
-      route-target import evpn 13:13
-      route-target export evpn 13:13
+      route-target import evpn 100000:13
+      route-target export evpn 100000:13
       router-id 192.168.255.10
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
       rd 65001:10
-      route-target import evpn 10:10
-      route-target export evpn 10:10
+      route-target import evpn 100000:10
+      route-target export evpn 100000:10
       router-id 192.168.255.10
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
       rd 65001:11
-      route-target import evpn 11:11
-      route-target export evpn 11:11
+      route-target import evpn 100000:11
+      route-target export evpn 100000:11
       router-id 192.168.255.10
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
       rd 65001:20
-      route-target import evpn 20:20
-      route-target export evpn 20:20
+      route-target import evpn 100000:20
+      route-target export evpn 100000:20
       router-id 192.168.255.10
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
       rd 65001:30
-      route-target import evpn 30:30
-      route-target export evpn 30:30
+      route-target import evpn 100000:30
+      route-target export evpn 100000:30
       router-id 192.168.255.10
       redistribute connected
 ```

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2A.md
@@ -878,9 +878,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | ----------------- | ------------------- | ----------------- | ------------------- | ------------------- | ------------ | ----- |
 | Tenant_A_APP_Zone | 65001:12 | 100000:12 | - | - | learned | 130-131 |
 | Tenant_A_DB_Zone | 65001:13 | 100000:13 | - | - | learned | 140-141 |
-| Tenant_A_NFS | 65001:10161 | 100000:10161 | - | - | learned | 161 |
+| Tenant_A_NFS | 65001:20161 | 100000:20161 | - | - | learned | 161 |
 | Tenant_A_OP_Zone | 65001:9 | 100000:9 | - | - | learned | 110-111 |
-| Tenant_A_VMOTION | 65001:10160 | 100000:10160 | - | - | learned | 160 |
+| Tenant_A_VMOTION | 65001:20160 | 100000:20160 | - | - | learned | 160 |
 | Tenant_A_WEB_Zone | 65001:11 | 100000:11 | - | - | learned | 120-121 |
 | Tenant_B_OP_Zone | 65001:20 | 100000:20 | - | - | learned | 210-211 |
 | Tenant_C_OP_Zone | 65001:30 | 100000:30 | - | - | learned | 310-311 |
@@ -955,8 +955,8 @@ router bgp 65102
       vlan 140-141
    !
    vlan-aware-bundle Tenant_A_NFS
-      rd 65001:10161
-      route-target both 100000:10161
+      rd 65001:20161
+      route-target both 100000:20161
       redistribute learned
       vlan 161
    !
@@ -967,8 +967,8 @@ router bgp 65102
       vlan 110-111
    !
    vlan-aware-bundle Tenant_A_VMOTION
-      rd 65001:10160
-      route-target both 100000:10160
+      rd 65001:20160
+      route-target both 100000:20160
       redistribute learned
       vlan 160
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2B.md
@@ -879,7 +879,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | Tenant_A_APP_Zone | 65001:12 | 100000:12 | - | - | learned | 130-131 |
 | Tenant_A_DB_Zone | 65001:13 | 100000:13 | - | - | learned | 140-141 |
 | Tenant_A_NFS | 65001:10161 | 100000:10161 | - | - | learned | 161 |
-| Tenant_A_OP_Zone | 65001:10 | 100000:10 | - | - | learned | 110-111 |
+| Tenant_A_OP_Zone | 65001:9 | 100000:9 | - | - | learned | 110-111 |
 | Tenant_A_VMOTION | 65001:10160 | 100000:10160 | - | - | learned | 160 |
 | Tenant_A_WEB_Zone | 65001:11 | 100000:11 | - | - | learned | 120-121 |
 | Tenant_B_OP_Zone | 65001:20 | 100000:20 | - | - | learned | 210-211 |
@@ -891,7 +891,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | --- | ------------------- | ------------ |
 | Tenant_A_APP_Zone | 65001:12 | connected |
 | Tenant_A_DB_Zone | 65001:13 | connected |
-| Tenant_A_OP_Zone | 65001:10 | connected |
+| Tenant_A_OP_Zone | 65001:9 | connected |
 | Tenant_A_WEB_Zone | 65001:11 | connected |
 | Tenant_B_OP_Zone | 65001:20 | connected |
 | Tenant_C_OP_Zone | 65001:30 | connected |
@@ -961,8 +961,8 @@ router bgp 65102
       vlan 161
    !
    vlan-aware-bundle Tenant_A_OP_Zone
-      rd 65001:10
-      route-target both 100000:10
+      rd 65001:9
+      route-target both 100000:9
       redistribute learned
       vlan 110-111
    !
@@ -1012,9 +1012,9 @@ router bgp 65102
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
-      rd 65001:10
-      route-target import evpn 100000:10
-      route-target export evpn 100000:10
+      rd 65001:9
+      route-target import evpn 100000:9
+      route-target export evpn 100000:9
       router-id 192.168.255.11
       redistribute connected
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2B.md
@@ -876,14 +876,14 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | VLAN Aware Bundle | Route-Distinguisher | Both Route-Target | Import Route Target | Export Route-Target | Redistribute | VLANs |
 | ----------------- | ------------------- | ----------------- | ------------------- | ------------------- | ------------ | ----- |
-| Tenant_A_APP_Zone | 65001:12 | 12:12 | - | - | learned | 130-131 |
-| Tenant_A_DB_Zone | 65001:13 | 13:13 | - | - | learned | 140-141 |
-| Tenant_A_NFS | 65001:10161 | 10161:10161 | - | - | learned | 161 |
-| Tenant_A_OP_Zone | 65001:10 | 10:10 | - | - | learned | 110-111 |
-| Tenant_A_VMOTION | 65001:10160 | 10160:10160 | - | - | learned | 160 |
-| Tenant_A_WEB_Zone | 65001:11 | 11:11 | - | - | learned | 120-121 |
-| Tenant_B_OP_Zone | 65001:20 | 20:20 | - | - | learned | 210-211 |
-| Tenant_C_OP_Zone | 65001:30 | 30:30 | - | - | learned | 310-311 |
+| Tenant_A_APP_Zone | 65001:12 | 100000:12 | - | - | learned | 130-131 |
+| Tenant_A_DB_Zone | 65001:13 | 100000:13 | - | - | learned | 140-141 |
+| Tenant_A_NFS | 65001:10161 | 100000:10161 | - | - | learned | 161 |
+| Tenant_A_OP_Zone | 65001:10 | 100000:10 | - | - | learned | 110-111 |
+| Tenant_A_VMOTION | 65001:10160 | 100000:10160 | - | - | learned | 160 |
+| Tenant_A_WEB_Zone | 65001:11 | 100000:11 | - | - | learned | 120-121 |
+| Tenant_B_OP_Zone | 65001:20 | 100000:20 | - | - | learned | 210-211 |
+| Tenant_C_OP_Zone | 65001:30 | 100000:30 | - | - | learned | 310-311 |
 
 ### Router BGP VRFs
 
@@ -944,49 +944,49 @@ router bgp 65102
    !
    vlan-aware-bundle Tenant_A_APP_Zone
       rd 65001:12
-      route-target both 12:12
+      route-target both 100000:12
       redistribute learned
       vlan 130-131
    !
    vlan-aware-bundle Tenant_A_DB_Zone
       rd 65001:13
-      route-target both 13:13
+      route-target both 100000:13
       redistribute learned
       vlan 140-141
    !
    vlan-aware-bundle Tenant_A_NFS
       rd 65001:10161
-      route-target both 10161:10161
+      route-target both 100000:10161
       redistribute learned
       vlan 161
    !
    vlan-aware-bundle Tenant_A_OP_Zone
       rd 65001:10
-      route-target both 10:10
+      route-target both 100000:10
       redistribute learned
       vlan 110-111
    !
    vlan-aware-bundle Tenant_A_VMOTION
       rd 65001:10160
-      route-target both 10160:10160
+      route-target both 100000:10160
       redistribute learned
       vlan 160
    !
    vlan-aware-bundle Tenant_A_WEB_Zone
       rd 65001:11
-      route-target both 11:11
+      route-target both 100000:11
       redistribute learned
       vlan 120-121
    !
    vlan-aware-bundle Tenant_B_OP_Zone
       rd 65001:20
-      route-target both 20:20
+      route-target both 100000:20
       redistribute learned
       vlan 210-211
    !
    vlan-aware-bundle Tenant_C_OP_Zone
       rd 65001:30
-      route-target both 30:30
+      route-target both 100000:30
       redistribute learned
       vlan 310-311
    !
@@ -999,43 +999,43 @@ router bgp 65102
    !
    vrf Tenant_A_APP_Zone
       rd 65001:12
-      route-target import evpn 12:12
-      route-target export evpn 12:12
+      route-target import evpn 100000:12
+      route-target export evpn 100000:12
       router-id 192.168.255.11
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
       rd 65001:13
-      route-target import evpn 13:13
-      route-target export evpn 13:13
+      route-target import evpn 100000:13
+      route-target export evpn 100000:13
       router-id 192.168.255.11
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
       rd 65001:10
-      route-target import evpn 10:10
-      route-target export evpn 10:10
+      route-target import evpn 100000:10
+      route-target export evpn 100000:10
       router-id 192.168.255.11
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
       rd 65001:11
-      route-target import evpn 11:11
-      route-target export evpn 11:11
+      route-target import evpn 100000:11
+      route-target export evpn 100000:11
       router-id 192.168.255.11
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
       rd 65001:20
-      route-target import evpn 20:20
-      route-target export evpn 20:20
+      route-target import evpn 100000:20
+      route-target export evpn 100000:20
       router-id 192.168.255.11
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
       rd 65001:30
-      route-target import evpn 30:30
-      route-target export evpn 30:30
+      route-target import evpn 100000:30
+      route-target export evpn 100000:30
       router-id 192.168.255.11
       redistribute connected
 ```

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2B.md
@@ -878,9 +878,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | ----------------- | ------------------- | ----------------- | ------------------- | ------------------- | ------------ | ----- |
 | Tenant_A_APP_Zone | 65001:12 | 100000:12 | - | - | learned | 130-131 |
 | Tenant_A_DB_Zone | 65001:13 | 100000:13 | - | - | learned | 140-141 |
-| Tenant_A_NFS | 65001:10161 | 100000:10161 | - | - | learned | 161 |
+| Tenant_A_NFS | 65001:20161 | 100000:20161 | - | - | learned | 161 |
 | Tenant_A_OP_Zone | 65001:9 | 100000:9 | - | - | learned | 110-111 |
-| Tenant_A_VMOTION | 65001:10160 | 100000:10160 | - | - | learned | 160 |
+| Tenant_A_VMOTION | 65001:20160 | 100000:20160 | - | - | learned | 160 |
 | Tenant_A_WEB_Zone | 65001:11 | 100000:11 | - | - | learned | 120-121 |
 | Tenant_B_OP_Zone | 65001:20 | 100000:20 | - | - | learned | 210-211 |
 | Tenant_C_OP_Zone | 65001:30 | 100000:30 | - | - | learned | 310-311 |
@@ -955,8 +955,8 @@ router bgp 65102
       vlan 140-141
    !
    vlan-aware-bundle Tenant_A_NFS
-      rd 65001:10161
-      route-target both 100000:10161
+      rd 65001:20161
+      route-target both 100000:20161
       redistribute learned
       vlan 161
    !
@@ -967,8 +967,8 @@ router bgp 65102
       vlan 110-111
    !
    vlan-aware-bundle Tenant_A_VMOTION
-      rd 65001:10160
-      route-target both 100000:10160
+      rd 65001:20160
+      route-target both 100000:20160
       redistribute learned
       vlan 160
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3A.md
@@ -292,7 +292,7 @@ vlan internal order ascending range 1006 1199
 | 310 | Tenant_C_OP_Zone_1 | - |
 | 311 | Tenant_C_OP_Zone_2 | - |
 | 350 | Tenant_C_WAN_Zone_1 | - |
-| 3009 | MLAG_iBGP_Tenant_A_OP_Zone | LEAF_PEER_L3 |
+| 3008 | MLAG_iBGP_Tenant_A_OP_Zone | LEAF_PEER_L3 |
 | 3010 | MLAG_iBGP_Tenant_A_WEB_Zone | LEAF_PEER_L3 |
 | 3011 | MLAG_iBGP_Tenant_A_APP_Zone | LEAF_PEER_L3 |
 | 3012 | MLAG_iBGP_Tenant_A_DB_Zone | LEAF_PEER_L3 |
@@ -362,7 +362,7 @@ vlan 311
 vlan 350
    name Tenant_C_WAN_Zone_1
 !
-vlan 3009
+vlan 3008
    name MLAG_iBGP_Tenant_A_OP_Zone
    trunk group LEAF_PEER_L3
 !
@@ -840,7 +840,7 @@ interface Loopback100
 | Vlan310 |  Tenant_C_OP_Zone_1  |  Tenant_C_OP_Zone  |  -  |  false  |
 | Vlan311 |  Tenant_C_OP_Zone_2  |  Tenant_C_OP_Zone  |  -  |  false  |
 | Vlan350 |  Tenant_C_WAN_Zone_1  |  Tenant_C_WAN_Zone  |  -  |  false  |
-| Vlan3009 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone  |  Tenant_A_OP_Zone  |  1500  |  false  |
+| Vlan3008 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone  |  Tenant_A_OP_Zone  |  1500  |  false  |
 | Vlan3010 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone  |  Tenant_A_WEB_Zone  |  1500  |  false  |
 | Vlan3011 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone  |  Tenant_A_APP_Zone  |  1500  |  false  |
 | Vlan3012 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone  |  Tenant_A_DB_Zone  |  1500  |  false  |
@@ -871,7 +871,7 @@ interface Loopback100
 | Vlan310 |  Tenant_C_OP_Zone  |  -  |  10.3.10.1/24  |  -  |  -  |  -  |  -  |
 | Vlan311 |  Tenant_C_OP_Zone  |  -  |  10.3.11.1/24  |  -  |  -  |  -  |  -  |
 | Vlan350 |  Tenant_C_WAN_Zone  |  -  |  10.3.50.1/24  |  -  |  -  |  -  |  -  |
-| Vlan3009 |  Tenant_A_OP_Zone  |  10.255.251.6/31  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3008 |  Tenant_A_OP_Zone  |  10.255.251.6/31  |  -  |  -  |  -  |  -  |  -  |
 | Vlan3010 |  Tenant_A_WEB_Zone  |  10.255.251.6/31  |  -  |  -  |  -  |  -  |  -  |
 | Vlan3011 |  Tenant_A_APP_Zone  |  10.255.251.6/31  |  -  |  -  |  -  |  -  |  -  |
 | Vlan3012 |  Tenant_A_DB_Zone  |  10.255.251.6/31  |  -  |  -  |  -  |  -  |  -  |
@@ -993,7 +993,7 @@ interface Vlan350
    vrf Tenant_C_WAN_Zone
    ip address virtual 10.3.50.1/24
 !
-interface Vlan3009
+interface Vlan3008
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone
    no shutdown
    mtu 1500
@@ -1319,7 +1319,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | Tenant_A_APP_Zone | 65103:12 | 12:12 | - | - | learned | 130-131 |
 | Tenant_A_DB_Zone | 65103:13 | 13:13 | - | - | learned | 140-141 |
 | Tenant_A_NFS | 65103:10161 | 10161:10161 | - | - | learned | 161 |
-| Tenant_A_OP_Zone | 65103:10 | 10:10 | - | - | learned | 110-111 |
+| Tenant_A_OP_Zone | 65103:9 | 9:9 | - | - | learned | 110-111 |
 | Tenant_A_VMOTION | 65103:10160 | 10160:10160 | - | - | learned | 160 |
 | Tenant_A_WAN_Zone | 65103:14 | 14:14 | - | - | learned | 150 |
 | Tenant_A_WEB_Zone | 65103:11 | 11:11 | - | - | learned | 120-121 |
@@ -1334,7 +1334,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | --- | ------------------- | ------------ |
 | Tenant_A_APP_Zone | 65103:12 | connected |
 | Tenant_A_DB_Zone | 65103:13 | connected |
-| Tenant_A_OP_Zone | 65103:10 | connected |
+| Tenant_A_OP_Zone | 65103:9 | connected |
 | Tenant_A_WAN_Zone | 65103:14 | connected |
 | Tenant_A_WEB_Zone | 65103:11 | connected |
 | Tenant_B_OP_Zone | 65103:20 | connected |
@@ -1416,8 +1416,8 @@ router bgp 65103
       vlan 161
    !
    vlan-aware-bundle Tenant_A_OP_Zone
-      rd 65103:10
-      route-target both 10:10
+      rd 65103:9
+      route-target both 9:9
       redistribute learned
       vlan 110-111
    !
@@ -1488,9 +1488,9 @@ router bgp 65103
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
-      rd 65103:10
-      route-target import evpn 10:10
-      route-target export evpn 10:10
+      rd 65103:9
+      route-target import evpn 9:9
+      route-target export evpn 9:9
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
       redistribute connected

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3A.md
@@ -1318,9 +1318,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | ----------------- | ------------------- | ----------------- | ------------------- | ------------------- | ------------ | ----- |
 | Tenant_A_APP_Zone | 65103:12 | 12:12 | - | - | learned | 130-131 |
 | Tenant_A_DB_Zone | 65103:13 | 13:13 | - | - | learned | 140-141 |
-| Tenant_A_NFS | 65103:10161 | 10161:10161 | - | - | learned | 161 |
+| Tenant_A_NFS | 65103:20161 | 20161:20161 | - | - | learned | 161 |
 | Tenant_A_OP_Zone | 65103:9 | 9:9 | - | - | learned | 110-111 |
-| Tenant_A_VMOTION | 65103:10160 | 10160:10160 | - | - | learned | 160 |
+| Tenant_A_VMOTION | 65103:20160 | 20160:20160 | - | - | learned | 160 |
 | Tenant_A_WAN_Zone | 65103:14 | 14:14 | - | - | learned | 150 |
 | Tenant_A_WEB_Zone | 65103:11 | 11:11 | - | - | learned | 120-121 |
 | Tenant_B_OP_Zone | 65103:20 | 20:20 | - | - | learned | 210-211 |
@@ -1410,8 +1410,8 @@ router bgp 65103
       vlan 140-141
    !
    vlan-aware-bundle Tenant_A_NFS
-      rd 65103:10161
-      route-target both 10161:10161
+      rd 65103:20161
+      route-target both 20161:20161
       redistribute learned
       vlan 161
    !
@@ -1422,8 +1422,8 @@ router bgp 65103
       vlan 110-111
    !
    vlan-aware-bundle Tenant_A_VMOTION
-      rd 65103:10160
-      route-target both 10160:10160
+      rd 65103:20160
+      route-target both 20160:20160
       redistribute learned
       vlan 160
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3B.md
@@ -1303,9 +1303,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | ----------------- | ------------------- | ----------------- | ------------------- | ------------------- | ------------ | ----- |
 | Tenant_A_APP_Zone | 65103:12 | 12:12 | - | - | learned | 130-131 |
 | Tenant_A_DB_Zone | 65103:13 | 13:13 | - | - | learned | 140-141 |
-| Tenant_A_NFS | 65103:10161 | 10161:10161 | - | - | learned | 161 |
+| Tenant_A_NFS | 65103:20161 | 20161:20161 | - | - | learned | 161 |
 | Tenant_A_OP_Zone | 65103:9 | 9:9 | - | - | learned | 110-111 |
-| Tenant_A_VMOTION | 65103:10160 | 10160:10160 | - | - | learned | 160 |
+| Tenant_A_VMOTION | 65103:20160 | 20160:20160 | - | - | learned | 160 |
 | Tenant_A_WAN_Zone | 65103:14 | 14:14 | - | - | learned | 150 |
 | Tenant_A_WEB_Zone | 65103:11 | 11:11 | - | - | learned | 120-121 |
 | Tenant_B_OP_Zone | 65103:20 | 20:20 | - | - | learned | 210-211 |
@@ -1395,8 +1395,8 @@ router bgp 65103
       vlan 140-141
    !
    vlan-aware-bundle Tenant_A_NFS
-      rd 65103:10161
-      route-target both 10161:10161
+      rd 65103:20161
+      route-target both 20161:20161
       redistribute learned
       vlan 161
    !
@@ -1407,8 +1407,8 @@ router bgp 65103
       vlan 110-111
    !
    vlan-aware-bundle Tenant_A_VMOTION
-      rd 65103:10160
-      route-target both 10160:10160
+      rd 65103:20160
+      route-target both 20160:20160
       redistribute learned
       vlan 160
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3B.md
@@ -292,7 +292,7 @@ vlan internal order ascending range 1006 1199
 | 310 | Tenant_C_OP_Zone_1 | - |
 | 311 | Tenant_C_OP_Zone_2 | - |
 | 350 | Tenant_C_WAN_Zone_1 | - |
-| 3009 | MLAG_iBGP_Tenant_A_OP_Zone | LEAF_PEER_L3 |
+| 3008 | MLAG_iBGP_Tenant_A_OP_Zone | LEAF_PEER_L3 |
 | 3010 | MLAG_iBGP_Tenant_A_WEB_Zone | LEAF_PEER_L3 |
 | 3011 | MLAG_iBGP_Tenant_A_APP_Zone | LEAF_PEER_L3 |
 | 3012 | MLAG_iBGP_Tenant_A_DB_Zone | LEAF_PEER_L3 |
@@ -362,7 +362,7 @@ vlan 311
 vlan 350
    name Tenant_C_WAN_Zone_1
 !
-vlan 3009
+vlan 3008
    name MLAG_iBGP_Tenant_A_OP_Zone
    trunk group LEAF_PEER_L3
 !
@@ -825,7 +825,7 @@ interface Loopback100
 | Vlan310 |  Tenant_C_OP_Zone_1  |  Tenant_C_OP_Zone  |  -  |  false  |
 | Vlan311 |  Tenant_C_OP_Zone_2  |  Tenant_C_OP_Zone  |  -  |  false  |
 | Vlan350 |  Tenant_C_WAN_Zone_1  |  Tenant_C_WAN_Zone  |  -  |  false  |
-| Vlan3009 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone  |  Tenant_A_OP_Zone  |  1500  |  false  |
+| Vlan3008 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone  |  Tenant_A_OP_Zone  |  1500  |  false  |
 | Vlan3010 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone  |  Tenant_A_WEB_Zone  |  1500  |  false  |
 | Vlan3011 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone  |  Tenant_A_APP_Zone  |  1500  |  false  |
 | Vlan3012 |  MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone  |  Tenant_A_DB_Zone  |  1500  |  false  |
@@ -856,7 +856,7 @@ interface Loopback100
 | Vlan310 |  Tenant_C_OP_Zone  |  -  |  10.3.10.1/24  |  -  |  -  |  -  |  -  |
 | Vlan311 |  Tenant_C_OP_Zone  |  -  |  10.3.11.1/24  |  -  |  -  |  -  |  -  |
 | Vlan350 |  Tenant_C_WAN_Zone  |  -  |  10.3.50.1/24  |  -  |  -  |  -  |  -  |
-| Vlan3009 |  Tenant_A_OP_Zone  |  10.255.251.7/31  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3008 |  Tenant_A_OP_Zone  |  10.255.251.7/31  |  -  |  -  |  -  |  -  |  -  |
 | Vlan3010 |  Tenant_A_WEB_Zone  |  10.255.251.7/31  |  -  |  -  |  -  |  -  |  -  |
 | Vlan3011 |  Tenant_A_APP_Zone  |  10.255.251.7/31  |  -  |  -  |  -  |  -  |  -  |
 | Vlan3012 |  Tenant_A_DB_Zone  |  10.255.251.7/31  |  -  |  -  |  -  |  -  |  -  |
@@ -978,7 +978,7 @@ interface Vlan350
    vrf Tenant_C_WAN_Zone
    ip address virtual 10.3.50.1/24
 !
-interface Vlan3009
+interface Vlan3008
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone
    no shutdown
    mtu 1500
@@ -1304,7 +1304,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | Tenant_A_APP_Zone | 65103:12 | 12:12 | - | - | learned | 130-131 |
 | Tenant_A_DB_Zone | 65103:13 | 13:13 | - | - | learned | 140-141 |
 | Tenant_A_NFS | 65103:10161 | 10161:10161 | - | - | learned | 161 |
-| Tenant_A_OP_Zone | 65103:10 | 10:10 | - | - | learned | 110-111 |
+| Tenant_A_OP_Zone | 65103:9 | 9:9 | - | - | learned | 110-111 |
 | Tenant_A_VMOTION | 65103:10160 | 10160:10160 | - | - | learned | 160 |
 | Tenant_A_WAN_Zone | 65103:14 | 14:14 | - | - | learned | 150 |
 | Tenant_A_WEB_Zone | 65103:11 | 11:11 | - | - | learned | 120-121 |
@@ -1319,7 +1319,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | --- | ------------------- | ------------ |
 | Tenant_A_APP_Zone | 65103:12 | connected |
 | Tenant_A_DB_Zone | 65103:13 | connected |
-| Tenant_A_OP_Zone | 65103:10 | connected |
+| Tenant_A_OP_Zone | 65103:9 | connected |
 | Tenant_A_WAN_Zone | 65103:14 | connected |
 | Tenant_A_WEB_Zone | 65103:11 | connected |
 | Tenant_B_OP_Zone | 65103:20 | connected |
@@ -1401,8 +1401,8 @@ router bgp 65103
       vlan 161
    !
    vlan-aware-bundle Tenant_A_OP_Zone
-      rd 65103:10
-      route-target both 10:10
+      rd 65103:9
+      route-target both 9:9
       redistribute learned
       vlan 110-111
    !
@@ -1473,9 +1473,9 @@ router bgp 65103
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
-      rd 65103:10
-      route-target import evpn 10:10
-      route-target export evpn 10:10
+      rd 65103:9
+      route-target import evpn 9:9
+      route-target export evpn 9:9
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
       redistribute connected

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/evpn_services_l2_only_false.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/evpn_services_l2_only_false.md
@@ -690,7 +690,7 @@ ip route vrf Tenant_A_APP_Zone 10.3.32.0/24 Vlan132 name VARP
 | Tenant_A_APP_Zone | 192.168.255.109:12 | 12:12 | - | - | learned | 130-132 |
 | Tenant_A_DB_Zone | 192.168.255.109:13 | 13:13 | - | - | learned | 140-141 |
 | Tenant_A_NFS | 192.168.255.109:10161 | 10161:10161 | - | - | learned | 161 |
-| Tenant_A_OP_Zone | 192.168.255.109:10 | 10:10 | - | - | learned | 110-111 |
+| Tenant_A_OP_Zone | 192.168.255.109:9 | 9:9 | - | - | learned | 110-111 |
 | Tenant_A_VMOTION | 192.168.255.109:10160 | 10160:10160 | - | - | learned | 160 |
 | Tenant_A_WAN_Zone | 192.168.255.109:14 | 14:14 | - | - | learned | 150 |
 | Tenant_A_WEB_Zone | 192.168.255.109:11 | 11:11 | - | - | learned | 120-121 |
@@ -705,7 +705,7 @@ ip route vrf Tenant_A_APP_Zone 10.3.32.0/24 Vlan132 name VARP
 | --- | ------------------- | ------------ |
 | Tenant_A_APP_Zone | 192.168.255.109:12 | connected |
 | Tenant_A_DB_Zone | 192.168.255.109:13 | connected |
-| Tenant_A_OP_Zone | 192.168.255.109:10 | connected |
+| Tenant_A_OP_Zone | 192.168.255.109:9 | connected |
 | Tenant_A_WAN_Zone | 192.168.255.109:14 | connected |
 | Tenant_A_WEB_Zone | 192.168.255.109:11 | connected |
 | Tenant_B_OP_Zone | 192.168.255.109:20 | connected |
@@ -752,8 +752,8 @@ router bgp 101
       vlan 161
    !
    vlan-aware-bundle Tenant_A_OP_Zone
-      rd 192.168.255.109:10
-      route-target both 10:10
+      rd 192.168.255.109:9
+      route-target both 9:9
       redistribute learned
       vlan 110-111
    !
@@ -821,9 +821,9 @@ router bgp 101
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
-      rd 192.168.255.109:10
-      route-target import evpn 10:10
-      route-target export evpn 10:10
+      rd 192.168.255.109:9
+      route-target import evpn 9:9
+      route-target export evpn 9:9
       router-id 192.168.255.109
       redistribute connected
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/evpn_services_l2_only_false.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/evpn_services_l2_only_false.md
@@ -689,9 +689,9 @@ ip route vrf Tenant_A_APP_Zone 10.3.32.0/24 Vlan132 name VARP
 | ----------------- | ------------------- | ----------------- | ------------------- | ------------------- | ------------ | ----- |
 | Tenant_A_APP_Zone | 192.168.255.109:12 | 12:12 | - | - | learned | 130-132 |
 | Tenant_A_DB_Zone | 192.168.255.109:13 | 13:13 | - | - | learned | 140-141 |
-| Tenant_A_NFS | 192.168.255.109:10161 | 10161:10161 | - | - | learned | 161 |
+| Tenant_A_NFS | 192.168.255.109:20161 | 20161:20161 | - | - | learned | 161 |
 | Tenant_A_OP_Zone | 192.168.255.109:9 | 9:9 | - | - | learned | 110-111 |
-| Tenant_A_VMOTION | 192.168.255.109:10160 | 10160:10160 | - | - | learned | 160 |
+| Tenant_A_VMOTION | 192.168.255.109:20160 | 20160:20160 | - | - | learned | 160 |
 | Tenant_A_WAN_Zone | 192.168.255.109:14 | 14:14 | - | - | learned | 150 |
 | Tenant_A_WEB_Zone | 192.168.255.109:11 | 11:11 | - | - | learned | 120-121 |
 | Tenant_B_OP_Zone | 192.168.255.109:20 | 20:20 | - | - | learned | 210-211 |
@@ -746,8 +746,8 @@ router bgp 101
       vlan 140-141
    !
    vlan-aware-bundle Tenant_A_NFS
-      rd 192.168.255.109:10161
-      route-target both 10161:10161
+      rd 192.168.255.109:20161
+      route-target both 20161:20161
       redistribute learned
       vlan 161
    !
@@ -758,8 +758,8 @@ router bgp 101
       vlan 110-111
    !
    vlan-aware-bundle Tenant_A_VMOTION
-      rd 192.168.255.109:10160
-      route-target both 10160:10160
+      rd 192.168.255.109:20160
+      route-target both 20160:20160
       redistribute learned
       vlan 160
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/evpn_services_l2_only_true.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/evpn_services_l2_only_true.md
@@ -456,7 +456,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | Tenant_A_APP_Zone | 192.168.255.109:12 | 12:12 | - | - | learned | 130-132 |
 | Tenant_A_DB_Zone | 192.168.255.109:13 | 13:13 | - | - | learned | 140-141 |
 | Tenant_A_NFS | 192.168.255.109:10161 | 10161:10161 | - | - | learned | 161 |
-| Tenant_A_OP_Zone | 192.168.255.109:10 | 10:10 | - | - | learned | 110-111 |
+| Tenant_A_OP_Zone | 192.168.255.109:9 | 9:9 | - | - | learned | 110-111 |
 | Tenant_A_VMOTION | 192.168.255.109:10160 | 10160:10160 | - | - | learned | 160 |
 | Tenant_A_WAN_Zone | 192.168.255.109:14 | 14:14 | - | - | learned | 150 |
 | Tenant_A_WEB_Zone | 192.168.255.109:11 | 11:11 | - | - | learned | 120-121 |
@@ -504,8 +504,8 @@ router bgp 101
       vlan 161
    !
    vlan-aware-bundle Tenant_A_OP_Zone
-      rd 192.168.255.109:10
-      route-target both 10:10
+      rd 192.168.255.109:9
+      route-target both 9:9
       redistribute learned
       vlan 110-111
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/evpn_services_l2_only_true.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/evpn_services_l2_only_true.md
@@ -455,9 +455,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | ----------------- | ------------------- | ----------------- | ------------------- | ------------------- | ------------ | ----- |
 | Tenant_A_APP_Zone | 192.168.255.109:12 | 12:12 | - | - | learned | 130-132 |
 | Tenant_A_DB_Zone | 192.168.255.109:13 | 13:13 | - | - | learned | 140-141 |
-| Tenant_A_NFS | 192.168.255.109:10161 | 10161:10161 | - | - | learned | 161 |
+| Tenant_A_NFS | 192.168.255.109:20161 | 20161:20161 | - | - | learned | 161 |
 | Tenant_A_OP_Zone | 192.168.255.109:9 | 9:9 | - | - | learned | 110-111 |
-| Tenant_A_VMOTION | 192.168.255.109:10160 | 10160:10160 | - | - | learned | 160 |
+| Tenant_A_VMOTION | 192.168.255.109:20160 | 20160:20160 | - | - | learned | 160 |
 | Tenant_A_WAN_Zone | 192.168.255.109:14 | 14:14 | - | - | learned | 150 |
 | Tenant_A_WEB_Zone | 192.168.255.109:11 | 11:11 | - | - | learned | 120-121 |
 | Tenant_B_OP_Zone | 192.168.255.109:20 | 20:20 | - | - | learned | 210-211 |
@@ -498,8 +498,8 @@ router bgp 101
       vlan 140-141
    !
    vlan-aware-bundle Tenant_A_NFS
-      rd 192.168.255.109:10161
-      route-target both 10161:10161
+      rd 192.168.255.109:20161
+      route-target both 20161:20161
       redistribute learned
       vlan 161
    !
@@ -510,8 +510,8 @@ router bgp 101
       vlan 110-111
    !
    vlan-aware-bundle Tenant_A_VMOTION
-      rd 192.168.255.109:10160
-      route-target both 10160:10160
+      rd 192.168.255.109:20160
+      route-target both 20160:20160
       redistribute learned
       vlan 160
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1A.cfg
@@ -253,19 +253,19 @@ router bgp 65104
    !
    vlan-aware-bundle Tenant_A_WAN_Zone
       rd 192.168.254.14:14
-      route-target both 14:14
+      route-target both 65104:14
       redistribute learned
       vlan 150
    !
    vlan-aware-bundle Tenant_B_WAN_Zone
       rd 192.168.254.14:21
-      route-target both 21:21
+      route-target both 65104:21
       redistribute learned
       vlan 250
    !
    vlan-aware-bundle Tenant_C_WAN_Zone
       rd 192.168.254.14:31
-      route-target both 31:31
+      route-target both 65104:31
       redistribute learned
       vlan 350
    !
@@ -278,10 +278,10 @@ router bgp 65104
    !
    vrf Tenant_A_WAN_Zone
       rd 192.168.254.14:14
-      route-target import evpn 14:14
+      route-target import evpn 65104:14
       route-target import evpn 65000:456
       route-target import vpn-ipv4 65000:123
-      route-target export evpn 14:14
+      route-target export evpn 65104:14
       route-target export evpn 65000:789
       route-target export vpn-ipv4 65000:123
       router-id 192.168.255.14
@@ -326,29 +326,29 @@ router bgp 65104
    !
    vrf Tenant_B_OP_Zone
       rd 192.168.254.14:20
-      route-target import evpn 20:20
-      route-target export evpn 20:20
+      route-target import evpn 65104:20
+      route-target export evpn 65104:20
       router-id 192.168.255.14
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
       rd 192.168.254.14:21
-      route-target import evpn 21:21
-      route-target export evpn 21:21
+      route-target import evpn 65104:21
+      route-target export evpn 65104:21
       router-id 192.168.255.14
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
       rd 192.168.254.14:31
-      route-target import evpn 31:31
-      route-target export evpn 31:31
+      route-target import evpn 65104:31
+      route-target export evpn 65104:31
       router-id 192.168.255.14
       redistribute connected
    !
    vrf Tenant_L3_VRF_Zone
       rd 192.168.254.14:15
-      route-target import evpn 15:15
-      route-target export evpn 15:15
+      route-target import evpn 65104:15
+      route-target export evpn 65104:15
       router-id 192.168.255.14
       redistribute connected
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1B.cfg
@@ -246,19 +246,19 @@ router bgp 65105
    !
    vlan-aware-bundle Tenant_A_WAN_Zone
       rd 192.168.254.15:14
-      route-target both 14:14
+      route-target both 65105:14
       redistribute learned
       vlan 150
    !
    vlan-aware-bundle Tenant_B_WAN_Zone
       rd 192.168.254.15:21
-      route-target both 21:21
+      route-target both 65105:21
       redistribute learned
       vlan 250
    !
    vlan-aware-bundle Tenant_C_WAN_Zone
       rd 192.168.254.15:31
-      route-target both 31:31
+      route-target both 65105:31
       redistribute learned
       vlan 350
    !
@@ -271,10 +271,10 @@ router bgp 65105
    !
    vrf Tenant_A_WAN_Zone
       rd 192.168.254.15:14
-      route-target import evpn 14:14
+      route-target import evpn 65105:14
       route-target import evpn 65000:456
       route-target import vpn-ipv4 65000:123
-      route-target export evpn 14:14
+      route-target export evpn 65105:14
       route-target export evpn 65000:789
       route-target export vpn-ipv4 65000:123
       router-id 192.168.255.15
@@ -319,29 +319,29 @@ router bgp 65105
    !
    vrf Tenant_B_OP_Zone
       rd 192.168.254.15:20
-      route-target import evpn 20:20
-      route-target export evpn 20:20
+      route-target import evpn 65105:20
+      route-target export evpn 65105:20
       router-id 192.168.255.15
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
       rd 192.168.254.15:21
-      route-target import evpn 21:21
-      route-target export evpn 21:21
+      route-target import evpn 65105:21
+      route-target export evpn 65105:21
       router-id 192.168.255.15
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
       rd 192.168.254.15:31
-      route-target import evpn 31:31
-      route-target export evpn 31:31
+      route-target import evpn 65105:31
+      route-target export evpn 65105:31
       router-id 192.168.255.15
       redistribute connected
    !
    vrf Tenant_L3_VRF_Zone
       rd 192.168.254.15:15
-      route-target import evpn 15:15
-      route-target export evpn 15:15
+      route-target import evpn 65105:15
+      route-target export evpn 65105:15
       router-id 192.168.255.15
       redistribute connected
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF1A.cfg
@@ -236,13 +236,13 @@ router bgp 65101
    !
    vlan-aware-bundle Tenant_A_APP_Zone
       rd 1.1.1.1:12
-      route-target both 12:12
+      route-target both 1234:12
       redistribute learned
       vlan 130-132
    !
    vlan-aware-bundle Tenant_A_WEB_Zone
       rd 1.1.1.1:11
-      route-target both 11:11
+      route-target both 1234:11
       redistribute learned
       vlan 120-121
    !
@@ -255,15 +255,15 @@ router bgp 65101
    !
    vrf Tenant_A_APP_Zone
       rd 1.1.1.1:12
-      route-target import evpn 12:12
-      route-target export evpn 12:12
+      route-target import evpn 1234:12
+      route-target export evpn 1234:12
       router-id 192.168.255.9
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
       rd 1.1.1.1:11
-      route-target import evpn 11:11
-      route-target export evpn 11:11
+      route-target import evpn 1234:11
+      route-target export evpn 1234:11
       router-id 192.168.255.9
       redistribute connected
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
@@ -438,8 +438,8 @@ router bgp 65102
       vlan 161
    !
    vlan-aware-bundle Tenant_A_OP_Zone
-      rd 65001:10
-      route-target both 100000:10
+      rd 65001:9
+      route-target both 100000:9
       redistribute learned
       vlan 110-111
    !
@@ -489,9 +489,9 @@ router bgp 65102
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
-      rd 65001:10
-      route-target import evpn 100000:10
-      route-target export evpn 100000:10
+      rd 65001:9
+      route-target import evpn 100000:9
+      route-target export evpn 100000:9
       router-id 192.168.255.10
       redistribute connected
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
@@ -432,8 +432,8 @@ router bgp 65102
       vlan 140-141
    !
    vlan-aware-bundle Tenant_A_NFS
-      rd 65001:10161
-      route-target both 100000:10161
+      rd 65001:20161
+      route-target both 100000:20161
       redistribute learned
       vlan 161
    !
@@ -444,8 +444,8 @@ router bgp 65102
       vlan 110-111
    !
    vlan-aware-bundle Tenant_A_VMOTION
-      rd 65001:10160
-      route-target both 100000:10160
+      rd 65001:20160
+      route-target both 100000:20160
       redistribute learned
       vlan 160
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
@@ -421,49 +421,49 @@ router bgp 65102
    !
    vlan-aware-bundle Tenant_A_APP_Zone
       rd 65001:12
-      route-target both 12:12
+      route-target both 100000:12
       redistribute learned
       vlan 130-131
    !
    vlan-aware-bundle Tenant_A_DB_Zone
       rd 65001:13
-      route-target both 13:13
+      route-target both 100000:13
       redistribute learned
       vlan 140-141
    !
    vlan-aware-bundle Tenant_A_NFS
       rd 65001:10161
-      route-target both 10161:10161
+      route-target both 100000:10161
       redistribute learned
       vlan 161
    !
    vlan-aware-bundle Tenant_A_OP_Zone
       rd 65001:10
-      route-target both 10:10
+      route-target both 100000:10
       redistribute learned
       vlan 110-111
    !
    vlan-aware-bundle Tenant_A_VMOTION
       rd 65001:10160
-      route-target both 10160:10160
+      route-target both 100000:10160
       redistribute learned
       vlan 160
    !
    vlan-aware-bundle Tenant_A_WEB_Zone
       rd 65001:11
-      route-target both 11:11
+      route-target both 100000:11
       redistribute learned
       vlan 120-121
    !
    vlan-aware-bundle Tenant_B_OP_Zone
       rd 65001:20
-      route-target both 20:20
+      route-target both 100000:20
       redistribute learned
       vlan 210-211
    !
    vlan-aware-bundle Tenant_C_OP_Zone
       rd 65001:30
-      route-target both 30:30
+      route-target both 100000:30
       redistribute learned
       vlan 310-311
    !
@@ -476,43 +476,43 @@ router bgp 65102
    !
    vrf Tenant_A_APP_Zone
       rd 65001:12
-      route-target import evpn 12:12
-      route-target export evpn 12:12
+      route-target import evpn 100000:12
+      route-target export evpn 100000:12
       router-id 192.168.255.10
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
       rd 65001:13
-      route-target import evpn 13:13
-      route-target export evpn 13:13
+      route-target import evpn 100000:13
+      route-target export evpn 100000:13
       router-id 192.168.255.10
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
       rd 65001:10
-      route-target import evpn 10:10
-      route-target export evpn 10:10
+      route-target import evpn 100000:10
+      route-target export evpn 100000:10
       router-id 192.168.255.10
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
       rd 65001:11
-      route-target import evpn 11:11
-      route-target export evpn 11:11
+      route-target import evpn 100000:11
+      route-target export evpn 100000:11
       router-id 192.168.255.10
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
       rd 65001:20
-      route-target import evpn 20:20
-      route-target export evpn 20:20
+      route-target import evpn 100000:20
+      route-target export evpn 100000:20
       router-id 192.168.255.10
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
       rd 65001:30
-      route-target import evpn 30:30
-      route-target export evpn 30:30
+      route-target import evpn 100000:30
+      route-target export evpn 100000:30
       router-id 192.168.255.10
       redistribute connected
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
@@ -432,8 +432,8 @@ router bgp 65102
       vlan 140-141
    !
    vlan-aware-bundle Tenant_A_NFS
-      rd 65001:10161
-      route-target both 100000:10161
+      rd 65001:20161
+      route-target both 100000:20161
       redistribute learned
       vlan 161
    !
@@ -444,8 +444,8 @@ router bgp 65102
       vlan 110-111
    !
    vlan-aware-bundle Tenant_A_VMOTION
-      rd 65001:10160
-      route-target both 100000:10160
+      rd 65001:20160
+      route-target both 100000:20160
       redistribute learned
       vlan 160
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
@@ -421,49 +421,49 @@ router bgp 65102
    !
    vlan-aware-bundle Tenant_A_APP_Zone
       rd 65001:12
-      route-target both 12:12
+      route-target both 100000:12
       redistribute learned
       vlan 130-131
    !
    vlan-aware-bundle Tenant_A_DB_Zone
       rd 65001:13
-      route-target both 13:13
+      route-target both 100000:13
       redistribute learned
       vlan 140-141
    !
    vlan-aware-bundle Tenant_A_NFS
       rd 65001:10161
-      route-target both 10161:10161
+      route-target both 100000:10161
       redistribute learned
       vlan 161
    !
    vlan-aware-bundle Tenant_A_OP_Zone
       rd 65001:10
-      route-target both 10:10
+      route-target both 100000:10
       redistribute learned
       vlan 110-111
    !
    vlan-aware-bundle Tenant_A_VMOTION
       rd 65001:10160
-      route-target both 10160:10160
+      route-target both 100000:10160
       redistribute learned
       vlan 160
    !
    vlan-aware-bundle Tenant_A_WEB_Zone
       rd 65001:11
-      route-target both 11:11
+      route-target both 100000:11
       redistribute learned
       vlan 120-121
    !
    vlan-aware-bundle Tenant_B_OP_Zone
       rd 65001:20
-      route-target both 20:20
+      route-target both 100000:20
       redistribute learned
       vlan 210-211
    !
    vlan-aware-bundle Tenant_C_OP_Zone
       rd 65001:30
-      route-target both 30:30
+      route-target both 100000:30
       redistribute learned
       vlan 310-311
    !
@@ -476,43 +476,43 @@ router bgp 65102
    !
    vrf Tenant_A_APP_Zone
       rd 65001:12
-      route-target import evpn 12:12
-      route-target export evpn 12:12
+      route-target import evpn 100000:12
+      route-target export evpn 100000:12
       router-id 192.168.255.11
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
       rd 65001:13
-      route-target import evpn 13:13
-      route-target export evpn 13:13
+      route-target import evpn 100000:13
+      route-target export evpn 100000:13
       router-id 192.168.255.11
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
       rd 65001:10
-      route-target import evpn 10:10
-      route-target export evpn 10:10
+      route-target import evpn 100000:10
+      route-target export evpn 100000:10
       router-id 192.168.255.11
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
       rd 65001:11
-      route-target import evpn 11:11
-      route-target export evpn 11:11
+      route-target import evpn 100000:11
+      route-target export evpn 100000:11
       router-id 192.168.255.11
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
       rd 65001:20
-      route-target import evpn 20:20
-      route-target export evpn 20:20
+      route-target import evpn 100000:20
+      route-target export evpn 100000:20
       router-id 192.168.255.11
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
       rd 65001:30
-      route-target import evpn 30:30
-      route-target export evpn 30:30
+      route-target import evpn 100000:30
+      route-target export evpn 100000:30
       router-id 192.168.255.11
       redistribute connected
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
@@ -438,8 +438,8 @@ router bgp 65102
       vlan 161
    !
    vlan-aware-bundle Tenant_A_OP_Zone
-      rd 65001:10
-      route-target both 100000:10
+      rd 65001:9
+      route-target both 100000:9
       redistribute learned
       vlan 110-111
    !
@@ -489,9 +489,9 @@ router bgp 65102
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
-      rd 65001:10
-      route-target import evpn 100000:10
-      route-target export evpn 100000:10
+      rd 65001:9
+      route-target import evpn 100000:9
+      route-target export evpn 100000:9
       router-id 192.168.255.11
       redistribute connected
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3A.cfg
@@ -784,8 +784,8 @@ router bgp 65103
       vlan 140-141
    !
    vlan-aware-bundle Tenant_A_NFS
-      rd 65103:10161
-      route-target both 10161:10161
+      rd 65103:20161
+      route-target both 20161:20161
       redistribute learned
       vlan 161
    !
@@ -796,8 +796,8 @@ router bgp 65103
       vlan 110-111
    !
    vlan-aware-bundle Tenant_A_VMOTION
-      rd 65103:10160
-      route-target both 10160:10160
+      rd 65103:20160
+      route-target both 20160:20160
       redistribute learned
       vlan 160
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3A.cfg
@@ -89,7 +89,7 @@ vlan 311
 vlan 350
    name Tenant_C_WAN_Zone_1
 !
-vlan 3009
+vlan 3008
    name MLAG_iBGP_Tenant_A_OP_Zone
    trunk group LEAF_PEER_L3
 !
@@ -579,7 +579,7 @@ interface Vlan350
    vrf Tenant_C_WAN_Zone
    ip address virtual 10.3.50.1/24
 !
-interface Vlan3009
+interface Vlan3008
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone
    no shutdown
    mtu 1500
@@ -790,8 +790,8 @@ router bgp 65103
       vlan 161
    !
    vlan-aware-bundle Tenant_A_OP_Zone
-      rd 65103:10
-      route-target both 10:10
+      rd 65103:9
+      route-target both 9:9
       redistribute learned
       vlan 110-111
    !
@@ -862,9 +862,9 @@ router bgp 65103
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
-      rd 65103:10
-      route-target import evpn 10:10
-      route-target export evpn 10:10
+      rd 65103:9
+      route-target import evpn 9:9
+      route-target export evpn 9:9
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
       redistribute connected

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3B.cfg
@@ -89,7 +89,7 @@ vlan 311
 vlan 350
    name Tenant_C_WAN_Zone_1
 !
-vlan 3009
+vlan 3008
    name MLAG_iBGP_Tenant_A_OP_Zone
    trunk group LEAF_PEER_L3
 !
@@ -566,7 +566,7 @@ interface Vlan350
    vrf Tenant_C_WAN_Zone
    ip address virtual 10.3.50.1/24
 !
-interface Vlan3009
+interface Vlan3008
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone
    no shutdown
    mtu 1500
@@ -777,8 +777,8 @@ router bgp 65103
       vlan 161
    !
    vlan-aware-bundle Tenant_A_OP_Zone
-      rd 65103:10
-      route-target both 10:10
+      rd 65103:9
+      route-target both 9:9
       redistribute learned
       vlan 110-111
    !
@@ -849,9 +849,9 @@ router bgp 65103
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
-      rd 65103:10
-      route-target import evpn 10:10
-      route-target export evpn 10:10
+      rd 65103:9
+      route-target import evpn 9:9
+      route-target export evpn 9:9
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
       redistribute connected

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3B.cfg
@@ -771,8 +771,8 @@ router bgp 65103
       vlan 140-141
    !
    vlan-aware-bundle Tenant_A_NFS
-      rd 65103:10161
-      route-target both 10161:10161
+      rd 65103:20161
+      route-target both 20161:20161
       redistribute learned
       vlan 161
    !
@@ -783,8 +783,8 @@ router bgp 65103
       vlan 110-111
    !
    vlan-aware-bundle Tenant_A_VMOTION
-      rd 65103:10160
-      route-target both 10160:10160
+      rd 65103:20160
+      route-target both 20160:20160
       redistribute learned
       vlan 160
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_false.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_false.cfg
@@ -323,8 +323,8 @@ router bgp 101
       vlan 161
    !
    vlan-aware-bundle Tenant_A_OP_Zone
-      rd 192.168.255.109:10
-      route-target both 10:10
+      rd 192.168.255.109:9
+      route-target both 9:9
       redistribute learned
       vlan 110-111
    !
@@ -392,9 +392,9 @@ router bgp 101
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
-      rd 192.168.255.109:10
-      route-target import evpn 10:10
-      route-target export evpn 10:10
+      rd 192.168.255.109:9
+      route-target import evpn 9:9
+      route-target export evpn 9:9
       router-id 192.168.255.109
       redistribute connected
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_false.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_false.cfg
@@ -317,8 +317,8 @@ router bgp 101
       vlan 140-141
    !
    vlan-aware-bundle Tenant_A_NFS
-      rd 192.168.255.109:10161
-      route-target both 10161:10161
+      rd 192.168.255.109:20161
+      route-target both 20161:20161
       redistribute learned
       vlan 161
    !
@@ -329,8 +329,8 @@ router bgp 101
       vlan 110-111
    !
    vlan-aware-bundle Tenant_A_VMOTION
-      rd 192.168.255.109:10160
-      route-target both 10160:10160
+      rd 192.168.255.109:20160
+      route-target both 20160:20160
       redistribute learned
       vlan 160
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_true.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_true.cfg
@@ -164,8 +164,8 @@ router bgp 101
       vlan 140-141
    !
    vlan-aware-bundle Tenant_A_NFS
-      rd 192.168.255.109:10161
-      route-target both 10161:10161
+      rd 192.168.255.109:20161
+      route-target both 20161:20161
       redistribute learned
       vlan 161
    !
@@ -176,8 +176,8 @@ router bgp 101
       vlan 110-111
    !
    vlan-aware-bundle Tenant_A_VMOTION
-      rd 192.168.255.109:10160
-      route-target both 10160:10160
+      rd 192.168.255.109:20160
+      route-target both 20160:20160
       redistribute learned
       vlan 160
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_true.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_true.cfg
@@ -170,8 +170,8 @@ router bgp 101
       vlan 161
    !
    vlan-aware-bundle Tenant_A_OP_Zone
-      rd 192.168.255.109:10
-      route-target both 10:10
+      rd 192.168.255.109:9
+      route-target both 9:9
       redistribute learned
       vlan 110-111
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
@@ -72,13 +72,13 @@ router_bgp:
       route_targets:
         import:
           evpn:
-          - '14:14'
+          - '65104:14'
           - 65000:456
           vpn-ipv4:
           - 65000:123
         export:
           evpn:
-          - '14:14'
+          - '65104:14'
           - 65000:789
           vpn-ipv4:
           - 65000:123
@@ -140,10 +140,10 @@ router_bgp:
       route_targets:
         import:
           evpn:
-          - '15:15'
+          - '65104:15'
         export:
           evpn:
-          - '15:15'
+          - '65104:15'
       redistribute_routes:
       - connected
     Tenant_B_OP_Zone:
@@ -152,10 +152,10 @@ router_bgp:
       route_targets:
         import:
           evpn:
-          - '20:20'
+          - '65104:20'
         export:
           evpn:
-          - '20:20'
+          - '65104:20'
       redistribute_routes:
       - connected
     Tenant_B_WAN_Zone:
@@ -164,10 +164,10 @@ router_bgp:
       route_targets:
         import:
           evpn:
-          - '21:21'
+          - '65104:21'
         export:
           evpn:
-          - '21:21'
+          - '65104:21'
       redistribute_routes:
       - connected
     Tenant_C_WAN_Zone:
@@ -176,10 +176,10 @@ router_bgp:
       route_targets:
         import:
           evpn:
-          - '31:31'
+          - '65104:31'
         export:
           evpn:
-          - '31:31'
+          - '65104:31'
       redistribute_routes:
       - connected
   vlan_aware_bundles:
@@ -187,7 +187,7 @@ router_bgp:
       rd: 192.168.254.14:14
       route_targets:
         both:
-        - '14:14'
+        - '65104:14'
       redistribute_routes:
       - learned
       vlan: 150
@@ -195,7 +195,7 @@ router_bgp:
       rd: 192.168.254.14:21
       route_targets:
         both:
-        - '21:21'
+        - '65104:21'
       redistribute_routes:
       - learned
       vlan: 250
@@ -203,7 +203,7 @@ router_bgp:
       rd: 192.168.254.14:31
       route_targets:
         both:
-        - '31:31'
+        - '65104:31'
       redistribute_routes:
       - learned
       vlan: 350

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1B.yml
@@ -72,13 +72,13 @@ router_bgp:
       route_targets:
         import:
           evpn:
-          - '14:14'
+          - '65105:14'
           - 65000:456
           vpn-ipv4:
           - 65000:123
         export:
           evpn:
-          - '14:14'
+          - '65105:14'
           - 65000:789
           vpn-ipv4:
           - 65000:123
@@ -140,10 +140,10 @@ router_bgp:
       route_targets:
         import:
           evpn:
-          - '15:15'
+          - '65105:15'
         export:
           evpn:
-          - '15:15'
+          - '65105:15'
       redistribute_routes:
       - connected
     Tenant_B_OP_Zone:
@@ -152,10 +152,10 @@ router_bgp:
       route_targets:
         import:
           evpn:
-          - '20:20'
+          - '65105:20'
         export:
           evpn:
-          - '20:20'
+          - '65105:20'
       redistribute_routes:
       - connected
     Tenant_B_WAN_Zone:
@@ -164,10 +164,10 @@ router_bgp:
       route_targets:
         import:
           evpn:
-          - '21:21'
+          - '65105:21'
         export:
           evpn:
-          - '21:21'
+          - '65105:21'
       redistribute_routes:
       - connected
     Tenant_C_WAN_Zone:
@@ -176,10 +176,10 @@ router_bgp:
       route_targets:
         import:
           evpn:
-          - '31:31'
+          - '65105:31'
         export:
           evpn:
-          - '31:31'
+          - '65105:31'
       redistribute_routes:
       - connected
   vlan_aware_bundles:
@@ -187,7 +187,7 @@ router_bgp:
       rd: 192.168.254.15:14
       route_targets:
         both:
-        - '14:14'
+        - '65105:14'
       redistribute_routes:
       - learned
       vlan: 150
@@ -195,7 +195,7 @@ router_bgp:
       rd: 192.168.254.15:21
       route_targets:
         both:
-        - '21:21'
+        - '65105:21'
       redistribute_routes:
       - learned
       vlan: 250
@@ -203,7 +203,7 @@ router_bgp:
       rd: 192.168.254.15:31
       route_targets:
         both:
-        - '31:31'
+        - '65105:31'
       redistribute_routes:
       - learned
       vlan: 350

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF1A.yml
@@ -72,10 +72,10 @@ router_bgp:
       route_targets:
         import:
           evpn:
-          - '12:12'
+          - '1234:12'
         export:
           evpn:
-          - '12:12'
+          - '1234:12'
       redistribute_routes:
       - connected
     Tenant_A_WEB_Zone:
@@ -84,10 +84,10 @@ router_bgp:
       route_targets:
         import:
           evpn:
-          - '11:11'
+          - '1234:11'
         export:
           evpn:
-          - '11:11'
+          - '1234:11'
       redistribute_routes:
       - connected
   vlan_aware_bundles:
@@ -95,7 +95,7 @@ router_bgp:
       rd: 1.1.1.1:12
       route_targets:
         both:
-        - '12:12'
+        - '1234:12'
       redistribute_routes:
       - learned
       vlan: 130-132
@@ -103,7 +103,7 @@ router_bgp:
       rd: 1.1.1.1:11
       route_targets:
         both:
-        - '11:11'
+        - '1234:11'
       redistribute_routes:
       - learned
       vlan: 120-121

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
@@ -92,14 +92,14 @@ router_bgp:
       - connected
     Tenant_A_OP_Zone:
       router_id: 192.168.255.10
-      rd: '65001:10'
+      rd: '65001:9'
       route_targets:
         import:
           evpn:
-          - '100000:10'
+          - '100000:9'
         export:
           evpn:
-          - '100000:10'
+          - '100000:9'
       redistribute_routes:
       - connected
     Tenant_A_WEB_Zone:
@@ -156,10 +156,10 @@ router_bgp:
       - learned
       vlan: 140-141
     Tenant_A_OP_Zone:
-      rd: '65001:10'
+      rd: '65001:9'
       route_targets:
         both:
-        - '100000:10'
+        - '100000:9'
       redistribute_routes:
       - learned
       vlan: 110-111

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
@@ -72,10 +72,10 @@ router_bgp:
       route_targets:
         import:
           evpn:
-          - '12:12'
+          - '100000:12'
         export:
           evpn:
-          - '12:12'
+          - '100000:12'
       redistribute_routes:
       - connected
     Tenant_A_DB_Zone:
@@ -84,10 +84,10 @@ router_bgp:
       route_targets:
         import:
           evpn:
-          - '13:13'
+          - '100000:13'
         export:
           evpn:
-          - '13:13'
+          - '100000:13'
       redistribute_routes:
       - connected
     Tenant_A_OP_Zone:
@@ -96,10 +96,10 @@ router_bgp:
       route_targets:
         import:
           evpn:
-          - '10:10'
+          - '100000:10'
         export:
           evpn:
-          - '10:10'
+          - '100000:10'
       redistribute_routes:
       - connected
     Tenant_A_WEB_Zone:
@@ -108,10 +108,10 @@ router_bgp:
       route_targets:
         import:
           evpn:
-          - '11:11'
+          - '100000:11'
         export:
           evpn:
-          - '11:11'
+          - '100000:11'
       redistribute_routes:
       - connected
     Tenant_B_OP_Zone:
@@ -120,10 +120,10 @@ router_bgp:
       route_targets:
         import:
           evpn:
-          - '20:20'
+          - '100000:20'
         export:
           evpn:
-          - '20:20'
+          - '100000:20'
       redistribute_routes:
       - connected
     Tenant_C_OP_Zone:
@@ -132,10 +132,10 @@ router_bgp:
       route_targets:
         import:
           evpn:
-          - '30:30'
+          - '100000:30'
         export:
           evpn:
-          - '30:30'
+          - '100000:30'
       redistribute_routes:
       - connected
   vlan_aware_bundles:
@@ -143,7 +143,7 @@ router_bgp:
       rd: '65001:12'
       route_targets:
         both:
-        - '12:12'
+        - '100000:12'
       redistribute_routes:
       - learned
       vlan: 130-131
@@ -151,7 +151,7 @@ router_bgp:
       rd: '65001:13'
       route_targets:
         both:
-        - '13:13'
+        - '100000:13'
       redistribute_routes:
       - learned
       vlan: 140-141
@@ -159,7 +159,7 @@ router_bgp:
       rd: '65001:10'
       route_targets:
         both:
-        - '10:10'
+        - '100000:10'
       redistribute_routes:
       - learned
       vlan: 110-111
@@ -167,7 +167,7 @@ router_bgp:
       rd: '65001:11'
       route_targets:
         both:
-        - '11:11'
+        - '100000:11'
       redistribute_routes:
       - learned
       vlan: 120-121
@@ -176,7 +176,7 @@ router_bgp:
       rd: 65001:10160
       route_targets:
         both:
-        - 10160:10160
+        - 100000:10160
       redistribute_routes:
       - learned
       vlan: 160
@@ -185,7 +185,7 @@ router_bgp:
       rd: 65001:10161
       route_targets:
         both:
-        - 10161:10161
+        - 100000:10161
       redistribute_routes:
       - learned
       vlan: 161
@@ -193,7 +193,7 @@ router_bgp:
       rd: '65001:20'
       route_targets:
         both:
-        - '20:20'
+        - '100000:20'
       redistribute_routes:
       - learned
       vlan: 210-211
@@ -201,7 +201,7 @@ router_bgp:
       rd: '65001:30'
       route_targets:
         both:
-        - '30:30'
+        - '100000:30'
       redistribute_routes:
       - learned
       vlan: 310-311

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
@@ -173,19 +173,19 @@ router_bgp:
       vlan: 120-121
     Tenant_A_VMOTION:
       tenant: Tenant_A
-      rd: 65001:10160
+      rd: 65001:20160
       route_targets:
         both:
-        - 100000:10160
+        - 100000:20160
       redistribute_routes:
       - learned
       vlan: 160
     Tenant_A_NFS:
       tenant: Tenant_A
-      rd: 65001:10161
+      rd: 65001:20161
       route_targets:
         both:
-        - 100000:10161
+        - 100000:20161
       redistribute_routes:
       - learned
       vlan: 161

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
@@ -72,10 +72,10 @@ router_bgp:
       route_targets:
         import:
           evpn:
-          - '12:12'
+          - '100000:12'
         export:
           evpn:
-          - '12:12'
+          - '100000:12'
       redistribute_routes:
       - connected
     Tenant_A_DB_Zone:
@@ -84,10 +84,10 @@ router_bgp:
       route_targets:
         import:
           evpn:
-          - '13:13'
+          - '100000:13'
         export:
           evpn:
-          - '13:13'
+          - '100000:13'
       redistribute_routes:
       - connected
     Tenant_A_OP_Zone:
@@ -96,10 +96,10 @@ router_bgp:
       route_targets:
         import:
           evpn:
-          - '10:10'
+          - '100000:10'
         export:
           evpn:
-          - '10:10'
+          - '100000:10'
       redistribute_routes:
       - connected
     Tenant_A_WEB_Zone:
@@ -108,10 +108,10 @@ router_bgp:
       route_targets:
         import:
           evpn:
-          - '11:11'
+          - '100000:11'
         export:
           evpn:
-          - '11:11'
+          - '100000:11'
       redistribute_routes:
       - connected
     Tenant_B_OP_Zone:
@@ -120,10 +120,10 @@ router_bgp:
       route_targets:
         import:
           evpn:
-          - '20:20'
+          - '100000:20'
         export:
           evpn:
-          - '20:20'
+          - '100000:20'
       redistribute_routes:
       - connected
     Tenant_C_OP_Zone:
@@ -132,10 +132,10 @@ router_bgp:
       route_targets:
         import:
           evpn:
-          - '30:30'
+          - '100000:30'
         export:
           evpn:
-          - '30:30'
+          - '100000:30'
       redistribute_routes:
       - connected
   vlan_aware_bundles:
@@ -143,7 +143,7 @@ router_bgp:
       rd: '65001:12'
       route_targets:
         both:
-        - '12:12'
+        - '100000:12'
       redistribute_routes:
       - learned
       vlan: 130-131
@@ -151,7 +151,7 @@ router_bgp:
       rd: '65001:13'
       route_targets:
         both:
-        - '13:13'
+        - '100000:13'
       redistribute_routes:
       - learned
       vlan: 140-141
@@ -159,7 +159,7 @@ router_bgp:
       rd: '65001:10'
       route_targets:
         both:
-        - '10:10'
+        - '100000:10'
       redistribute_routes:
       - learned
       vlan: 110-111
@@ -167,7 +167,7 @@ router_bgp:
       rd: '65001:11'
       route_targets:
         both:
-        - '11:11'
+        - '100000:11'
       redistribute_routes:
       - learned
       vlan: 120-121
@@ -176,7 +176,7 @@ router_bgp:
       rd: 65001:10160
       route_targets:
         both:
-        - 10160:10160
+        - 100000:10160
       redistribute_routes:
       - learned
       vlan: 160
@@ -185,7 +185,7 @@ router_bgp:
       rd: 65001:10161
       route_targets:
         both:
-        - 10161:10161
+        - 100000:10161
       redistribute_routes:
       - learned
       vlan: 161
@@ -193,7 +193,7 @@ router_bgp:
       rd: '65001:20'
       route_targets:
         both:
-        - '20:20'
+        - '100000:20'
       redistribute_routes:
       - learned
       vlan: 210-211
@@ -201,7 +201,7 @@ router_bgp:
       rd: '65001:30'
       route_targets:
         both:
-        - '30:30'
+        - '100000:30'
       redistribute_routes:
       - learned
       vlan: 310-311

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
@@ -173,19 +173,19 @@ router_bgp:
       vlan: 120-121
     Tenant_A_VMOTION:
       tenant: Tenant_A
-      rd: 65001:10160
+      rd: 65001:20160
       route_targets:
         both:
-        - 100000:10160
+        - 100000:20160
       redistribute_routes:
       - learned
       vlan: 160
     Tenant_A_NFS:
       tenant: Tenant_A
-      rd: 65001:10161
+      rd: 65001:20161
       route_targets:
         both:
-        - 100000:10161
+        - 100000:20161
       redistribute_routes:
       - learned
       vlan: 161

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
@@ -92,14 +92,14 @@ router_bgp:
       - connected
     Tenant_A_OP_Zone:
       router_id: 192.168.255.11
-      rd: '65001:10'
+      rd: '65001:9'
       route_targets:
         import:
           evpn:
-          - '100000:10'
+          - '100000:9'
         export:
           evpn:
-          - '100000:10'
+          - '100000:9'
       redistribute_routes:
       - connected
     Tenant_A_WEB_Zone:
@@ -156,10 +156,10 @@ router_bgp:
       - learned
       vlan: 140-141
     Tenant_A_OP_Zone:
-      rd: '65001:10'
+      rd: '65001:9'
       route_targets:
         both:
-        - '100000:10'
+        - '100000:9'
       redistribute_routes:
       - learned
       vlan: 110-111

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
@@ -259,19 +259,19 @@ router_bgp:
       vlan: 120-121
     Tenant_A_VMOTION:
       tenant: Tenant_A
-      rd: 65103:10160
+      rd: 65103:20160
       route_targets:
         both:
-        - 10160:10160
+        - 20160:20160
       redistribute_routes:
       - learned
       vlan: 160
     Tenant_A_NFS:
       tenant: Tenant_A
-      rd: 65103:10161
+      rd: 65103:20161
       route_targets:
         both:
-        - 10161:10161
+        - 20161:20161
       redistribute_routes:
       - learned
       vlan: 161

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
@@ -111,14 +111,14 @@ router_bgp:
       - connected
     Tenant_A_OP_Zone:
       router_id: 192.168.255.12
-      rd: '65103:10'
+      rd: '65103:9'
       route_targets:
         import:
           evpn:
-          - '10:10'
+          - '9:9'
         export:
           evpn:
-          - '10:10'
+          - '9:9'
       neighbors:
         10.255.251.7:
           peer_group: MLAG-PEERS
@@ -234,10 +234,10 @@ router_bgp:
       - learned
       vlan: 140-141
     Tenant_A_OP_Zone:
-      rd: '65103:10'
+      rd: '65103:9'
       route_targets:
         both:
-        - '10:10'
+        - '9:9'
       redistribute_routes:
       - learned
       vlan: 110-111
@@ -436,7 +436,7 @@ vlans:
   111:
     tenant: Tenant_A
     name: Tenant_A_OP_Zone_2
-  3009:
+  3008:
     tenant: Tenant_A
     name: MLAG_iBGP_Tenant_A_OP_Zone
     trunk_groups:
@@ -586,7 +586,7 @@ vlan_interfaces:
       1.1.1.1:
         source_interface: lo100
         vrf: MGMT
-  Vlan3009:
+  Vlan3008:
     tenant: Tenant_A
     type: underlay_peering
     shutdown: false

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
@@ -259,19 +259,19 @@ router_bgp:
       vlan: 120-121
     Tenant_A_VMOTION:
       tenant: Tenant_A
-      rd: 65103:10160
+      rd: 65103:20160
       route_targets:
         both:
-        - 10160:10160
+        - 20160:20160
       redistribute_routes:
       - learned
       vlan: 160
     Tenant_A_NFS:
       tenant: Tenant_A
-      rd: 65103:10161
+      rd: 65103:20161
       route_targets:
         both:
-        - 10161:10161
+        - 20161:20161
       redistribute_routes:
       - learned
       vlan: 161

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
@@ -111,14 +111,14 @@ router_bgp:
       - connected
     Tenant_A_OP_Zone:
       router_id: 192.168.255.13
-      rd: '65103:10'
+      rd: '65103:9'
       route_targets:
         import:
           evpn:
-          - '10:10'
+          - '9:9'
         export:
           evpn:
-          - '10:10'
+          - '9:9'
       neighbors:
         10.255.251.6:
           peer_group: MLAG-PEERS
@@ -234,10 +234,10 @@ router_bgp:
       - learned
       vlan: 140-141
     Tenant_A_OP_Zone:
-      rd: '65103:10'
+      rd: '65103:9'
       route_targets:
         both:
-        - '10:10'
+        - '9:9'
       redistribute_routes:
       - learned
       vlan: 110-111
@@ -436,7 +436,7 @@ vlans:
   111:
     tenant: Tenant_A
     name: Tenant_A_OP_Zone_2
-  3009:
+  3008:
     tenant: Tenant_A
     name: MLAG_iBGP_Tenant_A_OP_Zone
     trunk_groups:
@@ -586,7 +586,7 @@ vlan_interfaces:
       1.1.1.1:
         source_interface: lo100
         vrf: MGMT
-  Vlan3009:
+  Vlan3008:
     tenant: Tenant_A
     type: underlay_peering
     shutdown: false

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_false.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_false.yml
@@ -184,19 +184,19 @@ router_bgp:
       vlan: 120-121
     Tenant_A_VMOTION:
       tenant: Tenant_A
-      rd: 192.168.255.109:10160
+      rd: 192.168.255.109:20160
       route_targets:
         both:
-        - 10160:10160
+        - 20160:20160
       redistribute_routes:
       - learned
       vlan: 160
     Tenant_A_NFS:
       tenant: Tenant_A
-      rd: 192.168.255.109:10161
+      rd: 192.168.255.109:20161
       route_targets:
         both:
-        - 10161:10161
+        - 20161:20161
       redistribute_routes:
       - learned
       vlan: 161

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_false.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_false.yml
@@ -57,14 +57,14 @@ router_bgp:
       - connected
     Tenant_A_OP_Zone:
       router_id: 192.168.255.109
-      rd: 192.168.255.109:10
+      rd: 192.168.255.109:9
       route_targets:
         import:
           evpn:
-          - '10:10'
+          - '9:9'
         export:
           evpn:
-          - '10:10'
+          - '9:9'
       redistribute_routes:
       - connected
     Tenant_A_WAN_Zone:
@@ -159,10 +159,10 @@ router_bgp:
       - learned
       vlan: 140-141
     Tenant_A_OP_Zone:
-      rd: 192.168.255.109:10
+      rd: 192.168.255.109:9
       route_targets:
         both:
-        - '10:10'
+        - '9:9'
       redistribute_routes:
       - learned
       vlan: 110-111

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_true.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_true.yml
@@ -73,19 +73,19 @@ router_bgp:
       vlan: 120-121
     Tenant_A_VMOTION:
       tenant: Tenant_A
-      rd: 192.168.255.109:10160
+      rd: 192.168.255.109:20160
       route_targets:
         both:
-        - 10160:10160
+        - 20160:20160
       redistribute_routes:
       - learned
       vlan: 160
     Tenant_A_NFS:
       tenant: Tenant_A
-      rd: 192.168.255.109:10161
+      rd: 192.168.255.109:20161
       route_targets:
         both:
-        - 10161:10161
+        - 20161:20161
       redistribute_routes:
       - learned
       vlan: 161

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_true.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_true.yml
@@ -48,10 +48,10 @@ router_bgp:
       - learned
       vlan: 140-141
     Tenant_A_OP_Zone:
-      rd: 192.168.255.109:10
+      rd: 192.168.255.109:9
       route_targets:
         both:
-        - '10:10'
+        - '9:9'
       redistribute_routes:
       - learned
       vlan: 110-111

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_BL1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_BL1.yml
@@ -19,6 +19,11 @@ my_special_dci_ethernet_interfaces:
   Ethernet4000:
     description: My second test
 
+# rd type using the old name of the setting (backwards compatible)
 evpn_rd_type:
 #   # admin_subfield: < "overlay_loopback" | "vtep_loopback" | "leaf_asn" | "spine_asn" | < IPv4 Address > | <0-65535> | <0-4294967295> | default -> "overlay_loopback" >
   admin_subfield: vtep_loopback
+
+# rd type using the old name of the setting (backwards compatible)
+evpn_rt_type:
+  admin_subfield: "bgp_as"

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_FABRIC.yml
@@ -5,7 +5,7 @@
 fabric_name: DC1_FABRIC
 
 # Enable vlan aware bundles
-vxlan_vlan_aware_bundles: true
+evpn_vlan_aware_bundles: true
 
 # bgp peer groups passwords
 bgp_peer_groups:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_LEAF1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_LEAF1.yml
@@ -1,4 +1,7 @@
 ---
-evpn_rd_type:
+overlay_rd_type:
 #   # admin_subfield: < "overlay_loopback" | "vtep_loopback" | "leaf_asn" | "spine_asn" | < IPv4 Address > | <0-65535> | <0-4294967295> | default -> "overlay_loopback" >
   admin_subfield: 1.1.1.1
+
+overlay_rt_type:
+  admin_subfield: 1234

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_LEAF2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_LEAF2.yml
@@ -1,4 +1,7 @@
 ---
-evpn_rd_type:
+overlay_rd_type:
 #   # admin_subfield: < "overlay_loopback" | "vtep_loopback" | "leaf_asn" | "spine_asn" | < IPv4 Address > | <0-65535> | <0-4294967295> | default -> "overlay_loopback" >
   admin_subfield: 65001
+
+overlay_rt_type:
+  admin_subfield: 100000

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_SVC3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_SVC3.yml
@@ -1,4 +1,4 @@
 ---
-evpn_rd_type:
+overlay_rd_type:
 #   # admin_subfield: < "overlay_loopback" | "vtep_loopback" | "leaf_asn" | "spine_asn" | < IPv4 Address > | <0-65535> | <0-4294967295> | default -> "overlay_loopback" >
   admin_subfield: bgp_as

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS.yml
@@ -49,7 +49,7 @@ tenants:
             ip_address_virtual: 10.1.10.1/24
           # SVI as integer
           111:
-            vni_override: 50111
+            vni_override: 50111 #10111 would be the calculated value.
             name: Tenant_A_OP_Zone_2
             tags: ['opzone']
             enabled: True

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS.yml
@@ -35,6 +35,7 @@ tenants:
     vrfs:
       Tenant_A_OP_Zone:
         vrf_vni: 10
+        vrf_id: 9 # Check that RD and RT will use this number for this VRF. VNI should still respect vrf_vni
         vtep_diagnostic:
           loopback: 100
           loopback_ip_range: 10.255.1.0/24

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS.yml
@@ -32,6 +32,7 @@ tenants:
   # Tenant_A Specific Information - VRFs / VLANs
   Tenant_A:
     mac_vrf_vni_base: 10000
+    mac_vrf_id_base: 20000
     vrfs:
       Tenant_A_OP_Zone:
         vrf_vni: 10

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
@@ -55,7 +55,7 @@ node_type_keys:
 #   mlag_peer: 10.255.252.0/24
 
 # Enable vlan aware bundles
-vxlan_vlan_aware_bundles: true
+evpn_vlan_aware_bundles: true
 
 # Disable EVPN host-flap protection
 evpn_hostflap_detection:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/inventory/group_vars/DC1_FABRIC.yml
@@ -10,7 +10,7 @@ overlay_routing_protocol: ibgp
 bgp_as: 65000
 isis_area_id: "49.0001"
 
-# Enable vlan aware bundles
+# Enable vlan aware bundles using the old name of the setting (backwards compatible)
 vxlan_vlan_aware_bundles: true
 
 # bgp peer groups passwords

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
@@ -12,7 +12,7 @@ underlay_ospf_max_lsa: 12000
 underlay_ospf_bfd_enable: true
 
 # Enable vlan aware bundles
-vxlan_vlan_aware_bundles: true
+evpn_vlan_aware_bundles: true
 
 # Change EVPN host-flap threshold only
 evpn_hostflap_detection:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
@@ -12,7 +12,7 @@ fabric_name: DC1_FABRIC
 underlay_rfc5549: true
 
 # Enable vlan aware bundles
-vxlan_vlan_aware_bundles: true
+evpn_vlan_aware_bundles: true
 
 # EVPN host flapping settings
 evpn_hostflap_detection:

--- a/ansible_collections/arista/avd/roles/eos_designs/defaults/main/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/defaults/main/main.yml
@@ -65,7 +65,7 @@ isis_maximum_paths: 4
 bgp_maximum_paths: 4
 bgp_ecmp: 4
 
-vxlan_vlan_aware_bundles: false
+evpn_vlan_aware_bundles: false
 
 default_igmp_snooping_enabled: true
 

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-variables.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-variables.md
@@ -68,7 +68,8 @@ bgp_peer_groups:
       password: "< encrypted password >"
 
 # Enable vlan aware bundles for EVPN MAC-VRF | Required.
-vxlan_vlan_aware_bundles: < boolean | default -> false >
+# Old variable name vxlan_vlan_aware_bundles, supported for backward-compatibility.
+evpn_vlan_aware_bundles: < boolean | default -> false >
 
 # Disable IGMP snooping at fabric level.
 # If set, it overrides per vlan settings

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
@@ -89,7 +89,7 @@ tenants:
 
     # Base number for MAC VRF RD/RT ID | Required unless mac_vrf_vni_based is set.
     # ID is derived from the base number with simple addition.
-    # e.g. mac_vrf_id_base = 10000, svi 100 = VNI 10100, svi 300 = VNI 10300.
+    # e.g. mac_vrf_id_base = 10000, svi 100 = RD/RT 10100, svi 300 = RD/RT 10300.
     mac_vrf_id_base: < 10000-16770000 | default -> <mac_vrf_vni_base> >
 
     # Base number for vlan_aware_bundle | Optional.

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
@@ -18,25 +18,27 @@ mlag_ibgp_peering_vrfs:
 
 # Specify RD type | Optional
 # Route Distinguisher (RD) for L2 / L3 services is set to <overlay_loopback>:<vni> per default.
-# By configuring evpn_rd_type the Administrator subfield (first part of RD) can be set to other values.
+# By configuring overlay_rd_type the Administrator subfield (first part of RD) can be set to other values.
 #
 # Note:
 # RD is a 48-bit value which is split into <16-bit>:<32-bit> or <32-bit>:<16-bit>.
 # For loopback or 32-bit ASN/number the VNI can only be a 16-bit number.
 # For 16-bit ASN/number the VNI can be a 32-bit number.
-evpn_rd_type:
+# Old variable name "evpn_rd_type", supported for backward-compatibility.
+overlay_rd_type:
   admin_subfield: < "vtep_loopback" | "bgp_as" | < IPv4 Address > | <0-65535> | <0-4294967295> | default -> <overlay_loopback_ip> >
 
 # Specify RT type | Optional
 # Route Target (RT) for L2 / L3 services is set to <vni>:<vni> per default
-# By configuring evpn_rt_type the Administrator subfield (first part of RT) can be set to other values.
+# By configuring overlay_rt_type the Administrator subfield (first part of RT) can be set to other values.
 #
 # Note:
 # RT is a 48-bit value which is split into <16-bit>:<32-bit> or <32-bit>:<16-bit>.
 # For 32-bit ASN/number the VNI can only be a 16-bit number.
 # For 16-bit ASN/number the VNI can be a 32-bit number.
-evpn_rt_type:
-  admin_subfield: < "bgp_as" | <0-65535> | <0-4294967295> | default -> <vni> >
+# Old variable name "evpn_rt_type", supported for backward-compatibility.
+overlay_rt_type:
+  admin_subfield: < "bgp_as" | <0-65535> | <0-4294967295> | default -> <mac_vrf_id> >
 
 # Internal vlan allocation order and range | Required
 internal_vlan_order:
@@ -79,10 +81,15 @@ tenants:
   # Networks services can be filtered by tenant name.
   < tenant_a >:
 
-    # VXLAN Network Identifier for MAC VRF | Required.
+    # Base number for MAC VRF VXLAN Network Identifier | Required with VXLAN
     # VXLAN VNI is derived from the base number with simple addition.
     # e.g. mac_vrf_vni_base = 10000, svi 100 = VNI 10100, svi 300 = VNI 10300.
     mac_vrf_vni_base: < 10000-16770000 >
+
+    # Base number for MAC VRF RD/RT ID | Required unless mac_vrf_vni_based is set.
+    # ID is derived from the base number with simple addition.
+    # e.g. mac_vrf_id_base = 10000, svi 100 = VNI 10100, svi 300 = VNI 10300.
+    mac_vrf_id_base: < 10000-16770000 | default -> <mac_vrf_vni_base> >
 
     # Base number for vlan_aware_bundle | Optional.
     # The "Assigned Number" part of RD/RT is derived from vrf_vni + vlan_aware_bundle_number_base.
@@ -108,6 +115,7 @@ tenants:
 
         # VRF ID | Optional (required if "vrf_vni" is not set)
         # vrf_id is used as default value for "vrf_vni" and "ospf.process_id" unless those are set.
+        # vrf_id is also preferred for VRF RD/RT ID before vrf_vni
         vrf_id: < 1-1024 >
 
         # IP Helper for DHCP relay
@@ -169,9 +177,13 @@ tenants:
           # SVI interface id and VLAN id. | Required
           < 1-4096 >:
 
-            # By default the vni will be derived from "mac_vrf_vni_base:"
+            # By default the vni will be derived from "mac_vrf_vni_base"
             # The vni_override allows us to override this value and statically define it. | Optional
             vni_override: < 1-16777215 >
+
+            # By default the MAC VRF RD/RT ID will be derived from "mac_vrf_id_base"
+            # The rt_override allows us to override this value and statically define it. | Optional
+            rt_override: < 1-16777215 | default -> vni_override >
 
             # SVI profile to apply
             # If variables are configured in profile AND SVI, SVI information will overwrite profile.
@@ -394,6 +406,10 @@ tenants:
         # By default the vni will be derived from "mac_vrf_vni_base:"
         # The vni_override, allows to override this value and statically define it.
         vni_override: < 1-16777215 >
+
+        # By default the MAC VRF RD/RT ID will be derived from "mac_vrf_id_base"
+        # The rt_override allows us to override this value and statically define it. | Optional
+        rt_override: < 1-16777215 | default -> vni_override >
 
         # VLAN name.
         name: < description >

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
@@ -11,7 +11,8 @@
 
 ```yaml
 # On mlag leafs, an SVI interface is defined per vrf, to establish iBGP peering. | Required (when mlag leafs in topology)
-# The SVI id will be derived from the base vlan defined: mlag_ibgp_peering_vrfs.base_vlan + vrf_vni - 1
+# The SVI id will be derived from the base vlan defined: mlag_ibgp_peering_vrfs.base_vlan + (vrf_id or vrf_vni) - 1
+# Depending on the values of vrf_id / vrf_id it may be required to adjust the base_vlan to avoid overlaps or invalid vlan ids.
 # The SVI ip address derived from mlag_l3_peer_ipv4_pool is re-used across all iBGP peerings.
 mlag_ibgp_peering_vrfs:
   base_vlan: < 1-4000 | default -> 3000 >
@@ -107,15 +108,15 @@ tenants:
       < tenant_a_vrf_1 >:
 
         # VRF VNI | Optional (required if "vrf_id" is not set).
-        # The VRF VNI range is not limited, but it is recommended to keep vrf_vni <= 1024
-        # It is necessary to keep [ vrf_vni + MLAG IBGP base_vlan ] < 4094 to support MLAG IBGP peering in VRF.
-        # If vrf_vni > 1094 make sure to change mlag_ibgp_peering_vrfs: { base_vlan: < > } to a lower value (default 3000).
-        # If vrf_vni > 10000 make sure to adjust mac_vrf_vni_base accordingly to avoid overlap.
+        # The VRF VNI range is not limited, but if vrf_id is not set, "vrf_vni" is used for calculating MLAG IBGP peering vlan id.
+        # See "mlag_ibgp_peering_vrfs.base_vlan" for details.
+        # If vrf_vni > 10000 make sure to adjust "mac_vrf_vni_base" accordingly to avoid overlap.
         vrf_vni: < 1-1024 | default -> vrf_id >
 
         # VRF ID | Optional (required if "vrf_vni" is not set)
-        # vrf_id is used as default value for "vrf_vni" and "ospf.process_id" unless those are set.
-        # vrf_id is also preferred for VRF RD/RT ID before vrf_vni
+        # "vrf_id" is used as default value for "vrf_vni" and "ospf.process_id" unless those are set.
+        # "vrf_id" is preferred over "vrf_vni" for VRF RD/RT ID before vrf_vni
+        # "vrf_id" is preferred over "vrf_vni" for MLAG IBGP peering vlan, see "mlag_ibgp_peering_vrfs.base_vlan" for details
         vrf_id: < 1-1024 >
 
         # IP Helper for DHCP relay
@@ -130,7 +131,7 @@ tenants:
         enable_mlag_ibgp_peering_vrfs: < true | false >
 
         # Manually define the VLAN used on the MLAG pair for the iBGP session. | Optional
-        # By default this parameter is calculated using the following formula: <base_vlan> + <vrf_vni> - 1
+        # By default this parameter is calculated using the following formula: <mlag_ibgp_peering_vrfs.base_vlan> + <vrf_id> - 1
         mlag_ibgp_peering_vlan: <1-4096>
 
         # Enable VTEP Network diagnostics | Optional.

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-vlan-aware-bundles.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-vlan-aware-bundles.j2
@@ -16,7 +16,7 @@
 {%                 if svi_int_list | length == 0 %}
 {%                     continue %}
 {%                 endif %}
-{%                 set vrf_id_int = vrf.vrf_vni | arista.avd.default(vrf.vrf_id) | int %}
+{%                 set vrf_id_int = vrf.vrf_id | arista.avd.default(vrf.vrf_vni) | int %}
 {%                 set bundle_number =  vrf_id_int + tenant.vlan_aware_bundle_number_base | arista.avd.default(0) %}
     {{ vrf.name }}:
       rd: "{{ network_services_data.rd_admin_subfield }}:{{ bundle_number }}"

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-vlan-aware-bundles.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-vlan-aware-bundles.j2
@@ -1,6 +1,7 @@
 {# tenant router bgp evpn configuration - MAC-VRF VLAN Aware bundles #}
   vlan_aware_bundles:
-{% if vxlan_vlan_aware_bundles is arista.avd.defined(true) %}
+{% set evpn_vlan_aware_bundles = vxlan_vlan_aware_bundles | arista.avd.default(evpn_vlan_aware_bundles, false) %}
+{% if evpn_vlan_aware_bundles == true %}
 {%     for tenant in network_services_data.tenants %}
 {%         for vrf in tenant.vrfs %}
 {%             if vrf.svis | length > 0 %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-vlan-aware-bundles.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-vlan-aware-bundles.j2
@@ -3,6 +3,7 @@
 {% set evpn_vlan_aware_bundles = vxlan_vlan_aware_bundles | arista.avd.default(evpn_vlan_aware_bundles, false) %}
 {% if evpn_vlan_aware_bundles == true %}
 {%     for tenant in network_services_data.tenants %}
+{%         set tenant_mac_vrf_id_base = tenant.mac_vrf_rt_base | arista.avd.default(tenant.mac_vrf_vni_base) %}
 {%         for vrf in tenant.vrfs %}
 {%             if vrf.svis | length > 0 %}
 {%                 set svi_int_list = [] %}
@@ -15,13 +16,13 @@
 {%                 if svi_int_list | length == 0 %}
 {%                     continue %}
 {%                 endif %}
-{%                 set vrf_vni_int = vrf.vrf_vni | arista.avd.default(vrf.vrf_id) | int %}
-{%                 set bundle_number =  vrf_vni_int + tenant.vlan_aware_bundle_number_base | arista.avd.default(0) %}
+{%                 set vrf_id_int = vrf.vrf_vni | arista.avd.default(vrf.vrf_id) | int %}
+{%                 set bundle_number =  vrf_id_int + tenant.vlan_aware_bundle_number_base | arista.avd.default(0) %}
     {{ vrf.name }}:
-      rd: "{{ network_services_data.evpn_rd_admin_subfield }}:{{ bundle_number }}"
+      rd: "{{ network_services_data.rd_admin_subfield }}:{{ bundle_number }}"
       route_targets:
         both:
-          - "{{ network_services_data.evpn_rt_admin_subfield or bundle_number }}:{{ bundle_number }}"
+          - "{{ network_services_data.rt_admin_subfield or bundle_number }}:{{ bundle_number }}"
       redistribute_routes:
         - learned
       vlan: {{ svi_int_list | map('int') | arista.avd.list_compress }}
@@ -32,14 +33,15 @@
 {%                 continue %}
 {%             endif %}
 {%             set l2vlan_int = l2vlan.id | int %}
-{%             set vni = l2vlan.vni_override | arista.avd.default(
-                         tenant.mac_vrf_vni_base + l2vlan_int) %}
+{%             set vlan_rt = l2vlan.rt_override | arista.avd.default(
+                             l2vlan.vni_override,
+                             tenant_mac_vrf_id_base + l2vlan_int) %}
     {{ l2vlan.name }}:
       tenant: {{ tenant.name }}
-      rd: "{{ network_services_data.evpn_rd_admin_subfield }}:{{ vni }}"
+      rd: "{{ network_services_data.rd_admin_subfield }}:{{ vlan_rt }}"
       route_targets:
         both:
-          - "{{ network_services_data.evpn_rt_admin_subfield or vni }}:{{ vni }}"
+          - "{{ network_services_data.rt_admin_subfield or vlan_rt }}:{{ vlan_rt }}"
       redistribute_routes:
         - learned
       vlan: {{ l2vlan_int }}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-vlan-aware-bundles.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-vlan-aware-bundles.j2
@@ -3,7 +3,7 @@
 {% set evpn_vlan_aware_bundles = vxlan_vlan_aware_bundles | arista.avd.default(evpn_vlan_aware_bundles, false) %}
 {% if evpn_vlan_aware_bundles == true %}
 {%     for tenant in network_services_data.tenants %}
-{%         set tenant_mac_vrf_id_base = tenant.mac_vrf_rt_base | arista.avd.default(tenant.mac_vrf_vni_base) %}
+{%         set tenant_mac_vrf_id_base = tenant.mac_vrf_id_base | arista.avd.default(tenant.mac_vrf_vni_base) %}
 {%         for vrf in tenant.vrfs %}
 {%             if vrf.svis | length > 0 %}
 {%                 set svi_int_list = [] %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-vlans.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-vlans.j2
@@ -3,20 +3,22 @@
 {% set evpn_vlan_aware_bundles = vxlan_vlan_aware_bundles | arista.avd.default(evpn_vlan_aware_bundles, false) %}
 {% if evpn_vlan_aware_bundles == false %}
 {%     for tenant in network_services_data.tenants %}
+{%         set tenant_mac_vrf_id_base = tenant.mac_vrf_rt_base | arista.avd.default(tenant.mac_vrf_vni_base) %}
 {%         for vrf in tenant.vrfs %}
 {%             for svi in vrf.svis %}
 {%                 if svi.vxlan is arista.avd.defined(false) %}
 {%                     continue %}
 {%                 endif %}
 {%                 set svi_int = svi.id | int %}
-{%                 set vni = svi.vni_override | arista.avd.default(
-                             tenant.mac_vrf_vni_base + svi_int) %}
+{%                 set vlan_rt = svi.rt_override | arista.avd.default(
+                                 svi.vni_override,
+                                 tenant_mac_vrf_id_base + svi_int) %}
     {{ svi.id }}:
       tenant: {{ tenant.name }}
-      rd: "{{ network_services_data.evpn_rd_admin_subfield }}:{{ vni }}"
+      rd: "{{ network_services_data.rd_admin_subfield }}:{{ vlan_rt }}"
       route_targets:
         both:
-          - "{{ network_services_data.evpn_rt_admin_subfield or vni }}:{{ vni }}"
+          - "{{ network_services_data.rt_admin_subfield or vlan_rt }}:{{ vlan_rt }}"
       redistribute_routes:
         - learned
 {%             endfor %}
@@ -26,14 +28,15 @@
 {%                 continue %}
 {%             endif %}
 {%             set l2vlan_int = l2vlan.id | int %}
-{%             set vni = l2vlan.vni_override | arista.avd.default(
-                         tenant.mac_vrf_vni_base + l2vlan_int) %}
+{%             set vlan_rt = l2vlan.rt_override | arista.avd.default(
+                             l2vlan.vni_override,
+                             tenant_mac_vrf_id_base + l2vlan_int) %}
     {{ l2vlan.id }}:
       tenant: {{ tenant.name }}
-      rd: "{{ network_services_data.evpn_rd_admin_subfield }}:{{ vni }}"
+      rd: "{{ network_services_data.rd_admin_subfield }}:{{ vlan_rt }}"
       route_targets:
         both:
-          - "{{ network_services_data.evpn_rt_admin_subfield or vni }}:{{ vni }}"
+          - "{{ network_services_data.rt_admin_subfield or vlan_rt }}:{{ vlan_rt }}"
       redistribute_routes:
         - learned
 {%         endfor %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-vlans.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-vlans.j2
@@ -3,7 +3,7 @@
 {% set evpn_vlan_aware_bundles = vxlan_vlan_aware_bundles | arista.avd.default(evpn_vlan_aware_bundles, false) %}
 {% if evpn_vlan_aware_bundles == false %}
 {%     for tenant in network_services_data.tenants %}
-{%         set tenant_mac_vrf_id_base = tenant.mac_vrf_rt_base | arista.avd.default(tenant.mac_vrf_vni_base) %}
+{%         set tenant_mac_vrf_id_base = tenant.mac_vrf_id_base | arista.avd.default(tenant.mac_vrf_vni_base) %}
 {%         for vrf in tenant.vrfs %}
 {%             for svi in vrf.svis %}
 {%                 if svi.vxlan is arista.avd.defined(false) %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-vlans.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-vlans.j2
@@ -1,6 +1,7 @@
 {# tenant router bgp evpn configuration- MAC-VRF VLAN-Based #}
   vlans:
-{% if vxlan_vlan_aware_bundles == false %}
+{% set evpn_vlan_aware_bundles = vxlan_vlan_aware_bundles | arista.avd.default(evpn_vlan_aware_bundles, false) %}
+{% if evpn_vlan_aware_bundles == false %}
 {%     for tenant in network_services_data.tenants %}
 {%         for vrf in tenant.vrfs %}
 {%             for svi in vrf.svis %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-vlans.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-vlans.j2
@@ -1,7 +1,7 @@
 {# tenant router bgp evpn configuration- MAC-VRF VLAN-Based #}
   vlans:
 {% set evpn_vlan_aware_bundles = vxlan_vlan_aware_bundles | arista.avd.default(evpn_vlan_aware_bundles, false) %}
-{% if evpn_vlan_aware_bundles == false %}
+{% if evpn_vlan_aware_bundles != true %}
 {%     for tenant in network_services_data.tenants %}
 {%         set tenant_mac_vrf_id_base = tenant.mac_vrf_id_base | arista.avd.default(tenant.mac_vrf_vni_base) %}
 {%         for vrf in tenant.vrfs %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-vrfs.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-vrfs.j2
@@ -8,7 +8,7 @@
 {%             set bgp_vrf.address_family_ipv4_neighbors = [] %}
 {%             set bgp_vrf.address_family_ipv6_neighbors = [] %}
 {%             set bgp_vrf_vni = vrf.vrf_vni | arista.avd.default(vrf.vrf_id) %}
-{%             set leaf_evpn_rt = (network_services_data.evpn_rt_admin_subfield or bgp_vrf_vni) ~ ':' ~ bgp_vrf_vni %}
+{%             set leaf_evpn_rt = (network_services_data.rt_admin_subfield or bgp_vrf_vni) ~ ':' ~ bgp_vrf_vni %}
 {%             set route_targets = namespace(import={'evpn': [leaf_evpn_rt]}, export={'evpn': [leaf_evpn_rt]}) %}
 {%             for additional_route_target in vrf.additional_route_targets | arista.avd.natural_sort %}
 {%                 if inventory_hostname in additional_route_target.nodes | arista.avd.default([inventory_hostname]) %}
@@ -25,7 +25,7 @@
 {%             endfor %}
     {{ vrf.name }}:
       router_id: {{ switch.router_id }}
-      rd: "{{ network_services_data.evpn_rd_admin_subfield }}:{{ bgp_vrf_vni }}"
+      rd: "{{ network_services_data.rd_admin_subfield }}:{{ bgp_vrf_vni }}"
       route_targets:
         import: {{ route_targets.import | to_json }}
         export: {{ route_targets.export | to_json }}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-vrfs.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-vrfs.j2
@@ -7,8 +7,8 @@
 {%         for vrf in tenant.vrfs %}
 {%             set bgp_vrf.address_family_ipv4_neighbors = [] %}
 {%             set bgp_vrf.address_family_ipv6_neighbors = [] %}
-{%             set bgp_vrf_vni = vrf.vrf_vni | arista.avd.default(vrf.vrf_id) %}
-{%             set leaf_evpn_rt = (network_services_data.rt_admin_subfield or bgp_vrf_vni) ~ ':' ~ bgp_vrf_vni %}
+{%             set bgp_vrf_id = vrf.vrf_id | arista.avd.default(vrf.vrf_vni) %}
+{%             set leaf_evpn_rt = (network_services_data.rt_admin_subfield or bgp_vrf_id) ~ ':' ~ bgp_vrf_id %}
 {%             set route_targets = namespace(import={'evpn': [leaf_evpn_rt]}, export={'evpn': [leaf_evpn_rt]}) %}
 {%             for additional_route_target in vrf.additional_route_targets | arista.avd.natural_sort %}
 {%                 if inventory_hostname in additional_route_target.nodes | arista.avd.default([inventory_hostname]) %}
@@ -25,7 +25,7 @@
 {%             endfor %}
     {{ vrf.name }}:
       router_id: {{ switch.router_id }}
-      rd: "{{ network_services_data.rd_admin_subfield }}:{{ bgp_vrf_vni }}"
+      rd: "{{ network_services_data.rd_admin_subfield }}:{{ bgp_vrf_id }}"
       route_targets:
         import: {{ route_targets.import | to_json }}
         export: {{ route_targets.export | to_json }}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vlan-interfaces.j2
@@ -110,7 +110,7 @@ vlan_interfaces:
                                                  tenant.enable_mlag_ibgp_peering_vrfs,
                                                  true) %}
 {%             if configure_mlag_ibgp_peering %}
-{%                 set vrf_id_int = vrf.vrf_vni | arista.avd.default(vrf.vrf_id) | int  %}
+{%                 set vrf_id_int = vrf.vrf_id | arista.avd.default(vrf.vrf_vni) | int %}
   Vlan{{ vrf.mlag_ibgp_peering_vlan | arista.avd.default (mlag_ibgp_peering_vrfs.base_vlan + (vrf_id_int - 1)) }}:
     tenant: {{ tenant.name }}
     type: underlay_peering

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vlan-interfaces.j2
@@ -110,8 +110,8 @@ vlan_interfaces:
                                                  tenant.enable_mlag_ibgp_peering_vrfs,
                                                  true) %}
 {%             if configure_mlag_ibgp_peering %}
-{%                 set bgp_vrf_vni = vrf.vrf_vni | arista.avd.default(vrf.vrf_id) %}
-  Vlan{{ vrf.mlag_ibgp_peering_vlan | arista.avd.default (mlag_ibgp_peering_vrfs.base_vlan + (bgp_vrf_vni - 1)) }}:
+{%                 set vrf_id_int = vrf.vrf_vni | arista.avd.default(vrf.vrf_id) | int  %}
+  Vlan{{ vrf.mlag_ibgp_peering_vlan | arista.avd.default (mlag_ibgp_peering_vrfs.base_vlan + (vrf_id_int - 1)) }}:
     tenant: {{ tenant.name }}
     type: underlay_peering
     shutdown: false

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vlans.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vlans.j2
@@ -16,7 +16,7 @@ vlans:
                                                  tenant.enable_mlag_ibgp_peering_vrfs,
                                                  true) %}
 {%             if configure_mlag_ibgp_peering %}
-{%                 set vrf_id_int = vrf.vrf_vni | arista.avd.default(vrf.vrf_id) | int  %}
+{%                 set vrf_id_int = vrf.vrf_id | arista.avd.default(vrf.vrf_vni) | int %}
   {{ vrf.mlag_ibgp_peering_vlan | arista.avd.default(mlag_ibgp_peering_vrfs.base_vlan + (vrf_id_int - 1)) }}:
     tenant: {{ tenant.name }}
     name: MLAG_iBGP_{{ vrf.name }}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vlans.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vlans.j2
@@ -16,8 +16,8 @@ vlans:
                                                  tenant.enable_mlag_ibgp_peering_vrfs,
                                                  true) %}
 {%             if configure_mlag_ibgp_peering %}
-{%                 set bgp_vrf_vni = vrf.vrf_vni | arista.avd.default(vrf.vrf_id) %}
-  {{ vrf.mlag_ibgp_peering_vlan | arista.avd.default(mlag_ibgp_peering_vrfs.base_vlan + (bgp_vrf_vni - 1)) }}:
+{%                 set vrf_id_int = vrf.vrf_vni | arista.avd.default(vrf.vrf_id) | int  %}
+  {{ vrf.mlag_ibgp_peering_vlan | arista.avd.default(mlag_ibgp_peering_vrfs.base_vlan + (vrf_id_int - 1)) }}:
     tenant: {{ tenant.name }}
     name: MLAG_iBGP_{{ vrf.name }}
     trunk_groups:

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vtep-logic.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vtep-logic.j2
@@ -1,30 +1,28 @@
 {# Setting evpn_rd_admin_subfield #}
-{% set network_services_data.evpn_rd_admin_subfield = switch.router_id %}
-{% if evpn_rd_type is defined and evpn_rd_type is not none %}
-{%     if evpn_rd_type.admin_subfield is arista.avd.defined %}
-{%         if evpn_rd_type.admin_subfield == "vtep_loopback" %}
-{%             set network_services_data.evpn_rd_admin_subfield = switch.vtep_ip %}
-{%         elif evpn_rd_type.admin_subfield == "bgp_as" %}
-{%             set network_services_data.evpn_rd_admin_subfield = switch.bgp_as %}
-{%         elif evpn_rd_type.admin_subfield | ansible.netcommon.ipaddr %}
-{%             set network_services_data.evpn_rd_admin_subfield = evpn_rd_type.admin_subfield %}
-{%         elif evpn_rd_type.admin_subfield is number and
-                evpn_rd_type.admin_subfield >= 0 and
-                evpn_rd_type.admin_subfield <= 4294967295 %}
-{%             set network_services_data.evpn_rd_admin_subfield = evpn_rd_type.admin_subfield %}
-{%         endif %}
+{% set network_services_data.rd_admin_subfield = switch.router_id %}
+{% set tmp_admin_subfield = evpn_rd_type.admin_subfield | arista.avd.default(overlay_rd_type.admin_subfield) %}
+{% if tmp_admin_subfield is arista.avd.defined %}
+{%     if tmp_admin_subfield == "vtep_loopback" %}
+{%         set network_services_data.rd_admin_subfield = switch.vtep_ip %}
+{%     elif tmp_admin_subfield == "bgp_as" %}
+{%         set network_services_data.rd_admin_subfield = switch.bgp_as %}
+{%     elif tmp_admin_subfield | ansible.netcommon.ipaddr %}
+{%         set network_services_data.rd_admin_subfield = tmp_admin_subfield %}
+{%     elif tmp_admin_subfield is number and
+            tmp_admin_subfield >= 0 and
+            tmp_admin_subfield <= 4294967295 %}
+{%         set network_services_data.rd_admin_subfield = tmp_admin_subfield %}
 {%     endif %}
 {% endif %}
 {# Setting evpn_rt_admin_subfield #}
-{% set network_services_data.evpn_rt_admin_subfield = false %}
-{% if evpn_rt_type is defined and evpn_rt_type is not none %}
-{%     if evpn_rt_type.admin_subfield is arista.avd.defined %}
-{%         if evpn_rt_type.admin_subfield == "bgp_as" %}
-{%             set network_services_data.evpn_rt_admin_subfield = switch.bgp_as %}
-{%         elif evpn_rt_type.admin_subfield is number and
-                evpn_rt_type.admin_subfield >= 0 and
-                evpn_rt_type.admin_subfield <= 4294967295 %}
-{%             set network_services_data.evpn_rt_admin_subfield = evpn_rt_type.admin_subfield %}
-{%         endif %}
+{% set network_services_data.rt_admin_subfield = false %}
+{% set tmp_admin_subfield = evpn_rt_type.admin_subfield | arista.avd.default(overlay_rt_type.admin_subfield) %}
+{% if tmp_admin_subfield is arista.avd.defined %}
+{%     if tmp_admin_subfield == "bgp_as" %}
+{%         set network_services_data.rt_admin_subfield = switch.bgp_as %}
+{%     elif tmp_admin_subfield is number and
+            tmp_admin_subfield >= 0 and
+            tmp_admin_subfield <= 4294967295 %}
+{%         set network_services_data.rt_admin_subfield = tmp_admin_subfield %}
 {%     endif %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vtep-logic.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vtep-logic.j2
@@ -1,4 +1,4 @@
-{# Setting evpn_rd_admin_subfield #}
+{# Setting rd_admin_subfield #}
 {% set network_services_data.rd_admin_subfield = switch.router_id %}
 {% set tmp_admin_subfield = evpn_rd_type.admin_subfield | arista.avd.default(overlay_rd_type.admin_subfield) %}
 {% if tmp_admin_subfield is arista.avd.defined %}
@@ -14,7 +14,7 @@
 {%         set network_services_data.rd_admin_subfield = tmp_admin_subfield %}
 {%     endif %}
 {% endif %}
-{# Setting evpn_rt_admin_subfield #}
+{# Setting rt_admin_subfield #}
 {% set network_services_data.rt_admin_subfield = false %}
 {% set tmp_admin_subfield = evpn_rt_type.admin_subfield | arista.avd.default(overlay_rt_type.admin_subfield) %}
 {% if tmp_admin_subfield is arista.avd.defined %}

--- a/ansible_collections/arista/avd/tests/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/tests/inventory/group_vars/DC1_FABRIC.yml
@@ -5,7 +5,7 @@
 fabric_name: DC1_FABRIC
 
 # Enable vlan aware bundles
-vxlan_vlan_aware_bundles: true
+evpn_vlan_aware_bundles: true
 
 # bgp peer groups passwords
 bgp_peer_groups:


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Add extra ID options to network services and rename rd/rt vars

## Related Issue(s)

This is in relation to the MPLS design, where we will need other IDs than VNI.

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

All ID variables are optional since they fall back to the VNI variants of the same.
All renamed variables still support their older name.

- `vxlan_vlan_aware_bundles` -> `evpn_vlan_aware_bundles`
- `evpn_rd_type` -> `overlay_rd_type`
- `evpn_rt_type` -> `overlay_rt_type`
- New `mac_vrf_id_base`
- New `rt_override` for `svis` and `l2vlans`
- Renaming internal vars in templates to make them neutral to the design.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
