### PR TITLE
Feat(eos_cli_config_gen): Add Management SSH log

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-ssh.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-ssh.md
@@ -89,6 +89,7 @@ management ssh
    connection limit 50
    connection per-host 10
    no shutdown
+   log-level debug
    vrf mgt
       no shutdown
 ```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-ssh.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-ssh.cfg
@@ -19,6 +19,7 @@ management ssh
    connection limit 50
    connection per-host 10
    no shutdown
+   log-level debug
    vrf mgt
       no shutdown
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/management-ssh.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/management-ssh.yml
@@ -11,3 +11,4 @@ management_ssh:
   vrfs:
     mgt:
       enable: true
+  log_level: debug

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1765,6 +1765,7 @@ management_ssh:
       enable: < true | false >
     < vrf_name_2 >:
       enable: < true | false >
+  log_level: < SSH daemon log level >
 ```
 
 #### IP SSH Client Source Interfaces

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-ssh.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-ssh.j2
@@ -48,6 +48,9 @@ management ssh
 {%     elif management_ssh.enable is arista.avd.defined(true) %}
    no shutdown
 {%     endif %}
+{%     if management_ssh.log_level is arista.avd.defined %}
+   log-level {{ management_ssh.log_level }}
+{%     endif %}
 {%     for vrf in management_ssh.vrfs | arista.avd.natural_sort %}
    vrf {{ vrf }}
 {%         if management_ssh.vrfs[vrf].enable is arista.avd.defined(true) %}


### PR DESCRIPTION
## Change Summary

Add the variable log_level to the data model to be able to configure the daemon. Template for EOS CLI is also added and molecule scenario too.

## Related Issue(s)

Fixes #1507 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Adding the following to the data model:
```yaml
management_ssh:
  log_level: < SSH daemon log level >
```

## How to test
Molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
