### PR TITLE
Feat(eos_cli_config_gen): logging facility

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/logging-minimal.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/logging-minimal.md
@@ -64,6 +64,7 @@ interface Management1
 !
 logging console informational
 logging monitor debugging
+logging facility syslog
 ```
 
 # Internal VLAN Allocation Policy

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/logging-minimal.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/logging-minimal.md
@@ -58,6 +58,8 @@ interface Management1
 | Console | informational |
 | Monitor | debugging |
 
+**Syslog facility value:** syslog
+
 ### Logging Servers and Features Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/logging-minimal.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/logging-minimal.cfg
@@ -4,6 +4,7 @@ transceiver qsfp default-mode 4x10G
 !
 logging console informational
 logging monitor debugging
+logging facility syslog
 !
 hostname logging-minimal
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/logging-minimal.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/logging-minimal.yml
@@ -2,3 +2,4 @@
 logging:
   console: informational
   monitor: debugging
+  facility: syslog

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -2024,6 +2024,7 @@ logging:
     timestamp: < high-resolution | traditional >
     hostname: < fqdn | ipv4 >
     sequence_numbers: < true | false >
+  facility: < syslog facility value >
   source_interface: < source_interface_name >
   vrfs:
     < vrf_name >:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -2024,7 +2024,7 @@ logging:
     timestamp: < high-resolution | traditional >
     hostname: < fqdn | ipv4 >
     sequence_numbers: < true | false >
-  facility: < syslog facility value >
+  facility: < syslog_facility_value >
   source_interface: < source_interface_name >
   vrfs:
     < vrf_name >:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/logging.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/logging.j2
@@ -64,6 +64,10 @@
 {%             endif %}
 {%         endfor %}
 {%     endif %}
+{%     if logging.facility is arista.avd.defined %}
+
+**Syslog facility value:** {{ logging.facility }}
+{%     endif %}
 
 ### Logging Servers and Features Device Configuration
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/logging.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/logging.j2
@@ -42,6 +42,9 @@ logging format hostname ipv4
 {%     if logging.format.sequence_numbers is arista.avd.defined(true) %}
 logging format sequence-numbers
 {%     endif %}
+{%     if logging.facility is arista.avd.defined %}
+logging facility {{ logging.facility }}
+{%     endif %}
 {%     if logging.source_interface is arista.avd.defined %}
 logging source-interface {{ logging.source_interface }}
 {%     endif %}


### PR DESCRIPTION
## Change Summary

Add support to define logging facility

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

```yaml
logging:
  facility: < syslog_facility_value >
```

## How to test

See Molecule test case.

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
