### PR TITLE
Doc(eos_cli_config_gen): Add information about gnmi provider configured with octa

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1677,6 +1677,9 @@ management_api_gnmi:
   octa:
 ```
 
+!!! info "gNMI provider"
+    Octa activates `eos-native` provider and it is the only provider currently supported by EOS.
+
 #### Management Console
 
 ```yaml


### PR DESCRIPTION
## Change Summary

Today `eos_cli_config_gen` uses `octa` as knob to configure EOS with `eos-native` gNMI provider. This PR tends to make it clear for the user with an admonition. 

## Related Issue(s)

None / Internally reported by a customer

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Extend documentation to state OCTA will generate eos-native gnmi provider

## How to test

```bash
make start
open http://127.0.0.1:800
```

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
