### PR TITLE
Feat(eos_cli_config_gen): Add support for bgp neighbor peer filter

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
@@ -111,6 +111,13 @@ interface Management1
 | 192.0.3.3 | 65434 | default | - | standard | - | - | - |
 | 192.0.3.4 | 65435 | default | - | large | - | - | - |
 
+### BGP Neighbor Interfaces
+
+| Neighbor Interface | Peer Group | Remote AS | Peer Filter |
+| ------------------ | ---------- | --------- | ----------- |
+| Ethernet2 | PG-FOO-v4 | 65102 | - |
+| Ethernet3 | PG-FOO-v4 | - | PF-BAR-v4 |
+
 ### BGP Route Aggregation
 
 | Prefix | AS Set | Summary Only | Attribute Map | Match Map | Advertise Only |
@@ -133,6 +140,8 @@ router bgp 65101
    graceful-restart restart-time 300
    graceful-restart
    bgp bestpath d-path
+   neighbor interface Ethernet2 peer-group PG-FOO-v4 remote-as 65102
+   neighbor interface Ethernet3 peer-group PG-FOO-v4 peer_filter PF-BAR-v4
    neighbor 192.0.3.1 remote-as 65432
    neighbor 192.0.3.1 default-originate always
    neighbor 192.0.3.1 send-community

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
@@ -141,7 +141,7 @@ router bgp 65101
    graceful-restart
    bgp bestpath d-path
    neighbor interface Ethernet2 peer-group PG-FOO-v4 remote-as 65102
-   neighbor interface Ethernet3 peer-group PG-FOO-v4 peer_filter PF-BAR-v4
+   neighbor interface Ethernet3 peer-group PG-FOO-v4 peer-filter PF-BAR-v4
    neighbor 192.0.3.1 remote-as 65432
    neighbor 192.0.3.1 default-originate always
    neighbor 192.0.3.1 send-community

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-base.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-base.cfg
@@ -22,6 +22,8 @@ router bgp 65101
    graceful-restart restart-time 300
    graceful-restart
    bgp bestpath d-path
+   neighbor interface Ethernet2 peer-group PG-FOO-v4 remote-as 65102
+   neighbor interface Ethernet3 peer-group PG-FOO-v4 peer_filter PF-BAR-v4
    neighbor 192.0.3.1 remote-as 65432
    neighbor 192.0.3.1 default-originate always
    neighbor 192.0.3.1 send-community

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-base.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-base.cfg
@@ -23,7 +23,7 @@ router bgp 65101
    graceful-restart
    bgp bestpath d-path
    neighbor interface Ethernet2 peer-group PG-FOO-v4 remote-as 65102
-   neighbor interface Ethernet3 peer-group PG-FOO-v4 peer_filter PF-BAR-v4
+   neighbor interface Ethernet3 peer-group PG-FOO-v4 peer-filter PF-BAR-v4
    neighbor 192.0.3.1 remote-as 65432
    neighbor 192.0.3.1 default-originate always
    neighbor 192.0.3.1 send-community

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-base.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-base.yml
@@ -86,3 +86,10 @@ router_bgp:
       send_community: large
       default_originate:
         enabled: false
+  neighbor_interfaces:
+    Ethernet2:
+      peer_group: PG-FOO-v4
+      remote_as: 65102
+    Ethernet3:
+      peer_group: PG-FOO-v4
+      peer_filter: PF-BAR-v4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -588,12 +588,12 @@ router general
 
 ### BGP Neighbor Interfaces
 
-| Neighbor Interface | Peer Group | Remote AS |
-| ------------------ | ---------- | --------- |
-| Ethernet1 | UNDERLAY_PEERS | 65001 |
-| Ethernet2 | UNDERLAY_PEERS | 65001 |
-| Ethernet3 | UNDERLAY_PEERS | 65001 |
-| Ethernet4 | UNDERLAY_PEERS | 65001 |
+| Neighbor Interface | Peer Group | Remote AS | Peer Filter |
+| ------------------ | ---------- | --------- | ----------- |
+| Ethernet1 | UNDERLAY_PEERS | 65001 | - |
+| Ethernet2 | UNDERLAY_PEERS | 65001 | - |
+| Ethernet3 | UNDERLAY_PEERS | 65001 | - |
+| Ethernet4 | UNDERLAY_PEERS | 65001 | - |
 
 ### Router BGP EVPN Address Family
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -569,12 +569,12 @@ ip route vrf Tenant_A_WAN_Zone 10.3.4.0/24 1.2.3.4
 
 ### BGP Neighbor Interfaces
 
-| Neighbor Interface | Peer Group | Remote AS |
-| ------------------ | ---------- | --------- |
-| Ethernet1 | UNDERLAY_PEERS | 65001 |
-| Ethernet2 | UNDERLAY_PEERS | 65001 |
-| Ethernet3 | UNDERLAY_PEERS | 65001 |
-| Ethernet4 | UNDERLAY_PEERS | 65001 |
+| Neighbor Interface | Peer Group | Remote AS | Peer Filter |
+| ------------------ | ---------- | --------- | ----------- |
+| Ethernet1 | UNDERLAY_PEERS | 65001 | - |
+| Ethernet2 | UNDERLAY_PEERS | 65001 | - |
+| Ethernet3 | UNDERLAY_PEERS | 65001 | - |
+| Ethernet4 | UNDERLAY_PEERS | 65001 | - |
 
 ### Router BGP EVPN Address Family
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -584,12 +584,12 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 ### BGP Neighbor Interfaces
 
-| Neighbor Interface | Peer Group | Remote AS |
-| ------------------ | ---------- | --------- |
-| Ethernet1 | UNDERLAY_PEERS | 65001 |
-| Ethernet2 | UNDERLAY_PEERS | 65001 |
-| Ethernet3 | UNDERLAY_PEERS | 65001 |
-| Ethernet4 | UNDERLAY_PEERS | 65001 |
+| Neighbor Interface | Peer Group | Remote AS | Peer Filter |
+| ------------------ | ---------- | --------- | ----------- |
+| Ethernet1 | UNDERLAY_PEERS | 65001 | - |
+| Ethernet2 | UNDERLAY_PEERS | 65001 | - |
+| Ethernet3 | UNDERLAY_PEERS | 65001 | - |
+| Ethernet4 | UNDERLAY_PEERS | 65001 | - |
 
 ### Router BGP EVPN Address Family
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -974,13 +974,13 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 ### BGP Neighbor Interfaces
 
-| Neighbor Interface | Peer Group | Remote AS |
-| ------------------ | ---------- | --------- |
-| Ethernet1 | UNDERLAY_PEERS | 65001 |
-| Ethernet2 | UNDERLAY_PEERS | 65001 |
-| Ethernet3 | UNDERLAY_PEERS | 65001 |
-| Ethernet4 | UNDERLAY_PEERS | 65001 |
-| Vlan4093 | MLAG_PEER | 65102 |
+| Neighbor Interface | Peer Group | Remote AS | Peer Filter |
+| ------------------ | ---------- | --------- | ----------- |
+| Ethernet1 | UNDERLAY_PEERS | 65001 | - |
+| Ethernet2 | UNDERLAY_PEERS | 65001 | - |
+| Ethernet3 | UNDERLAY_PEERS | 65001 | - |
+| Ethernet4 | UNDERLAY_PEERS | 65001 | - |
+| Vlan4093 | MLAG_PEER | 65102 | - |
 
 ### Router BGP EVPN Address Family
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -974,13 +974,13 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 ### BGP Neighbor Interfaces
 
-| Neighbor Interface | Peer Group | Remote AS |
-| ------------------ | ---------- | --------- |
-| Ethernet1 | UNDERLAY_PEERS | 65001 |
-| Ethernet2 | UNDERLAY_PEERS | 65001 |
-| Ethernet3 | UNDERLAY_PEERS | 65001 |
-| Ethernet4 | UNDERLAY_PEERS | 65001 |
-| Vlan4093 | MLAG_PEER | 65102 |
+| Neighbor Interface | Peer Group | Remote AS | Peer Filter |
+| ------------------ | ---------- | --------- | ----------- |
+| Ethernet1 | UNDERLAY_PEERS | 65001 | - |
+| Ethernet2 | UNDERLAY_PEERS | 65001 | - |
+| Ethernet3 | UNDERLAY_PEERS | 65001 | - |
+| Ethernet4 | UNDERLAY_PEERS | 65001 | - |
+| Vlan4093 | MLAG_PEER | 65102 | - |
 
 ### Router BGP EVPN Address Family
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE1.md
@@ -412,15 +412,15 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 ### BGP Neighbor Interfaces
 
-| Neighbor Interface | Peer Group | Remote AS |
-| ------------------ | ---------- | --------- |
-| Ethernet1 | UNDERLAY_PEERS | 65101 |
-| Ethernet2 | UNDERLAY_PEERS | 65102 |
-| Ethernet3 | UNDERLAY_PEERS | 65102 |
-| Ethernet4 | UNDERLAY_PEERS | 65103 |
-| Ethernet5 | UNDERLAY_PEERS | 65103 |
-| Ethernet6 | UNDERLAY_PEERS | 65104 |
-| Ethernet7 | UNDERLAY_PEERS | 65105 |
+| Neighbor Interface | Peer Group | Remote AS | Peer Filter |
+| ------------------ | ---------- | --------- | ----------- |
+| Ethernet1 | UNDERLAY_PEERS | 65101 | - |
+| Ethernet2 | UNDERLAY_PEERS | 65102 | - |
+| Ethernet3 | UNDERLAY_PEERS | 65102 | - |
+| Ethernet4 | UNDERLAY_PEERS | 65103 | - |
+| Ethernet5 | UNDERLAY_PEERS | 65103 | - |
+| Ethernet6 | UNDERLAY_PEERS | 65104 | - |
+| Ethernet7 | UNDERLAY_PEERS | 65105 | - |
 
 ### Router BGP EVPN Address Family
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE2.md
@@ -412,15 +412,15 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 ### BGP Neighbor Interfaces
 
-| Neighbor Interface | Peer Group | Remote AS |
-| ------------------ | ---------- | --------- |
-| Ethernet1 | UNDERLAY_PEERS | 65101 |
-| Ethernet2 | UNDERLAY_PEERS | 65102 |
-| Ethernet3 | UNDERLAY_PEERS | 65102 |
-| Ethernet4 | UNDERLAY_PEERS | 65103 |
-| Ethernet5 | UNDERLAY_PEERS | 65103 |
-| Ethernet6 | UNDERLAY_PEERS | 65104 |
-| Ethernet7 | UNDERLAY_PEERS | 65105 |
+| Neighbor Interface | Peer Group | Remote AS | Peer Filter |
+| ------------------ | ---------- | --------- | ----------- |
+| Ethernet1 | UNDERLAY_PEERS | 65101 | - |
+| Ethernet2 | UNDERLAY_PEERS | 65102 | - |
+| Ethernet3 | UNDERLAY_PEERS | 65102 | - |
+| Ethernet4 | UNDERLAY_PEERS | 65103 | - |
+| Ethernet5 | UNDERLAY_PEERS | 65103 | - |
+| Ethernet6 | UNDERLAY_PEERS | 65104 | - |
+| Ethernet7 | UNDERLAY_PEERS | 65105 | - |
 
 ### Router BGP EVPN Address Family
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE3.md
@@ -412,15 +412,15 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 ### BGP Neighbor Interfaces
 
-| Neighbor Interface | Peer Group | Remote AS |
-| ------------------ | ---------- | --------- |
-| Ethernet1 | UNDERLAY_PEERS | 65101 |
-| Ethernet2 | UNDERLAY_PEERS | 65102 |
-| Ethernet3 | UNDERLAY_PEERS | 65102 |
-| Ethernet4 | UNDERLAY_PEERS | 65103 |
-| Ethernet5 | UNDERLAY_PEERS | 65103 |
-| Ethernet6 | UNDERLAY_PEERS | 65104 |
-| Ethernet7 | UNDERLAY_PEERS | 65105 |
+| Neighbor Interface | Peer Group | Remote AS | Peer Filter |
+| ------------------ | ---------- | --------- | ----------- |
+| Ethernet1 | UNDERLAY_PEERS | 65101 | - |
+| Ethernet2 | UNDERLAY_PEERS | 65102 | - |
+| Ethernet3 | UNDERLAY_PEERS | 65102 | - |
+| Ethernet4 | UNDERLAY_PEERS | 65103 | - |
+| Ethernet5 | UNDERLAY_PEERS | 65103 | - |
+| Ethernet6 | UNDERLAY_PEERS | 65104 | - |
+| Ethernet7 | UNDERLAY_PEERS | 65105 | - |
 
 ### Router BGP EVPN Address Family
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE4.md
@@ -412,15 +412,15 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 ### BGP Neighbor Interfaces
 
-| Neighbor Interface | Peer Group | Remote AS |
-| ------------------ | ---------- | --------- |
-| Ethernet1 | UNDERLAY_PEERS | 65101 |
-| Ethernet2 | UNDERLAY_PEERS | 65102 |
-| Ethernet3 | UNDERLAY_PEERS | 65102 |
-| Ethernet4 | UNDERLAY_PEERS | 65103 |
-| Ethernet5 | UNDERLAY_PEERS | 65103 |
-| Ethernet6 | UNDERLAY_PEERS | 65104 |
-| Ethernet7 | UNDERLAY_PEERS | 65105 |
+| Neighbor Interface | Peer Group | Remote AS | Peer Filter |
+| ------------------ | ---------- | --------- | ----------- |
+| Ethernet1 | UNDERLAY_PEERS | 65101 | - |
+| Ethernet2 | UNDERLAY_PEERS | 65102 | - |
+| Ethernet3 | UNDERLAY_PEERS | 65102 | - |
+| Ethernet4 | UNDERLAY_PEERS | 65103 | - |
+| Ethernet5 | UNDERLAY_PEERS | 65103 | - |
+| Ethernet6 | UNDERLAY_PEERS | 65104 | - |
+| Ethernet7 | UNDERLAY_PEERS | 65105 | - |
 
 ### Router BGP EVPN Address Family
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -1151,13 +1151,13 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 ### BGP Neighbor Interfaces
 
-| Neighbor Interface | Peer Group | Remote AS |
-| ------------------ | ---------- | --------- |
-| Ethernet1 | UNDERLAY_PEERS | 65001 |
-| Ethernet2 | UNDERLAY_PEERS | 65001 |
-| Ethernet3 | UNDERLAY_PEERS | 65001 |
-| Ethernet4 | UNDERLAY_PEERS | 65001 |
-| Vlan4093 | MLAG_PEER | 65103 |
+| Neighbor Interface | Peer Group | Remote AS | Peer Filter |
+| ------------------ | ---------- | --------- | ----------- |
+| Ethernet1 | UNDERLAY_PEERS | 65001 | - |
+| Ethernet2 | UNDERLAY_PEERS | 65001 | - |
+| Ethernet3 | UNDERLAY_PEERS | 65001 | - |
+| Ethernet4 | UNDERLAY_PEERS | 65001 | - |
+| Vlan4093 | MLAG_PEER | 65103 | - |
 
 ### Router BGP EVPN Address Family
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -1136,13 +1136,13 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 ### BGP Neighbor Interfaces
 
-| Neighbor Interface | Peer Group | Remote AS |
-| ------------------ | ---------- | --------- |
-| Ethernet1 | UNDERLAY_PEERS | 65001 |
-| Ethernet2 | UNDERLAY_PEERS | 65001 |
-| Ethernet3 | UNDERLAY_PEERS | 65001 |
-| Ethernet4 | UNDERLAY_PEERS | 65001 |
-| Vlan4093 | MLAG_PEER | 65103 |
+| Neighbor Interface | Peer Group | Remote AS | Peer Filter |
+| ------------------ | ---------- | --------- | ----------- |
+| Ethernet1 | UNDERLAY_PEERS | 65001 | - |
+| Ethernet2 | UNDERLAY_PEERS | 65001 | - |
+| Ethernet3 | UNDERLAY_PEERS | 65001 | - |
+| Ethernet4 | UNDERLAY_PEERS | 65001 | - |
+| Vlan4093 | MLAG_PEER | 65103 | - |
 
 ### Router BGP EVPN Address Family
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -590,12 +590,12 @@ router general
 
 ### BGP Neighbor Interfaces
 
-| Neighbor Interface | Peer Group | Remote AS |
-| ------------------ | ---------- | --------- |
-| Ethernet1 | UNDERLAY_PEERS | 65001 |
-| Ethernet2 | UNDERLAY_PEERS | 65001 |
-| Ethernet3 | UNDERLAY_PEERS | 65001 |
-| Ethernet4 | UNDERLAY_PEERS | 65001 |
+| Neighbor Interface | Peer Group | Remote AS | Peer Filter |
+| ------------------ | ---------- | --------- | ----------- |
+| Ethernet1 | UNDERLAY_PEERS | 65001 | - |
+| Ethernet2 | UNDERLAY_PEERS | 65001 | - |
+| Ethernet3 | UNDERLAY_PEERS | 65001 | - |
+| Ethernet4 | UNDERLAY_PEERS | 65001 | - |
 
 ### Router BGP EVPN Address Family
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -571,12 +571,12 @@ ip route vrf Tenant_A_WAN_Zone 10.3.4.0/24 1.2.3.4
 
 ### BGP Neighbor Interfaces
 
-| Neighbor Interface | Peer Group | Remote AS |
-| ------------------ | ---------- | --------- |
-| Ethernet1 | UNDERLAY_PEERS | 65001 |
-| Ethernet2 | UNDERLAY_PEERS | 65001 |
-| Ethernet3 | UNDERLAY_PEERS | 65001 |
-| Ethernet4 | UNDERLAY_PEERS | 65001 |
+| Neighbor Interface | Peer Group | Remote AS | Peer Filter |
+| ------------------ | ---------- | --------- | ----------- |
+| Ethernet1 | UNDERLAY_PEERS | 65001 | - |
+| Ethernet2 | UNDERLAY_PEERS | 65001 | - |
+| Ethernet3 | UNDERLAY_PEERS | 65001 | - |
+| Ethernet4 | UNDERLAY_PEERS | 65001 | - |
 
 ### Router BGP EVPN Address Family
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -586,12 +586,12 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 ### BGP Neighbor Interfaces
 
-| Neighbor Interface | Peer Group | Remote AS |
-| ------------------ | ---------- | --------- |
-| Ethernet1 | UNDERLAY_PEERS | 65001 |
-| Ethernet2 | UNDERLAY_PEERS | 65001 |
-| Ethernet3 | UNDERLAY_PEERS | 65001 |
-| Ethernet4 | UNDERLAY_PEERS | 65001 |
+| Neighbor Interface | Peer Group | Remote AS | Peer Filter |
+| ------------------ | ---------- | --------- | ----------- |
+| Ethernet1 | UNDERLAY_PEERS | 65001 | - |
+| Ethernet2 | UNDERLAY_PEERS | 65001 | - |
+| Ethernet3 | UNDERLAY_PEERS | 65001 | - |
+| Ethernet4 | UNDERLAY_PEERS | 65001 | - |
 
 ### Router BGP EVPN Address Family
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -976,13 +976,13 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 ### BGP Neighbor Interfaces
 
-| Neighbor Interface | Peer Group | Remote AS |
-| ------------------ | ---------- | --------- |
-| Ethernet1 | UNDERLAY_PEERS | 65001 |
-| Ethernet2 | UNDERLAY_PEERS | 65001 |
-| Ethernet3 | UNDERLAY_PEERS | 65001 |
-| Ethernet4 | UNDERLAY_PEERS | 65001 |
-| Vlan4093 | MLAG_PEER | 65102 |
+| Neighbor Interface | Peer Group | Remote AS | Peer Filter |
+| ------------------ | ---------- | --------- | ----------- |
+| Ethernet1 | UNDERLAY_PEERS | 65001 | - |
+| Ethernet2 | UNDERLAY_PEERS | 65001 | - |
+| Ethernet3 | UNDERLAY_PEERS | 65001 | - |
+| Ethernet4 | UNDERLAY_PEERS | 65001 | - |
+| Vlan4093 | MLAG_PEER | 65102 | - |
 
 ### Router BGP EVPN Address Family
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -976,13 +976,13 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 ### BGP Neighbor Interfaces
 
-| Neighbor Interface | Peer Group | Remote AS |
-| ------------------ | ---------- | --------- |
-| Ethernet1 | UNDERLAY_PEERS | 65001 |
-| Ethernet2 | UNDERLAY_PEERS | 65001 |
-| Ethernet3 | UNDERLAY_PEERS | 65001 |
-| Ethernet4 | UNDERLAY_PEERS | 65001 |
-| Vlan4093 | MLAG_PEER | 65102 |
+| Neighbor Interface | Peer Group | Remote AS | Peer Filter |
+| ------------------ | ---------- | --------- | ----------- |
+| Ethernet1 | UNDERLAY_PEERS | 65001 | - |
+| Ethernet2 | UNDERLAY_PEERS | 65001 | - |
+| Ethernet3 | UNDERLAY_PEERS | 65001 | - |
+| Ethernet4 | UNDERLAY_PEERS | 65001 | - |
+| Vlan4093 | MLAG_PEER | 65102 | - |
 
 ### Router BGP EVPN Address Family
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE1.md
@@ -412,15 +412,15 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 ### BGP Neighbor Interfaces
 
-| Neighbor Interface | Peer Group | Remote AS |
-| ------------------ | ---------- | --------- |
-| Ethernet1 | UNDERLAY_PEERS | 65101 |
-| Ethernet2 | UNDERLAY_PEERS | 65102 |
-| Ethernet3 | UNDERLAY_PEERS | 65102 |
-| Ethernet4 | UNDERLAY_PEERS | 65103 |
-| Ethernet5 | UNDERLAY_PEERS | 65103 |
-| Ethernet6 | UNDERLAY_PEERS | 65104 |
-| Ethernet7 | UNDERLAY_PEERS | 65105 |
+| Neighbor Interface | Peer Group | Remote AS | Peer Filter |
+| ------------------ | ---------- | --------- | ----------- |
+| Ethernet1 | UNDERLAY_PEERS | 65101 | - |
+| Ethernet2 | UNDERLAY_PEERS | 65102 | - |
+| Ethernet3 | UNDERLAY_PEERS | 65102 | - |
+| Ethernet4 | UNDERLAY_PEERS | 65103 | - |
+| Ethernet5 | UNDERLAY_PEERS | 65103 | - |
+| Ethernet6 | UNDERLAY_PEERS | 65104 | - |
+| Ethernet7 | UNDERLAY_PEERS | 65105 | - |
 
 ### Router BGP EVPN Address Family
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE2.md
@@ -412,15 +412,15 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 ### BGP Neighbor Interfaces
 
-| Neighbor Interface | Peer Group | Remote AS |
-| ------------------ | ---------- | --------- |
-| Ethernet1 | UNDERLAY_PEERS | 65101 |
-| Ethernet2 | UNDERLAY_PEERS | 65102 |
-| Ethernet3 | UNDERLAY_PEERS | 65102 |
-| Ethernet4 | UNDERLAY_PEERS | 65103 |
-| Ethernet5 | UNDERLAY_PEERS | 65103 |
-| Ethernet6 | UNDERLAY_PEERS | 65104 |
-| Ethernet7 | UNDERLAY_PEERS | 65105 |
+| Neighbor Interface | Peer Group | Remote AS | Peer Filter |
+| ------------------ | ---------- | --------- | ----------- |
+| Ethernet1 | UNDERLAY_PEERS | 65101 | - |
+| Ethernet2 | UNDERLAY_PEERS | 65102 | - |
+| Ethernet3 | UNDERLAY_PEERS | 65102 | - |
+| Ethernet4 | UNDERLAY_PEERS | 65103 | - |
+| Ethernet5 | UNDERLAY_PEERS | 65103 | - |
+| Ethernet6 | UNDERLAY_PEERS | 65104 | - |
+| Ethernet7 | UNDERLAY_PEERS | 65105 | - |
 
 ### Router BGP EVPN Address Family
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE3.md
@@ -412,15 +412,15 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 ### BGP Neighbor Interfaces
 
-| Neighbor Interface | Peer Group | Remote AS |
-| ------------------ | ---------- | --------- |
-| Ethernet1 | UNDERLAY_PEERS | 65101 |
-| Ethernet2 | UNDERLAY_PEERS | 65102 |
-| Ethernet3 | UNDERLAY_PEERS | 65102 |
-| Ethernet4 | UNDERLAY_PEERS | 65103 |
-| Ethernet5 | UNDERLAY_PEERS | 65103 |
-| Ethernet6 | UNDERLAY_PEERS | 65104 |
-| Ethernet7 | UNDERLAY_PEERS | 65105 |
+| Neighbor Interface | Peer Group | Remote AS | Peer Filter |
+| ------------------ | ---------- | --------- | ----------- |
+| Ethernet1 | UNDERLAY_PEERS | 65101 | - |
+| Ethernet2 | UNDERLAY_PEERS | 65102 | - |
+| Ethernet3 | UNDERLAY_PEERS | 65102 | - |
+| Ethernet4 | UNDERLAY_PEERS | 65103 | - |
+| Ethernet5 | UNDERLAY_PEERS | 65103 | - |
+| Ethernet6 | UNDERLAY_PEERS | 65104 | - |
+| Ethernet7 | UNDERLAY_PEERS | 65105 | - |
 
 ### Router BGP EVPN Address Family
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SPINE4.md
@@ -412,15 +412,15 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 ### BGP Neighbor Interfaces
 
-| Neighbor Interface | Peer Group | Remote AS |
-| ------------------ | ---------- | --------- |
-| Ethernet1 | UNDERLAY_PEERS | 65101 |
-| Ethernet2 | UNDERLAY_PEERS | 65102 |
-| Ethernet3 | UNDERLAY_PEERS | 65102 |
-| Ethernet4 | UNDERLAY_PEERS | 65103 |
-| Ethernet5 | UNDERLAY_PEERS | 65103 |
-| Ethernet6 | UNDERLAY_PEERS | 65104 |
-| Ethernet7 | UNDERLAY_PEERS | 65105 |
+| Neighbor Interface | Peer Group | Remote AS | Peer Filter |
+| ------------------ | ---------- | --------- | ----------- |
+| Ethernet1 | UNDERLAY_PEERS | 65101 | - |
+| Ethernet2 | UNDERLAY_PEERS | 65102 | - |
+| Ethernet3 | UNDERLAY_PEERS | 65102 | - |
+| Ethernet4 | UNDERLAY_PEERS | 65103 | - |
+| Ethernet5 | UNDERLAY_PEERS | 65103 | - |
+| Ethernet6 | UNDERLAY_PEERS | 65104 | - |
+| Ethernet7 | UNDERLAY_PEERS | 65105 | - |
 
 ### Router BGP EVPN Address Family
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -1153,13 +1153,13 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 ### BGP Neighbor Interfaces
 
-| Neighbor Interface | Peer Group | Remote AS |
-| ------------------ | ---------- | --------- |
-| Ethernet1 | UNDERLAY_PEERS | 65001 |
-| Ethernet2 | UNDERLAY_PEERS | 65001 |
-| Ethernet3 | UNDERLAY_PEERS | 65001 |
-| Ethernet4 | UNDERLAY_PEERS | 65001 |
-| Vlan4093 | MLAG_PEER | 65103 |
+| Neighbor Interface | Peer Group | Remote AS | Peer Filter |
+| ------------------ | ---------- | --------- | ----------- |
+| Ethernet1 | UNDERLAY_PEERS | 65001 | - |
+| Ethernet2 | UNDERLAY_PEERS | 65001 | - |
+| Ethernet3 | UNDERLAY_PEERS | 65001 | - |
+| Ethernet4 | UNDERLAY_PEERS | 65001 | - |
+| Vlan4093 | MLAG_PEER | 65103 | - |
 
 ### Router BGP EVPN Address Family
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -1138,13 +1138,13 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 ### BGP Neighbor Interfaces
 
-| Neighbor Interface | Peer Group | Remote AS |
-| ------------------ | ---------- | --------- |
-| Ethernet1 | UNDERLAY_PEERS | 65001 |
-| Ethernet2 | UNDERLAY_PEERS | 65001 |
-| Ethernet3 | UNDERLAY_PEERS | 65001 |
-| Ethernet4 | UNDERLAY_PEERS | 65001 |
-| Vlan4093 | MLAG_PEER | 65103 |
+| Neighbor Interface | Peer Group | Remote AS | Peer Filter |
+| ------------------ | ---------- | --------- | ----------- |
+| Ethernet1 | UNDERLAY_PEERS | 65001 | - |
+| Ethernet2 | UNDERLAY_PEERS | 65001 | - |
+| Ethernet3 | UNDERLAY_PEERS | 65001 | - |
+| Ethernet4 | UNDERLAY_PEERS | 65001 | - |
+| Vlan4093 | MLAG_PEER | 65103 | - |
 
 ### Router BGP EVPN Address Family
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -2596,7 +2596,7 @@ router_bgp:
     < interface >:
       peer_group: < peer_group_name >
       remote_as: < bgp_as >
-      description: "< description as string >"
+      peer_filter: <peer_filter>
   aggregate_addresses:
     < aggregate_address_1/mask >:
       advertise_only: < true | false >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
@@ -266,13 +266,14 @@
 
 ### BGP Neighbor Interfaces
 
-| Neighbor Interface | Peer Group | Remote AS |
-| ------------------ | ---------- | --------- |
+| Neighbor Interface | Peer Group | Remote AS | Peer Filter |
+| ------------------ | ---------- | --------- | ----------- |
 {%         for neighbor_interface in router_bgp.neighbor_interfaces | arista.avd.natural_sort %}
 {%             set neighbor_interface = neighbor_interface %}
 {%             set peer_group = router_bgp.neighbor_interfaces[neighbor_interface].peer_group | arista.avd.default("-") %}
 {%             set remote_as = router_bgp.neighbor_interfaces[neighbor_interface].remote_as | arista.avd.default("-") %}
-| {{ neighbor_interface }} | {{ peer_group }} | {{ remote_as }} |
+{%             set peer_filter = router_bgp.neighbor_interfaces[neighbor_interface].peer_filter | arista.avd.default("-") %}
+| {{ neighbor_interface }} | {{ peer_group }} | {{ remote_as }} | {{ peer_filter }} |
 {%         endfor %}
 {%     endif %}
 {%     if router_bgp.aggregate_addresses is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -123,7 +123,7 @@ router bgp {{ router_bgp.as }}
 {%         if router_bgp.neighbor_interfaces[neighbor_interface].peer_group is arista.avd.defined and router_bgp.neighbor_interfaces[neighbor_interface].remote_as is arista.avd.defined %}
    neighbor interface {{ neighbor_interface }} peer-group {{ router_bgp.neighbor_interfaces[neighbor_interface].peer_group }} remote-as {{ router_bgp.neighbor_interfaces[neighbor_interface].remote_as }}
 {%         elif router_bgp.neighbor_interfaces[neighbor_interface].peer_group is arista.avd.defined and router_bgp.neighbor_interfaces[neighbor_interface].peer_filter is arista.avd.defined %}
-   neighbor interface {{ neighbor_interface }} peer-group {{ router_bgp.neighbor_interfaces[neighbor_interface].peer_group }} peer_filter {{ router_bgp.neighbor_interfaces[neighbor_interface].peer_filter }}
+   neighbor interface {{ neighbor_interface }} peer-group {{ router_bgp.neighbor_interfaces[neighbor_interface].peer_group }} peer-filter {{ router_bgp.neighbor_interfaces[neighbor_interface].peer_filter }}
 {%         endif %}
 {%     endfor %}
 {%     for neighbor in router_bgp.neighbors | arista.avd.natural_sort %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -120,14 +120,11 @@ router bgp {{ router_bgp.as }}
 {%         endif %}
 {%     endfor %}
 {%     for neighbor_interface in router_bgp.neighbor_interfaces | arista.avd.natural_sort %}
-{%         set neighbor_interface_cli = "neighbor interface " ~ neighbor_interface %}
-{%         if router_bgp.neighbor_interfaces[neighbor_interface].peer_group is arista.avd.defined %}
-{%             set neighbor_interface_cli = neighbor_interface_cli ~ " peer-group " ~ router_bgp.neighbor_interfaces[neighbor_interface].peer_group %}
+{%         if router_bgp.neighbor_interfaces[neighbor_interface].peer_group is arista.avd.defined and router_bgp.neighbor_interfaces[neighbor_interface].remote_as is arista.avd.defined %}
+   neighbor interface {{ neighbor_interface}} peer-group {{ router_bgp.neighbor_interfaces[neighbor_interface].peer_group }} remote-as {{ router_bgp.neighbor_interfaces[neighbor_interface].remote_as }}
+{%         elif router_bgp.neighbor_interfaces[neighbor_interface].peer_group is arista.avd.defined and router_bgp.neighbor_interfaces[neighbor_interface].peer_filter is arista.avd.defined %}
+   neighbor interface {{ neighbor_interface}} peer-group {{ router_bgp.neighbor_interfaces[neighbor_interface].peer_group }} peer_filter {{ router_bgp.neighbor_interfaces[neighbor_interface].peer_filter }}
 {%         endif %}
-{%         if router_bgp.neighbor_interfaces[neighbor_interface].remote_as is arista.avd.defined %}
-{%             set neighbor_interface_cli = neighbor_interface_cli ~ " remote-as " ~ router_bgp.neighbor_interfaces[neighbor_interface].remote_as %}
-{%         endif %}
-   {{ neighbor_interface_cli }}
 {%     endfor %}
 {%     for neighbor in router_bgp.neighbors | arista.avd.natural_sort %}
 {%         if router_bgp.neighbors[neighbor].peer_group is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -121,9 +121,9 @@ router bgp {{ router_bgp.as }}
 {%     endfor %}
 {%     for neighbor_interface in router_bgp.neighbor_interfaces | arista.avd.natural_sort %}
 {%         if router_bgp.neighbor_interfaces[neighbor_interface].peer_group is arista.avd.defined and router_bgp.neighbor_interfaces[neighbor_interface].remote_as is arista.avd.defined %}
-   neighbor interface {{ neighbor_interface}} peer-group {{ router_bgp.neighbor_interfaces[neighbor_interface].peer_group }} remote-as {{ router_bgp.neighbor_interfaces[neighbor_interface].remote_as }}
+   neighbor interface {{ neighbor_interface }} peer-group {{ router_bgp.neighbor_interfaces[neighbor_interface].peer_group }} remote-as {{ router_bgp.neighbor_interfaces[neighbor_interface].remote_as }}
 {%         elif router_bgp.neighbor_interfaces[neighbor_interface].peer_group is arista.avd.defined and router_bgp.neighbor_interfaces[neighbor_interface].peer_filter is arista.avd.defined %}
-   neighbor interface {{ neighbor_interface}} peer-group {{ router_bgp.neighbor_interfaces[neighbor_interface].peer_group }} peer_filter {{ router_bgp.neighbor_interfaces[neighbor_interface].peer_filter }}
+   neighbor interface {{ neighbor_interface }} peer-group {{ router_bgp.neighbor_interfaces[neighbor_interface].peer_group }} peer_filter {{ router_bgp.neighbor_interfaces[neighbor_interface].peer_filter }}
 {%         endif %}
 {%     endfor %}
 {%     for neighbor in router_bgp.neighbors | arista.avd.natural_sort %}


### PR DESCRIPTION
## Change Summary

Adding support for BGP neighbor interface peer-filter

## Related Issue(s)

Fixes #1553 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

1. Add support for BGP neighbor interface peer filter.
2. Make `peer_filter` a dependency of `peer_group` (can't add peer_filter without adding peer_group) 
3. Make 'remote_as` a dependency of `peer_group` (can't add remote_as without adding peer_group)
4. Remove `description` field from `README.md` as this feature is not available (not supported on CLI).
5. Adding molecule test (bgp neighbor interfaces was not being tested with molecule before).

Current model: 

```yaml
  neighbor_interfaces:
    < interface >:
      peer_group: < peer_group_name >
      remote_as: < bgp_as >
      description: "< description as string >"
```

Proposed model: 

```yaml
  neighbor_interfaces:
    < interface >:
      peer_group: < peer_group_name >
      remote_as: < bgp_as >
      peer_filter: <peer_filter>
```

## How to test

```yaml
router_bgp:
  as: 65101
  neighbor_interfaces:
    Ethernet2:
      peer_group: PG-FOO-v4
      remote_as: 65102
    Ethernet3:
      peer_group: PG-FOO-v4
      peer_filter: PF-BAR-v4
```

## Checklist

### User Checklist

- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
