### PR TITLE
Feat(eos_cli_config_gen): IPv6 ACL support for QOS policy map class maps

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/qos.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/qos.cfg
@@ -28,6 +28,19 @@ qos profile no_qos_trust
    qos cos 3
    qos dscp 4
 !
+qos profile qprof_testwithpolicy
+   service-policy type qos input pmap_test1
+   !
+   tx-queue 0
+      bandwidth percent 1
+   !
+   tx-queue 1
+      bandwidth percent 80
+   !
+   tx-queue 5
+      bandwidth percent 19
+      no priority
+!
 qos profile test
    qos trust dscp
    qos dscp 46
@@ -84,10 +97,29 @@ interface Ethernet6
    qos cos 2
    service-profile experiment
 !
+interface Ethernet7
+   description Test-with-policymap
+   switchport
+   switchport trunk allowed vlan 110-111,210-211
+   switchport mode trunk
+   service-profile qprof_testwithpolicy
+!
 interface Management1
    description oob_management
    vrf MGMT
    ip address 10.73.255.122/24
+!
+ipv6 access-list acl_qos_tc0_v6
+   10 permit ipv6 any any dscp cs1
+!
+ipv6 access-list acl_qos_tc5_v6
+   10 permit ipv6 any 2001:db8::/48
+!
+ip access-list acl_qos_tc0_v4
+   10 permit ip any 192.0.2.0/29
+!
+ip access-list acl_qos_tc5_v4
+   10 permit ip any any dscp ef
 !
 qos rewrite dscp
 qos map cos 1 2 3 4 to traffic-class 2
@@ -98,5 +130,34 @@ qos map dscp 46 to traffic-class 5
 qos map traffic-class 1 to dscp 56
 qos map traffic-class 2 4 5 to cos 7
 qos map traffic-class 6 to tx-queue 2
+!
+class-map type qos match-any cmap_tc0_v4
+   match ip access-group acl_qos_tc0_v4
+!
+class-map type qos match-any cmap_tc0_v6
+   match ipv6 access-group acl_qos_tc0_v6
+!
+class-map type qos match-any cmap_tc5_v4
+   match ip access-group acl_qos_tc5_v4
+!
+class-map type qos match-any cmap_tc5_v6
+   match ipv6 access-group acl_qos_tc5_v6
+!
+policy-map type quality-of-service pmap_test1
+   class class-default
+      set traffic-class 1
+   !
+   class cmap_tc0_v4
+      set traffic-class 0
+   !
+   class cmap_tc0_v6
+      set traffic-class 0
+   !
+   class cmap_tc5_v4
+      set traffic-class 5
+   !
+   class cmap_tc5_v6
+      set traffic-class 5
+   !
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/qos.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/qos.yml
@@ -51,8 +51,40 @@ qos_profiles:
     trust: disabled
     cos: 3
     dscp: 4
+  qprof_testwithpolicy:
+    service_policy:
+      type:
+        qos_input: pmap_test1
+    tx_queues:
+      5:
+        priority: 'no priority'
+        bandwidth_percent: 19
+      1:
+        bandwidth_percent: 80
+      0:
+        bandwidth_percent: 1
 
-### Port-Channel Interfaces ###
+policy_maps:
+  qos:
+    pmap_test1:
+      classes:
+        cmap_tc0_v4:
+          set:
+            traffic_class: 0
+        cmap_tc5_v4:
+          set:
+            traffic_class: 5
+        cmap_tc5_v6:
+          set:
+            traffic_class: 5
+        cmap_tc0_v6:
+          set:
+            traffic_class: 0
+        class-default:
+          set:
+            traffic_class: 1
+
+### Ethernet Interfaces ###
 ethernet_interfaces:
   Ethernet1:
     peer: DC1-SPINE1
@@ -97,6 +129,15 @@ ethernet_interfaces:
       id: 3
       mode: active
 
+  Ethernet7:
+    peer: SRV-POD03
+    peer_interface: Eth1
+    peer_type: server
+    description: Test-with-policymap
+    mode: trunk
+    vlans: 110-111,210-211
+    service_profile: qprof_testwithpolicy
+
 ### Port-Channel Interfaces ###
 port_channel_interfaces:
   Port-Channel3:
@@ -110,3 +151,39 @@ port_channel_interfaces:
     qos:
       trust: cos
       cos: 2
+
+### ACLs and Class Maps ###
+access_lists:
+  acl_qos_tc0_v4:
+    sequence_numbers:
+      10:
+        action: "permit ip any 192.0.2.0/29"
+  acl_qos_tc5_v4:
+    sequence_numbers:
+      10:
+        action: "permit ip any any dscp ef"
+
+ipv6_access_lists:
+  acl_qos_tc0_v6:
+    sequence_numbers:
+      10:
+        action: "permit ipv6 any any dscp cs1"
+  acl_qos_tc5_v6:
+    sequence_numbers:
+      10:
+        action: "permit ipv6 any 2001:db8::/48"
+
+class_maps:
+  qos:
+    cmap_tc5_v4:
+      ip:
+        access_group: acl_qos_tc5_v4
+    cmap_tc0_v6:
+      ipv6:
+        access_group: acl_qos_tc0_v6
+    cmap_tc0_v4:
+      ip:
+        access_group: acl_qos_tc0_v4
+    cmap_tc5_v6:
+      ipv6:
+        access_group: acl_qos_tc5_v6

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -2361,7 +2361,9 @@ class_maps:
       vlan: < VLAN value(s) or range(s) of VLAN values >
       cos: < CoS value(s) or range(s) of CoS values >
       ip:
-        access_group: < Standard access-list name >
+        access_group: < IPv4 access-list name >
+      ipv6:
+        access_group: < IPv6 access-list name >
 ```
 
 #### QOS Policy-map

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/class-maps-qos.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/class-maps-qos.j2
@@ -8,6 +8,8 @@ class-map type qos match-any {{ class_map }}
    match cos {{ class_maps.qos[class_map].cos }}
 {%     elif class_maps.qos[class_map].ip.access_group is arista.avd.defined %}
    match ip access-group {{ class_maps.qos[class_map].ip.access_group }}
+{%     elif class_maps.qos[class_map].ipv6.access_group is arista.avd.defined %}
+   match ipv6 access-group {{ class_maps.qos[class_map].ipv6.access_group }}
 {%     endif %}
 {% endfor %}
 {# PBR class-map #}


### PR DESCRIPTION
## Change Summary

Adds IPv6 ACLs as a possible class map match statement for QOS policy maps.

## Component(s) name

`arista.avd.eos_cli_config_gen`


## How to test
Module

## Checklist



### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
