### PR TITLE
Feat(eos_cli_config_gen): Add support for changing the notification timestamp mode for gnmi (Issues/1532)

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-gnmi-new-flags.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-gnmi-new-flags.md
@@ -1,4 +1,4 @@
-# management-gnmi
+# management-gnmi-new-flags
 # Table of Contents
 
 - [Management](#management)
@@ -49,10 +49,12 @@ interface Management1
 
 ### Management API GNMI Summary
 
-| VRF with GNMI | OCTA |
-| ------------- | ---- |
-| MGMT | enabled |
-| MONITORING | enabled |
+| Transport | VRF | Notification Timestamp | ACL |
+| --------- | --- | ---------------------- | --- |
+| MGMT | MGMT | send-time | acl1 |
+| mytransport | - | send-time | acl1 |
+
+Provider eos-native is configured.
 
 ### Management API gnmi configuration
 
@@ -60,10 +62,13 @@ interface Management1
 !
 management api gnmi
    transport grpc MGMT
-      ip access-group ACL-GNMI
       vrf MGMT
-   transport grpc MONITORING
-      vrf MONITORING
+      ip access-group acl1
+      notification timestamp send-time
+   transport grpc mytransport
+      ip access-group acl1
+      notification timestamp send-time
+   provider eos-native
 ```
 
 # Authentication

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-gnmi.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-gnmi.md
@@ -64,6 +64,7 @@ management api gnmi
       vrf MGMT
    transport grpc MONITORING
       vrf MONITORING
+   provider eos-native
 ```
 
 # Authentication

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-gnmi-new-flags.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-gnmi-new-flags.cfg
@@ -1,0 +1,25 @@
+!RANCID-CONTENT-TYPE: arista
+!
+transceiver qsfp default-mode 4x10G
+!
+hostname management-gnmi-new-flags
+!
+no enable password
+no aaa root
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+!
+management api gnmi
+   transport grpc MGMT
+      vrf MGMT
+      ip access-group acl1
+      notification timestamp send-time
+   transport grpc mytransport
+      ip access-group acl1
+      notification timestamp send-time
+   provider eos-native
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-gnmi.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-gnmi.cfg
@@ -18,5 +18,6 @@ management api gnmi
       vrf MGMT
    transport grpc MONITORING
       vrf MONITORING
+   provider eos-native
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/management-gnmi-new-flags.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/management-gnmi-new-flags.yml
@@ -1,0 +1,11 @@
+management_api_gnmi:
+  provider: "eos-native"
+  transport:
+    grpc:
+    - name: MGMT
+      vrf: MGMT
+      notification_timestamp: "send-time"
+      ip_access_group: acl1
+    - name: mytransport
+      notification_timestamp: "send-time"
+      ip_access_group: acl1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
@@ -49,6 +49,7 @@ mac-address-table
 maintenance
 management-api-http
 management-gnmi
+management-gnmi-new-flags
 management-console
 management-defaults
 management-interfaces

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/management-gnmi-new-flags.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/management-gnmi-new-flags.md
@@ -1,4 +1,4 @@
-# management-gnmi
+# management-gnmi-new-flags
 # Table of Contents
 
 - [Management](#management)
@@ -49,10 +49,12 @@ interface Management1
 
 ### Management API GNMI Summary
 
-| VRF with GNMI | OCTA |
-| ------------- | ---- |
-| MGMT | enabled |
-| MONITORING | enabled |
+| Transport | VRF | Notification Timestamp | ACL |
+| --------- | --- | ---------------------- | --- |
+| MGMT | MGMT | send-time | acl1 |
+| mytransport | - | send-time | acl1 |
+
+Provider eos-native is configured.
 
 ### Management API gnmi configuration
 
@@ -60,10 +62,13 @@ interface Management1
 !
 management api gnmi
    transport grpc MGMT
-      ip access-group ACL-GNMI
       vrf MGMT
-   transport grpc MONITORING
-      vrf MONITORING
+      ip access-group acl1
+      notification timestamp send-time
+   transport grpc mytransport
+      ip access-group acl1
+      notification timestamp send-time
+   provider eos-native
 ```
 
 # Authentication

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/management-gnmi.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/management-gnmi.md
@@ -50,7 +50,7 @@ interface Management1
 ### Management API GNMI Summary
 
 | VRF with GNMI | OCTA |
-| ---------- | ---------- |
+| ------------- | ---- |
 | MGMT | enabled |
 | MONITORING | enabled |
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/management-gnmi.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/management-gnmi.md
@@ -64,6 +64,7 @@ management api gnmi
       vrf MGMT
    transport grpc MONITORING
       vrf MONITORING
+   provider eos-native
 ```
 
 # Authentication

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/management-gnmi-new-flags.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/management-gnmi-new-flags.cfg
@@ -1,0 +1,25 @@
+!RANCID-CONTENT-TYPE: arista
+!
+transceiver qsfp default-mode 4x10G
+!
+hostname management-gnmi-new-flags
+!
+no enable password
+no aaa root
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+!
+management api gnmi
+   transport grpc MGMT
+      vrf MGMT
+      ip access-group acl1
+      notification timestamp send-time
+   transport grpc mytransport
+      ip access-group acl1
+      notification timestamp send-time
+   provider eos-native
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/management-gnmi.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/management-gnmi.cfg
@@ -18,5 +18,6 @@ management api gnmi
       vrf MGMT
    transport grpc MONITORING
       vrf MONITORING
+   provider eos-native
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/management-gnmi-new-flags.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/management-gnmi-new-flags.yml
@@ -1,0 +1,11 @@
+management_api_gnmi:
+  provider: "eos-native"
+  transport:
+    grpc:
+    - name: MGMT
+      vrf: MGMT
+      notification_timestamp: "send-time"
+      ip_access_group: acl1
+    - name: mytransport
+      notification_timestamp: "send-time"
+      ip_access_group: acl1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/hosts.ini
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/hosts.ini
@@ -49,6 +49,7 @@ mac-address-table
 maintenance
 management-api-http
 management-gnmi
+management-gnmi-new-flags
 management-console
 management-interfaces
 management-security

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1701,16 +1701,28 @@ ip_http_client_source_interfaces:
 
 ```yaml
 management_api_gnmi:
+  provider: < "eos-native" >
+  transport:
+     grpc:
+     - name: < transport_name >
+       # vrf is optional
+       vrf: < vrf_name >
+      # Per the GNMI specification, the default timestamp field of a notification message is set to be
+      # the time at which the value of the underlying data source changes or when the reported event takes place.
+      # In order to facilitate integration in legacy environments oriented around polling style operations,
+      # an option to support overriding the timestamp field to the send-time is available from EOS 4.27.0F.
+      notification_timestamp: < "send-time" | "last-change-time" >
+      ip_access_group: < acl_name >
+
+  # Below keys will be deprecated in AVD v4.0 - These should not be mixed with the new keys above.
   enable_vrfs:
     < vrf_name_1 >:
       access_group: < Standard IPv4 ACL name >
     < vrf_name_2 >:
       access_group: < Standard IPv4 ACL name >
+  # Enable provider 'eos-native' to stream both OpenConfig and EOS native paths.
   octa:
 ```
-
-!!! info "gNMI provider"
-    Octa activates `eos-native` provider and it is the only provider currently supported by EOS.
 
 #### Management Console
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1703,16 +1703,16 @@ ip_http_client_source_interfaces:
 management_api_gnmi:
   provider: < "eos-native" >
   transport:
-     grpc:
-     - name: < transport_name >
-       # vrf is optional
-       vrf: < vrf_name >
-      # Per the GNMI specification, the default timestamp field of a notification message is set to be
-      # the time at which the value of the underlying data source changes or when the reported event takes place.
-      # In order to facilitate integration in legacy environments oriented around polling style operations,
-      # an option to support overriding the timestamp field to the send-time is available from EOS 4.27.0F.
-      notification_timestamp: < "send-time" | "last-change-time" >
-      ip_access_group: < acl_name >
+    grpc:
+      - name: < transport_name >
+        # vrf is optional
+        vrf: < vrf_name >
+        # Per the GNMI specification, the default timestamp field of a notification message is set to be
+        # the time at which the value of the underlying data source changes or when the reported event takes place.
+        # In order to facilitate integration in legacy environments oriented around polling style operations,
+        # an option to support overriding the timestamp field to the send-time is available from EOS 4.27.0F.
+        notification_timestamp: < "send-time" | "last-change-time" >
+        ip_access_group: < acl_name >
 
   # Below keys will be deprecated in AVD v4.0 - These should not be mixed with the new keys above.
   enable_vrfs:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-api-gnmi.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-api-gnmi.j2
@@ -4,20 +4,40 @@
 ## Management API GNMI
 
 ### Management API GNMI Summary
-
+{# legacy table view that will be deprecated in future releases#}
 {%     if management_api_gnmi.enable_vrfs is defined %}
+{%         if management_api_gnmi.octa is defined  %}
+{%             set octa = 'enabled' %}
+{%         else %}
+{%             set octa = 'disabled' %}
+{%         endif %}
+
 | VRF with GNMI | OCTA |
-| ---------- | ---------- |
+| ------------- | ---- |
 {%         for vrf in management_api_gnmi.enable_vrfs | arista.avd.natural_sort %}
-{%             if management_api_gnmi.octa is defined  %}
-{%                 set octa= 'enabled' %}
-{%             else %}
-{%                 set octa= 'disabled' %}
-{%             endif %}
 | {{ vrf }} | {{ octa }} |
 {%         endfor %}
-{%     else %}
-GNMI is not configured on any VRF.
+{%     endif %}
+{# new table view using the new flags #}
+{%     if management_api_gnmi.transport is arista.avd.defined %}
+
+| Transport | VRF | Notification Timestamp | ACL |
+| --------- | --- | ---------------------- | --- |
+{%         if management_api_gnmi.transport.grpc is arista.avd.defined %}
+{%             for transport in management_api_gnmi.transport.grpc %}
+{%                 if transport.name is arista.avd.defined %}
+{%                     set transport_name = transport.name %}
+{%                     set vrf = transport.vrf | arista.avd.default('-') %}
+{%                     set notif = transport.notification_timestamp | arista.avd.default('last-change-time') %}
+{%                     set acl = transport.ip_access_group | arista.avd.default('-') %}
+| {{ transport_name }} | {{ vrf }} | {{ notif }} | {{ acl }} |
+{%                 endif %}
+{%             endfor %}
+{%         endif %}
+{%     endif %}
+{%     if management_api_gnmi.provider is arista.avd.defined %}
+
+Provider {{ management_api_gnmi.provider }} is configured.
 {%     endif %}
 
 ### Management API gnmi configuration

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-api-gnmi.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-api-gnmi.j2
@@ -4,7 +4,7 @@
 ## Management API GNMI
 
 ### Management API GNMI Summary
-{# legacy table view that will be deprecated in future releases#}
+{# legacy table view that will be deprecated in future releases #}
 {%     if management_api_gnmi.enable_vrfs is defined %}
 {%         if management_api_gnmi.octa is defined  %}
 {%             set octa = 'enabled' %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-api-gnmi.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-api-gnmi.j2
@@ -13,7 +13,7 @@ management api gnmi
       vrf {{ vrf }}
 {%         endif %}
 {%     endfor %}
-{%     if management_api_gnmi.octa is arista.avd.defined %}
+{%     if management_api_gnmi.octa is defined %}
    provider eos-native
 {%     endif %}
 {%     if management_api_gnmi.transport is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-api-gnmi.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-api-gnmi.j2
@@ -16,4 +16,25 @@ management api gnmi
 {%     if management_api_gnmi.octa is arista.avd.defined %}
    provider eos-native
 {%     endif %}
+{%     if management_api_gnmi.transport is arista.avd.defined %}
+{%         if management_api_gnmi.transport.grpc is arista.avd.defined %}
+{%             for transport in management_api_gnmi.transport.grpc %}
+{%                 if transport.name is arista.avd.defined %}
+   transport grpc {{ transport.name }}
+{%                     if transport.vrf is arista.avd.defined %}
+      vrf {{ transport.vrf }}
+{%                     endif %}
+{%                     if transport.ip_access_group is arista.avd.defined %}
+      ip access-group {{ transport.ip_access_group }}
+{%                     endif %}
+{%                     if transport.notification_timestamp is arista.avd.defined %}
+      notification timestamp {{ transport.notification_timestamp }}
+{%                     endif %}
+{%                 endif %}
+{%             endfor %}
+{%         endif %}
+{%     endif %}
+{%     if management_api_gnmi.provider is arista.avd.defined %}
+   provider {{ management_api_gnmi.provider }}
+{%     endif %}
 {% endif %}


### PR DESCRIPTION
## Change Summary

added support for `notification timestamp send-time` under `management api gnmi` that was introduced in EOS 4.27.0F (ref: https://aristanetworks.github.io/openmgmt/configuration/openconfig/#telemetry-timestamps)

## Related Issue(s)

Fixes #1532 

## Component(s) name

```arista.avd.eos_cli_config_gen```

## Proposed changes
didn't modify the existing data model, just added another key for `set_send_time`

## How to test

add `set_send_time: true` under `management_api_gnmi` in the fabric group_vars

```yaml
management_api_gnmi:
  set_send_time: true
  enable_vrfs:
    MGMT:
    #  access_group: test1
  octa: true
```



## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
