### PR TITLE
Fix: Set requirement for ansible.netcommon to <2.6

### DIFF
--- a/ansible_collections/arista/avd/collections.yml
+++ b/ansible_collections/arista/avd/collections.yml
@@ -1,5 +1,6 @@
 # collection requirements leveraged by molecule
 collections:
-  - arista.cvp
-  - arista.eos
-  - ansible.netcommon
+  - name: arista.cvp
+  - name: arista.eos
+  - name: ansible.netcommon
+    version: ">=2.4.0,<2.6.0"

--- a/ansible_collections/arista/avd/galaxy.yml
+++ b/ansible_collections/arista/avd/galaxy.yml
@@ -39,7 +39,7 @@ tags: ['arista', 'network', 'networking', 'eos', 'avd', 'cloudvision', 'cvp']
 dependencies:
     "arista.cvp": ">=3.2.0"
     "arista.eos": ">=3.1.0"
-    "ansible.netcommon": ">=2.4.0"
+    "ansible.netcommon": ">=2.4.0,<2.6.0"
 
 # The URL of the originating SCM repository
 repository: https://github.com/aristanetworks/ansible-avd


### PR DESCRIPTION
Some changes introduced in `ansible.netcommon` breaks AVD. Specifically around IP address calculations.
This change will temporarily cap the version of ansible.netcommon to <2.6.