### PR TITLE
Feat(eos_cli_config_gen): Add fast-failover and router-id support under router general

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-general.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-general.md
@@ -85,11 +85,21 @@ interface Management1
 
 ## Router General
 
+- Global IPv4 Router ID: 10.1.2.3
+
+- Global IPv6 Router ID: 2001:beef:cafe::1
+
+- Nexthop fast fail-over is enabled.
+
 ### Router General configuration
 
 ```eos
 !
 router general
+   router-id ipv4 10.1.2.3
+   router-id ipv6 2001:beef:cafe::1
+   hardware next-hop fast-failover
+   !
    vrf BLUE-C2
       leak routes source-vrf BLUE-C1 subscribe-policy RM-BLUE-LEAKING
       leak routes source-vrf BLUE-C3 subscribe-policy RM-BLUE-LEAKING

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-general.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-general.cfg
@@ -13,6 +13,10 @@ interface Management1
    ip address 10.73.255.122/24
 !
 router general
+   router-id ipv4 10.1.2.3
+   router-id ipv6 2001:beef:cafe::1
+   hardware next-hop fast-failover
+   !
    vrf BLUE-C2
       leak routes source-vrf BLUE-C1 subscribe-policy RM-BLUE-LEAKING
       leak routes source-vrf BLUE-C3 subscribe-policy RM-BLUE-LEAKING

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-general.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-general.yml
@@ -1,4 +1,8 @@
 router_general:
+  router_id:
+    ipv4: 10.1.2.3
+    ipv6: 2001:beef:cafe::1
+  nexthop_fast_failover: true
   vrfs:
     BLUE-C2:
       leak_routes:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-general.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-general.j2
@@ -1,18 +1,17 @@
 {% if router_general is arista.avd.defined %}
 
 ## Router General
-
 {%     if router_general.router_id.ipv4 is arista.avd.defined %}
-- Global IPv4 Router ID: {{ router_general.router_id.ipv4 }}
 
+- Global IPv4 Router ID: {{ router_general.router_id.ipv4 }}
 {%     endif %}
 {%     if router_general.router_id.ipv6 is arista.avd.defined %}
-- Global IPv6 Router ID: {{ router_general.router_id.ipv6 }}
 
+- Global IPv6 Router ID: {{ router_general.router_id.ipv6 }}
 {%     endif %}
 {%     if router_general.nexthop_fast_failover is arista.avd.defined(true) %}
-- Nexthop fast fail-over is enabled.
 
+- Nexthop fast fail-over is enabled.
 {%     endif %}
 {%     set has = namespace() %}
 {%     set has.found = false %}
@@ -24,6 +23,7 @@
 {%         endfor %}
 {%     endif %}
 {%     if has.found is arista.avd.defined(true) %}
+
 ### VRF Route leaking
 
 | VRF | Source VRF | Route Map Policy |
@@ -35,8 +35,8 @@
 {%                 endif %}
 {%             endfor %}
 {%         endfor %}
-
 {%     endif %}
+
 ### Router General configuration
 
 ```eos

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-general.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-general.j2
@@ -2,6 +2,18 @@
 
 ## Router General
 
+{%     if router_general.router_id.ipv4 is arista.avd.defined %}
+- Global IPv4 Router ID: {{ router_general.router_id.ipv4 }}
+
+{%     endif %}
+{%     if router_general.router_id.ipv6 is arista.avd.defined %}
+- Global IPv6 Router ID: {{ router_general.router_id.ipv6 }}
+
+{%     endif %}
+{%     if router_general.nexthop_fast_failover is arista.avd.defined(true) %}
+- Nexthop fast fail-over is enabled.
+
+{%     endif %}
 {%     set has = namespace() %}
 {%     set has.found = false %}
 {%     if router_general.vrfs is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-general.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-general.j2
@@ -2,6 +2,22 @@
 {% if router_general is arista.avd.defined %}
 !
 router general
+{%     set delimiter = false %}
+{%     if router_general.router_id.ipv4 is arista.avd.defined %}
+   router-id ipv4 {{ router_general.router_id.ipv4 }}
+{%         set delimiter = true %}
+{%     endif %}
+{%     if router_general.router_id.ipv6 is arista.avd.defined %}
+   router-id ipv6 {{ router_general.router_id.ipv6 }}
+{%         set delimiter = true %}
+{%     endif %}
+{%     if router_general.nexthop_fast_failover is arista.avd.defined(true) %}
+   hardware next-hop fast-failover
+{%         set delimiter = true %}
+{%     endif %}
+{%     if delimiter is arista.avd.defined(true) and router_general.vrfs is arista.avd.defined %}
+   !
+{%     endif %}
 {%     for vrf in router_general.vrfs | arista.avd.natural_sort %}
    vrf {{ vrf }}
 {%         for leak_route in router_general.vrfs[vrf].leak_routes | arista.avd.natural_sort %}


### PR DESCRIPTION
## Change Summary

Add knobs for router-id and next-hop fast-failover under router general context

## Related Issue(s)

N/A

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

### Data format
```yaml
router_general:
  router_id:
    ipv4: < ipv4 address >
    ipv6: < ipv6 address >
  nexthop_fast_failover: < true | false >
```

Example running-config section
```
!
router general
   router-id ipv4 10.1.2.3
   router-id ipv6 2001:beef:cafe::1
   hardware next-hop fast-failover
   !
!
```

## How to test
molecule test --scenario-name eos_cli_config_gen

## Checklist

### User Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
