### PR TITLE
Fix(eos_validate_state): lldp tests fails

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/lldp_topology_fqdn.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/lldp_topology_fqdn.yml
@@ -16,7 +16,7 @@
       - lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0] is defined
       - lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0].systemName == ethernet_interface.value.peer + '.' + hostvars[ethernet_interface.value.peer]['dns_domain']
       - lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0].neighborInterfaceInfo.interfaceId == "\"" + ethernet_interface.value.peer_interface + "\""
-    fail_msg: "{{ lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0].systemName | default('Interface Down') }} - {{ lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0].neighborInterfaceInfo.interfaceId | default('N/A') }}"
+    fail_msg: "{{ lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0].systemName | default('Interface Down') }} - {{ lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0].neighborInterfaceInfo.interfaceId | default('N/A') | replace('\"','') }}"
     quiet: true
   loop: "{{ ethernet_interfaces | default({}, true) | dict2items }}"
   loop_control:

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/lldp_topology_no_fqdn.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/lldp_topology_no_fqdn.yml
@@ -16,7 +16,7 @@
       - lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0] is defined
       - lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0].systemName == ethernet_interface.value.peer
       - lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0].neighborInterfaceInfo.interfaceId == "\"" + ethernet_interface.value.peer_interface + "\""
-    fail_msg: "{{ lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0].systemName | default('Interface Down') }} - {{ lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0].neighborInterfaceInfo.interfaceId | default('N/A') }}"
+    fail_msg: "{{ lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0].systemName | default('Interface Down') }} - {{ lldp_topology_state.stdout[0].lldpNeighbors[ethernet_interface.key].lldpNeighborInfo[0].neighborInterfaceInfo.interfaceId | default('N/A') | replace('\"','') }}"
     quiet: true
   loop: "{{ ethernet_interfaces | default({}, true) | dict2items }}"
   loop_control:


### PR DESCRIPTION
## Change Summary

Remove `"` from fail message generation causing the Generate Results task to fail:

```
TASK [arista.avd.eos_validate_state : Generate Results (Set eos_validate_state_report)] ***************
expected <block end>, but found '<scalar>'
  in "<unicode string>", line 20, column 53:
     ... C1-SUPERSPINE1.avd-lab.local - "Ethernet1""
                                         ^
fatal: [DC1-SUPERSPINE1 -> localhost]: FAILED! => 
  msg: Unexpected failure during module execution.
  stdout: ''
```

## Component(s) name

`arista.avd.eos_validate_state`

## Proposed changes

Remove `"` from fail message generation from lldp test tasks.

## How to test

Run validation test with topology with expected LLDP test failures.

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
