### PR TITLE
Feat(eos_cli_config_gen): Qos profile support for policy maps and IPv6 class maps

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/qos.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/qos.md
@@ -16,8 +16,12 @@
 - [Multicast](#multicast)
 - [Filters](#filters)
 - [ACL](#acl)
+  - [Extended Access-lists](#extended-access-lists)
+  - [IPv6 Extended Access-lists](#ipv6-extended-access-lists)
 - [Quality Of Service](#quality-of-service)
   - [QOS](#qos)
+  - [QOS Class Maps](#qos-class-maps)
+  - [QOS Policy Maps](#qos-policy-maps)
   - [QOS Profiles](#qos-profiles)
 
 # Management
@@ -75,6 +79,7 @@ interface Management1
 | Ethernet3 | MLAG_PEER_DC1-LEAF1B_Ethernet3 | *trunk | *2-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 3 |
 | Ethernet4 | MLAG_PEER_DC1-LEAF1B_Ethernet4 | *trunk | *2-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 3 |
 | Ethernet6 |  SRV-POD02_Eth1 | trunk | 110-111,210-211 | - | - | - |
+| Ethernet7 |  Test-with-policymap | trunk | 110-111,210-211 | - | - | - |
 
 *Inherited from Port-Channel Interface
 
@@ -113,6 +118,13 @@ interface Ethernet6
    qos trust cos
    qos cos 2
    service-profile experiment
+!
+interface Ethernet7
+   description Test-with-policymap
+   switchport
+   switchport trunk allowed vlan 110-111,210-211
+   switchport mode trunk
+   service-profile qprof_testwithpolicy
 ```
 
 ## Port-Channel Interfaces
@@ -169,6 +181,60 @@ interface Port-Channel3
 
 # ACL
 
+## Extended Access-lists
+
+### Extended Access-lists Summary
+
+#### acl_qos_tc0_v4
+
+| Sequence | Action |
+| -------- | ------ |
+| 10 | permit ip any 192.0.2.0/29 |
+
+#### acl_qos_tc5_v4
+
+| Sequence | Action |
+| -------- | ------ |
+| 10 | permit ip any any dscp ef |
+
+### Extended Access-lists Device Configuration
+
+```eos
+!
+ip access-list acl_qos_tc0_v4
+   10 permit ip any 192.0.2.0/29
+!
+ip access-list acl_qos_tc5_v4
+   10 permit ip any any dscp ef
+```
+
+## IPv6 Extended Access-lists
+
+### IPv6 Extended Access-lists Summary
+
+#### acl_qos_tc0_v6
+
+| Sequence | Action |
+| -------- | ------ |
+| 10 | permit ipv6 any any dscp cs1 |
+
+#### acl_qos_tc5_v6
+
+| Sequence | Action |
+| -------- | ------ |
+| 10 | permit ipv6 any 2001:db8::/48 |
+
+### IPv6 Extended Access-lists Device Configuration
+
+```eos
+!
+ipv6 access-list acl_qos_tc0_v6
+   10 permit ipv6 any any dscp cs1
+!
+ipv6 access-list acl_qos_tc5_v6
+   10 permit ipv6 any 2001:db8::/48
+```
+
 # Quality Of Service
 
 ## QOS
@@ -214,6 +280,70 @@ qos map traffic-class 2 4 5 to cos 7
 qos map traffic-class 6 to tx-queue 2
 ```
 
+## QOS Class Maps
+
+### QOS Class Maps Summary
+
+| Name | Field | Value |
+| ---- | ----- | ----- |
+| cmap_tc0_v4 | acl | acl_qos_tc0_v4 |
+| cmap_tc0_v6 | - | - |
+| cmap_tc5_v4 | acl | acl_qos_tc5_v4 |
+| cmap_tc5_v6 | - | - |
+
+### Class-maps Device Configuration
+
+```eos
+!
+class-map type qos match-any cmap_tc0_v4
+   match ip access-group acl_qos_tc0_v4
+!
+class-map type qos match-any cmap_tc0_v6
+   match ipv6 access-group acl_qos_tc0_v6
+!
+class-map type qos match-any cmap_tc5_v4
+   match ip access-group acl_qos_tc5_v4
+!
+class-map type qos match-any cmap_tc5_v6
+   match ipv6 access-group acl_qos_tc5_v6
+```
+
+## QOS Policy Maps
+
+### QOS Policy Maps Summary
+
+**pmap_test1**
+
+| class | Set | Value |
+| ---- | ----- | ----- |
+| class-default | traffic_class | 1 |
+| cmap_tc0_v4 | traffic_class | 0 |
+| cmap_tc0_v6 | traffic_class | 0 |
+| cmap_tc5_v4 | traffic_class | 5 |
+| cmap_tc5_v6 | traffic_class | 5 |
+
+### QOS Policy Maps configuration
+
+```eos
+!
+policy-map type quality-of-service pmap_test1
+   class class-default
+      set traffic-class 1
+   !
+   class cmap_tc0_v4
+      set traffic-class 0
+   !
+   class cmap_tc0_v6
+      set traffic-class 0
+   !
+   class cmap_tc5_v4
+      set traffic-class 5
+   !
+   class cmap_tc5_v6
+      set traffic-class 5
+   !
+```
+
 ## QOS Profiles
 
 ### QOS Profiles Summary
@@ -243,6 +373,22 @@ QOS Profile: **no_qos_trust**
 | Default COS | Default DSCP | Trust | Shape Rate |
 | ----------- | ------------ | ----- | ---------- |
 | 3 | 4 | disabled | - |
+
+QOS Profile: **qprof_testwithpolicy**
+
+**Settings**
+
+| Default COS | Default DSCP | Trust | Shape Rate |
+| ----------- | ------------ | ----- | ---------- |
+| - | - | - | - |
+
+**Tx-queues**
+
+| Tx-queue | Bandwidth | Priority | Shape Rate |
+| -------- | --------- | -------- | ---------- |
+| 0 | 1 | - | - |
+| 1 | 80 | - | - |
+| 5 | 19 | no priority | - |
 
 QOS Profile: **test**
 
@@ -286,6 +432,19 @@ qos profile no_qos_trust
    no qos trust
    qos cos 3
    qos dscp 4
+!
+qos profile qprof_testwithpolicy
+   service-policy type qos input pmap_test1
+   !
+   tx-queue 0
+      bandwidth percent 1
+   !
+   tx-queue 1
+      bandwidth percent 80
+   !
+   tx-queue 5
+      bandwidth percent 19
+      no priority
 !
 qos profile test
    qos trust dscp

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/qos.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/qos.cfg
@@ -27,6 +27,19 @@ qos profile no_qos_trust
    qos cos 3
    qos dscp 4
 !
+qos profile qprof_testwithpolicy
+   service-policy type qos input pmap_test1
+   !
+   tx-queue 0
+      bandwidth percent 1
+   !
+   tx-queue 1
+      bandwidth percent 80
+   !
+   tx-queue 5
+      bandwidth percent 19
+      no priority
+!
 qos profile test
    qos trust dscp
    qos dscp 46
@@ -83,10 +96,29 @@ interface Ethernet6
    qos cos 2
    service-profile experiment
 !
+interface Ethernet7
+   description Test-with-policymap
+   switchport
+   switchport trunk allowed vlan 110-111,210-211
+   switchport mode trunk
+   service-profile qprof_testwithpolicy
+!
 interface Management1
    description oob_management
    vrf MGMT
    ip address 10.73.255.122/24
+!
+ipv6 access-list acl_qos_tc0_v6
+   10 permit ipv6 any any dscp cs1
+!
+ipv6 access-list acl_qos_tc5_v6
+   10 permit ipv6 any 2001:db8::/48
+!
+ip access-list acl_qos_tc0_v4
+   10 permit ip any 192.0.2.0/29
+!
+ip access-list acl_qos_tc5_v4
+   10 permit ip any any dscp ef
 !
 qos rewrite dscp
 qos map cos 1 2 3 4 to traffic-class 2
@@ -97,5 +129,34 @@ qos map dscp 46 to traffic-class 5
 qos map traffic-class 1 to dscp 56
 qos map traffic-class 2 4 5 to cos 7
 qos map traffic-class 6 to tx-queue 2
+!
+class-map type qos match-any cmap_tc0_v4
+   match ip access-group acl_qos_tc0_v4
+!
+class-map type qos match-any cmap_tc0_v6
+   match ipv6 access-group acl_qos_tc0_v6
+!
+class-map type qos match-any cmap_tc5_v4
+   match ip access-group acl_qos_tc5_v4
+!
+class-map type qos match-any cmap_tc5_v6
+   match ipv6 access-group acl_qos_tc5_v6
+!
+policy-map type quality-of-service pmap_test1
+   class class-default
+      set traffic-class 1
+   !
+   class cmap_tc0_v4
+      set traffic-class 0
+   !
+   class cmap_tc0_v6
+      set traffic-class 0
+   !
+   class cmap_tc5_v4
+      set traffic-class 5
+   !
+   class cmap_tc5_v6
+      set traffic-class 5
+   !
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/qos.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/qos.yml
@@ -48,8 +48,38 @@ qos_profiles:
     trust: disabled
     cos: 3
     dscp: 4
+  qprof_testwithpolicy:
+    policy_map: pmap_test1
+    tx_queues:
+      5:
+        priority: no priority
+        bandwidth_percent: 19
+      1:
+        bandwidth_percent: 80
+      0:
+        bandwidth_percent: 1
 
-### Port-Channel Interfaces ###
+policy_maps:
+  qos:
+    pmap_test1:
+      classes:
+        cmap_tc0_v4:
+          set:
+            traffic_class: 0
+        cmap_tc5_v4:
+          set:
+            traffic_class: 5
+        cmap_tc5_v6:
+          set:
+            traffic_class: 5
+        cmap_tc0_v6:
+          set:
+            traffic_class: 0
+        class-default:
+          set:
+            traffic_class: 1
+
+### Ethernet Interfaces ###
 ethernet_interfaces:
   Ethernet1:
     peer: DC1-SPINE1
@@ -94,6 +124,15 @@ ethernet_interfaces:
       id: 3
       mode: active
 
+  Ethernet7:
+    peer: SRV-POD03
+    peer_interface: Eth1
+    peer_type: server
+    description: Test-with-policymap
+    mode: trunk
+    vlans: 110-111,210-211
+    service_profile: qprof_testwithpolicy
+
 ### Port-Channel Interfaces ###
 port_channel_interfaces:
   Port-Channel3:
@@ -107,3 +146,39 @@ port_channel_interfaces:
     qos:
       trust: cos
       cos: 2
+
+### ACLs and Class Maps ###
+access_lists:
+  acl_qos_tc0_v4:
+    sequence_numbers:
+      10:
+        action: "permit ip any 192.0.2.0/29"
+  acl_qos_tc5_v4:
+    sequence_numbers:
+      10:
+        action: "permit ip any any dscp ef"
+
+ipv6_access_lists:
+  acl_qos_tc0_v6:
+    sequence_numbers:
+      10:
+        action: "permit ipv6 any any dscp cs1"
+  acl_qos_tc5_v6:
+    sequence_numbers:
+      10:
+        action: "permit ipv6 any 2001:db8::/48"
+
+class_maps:
+  qos:
+    cmap_tc5_v4:
+      ip:
+        access_group: acl_qos_tc5_v4
+    cmap_tc0_v6:
+      ipv6:
+        access_group: acl_qos_tc0_v6
+    cmap_tc0_v4:
+      ip:
+        access_group: acl_qos_tc0_v4
+    cmap_tc5_v6:
+      ipv6:
+        access_group: acl_qos_tc5_v6

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -2362,6 +2362,8 @@ class_maps:
       cos: < CoS value(s) or range(s) of CoS values >
       ip:
         access_group: < Standard access-list name >
+      ipv6:
+        access_group: < Standard IPv6 access-list name >
 ```
 
 #### QOS Policy-map
@@ -2396,6 +2398,7 @@ qos_profiles:
     dscp: < dscp-value >
     shape:
       rate: < "< rate > kbps" | "1-100 percent" | "< rate > pps" , supported options are platform dependent >
+    policy_map: < qos-policy-map name >
     tx_queues:
       < tx-queue-id >:
         bandwidth_percent: < value >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/class-maps-qos.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/class-maps-qos.j2
@@ -8,6 +8,8 @@ class-map type qos match-any {{ class_map }}
    match cos {{ class_maps.qos[class_map].cos }}
 {%     elif class_maps.qos[class_map].ip.access_group is arista.avd.defined %}
    match ip access-group {{ class_maps.qos[class_map].ip.access_group }}
+{%     elif class_maps.qos[class_map].ipv6.access_group is arista.avd.defined %}
+   match ipv6 access-group {{ class_maps.qos[class_map].ipv6.access_group }}
 {%     endif %}
 {% endfor %}
 {# PBR class-map #}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/qos-profiles.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/qos-profiles.j2
@@ -18,6 +18,9 @@ qos profile {{ profile }}
 {%     if qos_profiles[profile].shape.rate is arista.avd.defined %}
    shape rate {{ qos_profiles[profile].shape.rate }}
 {%     endif %}
+{%     if qos_profiles[profile].policy_map is arista.avd.defined %}
+   service-policy type qos input {{ qos_profiles[profile].policy_map }}
+{%     endif %}
 {%     for tx_queue in qos_profiles[profile].tx_queues | arista.avd.natural_sort %}
    !
    tx-queue {{ tx_queue }}


### PR DESCRIPTION
## Change Summary

Added support to QOS profiles to have a policy map to classify traffic based on class maps in addition to trust DSCP or trust COS.

Also adds IPv6 support for class maps such that the policy maps can classify both v4 and v6 traffic

## Component(s) name

`arista.avd.eos_cli_config_gen`


## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
