### PR TITLE
Optimize(eos_designs): Store topology peer hints in temporary files

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_designs/defaults/main/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/defaults/main/main.yml
@@ -23,8 +23,6 @@ structured_dir: '{{ output_dir }}/{{ structured_dir_name }}'
 # Output for Internal Facts files:
 facts_dir_name: 'avd_facts'
 facts_dir: '{{ root_dir }}/{{ facts_dir_name }}'
-switch_facts_dir: '{{ facts_dir }}/switch'
-topology_facts_dir: '{{ facts_dir }}/topology'
 topology_peers_facts_dir: '{{ facts_dir }}/topology_peers'
 overlay_peers_facts_dir: '{{ facts_dir }}/overlay_peers'
 

--- a/ansible_collections/arista/avd/roles/eos_designs/defaults/main/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/defaults/main/main.yml
@@ -20,6 +20,14 @@ output_dir: '{{ root_dir }}/{{ output_dir_name }}'
 structured_dir_name: 'structured_configs'
 structured_dir: '{{ output_dir }}/{{ structured_dir_name }}'
 
+# Output for Internal Facts files:
+facts_dir_name: 'avd_facts'
+facts_dir: '{{ root_dir }}/{{ facts_dir_name }}'
+switch_facts_dir: '{{ facts_dir }}/switch'
+topology_facts_dir: '{{ facts_dir }}/topology'
+topology_peers_facts_dir: '{{ facts_dir }}/topology_peers'
+overlay_peers_facts_dir: '{{ facts_dir }}/overlay_peers'
+
 # Design variables
 design:
   type: "l3ls-evpn"

--- a/ansible_collections/arista/avd/roles/eos_designs/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/tasks/main.yml
@@ -18,7 +18,6 @@
   tags: [build, provision]
   yaml_templates_to_facts:
     templates: "{{ templates.facts }}"
-#    dest: "{{ switch_facts_dir }}/{{ inventory_hostname }}.json"
   delegate_to: localhost
   check_mode: no
   changed_when: False
@@ -27,7 +26,6 @@
   tags: [build, provision]
   yaml_templates_to_facts:
     templates: "{{ templates.topology_facts }}"
-#    dest: "{{ topology_facts_dir }}/{{ inventory_hostname }}.json"
   delegate_to: localhost
   check_mode: no
   changed_when: False

--- a/ansible_collections/arista/avd/roles/eos_designs/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/tasks/main.yml
@@ -8,8 +8,6 @@
   loop:
     - "{{ structured_dir }}"
     - "{{ fabric_dir }}"
-    - "{{ switch_facts_dir }}"
-    - "{{ topology_facts_dir }}"
     - "{{ topology_peers_facts_dir }}"
     - "{{ overlay_peers_facts_dir }}"
   delegate_to: localhost
@@ -81,8 +79,6 @@
     path: "{{ item }}"
     state: absent
   loop:
-    - "{{ switch_facts_dir }}"
-    - "{{ topology_facts_dir }}"
     - "{{ topology_peers_facts_dir }}"
     - "{{ overlay_peers_facts_dir }}"
     - "{{ facts_dir }}"

--- a/ansible_collections/arista/avd/roles/eos_designs/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/tasks/main.yml
@@ -8,13 +8,19 @@
   loop:
     - "{{ structured_dir }}"
     - "{{ fabric_dir }}"
+    - "{{ switch_facts_dir }}"
+    - "{{ topology_facts_dir }}"
+    - "{{ topology_peers_facts_dir }}"
+    - "{{ overlay_peers_facts_dir }}"
   delegate_to: localhost
   run_once: true
+  changed_when: False
 
 - name: Set AVD facts
   tags: [build, provision]
   yaml_templates_to_facts:
     templates: "{{ templates.facts }}"
+#    dest: "{{ switch_facts_dir }}/{{ inventory_hostname }}.json"
   delegate_to: localhost
   check_mode: no
   changed_when: False
@@ -23,6 +29,29 @@
   tags: [build, provision]
   yaml_templates_to_facts:
     templates: "{{ templates.topology_facts }}"
+#    dest: "{{ topology_facts_dir }}/{{ inventory_hostname }}.json"
+  delegate_to: localhost
+  check_mode: no
+  changed_when: False
+
+- name: Write topology_peers info to filesystem
+  tags: [build, provision]
+  ansible.builtin.file:
+    dest: "{{ topology_peers_facts_dir }}/{{ item }}_{{ inventory_hostname }}"
+    state: touch
+    mode: 0664
+  loop: "{{ topology.peers | arista.avd.default([]) }}"
+  delegate_to: localhost
+  check_mode: no
+  changed_when: False
+
+- name: Write overlay_peers info to filesystem
+  tags: [build, provision]
+  ansible.builtin.file:
+    dest: "{{ overlay_peers_facts_dir }}/{{ item }}_{{ inventory_hostname }}"
+    state: touch
+    mode: 0664
+  loop: "{{ switch.evpn_route_servers | arista.avd.default([]) }}"
   delegate_to: localhost
   check_mode: no
   changed_when: False
@@ -45,6 +74,21 @@
   delegate_to: localhost
   check_mode: no
   register: structured_config
+
+- name: "Cleanup AVD facts files"
+  tags: [build, provision, cleanup_facts]
+  file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - "{{ switch_facts_dir }}"
+    - "{{ topology_facts_dir }}"
+    - "{{ topology_peers_facts_dir }}"
+    - "{{ overlay_peers_facts_dir }}"
+    - "{{ facts_dir }}"
+  delegate_to: localhost
+  run_once: True
+  changed_when: False
 
 - name: Generate fabric documentation
   tags: [build, provision, documentation]

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/inband_management/parent-logic.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/inband_management/parent-logic.j2
@@ -4,18 +4,18 @@
 {# Add inband management variables defined on other devices pointing to this device #}
 
 {# List of fact files created by peers pointing to this device #}
-{% set topology_peers_facts_files = query('ansible.builtin.fileglob', topology_peers_facts_dir ~ '/' ~ inventory_hostname ~ '_*') %}
+{% set topology_peers_hints = query('ansible.builtin.fileglob', topology_peers_facts_dir ~ '/' ~ inventory_hostname ~ '_*') %}
 
-{# Run through list and parse topology facts for inband_management parents #}
-{% for topology_peers_facts_file in topology_peers_facts_files %}
-{%     set peer_hostname = topology_peers_facts_file.split('_') | last %}
+{# Run through list and parse switch facts for inband_management parents #}
+{% for topology_peers_hint in topology_peers_hints %}
+{%     set peer_hostname = topology_peers_hint.split('_') | last %}
 {%     set peer_facts = hostvars[peer_hostname] %}
-{%     if peer_facts.topology is arista.avd.defined(fail_action='warning',var_name='Topoology Facts for ' ~ peer_hostname) %}
-{%         if inventory_hostname in peer_facts.topology.inband_management_parents | arista.avd.default([]) %}
+{%     if peer_facts.switch is arista.avd.defined(fail_action='warning',var_name='Switch Facts for ' ~ peer_hostname) %}
+{%         if inventory_hostname in peer_facts.switch.inband_management_parents | arista.avd.default([]) %}
 {%             set inband_management_data.role = 'parent' %}
-{%             if peer_facts.topology.inband_management_subnet not in inband_management_data.subnets %}
-{%                 do inband_management_data.vlans.append(peer_facts.topology.inband_management_vlan) %}
-{%                 do inband_management_data.subnets.append(peer_facts.topology.inband_management_subnet) %}
+{%             if peer_facts.switch.inband_management_subnet not in inband_management_data.subnets %}
+{%                 do inband_management_data.vlans.append(peer_facts.switch.inband_management_vlan) %}
+{%                 do inband_management_data.subnets.append(peer_facts.switch.inband_management_subnet) %}
 {%             endif %}
 {%         endif %}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/inband_management/parent-logic.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/inband_management/parent-logic.j2
@@ -1,15 +1,22 @@
-{# Add underlay links defined on this device #}
 {% set inband_management_data.vlans = [] %}
 {% set inband_management_data.subnets = [] %}
 
-{# Add underlay links defined on other devices pointing to this device #}
-{% for fabric_switch in groups[fabric_name] | arista.avd.natural_sort %}
-{%     set fabric_switch_facts = hostvars[fabric_switch].switch | arista.avd.default %}
-{%     if inventory_hostname in fabric_switch_facts.inband_management_parents | arista.avd.default([]) %}
-{%         set inband_management_data.role = 'parent' %}
-{%         if fabric_switch_facts.inband_management_subnet not in inband_management_data.subnets %}
-{%             do inband_management_data.vlans.append(fabric_switch_facts.inband_management_vlan) %}
-{%             do inband_management_data.subnets.append(fabric_switch_facts.inband_management_subnet) %}
+{# Add inband management variables defined on other devices pointing to this device #}
+
+{# List of fact files created by peers pointing to this device #}
+{% set topology_peers_facts_files = query('ansible.builtin.fileglob', topology_peers_facts_dir ~ '/' ~ inventory_hostname ~ '_*') %}
+
+{# Run through list and parse topology facts for inband_management parents #}
+{% for topology_peers_facts_file in topology_peers_facts_files %}
+{%     set peer_hostname = topology_peers_facts_file.split('_') | last %}
+{%     set peer_facts = hostvars[peer_hostname] %}
+{%     if peer_facts.topology is arista.avd.defined(fail_action='warning',var_name='Topoology Facts for ' ~ peer_hostname) %}
+{%         if inventory_hostname in peer_facts.topology.inband_management_parents | arista.avd.default([]) %}
+{%             set inband_management_data.role = 'parent' %}
+{%             if peer_facts.topology.inband_management_subnet not in inband_management_data.subnets %}
+{%                 do inband_management_data.vlans.append(peer_facts.topology.inband_management_vlan) %}
+{%                 do inband_management_data.subnets.append(peer_facts.topology.inband_management_subnet) %}
+{%             endif %}
 {%         endif %}
 {%     endif %}
 {% endfor %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/logic-evpn-route-clients.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/logic-evpn-route-clients.j2
@@ -2,17 +2,23 @@
 {%     set overlay_data.evpn_route_clients = {} %}
 {# #}
 {# Look for switches pointing to us as evpn_route_server #}
-{%     for fabric_switch in groups[fabric_name] if fabric_switch not in overlay_data.evpn_route_servers | arista.avd.natural_sort %}
-{%         set fabric_switch_facts = hostvars[fabric_switch].switch | arista.avd.default %}
-{%         if fabric_switch_facts is arista.avd.defined(fail_action='warning',var_name='hostvars[' ~ fabric_switch ~ '].switch') %}
-{%             set fabric_switch_evpn_role = fabric_switch_facts.evpn_role | arista.avd.default('none') %}
-{%             set fabric_switch_evpn_route_servers = fabric_switch_facts.evpn_route_servers | arista.avd.default([]) %}
-{%             if inventory_hostname in fabric_switch_evpn_route_servers and fabric_switch_evpn_role in ['client', 'server'] %}
+
+{# List of fact files created by peers pointing to this device #}
+{%     set overlay_peers_facts_files = query('ansible.builtin.fileglob', overlay_peers_facts_dir ~ '/' ~ inventory_hostname ~ '_*') %}
+
+{# Run through list and parse the switch facts for that device for bgp details #}
+{%     for overlay_peers_facts_file in overlay_peers_facts_files %}
+{%         set peer_hostname = overlay_peers_facts_file.split('_') | last %}
+{%         set peer_facts = hostvars[peer_hostname] %}
+{%         if peer_facts.switch is arista.avd.defined(fail_action='warning',var_name='Switch Facts for ' ~ peer_hostname) %}
+{%             if inventory_hostname in peer_facts.switch.evpn_route_servers | arista.avd.default([]) and
+                  peer_facts.switch.evpn_role in ['client', 'server'] and
+                  peer_hostname not in overlay_data.evpn_route_servers | arista.avd.default([]) %}
 {# Found a matching client. Gathering information for this client #}
 {%                 set client = namespace() %}
-{%                 set client.bgp_as = fabric_switch_facts.bgp_as %}
-{%                 set client.ip_address = fabric_switch_facts.router_id %}
-{%                 do overlay_data.evpn_route_clients.update({ fabric_switch: client }) %}
+{%                 set client.bgp_as = peer_facts.switch.bgp_as %}
+{%                 set client.ip_address = peer_facts.switch.router_id %}
+{%                 do overlay_data.evpn_route_clients.update({ peer_hostname: client }) %}
 {%             endif %}
 {%         endif %}
 {%     endfor %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/logic-evpn-route-clients.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/logic-evpn-route-clients.j2
@@ -4,11 +4,11 @@
 {# Look for switches pointing to us as evpn_route_server #}
 
 {# List of fact files created by peers pointing to this device #}
-{%     set overlay_peers_facts_files = query('ansible.builtin.fileglob', overlay_peers_facts_dir ~ '/' ~ inventory_hostname ~ '_*') %}
+{%     set overlay_peers_hints = query('ansible.builtin.fileglob', overlay_peers_facts_dir ~ '/' ~ inventory_hostname ~ '_*') %}
 
 {# Run through list and parse the switch facts for that device for bgp details #}
-{%     for overlay_peers_facts_file in overlay_peers_facts_files %}
-{%         set peer_hostname = overlay_peers_facts_file.split('_') | last %}
+{%     for overlay_peers_hint in overlay_peers_hints %}
+{%         set peer_hostname = overlay_peers_hint.split('_') | last %}
 {%         set peer_facts = hostvars[peer_hostname] %}
 {%         if peer_facts.switch is arista.avd.defined(fail_action='warning',var_name='Switch Facts for ' ~ peer_hostname) %}
 {%             if inventory_hostname in peer_facts.switch.evpn_route_servers | arista.avd.default([]) and

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/logic-evpn-route-servers.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/logic-evpn-route-servers.j2
@@ -2,13 +2,13 @@
 {# #}
 {# Expand data for evpn_route_servers #}
 {% for route_server in switch.evpn_route_servers | arista.avd.natural_sort %}
-{%     set fabric_switch_switch_facts = hostvars[route_server].switch | arista.avd.default %}
-{%     if fabric_switch_switch_facts is arista.avd.defined(fail_action='warning',var_name='hostvars[' ~ route_server ~ '].switch') %}
-{%         if fabric_switch_switch_facts.evpn_role is arista.avd.defined('server') %}
+{%     set peer_facts = hostvars[route_server] %}
+{%     if peer_facts.switch is arista.avd.defined(fail_action='warning',var_name='Switch Facts for ' ~ route_server) %}
+{%         if peer_facts.switch.evpn_role is arista.avd.defined('server') %}
 {# Found a matching server. Gathering information for this server #}
 {%             set server = namespace() %}
-{%             set server.bgp_as = fabric_switch_switch_facts.bgp_as %}
-{%             set server.ip_address = fabric_switch_switch_facts.router_id %}
+{%             set server.bgp_as = peer_facts.switch.bgp_as %}
+{%             set server.ip_address = peer_facts.switch.router_id %}
 {%             do overlay_data.evpn_route_servers.update({ route_server: server }) %}
 {%         endif %}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/underlay/logic.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/underlay/logic.j2
@@ -2,31 +2,37 @@
 {% set underlay_data.links = topology.links | arista.avd.default({}) %}
 
 {# Add underlay links defined on other devices pointing to this device #}
-{% for fabric_switch in groups[fabric_name] | arista.avd.natural_sort %}
-{%     set fabric_switch_topology_facts = hostvars[fabric_switch].topology | arista.avd.default %}
-{%     if inventory_hostname in fabric_switch_topology_facts.peers | arista.avd.default([]) %}
-{%         set fabric_switch_switch_facts = hostvars[fabric_switch].switch | arista.avd.default %}
-{%         for fabric_switch_interface in fabric_switch_topology_facts.links | arista.avd.natural_sort %}
-{%             set fabric_switch_link = fabric_switch_topology_facts.links[fabric_switch_interface] %}
-{%             if fabric_switch_link.peer is arista.avd.defined(inventory_hostname) %}
+
+{# List of fact files created by peers pointing to this device #}
+{% set topology_peers_facts_files = query('ansible.builtin.fileglob', topology_peers_facts_dir ~ '/' ~ inventory_hostname ~ '_*') %}
+
+{# Run through list and parse topology facts for that device #}
+{% for topology_peers_facts_file in topology_peers_facts_files %}
+{%     set peer_hostname = topology_peers_facts_file.split('_') | last %}
+{%     set peer_facts = hostvars[peer_hostname] %}
+{%     if peer_facts.topology is arista.avd.defined(fail_action='warning',var_name='Topoology Facts for ' ~ peer_hostname) and
+          peer_facts.switch is arista.avd.defined(fail_action='warning',var_name='Switch Facts for ' ~ peer_hostname) %}
+{%         for fabric_switch_interface in peer_facts.topology.links | arista.avd.natural_sort %}
+{%             set peer_link = peer_facts.topology.links[fabric_switch_interface] %}
+{%             if peer_link.peer is arista.avd.defined(inventory_hostname) %}
 {%                 set link = namespace() %}
-{%                 set link.peer = fabric_switch %}
+{%                 set link.peer = peer_hostname %}
 {%                 set link.peer_interface = fabric_switch_interface %}
-{%                 set link.peer_type = fabric_switch_switch_facts.type %}
-{%                 set link.peer_bgp_as = fabric_switch_switch_facts.bgp_as | arista.avd.default() %}
-{%                 set link.type = fabric_switch_link.type | arista.avd.default() %}
-{%                 set link.speed = fabric_switch_link.speed | arista.avd.default() %}
-{%                 set link.ip_address = fabric_switch_link.peer_ip_address | arista.avd.default() %}
-{%                 set link.peer_ip_address = fabric_switch_link.ip_address | arista.avd.default() %}
-{%                 set link.channel_group_id = fabric_switch_link.peer_channel_group_id | arista.avd.default() %}
-{%                 set link.peer_channel_group_id = fabric_switch_link.channel_group_id | arista.avd.default() %}
-{%                 set link.channel_description = fabric_switch_link.peer_channel_description | arista.avd.default() %}
-{%                 set link.vlans = fabric_switch_link.vlans | arista.avd.default() %}
-{%                 set link.bfd = fabric_switch_link.bfd | arista.avd.default() %}
-{%                 set link.ptp = fabric_switch_link.ptp | arista.avd.default() %}
-{%                 set link.short_esi = fabric_switch_link.peer_short_esi | arista.avd.default() %}
-{%                 set link.ipv6_enable = fabric_switch_link.ipv6_enable | arista.avd.default() %}
-{%                 set interface = fabric_switch_link.peer_interface %}
+{%                 set link.peer_type = peer_facts.switch.type %}
+{%                 set link.peer_bgp_as = peer_facts.switch.bgp_as | arista.avd.default %}
+{%                 set link.type = peer_link.type | arista.avd.default %}
+{%                 set link.speed = peer_link.speed | arista.avd.default %}
+{%                 set link.ip_address = peer_link.peer_ip_address | arista.avd.default %}
+{%                 set link.peer_ip_address = peer_link.ip_address | arista.avd.default %}
+{%                 set link.channel_group_id = peer_link.peer_channel_group_id | arista.avd.default %}
+{%                 set link.peer_channel_group_id = peer_link.channel_group_id | arista.avd.default %}
+{%                 set link.channel_description = peer_link.peer_channel_description | arista.avd.default %}
+{%                 set link.vlans = peer_link.vlans | arista.avd.default %}
+{%                 set link.bfd = peer_link.bfd | arista.avd.default %}
+{%                 set link.ptp = peer_link.ptp | arista.avd.default %}
+{%                 set link.short_esi = peer_link.peer_short_esi | arista.avd.default %}
+{%                 set link.ipv6_enable = peer_link.ipv6_enable | arista.avd.default %}
+{%                 set interface = peer_link.peer_interface %}
 {%                 do underlay_data.links.update({interface: link}) %}
 {%             endif %}
 {%         endfor %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/underlay/logic.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/underlay/logic.j2
@@ -4,11 +4,11 @@
 {# Add underlay links defined on other devices pointing to this device #}
 
 {# List of fact files created by peers pointing to this device #}
-{% set topology_peers_facts_files = query('ansible.builtin.fileglob', topology_peers_facts_dir ~ '/' ~ inventory_hostname ~ '_*') %}
+{% set topology_peers_hints = query('ansible.builtin.fileglob', topology_peers_facts_dir ~ '/' ~ inventory_hostname ~ '_*') %}
 
 {# Run through list and parse topology facts for that device #}
-{% for topology_peers_facts_file in topology_peers_facts_files %}
-{%     set peer_hostname = topology_peers_facts_file.split('_') | last %}
+{% for topology_peers_hint in topology_peers_hints %}
+{%     set peer_hostname = topology_peers_hint.split('_') | last %}
 {%     set peer_facts = hostvars[peer_hostname] %}
 {%     if peer_facts.topology is arista.avd.defined(fail_action='warning',var_name='Topoology Facts for ' ~ peer_hostname) and
           peer_facts.switch is arista.avd.defined(fail_action='warning',var_name='Switch Facts for ' ~ peer_hostname) %}


### PR DESCRIPTION
## Change Summary

Store temporary AVD facts in files instead of hostvars
<!-- Enter short PR description -->

## Related Issue(s)

Optimizing speed

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- Creating directory `avd_facts/topology_peers` with empty files that work like hints for topology peers (children). File name is `<parent>_<child>`
- Creating directory `avd_facts/overlay_peers` with empty files that work like hints for route-server peers (clients). File name is `<server>_<client>`
- Changing all logic where we look for "childs" (ex. spine looking for leaf, route server looking for clients) to use files as hints
- Cleanup temporary files after completing `structured_config` creation

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
No changes and no errors in molecule proves that this change is a pure refactor
Tested runtime on large customer inventory. Going from ~12 min to ~6:30 for `eos_designs`

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
