### PR TITLE
Doc(eos_designs): Fix typos in Monitor Session Documentation

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_designs/doc/connected-endpoints.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/connected-endpoints.md
@@ -171,28 +171,28 @@ port_profiles:
             unit: < percent | pps > | Optional var and is hardware dependant - default is percent)
 
         # Monitor Session configuration: use defined switchports as source or destination for monitoring sessions | Optional
-        monitor_session:
-          name: < session_name >
-          role: < source | destination >
-          source_settings:
-            - direction: < rx | tx | both >
+        monitor_sessions:
+          - name: < session_name >
+            role: < source | destination >
+            source_settings:
+              - direction: < rx | tx | both >
+                access_group:
+                  type: < ip | ipv6 | mac >
+                  name: < acl_name >
+                  priority: < priority >
+            # Session settings are defined per session name. Different session_settings with for same session name will be combined/merged
+            session_settings:
+              encapsulation_gre_metadata_tx: < true | false >
+              header_remove_size: < bytes >
               access_group:
                 type: < ip | ipv6 | mac >
                 name: < acl_name >
-                priority: < priority >
-          # Session settings are defined per session name. Different session_settings with for same session name will be combined/merged
-          session_settings:
-            encapsulation_gre_metadata_tx: < true | false >
-            header_remove_size: < bytes >
-            access_group:
-              type: < ip | ipv6 | mac >
-              name: < acl_name >
-            rate_limit_per_ingress_chip: < "<int> bps" | "<int> kbps" | "<int> mbps" >
-            rate_limit_per_egress_chip: < "<int> bps" | "<int> kbps" | "<int> mbps" >
-            sample: < int >
-            truncate:
-              enabled: < true | false >
-              size: < bytes >
+              rate_limit_per_ingress_chip: < "<int> bps" | "<int> kbps" | "<int> mbps" >
+              rate_limit_per_egress_chip: < "<int> bps" | "<int> kbps" | "<int> mbps" >
+              sample: < int >
+              truncate:
+                enabled: < true | false >
+                size: < bytes >
 
       # Example of port-channel adapter
       - endpoint_ports: [ < interface_name_1 > , < interface_name_2 > ]

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/connected-endpoints.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/connected-endpoints.md
@@ -175,11 +175,11 @@ port_profiles:
           - name: < session_name >
             role: < source | destination >
             source_settings:
-              - direction: < rx | tx | both >
-                access_group:
-                  type: < ip | ipv6 | mac >
-                  name: < acl_name >
-                  priority: < priority >
+              direction: < rx | tx | both >
+              access_group:
+                type: < ip | ipv6 | mac >
+                name: < acl_name >
+                priority: < priority >
             # Session settings are defined per session name. Different session_settings with for same session name will be combined/merged
             session_settings:
               encapsulation_gre_metadata_tx: < true | false >


### PR DESCRIPTION
## Change Summary

Pasted old datamodel in documentation. Fixing by adding the actual datamodel that was used

## Related Issue(s)

Fixes #1472 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Correct data model is:

```
monitor_sessions:
  - name: < session_name >
    role: < source | destination >
    source_settings:
      direction: < rx | tx | both >
      access_group:
        type: < ip | ipv6 | mac >
        name: < acl_name >
        priority: < priority >
    session_settings:
      encapsulation_gre_metadata_tx: < true | false >
      header_remove_size: < bytes >
      access_group:
        type: < ip | ipv6 | mac >
        name: < acl_name >
      rate_limit_per_ingress_chip: < "<int> bps" | "<int> kbps" | "<int> mbps" >
      rate_limit_per_egress_chip: < "<int> bps" | "<int> kbps" | "<int> mbps" >
      sample: < int >
      truncate:
        enabled: < true | false >
        size: < bytes >
```

## How to test
Molecule tests

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [o] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
