### PR TITLE
Feat(eos_designs): Support vrf description in Network services

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2A.md
@@ -1149,6 +1149,7 @@ vrf instance Tenant_A_APP_Zone
 vrf instance Tenant_A_DB_Zone
 !
 vrf instance Tenant_A_OP_Zone
+   description Tenant_A_OP_Zone
 !
 vrf instance Tenant_A_WEB_Zone
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2B.md
@@ -1149,6 +1149,7 @@ vrf instance Tenant_A_APP_Zone
 vrf instance Tenant_A_DB_Zone
 !
 vrf instance Tenant_A_OP_Zone
+   description Tenant_A_OP_Zone
 !
 vrf instance Tenant_A_WEB_Zone
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3A.md
@@ -1770,6 +1770,7 @@ vrf instance Tenant_A_APP_Zone
 vrf instance Tenant_A_DB_Zone
 !
 vrf instance Tenant_A_OP_Zone
+   description Tenant_A_OP_Zone
 !
 vrf instance Tenant_A_WAN_Zone
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3B.md
@@ -1740,6 +1740,7 @@ vrf instance Tenant_A_APP_Zone
 vrf instance Tenant_A_DB_Zone
 !
 vrf instance Tenant_A_OP_Zone
+   description Tenant_A_OP_Zone
 !
 vrf instance Tenant_A_WAN_Zone
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/evpn_services_l2_only_false.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/evpn_services_l2_only_false.md
@@ -984,6 +984,7 @@ vrf instance Tenant_A_APP_Zone
 vrf instance Tenant_A_DB_Zone
 !
 vrf instance Tenant_A_OP_Zone
+   description Tenant_A_OP_Zone
 !
 vrf instance Tenant_A_WAN_Zone
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
@@ -89,6 +89,7 @@ vrf instance Tenant_A_APP_Zone
 vrf instance Tenant_A_DB_Zone
 !
 vrf instance Tenant_A_OP_Zone
+   description Tenant_A_OP_Zone
 !
 vrf instance Tenant_A_WEB_Zone
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
@@ -89,6 +89,7 @@ vrf instance Tenant_A_APP_Zone
 vrf instance Tenant_A_DB_Zone
 !
 vrf instance Tenant_A_OP_Zone
+   description Tenant_A_OP_Zone
 !
 vrf instance Tenant_A_WEB_Zone
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3A.cfg
@@ -136,6 +136,7 @@ vrf instance Tenant_A_APP_Zone
 vrf instance Tenant_A_DB_Zone
 !
 vrf instance Tenant_A_OP_Zone
+   description Tenant_A_OP_Zone
 !
 vrf instance Tenant_A_WAN_Zone
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3B.cfg
@@ -136,6 +136,7 @@ vrf instance Tenant_A_APP_Zone
 vrf instance Tenant_A_DB_Zone
 !
 vrf instance Tenant_A_OP_Zone
+   description Tenant_A_OP_Zone
 !
 vrf instance Tenant_A_WAN_Zone
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_false.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_false.cfg
@@ -90,6 +90,7 @@ vrf instance Tenant_A_APP_Zone
 vrf instance Tenant_A_DB_Zone
 !
 vrf instance Tenant_A_OP_Zone
+   description Tenant_A_OP_Zone
 !
 vrf instance Tenant_A_WAN_Zone
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
@@ -274,6 +274,7 @@ vrfs:
   Tenant_A_OP_Zone:
     tenant: Tenant_A
     ip_routing: true
+    description: Tenant_A_OP_Zone
   Tenant_A_WEB_Zone:
     tenant: Tenant_A
     ip_routing: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
@@ -274,6 +274,7 @@ vrfs:
   Tenant_A_OP_Zone:
     tenant: Tenant_A
     ip_routing: true
+    description: Tenant_A_OP_Zone
   Tenant_A_WEB_Zone:
     tenant: Tenant_A
     ip_routing: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
@@ -367,6 +367,7 @@ vrfs:
   Tenant_A_OP_Zone:
     tenant: Tenant_A
     ip_routing: true
+    description: Tenant_A_OP_Zone
   Tenant_A_WAN_Zone:
     tenant: Tenant_A
     ip_routing: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
@@ -367,6 +367,7 @@ vrfs:
   Tenant_A_OP_Zone:
     tenant: Tenant_A
     ip_routing: true
+    description: Tenant_A_OP_Zone
   Tenant_A_WAN_Zone:
     tenant: Tenant_A
     ip_routing: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_false.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_false.yml
@@ -293,6 +293,7 @@ vrfs:
   Tenant_A_OP_Zone:
     tenant: Tenant_A
     ip_routing: true
+    description: Tenant_A_OP_Zone
   Tenant_A_WAN_Zone:
     tenant: Tenant_A
     ip_routing: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS.yml
@@ -35,6 +35,7 @@ tenants:
     mac_vrf_id_base: 20000
     vrfs:
       Tenant_A_OP_Zone:
+        description: "Tenant_A_OP_Zone"
         vrf_vni: 10
         vrf_id: 9 # Check that RD and RT will use this number for this VRF. VNI should still respect vrf_vni
         vtep_diagnostic:

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
@@ -107,6 +107,9 @@ tenants:
       # VRF name | Required
       < tenant_a_vrf_1 >:
 
+        # Optional
+        description: < vrf_description >
+
         # VRF VNI | Optional (required if "vrf_id" is not set).
         # The VRF VNI range is not limited, but if vrf_id is not set, "vrf_vni" is used for calculating MLAG IBGP peering vlan id.
         # See "mlag_ibgp_peering_vrfs.base_vlan" for details.

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vrfs.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vrfs.j2
@@ -5,5 +5,8 @@ vrfs:
   {{ vrf.name }}:
     tenant: {{ tenant.name }}
     ip_routing: true
+{%         if vrf.description is arista.avd.defined %}
+    description: {{ vrf.description }}
+{%         endif %}
 {%     endfor %}
 {% endfor %}


### PR DESCRIPTION
## Change Summary

Support vrf description in network services. This will ease up the way to define vrf description (without custom_structured_configuration_)

## Related Issue(s)


## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

```
tenants:
  <tenant_name>:
    vrfs:
      <vrf_name>:
        description: <vrf_description>
```
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
