### PR TITLE
Feat(eos_cli_config_gen): Support cos in policy-map and service-policy in qos profile

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/policy-maps.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/policy-maps.md
@@ -98,7 +98,7 @@ interface Management1
 **PM_REPLICATION_LD**
 
 | class | Set | Value |
-| ---- | ----- | ----- |
+| ----- | --- | ----- |
 | CM_REPLICATION_LD | drop_precedence | 1 |
 | CM_REPLICATION_LD | dscp | af11 |
 | CM_REPLICATION_LD | traffic_class | 2 |
@@ -108,7 +108,8 @@ interface Management1
 **PM_REPLICATION_LD2**
 
 | class | Set | Value |
-| ---- | ----- | ----- |
+| ----- | --- | ----- |
+| CM_REPLICATION_LD | cos | 4 |
 | CM_REPLICATION_LD | dscp | af11 |
 
 ### QOS Policy Maps configuration
@@ -129,6 +130,7 @@ policy-map type quality-of-service PM_REPLICATION_LD
 policy-map type quality-of-service PM_REPLICATION_LD2
    class CM_REPLICATION_LD
       set dscp af11
+      set cos 4
    !
 !
 policy-map type pbr PM_PBR_BREAKOUT

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/qos.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/qos.md
@@ -223,7 +223,7 @@ QOS Profile: **experiment**
 
 **Settings**
 
-| Default COS | Default DSCP | Trust | Shape Rate | Qos Service Policy |
+| Default COS | Default DSCP | Trust | Shape Rate | QOS Service Policy |
 | ----------- | ------------ | ----- | ---------- | ------------------ |
 | 2 | - | cos | - | test_qos_policy_v1 |
 
@@ -240,7 +240,7 @@ QOS Profile: **no_qos_trust**
 
 **Settings**
 
-| Default COS | Default DSCP | Trust | Shape Rate | Qos Service Policy |
+| Default COS | Default DSCP | Trust | Shape Rate | QOS Service Policy |
 | ----------- | ------------ | ----- | ---------- | ------------------ |
 | 3 | 4 | disabled | - | - |
 
@@ -248,7 +248,7 @@ QOS Profile: **test**
 
 **Settings**
 
-| Default COS | Default DSCP | Trust | Shape Rate | Qos Service Policy |
+| Default COS | Default DSCP | Trust | Shape Rate | QOS Service Policy |
 | ----------- | ------------ | ----- | ---------- | ------------------ |
 | - | 46 | dscp | 80 percent | - |
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/qos.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/qos.md
@@ -223,9 +223,9 @@ QOS Profile: **experiment**
 
 **Settings**
 
-| Default COS | Default DSCP | Trust | Shape Rate |
-| ----------- | ------------ | ----- | ---------- |
-| 2 | - | cos | - |
+| Default COS | Default DSCP | Trust | Shape Rate | Qos Service Policy |
+| ----------- | ------------ | ----- | ---------- | ------------------ |
+| 2 | - | cos | - | test_qos_policy_v1 |
 
 **Tx-queues**
 
@@ -240,17 +240,17 @@ QOS Profile: **no_qos_trust**
 
 **Settings**
 
-| Default COS | Default DSCP | Trust | Shape Rate |
-| ----------- | ------------ | ----- | ---------- |
-| 3 | 4 | disabled | - |
+| Default COS | Default DSCP | Trust | Shape Rate | Qos Service Policy |
+| ----------- | ------------ | ----- | ---------- | ------------------ |
+| 3 | 4 | disabled | - | - |
 
 QOS Profile: **test**
 
 **Settings**
 
-| Default COS | Default DSCP | Trust | Shape Rate |
-| ----------- | ------------ | ----- | ---------- |
-| - | 46 | dscp | 80 percent |
+| Default COS | Default DSCP | Trust | Shape Rate | Qos Service Policy |
+| ----------- | ------------ | ----- | ---------- | ------------------ |
+| - | 46 | dscp | 80 percent | - |
 
 **Tx-queues**
 
@@ -267,6 +267,7 @@ QOS Profile: **test**
 qos profile experiment
    qos trust cos
    qos cos 2
+   service-policy type qos input test_qos_policy_v1
    !
    tx-queue 3
       bandwidth percent 30

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/policy-maps.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/policy-maps.cfg
@@ -26,6 +26,7 @@ policy-map type quality-of-service PM_REPLICATION_LD
 policy-map type quality-of-service PM_REPLICATION_LD2
    class CM_REPLICATION_LD
       set dscp af11
+      set cos 4
    !
 !
 policy-map type pbr PM_PBR_BREAKOUT

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/qos.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/qos.cfg
@@ -7,6 +7,7 @@ hostname qos
 qos profile experiment
    qos trust cos
    qos cos 2
+   service-policy type qos input test_qos_policy_v1
    !
    tx-queue 3
       bandwidth percent 30

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/policy-maps.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/policy-maps.yml
@@ -16,6 +16,7 @@ policy_maps:
         CM_REPLICATION_LD:
           set:
             dscp: af11
+            cos: 4
   pbr:
     PM_PBR_BREAKOUT:
       classes:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/qos.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/qos.yml
@@ -34,7 +34,7 @@ qos_profiles:
     cos: 2
     service_policy:
       type:
-        qos_input: test_qos_policy
+        qos_input: test_qos_policy_v1
     tx_queues:
       3:
         bandwidth_percent: 30

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/qos.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/qos.yml
@@ -32,6 +32,9 @@ qos_profiles:
   experiment:
     trust: cos
     cos: 2
+    service_policy:
+      type:
+        qos_input: test_qos_policy
     tx_queues:
       3:
         bandwidth_percent: 30

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -2381,6 +2381,7 @@ policy_maps:
       classes:
         < class name >:
           set:
+            cos: < cos_value >
             dscp: < dscp-code >
             traffic_class: < traffic-class ID >
             drop_precedence: < drop-precedence value >
@@ -2396,6 +2397,9 @@ qos_profiles:
     dscp: < dscp-value >
     shape:
       rate: < "< rate > kbps" | "1-100 percent" | "< rate > pps" , supported options are platform dependent >
+    service_policy:
+      type:
+        qos_input: < policy_map_name >
     tx_queues:
       < tx-queue-id >:
         bandwidth_percent: < value >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/policy-maps-qos.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/policy-maps-qos.j2
@@ -8,7 +8,7 @@
 **{{ policy_map }}**
 
 | class | Set | Value |
-| ---- | ----- | ----- |
+| ----- | --- | ----- |
 {%         for class in policy_maps.qos[policy_map].classes | arista.avd.natural_sort %}
 {%             for set in policy_maps.qos[policy_map].classes[class].set | arista.avd.natural_sort %}
 | {{ class }} | {{ set }} | {{ policy_maps.qos[policy_map].classes[class].set[set] }} |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/qos-profiles.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/qos-profiles.j2
@@ -10,7 +10,7 @@ QOS Profile: **{{ profile }}**
 
 **Settings**
 
-| Default COS | Default DSCP | Trust | Shape Rate | Qos Service Policy |
+| Default COS | Default DSCP | Trust | Shape Rate | QOS Service Policy |
 | ----------- | ------------ | ----- | ---------- | ------------------ |
 {%         set cos = qos_profiles[profile].cos | arista.avd.default('-') %}
 {%         set dscp = qos_profiles[profile].dscp | arista.avd.default('-') %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/qos-profiles.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/qos-profiles.j2
@@ -10,13 +10,14 @@ QOS Profile: **{{ profile }}**
 
 **Settings**
 
-| Default COS | Default DSCP | Trust | Shape Rate |
-| ----------- | ------------ | ----- | ---------- |
+| Default COS | Default DSCP | Trust | Shape Rate | Qos Service Policy |
+| ----------- | ------------ | ----- | ---------- | ------------------ |
 {%         set cos = qos_profiles[profile].cos | arista.avd.default('-') %}
 {%         set dscp = qos_profiles[profile].dscp | arista.avd.default('-') %}
 {%         set trust = qos_profiles[profile].trust | arista.avd.default('-') %}
 {%         set shape_rate = qos_profiles[profile].shape.rate | arista.avd.default('-') %}
-| {{ cos }} | {{ dscp }} | {{ trust }} | {{ shape_rate }} |
+{%         set qos_sp = qos_profiles[profile].service_policy.type.qos_input | arista.avd.default('-') %}
+| {{ cos }} | {{ dscp }} | {{ trust }} | {{ shape_rate }} | {{ qos_sp }} |
 {%         if qos_profiles[profile].tx_queues is arista.avd.defined %}
 
 **Tx-queues**

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/policy-maps-qos.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/policy-maps-qos.j2
@@ -7,7 +7,7 @@ policy-map type quality-of-service {{ policy_map }}
 {%         if policy_maps.qos[policy_map].classes[class].set is arista.avd.defined %}
 {%             for set in policy_maps.qos[policy_map].classes[class].set %}
 {%                 set cli_set = set | replace('_','-') | lower %}
-{%                 if cli_set in ['dscp', 'traffic-class', 'drop-precedence']  %}
+{%                 if cli_set in ['cos', 'dscp', 'traffic-class', 'drop-precedence']  %}
       set {{ cli_set }} {{ policy_maps.qos[policy_map].classes[class].set[set] }}
 {%                 endif %}
 {%             endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/qos-profiles.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/qos-profiles.j2
@@ -18,6 +18,9 @@ qos profile {{ profile }}
 {%     if qos_profiles[profile].shape.rate is arista.avd.defined %}
    shape rate {{ qos_profiles[profile].shape.rate }}
 {%     endif %}
+{%     if qos_profiles[profile].service_policy.type.qos_input is arista.avd.defined %}
+   service-policy type qos input {{ qos_profiles[profile].service_policy.type.qos_input }}
+{%     endif %}
 {%     for tx_queue in qos_profiles[profile].tx_queues | arista.avd.natural_sort %}
    !
    tx-queue {{ tx_queue }}


### PR DESCRIPTION
## Change Summary

Added knobs to set **cos** and its value in **policy_maps**, and qos **service_policy** in **qos_profiles**.
<!-- Enter short PR description -->

## Related Issue(s)

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Added the new knobs:

1) cos
```
policy_maps:
  qos:
    < policy-map name >:
      classes:
        < class name >:
          set:
            cos: < cos_value >
```

2) service_policy
```
qos_profiles:
  < profile_name >:
    service_policy:
      type:
        qos_input: < policy_map_name >
```

## How to test

molecule
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
