### PR TITLE
Doc(eos_designs): Fix missing max_parallel_uplinks

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-topology.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-topology.md
@@ -199,6 +199,9 @@ defaults <- node_group <- node_group.node <- node
     # Number of interfaces towards uplink switches | Optional
     max_uplink_switches: < integer >
 
+    # Number of parallel links towards uplink switches | Optional
+    max_parallel_uplinks: < integer >
+
     # Enable PTP on uplink links | Optional
     uplink_ptp:
       enable: < boolean >


### PR DESCRIPTION
## Change Summary

Add missing `max_parallel_uplinks` from eos_designs fabric topology documentation.

## Component(s) name

`arista.avd.eos_designs`

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
