### PR TITLE
Fix(eos_cli_config_gen): Remove policy sort, support index and drop command in policy-maps PBR

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/policy-maps-pbr.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/policy-maps-pbr.md
@@ -1,4 +1,4 @@
-# policy-maps
+# policy-maps-pbr
 # Table of Contents
 
 - [Management](#management)
@@ -16,7 +16,6 @@
 - [Filters](#filters)
 - [ACL](#acl)
 - [Quality Of Service](#quality-of-service)
-  - [QOS Policy Maps](#qos-policy-maps)
 
 # Management
 
@@ -88,22 +87,26 @@ interface Management1
 
 ### PBR Policy Maps Summary
 
-#### PM_PBR_BREAKOUT
+#### POLICY_DROP_THEN_NEXTHOP
 
 | Class | Index | Drop | Nexthop | Recursive |
 | ----- | ----- | ---- | ------- | --------- |
-| CM_PBR_EXCLUDE | - | - | - | - |
-| CM_PBR_INCLUDE | - | - | 192.168.4.2 | True |
+| CLASS_DROP | 10 | True | - | - |
+| CLASS_NEXTHOP | 20 | - | 172.30.1.2 | True |
+| NO_ACTION | - | - | - | - |
 
 ### PBR Policy Maps Configuration
 
 ```eos
 !
-policy-map type pbr PM_PBR_BREAKOUT
-   class CM_PBR_EXCLUDE
+policy-map type pbr POLICY_DROP_THEN_NEXTHOP
+   10 class CLASS_DROP
+      drop
    !
-   class CM_PBR_INCLUDE
-      set nexthop recursive 192.168.4.2
+   20 class CLASS_NEXTHOP
+      set nexthop recursive 172.30.1.2
+   !
+   class NO_ACTION
 ```
 
 # Multicast
@@ -113,46 +116,3 @@ policy-map type pbr PM_PBR_BREAKOUT
 # ACL
 
 # Quality Of Service
-
-## QOS Policy Maps
-
-### QOS Policy Maps Summary
-
-**PM_REPLICATION_LD**
-
-| class | Set | Value |
-| ----- | --- | ----- |
-| CM_REPLICATION_LD | drop_precedence | 1 |
-| CM_REPLICATION_LD | dscp | af11 |
-| CM_REPLICATION_LD | traffic_class | 2 |
-| CM_REPLICATION_LD_2 | dscp | af11 |
-| CM_REPLICATION_LD_2 | traffic_class | 2 |
-
-**PM_REPLICATION_LD2**
-
-| class | Set | Value |
-| ----- | --- | ----- |
-| CM_REPLICATION_LD | cos | 4 |
-| CM_REPLICATION_LD | dscp | af11 |
-
-### QOS Policy Maps configuration
-
-```eos
-!
-policy-map type quality-of-service PM_REPLICATION_LD
-   class CM_REPLICATION_LD
-      set dscp af11
-      set traffic-class 2
-      set drop-precedence 1
-   !
-   class CM_REPLICATION_LD_2
-      set dscp af11
-      set traffic-class 2
-   !
-!
-policy-map type quality-of-service PM_REPLICATION_LD2
-   class CM_REPLICATION_LD
-      set dscp af11
-      set cos 4
-   !
-```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/policy-maps-pbr.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/policy-maps-pbr.cfg
@@ -1,0 +1,24 @@
+!RANCID-CONTENT-TYPE: arista
+!
+transceiver qsfp default-mode 4x10G
+!
+hostname policy-maps-pbr
+!
+no aaa root
+no enable password
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+!
+policy-map type pbr POLICY_DROP_THEN_NEXTHOP
+   10 class CLASS_DROP
+      drop
+   !
+   20 class CLASS_NEXTHOP
+      set nexthop recursive 172.30.1.2
+   !
+   class NO_ACTION
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/policy-maps.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/policy-maps.cfg
@@ -12,6 +12,12 @@ interface Management1
    vrf MGMT
    ip address 10.73.255.122/24
 !
+policy-map type pbr PM_PBR_BREAKOUT
+   class CM_PBR_EXCLUDE
+   !
+   class CM_PBR_INCLUDE
+      set nexthop recursive 192.168.4.2
+!
 policy-map type quality-of-service PM_REPLICATION_LD
    class CM_REPLICATION_LD
       set dscp af11
@@ -27,13 +33,6 @@ policy-map type quality-of-service PM_REPLICATION_LD2
    class CM_REPLICATION_LD
       set dscp af11
       set cos 4
-   !
-!
-policy-map type pbr PM_PBR_BREAKOUT
-   class CM_PBR_EXCLUDE
-   !
-   class CM_PBR_INCLUDE
-      set nexthop recursive 192.168.4.2
    !
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/policy-maps-pbr.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/policy-maps-pbr.yml
@@ -1,0 +1,15 @@
+policy_maps:
+  pbr:
+    POLICY_DROP_THEN_NEXTHOP:
+      classes:
+        CLASS_DROP:
+          index: 10
+          drop: true
+        CLASS_NEXTHOP:
+          index: 20
+          set:
+            nexthop:
+              ip_address: 172.30.1.2
+              recursive: true
+        # Should create only class
+        NO_ACTION:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
@@ -66,6 +66,7 @@ ntp
 patch-panel
 platform
 policy-maps
+policy-maps-pbr
 port-channel-interfaces
 prefix-lists
 prompt

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -2374,6 +2374,9 @@ policy_maps:
     < policy-map name >:
       classes:
         < class name >:
+          index: < integer > # Optional
+          # Set only one of the below actions per class
+          drop: < true | false >
           set:
             nexthop:
               ip_address: < IPv4_address | IPv6_address >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/policy-maps-pbr.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/policy-maps-pbr.j2
@@ -1,0 +1,28 @@
+{% if policy_maps.pbr is arista.avd.defined %}
+
+## PBR Policy Maps
+
+### PBR Policy Maps Summary
+{%     for policy_map in policy_maps.pbr | arista.avd.natural_sort %}
+
+#### {{ policy_map }}
+{%         if policy_maps.pbr[policy_map].classes is arista.avd.defined %}
+
+| Class | Index | Drop | Nexthop | Recursive |
+| ----- | ----- | ---- | ------- | --------- |
+{%             for class in policy_maps.pbr[policy_map].classes %}
+{%                 set index = policy_maps.pbr[policy_map].classes[class].index | arista.avd.default('-') %}
+{%                 set drop = policy_maps.pbr[policy_map].classes[class].drop | arista.avd.default('-') %}
+{%                 set nexthop = policy_maps.pbr[policy_map].classes[class].set.nexthop.ip_address | arista.avd.default('-') %}
+{%                 set recur = policy_maps.pbr[policy_map].classes[class].set.nexthop.recursive | arista.avd.default('-') %}
+| {{ class }} | {{ index }} | {{ drop }} | {{ nexthop }} | {{ recur }} |
+{%             endfor %}
+{%         endif %}
+{%     endfor %}
+
+### PBR Policy Maps Configuration
+
+```eos
+{%     include 'eos/policy-maps-pbr.j2' %}
+```
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-device-documentation.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-device-documentation.j2
@@ -152,6 +152,8 @@
 {% include 'documentation/router-isis.j2' %}
 {## Router BGP #}
 {% include 'documentation/router-bgp.j2' %}
+{## PBR Policy Maps ##}
+{% include 'documentation/policy-maps-pbr.j2' %}
 {# BFD #}
 {% include 'documentation/bfd.j2' %}
 {# MPLS #}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
@@ -182,6 +182,8 @@
 {% include 'eos/ipv6-static-routes.j2' %}
 {# QOS class-map #}
 {% include 'eos/class-maps-qos.j2' %}
+{# PBR policy-map #}
+{% include 'eos/policy-maps-pbr.j2' %}
 {# QOS policy-map #}
 {% include 'eos/policy-maps-qos.j2' %}
 {# ARP #}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/policy-maps-pbr.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/policy-maps-pbr.j2
@@ -2,17 +2,15 @@
 {% for policy_map in policy_maps.pbr | arista.avd.natural_sort %}
 !
 policy-map type pbr {{ policy_map }}
-{%     set delimiter = namespace(is_set = false) %}
 {%     for class in policy_maps.pbr[policy_map].classes | arista.avd.default([]) %}
 {%         set class_cli = 'class ' ~ class %}
 {%         if policy_maps.pbr[policy_map].classes[class].index is arista.avd.defined %}
 {%             set class_cli = policy_maps.pbr[policy_map].classes[class].index ~ ' ' ~ class_cli %}
 {%         endif %}
-{%         if delimiter.is_set %}
+{%         if not loop.first %}
    !
 {%         endif %}
    {{ class_cli }}
-{%         set delimiter.is_set = true %}
 {%         if policy_maps.pbr[policy_map].classes[class].set.nexthop.ip_address is arista.avd.defined %}
 {%             set nexthop_cli = 'set nexthop' %}
 {%             if policy_maps.pbr[policy_map].classes[class].set.nexthop.recursive is arista.avd.defined(true) %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/policy-maps-pbr.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/policy-maps-pbr.j2
@@ -1,0 +1,28 @@
+{# PBR policy-map #}
+{% for policy_map in policy_maps.pbr | arista.avd.natural_sort %}
+!
+policy-map type pbr {{ policy_map }}
+{%     set delimiter = namespace(is_set = false) %}
+{%     for class in policy_maps.pbr[policy_map].classes | arista.avd.default([]) %}
+{%         set class_cli = 'class ' ~ class %}
+{%         if policy_maps.pbr[policy_map].classes[class].index is arista.avd.defined %}
+{%             set class_cli = policy_maps.pbr[policy_map].classes[class].index ~ ' ' ~ class_cli %}
+{%         endif %}
+{%         if delimiter.is_set %}
+   !
+{%         endif %}
+   {{ class_cli }}
+{%         set delimiter.is_set = true %}
+{%         if policy_maps.pbr[policy_map].classes[class].set.nexthop.ip_address is arista.avd.defined %}
+{%             set nexthop_cli = 'set nexthop' %}
+{%             if policy_maps.pbr[policy_map].classes[class].set.nexthop.recursive is arista.avd.defined(true) %}
+{%                 set nexthop_cli = nexthop_cli ~ ' recursive' %}
+{%             endif %}
+{%             set nexthop_cli = nexthop_cli ~ ' ' ~ policy_maps.pbr[policy_map].classes[class].set.nexthop.ip_address %}
+      {{ nexthop_cli }}
+{%         endif %}
+{%         if policy_maps.pbr[policy_map].classes[class].drop is arista.avd.defined(true) %}
+      drop
+{%         endif %}
+{%     endfor %}
+{% endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/policy-maps-qos.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/policy-maps-qos.j2
@@ -15,20 +15,3 @@ policy-map type quality-of-service {{ policy_map }}
 {%         endif %}
 {%     endfor %}
 {% endfor %}
-{# PBR policy-map #}
-{% for policy_map in policy_maps.pbr | arista.avd.natural_sort %}
-!
-policy-map type pbr {{ policy_map }}
-{%     for class in policy_maps.pbr[policy_map].classes | arista.avd.natural_sort %}
-   class {{ class }}
-{%         if policy_maps.pbr[policy_map].classes[class].set.nexthop.ip_address is arista.avd.defined %}
-{%             set nexthop_cli = 'set nexthop' %}
-{%             if policy_maps.pbr[policy_map].classes[class].set.nexthop.recursive is arista.avd.defined(true) %}
-{%                 set nexthop_cli = nexthop_cli ~ ' recursive' %}
-{%             endif %}
-{%             set nexthop_cli = nexthop_cli ~ ' ' ~ policy_maps.pbr[policy_map].classes[class].set.nexthop.ip_address %}
-      {{ nexthop_cli }}
-{%         endif %}
-   !
-{%     endfor %}
-{% endfor %}


### PR DESCRIPTION
## Change Summary

The old PBR rules were sorted based on the class name, which is not desired. The drop command needs to be added to the PBR rules. This drop policy might end up anywhere in the list based on it's class name. So the sorting over policies is removed and a new index field is added to support more flexibility.


<!-- Enter short PR description -->

## Related Issue(s)

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
The **drop**  knob is added.

```
policy_maps:
  pbr:
    < policy-map name >:
      classes:
        < class name >:
          index: < integer >
          # Set only one of the below actions per class
          drop: < true | false >
          set:
            nexthop:
              ip_address: < IPv4_address | IPv6_address >
              recursive: < true | false >
```
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test

molecule
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
