### PR TITLE
Feat(eos_designs): Add description to MLAG BGP peer on VRFs

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vrf-lite.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vrf-lite.md
@@ -180,20 +180,20 @@ router bgp 65001
    distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
-   neighbor OBS_WAN description BGP Connection to OBS WAN CPE
    neighbor OBS_WAN peer group
    neighbor OBS_WAN remote-as 65000
-   neighbor SEDI description BGP Connection to OBS WAN CPE
+   neighbor OBS_WAN description BGP Connection to OBS WAN CPE
    neighbor SEDI peer group
    neighbor SEDI remote-as 65003
    neighbor SEDI update-source Loopback101
+   neighbor SEDI description BGP Connection to OBS WAN CPE
    neighbor SEDI ebgp-multihop 10
-   neighbor SEDI-shut description BGP Peer Shutdown
    neighbor SEDI-shut shutdown
    neighbor SEDI-shut peer group
-   neighbor WELCOME_ROUTERS description BGP Connection to WELCOME ROUTER 02
+   neighbor SEDI-shut description BGP Peer Shutdown
    neighbor WELCOME_ROUTERS peer group
    neighbor WELCOME_ROUTERS remote-as 65001
+   neighbor WELCOME_ROUTERS description BGP Connection to WELCOME ROUTER 02
    redistribute static
    !
    address-family ipv4

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-vrf-lite.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-vrf-lite.cfg
@@ -39,20 +39,20 @@ router bgp 65001
    distance bgp 20 200 200
    graceful-restart restart-time 300
    graceful-restart
-   neighbor OBS_WAN description BGP Connection to OBS WAN CPE
    neighbor OBS_WAN peer group
    neighbor OBS_WAN remote-as 65000
-   neighbor SEDI description BGP Connection to OBS WAN CPE
+   neighbor OBS_WAN description BGP Connection to OBS WAN CPE
    neighbor SEDI peer group
    neighbor SEDI remote-as 65003
    neighbor SEDI update-source Loopback101
+   neighbor SEDI description BGP Connection to OBS WAN CPE
    neighbor SEDI ebgp-multihop 10
-   neighbor SEDI-shut description BGP Peer Shutdown
    neighbor SEDI-shut shutdown
    neighbor SEDI-shut peer group
-   neighbor WELCOME_ROUTERS description BGP Connection to WELCOME ROUTER 02
+   neighbor SEDI-shut description BGP Peer Shutdown
    neighbor WELCOME_ROUTERS peer group
    neighbor WELCOME_ROUTERS remote-as 65001
+   neighbor WELCOME_ROUTERS description BGP Connection to WELCOME ROUTER 02
    redistribute static
    !
    address-family ipv4

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1A.md
@@ -792,6 +792,7 @@ router bgp 65104
       route-target export evpn 14:14
       router-id 192.168.255.10
       neighbor 10.255.251.11 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.11 description DC1-BL1B
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -800,6 +801,7 @@ router bgp 65104
       route-target export evpn 21:21
       router-id 192.168.255.10
       neighbor 10.255.251.11 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.11 description DC1-BL1B
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -808,6 +810,7 @@ router bgp 65104
       route-target export evpn 31:31
       router-id 192.168.255.10
       neighbor 10.255.251.11 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.11 description DC1-BL1B
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1A.md
@@ -728,6 +728,7 @@ router bgp 65104
    neighbor MLAG-IPv4-UNDERLAY-PEER peer group
    neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65104
    neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
+   neighbor MLAG-IPv4-UNDERLAY-PEER description DC1-BL1B
    neighbor MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==
    neighbor MLAG-IPv4-UNDERLAY-PEER send-community
    neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000
@@ -792,7 +793,6 @@ router bgp 65104
       route-target export evpn 14:14
       router-id 192.168.255.10
       neighbor 10.255.251.11 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.11 description DC1-BL1B
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -801,7 +801,6 @@ router bgp 65104
       route-target export evpn 21:21
       router-id 192.168.255.10
       neighbor 10.255.251.11 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.11 description DC1-BL1B
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -810,7 +809,6 @@ router bgp 65104
       route-target export evpn 31:31
       router-id 192.168.255.10
       neighbor 10.255.251.11 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.11 description DC1-BL1B
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1B.md
@@ -728,6 +728,7 @@ router bgp 65104
    neighbor MLAG-IPv4-UNDERLAY-PEER peer group
    neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65104
    neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
+   neighbor MLAG-IPv4-UNDERLAY-PEER description DC1-BL1A
    neighbor MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==
    neighbor MLAG-IPv4-UNDERLAY-PEER send-community
    neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000
@@ -792,7 +793,6 @@ router bgp 65104
       route-target export evpn 14:14
       router-id 192.168.255.11
       neighbor 10.255.251.10 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.10 description DC1-BL1A
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -801,7 +801,6 @@ router bgp 65104
       route-target export evpn 21:21
       router-id 192.168.255.11
       neighbor 10.255.251.10 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.10 description DC1-BL1A
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -810,7 +809,6 @@ router bgp 65104
       route-target export evpn 31:31
       router-id 192.168.255.11
       neighbor 10.255.251.10 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.10 description DC1-BL1A
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1B.md
@@ -792,6 +792,7 @@ router bgp 65104
       route-target export evpn 14:14
       router-id 192.168.255.11
       neighbor 10.255.251.10 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.10 description DC1-BL1A
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -800,6 +801,7 @@ router bgp 65104
       route-target export evpn 21:21
       router-id 192.168.255.11
       neighbor 10.255.251.10 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.10 description DC1-BL1A
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -808,6 +810,7 @@ router bgp 65104
       route-target export evpn 31:31
       router-id 192.168.255.11
       neighbor 10.255.251.10 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.10 description DC1-BL1A
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2A.md
@@ -964,6 +964,7 @@ router bgp 65102
    neighbor MLAG-IPv4-UNDERLAY-PEER peer group
    neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65102
    neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
+   neighbor MLAG-IPv4-UNDERLAY-PEER description DC1-LEAF2B
    neighbor MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==
    neighbor MLAG-IPv4-UNDERLAY-PEER send-community
    neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000
@@ -1046,7 +1047,6 @@ router bgp 65102
       route-target export evpn 12:12
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1055,7 +1055,6 @@ router bgp 65102
       route-target export evpn 13:13
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1064,7 +1063,6 @@ router bgp 65102
       route-target export evpn 10:10
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1073,7 +1071,6 @@ router bgp 65102
       route-target export evpn 11:11
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1082,7 +1079,6 @@ router bgp 65102
       route-target export evpn 20:20
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1091,7 +1087,6 @@ router bgp 65102
       route-target export evpn 30:30
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2A.md
@@ -1046,6 +1046,7 @@ router bgp 65102
       route-target export evpn 12:12
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1054,6 +1055,7 @@ router bgp 65102
       route-target export evpn 13:13
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1062,6 +1064,7 @@ router bgp 65102
       route-target export evpn 10:10
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1070,6 +1073,7 @@ router bgp 65102
       route-target export evpn 11:11
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1078,6 +1082,7 @@ router bgp 65102
       route-target export evpn 20:20
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1086,6 +1091,7 @@ router bgp 65102
       route-target export evpn 30:30
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2B.md
@@ -1046,6 +1046,7 @@ router bgp 65102
       route-target export evpn 12:12
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1054,6 +1055,7 @@ router bgp 65102
       route-target export evpn 13:13
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1062,6 +1064,7 @@ router bgp 65102
       route-target export evpn 10:10
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1070,6 +1073,7 @@ router bgp 65102
       route-target export evpn 11:11
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1078,6 +1082,7 @@ router bgp 65102
       route-target export evpn 20:20
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1086,6 +1091,7 @@ router bgp 65102
       route-target export evpn 30:30
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2B.md
@@ -964,6 +964,7 @@ router bgp 65102
    neighbor MLAG-IPv4-UNDERLAY-PEER peer group
    neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65102
    neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
+   neighbor MLAG-IPv4-UNDERLAY-PEER description DC1-LEAF2A
    neighbor MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==
    neighbor MLAG-IPv4-UNDERLAY-PEER send-community
    neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000
@@ -1046,7 +1047,6 @@ router bgp 65102
       route-target export evpn 12:12
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1055,7 +1055,6 @@ router bgp 65102
       route-target export evpn 13:13
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1064,7 +1063,6 @@ router bgp 65102
       route-target export evpn 10:10
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1073,7 +1071,6 @@ router bgp 65102
       route-target export evpn 11:11
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1082,7 +1079,6 @@ router bgp 65102
       route-target export evpn 20:20
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1091,7 +1087,6 @@ router bgp 65102
       route-target export evpn 30:30
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3A.md
@@ -1078,6 +1078,7 @@ router bgp 65103
    neighbor MLAG-IPv4-UNDERLAY-PEER peer group
    neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65103
    neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
+   neighbor MLAG-IPv4-UNDERLAY-PEER description DC1-SVC3B
    neighbor MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==
    neighbor MLAG-IPv4-UNDERLAY-PEER send-community
    neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000
@@ -1178,7 +1179,6 @@ router bgp 65103
       route-target export evpn 12:12
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1187,7 +1187,6 @@ router bgp 65103
       route-target export evpn 13:13
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1196,7 +1195,6 @@ router bgp 65103
       route-target export evpn 10:10
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -1205,7 +1203,6 @@ router bgp 65103
       route-target export evpn 14:14
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1214,7 +1211,6 @@ router bgp 65103
       route-target export evpn 11:11
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1223,7 +1219,6 @@ router bgp 65103
       route-target export evpn 20:20
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -1232,7 +1227,6 @@ router bgp 65103
       route-target export evpn 21:21
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1241,7 +1235,6 @@ router bgp 65103
       route-target export evpn 30:30
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -1250,7 +1243,6 @@ router bgp 65103
       route-target export evpn 31:31
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3A.md
@@ -1178,6 +1178,7 @@ router bgp 65103
       route-target export evpn 12:12
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1186,6 +1187,7 @@ router bgp 65103
       route-target export evpn 13:13
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1194,6 +1196,7 @@ router bgp 65103
       route-target export evpn 10:10
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -1202,6 +1205,7 @@ router bgp 65103
       route-target export evpn 14:14
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1210,6 +1214,7 @@ router bgp 65103
       route-target export evpn 11:11
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1218,6 +1223,7 @@ router bgp 65103
       route-target export evpn 20:20
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -1226,6 +1232,7 @@ router bgp 65103
       route-target export evpn 21:21
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1234,6 +1241,7 @@ router bgp 65103
       route-target export evpn 30:30
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -1242,6 +1250,7 @@ router bgp 65103
       route-target export evpn 31:31
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3B.md
@@ -1163,6 +1163,7 @@ router bgp 65103
       route-target export evpn 12:12
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1171,6 +1172,7 @@ router bgp 65103
       route-target export evpn 13:13
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1179,6 +1181,7 @@ router bgp 65103
       route-target export evpn 10:10
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -1187,6 +1190,7 @@ router bgp 65103
       route-target export evpn 14:14
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1195,6 +1199,7 @@ router bgp 65103
       route-target export evpn 11:11
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1203,6 +1208,7 @@ router bgp 65103
       route-target export evpn 20:20
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -1211,6 +1217,7 @@ router bgp 65103
       route-target export evpn 21:21
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1219,6 +1226,7 @@ router bgp 65103
       route-target export evpn 30:30
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -1227,6 +1235,7 @@ router bgp 65103
       route-target export evpn 31:31
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3B.md
@@ -1063,6 +1063,7 @@ router bgp 65103
    neighbor MLAG-IPv4-UNDERLAY-PEER peer group
    neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65103
    neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
+   neighbor MLAG-IPv4-UNDERLAY-PEER description DC1-SVC3A
    neighbor MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==
    neighbor MLAG-IPv4-UNDERLAY-PEER send-community
    neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000
@@ -1163,7 +1164,6 @@ router bgp 65103
       route-target export evpn 12:12
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1172,7 +1172,6 @@ router bgp 65103
       route-target export evpn 13:13
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1181,7 +1180,6 @@ router bgp 65103
       route-target export evpn 10:10
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -1190,7 +1188,6 @@ router bgp 65103
       route-target export evpn 14:14
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1199,7 +1196,6 @@ router bgp 65103
       route-target export evpn 11:11
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1208,7 +1204,6 @@ router bgp 65103
       route-target export evpn 20:20
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -1217,7 +1212,6 @@ router bgp 65103
       route-target export evpn 21:21
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1226,7 +1220,6 @@ router bgp 65103
       route-target export evpn 30:30
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -1235,7 +1228,6 @@ router bgp 65103
       route-target export evpn 31:31
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-BL1A.cfg
@@ -306,6 +306,7 @@ router bgp 65104
       route-target export evpn 14:14
       router-id 192.168.255.10
       neighbor 10.255.251.11 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.11 description DC1-BL1B
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -314,6 +315,7 @@ router bgp 65104
       route-target export evpn 21:21
       router-id 192.168.255.10
       neighbor 10.255.251.11 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.11 description DC1-BL1B
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -322,6 +324,7 @@ router bgp 65104
       route-target export evpn 31:31
       router-id 192.168.255.10
       neighbor 10.255.251.11 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.11 description DC1-BL1B
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-BL1A.cfg
@@ -242,6 +242,7 @@ router bgp 65104
    neighbor MLAG-IPv4-UNDERLAY-PEER peer group
    neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65104
    neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
+   neighbor MLAG-IPv4-UNDERLAY-PEER description DC1-BL1B
    neighbor MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==
    neighbor MLAG-IPv4-UNDERLAY-PEER send-community
    neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000
@@ -306,7 +307,6 @@ router bgp 65104
       route-target export evpn 14:14
       router-id 192.168.255.10
       neighbor 10.255.251.11 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.11 description DC1-BL1B
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -315,7 +315,6 @@ router bgp 65104
       route-target export evpn 21:21
       router-id 192.168.255.10
       neighbor 10.255.251.11 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.11 description DC1-BL1B
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -324,7 +323,6 @@ router bgp 65104
       route-target export evpn 31:31
       router-id 192.168.255.10
       neighbor 10.255.251.11 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.11 description DC1-BL1B
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-BL1B.cfg
@@ -242,6 +242,7 @@ router bgp 65104
    neighbor MLAG-IPv4-UNDERLAY-PEER peer group
    neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65104
    neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
+   neighbor MLAG-IPv4-UNDERLAY-PEER description DC1-BL1A
    neighbor MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==
    neighbor MLAG-IPv4-UNDERLAY-PEER send-community
    neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000
@@ -306,7 +307,6 @@ router bgp 65104
       route-target export evpn 14:14
       router-id 192.168.255.11
       neighbor 10.255.251.10 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.10 description DC1-BL1A
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -315,7 +315,6 @@ router bgp 65104
       route-target export evpn 21:21
       router-id 192.168.255.11
       neighbor 10.255.251.10 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.10 description DC1-BL1A
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -324,7 +323,6 @@ router bgp 65104
       route-target export evpn 31:31
       router-id 192.168.255.11
       neighbor 10.255.251.10 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.10 description DC1-BL1A
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-BL1B.cfg
@@ -306,6 +306,7 @@ router bgp 65104
       route-target export evpn 14:14
       router-id 192.168.255.11
       neighbor 10.255.251.10 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.10 description DC1-BL1A
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -314,6 +315,7 @@ router bgp 65104
       route-target export evpn 21:21
       router-id 192.168.255.11
       neighbor 10.255.251.10 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.10 description DC1-BL1A
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -322,6 +324,7 @@ router bgp 65104
       route-target export evpn 31:31
       router-id 192.168.255.11
       neighbor 10.255.251.10 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.10 description DC1-BL1A
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-LEAF2A.cfg
@@ -498,6 +498,7 @@ router bgp 65102
       route-target export evpn 12:12
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -506,6 +507,7 @@ router bgp 65102
       route-target export evpn 13:13
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -514,6 +516,7 @@ router bgp 65102
       route-target export evpn 10:10
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -522,6 +525,7 @@ router bgp 65102
       route-target export evpn 11:11
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -530,6 +534,7 @@ router bgp 65102
       route-target export evpn 20:20
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -538,6 +543,7 @@ router bgp 65102
       route-target export evpn 30:30
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-LEAF2A.cfg
@@ -416,6 +416,7 @@ router bgp 65102
    neighbor MLAG-IPv4-UNDERLAY-PEER peer group
    neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65102
    neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
+   neighbor MLAG-IPv4-UNDERLAY-PEER description DC1-LEAF2B
    neighbor MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==
    neighbor MLAG-IPv4-UNDERLAY-PEER send-community
    neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000
@@ -498,7 +499,6 @@ router bgp 65102
       route-target export evpn 12:12
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -507,7 +507,6 @@ router bgp 65102
       route-target export evpn 13:13
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -516,7 +515,6 @@ router bgp 65102
       route-target export evpn 10:10
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -525,7 +523,6 @@ router bgp 65102
       route-target export evpn 11:11
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -534,7 +531,6 @@ router bgp 65102
       route-target export evpn 20:20
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -543,7 +539,6 @@ router bgp 65102
       route-target export evpn 30:30
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-LEAF2B.cfg
@@ -498,6 +498,7 @@ router bgp 65102
       route-target export evpn 12:12
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -506,6 +507,7 @@ router bgp 65102
       route-target export evpn 13:13
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -514,6 +516,7 @@ router bgp 65102
       route-target export evpn 10:10
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -522,6 +525,7 @@ router bgp 65102
       route-target export evpn 11:11
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -530,6 +534,7 @@ router bgp 65102
       route-target export evpn 20:20
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -538,6 +543,7 @@ router bgp 65102
       route-target export evpn 30:30
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-LEAF2B.cfg
@@ -416,6 +416,7 @@ router bgp 65102
    neighbor MLAG-IPv4-UNDERLAY-PEER peer group
    neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65102
    neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
+   neighbor MLAG-IPv4-UNDERLAY-PEER description DC1-LEAF2A
    neighbor MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==
    neighbor MLAG-IPv4-UNDERLAY-PEER send-community
    neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000
@@ -498,7 +499,6 @@ router bgp 65102
       route-target export evpn 12:12
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -507,7 +507,6 @@ router bgp 65102
       route-target export evpn 13:13
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -516,7 +515,6 @@ router bgp 65102
       route-target export evpn 10:10
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -525,7 +523,6 @@ router bgp 65102
       route-target export evpn 11:11
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -534,7 +531,6 @@ router bgp 65102
       route-target export evpn 20:20
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -543,7 +539,6 @@ router bgp 65102
       route-target export evpn 30:30
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SVC3A.cfg
@@ -596,6 +596,7 @@ router bgp 65103
       route-target export evpn 12:12
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -604,6 +605,7 @@ router bgp 65103
       route-target export evpn 13:13
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -612,6 +614,7 @@ router bgp 65103
       route-target export evpn 10:10
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -620,6 +623,7 @@ router bgp 65103
       route-target export evpn 14:14
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -628,6 +632,7 @@ router bgp 65103
       route-target export evpn 11:11
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -636,6 +641,7 @@ router bgp 65103
       route-target export evpn 20:20
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -644,6 +650,7 @@ router bgp 65103
       route-target export evpn 21:21
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -652,6 +659,7 @@ router bgp 65103
       route-target export evpn 30:30
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -660,6 +668,7 @@ router bgp 65103
       route-target export evpn 31:31
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SVC3A.cfg
@@ -496,6 +496,7 @@ router bgp 65103
    neighbor MLAG-IPv4-UNDERLAY-PEER peer group
    neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65103
    neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
+   neighbor MLAG-IPv4-UNDERLAY-PEER description DC1-SVC3B
    neighbor MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==
    neighbor MLAG-IPv4-UNDERLAY-PEER send-community
    neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000
@@ -596,7 +597,6 @@ router bgp 65103
       route-target export evpn 12:12
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -605,7 +605,6 @@ router bgp 65103
       route-target export evpn 13:13
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -614,7 +613,6 @@ router bgp 65103
       route-target export evpn 10:10
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -623,7 +621,6 @@ router bgp 65103
       route-target export evpn 14:14
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -632,7 +629,6 @@ router bgp 65103
       route-target export evpn 11:11
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -641,7 +637,6 @@ router bgp 65103
       route-target export evpn 20:20
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -650,7 +645,6 @@ router bgp 65103
       route-target export evpn 21:21
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -659,7 +653,6 @@ router bgp 65103
       route-target export evpn 30:30
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -668,7 +661,6 @@ router bgp 65103
       route-target export evpn 31:31
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SVC3B.cfg
@@ -583,6 +583,7 @@ router bgp 65103
       route-target export evpn 12:12
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -591,6 +592,7 @@ router bgp 65103
       route-target export evpn 13:13
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -599,6 +601,7 @@ router bgp 65103
       route-target export evpn 10:10
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -607,6 +610,7 @@ router bgp 65103
       route-target export evpn 14:14
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -615,6 +619,7 @@ router bgp 65103
       route-target export evpn 11:11
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -623,6 +628,7 @@ router bgp 65103
       route-target export evpn 20:20
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -631,6 +637,7 @@ router bgp 65103
       route-target export evpn 21:21
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -639,6 +646,7 @@ router bgp 65103
       route-target export evpn 30:30
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -647,6 +655,7 @@ router bgp 65103
       route-target export evpn 31:31
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SVC3B.cfg
@@ -483,6 +483,7 @@ router bgp 65103
    neighbor MLAG-IPv4-UNDERLAY-PEER peer group
    neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65103
    neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
+   neighbor MLAG-IPv4-UNDERLAY-PEER description DC1-SVC3A
    neighbor MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==
    neighbor MLAG-IPv4-UNDERLAY-PEER send-community
    neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000
@@ -583,7 +584,6 @@ router bgp 65103
       route-target export evpn 12:12
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -592,7 +592,6 @@ router bgp 65103
       route-target export evpn 13:13
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -601,7 +600,6 @@ router bgp 65103
       route-target export evpn 10:10
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -610,7 +608,6 @@ router bgp 65103
       route-target export evpn 14:14
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -619,7 +616,6 @@ router bgp 65103
       route-target export evpn 11:11
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -628,7 +624,6 @@ router bgp 65103
       route-target export evpn 20:20
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -637,7 +632,6 @@ router bgp 65103
       route-target export evpn 21:21
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -646,7 +640,6 @@ router bgp 65103
       route-target export evpn 30:30
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -655,7 +648,6 @@ router bgp 65103
       route-target export evpn 31:31
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1A.yml
@@ -92,6 +92,7 @@ router_bgp:
       neighbors:
         10.255.251.11:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
+          description: DC1-BL1B
       redistribute_routes:
       - connected
     Tenant_B_WAN_Zone:
@@ -107,6 +108,7 @@ router_bgp:
       neighbors:
         10.255.251.11:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
+          description: DC1-BL1B
       redistribute_routes:
       - connected
     Tenant_C_WAN_Zone:
@@ -122,6 +124,7 @@ router_bgp:
       neighbors:
         10.255.251.11:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
+          description: DC1-BL1B
       redistribute_routes:
       - connected
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1A.yml
@@ -10,6 +10,7 @@ router_bgp:
       type: ipv4
       remote_as: '65104'
       next_hop_self: true
+      description: DC1-BL1B
       password: vnEaG8gMeQf3d3cN6PktXQ==
       maximum_routes: 12000
       send_community: all
@@ -92,7 +93,6 @@ router_bgp:
       neighbors:
         10.255.251.11:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
-          description: DC1-BL1B
       redistribute_routes:
       - connected
     Tenant_B_WAN_Zone:
@@ -108,7 +108,6 @@ router_bgp:
       neighbors:
         10.255.251.11:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
-          description: DC1-BL1B
       redistribute_routes:
       - connected
     Tenant_C_WAN_Zone:
@@ -124,7 +123,6 @@ router_bgp:
       neighbors:
         10.255.251.11:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
-          description: DC1-BL1B
       redistribute_routes:
       - connected
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1B.yml
@@ -92,6 +92,7 @@ router_bgp:
       neighbors:
         10.255.251.10:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
+          description: DC1-BL1A
       redistribute_routes:
       - connected
     Tenant_B_WAN_Zone:
@@ -107,6 +108,7 @@ router_bgp:
       neighbors:
         10.255.251.10:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
+          description: DC1-BL1A
       redistribute_routes:
       - connected
     Tenant_C_WAN_Zone:
@@ -122,6 +124,7 @@ router_bgp:
       neighbors:
         10.255.251.10:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
+          description: DC1-BL1A
       redistribute_routes:
       - connected
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1B.yml
@@ -10,6 +10,7 @@ router_bgp:
       type: ipv4
       remote_as: '65104'
       next_hop_self: true
+      description: DC1-BL1A
       password: vnEaG8gMeQf3d3cN6PktXQ==
       maximum_routes: 12000
       send_community: all
@@ -92,7 +93,6 @@ router_bgp:
       neighbors:
         10.255.251.10:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
-          description: DC1-BL1A
       redistribute_routes:
       - connected
     Tenant_B_WAN_Zone:
@@ -108,7 +108,6 @@ router_bgp:
       neighbors:
         10.255.251.10:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
-          description: DC1-BL1A
       redistribute_routes:
       - connected
     Tenant_C_WAN_Zone:
@@ -124,7 +123,6 @@ router_bgp:
       neighbors:
         10.255.251.10:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
-          description: DC1-BL1A
       redistribute_routes:
       - connected
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2A.yml
@@ -10,6 +10,7 @@ router_bgp:
       type: ipv4
       remote_as: '65102'
       next_hop_self: true
+      description: DC1-LEAF2B
       password: vnEaG8gMeQf3d3cN6PktXQ==
       maximum_routes: 12000
       send_community: all
@@ -92,7 +93,6 @@ router_bgp:
       neighbors:
         10.255.251.3:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
-          description: DC1-LEAF2B
       redistribute_routes:
       - connected
     Tenant_A_DB_Zone:
@@ -108,7 +108,6 @@ router_bgp:
       neighbors:
         10.255.251.3:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
-          description: DC1-LEAF2B
       redistribute_routes:
       - connected
     Tenant_A_OP_Zone:
@@ -124,7 +123,6 @@ router_bgp:
       neighbors:
         10.255.251.3:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
-          description: DC1-LEAF2B
       redistribute_routes:
       - connected
     Tenant_A_WEB_Zone:
@@ -140,7 +138,6 @@ router_bgp:
       neighbors:
         10.255.251.3:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
-          description: DC1-LEAF2B
       redistribute_routes:
       - connected
     Tenant_B_OP_Zone:
@@ -156,7 +153,6 @@ router_bgp:
       neighbors:
         10.255.251.3:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
-          description: DC1-LEAF2B
       redistribute_routes:
       - connected
     Tenant_C_OP_Zone:
@@ -172,7 +168,6 @@ router_bgp:
       neighbors:
         10.255.251.3:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
-          description: DC1-LEAF2B
       redistribute_routes:
       - connected
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2A.yml
@@ -92,6 +92,7 @@ router_bgp:
       neighbors:
         10.255.251.3:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
+          description: DC1-LEAF2B
       redistribute_routes:
       - connected
     Tenant_A_DB_Zone:
@@ -107,6 +108,7 @@ router_bgp:
       neighbors:
         10.255.251.3:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
+          description: DC1-LEAF2B
       redistribute_routes:
       - connected
     Tenant_A_OP_Zone:
@@ -122,6 +124,7 @@ router_bgp:
       neighbors:
         10.255.251.3:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
+          description: DC1-LEAF2B
       redistribute_routes:
       - connected
     Tenant_A_WEB_Zone:
@@ -137,6 +140,7 @@ router_bgp:
       neighbors:
         10.255.251.3:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
+          description: DC1-LEAF2B
       redistribute_routes:
       - connected
     Tenant_B_OP_Zone:
@@ -152,6 +156,7 @@ router_bgp:
       neighbors:
         10.255.251.3:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
+          description: DC1-LEAF2B
       redistribute_routes:
       - connected
     Tenant_C_OP_Zone:
@@ -167,6 +172,7 @@ router_bgp:
       neighbors:
         10.255.251.3:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
+          description: DC1-LEAF2B
       redistribute_routes:
       - connected
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2B.yml
@@ -92,6 +92,7 @@ router_bgp:
       neighbors:
         10.255.251.2:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
+          description: DC1-LEAF2A
       redistribute_routes:
       - connected
     Tenant_A_DB_Zone:
@@ -107,6 +108,7 @@ router_bgp:
       neighbors:
         10.255.251.2:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
+          description: DC1-LEAF2A
       redistribute_routes:
       - connected
     Tenant_A_OP_Zone:
@@ -122,6 +124,7 @@ router_bgp:
       neighbors:
         10.255.251.2:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
+          description: DC1-LEAF2A
       redistribute_routes:
       - connected
     Tenant_A_WEB_Zone:
@@ -137,6 +140,7 @@ router_bgp:
       neighbors:
         10.255.251.2:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
+          description: DC1-LEAF2A
       redistribute_routes:
       - connected
     Tenant_B_OP_Zone:
@@ -152,6 +156,7 @@ router_bgp:
       neighbors:
         10.255.251.2:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
+          description: DC1-LEAF2A
       redistribute_routes:
       - connected
     Tenant_C_OP_Zone:
@@ -167,6 +172,7 @@ router_bgp:
       neighbors:
         10.255.251.2:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
+          description: DC1-LEAF2A
       redistribute_routes:
       - connected
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2B.yml
@@ -10,6 +10,7 @@ router_bgp:
       type: ipv4
       remote_as: '65102'
       next_hop_self: true
+      description: DC1-LEAF2A
       password: vnEaG8gMeQf3d3cN6PktXQ==
       maximum_routes: 12000
       send_community: all
@@ -92,7 +93,6 @@ router_bgp:
       neighbors:
         10.255.251.2:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
-          description: DC1-LEAF2A
       redistribute_routes:
       - connected
     Tenant_A_DB_Zone:
@@ -108,7 +108,6 @@ router_bgp:
       neighbors:
         10.255.251.2:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
-          description: DC1-LEAF2A
       redistribute_routes:
       - connected
     Tenant_A_OP_Zone:
@@ -124,7 +123,6 @@ router_bgp:
       neighbors:
         10.255.251.2:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
-          description: DC1-LEAF2A
       redistribute_routes:
       - connected
     Tenant_A_WEB_Zone:
@@ -140,7 +138,6 @@ router_bgp:
       neighbors:
         10.255.251.2:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
-          description: DC1-LEAF2A
       redistribute_routes:
       - connected
     Tenant_B_OP_Zone:
@@ -156,7 +153,6 @@ router_bgp:
       neighbors:
         10.255.251.2:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
-          description: DC1-LEAF2A
       redistribute_routes:
       - connected
     Tenant_C_OP_Zone:
@@ -172,7 +168,6 @@ router_bgp:
       neighbors:
         10.255.251.2:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
-          description: DC1-LEAF2A
       redistribute_routes:
       - connected
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3A.yml
@@ -92,6 +92,7 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_A_DB_Zone:
@@ -107,6 +108,7 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_A_OP_Zone:
@@ -122,6 +124,7 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_A_WAN_Zone:
@@ -137,6 +140,7 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_A_WEB_Zone:
@@ -152,6 +156,7 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_B_OP_Zone:
@@ -167,6 +172,7 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_B_WAN_Zone:
@@ -182,6 +188,7 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_C_OP_Zone:
@@ -197,6 +204,7 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_C_WAN_Zone:
@@ -212,6 +220,7 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3A.yml
@@ -10,6 +10,7 @@ router_bgp:
       type: ipv4
       remote_as: '65103'
       next_hop_self: true
+      description: DC1-SVC3B
       password: vnEaG8gMeQf3d3cN6PktXQ==
       maximum_routes: 12000
       send_community: all
@@ -92,7 +93,6 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
-          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_A_DB_Zone:
@@ -108,7 +108,6 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
-          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_A_OP_Zone:
@@ -124,7 +123,6 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
-          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_A_WAN_Zone:
@@ -140,7 +138,6 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
-          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_A_WEB_Zone:
@@ -156,7 +153,6 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
-          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_B_OP_Zone:
@@ -172,7 +168,6 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
-          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_B_WAN_Zone:
@@ -188,7 +183,6 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
-          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_C_OP_Zone:
@@ -204,7 +198,6 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
-          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_C_WAN_Zone:
@@ -220,7 +213,6 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
-          description: DC1-SVC3B
       redistribute_routes:
       - connected
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3B.yml
@@ -10,6 +10,7 @@ router_bgp:
       type: ipv4
       remote_as: '65103'
       next_hop_self: true
+      description: DC1-SVC3A
       password: vnEaG8gMeQf3d3cN6PktXQ==
       maximum_routes: 12000
       send_community: all
@@ -92,7 +93,6 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
-          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_A_DB_Zone:
@@ -108,7 +108,6 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
-          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_A_OP_Zone:
@@ -124,7 +123,6 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
-          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_A_WAN_Zone:
@@ -140,7 +138,6 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
-          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_A_WEB_Zone:
@@ -156,7 +153,6 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
-          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_B_OP_Zone:
@@ -172,7 +168,6 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
-          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_B_WAN_Zone:
@@ -188,7 +183,6 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
-          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_C_OP_Zone:
@@ -204,7 +198,6 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
-          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_C_WAN_Zone:
@@ -220,7 +213,6 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
-          description: DC1-SVC3A
       redistribute_routes:
       - connected
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3B.yml
@@ -92,6 +92,7 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_A_DB_Zone:
@@ -107,6 +108,7 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_A_OP_Zone:
@@ -122,6 +124,7 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_A_WAN_Zone:
@@ -137,6 +140,7 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_A_WEB_Zone:
@@ -152,6 +156,7 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_B_OP_Zone:
@@ -167,6 +172,7 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_B_WAN_Zone:
@@ -182,6 +188,7 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_C_OP_Zone:
@@ -197,6 +204,7 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_C_WAN_Zone:
@@ -212,6 +220,7 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG-IPv4-UNDERLAY-PEER
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/cvp/cv_server_configlets.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/cvp/cv_server_configlets.yml
@@ -106,14 +106,17 @@ CVP_CONFIGLETS:
     \ activate\n   !\n   vrf Tenant_A_WAN_Zone\n      rd 192.168.255.10:14\n     \
     \ route-target import evpn 14:14\n      route-target export evpn 14:14\n     \
     \ router-id 192.168.255.10\n      neighbor 10.255.251.11 peer group MLAG-IPv4-UNDERLAY-PEER\n\
-    \      redistribute connected\n   !\n   vrf Tenant_B_WAN_Zone\n      rd 192.168.255.10:21\n\
-    \      route-target import evpn 21:21\n      route-target export evpn 21:21\n\
-    \      router-id 192.168.255.10\n      neighbor 10.255.251.11 peer group MLAG-IPv4-UNDERLAY-PEER\n\
-    \      redistribute connected\n   !\n   vrf Tenant_C_WAN_Zone\n      rd 192.168.255.10:31\n\
-    \      route-target import evpn 31:31\n      route-target export evpn 31:31\n\
-    \      router-id 192.168.255.10\n      neighbor 10.255.251.11 peer group MLAG-IPv4-UNDERLAY-PEER\n\
-    \      redistribute connected\n!\nmanagement api http-commands\n   protocol https\n\
-    \   no shutdown\n   !\n   vrf MGMT\n      no shutdown\n!\nend\n"
+    \      neighbor 10.255.251.11 description DC1-BL1B\n      redistribute connected\n\
+    \   !\n   vrf Tenant_B_WAN_Zone\n      rd 192.168.255.10:21\n      route-target\
+    \ import evpn 21:21\n      route-target export evpn 21:21\n      router-id 192.168.255.10\n\
+    \      neighbor 10.255.251.11 peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor\
+    \ 10.255.251.11 description DC1-BL1B\n      redistribute connected\n   !\n   vrf\
+    \ Tenant_C_WAN_Zone\n      rd 192.168.255.10:31\n      route-target import evpn\
+    \ 31:31\n      route-target export evpn 31:31\n      router-id 192.168.255.10\n\
+    \      neighbor 10.255.251.11 peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor\
+    \ 10.255.251.11 description DC1-BL1B\n      redistribute connected\n!\nmanagement\
+    \ api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n  \
+    \    no shutdown\n!\nend\n"
   AVD_DC1-BL1B: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr\
     \ -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata\
     \ -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n\
@@ -221,14 +224,17 @@ CVP_CONFIGLETS:
     \ activate\n   !\n   vrf Tenant_A_WAN_Zone\n      rd 192.168.255.11:14\n     \
     \ route-target import evpn 14:14\n      route-target export evpn 14:14\n     \
     \ router-id 192.168.255.11\n      neighbor 10.255.251.10 peer group MLAG-IPv4-UNDERLAY-PEER\n\
-    \      redistribute connected\n   !\n   vrf Tenant_B_WAN_Zone\n      rd 192.168.255.11:21\n\
-    \      route-target import evpn 21:21\n      route-target export evpn 21:21\n\
-    \      router-id 192.168.255.11\n      neighbor 10.255.251.10 peer group MLAG-IPv4-UNDERLAY-PEER\n\
-    \      redistribute connected\n   !\n   vrf Tenant_C_WAN_Zone\n      rd 192.168.255.11:31\n\
-    \      route-target import evpn 31:31\n      route-target export evpn 31:31\n\
-    \      router-id 192.168.255.11\n      neighbor 10.255.251.10 peer group MLAG-IPv4-UNDERLAY-PEER\n\
-    \      redistribute connected\n!\nmanagement api http-commands\n   protocol https\n\
-    \   no shutdown\n   !\n   vrf MGMT\n      no shutdown\n!\nend\n"
+    \      neighbor 10.255.251.10 description DC1-BL1A\n      redistribute connected\n\
+    \   !\n   vrf Tenant_B_WAN_Zone\n      rd 192.168.255.11:21\n      route-target\
+    \ import evpn 21:21\n      route-target export evpn 21:21\n      router-id 192.168.255.11\n\
+    \      neighbor 10.255.251.10 peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor\
+    \ 10.255.251.10 description DC1-BL1A\n      redistribute connected\n   !\n   vrf\
+    \ Tenant_C_WAN_Zone\n      rd 192.168.255.11:31\n      route-target import evpn\
+    \ 31:31\n      route-target export evpn 31:31\n      router-id 192.168.255.11\n\
+    \      neighbor 10.255.251.10 peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor\
+    \ 10.255.251.10 description DC1-BL1A\n      redistribute connected\n!\nmanagement\
+    \ api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n  \
+    \    no shutdown\n!\nend\n"
   AVD_DC1-L2LEAF1A: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr\
     \ -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata\
     \ -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n\
@@ -572,24 +578,30 @@ CVP_CONFIGLETS:
     \ activate\n      neighbor MLAG-IPv4-UNDERLAY-PEER activate\n   !\n   vrf Tenant_A_APP_Zone\n\
     \      rd 192.168.255.6:12\n      route-target import evpn 12:12\n      route-target\
     \ export evpn 12:12\n      router-id 192.168.255.6\n      neighbor 10.255.251.3\
-    \ peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n   !\n   vrf\
-    \ Tenant_A_DB_Zone\n      rd 192.168.255.6:13\n      route-target import evpn\
-    \ 13:13\n      route-target export evpn 13:13\n      router-id 192.168.255.6\n\
-    \      neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute\
-    \ connected\n   !\n   vrf Tenant_A_OP_Zone\n      rd 192.168.255.6:10\n      route-target\
-    \ import evpn 10:10\n      route-target export evpn 10:10\n      router-id 192.168.255.6\n\
-    \      neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute\
-    \ connected\n   !\n   vrf Tenant_A_WEB_Zone\n      rd 192.168.255.6:11\n     \
-    \ route-target import evpn 11:11\n      route-target export evpn 11:11\n     \
-    \ router-id 192.168.255.6\n      neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER\n\
-    \      redistribute connected\n   !\n   vrf Tenant_B_OP_Zone\n      rd 192.168.255.6:20\n\
-    \      route-target import evpn 20:20\n      route-target export evpn 20:20\n\
-    \      router-id 192.168.255.6\n      neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER\n\
-    \      redistribute connected\n   !\n   vrf Tenant_C_OP_Zone\n      rd 192.168.255.6:30\n\
-    \      route-target import evpn 30:30\n      route-target export evpn 30:30\n\
-    \      router-id 192.168.255.6\n      neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER\n\
-    \      redistribute connected\n!\nmanagement api http-commands\n   protocol https\n\
-    \   no shutdown\n   !\n   vrf MGMT\n      no shutdown\n!\nend\n"
+    \ peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor 10.255.251.3 description\
+    \ DC1-LEAF2B\n      redistribute connected\n   !\n   vrf Tenant_A_DB_Zone\n  \
+    \    rd 192.168.255.6:13\n      route-target import evpn 13:13\n      route-target\
+    \ export evpn 13:13\n      router-id 192.168.255.6\n      neighbor 10.255.251.3\
+    \ peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor 10.255.251.3 description\
+    \ DC1-LEAF2B\n      redistribute connected\n   !\n   vrf Tenant_A_OP_Zone\n  \
+    \    rd 192.168.255.6:10\n      route-target import evpn 10:10\n      route-target\
+    \ export evpn 10:10\n      router-id 192.168.255.6\n      neighbor 10.255.251.3\
+    \ peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor 10.255.251.3 description\
+    \ DC1-LEAF2B\n      redistribute connected\n   !\n   vrf Tenant_A_WEB_Zone\n \
+    \     rd 192.168.255.6:11\n      route-target import evpn 11:11\n      route-target\
+    \ export evpn 11:11\n      router-id 192.168.255.6\n      neighbor 10.255.251.3\
+    \ peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor 10.255.251.3 description\
+    \ DC1-LEAF2B\n      redistribute connected\n   !\n   vrf Tenant_B_OP_Zone\n  \
+    \    rd 192.168.255.6:20\n      route-target import evpn 20:20\n      route-target\
+    \ export evpn 20:20\n      router-id 192.168.255.6\n      neighbor 10.255.251.3\
+    \ peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor 10.255.251.3 description\
+    \ DC1-LEAF2B\n      redistribute connected\n   !\n   vrf Tenant_C_OP_Zone\n  \
+    \    rd 192.168.255.6:30\n      route-target import evpn 30:30\n      route-target\
+    \ export evpn 30:30\n      router-id 192.168.255.6\n      neighbor 10.255.251.3\
+    \ peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor 10.255.251.3 description\
+    \ DC1-LEAF2B\n      redistribute connected\n!\nmanagement api http-commands\n\
+    \   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no shutdown\n!\n\
+    end\n"
   AVD_DC1-LEAF2B: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr\
     \ -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata\
     \ -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n\
@@ -750,24 +762,30 @@ CVP_CONFIGLETS:
     \ activate\n      neighbor MLAG-IPv4-UNDERLAY-PEER activate\n   !\n   vrf Tenant_A_APP_Zone\n\
     \      rd 192.168.255.7:12\n      route-target import evpn 12:12\n      route-target\
     \ export evpn 12:12\n      router-id 192.168.255.7\n      neighbor 10.255.251.2\
-    \ peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n   !\n   vrf\
-    \ Tenant_A_DB_Zone\n      rd 192.168.255.7:13\n      route-target import evpn\
-    \ 13:13\n      route-target export evpn 13:13\n      router-id 192.168.255.7\n\
-    \      neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute\
-    \ connected\n   !\n   vrf Tenant_A_OP_Zone\n      rd 192.168.255.7:10\n      route-target\
-    \ import evpn 10:10\n      route-target export evpn 10:10\n      router-id 192.168.255.7\n\
-    \      neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute\
-    \ connected\n   !\n   vrf Tenant_A_WEB_Zone\n      rd 192.168.255.7:11\n     \
-    \ route-target import evpn 11:11\n      route-target export evpn 11:11\n     \
-    \ router-id 192.168.255.7\n      neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER\n\
-    \      redistribute connected\n   !\n   vrf Tenant_B_OP_Zone\n      rd 192.168.255.7:20\n\
-    \      route-target import evpn 20:20\n      route-target export evpn 20:20\n\
-    \      router-id 192.168.255.7\n      neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER\n\
-    \      redistribute connected\n   !\n   vrf Tenant_C_OP_Zone\n      rd 192.168.255.7:30\n\
-    \      route-target import evpn 30:30\n      route-target export evpn 30:30\n\
-    \      router-id 192.168.255.7\n      neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER\n\
-    \      redistribute connected\n!\nmanagement api http-commands\n   protocol https\n\
-    \   no shutdown\n   !\n   vrf MGMT\n      no shutdown\n!\nend\n"
+    \ peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor 10.255.251.2 description\
+    \ DC1-LEAF2A\n      redistribute connected\n   !\n   vrf Tenant_A_DB_Zone\n  \
+    \    rd 192.168.255.7:13\n      route-target import evpn 13:13\n      route-target\
+    \ export evpn 13:13\n      router-id 192.168.255.7\n      neighbor 10.255.251.2\
+    \ peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor 10.255.251.2 description\
+    \ DC1-LEAF2A\n      redistribute connected\n   !\n   vrf Tenant_A_OP_Zone\n  \
+    \    rd 192.168.255.7:10\n      route-target import evpn 10:10\n      route-target\
+    \ export evpn 10:10\n      router-id 192.168.255.7\n      neighbor 10.255.251.2\
+    \ peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor 10.255.251.2 description\
+    \ DC1-LEAF2A\n      redistribute connected\n   !\n   vrf Tenant_A_WEB_Zone\n \
+    \     rd 192.168.255.7:11\n      route-target import evpn 11:11\n      route-target\
+    \ export evpn 11:11\n      router-id 192.168.255.7\n      neighbor 10.255.251.2\
+    \ peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor 10.255.251.2 description\
+    \ DC1-LEAF2A\n      redistribute connected\n   !\n   vrf Tenant_B_OP_Zone\n  \
+    \    rd 192.168.255.7:20\n      route-target import evpn 20:20\n      route-target\
+    \ export evpn 20:20\n      router-id 192.168.255.7\n      neighbor 10.255.251.2\
+    \ peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor 10.255.251.2 description\
+    \ DC1-LEAF2A\n      redistribute connected\n   !\n   vrf Tenant_C_OP_Zone\n  \
+    \    rd 192.168.255.7:30\n      route-target import evpn 30:30\n      route-target\
+    \ export evpn 30:30\n      router-id 192.168.255.7\n      neighbor 10.255.251.2\
+    \ peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor 10.255.251.2 description\
+    \ DC1-LEAF2A\n      redistribute connected\n!\nmanagement api http-commands\n\
+    \   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no shutdown\n!\n\
+    end\n"
   AVD_DC1-SPINE1: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr\
     \ -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata\
     \ -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n\
@@ -1240,33 +1258,42 @@ CVP_CONFIGLETS:
     \ neighbor IPv4-UNDERLAY-PEERS activate\n      neighbor MLAG-IPv4-UNDERLAY-PEER\
     \ activate\n   !\n   vrf Tenant_A_APP_Zone\n      rd 192.168.255.8:12\n      route-target\
     \ import evpn 12:12\n      route-target export evpn 12:12\n      router-id 192.168.255.8\n\
-    \      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute\
-    \ connected\n   !\n   vrf Tenant_A_DB_Zone\n      rd 192.168.255.8:13\n      route-target\
-    \ import evpn 13:13\n      route-target export evpn 13:13\n      router-id 192.168.255.8\n\
-    \      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute\
-    \ connected\n   !\n   vrf Tenant_A_OP_Zone\n      rd 192.168.255.8:10\n      route-target\
-    \ import evpn 10:10\n      route-target export evpn 10:10\n      router-id 192.168.255.8\n\
-    \      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute\
-    \ connected\n   !\n   vrf Tenant_A_WAN_Zone\n      rd 192.168.255.8:14\n     \
-    \ route-target import evpn 14:14\n      route-target export evpn 14:14\n     \
-    \ router-id 192.168.255.8\n      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n\
-    \      redistribute connected\n   !\n   vrf Tenant_A_WEB_Zone\n      rd 192.168.255.8:11\n\
-    \      route-target import evpn 11:11\n      route-target export evpn 11:11\n\
-    \      router-id 192.168.255.8\n      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n\
-    \      redistribute connected\n   !\n   vrf Tenant_B_OP_Zone\n      rd 192.168.255.8:20\n\
-    \      route-target import evpn 20:20\n      route-target export evpn 20:20\n\
-    \      router-id 192.168.255.8\n      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n\
-    \      redistribute connected\n   !\n   vrf Tenant_B_WAN_Zone\n      rd 192.168.255.8:21\n\
-    \      route-target import evpn 21:21\n      route-target export evpn 21:21\n\
-    \      router-id 192.168.255.8\n      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n\
-    \      redistribute connected\n   !\n   vrf Tenant_C_OP_Zone\n      rd 192.168.255.8:30\n\
-    \      route-target import evpn 30:30\n      route-target export evpn 30:30\n\
-    \      router-id 192.168.255.8\n      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n\
-    \      redistribute connected\n   !\n   vrf Tenant_C_WAN_Zone\n      rd 192.168.255.8:31\n\
-    \      route-target import evpn 31:31\n      route-target export evpn 31:31\n\
-    \      router-id 192.168.255.8\n      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n\
-    \      redistribute connected\n!\nmanagement api http-commands\n   protocol https\n\
-    \   no shutdown\n   !\n   vrf MGMT\n      no shutdown\n!\nend\n"
+    \      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor\
+    \ 10.255.251.7 description DC1-SVC3B\n      redistribute connected\n   !\n   vrf\
+    \ Tenant_A_DB_Zone\n      rd 192.168.255.8:13\n      route-target import evpn\
+    \ 13:13\n      route-target export evpn 13:13\n      router-id 192.168.255.8\n\
+    \      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor\
+    \ 10.255.251.7 description DC1-SVC3B\n      redistribute connected\n   !\n   vrf\
+    \ Tenant_A_OP_Zone\n      rd 192.168.255.8:10\n      route-target import evpn\
+    \ 10:10\n      route-target export evpn 10:10\n      router-id 192.168.255.8\n\
+    \      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor\
+    \ 10.255.251.7 description DC1-SVC3B\n      redistribute connected\n   !\n   vrf\
+    \ Tenant_A_WAN_Zone\n      rd 192.168.255.8:14\n      route-target import evpn\
+    \ 14:14\n      route-target export evpn 14:14\n      router-id 192.168.255.8\n\
+    \      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor\
+    \ 10.255.251.7 description DC1-SVC3B\n      redistribute connected\n   !\n   vrf\
+    \ Tenant_A_WEB_Zone\n      rd 192.168.255.8:11\n      route-target import evpn\
+    \ 11:11\n      route-target export evpn 11:11\n      router-id 192.168.255.8\n\
+    \      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor\
+    \ 10.255.251.7 description DC1-SVC3B\n      redistribute connected\n   !\n   vrf\
+    \ Tenant_B_OP_Zone\n      rd 192.168.255.8:20\n      route-target import evpn\
+    \ 20:20\n      route-target export evpn 20:20\n      router-id 192.168.255.8\n\
+    \      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor\
+    \ 10.255.251.7 description DC1-SVC3B\n      redistribute connected\n   !\n   vrf\
+    \ Tenant_B_WAN_Zone\n      rd 192.168.255.8:21\n      route-target import evpn\
+    \ 21:21\n      route-target export evpn 21:21\n      router-id 192.168.255.8\n\
+    \      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor\
+    \ 10.255.251.7 description DC1-SVC3B\n      redistribute connected\n   !\n   vrf\
+    \ Tenant_C_OP_Zone\n      rd 192.168.255.8:30\n      route-target import evpn\
+    \ 30:30\n      route-target export evpn 30:30\n      router-id 192.168.255.8\n\
+    \      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor\
+    \ 10.255.251.7 description DC1-SVC3B\n      redistribute connected\n   !\n   vrf\
+    \ Tenant_C_WAN_Zone\n      rd 192.168.255.8:31\n      route-target import evpn\
+    \ 31:31\n      route-target export evpn 31:31\n      router-id 192.168.255.8\n\
+    \      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor\
+    \ 10.255.251.7 description DC1-SVC3B\n      redistribute connected\n!\nmanagement\
+    \ api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n  \
+    \    no shutdown\n!\nend\n"
   AVD_DC1-SVC3B: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr\
     \ -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata\
     \ -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n\
@@ -1451,33 +1478,42 @@ CVP_CONFIGLETS:
     \ neighbor IPv4-UNDERLAY-PEERS activate\n      neighbor MLAG-IPv4-UNDERLAY-PEER\
     \ activate\n   !\n   vrf Tenant_A_APP_Zone\n      rd 192.168.255.9:12\n      route-target\
     \ import evpn 12:12\n      route-target export evpn 12:12\n      router-id 192.168.255.9\n\
-    \      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute\
-    \ connected\n   !\n   vrf Tenant_A_DB_Zone\n      rd 192.168.255.9:13\n      route-target\
-    \ import evpn 13:13\n      route-target export evpn 13:13\n      router-id 192.168.255.9\n\
-    \      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute\
-    \ connected\n   !\n   vrf Tenant_A_OP_Zone\n      rd 192.168.255.9:10\n      route-target\
-    \ import evpn 10:10\n      route-target export evpn 10:10\n      router-id 192.168.255.9\n\
-    \      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute\
-    \ connected\n   !\n   vrf Tenant_A_WAN_Zone\n      rd 192.168.255.9:14\n     \
-    \ route-target import evpn 14:14\n      route-target export evpn 14:14\n     \
-    \ router-id 192.168.255.9\n      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n\
-    \      redistribute connected\n   !\n   vrf Tenant_A_WEB_Zone\n      rd 192.168.255.9:11\n\
-    \      route-target import evpn 11:11\n      route-target export evpn 11:11\n\
-    \      router-id 192.168.255.9\n      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n\
-    \      redistribute connected\n   !\n   vrf Tenant_B_OP_Zone\n      rd 192.168.255.9:20\n\
-    \      route-target import evpn 20:20\n      route-target export evpn 20:20\n\
-    \      router-id 192.168.255.9\n      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n\
-    \      redistribute connected\n   !\n   vrf Tenant_B_WAN_Zone\n      rd 192.168.255.9:21\n\
-    \      route-target import evpn 21:21\n      route-target export evpn 21:21\n\
-    \      router-id 192.168.255.9\n      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n\
-    \      redistribute connected\n   !\n   vrf Tenant_C_OP_Zone\n      rd 192.168.255.9:30\n\
-    \      route-target import evpn 30:30\n      route-target export evpn 30:30\n\
-    \      router-id 192.168.255.9\n      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n\
-    \      redistribute connected\n   !\n   vrf Tenant_C_WAN_Zone\n      rd 192.168.255.9:31\n\
-    \      route-target import evpn 31:31\n      route-target export evpn 31:31\n\
-    \      router-id 192.168.255.9\n      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n\
-    \      redistribute connected\n!\nmanagement api http-commands\n   protocol https\n\
-    \   no shutdown\n   !\n   vrf MGMT\n      no shutdown\n!\nend\n"
+    \      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor\
+    \ 10.255.251.6 description DC1-SVC3A\n      redistribute connected\n   !\n   vrf\
+    \ Tenant_A_DB_Zone\n      rd 192.168.255.9:13\n      route-target import evpn\
+    \ 13:13\n      route-target export evpn 13:13\n      router-id 192.168.255.9\n\
+    \      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor\
+    \ 10.255.251.6 description DC1-SVC3A\n      redistribute connected\n   !\n   vrf\
+    \ Tenant_A_OP_Zone\n      rd 192.168.255.9:10\n      route-target import evpn\
+    \ 10:10\n      route-target export evpn 10:10\n      router-id 192.168.255.9\n\
+    \      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor\
+    \ 10.255.251.6 description DC1-SVC3A\n      redistribute connected\n   !\n   vrf\
+    \ Tenant_A_WAN_Zone\n      rd 192.168.255.9:14\n      route-target import evpn\
+    \ 14:14\n      route-target export evpn 14:14\n      router-id 192.168.255.9\n\
+    \      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor\
+    \ 10.255.251.6 description DC1-SVC3A\n      redistribute connected\n   !\n   vrf\
+    \ Tenant_A_WEB_Zone\n      rd 192.168.255.9:11\n      route-target import evpn\
+    \ 11:11\n      route-target export evpn 11:11\n      router-id 192.168.255.9\n\
+    \      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor\
+    \ 10.255.251.6 description DC1-SVC3A\n      redistribute connected\n   !\n   vrf\
+    \ Tenant_B_OP_Zone\n      rd 192.168.255.9:20\n      route-target import evpn\
+    \ 20:20\n      route-target export evpn 20:20\n      router-id 192.168.255.9\n\
+    \      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor\
+    \ 10.255.251.6 description DC1-SVC3A\n      redistribute connected\n   !\n   vrf\
+    \ Tenant_B_WAN_Zone\n      rd 192.168.255.9:21\n      route-target import evpn\
+    \ 21:21\n      route-target export evpn 21:21\n      router-id 192.168.255.9\n\
+    \      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor\
+    \ 10.255.251.6 description DC1-SVC3A\n      redistribute connected\n   !\n   vrf\
+    \ Tenant_C_OP_Zone\n      rd 192.168.255.9:30\n      route-target import evpn\
+    \ 30:30\n      route-target export evpn 30:30\n      router-id 192.168.255.9\n\
+    \      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor\
+    \ 10.255.251.6 description DC1-SVC3A\n      redistribute connected\n   !\n   vrf\
+    \ Tenant_C_WAN_Zone\n      rd 192.168.255.9:31\n      route-target import evpn\
+    \ 31:31\n      route-target export evpn 31:31\n      router-id 192.168.255.9\n\
+    \      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor\
+    \ 10.255.251.6 description DC1-SVC3A\n      redistribute connected\n!\nmanagement\
+    \ api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n  \
+    \    no shutdown\n!\nend\n"
 CVP_TOPOLOGY:
   DC1_BL1:
     devices:

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/cvp/cv_server_configlets.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/cvp/cv_server_configlets.yml
@@ -74,49 +74,47 @@ CVP_CONFIGLETS:
     \ password 7 AQQvKeimxJu+uGQ/yYvv9w==\n   neighbor IPv4-UNDERLAY-PEERS send-community\n\
     \   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000\n   neighbor MLAG-IPv4-UNDERLAY-PEER\
     \ peer group\n   neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65104\n   neighbor\
-    \ MLAG-IPv4-UNDERLAY-PEER next-hop-self\n   neighbor MLAG-IPv4-UNDERLAY-PEER password\
-    \ 7 vnEaG8gMeQf3d3cN6PktXQ==\n   neighbor MLAG-IPv4-UNDERLAY-PEER send-community\n\
-    \   neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000\n   neighbor MLAG-IPv4-UNDERLAY-PEER\
-    \ route-map RM-MLAG-PEER-IN in\n   neighbor 10.255.251.11 peer group MLAG-IPv4-UNDERLAY-PEER\n\
-    \   neighbor 10.255.251.11 description DC1-BL1B\n   neighbor 172.31.255.40 peer\
-    \ group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.40 remote-as 65001\n   neighbor\
-    \ 172.31.255.40 description DC1-SPINE1_Ethernet6\n   neighbor 172.31.255.42 peer\
-    \ group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.42 remote-as 65001\n   neighbor\
-    \ 172.31.255.42 description DC1-SPINE2_Ethernet6\n   neighbor 172.31.255.44 peer\
-    \ group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.44 remote-as 65001\n   neighbor\
-    \ 172.31.255.44 description DC1-SPINE3_Ethernet6\n   neighbor 172.31.255.46 peer\
-    \ group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.46 remote-as 65001\n   neighbor\
-    \ 172.31.255.46 description DC1-SPINE4_Ethernet6\n   neighbor 192.168.255.1 peer\
-    \ group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.1 remote-as 65001\n   neighbor\
-    \ 192.168.255.1 description DC1-SPINE1\n   neighbor 192.168.255.2 peer group EVPN-OVERLAY-PEERS\n\
-    \   neighbor 192.168.255.2 remote-as 65001\n   neighbor 192.168.255.2 description\
-    \ DC1-SPINE2\n   neighbor 192.168.255.3 peer group EVPN-OVERLAY-PEERS\n   neighbor\
-    \ 192.168.255.3 remote-as 65001\n   neighbor 192.168.255.3 description DC1-SPINE3\n\
-    \   neighbor 192.168.255.4 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.4\
-    \ remote-as 65001\n   neighbor 192.168.255.4 description DC1-SPINE4\n   redistribute\
-    \ connected route-map RM-CONN-2-BGP\n   !\n   vlan-aware-bundle Tenant_A_WAN_Zone\n\
-    \      rd 192.168.255.10:14\n      route-target both 14:14\n      redistribute\
-    \ learned\n      vlan 150\n   !\n   vlan-aware-bundle Tenant_B_WAN_Zone\n    \
-    \  rd 192.168.255.10:21\n      route-target both 21:21\n      redistribute learned\n\
-    \      vlan 250\n   !\n   vlan-aware-bundle Tenant_C_WAN_Zone\n      rd 192.168.255.10:31\n\
-    \      route-target both 31:31\n      redistribute learned\n      vlan 350\n \
-    \  !\n   address-family evpn\n      neighbor EVPN-OVERLAY-PEERS activate\n   !\n\
-    \   address-family ipv4\n      no neighbor EVPN-OVERLAY-PEERS activate\n     \
-    \ neighbor IPv4-UNDERLAY-PEERS activate\n      neighbor MLAG-IPv4-UNDERLAY-PEER\
-    \ activate\n   !\n   vrf Tenant_A_WAN_Zone\n      rd 192.168.255.10:14\n     \
-    \ route-target import evpn 14:14\n      route-target export evpn 14:14\n     \
-    \ router-id 192.168.255.10\n      neighbor 10.255.251.11 peer group MLAG-IPv4-UNDERLAY-PEER\n\
-    \      neighbor 10.255.251.11 description DC1-BL1B\n      redistribute connected\n\
-    \   !\n   vrf Tenant_B_WAN_Zone\n      rd 192.168.255.10:21\n      route-target\
-    \ import evpn 21:21\n      route-target export evpn 21:21\n      router-id 192.168.255.10\n\
-    \      neighbor 10.255.251.11 peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor\
-    \ 10.255.251.11 description DC1-BL1B\n      redistribute connected\n   !\n   vrf\
-    \ Tenant_C_WAN_Zone\n      rd 192.168.255.10:31\n      route-target import evpn\
-    \ 31:31\n      route-target export evpn 31:31\n      router-id 192.168.255.10\n\
-    \      neighbor 10.255.251.11 peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor\
-    \ 10.255.251.11 description DC1-BL1B\n      redistribute connected\n!\nmanagement\
-    \ api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n  \
-    \    no shutdown\n!\nend\n"
+    \ MLAG-IPv4-UNDERLAY-PEER next-hop-self\n   neighbor MLAG-IPv4-UNDERLAY-PEER description\
+    \ DC1-BL1B\n   neighbor MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==\n\
+    \   neighbor MLAG-IPv4-UNDERLAY-PEER send-community\n   neighbor MLAG-IPv4-UNDERLAY-PEER\
+    \ maximum-routes 12000\n   neighbor MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN\
+    \ in\n   neighbor 10.255.251.11 peer group MLAG-IPv4-UNDERLAY-PEER\n   neighbor\
+    \ 10.255.251.11 description DC1-BL1B\n   neighbor 172.31.255.40 peer group IPv4-UNDERLAY-PEERS\n\
+    \   neighbor 172.31.255.40 remote-as 65001\n   neighbor 172.31.255.40 description\
+    \ DC1-SPINE1_Ethernet6\n   neighbor 172.31.255.42 peer group IPv4-UNDERLAY-PEERS\n\
+    \   neighbor 172.31.255.42 remote-as 65001\n   neighbor 172.31.255.42 description\
+    \ DC1-SPINE2_Ethernet6\n   neighbor 172.31.255.44 peer group IPv4-UNDERLAY-PEERS\n\
+    \   neighbor 172.31.255.44 remote-as 65001\n   neighbor 172.31.255.44 description\
+    \ DC1-SPINE3_Ethernet6\n   neighbor 172.31.255.46 peer group IPv4-UNDERLAY-PEERS\n\
+    \   neighbor 172.31.255.46 remote-as 65001\n   neighbor 172.31.255.46 description\
+    \ DC1-SPINE4_Ethernet6\n   neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS\n\
+    \   neighbor 192.168.255.1 remote-as 65001\n   neighbor 192.168.255.1 description\
+    \ DC1-SPINE1\n   neighbor 192.168.255.2 peer group EVPN-OVERLAY-PEERS\n   neighbor\
+    \ 192.168.255.2 remote-as 65001\n   neighbor 192.168.255.2 description DC1-SPINE2\n\
+    \   neighbor 192.168.255.3 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.3\
+    \ remote-as 65001\n   neighbor 192.168.255.3 description DC1-SPINE3\n   neighbor\
+    \ 192.168.255.4 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.4 remote-as\
+    \ 65001\n   neighbor 192.168.255.4 description DC1-SPINE4\n   redistribute connected\
+    \ route-map RM-CONN-2-BGP\n   !\n   vlan-aware-bundle Tenant_A_WAN_Zone\n    \
+    \  rd 192.168.255.10:14\n      route-target both 14:14\n      redistribute learned\n\
+    \      vlan 150\n   !\n   vlan-aware-bundle Tenant_B_WAN_Zone\n      rd 192.168.255.10:21\n\
+    \      route-target both 21:21\n      redistribute learned\n      vlan 250\n \
+    \  !\n   vlan-aware-bundle Tenant_C_WAN_Zone\n      rd 192.168.255.10:31\n   \
+    \   route-target both 31:31\n      redistribute learned\n      vlan 350\n   !\n\
+    \   address-family evpn\n      neighbor EVPN-OVERLAY-PEERS activate\n   !\n  \
+    \ address-family ipv4\n      no neighbor EVPN-OVERLAY-PEERS activate\n      neighbor\
+    \ IPv4-UNDERLAY-PEERS activate\n      neighbor MLAG-IPv4-UNDERLAY-PEER activate\n\
+    \   !\n   vrf Tenant_A_WAN_Zone\n      rd 192.168.255.10:14\n      route-target\
+    \ import evpn 14:14\n      route-target export evpn 14:14\n      router-id 192.168.255.10\n\
+    \      neighbor 10.255.251.11 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute\
+    \ connected\n   !\n   vrf Tenant_B_WAN_Zone\n      rd 192.168.255.10:21\n    \
+    \  route-target import evpn 21:21\n      route-target export evpn 21:21\n    \
+    \  router-id 192.168.255.10\n      neighbor 10.255.251.11 peer group MLAG-IPv4-UNDERLAY-PEER\n\
+    \      redistribute connected\n   !\n   vrf Tenant_C_WAN_Zone\n      rd 192.168.255.10:31\n\
+    \      route-target import evpn 31:31\n      route-target export evpn 31:31\n\
+    \      router-id 192.168.255.10\n      neighbor 10.255.251.11 peer group MLAG-IPv4-UNDERLAY-PEER\n\
+    \      redistribute connected\n!\nmanagement api http-commands\n   protocol https\n\
+    \   no shutdown\n   !\n   vrf MGMT\n      no shutdown\n!\nend\n"
   AVD_DC1-BL1B: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr\
     \ -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata\
     \ -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n\
@@ -192,49 +190,47 @@ CVP_CONFIGLETS:
     \ password 7 AQQvKeimxJu+uGQ/yYvv9w==\n   neighbor IPv4-UNDERLAY-PEERS send-community\n\
     \   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000\n   neighbor MLAG-IPv4-UNDERLAY-PEER\
     \ peer group\n   neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65104\n   neighbor\
-    \ MLAG-IPv4-UNDERLAY-PEER next-hop-self\n   neighbor MLAG-IPv4-UNDERLAY-PEER password\
-    \ 7 vnEaG8gMeQf3d3cN6PktXQ==\n   neighbor MLAG-IPv4-UNDERLAY-PEER send-community\n\
-    \   neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000\n   neighbor MLAG-IPv4-UNDERLAY-PEER\
-    \ route-map RM-MLAG-PEER-IN in\n   neighbor 10.255.251.10 peer group MLAG-IPv4-UNDERLAY-PEER\n\
-    \   neighbor 10.255.251.10 description DC1-BL1A\n   neighbor 172.31.255.48 peer\
-    \ group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.48 remote-as 65001\n   neighbor\
-    \ 172.31.255.48 description DC1-SPINE1_Ethernet7\n   neighbor 172.31.255.50 peer\
-    \ group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.50 remote-as 65001\n   neighbor\
-    \ 172.31.255.50 description DC1-SPINE2_Ethernet7\n   neighbor 172.31.255.52 peer\
-    \ group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.52 remote-as 65001\n   neighbor\
-    \ 172.31.255.52 description DC1-SPINE3_Ethernet7\n   neighbor 172.31.255.54 peer\
-    \ group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.54 remote-as 65001\n   neighbor\
-    \ 172.31.255.54 description DC1-SPINE4_Ethernet7\n   neighbor 192.168.255.1 peer\
-    \ group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.1 remote-as 65001\n   neighbor\
-    \ 192.168.255.1 description DC1-SPINE1\n   neighbor 192.168.255.2 peer group EVPN-OVERLAY-PEERS\n\
-    \   neighbor 192.168.255.2 remote-as 65001\n   neighbor 192.168.255.2 description\
-    \ DC1-SPINE2\n   neighbor 192.168.255.3 peer group EVPN-OVERLAY-PEERS\n   neighbor\
-    \ 192.168.255.3 remote-as 65001\n   neighbor 192.168.255.3 description DC1-SPINE3\n\
-    \   neighbor 192.168.255.4 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.4\
-    \ remote-as 65001\n   neighbor 192.168.255.4 description DC1-SPINE4\n   redistribute\
-    \ connected route-map RM-CONN-2-BGP\n   !\n   vlan-aware-bundle Tenant_A_WAN_Zone\n\
-    \      rd 192.168.255.11:14\n      route-target both 14:14\n      redistribute\
-    \ learned\n      vlan 150\n   !\n   vlan-aware-bundle Tenant_B_WAN_Zone\n    \
-    \  rd 192.168.255.11:21\n      route-target both 21:21\n      redistribute learned\n\
-    \      vlan 250\n   !\n   vlan-aware-bundle Tenant_C_WAN_Zone\n      rd 192.168.255.11:31\n\
-    \      route-target both 31:31\n      redistribute learned\n      vlan 350\n \
-    \  !\n   address-family evpn\n      neighbor EVPN-OVERLAY-PEERS activate\n   !\n\
-    \   address-family ipv4\n      no neighbor EVPN-OVERLAY-PEERS activate\n     \
-    \ neighbor IPv4-UNDERLAY-PEERS activate\n      neighbor MLAG-IPv4-UNDERLAY-PEER\
-    \ activate\n   !\n   vrf Tenant_A_WAN_Zone\n      rd 192.168.255.11:14\n     \
-    \ route-target import evpn 14:14\n      route-target export evpn 14:14\n     \
-    \ router-id 192.168.255.11\n      neighbor 10.255.251.10 peer group MLAG-IPv4-UNDERLAY-PEER\n\
-    \      neighbor 10.255.251.10 description DC1-BL1A\n      redistribute connected\n\
-    \   !\n   vrf Tenant_B_WAN_Zone\n      rd 192.168.255.11:21\n      route-target\
-    \ import evpn 21:21\n      route-target export evpn 21:21\n      router-id 192.168.255.11\n\
-    \      neighbor 10.255.251.10 peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor\
-    \ 10.255.251.10 description DC1-BL1A\n      redistribute connected\n   !\n   vrf\
-    \ Tenant_C_WAN_Zone\n      rd 192.168.255.11:31\n      route-target import evpn\
-    \ 31:31\n      route-target export evpn 31:31\n      router-id 192.168.255.11\n\
-    \      neighbor 10.255.251.10 peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor\
-    \ 10.255.251.10 description DC1-BL1A\n      redistribute connected\n!\nmanagement\
-    \ api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n  \
-    \    no shutdown\n!\nend\n"
+    \ MLAG-IPv4-UNDERLAY-PEER next-hop-self\n   neighbor MLAG-IPv4-UNDERLAY-PEER description\
+    \ DC1-BL1A\n   neighbor MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==\n\
+    \   neighbor MLAG-IPv4-UNDERLAY-PEER send-community\n   neighbor MLAG-IPv4-UNDERLAY-PEER\
+    \ maximum-routes 12000\n   neighbor MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN\
+    \ in\n   neighbor 10.255.251.10 peer group MLAG-IPv4-UNDERLAY-PEER\n   neighbor\
+    \ 10.255.251.10 description DC1-BL1A\n   neighbor 172.31.255.48 peer group IPv4-UNDERLAY-PEERS\n\
+    \   neighbor 172.31.255.48 remote-as 65001\n   neighbor 172.31.255.48 description\
+    \ DC1-SPINE1_Ethernet7\n   neighbor 172.31.255.50 peer group IPv4-UNDERLAY-PEERS\n\
+    \   neighbor 172.31.255.50 remote-as 65001\n   neighbor 172.31.255.50 description\
+    \ DC1-SPINE2_Ethernet7\n   neighbor 172.31.255.52 peer group IPv4-UNDERLAY-PEERS\n\
+    \   neighbor 172.31.255.52 remote-as 65001\n   neighbor 172.31.255.52 description\
+    \ DC1-SPINE3_Ethernet7\n   neighbor 172.31.255.54 peer group IPv4-UNDERLAY-PEERS\n\
+    \   neighbor 172.31.255.54 remote-as 65001\n   neighbor 172.31.255.54 description\
+    \ DC1-SPINE4_Ethernet7\n   neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS\n\
+    \   neighbor 192.168.255.1 remote-as 65001\n   neighbor 192.168.255.1 description\
+    \ DC1-SPINE1\n   neighbor 192.168.255.2 peer group EVPN-OVERLAY-PEERS\n   neighbor\
+    \ 192.168.255.2 remote-as 65001\n   neighbor 192.168.255.2 description DC1-SPINE2\n\
+    \   neighbor 192.168.255.3 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.3\
+    \ remote-as 65001\n   neighbor 192.168.255.3 description DC1-SPINE3\n   neighbor\
+    \ 192.168.255.4 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.4 remote-as\
+    \ 65001\n   neighbor 192.168.255.4 description DC1-SPINE4\n   redistribute connected\
+    \ route-map RM-CONN-2-BGP\n   !\n   vlan-aware-bundle Tenant_A_WAN_Zone\n    \
+    \  rd 192.168.255.11:14\n      route-target both 14:14\n      redistribute learned\n\
+    \      vlan 150\n   !\n   vlan-aware-bundle Tenant_B_WAN_Zone\n      rd 192.168.255.11:21\n\
+    \      route-target both 21:21\n      redistribute learned\n      vlan 250\n \
+    \  !\n   vlan-aware-bundle Tenant_C_WAN_Zone\n      rd 192.168.255.11:31\n   \
+    \   route-target both 31:31\n      redistribute learned\n      vlan 350\n   !\n\
+    \   address-family evpn\n      neighbor EVPN-OVERLAY-PEERS activate\n   !\n  \
+    \ address-family ipv4\n      no neighbor EVPN-OVERLAY-PEERS activate\n      neighbor\
+    \ IPv4-UNDERLAY-PEERS activate\n      neighbor MLAG-IPv4-UNDERLAY-PEER activate\n\
+    \   !\n   vrf Tenant_A_WAN_Zone\n      rd 192.168.255.11:14\n      route-target\
+    \ import evpn 14:14\n      route-target export evpn 14:14\n      router-id 192.168.255.11\n\
+    \      neighbor 10.255.251.10 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute\
+    \ connected\n   !\n   vrf Tenant_B_WAN_Zone\n      rd 192.168.255.11:21\n    \
+    \  route-target import evpn 21:21\n      route-target export evpn 21:21\n    \
+    \  router-id 192.168.255.11\n      neighbor 10.255.251.10 peer group MLAG-IPv4-UNDERLAY-PEER\n\
+    \      redistribute connected\n   !\n   vrf Tenant_C_WAN_Zone\n      rd 192.168.255.11:31\n\
+    \      route-target import evpn 31:31\n      route-target export evpn 31:31\n\
+    \      router-id 192.168.255.11\n      neighbor 10.255.251.10 peer group MLAG-IPv4-UNDERLAY-PEER\n\
+    \      redistribute connected\n!\nmanagement api http-commands\n   protocol https\n\
+    \   no shutdown\n   !\n   vrf MGMT\n      no shutdown\n!\nend\n"
   AVD_DC1-L2LEAF1A: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr\
     \ -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata\
     \ -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n\
@@ -541,8 +537,9 @@ CVP_CONFIGLETS:
     \   neighbor IPv4-UNDERLAY-PEERS send-community\n   neighbor IPv4-UNDERLAY-PEERS\
     \ maximum-routes 12000\n   neighbor MLAG-IPv4-UNDERLAY-PEER peer group\n   neighbor\
     \ MLAG-IPv4-UNDERLAY-PEER remote-as 65102\n   neighbor MLAG-IPv4-UNDERLAY-PEER\
-    \ next-hop-self\n   neighbor MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==\n\
-    \   neighbor MLAG-IPv4-UNDERLAY-PEER send-community\n   neighbor MLAG-IPv4-UNDERLAY-PEER\
+    \ next-hop-self\n   neighbor MLAG-IPv4-UNDERLAY-PEER description DC1-LEAF2B\n\
+    \   neighbor MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==\n   neighbor\
+    \ MLAG-IPv4-UNDERLAY-PEER send-community\n   neighbor MLAG-IPv4-UNDERLAY-PEER\
     \ maximum-routes 12000\n   neighbor MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN\
     \ in\n   neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER\n   neighbor\
     \ 10.255.251.3 description DC1-LEAF2B\n   neighbor 172.31.255.8 peer group IPv4-UNDERLAY-PEERS\n\
@@ -578,30 +575,24 @@ CVP_CONFIGLETS:
     \ activate\n      neighbor MLAG-IPv4-UNDERLAY-PEER activate\n   !\n   vrf Tenant_A_APP_Zone\n\
     \      rd 192.168.255.6:12\n      route-target import evpn 12:12\n      route-target\
     \ export evpn 12:12\n      router-id 192.168.255.6\n      neighbor 10.255.251.3\
-    \ peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor 10.255.251.3 description\
-    \ DC1-LEAF2B\n      redistribute connected\n   !\n   vrf Tenant_A_DB_Zone\n  \
-    \    rd 192.168.255.6:13\n      route-target import evpn 13:13\n      route-target\
-    \ export evpn 13:13\n      router-id 192.168.255.6\n      neighbor 10.255.251.3\
-    \ peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor 10.255.251.3 description\
-    \ DC1-LEAF2B\n      redistribute connected\n   !\n   vrf Tenant_A_OP_Zone\n  \
-    \    rd 192.168.255.6:10\n      route-target import evpn 10:10\n      route-target\
-    \ export evpn 10:10\n      router-id 192.168.255.6\n      neighbor 10.255.251.3\
-    \ peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor 10.255.251.3 description\
-    \ DC1-LEAF2B\n      redistribute connected\n   !\n   vrf Tenant_A_WEB_Zone\n \
-    \     rd 192.168.255.6:11\n      route-target import evpn 11:11\n      route-target\
-    \ export evpn 11:11\n      router-id 192.168.255.6\n      neighbor 10.255.251.3\
-    \ peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor 10.255.251.3 description\
-    \ DC1-LEAF2B\n      redistribute connected\n   !\n   vrf Tenant_B_OP_Zone\n  \
-    \    rd 192.168.255.6:20\n      route-target import evpn 20:20\n      route-target\
-    \ export evpn 20:20\n      router-id 192.168.255.6\n      neighbor 10.255.251.3\
-    \ peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor 10.255.251.3 description\
-    \ DC1-LEAF2B\n      redistribute connected\n   !\n   vrf Tenant_C_OP_Zone\n  \
-    \    rd 192.168.255.6:30\n      route-target import evpn 30:30\n      route-target\
-    \ export evpn 30:30\n      router-id 192.168.255.6\n      neighbor 10.255.251.3\
-    \ peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor 10.255.251.3 description\
-    \ DC1-LEAF2B\n      redistribute connected\n!\nmanagement api http-commands\n\
-    \   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no shutdown\n!\n\
-    end\n"
+    \ peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n   !\n   vrf\
+    \ Tenant_A_DB_Zone\n      rd 192.168.255.6:13\n      route-target import evpn\
+    \ 13:13\n      route-target export evpn 13:13\n      router-id 192.168.255.6\n\
+    \      neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute\
+    \ connected\n   !\n   vrf Tenant_A_OP_Zone\n      rd 192.168.255.6:10\n      route-target\
+    \ import evpn 10:10\n      route-target export evpn 10:10\n      router-id 192.168.255.6\n\
+    \      neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute\
+    \ connected\n   !\n   vrf Tenant_A_WEB_Zone\n      rd 192.168.255.6:11\n     \
+    \ route-target import evpn 11:11\n      route-target export evpn 11:11\n     \
+    \ router-id 192.168.255.6\n      neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER\n\
+    \      redistribute connected\n   !\n   vrf Tenant_B_OP_Zone\n      rd 192.168.255.6:20\n\
+    \      route-target import evpn 20:20\n      route-target export evpn 20:20\n\
+    \      router-id 192.168.255.6\n      neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER\n\
+    \      redistribute connected\n   !\n   vrf Tenant_C_OP_Zone\n      rd 192.168.255.6:30\n\
+    \      route-target import evpn 30:30\n      route-target export evpn 30:30\n\
+    \      router-id 192.168.255.6\n      neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER\n\
+    \      redistribute connected\n!\nmanagement api http-commands\n   protocol https\n\
+    \   no shutdown\n   !\n   vrf MGMT\n      no shutdown\n!\nend\n"
   AVD_DC1-LEAF2B: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr\
     \ -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata\
     \ -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n\
@@ -725,8 +716,9 @@ CVP_CONFIGLETS:
     \   neighbor IPv4-UNDERLAY-PEERS send-community\n   neighbor IPv4-UNDERLAY-PEERS\
     \ maximum-routes 12000\n   neighbor MLAG-IPv4-UNDERLAY-PEER peer group\n   neighbor\
     \ MLAG-IPv4-UNDERLAY-PEER remote-as 65102\n   neighbor MLAG-IPv4-UNDERLAY-PEER\
-    \ next-hop-self\n   neighbor MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==\n\
-    \   neighbor MLAG-IPv4-UNDERLAY-PEER send-community\n   neighbor MLAG-IPv4-UNDERLAY-PEER\
+    \ next-hop-self\n   neighbor MLAG-IPv4-UNDERLAY-PEER description DC1-LEAF2A\n\
+    \   neighbor MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==\n   neighbor\
+    \ MLAG-IPv4-UNDERLAY-PEER send-community\n   neighbor MLAG-IPv4-UNDERLAY-PEER\
     \ maximum-routes 12000\n   neighbor MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN\
     \ in\n   neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER\n   neighbor\
     \ 10.255.251.2 description DC1-LEAF2A\n   neighbor 172.31.255.16 peer group IPv4-UNDERLAY-PEERS\n\
@@ -762,30 +754,24 @@ CVP_CONFIGLETS:
     \ activate\n      neighbor MLAG-IPv4-UNDERLAY-PEER activate\n   !\n   vrf Tenant_A_APP_Zone\n\
     \      rd 192.168.255.7:12\n      route-target import evpn 12:12\n      route-target\
     \ export evpn 12:12\n      router-id 192.168.255.7\n      neighbor 10.255.251.2\
-    \ peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor 10.255.251.2 description\
-    \ DC1-LEAF2A\n      redistribute connected\n   !\n   vrf Tenant_A_DB_Zone\n  \
-    \    rd 192.168.255.7:13\n      route-target import evpn 13:13\n      route-target\
-    \ export evpn 13:13\n      router-id 192.168.255.7\n      neighbor 10.255.251.2\
-    \ peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor 10.255.251.2 description\
-    \ DC1-LEAF2A\n      redistribute connected\n   !\n   vrf Tenant_A_OP_Zone\n  \
-    \    rd 192.168.255.7:10\n      route-target import evpn 10:10\n      route-target\
-    \ export evpn 10:10\n      router-id 192.168.255.7\n      neighbor 10.255.251.2\
-    \ peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor 10.255.251.2 description\
-    \ DC1-LEAF2A\n      redistribute connected\n   !\n   vrf Tenant_A_WEB_Zone\n \
-    \     rd 192.168.255.7:11\n      route-target import evpn 11:11\n      route-target\
-    \ export evpn 11:11\n      router-id 192.168.255.7\n      neighbor 10.255.251.2\
-    \ peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor 10.255.251.2 description\
-    \ DC1-LEAF2A\n      redistribute connected\n   !\n   vrf Tenant_B_OP_Zone\n  \
-    \    rd 192.168.255.7:20\n      route-target import evpn 20:20\n      route-target\
-    \ export evpn 20:20\n      router-id 192.168.255.7\n      neighbor 10.255.251.2\
-    \ peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor 10.255.251.2 description\
-    \ DC1-LEAF2A\n      redistribute connected\n   !\n   vrf Tenant_C_OP_Zone\n  \
-    \    rd 192.168.255.7:30\n      route-target import evpn 30:30\n      route-target\
-    \ export evpn 30:30\n      router-id 192.168.255.7\n      neighbor 10.255.251.2\
-    \ peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor 10.255.251.2 description\
-    \ DC1-LEAF2A\n      redistribute connected\n!\nmanagement api http-commands\n\
-    \   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no shutdown\n!\n\
-    end\n"
+    \ peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n   !\n   vrf\
+    \ Tenant_A_DB_Zone\n      rd 192.168.255.7:13\n      route-target import evpn\
+    \ 13:13\n      route-target export evpn 13:13\n      router-id 192.168.255.7\n\
+    \      neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute\
+    \ connected\n   !\n   vrf Tenant_A_OP_Zone\n      rd 192.168.255.7:10\n      route-target\
+    \ import evpn 10:10\n      route-target export evpn 10:10\n      router-id 192.168.255.7\n\
+    \      neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute\
+    \ connected\n   !\n   vrf Tenant_A_WEB_Zone\n      rd 192.168.255.7:11\n     \
+    \ route-target import evpn 11:11\n      route-target export evpn 11:11\n     \
+    \ router-id 192.168.255.7\n      neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER\n\
+    \      redistribute connected\n   !\n   vrf Tenant_B_OP_Zone\n      rd 192.168.255.7:20\n\
+    \      route-target import evpn 20:20\n      route-target export evpn 20:20\n\
+    \      router-id 192.168.255.7\n      neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER\n\
+    \      redistribute connected\n   !\n   vrf Tenant_C_OP_Zone\n      rd 192.168.255.7:30\n\
+    \      route-target import evpn 30:30\n      route-target export evpn 30:30\n\
+    \      router-id 192.168.255.7\n      neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER\n\
+    \      redistribute connected\n!\nmanagement api http-commands\n   protocol https\n\
+    \   no shutdown\n   !\n   vrf MGMT\n      no shutdown\n!\nend\n"
   AVD_DC1-SPINE1: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr\
     \ -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata\
     \ -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n\
@@ -1216,8 +1202,9 @@ CVP_CONFIGLETS:
     \   neighbor IPv4-UNDERLAY-PEERS send-community\n   neighbor IPv4-UNDERLAY-PEERS\
     \ maximum-routes 12000\n   neighbor MLAG-IPv4-UNDERLAY-PEER peer group\n   neighbor\
     \ MLAG-IPv4-UNDERLAY-PEER remote-as 65103\n   neighbor MLAG-IPv4-UNDERLAY-PEER\
-    \ next-hop-self\n   neighbor MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==\n\
-    \   neighbor MLAG-IPv4-UNDERLAY-PEER send-community\n   neighbor MLAG-IPv4-UNDERLAY-PEER\
+    \ next-hop-self\n   neighbor MLAG-IPv4-UNDERLAY-PEER description DC1-SVC3B\n \
+    \  neighbor MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==\n   neighbor\
+    \ MLAG-IPv4-UNDERLAY-PEER send-community\n   neighbor MLAG-IPv4-UNDERLAY-PEER\
     \ maximum-routes 12000\n   neighbor MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN\
     \ in\n   neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n   neighbor\
     \ 10.255.251.7 description DC1-SVC3B\n   neighbor 172.31.255.24 peer group IPv4-UNDERLAY-PEERS\n\
@@ -1258,42 +1245,33 @@ CVP_CONFIGLETS:
     \ neighbor IPv4-UNDERLAY-PEERS activate\n      neighbor MLAG-IPv4-UNDERLAY-PEER\
     \ activate\n   !\n   vrf Tenant_A_APP_Zone\n      rd 192.168.255.8:12\n      route-target\
     \ import evpn 12:12\n      route-target export evpn 12:12\n      router-id 192.168.255.8\n\
-    \      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor\
-    \ 10.255.251.7 description DC1-SVC3B\n      redistribute connected\n   !\n   vrf\
-    \ Tenant_A_DB_Zone\n      rd 192.168.255.8:13\n      route-target import evpn\
-    \ 13:13\n      route-target export evpn 13:13\n      router-id 192.168.255.8\n\
-    \      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor\
-    \ 10.255.251.7 description DC1-SVC3B\n      redistribute connected\n   !\n   vrf\
-    \ Tenant_A_OP_Zone\n      rd 192.168.255.8:10\n      route-target import evpn\
-    \ 10:10\n      route-target export evpn 10:10\n      router-id 192.168.255.8\n\
-    \      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor\
-    \ 10.255.251.7 description DC1-SVC3B\n      redistribute connected\n   !\n   vrf\
-    \ Tenant_A_WAN_Zone\n      rd 192.168.255.8:14\n      route-target import evpn\
-    \ 14:14\n      route-target export evpn 14:14\n      router-id 192.168.255.8\n\
-    \      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor\
-    \ 10.255.251.7 description DC1-SVC3B\n      redistribute connected\n   !\n   vrf\
-    \ Tenant_A_WEB_Zone\n      rd 192.168.255.8:11\n      route-target import evpn\
-    \ 11:11\n      route-target export evpn 11:11\n      router-id 192.168.255.8\n\
-    \      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor\
-    \ 10.255.251.7 description DC1-SVC3B\n      redistribute connected\n   !\n   vrf\
-    \ Tenant_B_OP_Zone\n      rd 192.168.255.8:20\n      route-target import evpn\
-    \ 20:20\n      route-target export evpn 20:20\n      router-id 192.168.255.8\n\
-    \      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor\
-    \ 10.255.251.7 description DC1-SVC3B\n      redistribute connected\n   !\n   vrf\
-    \ Tenant_B_WAN_Zone\n      rd 192.168.255.8:21\n      route-target import evpn\
-    \ 21:21\n      route-target export evpn 21:21\n      router-id 192.168.255.8\n\
-    \      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor\
-    \ 10.255.251.7 description DC1-SVC3B\n      redistribute connected\n   !\n   vrf\
-    \ Tenant_C_OP_Zone\n      rd 192.168.255.8:30\n      route-target import evpn\
-    \ 30:30\n      route-target export evpn 30:30\n      router-id 192.168.255.8\n\
-    \      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor\
-    \ 10.255.251.7 description DC1-SVC3B\n      redistribute connected\n   !\n   vrf\
-    \ Tenant_C_WAN_Zone\n      rd 192.168.255.8:31\n      route-target import evpn\
-    \ 31:31\n      route-target export evpn 31:31\n      router-id 192.168.255.8\n\
-    \      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor\
-    \ 10.255.251.7 description DC1-SVC3B\n      redistribute connected\n!\nmanagement\
-    \ api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n  \
-    \    no shutdown\n!\nend\n"
+    \      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute\
+    \ connected\n   !\n   vrf Tenant_A_DB_Zone\n      rd 192.168.255.8:13\n      route-target\
+    \ import evpn 13:13\n      route-target export evpn 13:13\n      router-id 192.168.255.8\n\
+    \      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute\
+    \ connected\n   !\n   vrf Tenant_A_OP_Zone\n      rd 192.168.255.8:10\n      route-target\
+    \ import evpn 10:10\n      route-target export evpn 10:10\n      router-id 192.168.255.8\n\
+    \      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute\
+    \ connected\n   !\n   vrf Tenant_A_WAN_Zone\n      rd 192.168.255.8:14\n     \
+    \ route-target import evpn 14:14\n      route-target export evpn 14:14\n     \
+    \ router-id 192.168.255.8\n      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n\
+    \      redistribute connected\n   !\n   vrf Tenant_A_WEB_Zone\n      rd 192.168.255.8:11\n\
+    \      route-target import evpn 11:11\n      route-target export evpn 11:11\n\
+    \      router-id 192.168.255.8\n      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n\
+    \      redistribute connected\n   !\n   vrf Tenant_B_OP_Zone\n      rd 192.168.255.8:20\n\
+    \      route-target import evpn 20:20\n      route-target export evpn 20:20\n\
+    \      router-id 192.168.255.8\n      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n\
+    \      redistribute connected\n   !\n   vrf Tenant_B_WAN_Zone\n      rd 192.168.255.8:21\n\
+    \      route-target import evpn 21:21\n      route-target export evpn 21:21\n\
+    \      router-id 192.168.255.8\n      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n\
+    \      redistribute connected\n   !\n   vrf Tenant_C_OP_Zone\n      rd 192.168.255.8:30\n\
+    \      route-target import evpn 30:30\n      route-target export evpn 30:30\n\
+    \      router-id 192.168.255.8\n      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n\
+    \      redistribute connected\n   !\n   vrf Tenant_C_WAN_Zone\n      rd 192.168.255.8:31\n\
+    \      route-target import evpn 31:31\n      route-target export evpn 31:31\n\
+    \      router-id 192.168.255.8\n      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n\
+    \      redistribute connected\n!\nmanagement api http-commands\n   protocol https\n\
+    \   no shutdown\n   !\n   vrf MGMT\n      no shutdown\n!\nend\n"
   AVD_DC1-SVC3B: "!RANCID-CONTENT-TYPE: arista\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr\
     \ -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata\
     \ -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n\
@@ -1436,8 +1414,9 @@ CVP_CONFIGLETS:
     \   neighbor IPv4-UNDERLAY-PEERS send-community\n   neighbor IPv4-UNDERLAY-PEERS\
     \ maximum-routes 12000\n   neighbor MLAG-IPv4-UNDERLAY-PEER peer group\n   neighbor\
     \ MLAG-IPv4-UNDERLAY-PEER remote-as 65103\n   neighbor MLAG-IPv4-UNDERLAY-PEER\
-    \ next-hop-self\n   neighbor MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==\n\
-    \   neighbor MLAG-IPv4-UNDERLAY-PEER send-community\n   neighbor MLAG-IPv4-UNDERLAY-PEER\
+    \ next-hop-self\n   neighbor MLAG-IPv4-UNDERLAY-PEER description DC1-SVC3A\n \
+    \  neighbor MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==\n   neighbor\
+    \ MLAG-IPv4-UNDERLAY-PEER send-community\n   neighbor MLAG-IPv4-UNDERLAY-PEER\
     \ maximum-routes 12000\n   neighbor MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN\
     \ in\n   neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n   neighbor\
     \ 10.255.251.6 description DC1-SVC3A\n   neighbor 172.31.255.32 peer group IPv4-UNDERLAY-PEERS\n\
@@ -1478,42 +1457,33 @@ CVP_CONFIGLETS:
     \ neighbor IPv4-UNDERLAY-PEERS activate\n      neighbor MLAG-IPv4-UNDERLAY-PEER\
     \ activate\n   !\n   vrf Tenant_A_APP_Zone\n      rd 192.168.255.9:12\n      route-target\
     \ import evpn 12:12\n      route-target export evpn 12:12\n      router-id 192.168.255.9\n\
-    \      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor\
-    \ 10.255.251.6 description DC1-SVC3A\n      redistribute connected\n   !\n   vrf\
-    \ Tenant_A_DB_Zone\n      rd 192.168.255.9:13\n      route-target import evpn\
-    \ 13:13\n      route-target export evpn 13:13\n      router-id 192.168.255.9\n\
-    \      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor\
-    \ 10.255.251.6 description DC1-SVC3A\n      redistribute connected\n   !\n   vrf\
-    \ Tenant_A_OP_Zone\n      rd 192.168.255.9:10\n      route-target import evpn\
-    \ 10:10\n      route-target export evpn 10:10\n      router-id 192.168.255.9\n\
-    \      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor\
-    \ 10.255.251.6 description DC1-SVC3A\n      redistribute connected\n   !\n   vrf\
-    \ Tenant_A_WAN_Zone\n      rd 192.168.255.9:14\n      route-target import evpn\
-    \ 14:14\n      route-target export evpn 14:14\n      router-id 192.168.255.9\n\
-    \      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor\
-    \ 10.255.251.6 description DC1-SVC3A\n      redistribute connected\n   !\n   vrf\
-    \ Tenant_A_WEB_Zone\n      rd 192.168.255.9:11\n      route-target import evpn\
-    \ 11:11\n      route-target export evpn 11:11\n      router-id 192.168.255.9\n\
-    \      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor\
-    \ 10.255.251.6 description DC1-SVC3A\n      redistribute connected\n   !\n   vrf\
-    \ Tenant_B_OP_Zone\n      rd 192.168.255.9:20\n      route-target import evpn\
-    \ 20:20\n      route-target export evpn 20:20\n      router-id 192.168.255.9\n\
-    \      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor\
-    \ 10.255.251.6 description DC1-SVC3A\n      redistribute connected\n   !\n   vrf\
-    \ Tenant_B_WAN_Zone\n      rd 192.168.255.9:21\n      route-target import evpn\
-    \ 21:21\n      route-target export evpn 21:21\n      router-id 192.168.255.9\n\
-    \      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor\
-    \ 10.255.251.6 description DC1-SVC3A\n      redistribute connected\n   !\n   vrf\
-    \ Tenant_C_OP_Zone\n      rd 192.168.255.9:30\n      route-target import evpn\
-    \ 30:30\n      route-target export evpn 30:30\n      router-id 192.168.255.9\n\
-    \      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor\
-    \ 10.255.251.6 description DC1-SVC3A\n      redistribute connected\n   !\n   vrf\
-    \ Tenant_C_WAN_Zone\n      rd 192.168.255.9:31\n      route-target import evpn\
-    \ 31:31\n      route-target export evpn 31:31\n      router-id 192.168.255.9\n\
-    \      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor\
-    \ 10.255.251.6 description DC1-SVC3A\n      redistribute connected\n!\nmanagement\
-    \ api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n  \
-    \    no shutdown\n!\nend\n"
+    \      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute\
+    \ connected\n   !\n   vrf Tenant_A_DB_Zone\n      rd 192.168.255.9:13\n      route-target\
+    \ import evpn 13:13\n      route-target export evpn 13:13\n      router-id 192.168.255.9\n\
+    \      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute\
+    \ connected\n   !\n   vrf Tenant_A_OP_Zone\n      rd 192.168.255.9:10\n      route-target\
+    \ import evpn 10:10\n      route-target export evpn 10:10\n      router-id 192.168.255.9\n\
+    \      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute\
+    \ connected\n   !\n   vrf Tenant_A_WAN_Zone\n      rd 192.168.255.9:14\n     \
+    \ route-target import evpn 14:14\n      route-target export evpn 14:14\n     \
+    \ router-id 192.168.255.9\n      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n\
+    \      redistribute connected\n   !\n   vrf Tenant_A_WEB_Zone\n      rd 192.168.255.9:11\n\
+    \      route-target import evpn 11:11\n      route-target export evpn 11:11\n\
+    \      router-id 192.168.255.9\n      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n\
+    \      redistribute connected\n   !\n   vrf Tenant_B_OP_Zone\n      rd 192.168.255.9:20\n\
+    \      route-target import evpn 20:20\n      route-target export evpn 20:20\n\
+    \      router-id 192.168.255.9\n      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n\
+    \      redistribute connected\n   !\n   vrf Tenant_B_WAN_Zone\n      rd 192.168.255.9:21\n\
+    \      route-target import evpn 21:21\n      route-target export evpn 21:21\n\
+    \      router-id 192.168.255.9\n      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n\
+    \      redistribute connected\n   !\n   vrf Tenant_C_OP_Zone\n      rd 192.168.255.9:30\n\
+    \      route-target import evpn 30:30\n      route-target export evpn 30:30\n\
+    \      router-id 192.168.255.9\n      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n\
+    \      redistribute connected\n   !\n   vrf Tenant_C_WAN_Zone\n      rd 192.168.255.9:31\n\
+    \      route-target import evpn 31:31\n      route-target export evpn 31:31\n\
+    \      router-id 192.168.255.9\n      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n\
+    \      redistribute connected\n!\nmanagement api http-commands\n   protocol https\n\
+    \   no shutdown\n   !\n   vrf MGMT\n      no shutdown\n!\nend\n"
 CVP_TOPOLOGY:
   DC1_BL1:
     devices:

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2A.md
@@ -861,6 +861,7 @@ router bgp 65112.100
    neighbor MLAG-IPv4-UNDERLAY-PEER peer group
    neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65112.100
    neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
+   neighbor MLAG-IPv4-UNDERLAY-PEER description DC1-POD1-LEAF2B
    neighbor MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==
    neighbor MLAG-IPv4-UNDERLAY-PEER send-community
    neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
@@ -886,6 +886,7 @@ router bgp 65112.100
    neighbor MLAG-IPv4-UNDERLAY-PEER peer group
    neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65112.100
    neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
+   neighbor MLAG-IPv4-UNDERLAY-PEER description DC1-POD1-LEAF2A
    neighbor MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==
    neighbor MLAG-IPv4-UNDERLAY-PEER send-community
    neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2A.cfg
@@ -412,6 +412,7 @@ router bgp 65112.100
    neighbor MLAG-IPv4-UNDERLAY-PEER peer group
    neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65112.100
    neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
+   neighbor MLAG-IPv4-UNDERLAY-PEER description DC1-POD1-LEAF2B
    neighbor MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==
    neighbor MLAG-IPv4-UNDERLAY-PEER send-community
    neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2B.cfg
@@ -416,6 +416,7 @@ router bgp 65112.100
    neighbor MLAG-IPv4-UNDERLAY-PEER peer group
    neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65112.100
    neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
+   neighbor MLAG-IPv4-UNDERLAY-PEER description DC1-POD1-LEAF2A
    neighbor MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==
    neighbor MLAG-IPv4-UNDERLAY-PEER send-community
    neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2A.yml
@@ -12,6 +12,7 @@ router_bgp:
       type: ipv4
       remote_as: '65112.100'
       next_hop_self: true
+      description: DC1-POD1-LEAF2B
       password: vnEaG8gMeQf3d3cN6PktXQ==
       maximum_routes: 12000
       send_community: all

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
@@ -12,6 +12,7 @@ router_bgp:
       type: ipv4
       remote_as: '65112.100'
       next_hop_self: true
+      description: DC1-POD1-LEAF2A
       password: vnEaG8gMeQf3d3cN6PktXQ==
       maximum_routes: 12000
       send_community: all

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3A.md
@@ -1580,6 +1580,7 @@ router bgp 65103
       route-target export evpn 12:12
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1588,6 +1589,7 @@ router bgp 65103
       route-target export evpn 13:13
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1596,6 +1598,7 @@ router bgp 65103
       route-target export evpn 9:9
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -1606,6 +1609,7 @@ router bgp 65103
       route-target export evpn 65000:789
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1614,6 +1618,7 @@ router bgp 65103
       route-target export evpn 11:11
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1622,6 +1627,7 @@ router bgp 65103
       route-target export evpn 20:20
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -1630,6 +1636,7 @@ router bgp 65103
       route-target export evpn 21:21
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1638,6 +1645,7 @@ router bgp 65103
       route-target export evpn 30:30
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -1646,6 +1654,7 @@ router bgp 65103
       route-target export evpn 31:31
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3A.md
@@ -1464,6 +1464,7 @@ router bgp 65103
    neighbor MLAG-PEERS peer group
    neighbor MLAG-PEERS remote-as 65103
    neighbor MLAG-PEERS next-hop-self
+   neighbor MLAG-PEERS description DC1-SVC3B
    neighbor MLAG-PEERS password 7 vnEaG8gMeQf3d3cN6PktXQ==
    neighbor MLAG-PEERS send-community
    neighbor MLAG-PEERS maximum-routes 12000
@@ -1580,7 +1581,6 @@ router bgp 65103
       route-target export evpn 12:12
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1589,7 +1589,6 @@ router bgp 65103
       route-target export evpn 13:13
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1598,7 +1597,6 @@ router bgp 65103
       route-target export evpn 9:9
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -1609,7 +1607,6 @@ router bgp 65103
       route-target export evpn 65000:789
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1618,7 +1615,6 @@ router bgp 65103
       route-target export evpn 11:11
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1627,7 +1623,6 @@ router bgp 65103
       route-target export evpn 20:20
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -1636,7 +1631,6 @@ router bgp 65103
       route-target export evpn 21:21
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1645,7 +1639,6 @@ router bgp 65103
       route-target export evpn 30:30
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -1654,7 +1647,6 @@ router bgp 65103
       route-target export evpn 31:31
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3B.md
@@ -1550,6 +1550,7 @@ router bgp 65103
       route-target export evpn 12:12
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1558,6 +1559,7 @@ router bgp 65103
       route-target export evpn 13:13
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1566,6 +1568,7 @@ router bgp 65103
       route-target export evpn 9:9
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -1576,6 +1579,7 @@ router bgp 65103
       route-target export evpn 65000:789
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1584,6 +1588,7 @@ router bgp 65103
       route-target export evpn 11:11
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1592,6 +1597,7 @@ router bgp 65103
       route-target export evpn 20:20
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -1600,6 +1606,7 @@ router bgp 65103
       route-target export evpn 21:21
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1608,6 +1615,7 @@ router bgp 65103
       route-target export evpn 30:30
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -1616,6 +1624,7 @@ router bgp 65103
       route-target export evpn 31:31
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3B.md
@@ -1434,6 +1434,7 @@ router bgp 65103
    neighbor MLAG-PEERS peer group
    neighbor MLAG-PEERS remote-as 65103
    neighbor MLAG-PEERS next-hop-self
+   neighbor MLAG-PEERS description DC1-SVC3A
    neighbor MLAG-PEERS password 7 vnEaG8gMeQf3d3cN6PktXQ==
    neighbor MLAG-PEERS send-community
    neighbor MLAG-PEERS maximum-routes 12000
@@ -1550,7 +1551,6 @@ router bgp 65103
       route-target export evpn 12:12
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1559,7 +1559,6 @@ router bgp 65103
       route-target export evpn 13:13
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1568,7 +1567,6 @@ router bgp 65103
       route-target export evpn 9:9
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -1579,7 +1577,6 @@ router bgp 65103
       route-target export evpn 65000:789
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1588,7 +1585,6 @@ router bgp 65103
       route-target export evpn 11:11
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1597,7 +1593,6 @@ router bgp 65103
       route-target export evpn 20:20
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -1606,7 +1601,6 @@ router bgp 65103
       route-target export evpn 21:21
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1615,7 +1609,6 @@ router bgp 65103
       route-target export evpn 30:30
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -1624,7 +1617,6 @@ router bgp 65103
       route-target export evpn 31:31
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3A.cfg
@@ -796,6 +796,7 @@ router bgp 65103
    neighbor MLAG-PEERS peer group
    neighbor MLAG-PEERS remote-as 65103
    neighbor MLAG-PEERS next-hop-self
+   neighbor MLAG-PEERS description DC1-SVC3B
    neighbor MLAG-PEERS password 7 vnEaG8gMeQf3d3cN6PktXQ==
    neighbor MLAG-PEERS send-community
    neighbor MLAG-PEERS maximum-routes 12000
@@ -912,7 +913,6 @@ router bgp 65103
       route-target export evpn 12:12
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -921,7 +921,6 @@ router bgp 65103
       route-target export evpn 13:13
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -930,7 +929,6 @@ router bgp 65103
       route-target export evpn 9:9
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -941,7 +939,6 @@ router bgp 65103
       route-target export evpn 65000:789
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -950,7 +947,6 @@ router bgp 65103
       route-target export evpn 11:11
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -959,7 +955,6 @@ router bgp 65103
       route-target export evpn 20:20
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -968,7 +963,6 @@ router bgp 65103
       route-target export evpn 21:21
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -977,7 +971,6 @@ router bgp 65103
       route-target export evpn 30:30
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -986,7 +979,6 @@ router bgp 65103
       route-target export evpn 31:31
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3A.cfg
@@ -912,6 +912,7 @@ router bgp 65103
       route-target export evpn 12:12
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -920,6 +921,7 @@ router bgp 65103
       route-target export evpn 13:13
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -928,6 +930,7 @@ router bgp 65103
       route-target export evpn 9:9
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -938,6 +941,7 @@ router bgp 65103
       route-target export evpn 65000:789
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -946,6 +950,7 @@ router bgp 65103
       route-target export evpn 11:11
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -954,6 +959,7 @@ router bgp 65103
       route-target export evpn 20:20
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -962,6 +968,7 @@ router bgp 65103
       route-target export evpn 21:21
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -970,6 +977,7 @@ router bgp 65103
       route-target export evpn 30:30
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -978,6 +986,7 @@ router bgp 65103
       route-target export evpn 31:31
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3B.cfg
@@ -770,6 +770,7 @@ router bgp 65103
    neighbor MLAG-PEERS peer group
    neighbor MLAG-PEERS remote-as 65103
    neighbor MLAG-PEERS next-hop-self
+   neighbor MLAG-PEERS description DC1-SVC3A
    neighbor MLAG-PEERS password 7 vnEaG8gMeQf3d3cN6PktXQ==
    neighbor MLAG-PEERS send-community
    neighbor MLAG-PEERS maximum-routes 12000
@@ -886,7 +887,6 @@ router bgp 65103
       route-target export evpn 12:12
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -895,7 +895,6 @@ router bgp 65103
       route-target export evpn 13:13
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -904,7 +903,6 @@ router bgp 65103
       route-target export evpn 9:9
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -915,7 +913,6 @@ router bgp 65103
       route-target export evpn 65000:789
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -924,7 +921,6 @@ router bgp 65103
       route-target export evpn 11:11
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -933,7 +929,6 @@ router bgp 65103
       route-target export evpn 20:20
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -942,7 +937,6 @@ router bgp 65103
       route-target export evpn 21:21
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -951,7 +945,6 @@ router bgp 65103
       route-target export evpn 30:30
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -960,7 +953,6 @@ router bgp 65103
       route-target export evpn 31:31
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3B.cfg
@@ -886,6 +886,7 @@ router bgp 65103
       route-target export evpn 12:12
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -894,6 +895,7 @@ router bgp 65103
       route-target export evpn 13:13
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -902,6 +904,7 @@ router bgp 65103
       route-target export evpn 9:9
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -912,6 +915,7 @@ router bgp 65103
       route-target export evpn 65000:789
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -920,6 +924,7 @@ router bgp 65103
       route-target export evpn 11:11
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -928,6 +933,7 @@ router bgp 65103
       route-target export evpn 20:20
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -936,6 +942,7 @@ router bgp 65103
       route-target export evpn 21:21
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -944,6 +951,7 @@ router bgp 65103
       route-target export evpn 30:30
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -952,6 +960,7 @@ router bgp 65103
       route-target export evpn 31:31
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
@@ -10,6 +10,7 @@ router_bgp:
       type: ipv4
       remote_as: '65103'
       next_hop_self: true
+      description: DC1-SVC3B
       password: vnEaG8gMeQf3d3cN6PktXQ==
       maximum_routes: 12000
       send_community: all
@@ -92,7 +93,6 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG-PEERS
-          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_A_DB_Zone:
@@ -108,7 +108,6 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG-PEERS
-          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_A_OP_Zone:
@@ -124,7 +123,6 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG-PEERS
-          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_A_WAN_Zone:
@@ -142,7 +140,6 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG-PEERS
-          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_A_WEB_Zone:
@@ -158,7 +155,6 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG-PEERS
-          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_B_OP_Zone:
@@ -174,7 +170,6 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG-PEERS
-          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_B_WAN_Zone:
@@ -190,7 +185,6 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG-PEERS
-          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_C_OP_Zone:
@@ -206,7 +200,6 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG-PEERS
-          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_C_WAN_Zone:
@@ -222,7 +215,6 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG-PEERS
-          description: DC1-SVC3B
       redistribute_routes:
       - connected
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
@@ -92,6 +92,7 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG-PEERS
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_A_DB_Zone:
@@ -107,6 +108,7 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG-PEERS
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_A_OP_Zone:
@@ -122,6 +124,7 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG-PEERS
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_A_WAN_Zone:
@@ -139,6 +142,7 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG-PEERS
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_A_WEB_Zone:
@@ -154,6 +158,7 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG-PEERS
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_B_OP_Zone:
@@ -169,6 +174,7 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG-PEERS
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_B_WAN_Zone:
@@ -184,6 +190,7 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG-PEERS
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_C_OP_Zone:
@@ -199,6 +206,7 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG-PEERS
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_C_WAN_Zone:
@@ -214,6 +222,7 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG-PEERS
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
@@ -10,6 +10,7 @@ router_bgp:
       type: ipv4
       remote_as: '65103'
       next_hop_self: true
+      description: DC1-SVC3A
       password: vnEaG8gMeQf3d3cN6PktXQ==
       maximum_routes: 12000
       send_community: all
@@ -92,7 +93,6 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG-PEERS
-          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_A_DB_Zone:
@@ -108,7 +108,6 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG-PEERS
-          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_A_OP_Zone:
@@ -124,7 +123,6 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG-PEERS
-          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_A_WAN_Zone:
@@ -142,7 +140,6 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG-PEERS
-          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_A_WEB_Zone:
@@ -158,7 +155,6 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG-PEERS
-          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_B_OP_Zone:
@@ -174,7 +170,6 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG-PEERS
-          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_B_WAN_Zone:
@@ -190,7 +185,6 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG-PEERS
-          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_C_OP_Zone:
@@ -206,7 +200,6 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG-PEERS
-          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_C_WAN_Zone:
@@ -222,7 +215,6 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG-PEERS
-          description: DC1-SVC3A
       redistribute_routes:
       - connected
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
@@ -92,6 +92,7 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG-PEERS
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_A_DB_Zone:
@@ -107,6 +108,7 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG-PEERS
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_A_OP_Zone:
@@ -122,6 +124,7 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG-PEERS
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_A_WAN_Zone:
@@ -139,6 +142,7 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG-PEERS
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_A_WEB_Zone:
@@ -154,6 +158,7 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG-PEERS
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_B_OP_Zone:
@@ -169,6 +174,7 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG-PEERS
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_B_WAN_Zone:
@@ -184,6 +190,7 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG-PEERS
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_C_OP_Zone:
@@ -199,6 +206,7 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG-PEERS
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_C_WAN_Zone:
@@ -214,6 +222,7 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG-PEERS
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -1361,6 +1361,7 @@ router bgp 65103
    neighbor MLAG-PEERS peer group
    neighbor MLAG-PEERS remote-as 65103
    neighbor MLAG-PEERS next-hop-self
+   neighbor MLAG-PEERS description DC1-SVC3B
    neighbor MLAG-PEERS password 7 vnEaG8gMeQf3d3cN6PktXQ==
    neighbor MLAG-PEERS send-community
    neighbor MLAG-PEERS maximum-routes 12000
@@ -1478,7 +1479,6 @@ router bgp 65103
       route-target export evpn 12:12
       router-id 192.168.255.12
       neighbor 10.255.252.7 peer group MLAG-PEERS
-      neighbor 10.255.252.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1487,7 +1487,6 @@ router bgp 65103
       route-target export evpn 13:13
       router-id 192.168.255.12
       neighbor 10.255.252.7 peer group MLAG-PEERS
-      neighbor 10.255.252.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1496,7 +1495,6 @@ router bgp 65103
       route-target export evpn 10:10
       router-id 192.168.255.12
       neighbor 10.255.252.7 peer group MLAG-PEERS
-      neighbor 10.255.252.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -1507,7 +1505,6 @@ router bgp 65103
       route-target export evpn 65000:789
       router-id 192.168.255.12
       neighbor 10.255.252.7 peer group MLAG-PEERS
-      neighbor 10.255.252.7 description DC1-SVC3B
       redistribute connected
       redistribute static
    !
@@ -1517,7 +1514,6 @@ router bgp 65103
       route-target export evpn 11:11
       router-id 192.168.255.12
       neighbor 10.255.252.7 peer group MLAG-PEERS
-      neighbor 10.255.252.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1526,7 +1522,6 @@ router bgp 65103
       route-target export evpn 20:20
       router-id 192.168.255.12
       neighbor 10.255.252.7 peer group MLAG-PEERS
-      neighbor 10.255.252.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -1535,7 +1530,6 @@ router bgp 65103
       route-target export evpn 21:21
       router-id 192.168.255.12
       neighbor 10.255.252.7 peer group MLAG-PEERS
-      neighbor 10.255.252.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1544,7 +1538,6 @@ router bgp 65103
       route-target export evpn 30:30
       router-id 192.168.255.12
       neighbor 10.255.252.7 peer group MLAG-PEERS
-      neighbor 10.255.252.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -1553,7 +1546,6 @@ router bgp 65103
       route-target export evpn 31:31
       router-id 192.168.255.12
       neighbor 10.255.252.7 peer group MLAG-PEERS
-      neighbor 10.255.252.7 description DC1-SVC3B
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -1478,6 +1478,7 @@ router bgp 65103
       route-target export evpn 12:12
       router-id 192.168.255.12
       neighbor 10.255.252.7 peer group MLAG-PEERS
+      neighbor 10.255.252.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1486,6 +1487,7 @@ router bgp 65103
       route-target export evpn 13:13
       router-id 192.168.255.12
       neighbor 10.255.252.7 peer group MLAG-PEERS
+      neighbor 10.255.252.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1494,6 +1496,7 @@ router bgp 65103
       route-target export evpn 10:10
       router-id 192.168.255.12
       neighbor 10.255.252.7 peer group MLAG-PEERS
+      neighbor 10.255.252.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -1504,6 +1507,7 @@ router bgp 65103
       route-target export evpn 65000:789
       router-id 192.168.255.12
       neighbor 10.255.252.7 peer group MLAG-PEERS
+      neighbor 10.255.252.7 description DC1-SVC3B
       redistribute connected
       redistribute static
    !
@@ -1513,6 +1517,7 @@ router bgp 65103
       route-target export evpn 11:11
       router-id 192.168.255.12
       neighbor 10.255.252.7 peer group MLAG-PEERS
+      neighbor 10.255.252.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1521,6 +1526,7 @@ router bgp 65103
       route-target export evpn 20:20
       router-id 192.168.255.12
       neighbor 10.255.252.7 peer group MLAG-PEERS
+      neighbor 10.255.252.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -1529,6 +1535,7 @@ router bgp 65103
       route-target export evpn 21:21
       router-id 192.168.255.12
       neighbor 10.255.252.7 peer group MLAG-PEERS
+      neighbor 10.255.252.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1537,6 +1544,7 @@ router bgp 65103
       route-target export evpn 30:30
       router-id 192.168.255.12
       neighbor 10.255.252.7 peer group MLAG-PEERS
+      neighbor 10.255.252.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -1545,6 +1553,7 @@ router bgp 65103
       route-target export evpn 31:31
       router-id 192.168.255.12
       neighbor 10.255.252.7 peer group MLAG-PEERS
+      neighbor 10.255.252.7 description DC1-SVC3B
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -1361,6 +1361,7 @@ router bgp 65103
    neighbor MLAG-PEERS peer group
    neighbor MLAG-PEERS remote-as 65103
    neighbor MLAG-PEERS next-hop-self
+   neighbor MLAG-PEERS description DC1-SVC3A
    neighbor MLAG-PEERS password 7 vnEaG8gMeQf3d3cN6PktXQ==
    neighbor MLAG-PEERS send-community
    neighbor MLAG-PEERS maximum-routes 12000
@@ -1478,7 +1479,6 @@ router bgp 65103
       route-target export evpn 12:12
       router-id 192.168.255.13
       neighbor 10.255.252.6 peer group MLAG-PEERS
-      neighbor 10.255.252.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1487,7 +1487,6 @@ router bgp 65103
       route-target export evpn 13:13
       router-id 192.168.255.13
       neighbor 10.255.252.6 peer group MLAG-PEERS
-      neighbor 10.255.252.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1496,7 +1495,6 @@ router bgp 65103
       route-target export evpn 10:10
       router-id 192.168.255.13
       neighbor 10.255.252.6 peer group MLAG-PEERS
-      neighbor 10.255.252.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -1507,7 +1505,6 @@ router bgp 65103
       route-target export evpn 65000:789
       router-id 192.168.255.13
       neighbor 10.255.252.6 peer group MLAG-PEERS
-      neighbor 10.255.252.6 description DC1-SVC3A
       redistribute connected
       redistribute static
    !
@@ -1517,7 +1514,6 @@ router bgp 65103
       route-target export evpn 11:11
       router-id 192.168.255.13
       neighbor 10.255.252.6 peer group MLAG-PEERS
-      neighbor 10.255.252.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1526,7 +1522,6 @@ router bgp 65103
       route-target export evpn 20:20
       router-id 192.168.255.13
       neighbor 10.255.252.6 peer group MLAG-PEERS
-      neighbor 10.255.252.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -1535,7 +1530,6 @@ router bgp 65103
       route-target export evpn 21:21
       router-id 192.168.255.13
       neighbor 10.255.252.6 peer group MLAG-PEERS
-      neighbor 10.255.252.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1544,7 +1538,6 @@ router bgp 65103
       route-target export evpn 30:30
       router-id 192.168.255.13
       neighbor 10.255.252.6 peer group MLAG-PEERS
-      neighbor 10.255.252.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -1553,7 +1546,6 @@ router bgp 65103
       route-target export evpn 31:31
       router-id 192.168.255.13
       neighbor 10.255.252.6 peer group MLAG-PEERS
-      neighbor 10.255.252.6 description DC1-SVC3A
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -1478,6 +1478,7 @@ router bgp 65103
       route-target export evpn 12:12
       router-id 192.168.255.13
       neighbor 10.255.252.6 peer group MLAG-PEERS
+      neighbor 10.255.252.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1486,6 +1487,7 @@ router bgp 65103
       route-target export evpn 13:13
       router-id 192.168.255.13
       neighbor 10.255.252.6 peer group MLAG-PEERS
+      neighbor 10.255.252.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1494,6 +1496,7 @@ router bgp 65103
       route-target export evpn 10:10
       router-id 192.168.255.13
       neighbor 10.255.252.6 peer group MLAG-PEERS
+      neighbor 10.255.252.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -1504,6 +1507,7 @@ router bgp 65103
       route-target export evpn 65000:789
       router-id 192.168.255.13
       neighbor 10.255.252.6 peer group MLAG-PEERS
+      neighbor 10.255.252.6 description DC1-SVC3A
       redistribute connected
       redistribute static
    !
@@ -1513,6 +1517,7 @@ router bgp 65103
       route-target export evpn 11:11
       router-id 192.168.255.13
       neighbor 10.255.252.6 peer group MLAG-PEERS
+      neighbor 10.255.252.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1521,6 +1526,7 @@ router bgp 65103
       route-target export evpn 20:20
       router-id 192.168.255.13
       neighbor 10.255.252.6 peer group MLAG-PEERS
+      neighbor 10.255.252.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -1529,6 +1535,7 @@ router bgp 65103
       route-target export evpn 21:21
       router-id 192.168.255.13
       neighbor 10.255.252.6 peer group MLAG-PEERS
+      neighbor 10.255.252.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1537,6 +1544,7 @@ router bgp 65103
       route-target export evpn 30:30
       router-id 192.168.255.13
       neighbor 10.255.252.6 peer group MLAG-PEERS
+      neighbor 10.255.252.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -1545,6 +1553,7 @@ router bgp 65103
       route-target export evpn 31:31
       router-id 192.168.255.13
       neighbor 10.255.252.6 peer group MLAG-PEERS
+      neighbor 10.255.252.6 description DC1-SVC3A
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
@@ -845,6 +845,7 @@ router bgp 65103
       route-target export evpn 12:12
       router-id 192.168.255.12
       neighbor 10.255.252.7 peer group MLAG-PEERS
+      neighbor 10.255.252.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -853,6 +854,7 @@ router bgp 65103
       route-target export evpn 13:13
       router-id 192.168.255.12
       neighbor 10.255.252.7 peer group MLAG-PEERS
+      neighbor 10.255.252.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -861,6 +863,7 @@ router bgp 65103
       route-target export evpn 10:10
       router-id 192.168.255.12
       neighbor 10.255.252.7 peer group MLAG-PEERS
+      neighbor 10.255.252.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -871,6 +874,7 @@ router bgp 65103
       route-target export evpn 65000:789
       router-id 192.168.255.12
       neighbor 10.255.252.7 peer group MLAG-PEERS
+      neighbor 10.255.252.7 description DC1-SVC3B
       redistribute connected
       redistribute static
    !
@@ -880,6 +884,7 @@ router bgp 65103
       route-target export evpn 11:11
       router-id 192.168.255.12
       neighbor 10.255.252.7 peer group MLAG-PEERS
+      neighbor 10.255.252.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -888,6 +893,7 @@ router bgp 65103
       route-target export evpn 20:20
       router-id 192.168.255.12
       neighbor 10.255.252.7 peer group MLAG-PEERS
+      neighbor 10.255.252.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -896,6 +902,7 @@ router bgp 65103
       route-target export evpn 21:21
       router-id 192.168.255.12
       neighbor 10.255.252.7 peer group MLAG-PEERS
+      neighbor 10.255.252.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -904,6 +911,7 @@ router bgp 65103
       route-target export evpn 30:30
       router-id 192.168.255.12
       neighbor 10.255.252.7 peer group MLAG-PEERS
+      neighbor 10.255.252.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -912,6 +920,7 @@ router bgp 65103
       route-target export evpn 31:31
       router-id 192.168.255.12
       neighbor 10.255.252.7 peer group MLAG-PEERS
+      neighbor 10.255.252.7 description DC1-SVC3B
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
@@ -728,6 +728,7 @@ router bgp 65103
    neighbor MLAG-PEERS peer group
    neighbor MLAG-PEERS remote-as 65103
    neighbor MLAG-PEERS next-hop-self
+   neighbor MLAG-PEERS description DC1-SVC3B
    neighbor MLAG-PEERS password 7 vnEaG8gMeQf3d3cN6PktXQ==
    neighbor MLAG-PEERS send-community
    neighbor MLAG-PEERS maximum-routes 12000
@@ -845,7 +846,6 @@ router bgp 65103
       route-target export evpn 12:12
       router-id 192.168.255.12
       neighbor 10.255.252.7 peer group MLAG-PEERS
-      neighbor 10.255.252.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -854,7 +854,6 @@ router bgp 65103
       route-target export evpn 13:13
       router-id 192.168.255.12
       neighbor 10.255.252.7 peer group MLAG-PEERS
-      neighbor 10.255.252.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -863,7 +862,6 @@ router bgp 65103
       route-target export evpn 10:10
       router-id 192.168.255.12
       neighbor 10.255.252.7 peer group MLAG-PEERS
-      neighbor 10.255.252.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -874,7 +872,6 @@ router bgp 65103
       route-target export evpn 65000:789
       router-id 192.168.255.12
       neighbor 10.255.252.7 peer group MLAG-PEERS
-      neighbor 10.255.252.7 description DC1-SVC3B
       redistribute connected
       redistribute static
    !
@@ -884,7 +881,6 @@ router bgp 65103
       route-target export evpn 11:11
       router-id 192.168.255.12
       neighbor 10.255.252.7 peer group MLAG-PEERS
-      neighbor 10.255.252.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -893,7 +889,6 @@ router bgp 65103
       route-target export evpn 20:20
       router-id 192.168.255.12
       neighbor 10.255.252.7 peer group MLAG-PEERS
-      neighbor 10.255.252.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -902,7 +897,6 @@ router bgp 65103
       route-target export evpn 21:21
       router-id 192.168.255.12
       neighbor 10.255.252.7 peer group MLAG-PEERS
-      neighbor 10.255.252.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -911,7 +905,6 @@ router bgp 65103
       route-target export evpn 30:30
       router-id 192.168.255.12
       neighbor 10.255.252.7 peer group MLAG-PEERS
-      neighbor 10.255.252.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -920,7 +913,6 @@ router bgp 65103
       route-target export evpn 31:31
       router-id 192.168.255.12
       neighbor 10.255.252.7 peer group MLAG-PEERS
-      neighbor 10.255.252.7 description DC1-SVC3B
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
@@ -845,6 +845,7 @@ router bgp 65103
       route-target export evpn 12:12
       router-id 192.168.255.13
       neighbor 10.255.252.6 peer group MLAG-PEERS
+      neighbor 10.255.252.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -853,6 +854,7 @@ router bgp 65103
       route-target export evpn 13:13
       router-id 192.168.255.13
       neighbor 10.255.252.6 peer group MLAG-PEERS
+      neighbor 10.255.252.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -861,6 +863,7 @@ router bgp 65103
       route-target export evpn 10:10
       router-id 192.168.255.13
       neighbor 10.255.252.6 peer group MLAG-PEERS
+      neighbor 10.255.252.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -871,6 +874,7 @@ router bgp 65103
       route-target export evpn 65000:789
       router-id 192.168.255.13
       neighbor 10.255.252.6 peer group MLAG-PEERS
+      neighbor 10.255.252.6 description DC1-SVC3A
       redistribute connected
       redistribute static
    !
@@ -880,6 +884,7 @@ router bgp 65103
       route-target export evpn 11:11
       router-id 192.168.255.13
       neighbor 10.255.252.6 peer group MLAG-PEERS
+      neighbor 10.255.252.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -888,6 +893,7 @@ router bgp 65103
       route-target export evpn 20:20
       router-id 192.168.255.13
       neighbor 10.255.252.6 peer group MLAG-PEERS
+      neighbor 10.255.252.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -896,6 +902,7 @@ router bgp 65103
       route-target export evpn 21:21
       router-id 192.168.255.13
       neighbor 10.255.252.6 peer group MLAG-PEERS
+      neighbor 10.255.252.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -904,6 +911,7 @@ router bgp 65103
       route-target export evpn 30:30
       router-id 192.168.255.13
       neighbor 10.255.252.6 peer group MLAG-PEERS
+      neighbor 10.255.252.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -912,6 +920,7 @@ router bgp 65103
       route-target export evpn 31:31
       router-id 192.168.255.13
       neighbor 10.255.252.6 peer group MLAG-PEERS
+      neighbor 10.255.252.6 description DC1-SVC3A
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
@@ -728,6 +728,7 @@ router bgp 65103
    neighbor MLAG-PEERS peer group
    neighbor MLAG-PEERS remote-as 65103
    neighbor MLAG-PEERS next-hop-self
+   neighbor MLAG-PEERS description DC1-SVC3A
    neighbor MLAG-PEERS password 7 vnEaG8gMeQf3d3cN6PktXQ==
    neighbor MLAG-PEERS send-community
    neighbor MLAG-PEERS maximum-routes 12000
@@ -845,7 +846,6 @@ router bgp 65103
       route-target export evpn 12:12
       router-id 192.168.255.13
       neighbor 10.255.252.6 peer group MLAG-PEERS
-      neighbor 10.255.252.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -854,7 +854,6 @@ router bgp 65103
       route-target export evpn 13:13
       router-id 192.168.255.13
       neighbor 10.255.252.6 peer group MLAG-PEERS
-      neighbor 10.255.252.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -863,7 +862,6 @@ router bgp 65103
       route-target export evpn 10:10
       router-id 192.168.255.13
       neighbor 10.255.252.6 peer group MLAG-PEERS
-      neighbor 10.255.252.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -874,7 +872,6 @@ router bgp 65103
       route-target export evpn 65000:789
       router-id 192.168.255.13
       neighbor 10.255.252.6 peer group MLAG-PEERS
-      neighbor 10.255.252.6 description DC1-SVC3A
       redistribute connected
       redistribute static
    !
@@ -884,7 +881,6 @@ router bgp 65103
       route-target export evpn 11:11
       router-id 192.168.255.13
       neighbor 10.255.252.6 peer group MLAG-PEERS
-      neighbor 10.255.252.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -893,7 +889,6 @@ router bgp 65103
       route-target export evpn 20:20
       router-id 192.168.255.13
       neighbor 10.255.252.6 peer group MLAG-PEERS
-      neighbor 10.255.252.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -902,7 +897,6 @@ router bgp 65103
       route-target export evpn 21:21
       router-id 192.168.255.13
       neighbor 10.255.252.6 peer group MLAG-PEERS
-      neighbor 10.255.252.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -911,7 +905,6 @@ router bgp 65103
       route-target export evpn 30:30
       router-id 192.168.255.13
       neighbor 10.255.252.6 peer group MLAG-PEERS
-      neighbor 10.255.252.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -920,7 +913,6 @@ router bgp 65103
       route-target export evpn 31:31
       router-id 192.168.255.13
       neighbor 10.255.252.6 peer group MLAG-PEERS
-      neighbor 10.255.252.6 description DC1-SVC3A
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -96,6 +96,7 @@ router_bgp:
       neighbors:
         10.255.252.7:
           peer_group: MLAG-PEERS
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_A_DB_Zone:
@@ -111,6 +112,7 @@ router_bgp:
       neighbors:
         10.255.252.7:
           peer_group: MLAG-PEERS
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_A_OP_Zone:
@@ -126,6 +128,7 @@ router_bgp:
       neighbors:
         10.255.252.7:
           peer_group: MLAG-PEERS
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_A_WAN_Zone:
@@ -143,6 +146,7 @@ router_bgp:
       neighbors:
         10.255.252.7:
           peer_group: MLAG-PEERS
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
       - static
@@ -159,6 +163,7 @@ router_bgp:
       neighbors:
         10.255.252.7:
           peer_group: MLAG-PEERS
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_B_OP_Zone:
@@ -174,6 +179,7 @@ router_bgp:
       neighbors:
         10.255.252.7:
           peer_group: MLAG-PEERS
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_B_WAN_Zone:
@@ -189,6 +195,7 @@ router_bgp:
       neighbors:
         10.255.252.7:
           peer_group: MLAG-PEERS
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_C_OP_Zone:
@@ -204,6 +211,7 @@ router_bgp:
       neighbors:
         10.255.252.7:
           peer_group: MLAG-PEERS
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_C_WAN_Zone:
@@ -219,6 +227,7 @@ router_bgp:
       neighbors:
         10.255.252.7:
           peer_group: MLAG-PEERS
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -10,6 +10,7 @@ router_bgp:
       type: ipv4
       remote_as: '65103'
       next_hop_self: true
+      description: DC1-SVC3B
       password: vnEaG8gMeQf3d3cN6PktXQ==
       maximum_routes: 12000
       send_community: all
@@ -96,7 +97,6 @@ router_bgp:
       neighbors:
         10.255.252.7:
           peer_group: MLAG-PEERS
-          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_A_DB_Zone:
@@ -112,7 +112,6 @@ router_bgp:
       neighbors:
         10.255.252.7:
           peer_group: MLAG-PEERS
-          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_A_OP_Zone:
@@ -128,7 +127,6 @@ router_bgp:
       neighbors:
         10.255.252.7:
           peer_group: MLAG-PEERS
-          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_A_WAN_Zone:
@@ -146,7 +144,6 @@ router_bgp:
       neighbors:
         10.255.252.7:
           peer_group: MLAG-PEERS
-          description: DC1-SVC3B
       redistribute_routes:
       - connected
       - static
@@ -163,7 +160,6 @@ router_bgp:
       neighbors:
         10.255.252.7:
           peer_group: MLAG-PEERS
-          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_B_OP_Zone:
@@ -179,7 +175,6 @@ router_bgp:
       neighbors:
         10.255.252.7:
           peer_group: MLAG-PEERS
-          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_B_WAN_Zone:
@@ -195,7 +190,6 @@ router_bgp:
       neighbors:
         10.255.252.7:
           peer_group: MLAG-PEERS
-          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_C_OP_Zone:
@@ -211,7 +205,6 @@ router_bgp:
       neighbors:
         10.255.252.7:
           peer_group: MLAG-PEERS
-          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_C_WAN_Zone:
@@ -227,7 +220,6 @@ router_bgp:
       neighbors:
         10.255.252.7:
           peer_group: MLAG-PEERS
-          description: DC1-SVC3B
       redistribute_routes:
       - connected
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -10,6 +10,7 @@ router_bgp:
       type: ipv4
       remote_as: '65103'
       next_hop_self: true
+      description: DC1-SVC3A
       password: vnEaG8gMeQf3d3cN6PktXQ==
       maximum_routes: 12000
       send_community: all
@@ -96,7 +97,6 @@ router_bgp:
       neighbors:
         10.255.252.6:
           peer_group: MLAG-PEERS
-          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_A_DB_Zone:
@@ -112,7 +112,6 @@ router_bgp:
       neighbors:
         10.255.252.6:
           peer_group: MLAG-PEERS
-          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_A_OP_Zone:
@@ -128,7 +127,6 @@ router_bgp:
       neighbors:
         10.255.252.6:
           peer_group: MLAG-PEERS
-          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_A_WAN_Zone:
@@ -146,7 +144,6 @@ router_bgp:
       neighbors:
         10.255.252.6:
           peer_group: MLAG-PEERS
-          description: DC1-SVC3A
       redistribute_routes:
       - connected
       - static
@@ -163,7 +160,6 @@ router_bgp:
       neighbors:
         10.255.252.6:
           peer_group: MLAG-PEERS
-          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_B_OP_Zone:
@@ -179,7 +175,6 @@ router_bgp:
       neighbors:
         10.255.252.6:
           peer_group: MLAG-PEERS
-          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_B_WAN_Zone:
@@ -195,7 +190,6 @@ router_bgp:
       neighbors:
         10.255.252.6:
           peer_group: MLAG-PEERS
-          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_C_OP_Zone:
@@ -211,7 +205,6 @@ router_bgp:
       neighbors:
         10.255.252.6:
           peer_group: MLAG-PEERS
-          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_C_WAN_Zone:
@@ -227,7 +220,6 @@ router_bgp:
       neighbors:
         10.255.252.6:
           peer_group: MLAG-PEERS
-          description: DC1-SVC3A
       redistribute_routes:
       - connected
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -96,6 +96,7 @@ router_bgp:
       neighbors:
         10.255.252.6:
           peer_group: MLAG-PEERS
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_A_DB_Zone:
@@ -111,6 +112,7 @@ router_bgp:
       neighbors:
         10.255.252.6:
           peer_group: MLAG-PEERS
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_A_OP_Zone:
@@ -126,6 +128,7 @@ router_bgp:
       neighbors:
         10.255.252.6:
           peer_group: MLAG-PEERS
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_A_WAN_Zone:
@@ -143,6 +146,7 @@ router_bgp:
       neighbors:
         10.255.252.6:
           peer_group: MLAG-PEERS
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
       - static
@@ -159,6 +163,7 @@ router_bgp:
       neighbors:
         10.255.252.6:
           peer_group: MLAG-PEERS
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_B_OP_Zone:
@@ -174,6 +179,7 @@ router_bgp:
       neighbors:
         10.255.252.6:
           peer_group: MLAG-PEERS
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_B_WAN_Zone:
@@ -189,6 +195,7 @@ router_bgp:
       neighbors:
         10.255.252.6:
           peer_group: MLAG-PEERS
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_C_OP_Zone:
@@ -204,6 +211,7 @@ router_bgp:
       neighbors:
         10.255.252.6:
           peer_group: MLAG-PEERS
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_C_WAN_Zone:
@@ -219,6 +227,7 @@ router_bgp:
       neighbors:
         10.255.252.6:
           peer_group: MLAG-PEERS
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -1132,6 +1132,7 @@ router bgp 65102
       route-target export evpn 12:12
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG_PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1140,6 +1141,7 @@ router bgp 65102
       route-target export evpn 13:13
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG_PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1148,6 +1150,7 @@ router bgp 65102
       route-target export evpn 10:10
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG_PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1156,6 +1159,7 @@ router bgp 65102
       route-target export evpn 11:11
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG_PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1164,6 +1168,7 @@ router bgp 65102
       route-target export evpn 20:20
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG_PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1172,6 +1177,7 @@ router bgp 65102
       route-target export evpn 30:30
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG_PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -1039,6 +1039,7 @@ router bgp 65102
    neighbor MLAG_PEER peer group
    neighbor MLAG_PEER remote-as 65102
    neighbor MLAG_PEER next-hop-self
+   neighbor MLAG_PEER description DC1-LEAF2B
    neighbor MLAG_PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==
    neighbor MLAG_PEER send-community
    neighbor MLAG_PEER maximum-routes 12000
@@ -1132,7 +1133,6 @@ router bgp 65102
       route-target export evpn 12:12
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG_PEER
-      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1141,7 +1141,6 @@ router bgp 65102
       route-target export evpn 13:13
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG_PEER
-      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1150,7 +1149,6 @@ router bgp 65102
       route-target export evpn 10:10
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG_PEER
-      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1159,7 +1157,6 @@ router bgp 65102
       route-target export evpn 11:11
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG_PEER
-      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1168,7 +1165,6 @@ router bgp 65102
       route-target export evpn 20:20
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG_PEER
-      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1177,7 +1173,6 @@ router bgp 65102
       route-target export evpn 30:30
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG_PEER
-      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -1039,6 +1039,7 @@ router bgp 65102
    neighbor MLAG_PEER peer group
    neighbor MLAG_PEER remote-as 65102
    neighbor MLAG_PEER next-hop-self
+   neighbor MLAG_PEER description DC1-LEAF2A
    neighbor MLAG_PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==
    neighbor MLAG_PEER send-community
    neighbor MLAG_PEER maximum-routes 12000
@@ -1132,7 +1133,6 @@ router bgp 65102
       route-target export evpn 12:12
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG_PEER
-      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1141,7 +1141,6 @@ router bgp 65102
       route-target export evpn 13:13
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG_PEER
-      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1150,7 +1149,6 @@ router bgp 65102
       route-target export evpn 10:10
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG_PEER
-      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1159,7 +1157,6 @@ router bgp 65102
       route-target export evpn 11:11
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG_PEER
-      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1168,7 +1165,6 @@ router bgp 65102
       route-target export evpn 20:20
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG_PEER
-      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1177,7 +1173,6 @@ router bgp 65102
       route-target export evpn 30:30
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG_PEER
-      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -1132,6 +1132,7 @@ router bgp 65102
       route-target export evpn 12:12
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG_PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1140,6 +1141,7 @@ router bgp 65102
       route-target export evpn 13:13
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG_PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1148,6 +1150,7 @@ router bgp 65102
       route-target export evpn 10:10
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG_PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1156,6 +1159,7 @@ router bgp 65102
       route-target export evpn 11:11
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG_PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1164,6 +1168,7 @@ router bgp 65102
       route-target export evpn 20:20
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG_PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1172,6 +1177,7 @@ router bgp 65102
       route-target export evpn 30:30
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG_PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -1333,6 +1333,7 @@ router bgp 65103
       route-target export evpn 12:12
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1341,6 +1342,7 @@ router bgp 65103
       route-target export evpn 13:13
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1349,6 +1351,7 @@ router bgp 65103
       route-target export evpn 10:10
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -1357,6 +1360,7 @@ router bgp 65103
       route-target export evpn 14:14
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1365,6 +1369,7 @@ router bgp 65103
       route-target export evpn 11:11
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1373,6 +1378,7 @@ router bgp 65103
       route-target export evpn 20:20
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -1381,6 +1387,7 @@ router bgp 65103
       route-target export evpn 21:21
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1389,6 +1396,7 @@ router bgp 65103
       route-target export evpn 30:30
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -1397,6 +1405,7 @@ router bgp 65103
       route-target export evpn 31:31
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -1222,6 +1222,7 @@ router bgp 65103
    neighbor MLAG_PEER peer group
    neighbor MLAG_PEER remote-as 65103
    neighbor MLAG_PEER next-hop-self
+   neighbor MLAG_PEER description DC1-SVC3B
    neighbor MLAG_PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==
    neighbor MLAG_PEER send-community
    neighbor MLAG_PEER maximum-routes 12000
@@ -1333,7 +1334,6 @@ router bgp 65103
       route-target export evpn 12:12
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1342,7 +1342,6 @@ router bgp 65103
       route-target export evpn 13:13
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1351,7 +1350,6 @@ router bgp 65103
       route-target export evpn 10:10
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -1360,7 +1358,6 @@ router bgp 65103
       route-target export evpn 14:14
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1369,7 +1366,6 @@ router bgp 65103
       route-target export evpn 11:11
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1378,7 +1374,6 @@ router bgp 65103
       route-target export evpn 20:20
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -1387,7 +1382,6 @@ router bgp 65103
       route-target export evpn 21:21
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1396,7 +1390,6 @@ router bgp 65103
       route-target export evpn 30:30
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -1405,7 +1398,6 @@ router bgp 65103
       route-target export evpn 31:31
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -1207,6 +1207,7 @@ router bgp 65103
    neighbor MLAG_PEER peer group
    neighbor MLAG_PEER remote-as 65103
    neighbor MLAG_PEER next-hop-self
+   neighbor MLAG_PEER description DC1-SVC3A
    neighbor MLAG_PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==
    neighbor MLAG_PEER send-community
    neighbor MLAG_PEER maximum-routes 12000
@@ -1318,7 +1319,6 @@ router bgp 65103
       route-target export evpn 12:12
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1327,7 +1327,6 @@ router bgp 65103
       route-target export evpn 13:13
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1336,7 +1335,6 @@ router bgp 65103
       route-target export evpn 10:10
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -1345,7 +1343,6 @@ router bgp 65103
       route-target export evpn 14:14
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1354,7 +1351,6 @@ router bgp 65103
       route-target export evpn 11:11
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1363,7 +1359,6 @@ router bgp 65103
       route-target export evpn 20:20
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -1372,7 +1367,6 @@ router bgp 65103
       route-target export evpn 21:21
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1381,7 +1375,6 @@ router bgp 65103
       route-target export evpn 30:30
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -1390,7 +1383,6 @@ router bgp 65103
       route-target export evpn 31:31
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -1318,6 +1318,7 @@ router bgp 65103
       route-target export evpn 12:12
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1326,6 +1327,7 @@ router bgp 65103
       route-target export evpn 13:13
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1334,6 +1336,7 @@ router bgp 65103
       route-target export evpn 10:10
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -1342,6 +1345,7 @@ router bgp 65103
       route-target export evpn 14:14
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1350,6 +1354,7 @@ router bgp 65103
       route-target export evpn 11:11
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1358,6 +1363,7 @@ router bgp 65103
       route-target export evpn 20:20
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -1366,6 +1372,7 @@ router bgp 65103
       route-target export evpn 21:21
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1374,6 +1381,7 @@ router bgp 65103
       route-target export evpn 30:30
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -1382,6 +1390,7 @@ router bgp 65103
       route-target export evpn 31:31
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
@@ -453,6 +453,7 @@ router bgp 65102
    neighbor MLAG_PEER peer group
    neighbor MLAG_PEER remote-as 65102
    neighbor MLAG_PEER next-hop-self
+   neighbor MLAG_PEER description DC1-LEAF2B
    neighbor MLAG_PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==
    neighbor MLAG_PEER send-community
    neighbor MLAG_PEER maximum-routes 12000
@@ -546,7 +547,6 @@ router bgp 65102
       route-target export evpn 12:12
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG_PEER
-      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -555,7 +555,6 @@ router bgp 65102
       route-target export evpn 13:13
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG_PEER
-      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -564,7 +563,6 @@ router bgp 65102
       route-target export evpn 10:10
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG_PEER
-      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -573,7 +571,6 @@ router bgp 65102
       route-target export evpn 11:11
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG_PEER
-      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -582,7 +579,6 @@ router bgp 65102
       route-target export evpn 20:20
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG_PEER
-      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -591,7 +587,6 @@ router bgp 65102
       route-target export evpn 30:30
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG_PEER
-      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
@@ -546,6 +546,7 @@ router bgp 65102
       route-target export evpn 12:12
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG_PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -554,6 +555,7 @@ router bgp 65102
       route-target export evpn 13:13
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG_PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -562,6 +564,7 @@ router bgp 65102
       route-target export evpn 10:10
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG_PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -570,6 +573,7 @@ router bgp 65102
       route-target export evpn 11:11
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG_PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -578,6 +582,7 @@ router bgp 65102
       route-target export evpn 20:20
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG_PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -586,6 +591,7 @@ router bgp 65102
       route-target export evpn 30:30
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG_PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
@@ -546,6 +546,7 @@ router bgp 65102
       route-target export evpn 12:12
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG_PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -554,6 +555,7 @@ router bgp 65102
       route-target export evpn 13:13
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG_PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -562,6 +564,7 @@ router bgp 65102
       route-target export evpn 10:10
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG_PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -570,6 +573,7 @@ router bgp 65102
       route-target export evpn 11:11
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG_PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -578,6 +582,7 @@ router bgp 65102
       route-target export evpn 20:20
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG_PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -586,6 +591,7 @@ router bgp 65102
       route-target export evpn 30:30
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG_PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
@@ -453,6 +453,7 @@ router bgp 65102
    neighbor MLAG_PEER peer group
    neighbor MLAG_PEER remote-as 65102
    neighbor MLAG_PEER next-hop-self
+   neighbor MLAG_PEER description DC1-LEAF2A
    neighbor MLAG_PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==
    neighbor MLAG_PEER send-community
    neighbor MLAG_PEER maximum-routes 12000
@@ -546,7 +547,6 @@ router bgp 65102
       route-target export evpn 12:12
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG_PEER
-      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -555,7 +555,6 @@ router bgp 65102
       route-target export evpn 13:13
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG_PEER
-      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -564,7 +563,6 @@ router bgp 65102
       route-target export evpn 10:10
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG_PEER
-      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -573,7 +571,6 @@ router bgp 65102
       route-target export evpn 11:11
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG_PEER
-      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -582,7 +579,6 @@ router bgp 65102
       route-target export evpn 20:20
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG_PEER
-      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -591,7 +587,6 @@ router bgp 65102
       route-target export evpn 30:30
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG_PEER
-      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
@@ -598,6 +598,7 @@ router bgp 65103
    neighbor MLAG_PEER peer group
    neighbor MLAG_PEER remote-as 65103
    neighbor MLAG_PEER next-hop-self
+   neighbor MLAG_PEER description DC1-SVC3B
    neighbor MLAG_PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==
    neighbor MLAG_PEER send-community
    neighbor MLAG_PEER maximum-routes 12000
@@ -709,7 +710,6 @@ router bgp 65103
       route-target export evpn 12:12
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -718,7 +718,6 @@ router bgp 65103
       route-target export evpn 13:13
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -727,7 +726,6 @@ router bgp 65103
       route-target export evpn 10:10
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -736,7 +734,6 @@ router bgp 65103
       route-target export evpn 14:14
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -745,7 +742,6 @@ router bgp 65103
       route-target export evpn 11:11
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -754,7 +750,6 @@ router bgp 65103
       route-target export evpn 20:20
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -763,7 +758,6 @@ router bgp 65103
       route-target export evpn 21:21
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -772,7 +766,6 @@ router bgp 65103
       route-target export evpn 30:30
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -781,7 +774,6 @@ router bgp 65103
       route-target export evpn 31:31
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
@@ -709,6 +709,7 @@ router bgp 65103
       route-target export evpn 12:12
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -717,6 +718,7 @@ router bgp 65103
       route-target export evpn 13:13
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -725,6 +727,7 @@ router bgp 65103
       route-target export evpn 10:10
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -733,6 +736,7 @@ router bgp 65103
       route-target export evpn 14:14
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -741,6 +745,7 @@ router bgp 65103
       route-target export evpn 11:11
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -749,6 +754,7 @@ router bgp 65103
       route-target export evpn 20:20
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -757,6 +763,7 @@ router bgp 65103
       route-target export evpn 21:21
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -765,6 +772,7 @@ router bgp 65103
       route-target export evpn 30:30
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -773,6 +781,7 @@ router bgp 65103
       route-target export evpn 31:31
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
@@ -696,6 +696,7 @@ router bgp 65103
       route-target export evpn 12:12
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -704,6 +705,7 @@ router bgp 65103
       route-target export evpn 13:13
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -712,6 +714,7 @@ router bgp 65103
       route-target export evpn 10:10
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -720,6 +723,7 @@ router bgp 65103
       route-target export evpn 14:14
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -728,6 +732,7 @@ router bgp 65103
       route-target export evpn 11:11
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -736,6 +741,7 @@ router bgp 65103
       route-target export evpn 20:20
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -744,6 +750,7 @@ router bgp 65103
       route-target export evpn 21:21
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -752,6 +759,7 @@ router bgp 65103
       route-target export evpn 30:30
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -760,6 +768,7 @@ router bgp 65103
       route-target export evpn 31:31
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
@@ -585,6 +585,7 @@ router bgp 65103
    neighbor MLAG_PEER peer group
    neighbor MLAG_PEER remote-as 65103
    neighbor MLAG_PEER next-hop-self
+   neighbor MLAG_PEER description DC1-SVC3A
    neighbor MLAG_PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==
    neighbor MLAG_PEER send-community
    neighbor MLAG_PEER maximum-routes 12000
@@ -696,7 +697,6 @@ router bgp 65103
       route-target export evpn 12:12
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -705,7 +705,6 @@ router bgp 65103
       route-target export evpn 13:13
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -714,7 +713,6 @@ router bgp 65103
       route-target export evpn 10:10
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -723,7 +721,6 @@ router bgp 65103
       route-target export evpn 14:14
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -732,7 +729,6 @@ router bgp 65103
       route-target export evpn 11:11
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -741,7 +737,6 @@ router bgp 65103
       route-target export evpn 20:20
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -750,7 +745,6 @@ router bgp 65103
       route-target export evpn 21:21
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -759,7 +753,6 @@ router bgp 65103
       route-target export evpn 30:30
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -768,7 +761,6 @@ router bgp 65103
       route-target export evpn 31:31
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -102,6 +102,7 @@ router_bgp:
       neighbors:
         10.255.251.3:
           peer_group: MLAG_PEER
+          description: DC1-LEAF2B
       redistribute_routes:
       - connected
     Tenant_A_DB_Zone:
@@ -117,6 +118,7 @@ router_bgp:
       neighbors:
         10.255.251.3:
           peer_group: MLAG_PEER
+          description: DC1-LEAF2B
       redistribute_routes:
       - connected
     Tenant_A_OP_Zone:
@@ -132,6 +134,7 @@ router_bgp:
       neighbors:
         10.255.251.3:
           peer_group: MLAG_PEER
+          description: DC1-LEAF2B
       redistribute_routes:
       - connected
     Tenant_A_WEB_Zone:
@@ -147,6 +150,7 @@ router_bgp:
       neighbors:
         10.255.251.3:
           peer_group: MLAG_PEER
+          description: DC1-LEAF2B
       redistribute_routes:
       - connected
     Tenant_B_OP_Zone:
@@ -162,6 +166,7 @@ router_bgp:
       neighbors:
         10.255.251.3:
           peer_group: MLAG_PEER
+          description: DC1-LEAF2B
       redistribute_routes:
       - connected
     Tenant_C_OP_Zone:
@@ -177,6 +182,7 @@ router_bgp:
       neighbors:
         10.255.251.3:
           peer_group: MLAG_PEER
+          description: DC1-LEAF2B
       redistribute_routes:
       - connected
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -10,6 +10,7 @@ router_bgp:
       type: ipv4
       remote_as: '65102'
       next_hop_self: true
+      description: DC1-LEAF2B
       password: vnEaG8gMeQf3d3cN6PktXQ==
       maximum_routes: 12000
       send_community: all
@@ -102,7 +103,6 @@ router_bgp:
       neighbors:
         10.255.251.3:
           peer_group: MLAG_PEER
-          description: DC1-LEAF2B
       redistribute_routes:
       - connected
     Tenant_A_DB_Zone:
@@ -118,7 +118,6 @@ router_bgp:
       neighbors:
         10.255.251.3:
           peer_group: MLAG_PEER
-          description: DC1-LEAF2B
       redistribute_routes:
       - connected
     Tenant_A_OP_Zone:
@@ -134,7 +133,6 @@ router_bgp:
       neighbors:
         10.255.251.3:
           peer_group: MLAG_PEER
-          description: DC1-LEAF2B
       redistribute_routes:
       - connected
     Tenant_A_WEB_Zone:
@@ -150,7 +148,6 @@ router_bgp:
       neighbors:
         10.255.251.3:
           peer_group: MLAG_PEER
-          description: DC1-LEAF2B
       redistribute_routes:
       - connected
     Tenant_B_OP_Zone:
@@ -166,7 +163,6 @@ router_bgp:
       neighbors:
         10.255.251.3:
           peer_group: MLAG_PEER
-          description: DC1-LEAF2B
       redistribute_routes:
       - connected
     Tenant_C_OP_Zone:
@@ -182,7 +178,6 @@ router_bgp:
       neighbors:
         10.255.251.3:
           peer_group: MLAG_PEER
-          description: DC1-LEAF2B
       redistribute_routes:
       - connected
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -10,6 +10,7 @@ router_bgp:
       type: ipv4
       remote_as: '65102'
       next_hop_self: true
+      description: DC1-LEAF2A
       password: vnEaG8gMeQf3d3cN6PktXQ==
       maximum_routes: 12000
       send_community: all
@@ -102,7 +103,6 @@ router_bgp:
       neighbors:
         10.255.251.2:
           peer_group: MLAG_PEER
-          description: DC1-LEAF2A
       redistribute_routes:
       - connected
     Tenant_A_DB_Zone:
@@ -118,7 +118,6 @@ router_bgp:
       neighbors:
         10.255.251.2:
           peer_group: MLAG_PEER
-          description: DC1-LEAF2A
       redistribute_routes:
       - connected
     Tenant_A_OP_Zone:
@@ -134,7 +133,6 @@ router_bgp:
       neighbors:
         10.255.251.2:
           peer_group: MLAG_PEER
-          description: DC1-LEAF2A
       redistribute_routes:
       - connected
     Tenant_A_WEB_Zone:
@@ -150,7 +148,6 @@ router_bgp:
       neighbors:
         10.255.251.2:
           peer_group: MLAG_PEER
-          description: DC1-LEAF2A
       redistribute_routes:
       - connected
     Tenant_B_OP_Zone:
@@ -166,7 +163,6 @@ router_bgp:
       neighbors:
         10.255.251.2:
           peer_group: MLAG_PEER
-          description: DC1-LEAF2A
       redistribute_routes:
       - connected
     Tenant_C_OP_Zone:
@@ -182,7 +178,6 @@ router_bgp:
       neighbors:
         10.255.251.2:
           peer_group: MLAG_PEER
-          description: DC1-LEAF2A
       redistribute_routes:
       - connected
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -102,6 +102,7 @@ router_bgp:
       neighbors:
         10.255.251.2:
           peer_group: MLAG_PEER
+          description: DC1-LEAF2A
       redistribute_routes:
       - connected
     Tenant_A_DB_Zone:
@@ -117,6 +118,7 @@ router_bgp:
       neighbors:
         10.255.251.2:
           peer_group: MLAG_PEER
+          description: DC1-LEAF2A
       redistribute_routes:
       - connected
     Tenant_A_OP_Zone:
@@ -132,6 +134,7 @@ router_bgp:
       neighbors:
         10.255.251.2:
           peer_group: MLAG_PEER
+          description: DC1-LEAF2A
       redistribute_routes:
       - connected
     Tenant_A_WEB_Zone:
@@ -147,6 +150,7 @@ router_bgp:
       neighbors:
         10.255.251.2:
           peer_group: MLAG_PEER
+          description: DC1-LEAF2A
       redistribute_routes:
       - connected
     Tenant_B_OP_Zone:
@@ -162,6 +166,7 @@ router_bgp:
       neighbors:
         10.255.251.2:
           peer_group: MLAG_PEER
+          description: DC1-LEAF2A
       redistribute_routes:
       - connected
     Tenant_C_OP_Zone:
@@ -177,6 +182,7 @@ router_bgp:
       neighbors:
         10.255.251.2:
           peer_group: MLAG_PEER
+          description: DC1-LEAF2A
       redistribute_routes:
       - connected
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -10,6 +10,7 @@ router_bgp:
       type: ipv4
       remote_as: '65103'
       next_hop_self: true
+      description: DC1-SVC3B
       password: vnEaG8gMeQf3d3cN6PktXQ==
       maximum_routes: 12000
       send_community: all
@@ -102,7 +103,6 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG_PEER
-          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_A_DB_Zone:
@@ -118,7 +118,6 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG_PEER
-          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_A_OP_Zone:
@@ -134,7 +133,6 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG_PEER
-          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_A_WAN_Zone:
@@ -150,7 +148,6 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG_PEER
-          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_A_WEB_Zone:
@@ -166,7 +163,6 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG_PEER
-          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_B_OP_Zone:
@@ -182,7 +178,6 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG_PEER
-          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_B_WAN_Zone:
@@ -198,7 +193,6 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG_PEER
-          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_C_OP_Zone:
@@ -214,7 +208,6 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG_PEER
-          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_C_WAN_Zone:
@@ -230,7 +223,6 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG_PEER
-          description: DC1-SVC3B
       redistribute_routes:
       - connected
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -102,6 +102,7 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG_PEER
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_A_DB_Zone:
@@ -117,6 +118,7 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG_PEER
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_A_OP_Zone:
@@ -132,6 +134,7 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG_PEER
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_A_WAN_Zone:
@@ -147,6 +150,7 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG_PEER
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_A_WEB_Zone:
@@ -162,6 +166,7 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG_PEER
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_B_OP_Zone:
@@ -177,6 +182,7 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG_PEER
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_B_WAN_Zone:
@@ -192,6 +198,7 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG_PEER
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_C_OP_Zone:
@@ -207,6 +214,7 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG_PEER
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_C_WAN_Zone:
@@ -222,6 +230,7 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG_PEER
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -102,6 +102,7 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG_PEER
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_A_DB_Zone:
@@ -117,6 +118,7 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG_PEER
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_A_OP_Zone:
@@ -132,6 +134,7 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG_PEER
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_A_WAN_Zone:
@@ -147,6 +150,7 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG_PEER
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_A_WEB_Zone:
@@ -162,6 +166,7 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG_PEER
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_B_OP_Zone:
@@ -177,6 +182,7 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG_PEER
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_B_WAN_Zone:
@@ -192,6 +198,7 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG_PEER
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_C_OP_Zone:
@@ -207,6 +214,7 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG_PEER
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_C_WAN_Zone:
@@ -222,6 +230,7 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG_PEER
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -10,6 +10,7 @@ router_bgp:
       type: ipv4
       remote_as: '65103'
       next_hop_self: true
+      description: DC1-SVC3A
       password: vnEaG8gMeQf3d3cN6PktXQ==
       maximum_routes: 12000
       send_community: all
@@ -102,7 +103,6 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG_PEER
-          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_A_DB_Zone:
@@ -118,7 +118,6 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG_PEER
-          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_A_OP_Zone:
@@ -134,7 +133,6 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG_PEER
-          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_A_WAN_Zone:
@@ -150,7 +148,6 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG_PEER
-          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_A_WEB_Zone:
@@ -166,7 +163,6 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG_PEER
-          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_B_OP_Zone:
@@ -182,7 +178,6 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG_PEER
-          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_B_WAN_Zone:
@@ -198,7 +193,6 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG_PEER
-          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_C_OP_Zone:
@@ -214,7 +208,6 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG_PEER
-          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_C_WAN_Zone:
@@ -230,7 +223,6 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG_PEER
-          description: DC1-SVC3A
       redistribute_routes:
       - connected
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2A.md
@@ -741,6 +741,7 @@ router bgp 65112
    neighbor MLAG-IPv4-UNDERLAY-PEER peer group
    neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65112
    neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
+   neighbor MLAG-IPv4-UNDERLAY-PEER description DC1-POD1-LEAF2B
    neighbor MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==
    neighbor MLAG-IPv4-UNDERLAY-PEER send-community
    neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
@@ -768,6 +768,7 @@ router bgp 65112
    neighbor MLAG-IPv4-UNDERLAY-PEER peer group
    neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65112
    neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
+   neighbor MLAG-IPv4-UNDERLAY-PEER description DC1-POD1-LEAF2A
    neighbor MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==
    neighbor MLAG-IPv4-UNDERLAY-PEER send-community
    neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2A.cfg
@@ -330,6 +330,7 @@ router bgp 65112
    neighbor MLAG-IPv4-UNDERLAY-PEER peer group
    neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65112
    neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
+   neighbor MLAG-IPv4-UNDERLAY-PEER description DC1-POD1-LEAF2B
    neighbor MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==
    neighbor MLAG-IPv4-UNDERLAY-PEER send-community
    neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2B.cfg
@@ -335,6 +335,7 @@ router bgp 65112
    neighbor MLAG-IPv4-UNDERLAY-PEER peer group
    neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65112
    neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
+   neighbor MLAG-IPv4-UNDERLAY-PEER description DC1-POD1-LEAF2A
    neighbor MLAG-IPv4-UNDERLAY-PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==
    neighbor MLAG-IPv4-UNDERLAY-PEER send-community
    neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2A.yml
@@ -12,6 +12,7 @@ router_bgp:
       type: ipv4
       remote_as: '65112'
       next_hop_self: true
+      description: DC1-POD1-LEAF2B
       password: vnEaG8gMeQf3d3cN6PktXQ==
       maximum_routes: 12000
       send_community: all

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
@@ -12,6 +12,7 @@ router_bgp:
       type: ipv4
       remote_as: '65112'
       next_hop_self: true
+      description: DC1-POD1-LEAF2A
       password: vnEaG8gMeQf3d3cN6PktXQ==
       maximum_routes: 12000
       send_community: all

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -1297,6 +1297,7 @@ router bgp 65103
    neighbor MLAG-PEERS peer group
    neighbor MLAG-PEERS remote-as 65103
    neighbor MLAG-PEERS next-hop-self
+   neighbor MLAG-PEERS description DC1-SVC3B
    neighbor MLAG-PEERS password 7 vnEaG8gMeQf3d3cN6PktXQ==
    neighbor MLAG-PEERS send-community
    neighbor MLAG-PEERS maximum-routes 12000
@@ -1415,7 +1416,6 @@ router bgp 65103
       route-target export evpn 12:12
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1424,7 +1424,6 @@ router bgp 65103
       route-target export evpn 13:13
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1433,7 +1432,6 @@ router bgp 65103
       route-target export evpn 10:10
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -1444,7 +1442,6 @@ router bgp 65103
       route-target export evpn 65000:789
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1453,7 +1450,6 @@ router bgp 65103
       route-target export evpn 11:11
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1462,7 +1458,6 @@ router bgp 65103
       route-target export evpn 20:20
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -1471,7 +1466,6 @@ router bgp 65103
       route-target export evpn 21:21
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1480,7 +1474,6 @@ router bgp 65103
       route-target export evpn 30:30
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -1489,7 +1482,6 @@ router bgp 65103
       route-target export evpn 31:31
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -1415,6 +1415,7 @@ router bgp 65103
       route-target export evpn 12:12
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1423,6 +1424,7 @@ router bgp 65103
       route-target export evpn 13:13
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1431,6 +1433,7 @@ router bgp 65103
       route-target export evpn 10:10
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -1441,6 +1444,7 @@ router bgp 65103
       route-target export evpn 65000:789
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1449,6 +1453,7 @@ router bgp 65103
       route-target export evpn 11:11
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1457,6 +1462,7 @@ router bgp 65103
       route-target export evpn 20:20
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -1465,6 +1471,7 @@ router bgp 65103
       route-target export evpn 21:21
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1473,6 +1480,7 @@ router bgp 65103
       route-target export evpn 30:30
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -1481,6 +1489,7 @@ router bgp 65103
       route-target export evpn 31:31
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -1297,6 +1297,7 @@ router bgp 65103
    neighbor MLAG-PEERS peer group
    neighbor MLAG-PEERS remote-as 65103
    neighbor MLAG-PEERS next-hop-self
+   neighbor MLAG-PEERS description DC1-SVC3A
    neighbor MLAG-PEERS password 7 vnEaG8gMeQf3d3cN6PktXQ==
    neighbor MLAG-PEERS send-community
    neighbor MLAG-PEERS maximum-routes 12000
@@ -1415,7 +1416,6 @@ router bgp 65103
       route-target export evpn 12:12
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1424,7 +1424,6 @@ router bgp 65103
       route-target export evpn 13:13
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1433,7 +1432,6 @@ router bgp 65103
       route-target export evpn 10:10
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -1444,7 +1442,6 @@ router bgp 65103
       route-target export evpn 65000:789
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1453,7 +1450,6 @@ router bgp 65103
       route-target export evpn 11:11
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1462,7 +1458,6 @@ router bgp 65103
       route-target export evpn 20:20
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -1471,7 +1466,6 @@ router bgp 65103
       route-target export evpn 21:21
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1480,7 +1474,6 @@ router bgp 65103
       route-target export evpn 30:30
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -1489,7 +1482,6 @@ router bgp 65103
       route-target export evpn 31:31
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -1415,6 +1415,7 @@ router bgp 65103
       route-target export evpn 12:12
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1423,6 +1424,7 @@ router bgp 65103
       route-target export evpn 13:13
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1431,6 +1433,7 @@ router bgp 65103
       route-target export evpn 10:10
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -1441,6 +1444,7 @@ router bgp 65103
       route-target export evpn 65000:789
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1449,6 +1453,7 @@ router bgp 65103
       route-target export evpn 11:11
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1457,6 +1462,7 @@ router bgp 65103
       route-target export evpn 20:20
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -1465,6 +1471,7 @@ router bgp 65103
       route-target export evpn 21:21
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1473,6 +1480,7 @@ router bgp 65103
       route-target export evpn 30:30
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -1481,6 +1489,7 @@ router bgp 65103
       route-target export evpn 31:31
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
@@ -671,6 +671,7 @@ router bgp 65103
    neighbor MLAG-PEERS peer group
    neighbor MLAG-PEERS remote-as 65103
    neighbor MLAG-PEERS next-hop-self
+   neighbor MLAG-PEERS description DC1-SVC3B
    neighbor MLAG-PEERS password 7 vnEaG8gMeQf3d3cN6PktXQ==
    neighbor MLAG-PEERS send-community
    neighbor MLAG-PEERS maximum-routes 12000
@@ -789,7 +790,6 @@ router bgp 65103
       route-target export evpn 12:12
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -798,7 +798,6 @@ router bgp 65103
       route-target export evpn 13:13
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -807,7 +806,6 @@ router bgp 65103
       route-target export evpn 10:10
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -818,7 +816,6 @@ router bgp 65103
       route-target export evpn 65000:789
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -827,7 +824,6 @@ router bgp 65103
       route-target export evpn 11:11
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -836,7 +832,6 @@ router bgp 65103
       route-target export evpn 20:20
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -845,7 +840,6 @@ router bgp 65103
       route-target export evpn 21:21
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -854,7 +848,6 @@ router bgp 65103
       route-target export evpn 30:30
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -863,7 +856,6 @@ router bgp 65103
       route-target export evpn 31:31
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
@@ -789,6 +789,7 @@ router bgp 65103
       route-target export evpn 12:12
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -797,6 +798,7 @@ router bgp 65103
       route-target export evpn 13:13
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -805,6 +807,7 @@ router bgp 65103
       route-target export evpn 10:10
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -815,6 +818,7 @@ router bgp 65103
       route-target export evpn 65000:789
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -823,6 +827,7 @@ router bgp 65103
       route-target export evpn 11:11
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -831,6 +836,7 @@ router bgp 65103
       route-target export evpn 20:20
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -839,6 +845,7 @@ router bgp 65103
       route-target export evpn 21:21
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -847,6 +854,7 @@ router bgp 65103
       route-target export evpn 30:30
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -855,6 +863,7 @@ router bgp 65103
       route-target export evpn 31:31
       router-id 192.168.255.12
       neighbor 10.255.251.7 peer group MLAG-PEERS
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
@@ -789,6 +789,7 @@ router bgp 65103
       route-target export evpn 12:12
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -797,6 +798,7 @@ router bgp 65103
       route-target export evpn 13:13
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -805,6 +807,7 @@ router bgp 65103
       route-target export evpn 10:10
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -815,6 +818,7 @@ router bgp 65103
       route-target export evpn 65000:789
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -823,6 +827,7 @@ router bgp 65103
       route-target export evpn 11:11
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -831,6 +836,7 @@ router bgp 65103
       route-target export evpn 20:20
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -839,6 +845,7 @@ router bgp 65103
       route-target export evpn 21:21
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -847,6 +854,7 @@ router bgp 65103
       route-target export evpn 30:30
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -855,6 +863,7 @@ router bgp 65103
       route-target export evpn 31:31
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
@@ -671,6 +671,7 @@ router bgp 65103
    neighbor MLAG-PEERS peer group
    neighbor MLAG-PEERS remote-as 65103
    neighbor MLAG-PEERS next-hop-self
+   neighbor MLAG-PEERS description DC1-SVC3A
    neighbor MLAG-PEERS password 7 vnEaG8gMeQf3d3cN6PktXQ==
    neighbor MLAG-PEERS send-community
    neighbor MLAG-PEERS maximum-routes 12000
@@ -789,7 +790,6 @@ router bgp 65103
       route-target export evpn 12:12
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -798,7 +798,6 @@ router bgp 65103
       route-target export evpn 13:13
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -807,7 +806,6 @@ router bgp 65103
       route-target export evpn 10:10
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -818,7 +816,6 @@ router bgp 65103
       route-target export evpn 65000:789
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -827,7 +824,6 @@ router bgp 65103
       route-target export evpn 11:11
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -836,7 +832,6 @@ router bgp 65103
       route-target export evpn 20:20
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -845,7 +840,6 @@ router bgp 65103
       route-target export evpn 21:21
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -854,7 +848,6 @@ router bgp 65103
       route-target export evpn 30:30
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -863,7 +856,6 @@ router bgp 65103
       route-target export evpn 31:31
       router-id 192.168.255.13
       neighbor 10.255.251.6 peer group MLAG-PEERS
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -98,6 +98,7 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG-PEERS
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_A_DB_Zone:
@@ -113,6 +114,7 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG-PEERS
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_A_OP_Zone:
@@ -128,6 +130,7 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG-PEERS
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_A_WAN_Zone:
@@ -145,6 +148,7 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG-PEERS
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_A_WEB_Zone:
@@ -160,6 +164,7 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG-PEERS
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_B_OP_Zone:
@@ -175,6 +180,7 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG-PEERS
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_B_WAN_Zone:
@@ -190,6 +196,7 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG-PEERS
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_C_OP_Zone:
@@ -205,6 +212,7 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG-PEERS
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_C_WAN_Zone:
@@ -220,6 +228,7 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG-PEERS
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -10,6 +10,7 @@ router_bgp:
       type: ipv4
       remote_as: '65103'
       next_hop_self: true
+      description: DC1-SVC3B
       password: vnEaG8gMeQf3d3cN6PktXQ==
       maximum_routes: 12000
       send_community: all
@@ -98,7 +99,6 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG-PEERS
-          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_A_DB_Zone:
@@ -114,7 +114,6 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG-PEERS
-          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_A_OP_Zone:
@@ -130,7 +129,6 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG-PEERS
-          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_A_WAN_Zone:
@@ -148,7 +146,6 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG-PEERS
-          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_A_WEB_Zone:
@@ -164,7 +161,6 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG-PEERS
-          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_B_OP_Zone:
@@ -180,7 +176,6 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG-PEERS
-          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_B_WAN_Zone:
@@ -196,7 +191,6 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG-PEERS
-          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_C_OP_Zone:
@@ -212,7 +206,6 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG-PEERS
-          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_C_WAN_Zone:
@@ -228,7 +221,6 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG-PEERS
-          description: DC1-SVC3B
       redistribute_routes:
       - connected
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -98,6 +98,7 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG-PEERS
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_A_DB_Zone:
@@ -113,6 +114,7 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG-PEERS
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_A_OP_Zone:
@@ -128,6 +130,7 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG-PEERS
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_A_WAN_Zone:
@@ -145,6 +148,7 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG-PEERS
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_A_WEB_Zone:
@@ -160,6 +164,7 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG-PEERS
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_B_OP_Zone:
@@ -175,6 +180,7 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG-PEERS
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_B_WAN_Zone:
@@ -190,6 +196,7 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG-PEERS
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_C_OP_Zone:
@@ -205,6 +212,7 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG-PEERS
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_C_WAN_Zone:
@@ -220,6 +228,7 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG-PEERS
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -10,6 +10,7 @@ router_bgp:
       type: ipv4
       remote_as: '65103'
       next_hop_self: true
+      description: DC1-SVC3A
       password: vnEaG8gMeQf3d3cN6PktXQ==
       maximum_routes: 12000
       send_community: all
@@ -98,7 +99,6 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG-PEERS
-          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_A_DB_Zone:
@@ -114,7 +114,6 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG-PEERS
-          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_A_OP_Zone:
@@ -130,7 +129,6 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG-PEERS
-          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_A_WAN_Zone:
@@ -148,7 +146,6 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG-PEERS
-          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_A_WEB_Zone:
@@ -164,7 +161,6 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG-PEERS
-          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_B_OP_Zone:
@@ -180,7 +176,6 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG-PEERS
-          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_B_WAN_Zone:
@@ -196,7 +191,6 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG-PEERS
-          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_C_OP_Zone:
@@ -212,7 +206,6 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG-PEERS
-          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_C_WAN_Zone:
@@ -228,7 +221,6 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG-PEERS
-          description: DC1-SVC3A
       redistribute_routes:
       - connected
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -1042,6 +1042,7 @@ router bgp 65102
    neighbor MLAG_PEER peer group
    neighbor MLAG_PEER remote-as 65102
    neighbor MLAG_PEER next-hop-self
+   neighbor MLAG_PEER description DC1-LEAF2B
    neighbor MLAG_PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==
    neighbor MLAG_PEER send-community
    neighbor MLAG_PEER maximum-routes 12000
@@ -1136,7 +1137,6 @@ router bgp 65102
       route-target export evpn 12:12
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG_PEER
-      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1145,7 +1145,6 @@ router bgp 65102
       route-target export evpn 13:13
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG_PEER
-      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1154,7 +1153,6 @@ router bgp 65102
       route-target export evpn 10:10
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG_PEER
-      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1163,7 +1161,6 @@ router bgp 65102
       route-target export evpn 11:11
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG_PEER
-      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1172,7 +1169,6 @@ router bgp 65102
       route-target export evpn 20:20
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG_PEER
-      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1181,7 +1177,6 @@ router bgp 65102
       route-target export evpn 30:30
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG_PEER
-      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -1136,6 +1136,7 @@ router bgp 65102
       route-target export evpn 12:12
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG_PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1144,6 +1145,7 @@ router bgp 65102
       route-target export evpn 13:13
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG_PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1152,6 +1154,7 @@ router bgp 65102
       route-target export evpn 10:10
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG_PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1160,6 +1163,7 @@ router bgp 65102
       route-target export evpn 11:11
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG_PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1168,6 +1172,7 @@ router bgp 65102
       route-target export evpn 20:20
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG_PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1176,6 +1181,7 @@ router bgp 65102
       route-target export evpn 30:30
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG_PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -1136,6 +1136,7 @@ router bgp 65102
       route-target export evpn 12:12
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG_PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1144,6 +1145,7 @@ router bgp 65102
       route-target export evpn 13:13
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG_PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1152,6 +1154,7 @@ router bgp 65102
       route-target export evpn 10:10
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG_PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1160,6 +1163,7 @@ router bgp 65102
       route-target export evpn 11:11
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG_PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1168,6 +1172,7 @@ router bgp 65102
       route-target export evpn 20:20
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG_PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1176,6 +1181,7 @@ router bgp 65102
       route-target export evpn 30:30
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG_PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -1042,6 +1042,7 @@ router bgp 65102
    neighbor MLAG_PEER peer group
    neighbor MLAG_PEER remote-as 65102
    neighbor MLAG_PEER next-hop-self
+   neighbor MLAG_PEER description DC1-LEAF2A
    neighbor MLAG_PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==
    neighbor MLAG_PEER send-community
    neighbor MLAG_PEER maximum-routes 12000
@@ -1136,7 +1137,6 @@ router bgp 65102
       route-target export evpn 12:12
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG_PEER
-      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1145,7 +1145,6 @@ router bgp 65102
       route-target export evpn 13:13
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG_PEER
-      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1154,7 +1153,6 @@ router bgp 65102
       route-target export evpn 10:10
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG_PEER
-      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1163,7 +1161,6 @@ router bgp 65102
       route-target export evpn 11:11
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG_PEER
-      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1172,7 +1169,6 @@ router bgp 65102
       route-target export evpn 20:20
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG_PEER
-      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1181,7 +1177,6 @@ router bgp 65102
       route-target export evpn 30:30
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG_PEER
-      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -1225,6 +1225,7 @@ router bgp 65103
    neighbor MLAG_PEER peer group
    neighbor MLAG_PEER remote-as 65103
    neighbor MLAG_PEER next-hop-self
+   neighbor MLAG_PEER description DC1-SVC3B
    neighbor MLAG_PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==
    neighbor MLAG_PEER send-community
    neighbor MLAG_PEER maximum-routes 12000
@@ -1337,7 +1338,6 @@ router bgp 65103
       route-target export evpn 12:12
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1346,7 +1346,6 @@ router bgp 65103
       route-target export evpn 13:13
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1355,7 +1354,6 @@ router bgp 65103
       route-target export evpn 10:10
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -1364,7 +1362,6 @@ router bgp 65103
       route-target export evpn 14:14
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1373,7 +1370,6 @@ router bgp 65103
       route-target export evpn 11:11
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1382,7 +1378,6 @@ router bgp 65103
       route-target export evpn 20:20
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -1391,7 +1386,6 @@ router bgp 65103
       route-target export evpn 21:21
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1400,7 +1394,6 @@ router bgp 65103
       route-target export evpn 30:30
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -1409,7 +1402,6 @@ router bgp 65103
       route-target export evpn 31:31
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -1337,6 +1337,7 @@ router bgp 65103
       route-target export evpn 12:12
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1345,6 +1346,7 @@ router bgp 65103
       route-target export evpn 13:13
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1353,6 +1355,7 @@ router bgp 65103
       route-target export evpn 10:10
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -1361,6 +1364,7 @@ router bgp 65103
       route-target export evpn 14:14
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1369,6 +1373,7 @@ router bgp 65103
       route-target export evpn 11:11
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1377,6 +1382,7 @@ router bgp 65103
       route-target export evpn 20:20
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -1385,6 +1391,7 @@ router bgp 65103
       route-target export evpn 21:21
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1393,6 +1400,7 @@ router bgp 65103
       route-target export evpn 30:30
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -1401,6 +1409,7 @@ router bgp 65103
       route-target export evpn 31:31
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -1210,6 +1210,7 @@ router bgp 65103
    neighbor MLAG_PEER peer group
    neighbor MLAG_PEER remote-as 65103
    neighbor MLAG_PEER next-hop-self
+   neighbor MLAG_PEER description DC1-SVC3A
    neighbor MLAG_PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==
    neighbor MLAG_PEER send-community
    neighbor MLAG_PEER maximum-routes 12000
@@ -1322,7 +1323,6 @@ router bgp 65103
       route-target export evpn 12:12
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1331,7 +1331,6 @@ router bgp 65103
       route-target export evpn 13:13
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1340,7 +1339,6 @@ router bgp 65103
       route-target export evpn 10:10
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -1349,7 +1347,6 @@ router bgp 65103
       route-target export evpn 14:14
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1358,7 +1355,6 @@ router bgp 65103
       route-target export evpn 11:11
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1367,7 +1363,6 @@ router bgp 65103
       route-target export evpn 20:20
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -1376,7 +1371,6 @@ router bgp 65103
       route-target export evpn 21:21
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1385,7 +1379,6 @@ router bgp 65103
       route-target export evpn 30:30
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -1394,7 +1387,6 @@ router bgp 65103
       route-target export evpn 31:31
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -1322,6 +1322,7 @@ router bgp 65103
       route-target export evpn 12:12
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1330,6 +1331,7 @@ router bgp 65103
       route-target export evpn 13:13
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1338,6 +1340,7 @@ router bgp 65103
       route-target export evpn 10:10
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -1346,6 +1349,7 @@ router bgp 65103
       route-target export evpn 14:14
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1354,6 +1358,7 @@ router bgp 65103
       route-target export evpn 11:11
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1362,6 +1367,7 @@ router bgp 65103
       route-target export evpn 20:20
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -1370,6 +1376,7 @@ router bgp 65103
       route-target export evpn 21:21
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1378,6 +1385,7 @@ router bgp 65103
       route-target export evpn 30:30
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -1386,6 +1394,7 @@ router bgp 65103
       route-target export evpn 31:31
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
@@ -454,6 +454,7 @@ router bgp 65102
    neighbor MLAG_PEER peer group
    neighbor MLAG_PEER remote-as 65102
    neighbor MLAG_PEER next-hop-self
+   neighbor MLAG_PEER description DC1-LEAF2B
    neighbor MLAG_PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==
    neighbor MLAG_PEER send-community
    neighbor MLAG_PEER maximum-routes 12000
@@ -548,7 +549,6 @@ router bgp 65102
       route-target export evpn 12:12
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG_PEER
-      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -557,7 +557,6 @@ router bgp 65102
       route-target export evpn 13:13
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG_PEER
-      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -566,7 +565,6 @@ router bgp 65102
       route-target export evpn 10:10
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG_PEER
-      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -575,7 +573,6 @@ router bgp 65102
       route-target export evpn 11:11
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG_PEER
-      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -584,7 +581,6 @@ router bgp 65102
       route-target export evpn 20:20
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG_PEER
-      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -593,7 +589,6 @@ router bgp 65102
       route-target export evpn 30:30
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG_PEER
-      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
@@ -548,6 +548,7 @@ router bgp 65102
       route-target export evpn 12:12
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG_PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -556,6 +557,7 @@ router bgp 65102
       route-target export evpn 13:13
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG_PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -564,6 +566,7 @@ router bgp 65102
       route-target export evpn 10:10
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG_PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -572,6 +575,7 @@ router bgp 65102
       route-target export evpn 11:11
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG_PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -580,6 +584,7 @@ router bgp 65102
       route-target export evpn 20:20
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG_PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -588,6 +593,7 @@ router bgp 65102
       route-target export evpn 30:30
       router-id 192.168.255.6
       neighbor 10.255.251.3 peer group MLAG_PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
@@ -454,6 +454,7 @@ router bgp 65102
    neighbor MLAG_PEER peer group
    neighbor MLAG_PEER remote-as 65102
    neighbor MLAG_PEER next-hop-self
+   neighbor MLAG_PEER description DC1-LEAF2A
    neighbor MLAG_PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==
    neighbor MLAG_PEER send-community
    neighbor MLAG_PEER maximum-routes 12000
@@ -548,7 +549,6 @@ router bgp 65102
       route-target export evpn 12:12
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG_PEER
-      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -557,7 +557,6 @@ router bgp 65102
       route-target export evpn 13:13
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG_PEER
-      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -566,7 +565,6 @@ router bgp 65102
       route-target export evpn 10:10
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG_PEER
-      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -575,7 +573,6 @@ router bgp 65102
       route-target export evpn 11:11
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG_PEER
-      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -584,7 +581,6 @@ router bgp 65102
       route-target export evpn 20:20
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG_PEER
-      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -593,7 +589,6 @@ router bgp 65102
       route-target export evpn 30:30
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG_PEER
-      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
@@ -548,6 +548,7 @@ router bgp 65102
       route-target export evpn 12:12
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG_PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -556,6 +557,7 @@ router bgp 65102
       route-target export evpn 13:13
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG_PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -564,6 +566,7 @@ router bgp 65102
       route-target export evpn 10:10
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG_PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -572,6 +575,7 @@ router bgp 65102
       route-target export evpn 11:11
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG_PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -580,6 +584,7 @@ router bgp 65102
       route-target export evpn 20:20
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG_PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -588,6 +593,7 @@ router bgp 65102
       route-target export evpn 30:30
       router-id 192.168.255.7
       neighbor 10.255.251.2 peer group MLAG_PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
@@ -711,6 +711,7 @@ router bgp 65103
       route-target export evpn 12:12
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -719,6 +720,7 @@ router bgp 65103
       route-target export evpn 13:13
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -727,6 +729,7 @@ router bgp 65103
       route-target export evpn 10:10
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -735,6 +738,7 @@ router bgp 65103
       route-target export evpn 14:14
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -743,6 +747,7 @@ router bgp 65103
       route-target export evpn 11:11
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -751,6 +756,7 @@ router bgp 65103
       route-target export evpn 20:20
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -759,6 +765,7 @@ router bgp 65103
       route-target export evpn 21:21
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -767,6 +774,7 @@ router bgp 65103
       route-target export evpn 30:30
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -775,6 +783,7 @@ router bgp 65103
       route-target export evpn 31:31
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
@@ -599,6 +599,7 @@ router bgp 65103
    neighbor MLAG_PEER peer group
    neighbor MLAG_PEER remote-as 65103
    neighbor MLAG_PEER next-hop-self
+   neighbor MLAG_PEER description DC1-SVC3B
    neighbor MLAG_PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==
    neighbor MLAG_PEER send-community
    neighbor MLAG_PEER maximum-routes 12000
@@ -711,7 +712,6 @@ router bgp 65103
       route-target export evpn 12:12
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -720,7 +720,6 @@ router bgp 65103
       route-target export evpn 13:13
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -729,7 +728,6 @@ router bgp 65103
       route-target export evpn 10:10
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -738,7 +736,6 @@ router bgp 65103
       route-target export evpn 14:14
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -747,7 +744,6 @@ router bgp 65103
       route-target export evpn 11:11
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -756,7 +752,6 @@ router bgp 65103
       route-target export evpn 20:20
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -765,7 +760,6 @@ router bgp 65103
       route-target export evpn 21:21
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -774,7 +768,6 @@ router bgp 65103
       route-target export evpn 30:30
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -783,7 +776,6 @@ router bgp 65103
       route-target export evpn 31:31
       router-id 192.168.255.8
       neighbor 10.255.251.7 peer group MLAG_PEER
-      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
@@ -586,6 +586,7 @@ router bgp 65103
    neighbor MLAG_PEER peer group
    neighbor MLAG_PEER remote-as 65103
    neighbor MLAG_PEER next-hop-self
+   neighbor MLAG_PEER description DC1-SVC3A
    neighbor MLAG_PEER password 7 vnEaG8gMeQf3d3cN6PktXQ==
    neighbor MLAG_PEER send-community
    neighbor MLAG_PEER maximum-routes 12000
@@ -698,7 +699,6 @@ router bgp 65103
       route-target export evpn 12:12
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -707,7 +707,6 @@ router bgp 65103
       route-target export evpn 13:13
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -716,7 +715,6 @@ router bgp 65103
       route-target export evpn 10:10
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -725,7 +723,6 @@ router bgp 65103
       route-target export evpn 14:14
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -734,7 +731,6 @@ router bgp 65103
       route-target export evpn 11:11
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -743,7 +739,6 @@ router bgp 65103
       route-target export evpn 20:20
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -752,7 +747,6 @@ router bgp 65103
       route-target export evpn 21:21
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -761,7 +755,6 @@ router bgp 65103
       route-target export evpn 30:30
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -770,7 +763,6 @@ router bgp 65103
       route-target export evpn 31:31
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
-      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
@@ -698,6 +698,7 @@ router bgp 65103
       route-target export evpn 12:12
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -706,6 +707,7 @@ router bgp 65103
       route-target export evpn 13:13
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -714,6 +716,7 @@ router bgp 65103
       route-target export evpn 10:10
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -722,6 +725,7 @@ router bgp 65103
       route-target export evpn 14:14
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -730,6 +734,7 @@ router bgp 65103
       route-target export evpn 11:11
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -738,6 +743,7 @@ router bgp 65103
       route-target export evpn 20:20
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -746,6 +752,7 @@ router bgp 65103
       route-target export evpn 21:21
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -754,6 +761,7 @@ router bgp 65103
       route-target export evpn 30:30
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -762,6 +770,7 @@ router bgp 65103
       route-target export evpn 31:31
       router-id 192.168.255.9
       neighbor 10.255.251.6 peer group MLAG_PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -10,6 +10,7 @@ router_bgp:
       type: ipv4
       remote_as: '65102'
       next_hop_self: true
+      description: DC1-LEAF2B
       password: vnEaG8gMeQf3d3cN6PktXQ==
       maximum_routes: 12000
       send_community: all
@@ -104,7 +105,6 @@ router_bgp:
       neighbors:
         10.255.251.3:
           peer_group: MLAG_PEER
-          description: DC1-LEAF2B
       redistribute_routes:
       - connected
     Tenant_A_DB_Zone:
@@ -120,7 +120,6 @@ router_bgp:
       neighbors:
         10.255.251.3:
           peer_group: MLAG_PEER
-          description: DC1-LEAF2B
       redistribute_routes:
       - connected
     Tenant_A_OP_Zone:
@@ -136,7 +135,6 @@ router_bgp:
       neighbors:
         10.255.251.3:
           peer_group: MLAG_PEER
-          description: DC1-LEAF2B
       redistribute_routes:
       - connected
     Tenant_A_WEB_Zone:
@@ -152,7 +150,6 @@ router_bgp:
       neighbors:
         10.255.251.3:
           peer_group: MLAG_PEER
-          description: DC1-LEAF2B
       redistribute_routes:
       - connected
     Tenant_B_OP_Zone:
@@ -168,7 +165,6 @@ router_bgp:
       neighbors:
         10.255.251.3:
           peer_group: MLAG_PEER
-          description: DC1-LEAF2B
       redistribute_routes:
       - connected
     Tenant_C_OP_Zone:
@@ -184,7 +180,6 @@ router_bgp:
       neighbors:
         10.255.251.3:
           peer_group: MLAG_PEER
-          description: DC1-LEAF2B
       redistribute_routes:
       - connected
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -104,6 +104,7 @@ router_bgp:
       neighbors:
         10.255.251.3:
           peer_group: MLAG_PEER
+          description: DC1-LEAF2B
       redistribute_routes:
       - connected
     Tenant_A_DB_Zone:
@@ -119,6 +120,7 @@ router_bgp:
       neighbors:
         10.255.251.3:
           peer_group: MLAG_PEER
+          description: DC1-LEAF2B
       redistribute_routes:
       - connected
     Tenant_A_OP_Zone:
@@ -134,6 +136,7 @@ router_bgp:
       neighbors:
         10.255.251.3:
           peer_group: MLAG_PEER
+          description: DC1-LEAF2B
       redistribute_routes:
       - connected
     Tenant_A_WEB_Zone:
@@ -149,6 +152,7 @@ router_bgp:
       neighbors:
         10.255.251.3:
           peer_group: MLAG_PEER
+          description: DC1-LEAF2B
       redistribute_routes:
       - connected
     Tenant_B_OP_Zone:
@@ -164,6 +168,7 @@ router_bgp:
       neighbors:
         10.255.251.3:
           peer_group: MLAG_PEER
+          description: DC1-LEAF2B
       redistribute_routes:
       - connected
     Tenant_C_OP_Zone:
@@ -179,6 +184,7 @@ router_bgp:
       neighbors:
         10.255.251.3:
           peer_group: MLAG_PEER
+          description: DC1-LEAF2B
       redistribute_routes:
       - connected
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -10,6 +10,7 @@ router_bgp:
       type: ipv4
       remote_as: '65102'
       next_hop_self: true
+      description: DC1-LEAF2A
       password: vnEaG8gMeQf3d3cN6PktXQ==
       maximum_routes: 12000
       send_community: all
@@ -104,7 +105,6 @@ router_bgp:
       neighbors:
         10.255.251.2:
           peer_group: MLAG_PEER
-          description: DC1-LEAF2A
       redistribute_routes:
       - connected
     Tenant_A_DB_Zone:
@@ -120,7 +120,6 @@ router_bgp:
       neighbors:
         10.255.251.2:
           peer_group: MLAG_PEER
-          description: DC1-LEAF2A
       redistribute_routes:
       - connected
     Tenant_A_OP_Zone:
@@ -136,7 +135,6 @@ router_bgp:
       neighbors:
         10.255.251.2:
           peer_group: MLAG_PEER
-          description: DC1-LEAF2A
       redistribute_routes:
       - connected
     Tenant_A_WEB_Zone:
@@ -152,7 +150,6 @@ router_bgp:
       neighbors:
         10.255.251.2:
           peer_group: MLAG_PEER
-          description: DC1-LEAF2A
       redistribute_routes:
       - connected
     Tenant_B_OP_Zone:
@@ -168,7 +165,6 @@ router_bgp:
       neighbors:
         10.255.251.2:
           peer_group: MLAG_PEER
-          description: DC1-LEAF2A
       redistribute_routes:
       - connected
     Tenant_C_OP_Zone:
@@ -184,7 +180,6 @@ router_bgp:
       neighbors:
         10.255.251.2:
           peer_group: MLAG_PEER
-          description: DC1-LEAF2A
       redistribute_routes:
       - connected
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -104,6 +104,7 @@ router_bgp:
       neighbors:
         10.255.251.2:
           peer_group: MLAG_PEER
+          description: DC1-LEAF2A
       redistribute_routes:
       - connected
     Tenant_A_DB_Zone:
@@ -119,6 +120,7 @@ router_bgp:
       neighbors:
         10.255.251.2:
           peer_group: MLAG_PEER
+          description: DC1-LEAF2A
       redistribute_routes:
       - connected
     Tenant_A_OP_Zone:
@@ -134,6 +136,7 @@ router_bgp:
       neighbors:
         10.255.251.2:
           peer_group: MLAG_PEER
+          description: DC1-LEAF2A
       redistribute_routes:
       - connected
     Tenant_A_WEB_Zone:
@@ -149,6 +152,7 @@ router_bgp:
       neighbors:
         10.255.251.2:
           peer_group: MLAG_PEER
+          description: DC1-LEAF2A
       redistribute_routes:
       - connected
     Tenant_B_OP_Zone:
@@ -164,6 +168,7 @@ router_bgp:
       neighbors:
         10.255.251.2:
           peer_group: MLAG_PEER
+          description: DC1-LEAF2A
       redistribute_routes:
       - connected
     Tenant_C_OP_Zone:
@@ -179,6 +184,7 @@ router_bgp:
       neighbors:
         10.255.251.2:
           peer_group: MLAG_PEER
+          description: DC1-LEAF2A
       redistribute_routes:
       - connected
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -10,6 +10,7 @@ router_bgp:
       type: ipv4
       remote_as: '65103'
       next_hop_self: true
+      description: DC1-SVC3B
       password: vnEaG8gMeQf3d3cN6PktXQ==
       maximum_routes: 12000
       send_community: all
@@ -104,7 +105,6 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG_PEER
-          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_A_DB_Zone:
@@ -120,7 +120,6 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG_PEER
-          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_A_OP_Zone:
@@ -136,7 +135,6 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG_PEER
-          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_A_WAN_Zone:
@@ -152,7 +150,6 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG_PEER
-          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_A_WEB_Zone:
@@ -168,7 +165,6 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG_PEER
-          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_B_OP_Zone:
@@ -184,7 +180,6 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG_PEER
-          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_B_WAN_Zone:
@@ -200,7 +195,6 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG_PEER
-          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_C_OP_Zone:
@@ -216,7 +210,6 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG_PEER
-          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_C_WAN_Zone:
@@ -232,7 +225,6 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG_PEER
-          description: DC1-SVC3B
       redistribute_routes:
       - connected
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -104,6 +104,7 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG_PEER
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_A_DB_Zone:
@@ -119,6 +120,7 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG_PEER
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_A_OP_Zone:
@@ -134,6 +136,7 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG_PEER
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_A_WAN_Zone:
@@ -149,6 +152,7 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG_PEER
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_A_WEB_Zone:
@@ -164,6 +168,7 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG_PEER
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_B_OP_Zone:
@@ -179,6 +184,7 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG_PEER
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_B_WAN_Zone:
@@ -194,6 +200,7 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG_PEER
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_C_OP_Zone:
@@ -209,6 +216,7 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG_PEER
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_C_WAN_Zone:
@@ -224,6 +232,7 @@ router_bgp:
       neighbors:
         10.255.251.7:
           peer_group: MLAG_PEER
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -104,6 +104,7 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG_PEER
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_A_DB_Zone:
@@ -119,6 +120,7 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG_PEER
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_A_OP_Zone:
@@ -134,6 +136,7 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG_PEER
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_A_WAN_Zone:
@@ -149,6 +152,7 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG_PEER
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_A_WEB_Zone:
@@ -164,6 +168,7 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG_PEER
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_B_OP_Zone:
@@ -179,6 +184,7 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG_PEER
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_B_WAN_Zone:
@@ -194,6 +200,7 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG_PEER
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_C_OP_Zone:
@@ -209,6 +216,7 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG_PEER
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_C_WAN_Zone:
@@ -224,6 +232,7 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG_PEER
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -10,6 +10,7 @@ router_bgp:
       type: ipv4
       remote_as: '65103'
       next_hop_self: true
+      description: DC1-SVC3A
       password: vnEaG8gMeQf3d3cN6PktXQ==
       maximum_routes: 12000
       send_community: all
@@ -104,7 +105,6 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG_PEER
-          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_A_DB_Zone:
@@ -120,7 +120,6 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG_PEER
-          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_A_OP_Zone:
@@ -136,7 +135,6 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG_PEER
-          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_A_WAN_Zone:
@@ -152,7 +150,6 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG_PEER
-          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_A_WEB_Zone:
@@ -168,7 +165,6 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG_PEER
-          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_B_OP_Zone:
@@ -184,7 +180,6 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG_PEER
-          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_B_WAN_Zone:
@@ -200,7 +195,6 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG_PEER
-          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_C_OP_Zone:
@@ -216,7 +210,6 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG_PEER
-          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_C_WAN_Zone:
@@ -232,7 +225,6 @@ router_bgp:
       neighbors:
         10.255.251.6:
           peer_group: MLAG_PEER
-          description: DC1-SVC3A
       redistribute_routes:
       - connected
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -40,9 +40,6 @@ router bgp {{ router_bgp.as }}
 {%         endif %}
 {%     endfor %}
 {%     for peer_group in router_bgp.peer_groups | arista.avd.natural_sort %}
-{%         if router_bgp.peer_groups[peer_group].description is arista.avd.defined %}
-   neighbor {{ peer_group }} description {{ router_bgp.peer_groups[peer_group].description }}
-{%         endif %}
 {%         if router_bgp.peer_groups[peer_group].shutdown is arista.avd.defined(true) %}
    neighbor {{ peer_group }} shutdown
 {%         endif %}
@@ -61,6 +58,9 @@ router bgp {{ router_bgp.as }}
 {%         endif %}
 {%         if router_bgp.peer_groups[peer_group].update_source is arista.avd.defined %}
    neighbor {{ peer_group }} update-source {{ router_bgp.peer_groups[peer_group].update_source }}
+{%         endif %}
+{%         if router_bgp.peer_groups[peer_group].description is arista.avd.defined %}
+   neighbor {{ peer_group }} description {{ router_bgp.peer_groups[peer_group].description }}
 {%         endif %}
 {%         if router_bgp.peer_groups[peer_group].route_reflector_client is arista.avd.defined(true) %}
    neighbor {{ peer_group }} route-reflector-client

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/mlag/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/mlag/router-bgp.j2
@@ -7,7 +7,7 @@ router_bgp:
       type: ipv4
       remote_as: "{{ switch.bgp_as }}"
       next_hop_self: true
-      description: {{ switch.mlag_peer | arista.avd.default(switch.mlag_peer_l3_ip, switch.mlag_peer_ip) }}
+      description: {{ switch.mlag_peer }}
 {%     if bgp_peer_groups.MLAG_IPv4_UNDERLAY_PEER.password is arista.avd.defined() %}
       password: "{{ bgp_peer_groups.MLAG_IPv4_UNDERLAY_PEER.password }}"
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/mlag/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/mlag/router-bgp.j2
@@ -7,6 +7,7 @@ router_bgp:
       type: ipv4
       remote_as: "{{ switch.bgp_as }}"
       next_hop_self: true
+      description: {{ switch.mlag_peer | arista.avd.default(switch.mlag_peer_l3_ip, switch.mlag_peer_ip) }}
 {%     if bgp_peer_groups.MLAG_IPv4_UNDERLAY_PEER.password is arista.avd.defined() %}
       password: "{{ bgp_peer_groups.MLAG_IPv4_UNDERLAY_PEER.password }}"
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-vrfs.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-vrfs.j2
@@ -37,6 +37,7 @@
 {%                 if configure_mlag_ibgp_peering %}
         {{ switch.mlag_peer_l3_ip | arista.avd.default(switch.mlag_peer_ip) }}:
           peer_group: {{ bgp_peer_groups.MLAG_IPv4_UNDERLAY_PEER.name | arista.avd.default("MLAG-IPv4-UNDERLAY-PEER") }}
+          description: {{ switch.mlag_peer | arista.avd.default(switch.mlag_peer_l3_ip, switch.mlag_peer_ip) }}
 {%                 endif %}
 {%             endif %}
 {%             for bgp_peer in vrf.bgp_peers %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-vrfs.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-vrfs.j2
@@ -37,7 +37,6 @@
 {%                 if configure_mlag_ibgp_peering %}
         {{ switch.mlag_peer_l3_ip | arista.avd.default(switch.mlag_peer_ip) }}:
           peer_group: {{ bgp_peer_groups.MLAG_IPv4_UNDERLAY_PEER.name | arista.avd.default("MLAG-IPv4-UNDERLAY-PEER") }}
-          description: {{ switch.mlag_peer | arista.avd.default(switch.mlag_peer_l3_ip, switch.mlag_peer_ip) }}
 {%                 endif %}
 {%             endif %}
 {%             for bgp_peer in vrf.bgp_peers %}


### PR DESCRIPTION
## Change Summary

Under the VRF definition on eos_designs, add a description field that will be included on all VRFs for the MLAG peers.

## Related Issue(s)

Fixes #1311 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Add the description field under router-bgp-vrfs j2 template:
```yaml
{%                 if configure_mlag_ibgp_peering %}
        {{ switch.mlag_peer_l3_ip | arista.avd.default(switch.mlag_peer_ip) }}:
          peer_group: {{ bgp_peer_groups.MLAG_IPv4_UNDERLAY_PEER.name | arista.avd.default("MLAG-IPv4-UNDERLAY-PEER") }}
          description: {{ switch.mlag_peer | arista.avd.default(switch.mlag_peer_l3_ip, switch.mlag_peer_ip) }}
{%                 endif %}
```

## How to test
molecule, any scenario with VRFs defined in the L3LS fabric.

Output seen:
```cli
POD1_LEAF01A(config-router-bgp-vrf-TENANT_A_VRF1)#sh ip bgp sum vrf all
BGP summary information for VRF default
Router identifier 192.168.255.7, local AS number 65101
Neighbor Status Codes: m - Under maintenance
  Description              Neighbor         V  AS           MsgRcvd   MsgSent  InQ OutQ  Up/Down State   PfxRcd PfxAcc
  POD1_LEAF01B             10.255.254.5     4 65101          57507     57547    0    0   22d11h Estab   15     15
  POD1_SPINE01_Ethernet1   192.168.0.8      4 65100          57489     57486    0    0   33d23h Estab   12     12
  POD1_SPINE02_Ethernet1   192.168.0.10     4 65100          57503     57496    0    0   33d23h Estab   12     12

BGP summary information for VRF TENANT_A_VRF1
Router identifier 192.168.255.7, local AS number 65101
Neighbor Status Codes: m - Under maintenance
  Description              Neighbor         V  AS           MsgRcvd   MsgSent  InQ OutQ  Up/Down State   PfxRcd PfxAcc
  POD1_LEAF01B             10.255.254.5     4 65101           1229      1223    0    0 17:18:32 Estab   2      2

BGP summary information for VRF TENANT_B_VRF1
Router identifier 192.168.255.7, local AS number 65101
Neighbor Status Codes: m - Under maintenance
  Description              Neighbor         V  AS           MsgRcvd   MsgSent  InQ OutQ  Up/Down State   PfxRcd PfxAcc
  POD1_LEAF01B             10.255.254.5     4 65101           1220      1231    0    0 17:18:31 Estab   2      2
```

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
