### PR TITLE
Feat(eos_cli_config_gen): Add vpws control-word, mtu and label flow knobs

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vpws.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vpws.md
@@ -101,11 +101,11 @@ interface Management1
 
 ### Router BGP VPWS Instances
 
-| Instance | Route-Distinguisher | Both Route-Target | Pseudowire | Local ID | Remote ID |
-| -------- | ------------------- | ----------------- | ---------- | -------- | --------- |
-| TENANT_A | 100.70.0.2:1000 | 65000:1000 | TEN_A_site1_site3_pw | 15 | 35 |
-| TENANT_A | 100.70.0.2:1000 | 65000:1000 | TEN_A_site2_site5_pw | 25 | 57 |
-| TENANT_B | 100.70.0.2:2000 | 65000:2000 | TEN_B_site2_site5_pw | 26 | 58 |
+| Instance | Route-Distinguisher | Both Route-Target | MPLS Control Word | Label Flow | MTU | Pseudowire | Local ID | Remote ID |
+| -------- | ------------------- | ----------------- | ----------------- | -----------| --- | ---------- | -------- | --------- |
+| TENANT_A | 100.70.0.2:1000 | 65000:1000 | True | True | 1600 | TEN_A_site1_site3_pw | 15 | 35 |
+| TENANT_A | 100.70.0.2:1000 | 65000:1000 | True | True | 1600 | TEN_A_site2_site5_pw | 25 | 57 |
+| TENANT_B | 100.70.0.2:2000 | 65000:2000 | False | False | ignore | TEN_B_site2_site5_pw | 26 | 58 |
 
 ### Router BGP Device Configuration
 
@@ -122,6 +122,9 @@ router bgp 65101
    vpws TENANT_A
       rd 100.70.0.2:1000
       route-target import export evpn 65000:1000
+      mpls control-word
+      label flow
+      mtu 1600
       !
       pseudowire TEN_A_site1_site3_pw
          evpn vpws id local 15 remote 35

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vpws.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vpws.md
@@ -103,8 +103,8 @@ interface Management1
 
 | Instance | Route-Distinguisher | Both Route-Target | MPLS Control Word | Label Flow | MTU | Pseudowire | Local ID | Remote ID |
 | -------- | ------------------- | ----------------- | ----------------- | -----------| --- | ---------- | -------- | --------- |
-| TENANT_A | 100.70.0.2:1000 | 65000:1000 | True | True | 1601 | TEN_A_site1_site3_pw | 15 | 35 |
-| TENANT_A | 100.70.0.2:1000 | 65000:1000 | True | True | 1601 | TEN_A_site2_site5_pw | 25 | 57 |
+| TENANT_A | 100.70.0.2:1000 | 65000:1000 | True | True | 1600 | TEN_A_site1_site3_pw | 15 | 35 |
+| TENANT_A | 100.70.0.2:1000 | 65000:1000 | True | True | 1600 | TEN_A_site2_site5_pw | 25 | 57 |
 | TENANT_B | 100.70.0.2:2000 | 65000:2000 | False | False | - | TEN_B_site2_site5_pw | 26 | 58 |
 
 ### Router BGP Device Configuration
@@ -124,7 +124,7 @@ router bgp 65101
       route-target import export evpn 65000:1000
       mpls control-word
       label flow
-      mtu 1601
+      mtu 1600
       !
       pseudowire TEN_A_site1_site3_pw
          evpn vpws id local 15 remote 35

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vpws.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vpws.md
@@ -105,7 +105,7 @@ interface Management1
 | -------- | ------------------- | ----------------- | ----------------- | -----------| --- | ---------- | -------- | --------- |
 | TENANT_A | 100.70.0.2:1000 | 65000:1000 | True | True | 1601 | TEN_A_site1_site3_pw | 15 | 35 |
 | TENANT_A | 100.70.0.2:1000 | 65000:1000 | True | True | 1601 | TEN_A_site2_site5_pw | 25 | 57 |
-| TENANT_B | 100.70.0.2:2000 | 65000:2000 | False | False | ignore | TEN_B_site2_site5_pw | 26 | 58 |
+| TENANT_B | 100.70.0.2:2000 | 65000:2000 | False | False | - | TEN_B_site2_site5_pw | 26 | 58 |
 
 ### Router BGP Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vpws.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vpws.md
@@ -103,8 +103,8 @@ interface Management1
 
 | Instance | Route-Distinguisher | Both Route-Target | MPLS Control Word | Label Flow | MTU | Pseudowire | Local ID | Remote ID |
 | -------- | ------------------- | ----------------- | ----------------- | -----------| --- | ---------- | -------- | --------- |
-| TENANT_A | 100.70.0.2:1000 | 65000:1000 | True | True | 1600 | TEN_A_site1_site3_pw | 15 | 35 |
-| TENANT_A | 100.70.0.2:1000 | 65000:1000 | True | True | 1600 | TEN_A_site2_site5_pw | 25 | 57 |
+| TENANT_A | 100.70.0.2:1000 | 65000:1000 | True | True | 1601 | TEN_A_site1_site3_pw | 15 | 35 |
+| TENANT_A | 100.70.0.2:1000 | 65000:1000 | True | True | 1601 | TEN_A_site2_site5_pw | 25 | 57 |
 | TENANT_B | 100.70.0.2:2000 | 65000:2000 | False | False | ignore | TEN_B_site2_site5_pw | 26 | 58 |
 
 ### Router BGP Device Configuration
@@ -124,7 +124,7 @@ router bgp 65101
       route-target import export evpn 65000:1000
       mpls control-word
       label flow
-      mtu 1600
+      mtu 1601
       !
       pseudowire TEN_A_site1_site3_pw
          evpn vpws id local 15 remote 35

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-vpws.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-vpws.cfg
@@ -25,7 +25,7 @@ router bgp 65101
       route-target import export evpn 65000:1000
       mpls control-word
       label flow
-      mtu 1601
+      mtu 1600
       !
       pseudowire TEN_A_site1_site3_pw
          evpn vpws id local 15 remote 35

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-vpws.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-vpws.cfg
@@ -23,6 +23,9 @@ router bgp 65101
    vpws TENANT_A
       rd 100.70.0.2:1000
       route-target import export evpn 65000:1000
+      mpls control-word
+      label flow
+      mtu 1600
       !
       pseudowire TEN_A_site1_site3_pw
          evpn vpws id local 15 remote 35

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-vpws.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-vpws.cfg
@@ -25,7 +25,7 @@ router bgp 65101
       route-target import export evpn 65000:1000
       mpls control-word
       label flow
-      mtu 1600
+      mtu 1601
       !
       pseudowire TEN_A_site1_site3_pw
          evpn vpws id local 15 remote 35

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-vpws.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-vpws.yml
@@ -14,7 +14,7 @@ router_bgp:
         import_export: 65000:1000
       mpls_control_word: true
       label_flow: true
-      mtu: 1601
+      mtu: 1600
       pseudowires:
         - name: TEN_A_site2_site5_pw
           id_local: 25

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-vpws.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-vpws.yml
@@ -12,6 +12,9 @@ router_bgp:
       rd: 100.70.0.2:1000
       route_targets:
         import_export: 65000:1000
+      mpls_control_word: true
+      label_flow: true
+      mtu: 1600
       pseudowires:
         - name: TEN_A_site2_site5_pw
           id_local: 25

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-vpws.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-vpws.yml
@@ -14,7 +14,7 @@ router_bgp:
         import_export: 65000:1000
       mpls_control_word: true
       label_flow: true
-      mtu: 1600
+      mtu: 1601
       pseudowires:
         - name: TEN_A_site2_site5_pw
           id_local: 25

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -2689,7 +2689,7 @@ router_bgp:
         import_export: < route target >
       mpls_control_word: < true | false, Default -> false >
       label_flow: < true | false, Default -> false >
-      mtu: < 1-65535 >
+      mtu: < mtu >
       pseudowires:
         - name: < pseudowire name >
           id_local: < integer, must match id_remote on other pe >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -2687,6 +2687,9 @@ router_bgp:
       rd: < route distinguisher >
       route_targets:
         import_export: < route target >
+      mpls_control_word: < true | false, Default -> false >
+      label_flow: < true | false, Default -> false >
+      mtu: < 1-65535, Default -> ignore mtu >
       pseudowires:
         - name: < pseudowire name >
           id_local: < integer, must match id_remote on other pe >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -2689,7 +2689,7 @@ router_bgp:
         import_export: < route target >
       mpls_control_word: < true | false, Default -> false >
       label_flow: < true | false, Default -> false >
-      mtu: < 1-65535, Default -> ignore mtu >
+      mtu: < 1-65535 >
       pseudowires:
         - name: < pseudowire name >
           id_local: < integer, must match id_remote on other pe >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
@@ -451,7 +451,7 @@
 {%                     if pseudowire.name is arista.avd.defined %}
 {%                         set row_mpls_control_word = vpws_service.mpls_control_word | arista.avd.default(false) %}
 {%                         set row_label_flow = vpws_service.label_flow | arista.avd.default(false) %}
-{%                         set row_mtu = vpws_service.mtu | arista.avd.default("ignore") %}
+{%                         set row_mtu = vpws_service.mtu | arista.avd.default("-") %}
 | {{ vpws_service.name }} | {{ vpws_service.rd }} | {{ vpws_service.route_targets.import_export }} | {{ row_mpls_control_word }} | {{ row_label_flow }} | {{ row_mtu }} | {{ pseudowire.name }} | {{ pseudowire.id_local }} | {{ pseudowire.id_remote }} |
 {%                     endif %}
 {%                 endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
@@ -443,13 +443,16 @@
 
 ### Router BGP VPWS Instances
 
-| Instance | Route-Distinguisher | Both Route-Target | Pseudowire | Local ID | Remote ID |
-| -------- | ------------------- | ----------------- | ---------- | -------- | --------- |
+| Instance | Route-Distinguisher | Both Route-Target | MPLS Control Word | Label Flow | MTU | Pseudowire | Local ID | Remote ID |
+| -------- | ------------------- | ----------------- | ----------------- | -----------| --- | ---------- | -------- | --------- |
 {%         for vpws_service in router_bgp.vpws %}
 {%             if vpws_service.name is arista.avd.defined and vpws_service.rd is arista.avd.defined and vpws_service.route_targets.import_export is arista.avd.defined %}
 {%                 for pseudowire in vpws_service.pseudowires | arista.avd.natural_sort("name") %}
 {%                     if pseudowire.name is arista.avd.defined %}
-| {{ vpws_service.name }} | {{ vpws_service.rd }} | {{ vpws_service.route_targets.import_export }} | {{ pseudowire.name }} | {{ pseudowire.id_local }} | {{ pseudowire.id_remote }} |
+{%                         set row_mpls_control_word = vpws_service.mpls_control_word | arista.avd.default(false) %}
+{%                         set row_label_flow = vpws_service.label_flow | arista.avd.default(false) %}
+{%                         set row_mtu = vpws_service.mtu | arista.avd.default("ignore") %}
+| {{ vpws_service.name }} | {{ vpws_service.rd }} | {{ vpws_service.route_targets.import_export }} | {{ row_mpls_control_word }} | {{ row_label_flow }} | {{ row_mtu }} | {{ pseudowire.name }} | {{ pseudowire.id_local }} | {{ pseudowire.id_remote }} |
 {%                     endif %}
 {%                 endfor %}
 {%             endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -291,6 +291,15 @@ router bgp {{ router_bgp.as }}
 {%                 if vpws_service.route_targets.import_export is arista.avd.defined %}
       route-target import export evpn {{ vpws_service.route_targets.import_export }}
 {%                 endif %}
+{%                 if vpws_service.mpls_control_word is arista.avd.defined(true) %}
+      mpls control-word
+{%                 endif %}
+{%                 if vpws_service.label_flow is arista.avd.defined(true) %}
+      label flow
+{%                 endif %}
+{%                 if vpws_service.mtu is arista.avd.defined %}
+      mtu {{ vpws_service.mtu }}
+{%                 endif %}
 {%                 for pw in vpws_service.pseudowires | arista.avd.natural_sort %}
 {%                     if pw.name is arista.avd.defined and pw.id_local is arista.avd.defined and pw.id_remote is arista.avd.defined %}
       !


### PR DESCRIPTION
## Change Summary

This PR adds per-instance mpls control-word and label flow support to vpws in eos_cli_config_gen.

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
```yaml
router_bgp
  vpws:
    - ...
      mpls_control_word: < true | false >
      label_flow: < true | false >
      mtu: < 1-9214 >
```

## How to test

Tested with molecule. 

### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
