### PR TITLE
Fix: Detection of default PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,35 @@
+## Change Summary
+
+<!-- Enter short PR description -->
+
+## Related Issue(s)
+
+Fixes #<ISSUE ID>
+
+## Component(s) name
+
+`arista.avd.<role-name>`
+
+## Proposed changes
+<!--- Describe your changes in detail -->
+<!--- Describe data model implemented for new features -->
+
+## How to test
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to -->
+
+## Checklist
+
+### User Checklist
+
+<!-- Add your own checklist using MD syntax and by replacing N/A -->
+- N/A
+
+### Repository Checklist
+
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+- [ ] My code has been rebased from devel before I start
+- [ ] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
+- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
+- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,1 +1,0 @@
-PULL_REQUEST_TEMPLATE/pull_request_template.md


### PR DESCRIPTION
github is not consistent in using the default PR template, unless we place it in both `.github/` and `.github/PULL_REQUEST_TEMPLATE/` folders. This slipped through because of browser caching kicking in, when there is no default template