### PR TITLE
Fix(eos_designs): Documentation CSVs column headings

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/fabric/DC1_FABRIC-p2p-links.csv
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/fabric/DC1_FABRIC-p2p-links.csv
@@ -1,4 +1,4 @@
-Type, Node,Node Interface,Leaf IP Address,Peer Type,Peer Node,Peer Interface,Peer IP Address
+Type,Node,Node Interface,Leaf IP Address,Peer Type,Peer Node,Peer Interface,Peer IP Address
 l3leaf,DC1-BL1A,Ethernet1,172.31.255.41/31,spine,DC1-SPINE1,Ethernet6,172.31.255.40/31
 l3leaf,DC1-BL1A,Ethernet2,172.31.255.43/31,spine,DC1-SPINE2,Ethernet6,172.31.255.42/31
 l3leaf,DC1-BL1A,Ethernet3,172.31.255.45/31,spine,DC1-SPINE3,Ethernet6,172.31.255.44/31

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/fabric/DC1_FABRIC-topology.csv
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/fabric/DC1_FABRIC-topology.csv
@@ -1,4 +1,4 @@
-Node Type,Node,Node Interface,Peer Type,Peer,Peer Interface
+Node Type,Node,Node Interface,Peer Type,Peer Node,Peer Interface
 l3leaf,DC1-BL1A,Ethernet1,spine,DC1-SPINE1,Ethernet6
 l3leaf,DC1-BL1A,Ethernet2,spine,DC1-SPINE2,Ethernet6
 l3leaf,DC1-BL1A,Ethernet3,spine,DC1-SPINE3,Ethernet6

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/fabric/TWODC_5STAGE_CLOS-p2p-links.csv
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/fabric/TWODC_5STAGE_CLOS-p2p-links.csv
@@ -1,4 +1,4 @@
-Type, Node,Node Interface,Leaf IP Address,Peer Type,Peer Node,Peer Interface,Peer IP Address
+Type,Node,Node Interface,Leaf IP Address,Peer Type,Peer Node,Peer Interface,Peer IP Address
 l3leaf,DC1-POD1-LEAF1A,Ethernet1,172.17.110.1/31,spine,DC1-POD1-SPINE1,Ethernet3,172.17.110.0/31
 l3leaf,DC1-POD1-LEAF1A,Ethernet2,172.17.110.3/31,spine,DC1-POD1-SPINE2,Ethernet3,172.17.110.2/31
 l3leaf,DC1-POD1-LEAF1A,Ethernet4,172.17.10.4/31,overlay-controller,DC1-RS1,Ethernet3,172.17.10.5/31

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/fabric/TWODC_5STAGE_CLOS-topology.csv
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/fabric/TWODC_5STAGE_CLOS-topology.csv
@@ -1,4 +1,4 @@
-Node Type,Node,Node Interface,Peer Type,Peer,Peer Interface
+Node Type,Node,Node Interface,Peer Type,Peer Node,Peer Interface
 l2leaf,DC1-POD1-L2LEAF1A,Ethernet1,l3leaf,DC1-POD1-LEAF1A,Ethernet3
 l2leaf,DC1-POD1-L2LEAF2A,Ethernet1,l3leaf,DC1-POD1-LEAF2A,Ethernet3
 l2leaf,DC1-POD1-L2LEAF2A,Ethernet2,l3leaf,DC1-POD1-LEAF2B,Ethernet3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/fabric/DC1_FABRIC-p2p-links.csv
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/fabric/DC1_FABRIC-p2p-links.csv
@@ -1,4 +1,4 @@
-Type, Node,Node Interface,Leaf IP Address,Peer Type,Peer Node,Peer Interface,Peer IP Address
+Type,Node,Node Interface,Leaf IP Address,Peer Type,Peer Node,Peer Interface,Peer IP Address
 l3leaf,DC1-BL1A,Ethernet1,172.31.255.81/31,spine,DC1-SPINE1,Ethernet6,172.31.255.80/31
 l3leaf,DC1-BL1A,Ethernet2,172.31.255.83/31,spine,DC1-SPINE2,Ethernet6,172.31.255.82/31
 l3leaf,DC1-BL1A,Ethernet3,172.31.255.85/31,spine,DC1-SPINE3,Ethernet6,172.31.255.84/31

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/fabric/DC1_FABRIC-topology.csv
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/fabric/DC1_FABRIC-topology.csv
@@ -1,4 +1,4 @@
-Node Type,Node,Node Interface,Peer Type,Peer,Peer Interface
+Node Type,Node,Node Interface,Peer Type,Peer Node,Peer Interface
 l3leaf,DC1-BL1A,Ethernet1,spine,DC1-SPINE1,Ethernet6
 l3leaf,DC1-BL1A,Ethernet2,spine,DC1-SPINE2,Ethernet6
 l3leaf,DC1-BL1A,Ethernet3,spine,DC1-SPINE3,Ethernet6

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/fabric/DC1_FABRIC-p2p-links.csv
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/fabric/DC1_FABRIC-p2p-links.csv
@@ -1,4 +1,4 @@
-Type, Node,Node Interface,Leaf IP Address,Peer Type,Peer Node,Peer Interface,Peer IP Address
+Type,Node,Node Interface,Leaf IP Address,Peer Type,Peer Node,Peer Interface,Peer IP Address
 l3leaf,DC1-BL1A,Ethernet41,172.31.255.81/31,spine,DC1-SPINE1,Ethernet6,172.31.255.80/31
 l3leaf,DC1-BL1A,Ethernet42,172.31.255.83/31,spine,DC1-SPINE2,Ethernet6,172.31.255.82/31
 l3leaf,DC1-BL1A,Ethernet43,172.31.255.85/31,spine,DC1-SPINE3,Ethernet6,172.31.255.84/31

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/fabric/DC1_FABRIC-topology.csv
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/fabric/DC1_FABRIC-topology.csv
@@ -1,4 +1,4 @@
-Node Type,Node,Node Interface,Peer Type,Peer,Peer Interface
+Node Type,Node,Node Interface,Peer Type,Peer Node,Peer Interface
 l3leaf,DC1-BL1A,Ethernet7,l3_interface,,
 l3leaf,DC1-BL1A,Ethernet8,l3_interface,,
 l3leaf,DC1-BL1A,Ethernet9,l3_interface,,

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/fabric/DC1_FABRIC-p2p-links.csv
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/fabric/DC1_FABRIC-p2p-links.csv
@@ -1,4 +1,4 @@
-Type, Node,Node Interface,Leaf IP Address,Peer Type,Peer Node,Peer Interface,Peer IP Address
+Type,Node,Node Interface,Leaf IP Address,Peer Type,Peer Node,Peer Interface,Peer IP Address
 l3leaf,DC1-BL1A,Ethernet1,172.31.255.41/31,spine,DC1-SPINE1,Ethernet6,172.31.255.40/31
 l3leaf,DC1-BL1A,Ethernet2,172.31.255.43/31,spine,DC1-SPINE2,Ethernet6,172.31.255.42/31
 l3leaf,DC1-BL1A,Ethernet3,172.31.255.45/31,spine,DC1-SPINE3,Ethernet6,172.31.255.44/31

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/fabric/DC1_FABRIC-topology.csv
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/fabric/DC1_FABRIC-topology.csv
@@ -1,4 +1,4 @@
-Node Type,Node,Node Interface,Peer Type,Peer,Peer Interface
+Node Type,Node,Node Interface,Peer Type,Peer Node,Peer Interface
 l3leaf,DC1-BL1A,Ethernet1,spine,DC1-SPINE1,Ethernet6
 l3leaf,DC1-BL1A,Ethernet2,spine,DC1-SPINE2,Ethernet6
 l3leaf,DC1-BL1A,Ethernet3,spine,DC1-SPINE3,Ethernet6

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/fabric/DC1_FABRIC-p2p-links.csv
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/fabric/DC1_FABRIC-p2p-links.csv
@@ -1,4 +1,4 @@
-Type, Node,Node Interface,Leaf IP Address,Peer Type,Peer Node,Peer Interface,Peer IP Address
+Type,Node,Node Interface,Leaf IP Address,Peer Type,Peer Node,Peer Interface,Peer IP Address
 l3leaf,DC1-BL1A,Ethernet1,172.31.255.41/31,spine,DC1-SPINE1,Ethernet6,172.31.255.40/31
 l3leaf,DC1-BL1A,Ethernet2,172.31.255.43/31,spine,DC1-SPINE2,Ethernet6,172.31.255.42/31
 l3leaf,DC1-BL1A,Ethernet3,172.31.255.45/31,spine,DC1-SPINE3,Ethernet6,172.31.255.44/31

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/fabric/DC1_FABRIC-topology.csv
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/fabric/DC1_FABRIC-topology.csv
@@ -1,4 +1,4 @@
-Node Type,Node,Node Interface,Peer Type,Peer,Peer Interface
+Node Type,Node,Node Interface,Peer Type,Peer Node,Peer Interface
 l3leaf,DC1-BL1A,Ethernet1,spine,DC1-SPINE1,Ethernet6
 l3leaf,DC1-BL1A,Ethernet2,spine,DC1-SPINE2,Ethernet6
 l3leaf,DC1-BL1A,Ethernet3,spine,DC1-SPINE3,Ethernet6

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/fabric/DC1_FABRIC-p2p-links.csv
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/fabric/DC1_FABRIC-p2p-links.csv
@@ -1,4 +1,4 @@
-Type, Node,Node Interface,Leaf IP Address,Peer Type,Peer Node,Peer Interface,Peer IP Address
+Type,Node,Node Interface,Leaf IP Address,Peer Type,Peer Node,Peer Interface,Peer IP Address
 l3leaf,DC1-BL1A,Ethernet1,,spine,DC1-SPINE1,Ethernet6,
 l3leaf,DC1-BL1A,Ethernet2,,spine,DC1-SPINE2,Ethernet6,
 l3leaf,DC1-BL1A,Ethernet3,,spine,DC1-SPINE3,Ethernet6,

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/fabric/DC1_FABRIC-topology.csv
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/fabric/DC1_FABRIC-topology.csv
@@ -1,4 +1,4 @@
-Node Type,Node,Node Interface,Peer Type,Peer,Peer Interface
+Node Type,Node,Node Interface,Peer Type,Peer Node,Peer Interface
 l3leaf,DC1-BL1A,Ethernet1,spine,DC1-SPINE1,Ethernet6
 l3leaf,DC1-BL1A,Ethernet2,spine,DC1-SPINE2,Ethernet6
 l3leaf,DC1-BL1A,Ethernet3,spine,DC1-SPINE3,Ethernet6

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/fabric/TWODC_5STAGE_CLOS-p2p-links.csv
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/fabric/TWODC_5STAGE_CLOS-p2p-links.csv
@@ -1,4 +1,4 @@
-Type, Node,Node Interface,Leaf IP Address,Peer Type,Peer Node,Peer Interface,Peer IP Address
+Type,Node,Node Interface,Leaf IP Address,Peer Type,Peer Node,Peer Interface,Peer IP Address
 l3leaf,DC1-POD1-LEAF1A,Ethernet1,172.17.110.1/31,spine,DC1-POD1-SPINE1,Ethernet3,172.17.110.0/31
 l3leaf,DC1-POD1-LEAF1A,Ethernet2,172.17.110.3/31,spine,DC1-POD1-SPINE2,Ethernet3,172.17.110.2/31
 l3leaf,DC1-POD1-LEAF1A,Ethernet4,172.17.10.4/31,overlay-controller,DC1-RS1,Ethernet3,172.17.10.5/31

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/fabric/TWODC_5STAGE_CLOS-topology.csv
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/fabric/TWODC_5STAGE_CLOS-topology.csv
@@ -1,4 +1,4 @@
-Node Type,Node,Node Interface,Peer Type,Peer,Peer Interface
+Node Type,Node,Node Interface,Peer Type,Peer Node,Peer Interface
 l2leaf,DC1-POD1-L2LEAF1A,Ethernet1,l3leaf,DC1-POD1-LEAF1A,Ethernet3
 l2leaf,DC1-POD1-L2LEAF2A,Ethernet1,l3leaf,DC1-POD1-LEAF2A,Ethernet3
 l2leaf,DC1-POD1-L2LEAF2A,Ethernet2,l3leaf,DC1-POD1-LEAF2B,Ethernet3

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/fabric/DC1_FABRIC-p2p-links.csv
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/fabric/DC1_FABRIC-p2p-links.csv
@@ -1,4 +1,4 @@
-Type, Node,Node Interface,Leaf IP Address,Peer Type,Peer Node,Peer Interface,Peer IP Address
+Type,Node,Node Interface,Leaf IP Address,Peer Type,Peer Node,Peer Interface,Peer IP Address
 l3leaf,DC1-BL1A,Ethernet41,172.31.255.81/31,spine,DC1-SPINE1,Ethernet6,172.31.255.80/31
 l3leaf,DC1-BL1A,Ethernet42,172.31.255.83/31,spine,DC1-SPINE2,Ethernet6,172.31.255.82/31
 l3leaf,DC1-BL1A,Ethernet43,172.31.255.85/31,spine,DC1-SPINE3,Ethernet6,172.31.255.84/31

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/fabric/DC1_FABRIC-topology.csv
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/fabric/DC1_FABRIC-topology.csv
@@ -1,4 +1,4 @@
-Node Type,Node,Node Interface,Peer Type,Peer,Peer Interface
+Node Type,Node,Node Interface,Peer Type,Peer Node,Peer Interface
 l3leaf,DC1-BL1A,Ethernet7,l3_interface,,
 l3leaf,DC1-BL1A,Ethernet8,l3_interface,,
 l3leaf,DC1-BL1A,Ethernet9,l3_interface,,

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/fabric/DC1_FABRIC-p2p-links.csv
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/fabric/DC1_FABRIC-p2p-links.csv
@@ -1,4 +1,4 @@
-Type, Node,Node Interface,Leaf IP Address,Peer Type,Peer Node,Peer Interface,Peer IP Address
+Type,Node,Node Interface,Leaf IP Address,Peer Type,Peer Node,Peer Interface,Peer IP Address
 l3leaf,DC1-BL1A,Ethernet1,172.31.255.41/31,spine,DC1-SPINE1,Ethernet6,172.31.255.40/31
 l3leaf,DC1-BL1A,Ethernet2,172.31.255.43/31,spine,DC1-SPINE2,Ethernet6,172.31.255.42/31
 l3leaf,DC1-BL1A,Ethernet3,172.31.255.45/31,spine,DC1-SPINE3,Ethernet6,172.31.255.44/31

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/fabric/DC1_FABRIC-topology.csv
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp/documentation/fabric/DC1_FABRIC-topology.csv
@@ -1,4 +1,4 @@
-Node Type,Node,Node Interface,Peer Type,Peer,Peer Interface
+Node Type,Node,Node Interface,Peer Type,Peer Node,Peer Interface
 l3leaf,DC1-BL1A,Ethernet1,spine,DC1-SPINE1,Ethernet6
 l3leaf,DC1-BL1A,Ethernet2,spine,DC1-SPINE2,Ethernet6
 l3leaf,DC1-BL1A,Ethernet3,spine,DC1-SPINE3,Ethernet6

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/fabric/DC1_FABRIC-p2p-links.csv
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/fabric/DC1_FABRIC-p2p-links.csv
@@ -1,4 +1,4 @@
-Type, Node,Node Interface,Leaf IP Address,Peer Type,Peer Node,Peer Interface,Peer IP Address
+Type,Node,Node Interface,Leaf IP Address,Peer Type,Peer Node,Peer Interface,Peer IP Address
 l3leaf,DC1-BL1A,Ethernet1,172.31.255.41/31,spine,DC1-SPINE1,Ethernet6,172.31.255.40/31
 l3leaf,DC1-BL1A,Ethernet2,172.31.255.43/31,spine,DC1-SPINE2,Ethernet6,172.31.255.42/31
 l3leaf,DC1-BL1A,Ethernet3,172.31.255.45/31,spine,DC1-SPINE3,Ethernet6,172.31.255.44/31

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/fabric/DC1_FABRIC-topology.csv
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp/documentation/fabric/DC1_FABRIC-topology.csv
@@ -1,4 +1,4 @@
-Node Type,Node,Node Interface,Peer Type,Peer,Peer Interface
+Node Type,Node,Node Interface,Peer Type,Peer Node,Peer Interface
 l3leaf,DC1-BL1A,Ethernet1,spine,DC1-SPINE1,Ethernet6
 l3leaf,DC1-BL1A,Ethernet2,spine,DC1-SPINE2,Ethernet6
 l3leaf,DC1-BL1A,Ethernet3,spine,DC1-SPINE3,Ethernet6

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/fabric/DC1_FABRIC-p2p-links.csv
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/fabric/DC1_FABRIC-p2p-links.csv
@@ -1,4 +1,4 @@
-Type, Node,Node Interface,Leaf IP Address,Peer Type,Peer Node,Peer Interface,Peer IP Address
+Type,Node,Node Interface,Leaf IP Address,Peer Type,Peer Node,Peer Interface,Peer IP Address
 l3leaf,DC1-BL1A,Ethernet1,,spine,DC1-SPINE1,Ethernet6,
 l3leaf,DC1-BL1A,Ethernet2,,spine,DC1-SPINE2,Ethernet6,
 l3leaf,DC1-BL1A,Ethernet3,,spine,DC1-SPINE3,Ethernet6,

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/fabric/DC1_FABRIC-topology.csv
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/fabric/DC1_FABRIC-topology.csv
@@ -1,4 +1,4 @@
-Node Type,Node,Node Interface,Peer Type,Peer,Peer Interface
+Node Type,Node,Node Interface,Peer Type,Peer Node,Peer Interface
 l3leaf,DC1-BL1A,Ethernet1,spine,DC1-SPINE1,Ethernet6
 l3leaf,DC1-BL1A,Ethernet2,spine,DC1-SPINE2,Ethernet6
 l3leaf,DC1-BL1A,Ethernet3,spine,DC1-SPINE3,Ethernet6

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/documentation/fabric-p2p-links.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/documentation/fabric-p2p-links.j2
@@ -1,4 +1,4 @@
-Type, Node,Node Interface,Leaf IP Address,Peer Type,Peer Node,Peer Interface,Peer IP Address
+Type,Node,Node Interface,Leaf IP Address,Peer Type,Peer Node,Peer Interface,Peer IP Address
 {% set interfaces_done = [] %}
 {% for node in groups[fabric_name] | arista.avd.natural_sort %}
 {%     set node_hostvars = hostvars[node] %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/documentation/fabric-topology.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/documentation/fabric-topology.j2
@@ -1,4 +1,4 @@
-Node Type,Node,Node Interface,Peer Type,Peer,Peer Interface
+Node Type,Node,Node Interface,Peer Type,Peer Node,Peer Interface
 {% for node in groups[fabric_name] | arista.avd.natural_sort %}
 {%     set node_hostvars = hostvars[node] %}
 {%     if node_hostvars.type | arista.avd.default('undefined') in node_type_keys | dict2items | map(attribute='value.type') | list %}


### PR DESCRIPTION
## Change Summary

- Remove space in p2p-links.csv
- Update topology.csv heading `Peer` -> `Peer Node` to match p2p-links.csv

## Component(s) name

`arista.avd.designs`

## How to test

See Molecule Results

## Checklist

### User Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
