### PR TITLE
Cut: Requirement for community.general

### DIFF
--- a/ansible_collections/arista/avd/collections.yml
+++ b/ansible_collections/arista/avd/collections.yml
@@ -3,4 +3,3 @@ collections:
   - arista.cvp
   - arista.eos
   - ansible.netcommon
-  - community.general

--- a/ansible_collections/arista/avd/galaxy.yml
+++ b/ansible_collections/arista/avd/galaxy.yml
@@ -40,7 +40,6 @@ dependencies:
     "arista.cvp": ">=3.2.0"
     "arista.eos": ">=3.1.0"
     "ansible.netcommon": ">=2.4.0"
-    "community.general": ">=3.8.0"
 
 # The URL of the originating SCM repository
 repository: https://github.com/aristanetworks/ansible-avd


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Remove requirement for the `community.general` collection

## Related Issue(s)

Required to pass Ansible Automation Hub certification.

## Component(s) name

`arista.avd`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

After the refactoring of `validate_state` report generation, we no longer require the `community.general` collection.
Most users will still use this collection for callbacks etc, but that depends on their local config so should not be covered by our requirements.

This requirement is blocking us from automation-hub.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
