### PR TITLE
Feat(eos_cli_config_gen): Add support for dual primary detection recovery delay

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mlag-configuration.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mlag-configuration.md
@@ -61,6 +61,8 @@ interface Management1
 
 Heartbeat Interval is 5000 milliseconds.
 Dual primary detection is enabled. The detection delay is 5 seconds.
+Dual primary recovery delay for MLAG interfaces is 90 seconds.
+Dual primary recovery delay for NON-MLAG interfaces is 30 seconds.
 
 ## MLAG Device Configuration
 
@@ -73,6 +75,7 @@ mlag configuration
    peer-address 172.16.0.1
    peer-link Port-Channel12
    dual-primary detection delay 5 action errdisable all-interfaces
+   dual-primary recovery delay mlag 90 non-mlag 30
    reload-delay mlag 400
    reload-delay non-mlag 450
 ```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/mlag-configuration.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/mlag-configuration.cfg
@@ -19,6 +19,7 @@ mlag configuration
    peer-address 172.16.0.1
    peer-link Port-Channel12
    dual-primary detection delay 5 action errdisable all-interfaces
+   dual-primary recovery delay mlag 90 non-mlag 30
    reload-delay mlag 400
    reload-delay non-mlag 450
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/mlag-configuration.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/mlag-configuration.yml
@@ -5,5 +5,7 @@ mlag_configuration:
   peer_link: Port-Channel12
   heartbeat_interval: 5000
   dual_primary_detection_delay: 5
+  dual_primary_recovery_delay_mlag: 90
+  dual_primary_recovery_delay_non_mlag: 30
   reload_delay_mlag: 400
   reload_delay_non_mlag: 450

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1827,6 +1827,8 @@ mlag_configuration:
     peer_ip: < IPv4_address >
     vrf: < vrf_name >
   dual_primary_detection_delay: < seconds >
+  dual_primary_recovery_delay_mlag: < 0 - 1000 >
+  dual_primary_recovery_delay_non_mlag: < 0 - 1000 >
   peer_link: < Port-Channel_id >
   reload_delay_mlag: < seconds >
   reload_delay_non_mlag: < seconds >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/mlag-configuration.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/mlag-configuration.j2
@@ -1,4 +1,4 @@
-{% if mlag_configuration is defined and mlag_configuration is not none %}
+{% if mlag_configuration is arista.avd.defined %}
 
 # MLAG
 
@@ -11,9 +11,13 @@
 {%     if mlag_configuration.heartbeat_interval is arista.avd.defined %}
 Heartbeat Interval is {{ mlag_configuration.heartbeat_interval }} milliseconds.
 {%     endif %}
-{%     if mlag_configuration.dual_primary_detection_delay is defined and mlag_configuration.peer_mlag_configuration.dual_primary_detection_delay
-is not none %}
+{%     if mlag_configuration.dual_primary_detection_delay is arista.avd.defined %}
 Dual primary detection is enabled. The detection delay is {{ mlag_configuration.dual_primary_detection_delay }} seconds.
+{%         if mlag_configuration.dual_primary_recovery_delay_mlag is arista.avd.defined and
+              mlag_configuration.dual_primary_recovery_delay_non_mlag is arista.avd.defined %}
+Dual primary recovery delay for MLAG interfaces is {{ mlag_configuration.dual_primary_recovery_delay_mlag }} seconds.
+Dual primary recovery delay for NON-MLAG interfaces is {{ mlag_configuration.dual_primary_recovery_delay_non_mlag }} seconds.
+{%         endif %}
 {%     else %}
 Dual primary detection is disabled.
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/mlag-configuration.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/mlag-configuration.j2
@@ -28,6 +28,10 @@ mlag configuration
 {%     if mlag_configuration.dual_primary_detection_delay is arista.avd.defined %}
    dual-primary detection delay {{ mlag_configuration.dual_primary_detection_delay }} action errdisable all-interfaces
 {%     endif %}
+{%     if mlag_configuration.dual_primary_recovery_delay_mlag is arista.avd.defined and
+          mlag_configuration.dual_primary_recovery_delay_non_mlag is arista.avd.defined %}
+   dual-primary recovery delay mlag {{ mlag_configuration.dual_primary_recovery_delay_mlag }} non-mlag {{ mlag_configuration.dual_primary_recovery_delay_non_mlag }}
+{%     endif %}
 {%     if mlag_configuration.reload_delay_mlag is arista.avd.defined %}
    reload-delay mlag {{ mlag_configuration.reload_delay_mlag }}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/mlag-configuration.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/mlag-configuration.j2
@@ -27,11 +27,11 @@ mlag configuration
 {%     endif %}
 {%     if mlag_configuration.dual_primary_detection_delay is arista.avd.defined %}
    dual-primary detection delay {{ mlag_configuration.dual_primary_detection_delay }} action errdisable all-interfaces
-{%     endif %}
 {%         if mlag_configuration.dual_primary_recovery_delay_mlag is arista.avd.defined and
               mlag_configuration.dual_primary_recovery_delay_non_mlag is arista.avd.defined %}
    dual-primary recovery delay mlag {{ mlag_configuration.dual_primary_recovery_delay_mlag }} non-mlag {{ mlag_configuration.dual_primary_recovery_delay_non_mlag }}
 {%         endif %}
+{%     endif %}
 {%     if mlag_configuration.reload_delay_mlag is arista.avd.defined %}
    reload-delay mlag {{ mlag_configuration.reload_delay_mlag }}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/mlag-configuration.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/mlag-configuration.j2
@@ -28,10 +28,10 @@ mlag configuration
 {%     if mlag_configuration.dual_primary_detection_delay is arista.avd.defined %}
    dual-primary detection delay {{ mlag_configuration.dual_primary_detection_delay }} action errdisable all-interfaces
 {%     endif %}
-{%     if mlag_configuration.dual_primary_recovery_delay_mlag is arista.avd.defined and
-          mlag_configuration.dual_primary_recovery_delay_non_mlag is arista.avd.defined %}
+{%         if mlag_configuration.dual_primary_recovery_delay_mlag is arista.avd.defined and
+              mlag_configuration.dual_primary_recovery_delay_non_mlag is arista.avd.defined %}
    dual-primary recovery delay mlag {{ mlag_configuration.dual_primary_recovery_delay_mlag }} non-mlag {{ mlag_configuration.dual_primary_recovery_delay_non_mlag }}
-{%     endif %}
+{%         endif %}
 {%     if mlag_configuration.reload_delay_mlag is arista.avd.defined %}
    reload-delay mlag {{ mlag_configuration.reload_delay_mlag }}
 {%     endif %}


### PR DESCRIPTION
## Change Summary

Modify the `mlag_configuration` data model  to add support for the following command:

```
dual-primary recovery delay mlag < 0 - 1000 > non-mlag < 0 - 1000 >
```

This is part of the standard MLAG dual primary detection configuration. Thus the commands are only rendered if dual primary detaction is activated.

## Related Issue(s)

Partially fixes #1527 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Changes to the `mlag_configuration` data model:

```yaml
mlag_configuration:
  domain_id: < domain_id_name >
  heartbeat_interval: < milliseconds >
  local_interface: < interface_name >
  peer_address: < IPv4_address >
  peer_address_heartbeat:
    peer_ip: < IPv4_address >
    vrf: < vrf_name >
  dual_primary_detection_delay: < seconds >
  dual_primary_recovery_delay_mlag: < 0 - 1000 >
  dual_primary_recovery_delay_non_mlag: < 0 - 1000 >
  peer_link: < Port-Channel_id >
  reload_delay_mlag: < seconds >
  reload_delay_non_mlag: < seconds >
```

The configuration for dual primary recovery delay is only rendered if both `mlag` and `non-mlag` are defined. According to the documentation, both need to be defined and the latter should be less than the former. This is however not validated here.
In addition to both `mlag` and `non-mlag` recovery delays being defined, dual primary detection needs to be activated, otherwise the dual primary recovery configuration is not rendered.

## How to test
See molecule tests

## Checklist

### User Checklist

- N/A

### Repository Checklist

- [X] My code has been rebased from devel before I start
- [X] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [X] My change requires a change to the documentation and documentation have been updated accordingly.
- [X] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
