### PR TITLE
Refactor(eos_cli_config_gen): Wildcard dict to list for `access_lists`

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/acl.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/acl.yml
@@ -1,30 +1,30 @@
 ### Access-Lists ###
 access_lists:
-  ACL-01:
+  - name: ACL-01
     sequence_numbers:
-      10:
+      - sequence: 10
         action: "remark ACL to restrict access to switch API to CVP and Ansible"
-      20:
+      - sequence: 20
         action: "deny ip host 192.0.2.1 any"
-      30:
+      - sequence: 30
         action: "permit ip 192.0.2.0/24 any"
-  ACL-02:
+  - name: ACL-02
     counters_per_entry: true
     sequence_numbers:
-      10:
+      - sequence: 10
         action: "remark ACL to restrict access RFC1918 addresses"
-      20:
+      - sequence: 20
         action: "permit ip 10.0.0.0/8 any"
-      30:
+      - sequence: 30
         action: "permit ip 192.0.2.0/24 any"
-  ACL-03:
+  - name: ACL-03
     counters_per_entry: false
     sequence_numbers:
-      10:
+      - sequence: 10
         action: "remark ACL to restrict access RFC1918 addresses"
-      20:
+      - sequence: 20
         action: "deny ip 10.0.0.0/8 any"
-      30:
+      - sequence: 30
         action: "permit ip 192.0.2.0/24 any"
 
 ### Standard Access-Lists ###

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/qos.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/qos.yml
@@ -154,13 +154,13 @@ port_channel_interfaces:
 
 ### ACLs and Class Maps ###
 access_lists:
-  acl_qos_tc0_v4:
+  - name: acl_qos_tc0_v4
     sequence_numbers:
-      10:
+      - sequence: 10
         action: "permit ip any 192.0.2.0/29"
-  acl_qos_tc5_v4:
+  - name: acl_qos_tc5_v4
     sequence_numbers:
-      10:
+      - sequence: 10
         action: "permit ip any any dscp ef"
 
 ipv6_access_lists:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
@@ -203,17 +203,17 @@ The legacy data model supports simplified ACL definition with `sequence_number` 
 
 ```yaml
 access_lists:
-  < access_list_name_1 >:
+  - name: < access_list_name_1 >
     counters_per_entry: < true | false >
     sequence_numbers:
-      < sequence_id_1 >:
+      - sequence: < sequence_id_1 >
         action: "< action as string >"
-      < sequence_id_2 >:
+      - sequence: < sequence_id_2 >
         action: "< action as string >"
-  < access_list_name_2 >:
+  - name: < access_list_name_2 >
     counters_per_entry: < true | false >
     sequence_numbers:
-      < sequence_id_1 >:
+      - sequence: < sequence_id_1 >
         action: "< action as string >"
 ```
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/access-lists.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/access-lists.j2
@@ -1,20 +1,20 @@
-{% if access_lists is defined and access_lists is not none %}
+{% if access_lists is arista.avd.defined %}
 
 ## Extended Access-lists
 
 ### Extended Access-lists Summary
 
-{%     for access_list in access_lists | arista.avd.natural_sort %}
-#### {{ access_list }}
-{%         if access_lists[access_list].counters_per_entry is arista.avd.defined(true) %}
+{%     for access_list in access_lists | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+#### {{ access_list.name }}
+{%         if access_list.counters_per_entry is arista.avd.defined(true) %}
 
 ACL has counting mode `counters per-entry` enabled!
 {%         endif %}
 
 | Sequence | Action |
 | -------- | ------ |
-{%         for sequence in access_lists[access_list].sequence_numbers | arista.avd.natural_sort %}
-| {{ sequence }} | {{ access_lists[access_list].sequence_numbers[sequence].action }} |
+{%         for sequence in access_list.sequence_numbers | arista.avd.convert_dicts('sequence') | arista.avd.natural_sort('sequence') %}
+| {{ sequence.sequence }} | {{ sequence.action }} |
 {%         endfor %}
 
 {%     endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/access-lists.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/access-lists.j2
@@ -1,13 +1,13 @@
 {# eos - extended access-lists #}
-{% for access_list in access_lists | arista.avd.natural_sort %}
+{% for access_list in access_lists | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
 !
-ip access-list {{ access_list }}
-{%     if access_lists[access_list].counters_per_entry is arista.avd.defined(true) %}
+ip access-list {{ access_list.name }}
+{%     if access_list.counters_per_entry is arista.avd.defined(true) %}
    counters per-entry
 {%     endif %}
-{%     for sequence in access_lists[access_list].sequence_numbers | arista.avd.natural_sort %}
-{%         if access_lists[access_list].sequence_numbers[sequence].action is arista.avd.defined %}
-   {{ sequence }} {{ access_lists[access_list].sequence_numbers[sequence].action }}
+{%     for sequence in access_list.sequence_numbers | arista.avd.convert_dicts('sequence') | arista.avd.natural_sort('sequence') %}
+{%         if sequence.action is arista.avd.defined %}
+   {{ sequence.sequence }} {{ sequence.action }}
 {%         endif %}
 {%     endfor %}
 {% endfor %}


### PR DESCRIPTION
## "Wildcard Keyed Dict" to "List of Dicts" Data model migration

<!-- Use this PR Title: Refactor(eos_cli_config_gen): Wildcard dict to list for `< data_model_key >` -->

## Data model key

`access_lists`

## Checklist

### Contributor Checklist

- [x] Update `README_v4.0.md` with new data model
- [x] Update all `host_vars` under molecule scenario `eos_cli_config_gen_v4.0` with new data model
- [x] Update `templates/eos/< template >.j2` and `templates/documentation/< template >.j2`:
  - [x] Add `arista.avd.convert_dicts('<primary key>')` filter for loops previously using wildcard keys
  - [x] Update `arista.avd.natural_sort('<primary key>')` to sort on the primary key (if applicable)
- [x] Run molecule `cd ansible_collections/arista/avd ; molecule converge -s eos_cli_config_gen`
  - [x] Verify no changes to generated configs/docs
- [x] Run molecule `cd ansible_collections/arista/avd ; molecule converge -s eos_cli_config_gen_v4.0`
  - [x] Verify no changes to generated configs/docs

### Reviewer Checklist

- Reviewer 1 (@carlbuchmann ):
  - [x] Verify data model changes
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2:
  - [ ] Verify data model changes
  - [ ] Verify no changes to configs/docs on any molecule scenario
  - [ ] Verify that CI pass
