### PR TITLE
Feat(eos_designs): Add L2 subinterface support on port-channels under Connected-endpoints

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/MH-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/MH-LEAF1A.md
@@ -304,6 +304,11 @@ interface Ethernet10
    description server01_ES1_Eth1
    no shutdown
    channel-group 10 mode active
+!
+interface Ethernet11
+   description ROUTER02_WITH_SUBIF_Eth1
+   no shutdown
+   channel-group 11 mode active
 ```
 
 ## Port-Channel Interfaces
@@ -315,6 +320,13 @@ interface Ethernet10
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
 | Port-Channel10 | server01_ES1_PortChanne1 | switched | access | 310 | - | - | - | - | - | 0000:0000:0001:1010:1010 |
+
+#### Flexible Encapsulation Interfaces
+
+| Interface | Description | Type | Vlan ID | Client Unmatched | Client Dot1q VLAN | Client Dot1q Outer Tag | Client Dot1q Inner Tag | Network Retain Client Encapsulation | Network Dot1q VLAN | Network Dot1q Outer Tag | Network Dot1q Inner Tag |
+| --------- | ----------- | ---- | ------- | -----------------| ----------------- | ---------------------- | ---------------------- | ----------------------------------- | ------------------ | ----------------------- | ----------------------- |
+| Port-Channel11.101 | - | l2dot1q | 101 | False | 101 | - | - | True | - | - | - |
+| Port-Channel11.102 | - | l2dot1q | 1102 | False | 2102 | - | - | True | - | - | - |
 
 #### Link Tracking Groups
 
@@ -336,6 +348,27 @@ interface Port-Channel10
       route-target import 00:01:10:10:10:10
    lacp system-id 0001.1010.1010
    link tracking group LT_GROUP1 downstream
+!
+interface Port-Channel11
+   description ROUTER02_WITH_SUBIF_
+   no shutdown
+   no switchport
+!
+interface Port-Channel11.101
+   vlan id 101
+   encapsulation vlan
+      client dot1q 101 network client
+   evpn ethernet-segment
+      identifier 0000:0000:0000:0000:0101
+      route-target import 00:00:00:00:01:01
+!
+interface Port-Channel11.102
+   vlan id 1102
+   encapsulation vlan
+      client dot1q 2102 network client
+   evpn ethernet-segment
+      identifier 0000:0000:0000:0000:0102
+      route-target import 00:00:00:00:01:02
 ```
 
 ## Loopback Interfaces

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/MH-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/MH-LEAF1A.md
@@ -350,7 +350,7 @@ interface Port-Channel10
    link tracking group LT_GROUP1 downstream
 !
 interface Port-Channel11
-   description ROUTER02_WITH_SUBIF_
+   description ROUTER02_WITH_SUBIF_Testing L2 subinterfaces
    no shutdown
    no switchport
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/MH-LEAF1B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/MH-LEAF1B.md
@@ -304,6 +304,11 @@ interface Ethernet10
    description server01_ES1_Eth2
    no shutdown
    channel-group 10 mode active
+!
+interface Ethernet11
+   description ROUTER02_WITH_SUBIF_Eth2
+   no shutdown
+   channel-group 11 mode active
 ```
 
 ## Port-Channel Interfaces
@@ -315,6 +320,13 @@ interface Ethernet10
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
 | Port-Channel10 | server01_ES1_PortChanne1 | switched | access | 310 | - | - | - | - | - | 0000:0000:0001:1010:1010 |
+
+#### Flexible Encapsulation Interfaces
+
+| Interface | Description | Type | Vlan ID | Client Unmatched | Client Dot1q VLAN | Client Dot1q Outer Tag | Client Dot1q Inner Tag | Network Retain Client Encapsulation | Network Dot1q VLAN | Network Dot1q Outer Tag | Network Dot1q Inner Tag |
+| --------- | ----------- | ---- | ------- | -----------------| ----------------- | ---------------------- | ---------------------- | ----------------------------------- | ------------------ | ----------------------- | ----------------------- |
+| Port-Channel11.101 | - | l2dot1q | 101 | False | 101 | - | - | True | - | - | - |
+| Port-Channel11.102 | - | l2dot1q | 1102 | False | 2102 | - | - | True | - | - | - |
 
 #### Link Tracking Groups
 
@@ -336,6 +348,27 @@ interface Port-Channel10
       route-target import 00:01:10:10:10:10
    lacp system-id 0001.1010.1010
    link tracking group LT_GROUP1 downstream
+!
+interface Port-Channel11
+   description ROUTER02_WITH_SUBIF_
+   no shutdown
+   no switchport
+!
+interface Port-Channel11.101
+   vlan id 101
+   encapsulation vlan
+      client dot1q 101 network client
+   evpn ethernet-segment
+      identifier 0000:0000:0000:0000:0101
+      route-target import 00:00:00:00:01:01
+!
+interface Port-Channel11.102
+   vlan id 1102
+   encapsulation vlan
+      client dot1q 2102 network client
+   evpn ethernet-segment
+      identifier 0000:0000:0000:0000:0102
+      route-target import 00:00:00:00:01:02
 ```
 
 ## Loopback Interfaces

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/MH-LEAF1B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/MH-LEAF1B.md
@@ -350,7 +350,7 @@ interface Port-Channel10
    link tracking group LT_GROUP1 downstream
 !
 interface Port-Channel11
-   description ROUTER02_WITH_SUBIF_
+   description ROUTER02_WITH_SUBIF_Testing L2 subinterfaces
    no shutdown
    no switchport
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/fabric/DC1_FABRIC-topology.csv
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/fabric/DC1_FABRIC-topology.csv
@@ -159,8 +159,10 @@ l2leaf,MH-L2LEAF1A,Ethernet1,l3leaf,MH-LEAF2A,Ethernet2
 l2leaf,MH-L2LEAF1A,Ethernet10,server,server02,Eth1
 l3leaf,MH-LEAF1A,Ethernet1,spine,DC1-SPINE1,Ethernet10
 l3leaf,MH-LEAF1A,Ethernet10,server,server01_ES1,Eth1
+l3leaf,MH-LEAF1A,Ethernet11,router,ROUTER02_WITH_SUBIF,Eth1
 l3leaf,MH-LEAF1B,Ethernet1,spine,DC1-SPINE1,Ethernet11
 l3leaf,MH-LEAF1B,Ethernet10,server,server01_ES1,Eth2
+l3leaf,MH-LEAF1B,Ethernet11,router,ROUTER02_WITH_SUBIF,Eth2
 l3leaf,MH-LEAF2A,Ethernet1,spine,DC1-SPINE1,Ethernet12
 l3leaf,MH-LEAF2A,Ethernet2,l2leaf,MH-L2LEAF1A,Ethernet1
 l3leaf,MH-LEAF2A,Ethernet10,router,ROUTER01,Eth1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MH-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MH-LEAF1A.cfg
@@ -50,6 +50,27 @@ interface Port-Channel10
    lacp system-id 0001.1010.1010
    link tracking group LT_GROUP1 downstream
 !
+interface Port-Channel11
+   description ROUTER02_WITH_SUBIF_
+   no shutdown
+   no switchport
+!
+interface Port-Channel11.101
+   vlan id 101
+   encapsulation vlan
+      client dot1q 101 network client
+   evpn ethernet-segment
+      identifier 0000:0000:0000:0000:0101
+      route-target import 00:00:00:00:01:01
+!
+interface Port-Channel11.102
+   vlan id 1102
+   encapsulation vlan
+      client dot1q 2102 network client
+   evpn ethernet-segment
+      identifier 0000:0000:0000:0000:0102
+      route-target import 00:00:00:00:01:02
+!
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet10
    no shutdown
@@ -62,6 +83,11 @@ interface Ethernet10
    description server01_ES1_Eth1
    no shutdown
    channel-group 10 mode active
+!
+interface Ethernet11
+   description ROUTER02_WITH_SUBIF_Eth1
+   no shutdown
+   channel-group 11 mode active
 !
 interface Loopback0
    description EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MH-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MH-LEAF1A.cfg
@@ -51,7 +51,7 @@ interface Port-Channel10
    link tracking group LT_GROUP1 downstream
 !
 interface Port-Channel11
-   description ROUTER02_WITH_SUBIF_
+   description ROUTER02_WITH_SUBIF_Testing L2 subinterfaces
    no shutdown
    no switchport
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MH-LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MH-LEAF1B.cfg
@@ -51,7 +51,7 @@ interface Port-Channel10
    link tracking group LT_GROUP1 downstream
 !
 interface Port-Channel11
-   description ROUTER02_WITH_SUBIF_
+   description ROUTER02_WITH_SUBIF_Testing L2 subinterfaces
    no shutdown
    no switchport
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MH-LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MH-LEAF1B.cfg
@@ -50,6 +50,27 @@ interface Port-Channel10
    lacp system-id 0001.1010.1010
    link tracking group LT_GROUP1 downstream
 !
+interface Port-Channel11
+   description ROUTER02_WITH_SUBIF_
+   no shutdown
+   no switchport
+!
+interface Port-Channel11.101
+   vlan id 101
+   encapsulation vlan
+      client dot1q 101 network client
+   evpn ethernet-segment
+      identifier 0000:0000:0000:0000:0101
+      route-target import 00:00:00:00:01:01
+!
+interface Port-Channel11.102
+   vlan id 1102
+   encapsulation vlan
+      client dot1q 2102 network client
+   evpn ethernet-segment
+      identifier 0000:0000:0000:0000:0102
+      route-target import 00:00:00:00:01:02
+!
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet11
    no shutdown
@@ -62,6 +83,11 @@ interface Ethernet10
    description server01_ES1_Eth2
    no shutdown
    channel-group 10 mode active
+!
+interface Ethernet11
+   description ROUTER02_WITH_SUBIF_Eth2
+   no shutdown
+   channel-group 11 mode active
 !
 interface Loopback0
    description EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
@@ -472,18 +472,18 @@ port_channel_interfaces:
     description: server01_MTU_ADAPTOR_MLAG_PortChanne1
     type: switched
     shutdown: false
-    mtu: 1601
     spanning_tree_bpdufilter: true
     spanning_tree_bpduguard: true
+    mtu: 1601
   Port-Channel11:
     description: server01_MTU_PROFILE_MLAG_PortChanne1
     type: switched
     shutdown: false
     mode: access
-    mtu: 1600
     vlans: 110
     spanning_tree_bpdufilter: enabled
     spanning_tree_bpduguard: enabled
+    mtu: 1600
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
@@ -472,18 +472,18 @@ port_channel_interfaces:
     description: server01_MTU_ADAPTOR_MLAG_PortChanne1
     type: switched
     shutdown: false
-    mtu: 1601
     spanning_tree_bpdufilter: true
     spanning_tree_bpduguard: true
+    mtu: 1601
   Port-Channel11:
     description: server01_MTU_PROFILE_MLAG_PortChanne1
     type: switched
     shutdown: false
     mode: access
-    mtu: 1600
     vlans: 110
     spanning_tree_bpdufilter: enabled
     spanning_tree_bpduguard: enabled
+    mtu: 1600
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1A.yml
@@ -228,7 +228,7 @@ vxlan_interface:
         Tenant_X_OP_Zone: {}
 port_channel_interfaces:
   Port-Channel11:
-    description: ROUTER02_WITH_SUBIF_
+    description: ROUTER02_WITH_SUBIF_Testing L2 subinterfaces
     type: routed
     shutdown: false
   Port-Channel11.101:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1A.yml
@@ -233,7 +233,6 @@ port_channel_interfaces:
     shutdown: false
   Port-Channel11.101:
     type: l2dot1q
-    mode: flexencap
     esi: 0000:0000:0000:0000:0101
     rt: 00:00:00:00:01:01
     vlan_id: 101
@@ -245,7 +244,6 @@ port_channel_interfaces:
         client: true
   Port-Channel11.102:
     type: l2dot1q
-    mode: flexencap
     esi: 0000:0000:0000:0000:0102
     rt: 00:00:00:00:01:02
     vlan_id: 1102

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1A.yml
@@ -141,6 +141,16 @@ ethernet_interfaces:
     link_tracking_groups:
     - name: LT_GROUP1
       direction: upstream
+  Ethernet11:
+    peer: ROUTER02_WITH_SUBIF
+    peer_interface: Eth1
+    peer_type: router
+    description: ROUTER02_WITH_SUBIF_Eth1
+    type: switched
+    shutdown: false
+    channel_group:
+      id: 11
+      mode: active
   Ethernet10:
     peer: server01_ES1
     peer_interface: Eth1
@@ -217,6 +227,34 @@ vxlan_interface:
       vrfs:
         Tenant_X_OP_Zone: {}
 port_channel_interfaces:
+  Port-Channel11:
+    description: ROUTER02_WITH_SUBIF_
+    type: routed
+    shutdown: false
+  Port-Channel11.101:
+    type: l2dot1q
+    mode: flexencap
+    esi: 0000:0000:0000:0000:0101
+    rt: 00:00:00:00:01:01
+    vlan_id: 101
+    encapsulation_vlan:
+      client:
+        dot1q:
+          vlan: 101
+      network:
+        client: true
+  Port-Channel11.102:
+    type: l2dot1q
+    mode: flexencap
+    esi: 0000:0000:0000:0000:0102
+    rt: 00:00:00:00:01:02
+    vlan_id: 1102
+    encapsulation_vlan:
+      client:
+        dot1q:
+          vlan: 2102
+      network:
+        client: true
   Port-Channel10:
     description: server01_ES1_PortChanne1
     type: switched

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1B.yml
@@ -228,7 +228,7 @@ vxlan_interface:
         Tenant_X_OP_Zone: {}
 port_channel_interfaces:
   Port-Channel11:
-    description: ROUTER02_WITH_SUBIF_
+    description: ROUTER02_WITH_SUBIF_Testing L2 subinterfaces
     type: routed
     shutdown: false
   Port-Channel11.101:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1B.yml
@@ -141,6 +141,16 @@ ethernet_interfaces:
     link_tracking_groups:
     - name: LT_GROUP1
       direction: upstream
+  Ethernet11:
+    peer: ROUTER02_WITH_SUBIF
+    peer_interface: Eth2
+    peer_type: router
+    description: ROUTER02_WITH_SUBIF_Eth2
+    type: switched
+    shutdown: false
+    channel_group:
+      id: 11
+      mode: active
   Ethernet10:
     peer: server01_ES1
     peer_interface: Eth2
@@ -217,6 +227,34 @@ vxlan_interface:
       vrfs:
         Tenant_X_OP_Zone: {}
 port_channel_interfaces:
+  Port-Channel11:
+    description: ROUTER02_WITH_SUBIF_
+    type: routed
+    shutdown: false
+  Port-Channel11.101:
+    type: l2dot1q
+    mode: flexencap
+    esi: 0000:0000:0000:0000:0101
+    rt: 00:00:00:00:01:01
+    vlan_id: 101
+    encapsulation_vlan:
+      client:
+        dot1q:
+          vlan: 101
+      network:
+        client: true
+  Port-Channel11.102:
+    type: l2dot1q
+    mode: flexencap
+    esi: 0000:0000:0000:0000:0102
+    rt: 00:00:00:00:01:02
+    vlan_id: 1102
+    encapsulation_vlan:
+      client:
+        dot1q:
+          vlan: 2102
+      network:
+        client: true
   Port-Channel10:
     description: server01_ES1_PortChanne1
     type: switched

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1B.yml
@@ -233,7 +233,6 @@ port_channel_interfaces:
     shutdown: false
   Port-Channel11.101:
     type: l2dot1q
-    mode: flexencap
     esi: 0000:0000:0000:0000:0101
     rt: 00:00:00:00:01:01
     vlan_id: 101
@@ -245,7 +244,6 @@ port_channel_interfaces:
         client: true
   Port-Channel11.102:
     type: l2dot1q
-    mode: flexencap
     esi: 0000:0000:0000:0000:0102
     rt: 00:00:00:00:01:02
     vlan_id: 1102

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/MH_SERVERS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/MH_SERVERS.yml
@@ -52,6 +52,7 @@ routers:
         switch_ports: [ Ethernet11, Ethernet11 ]
         switches: [ MH-LEAF1A, MH-LEAF1B ]
         port_channel:
+          description: Testing L2 subinterfaces
           mode: active
           # Port-Channel L2 Subinterfaces
           # Subinterfaces are only supported on routed port-channels, which means they cannot be configured on MLAG port-channels.

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/MH_SERVERS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/MH_SERVERS.yml
@@ -45,3 +45,26 @@ routers:
         switch_ports: [ Ethernet10 ]
         switches: [ MH-LEAF2A ]
         profile: Tenant_X_LT
+
+  ROUTER02_WITH_SUBIF:
+    adapters:
+      - endpoint_ports: [ Eth1, Eth2 ]
+        switch_ports: [ Ethernet11, Ethernet11 ]
+        switches: [ MH-LEAF1A, MH-LEAF1B ]
+        port_channel:
+          mode: active
+          # Port-Channel L2 Subinterfaces
+          # Subinterfaces are only supported on routed port-channels, which means they cannot be configured on MLAG port-channels.
+          subinterfaces:
+            - number: 101
+              short_esi: 0000:0000:0101 # Required for multihomed port-channels with subinterfaces
+              #vlan_id: 1101 # default is subinterface number
+              # Flexible encapsulation parameters
+              encapsulation_vlan:
+                #client_dot1q: 2101 # default is subinterface number
+            - number: 102
+              short_esi: 0000:0000:0102 # Required for multihomed port-channels with subinterfaces
+              vlan_id: 1102 # default is subinterface number
+              # Flexible encapsulation parameters
+              encapsulation_vlan:
+                client_dot1q: 2102 # default is subinterface number

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -496,8 +496,8 @@ port_channel_interfaces:
     type: switched
     shutdown: false
     mode: access
-    mtu: 1600
     vlans: 110
+    mtu: 1600
 loopback_interfaces:
   Loopback0:
     description: CUSTOM_EVPN_Overlay_Peering_L3LEAF

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -496,8 +496,8 @@ port_channel_interfaces:
     type: switched
     shutdown: false
     mode: access
-    mtu: 1600
     vlans: 110
+    mtu: 1600
 loopback_interfaces:
   Loopback0:
     description: CUSTOM_EVPN_Overlay_Peering_L3LEAF

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -615,8 +615,8 @@ port_channel_interfaces:
     type: switched
     shutdown: false
     mode: access
-    mtu: 1600
     vlans: 110
+    mtu: 1600
     mlag: 11
 ethernet_interfaces:
   Ethernet5:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -615,8 +615,8 @@ port_channel_interfaces:
     type: switched
     shutdown: false
     mode: access
-    mtu: 1600
     vlans: 110
+    mtu: 1600
     mlag: 11
 ethernet_interfaces:
   Ethernet5:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -492,8 +492,8 @@ port_channel_interfaces:
     type: switched
     shutdown: false
     mode: access
-    mtu: 1600
     vlans: 110
+    mtu: 1600
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -492,8 +492,8 @@ port_channel_interfaces:
     type: switched
     shutdown: false
     mode: access
-    mtu: 1600
     vlans: 110
+    mtu: 1600
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -624,8 +624,8 @@ port_channel_interfaces:
     type: switched
     shutdown: false
     mode: access
-    mtu: 1600
     vlans: 110
+    mtu: 1600
     mlag: 11
 ethernet_interfaces:
   Ethernet5:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -624,8 +624,8 @@ port_channel_interfaces:
     type: switched
     shutdown: false
     mode: access
-    mtu: 1600
     vlans: 110
+    mtu: 1600
     mlag: 11
 ethernet_interfaces:
   Ethernet5:

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/connected-endpoints.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/connected-endpoints.md
@@ -195,6 +195,16 @@ port_profiles:
             mode: < static > Currently only static mode is supported
             timeout: < timeout in seconds > | Optional - default is 90 seconds
 
+          # Port-Channel L2 Subinterfaces
+          # Subinterfaces are only supported on routed port-channels, which means they cannot be configured on MLAG port-channels.
+          subinterfaces:
+          - number: < subinterface number >
+            short_esi: < 0000:0000:0000 > Required for multihomed port-channels with subinterfaces
+            vlan_id: < VLAN ID to bridge > | Optional - default is subinterface number
+            # Flexible encapsulation parameters
+            encapsulation_vlan:
+              client_dot1q: < client vlan id encapsulation > | Optional - default is subinterface number
+
           # EOS CLI rendered directly on the port-channel interface in the final EOS configuration
           raw_eos_cli: |
             < multiline eos cli >

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/port-channel-interfaces.j2
@@ -100,7 +100,6 @@ port_channel_interfaces:
 {%                             if subinterface.number is arista.avd.defined %}
   Port-Channel{{ channel_group_id }}.{{ subinterface.number }}:
     type: l2dot1q
-    mode: flexencap
 {%                                 if subinterface.short_esi is arista.avd.defined %}
 {%                                     if subinterface.short_esi.split(':') | length == 3 %}
     esi: {{ subinterface.short_esi | arista.avd.generate_esi(evpn_short_esi_prefix) }}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/port-channel-interfaces.j2
@@ -20,41 +20,48 @@ port_channel_interfaces:
   Port-Channel{{ channel_group_id }}:
 {%                         set peer = connected_endpoint %}
     description: "{% include switch.interface_descriptions.connected_endpoints_port_channel_interfaces %}"
-    type: switched
+{%                         if adapter_settings.port_channel.subinterfaces is arista.avd.defined %}
+{%                             set po_type = "routed" %}
+{%                         else %}
+{%                             set po_type = "switched" %}
+{%                         endif %}
+    type: {{ po_type }}
 {%                         if adapter_settings.port_channel.enabled is arista.avd.defined(false) %}
     shutdown: true
 {%                         else %}
     shutdown: false
 {%                         endif %}
+{%                         if po_type == "switched" %}
     mode: {{ adapter_settings.mode | arista.avd.default }}
-{%                         if adapter_settings.mtu is arista.avd.defined %}
-    mtu: {{ adapter_settings.mtu }}
-{%                         endif %}
-{%                         if adapter_settings.l2_mtu is arista.avd.defined  %}
+{%                             if adapter_settings.l2_mtu is arista.avd.defined  %}
     l2_mtu: {{ adapter_settings.l2_mtu }}
-{%                         endif %}
+{%                             endif %}
     vlans: {{ adapter_settings.vlans | arista.avd.default }}
-{%                         if adapter_settings.native_vlan is arista.avd.defined %}
+{%                             if adapter_settings.native_vlan is arista.avd.defined %}
     native_vlan: {{ adapter_settings.native_vlan }}
-{%                         endif %}
-{%                         if adapter_settings.spanning_tree_portfast is arista.avd.defined %}
+{%                             endif %}
+{%                             if adapter_settings.spanning_tree_portfast is arista.avd.defined %}
     spanning_tree_portfast: {{ adapter_settings.spanning_tree_portfast }}
-{%                         endif %}
-{%                         if adapter_settings.spanning_tree_bpdufilter is arista.avd.defined %}
+{%                             endif %}
+{%                             if adapter_settings.spanning_tree_bpdufilter is arista.avd.defined %}
     spanning_tree_bpdufilter: {{ adapter_settings.spanning_tree_bpdufilter }}
-{%                         endif %}
-{%                         if adapter_settings.spanning_tree_bpduguard is arista.avd.defined %}
+{%                             endif %}
+{%                             if adapter_settings.spanning_tree_bpduguard is arista.avd.defined %}
     spanning_tree_bpduguard: {{ adapter_settings.spanning_tree_bpduguard }}
-{%                         endif %}
-{%                         if adapter_settings.storm_control is arista.avd.defined and switch.platform_settings.feature_support.interface_storm_control is not arista.avd.defined(false) %}
+{%                             endif %}
+{%                             if adapter_settings.storm_control is arista.avd.defined and switch.platform_settings.feature_support.interface_storm_control is not arista.avd.defined(false) %}
     storm_control:
-{%                             for section in adapter_settings.storm_control %}
+{%                                 for section in adapter_settings.storm_control %}
       {{ section }}:
         level: {{ adapter_settings.storm_control[section].level }}
-{%                                 if adapter_settings.storm_control[section].unit is arista.avd.defined %}
+{%                                     if adapter_settings.storm_control[section].unit is arista.avd.defined %}
         unit: {{ adapter_settings.storm_control[section].unit }}
-{%                                 endif %}
-{%                             endfor %}
+{%                                     endif %}
+{%                                 endfor %}
+{%                             endif %}
+{%                         endif %}
+{%                         if adapter_settings.mtu is arista.avd.defined %}
+    mtu: {{ adapter_settings.mtu }}
 {%                         endif %}
 {%                         if adapter_settings.switches | unique | list | length > 1 %}
 {%                             if adapter.port_channel.short_esi is arista.avd.defined %}
@@ -88,6 +95,27 @@ port_channel_interfaces:
 {%                         if adapter_settings.port_channel.structured_config is arista.avd.defined %}
     struct_cfg: {{ adapter_settings.port_channel.structured_config }}
 {%                         endif %}
+{# Render Port-Channel subinterfaces #}
+{%                         for subinterface in adapter_settings.port_channel.subinterfaces | arista.avd.natural_sort %}
+{%                             if subinterface.number is arista.avd.defined %}
+  Port-Channel{{ channel_group_id }}.{{ subinterface.number }}:
+    type: l2dot1q
+    mode: flexencap
+{%                                 if subinterface.short_esi is arista.avd.defined %}
+{%                                     if subinterface.short_esi.split(':') | length == 3 %}
+    esi: {{ subinterface.short_esi | arista.avd.generate_esi(evpn_short_esi_prefix) }}
+    rt: {{ subinterface.short_esi | arista.avd.generate_route_target }}
+{%                                     endif %}
+{%                                 endif %}
+    vlan_id: {{ subinterface.vlan_id | arista.avd.default(subinterface.number) }}
+    encapsulation_vlan:
+      client:
+        dot1q:
+          vlan: {{ subinterface.client_dot1q | arista.avd.default(subinterface.number) }}
+      network:
+        client: true
+{%                             endif %}
+{%                         endfor %}
 {%                         break %}
 {%                     endif %}
 {%                 endfor %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/port-channel-interfaces.j2
@@ -111,7 +111,7 @@ port_channel_interfaces:
     encapsulation_vlan:
       client:
         dot1q:
-          vlan: {{ subinterface.client_dot1q | arista.avd.default(subinterface.number) }}
+          vlan: {{ subinterface.encapsulation_vlan.client_dot1q | arista.avd.default(subinterface.number) }}
       network:
         client: true
 {%                             endif %}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Add L2 subinterface support on port-channels under Connected-endpoints
## Related Issue(s)

Part of the preparations for MPLS design

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

```jinja
<connected-endpoints-key>:
  <connected-endpoint-name>:
    adapters:
      - port_channel:
          # Port-Channel L2 Subinterfaces
          # Subinterfaces are only supported on routed port-channels, which means they cannot be configured on MLAG port-channels.
          subinterfaces:
          - number: < subinterface number >
            short_esi: < 0000:0000:0000 > Required for multihomed port-channels with subinterfaces
            vlan_id: < VLAN ID to bridge > | Optional - default is subinterface number
            # Flexible encapsulation parameters
            encapsulation_vlan:
              client_dot1q: < client vlan id encapsulation > | Optional - default is subinterface number
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Added molecule
Tested previously by @mpergament as part of the larger MPLS project.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
