### PR TITLE
Feat(eos_cli_config_gen): Add dr_priority to pim ipv4 configuration on interface

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -273,6 +273,7 @@ interface Ethernet5
    isis authentication mode md5
    isis authentication key 7 asfddja23452
    pim ipv4 sparse-mode
+   pim ipv4 dr-priority 200
 !
 interface Ethernet6
    description SRV-POD02_Eth1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
@@ -282,6 +282,7 @@ interface Ethernet50
 | Port-Channel8.101 | to Dev02 Port-Channel8.101 - VRF-C1 | routed | - | 10.1.2.3/31 | default | - | - | - | - |
 | Port-Channel9 | - | routed | - | 10.9.2.3/31 | default | - | - | - | - |
 | Port-Channel17 | PBR Description | routed | - | 192.0.2.3/31 | default | - | - | - | - |
+| Port-Channel99 | MCAST | routed | - | 192.0.2.10/31 | default | - | - | - | - |
 | Port-Channel113 | interface_with_mpls_enabled | routed | - | 172.31.128.9/31 | default | - | - | - | - |
 | Port-Channel114 | interface_with_mpls_disabled | routed | - | 172.31.128.10/31 | default | - | - | - | - |
 
@@ -416,6 +417,12 @@ interface Port-Channel51
    switchport trunk allowed vlan 1-500
    switchport mode trunk
    ipv6 nd prefix a1::/64 infinite infinite no-autoconfig
+!
+interface Port-Channel99
+   description MCAST
+   no switchport
+   ip address 192.0.2.10/31
+   pim ipv4 sparse-mode
 !
 interface Port-Channel100
    logging event link-status

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
@@ -423,6 +423,7 @@ interface Port-Channel99
    no switchport
    ip address 192.0.2.10/31
    pim ipv4 sparse-mode
+   pim ipv4 dr-priority 200
 !
 interface Port-Channel100
    logging event link-status

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
@@ -292,6 +292,7 @@ interface Vlan4094
    ip address 169.254.252.0/31
    ipv6 address fe80::a/64 link-local
    pim ipv4 sparse-mode
+   pim ipv4 dr-priority 200
 ```
 
 # Routing

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
@@ -83,6 +83,7 @@ interface Ethernet5
    isis authentication mode md5
    isis authentication key 7 asfddja23452
    pim ipv4 sparse-mode
+   pim ipv4 dr-priority 200
 !
 interface Ethernet6
    description SRV-POD02_Eth1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
@@ -134,6 +134,7 @@ interface Port-Channel99
    no switchport
    ip address 192.0.2.10/31
    pim ipv4 sparse-mode
+   pim ipv4 dr-priority 200
 !
 interface Port-Channel100
    logging event link-status

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
@@ -129,6 +129,12 @@ interface Port-Channel51
    switchport mode trunk
    ipv6 nd prefix a1::/64 infinite infinite no-autoconfig
 !
+interface Port-Channel99
+   description MCAST
+   no switchport
+   ip address 192.0.2.10/31
+   pim ipv4 sparse-mode
+!
 interface Port-Channel100
    logging event link-status
    no switchport

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
@@ -164,5 +164,6 @@ interface Vlan4094
    ip address 169.254.252.0/31
    ipv6 address fe80::a/64 link-local
    pim ipv4 sparse-mode
+   pim ipv4 dr-priority 200
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
@@ -112,6 +112,7 @@ ethernet_interfaces:
         key: "asfddja23452"
     pim:
       ipv4:
+        dr_priority: 200
         sparse_mode: true
     isis_enable: ISIS_TEST
     isis_passive: false

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
@@ -167,6 +167,15 @@ port_channel_interfaces:
       pbr:
         input: MyPolicy
 
+  Port-Channel99:
+    description: MCAST
+    type: routed
+    ip_address: 192.0.2.10/31
+    pim:
+      ipv4:
+        dr_priority: 200
+        sparse_mode: true
+
   Port-Channel101:
     description: PVLAN Promiscuous Access - only one secondary
     mode: access

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
@@ -90,6 +90,7 @@ vlan_interfaces:
     mtu: 9214
     pim:
       ipv4:
+        dr_priority: 200
         sparse_mode: true
 
 # Helpers on SVI

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -894,6 +894,7 @@ ethernet_interfaces:
         key: "< encrypted_password >"
     pim:
       ipv4:
+        dr_priority: < 0-429467295 >
         sparse_mode: < true | false >
     mac_security:
       profile: < profile >
@@ -1295,6 +1296,7 @@ port_channel_interfaces:
     mac_access_group_out: < mac_access_list_name >
     pim:
       ipv4:
+        dr_priority: < 0-429467295 >
         sparse_mode: < true | false >
     service_profile: < qos_profile >
     ospf_network_point_to_point: < true | false >
@@ -1371,6 +1373,7 @@ vlan_interfaces:
         key: "< encrypted_password >"
     pim:
       ipv4:
+        dr_priority: < 0-429467295 >
         sparse_mode: < true | false >
         local_interface: < local_interface_name >
     ipv6_virtual_router_address: < IPv6_address >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -349,6 +349,9 @@ interface {{ ethernet_interface }}
 {%         if ethernet_interfaces[ethernet_interface].pim.ipv4.sparse_mode is arista.avd.defined(true) %}
    pim ipv4 sparse-mode
 {%         endif %}
+{%         if ethernet_interfaces[ethernet_interface].pim.ipv4.dr_priority is arista.avd.defined %}
+   pim ipv4 dr-priority {{ ethernet_interfaces[ethernet_interface].pim.ipv4.dr_priority }}
+{%         endif %}
 {%         if ethernet_interfaces[ethernet_interface].vmtracer is arista.avd.defined(true) %}
    vmtracer vmware-esx
 {%         endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
@@ -267,10 +267,10 @@ interface {{ port_channel_interface }}
    ip ospf message-digest-key {{ ospf_message_digest_key }} {{ port_channel_interfaces[port_channel_interface].ospf_message_digest_keys[ospf_message_digest_key].hash_algorithm }} 7 {{ port_channel_interfaces[port_channel_interface].ospf_message_digest_keys[ospf_message_digest_key].key }}
 {%         endif %}
 {%     endfor %}
-{%     if port_channel_interfaces[port_channel_interface].pim.ipv4.sparse_mode is arista.avd.defined %}
+{%     if port_channel_interfaces[port_channel_interface].pim.ipv4.sparse_mode is arista.avd.defined(true) %}
    pim ipv4 sparse-mode
 {%     endif %}
-{%     if port_channel_interfaces[port_channel_interface].pim.ipv4.dr_priority is arista.avd.defined(true) %}
+{%     if port_channel_interfaces[port_channel_interface].pim.ipv4.dr_priority is arista.avd.defined %}
    pim ipv4 dr-priority {{ port_channel_interfaces[port_channel_interface].pim.ipv4.dr_priority }}
 {%     endif %}
 {%     if port_channel_interfaces[port_channel_interface].vmtracer is arista.avd.defined(true) %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
@@ -267,8 +267,11 @@ interface {{ port_channel_interface }}
    ip ospf message-digest-key {{ ospf_message_digest_key }} {{ port_channel_interfaces[port_channel_interface].ospf_message_digest_keys[ospf_message_digest_key].hash_algorithm }} 7 {{ port_channel_interfaces[port_channel_interface].ospf_message_digest_keys[ospf_message_digest_key].key }}
 {%         endif %}
 {%     endfor %}
-{%     if port_channel_interfaces[port_channel_interface].pim.ipv4.sparse_mode is arista.avd.defined(true) %}
+{%     if port_channel_interfaces[port_channel_interface].pim.ipv4.sparse_mode is arista.avd.defined %}
    pim ipv4 sparse-mode
+{%     endif %}
+{%     if port_channel_interfaces[port_channel_interface].pim.ipv4.dr_priority is arista.avd.defined(true) %}
+   pim ipv4 dr-priority {{ port_channel_interfaces[port_channel_interface].pim.ipv4.dr_priority }}
 {%     endif %}
 {%     if port_channel_interfaces[port_channel_interface].vmtracer is arista.avd.defined(true) %}
    vmtracer vmware-esx

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
@@ -148,6 +148,9 @@ interface {{ vlan_interface }}
 {%     if vlan_interfaces[vlan_interface].pim.ipv4.sparse_mode is arista.avd.defined(true) %}
    pim ipv4 sparse-mode
 {%     endif %}
+{%     if vlan_interfaces[vlan_interface].pim.ipv4.dr_priority is arista.avd.defined %}
+   pim ipv4 dr-priority {{ vlan_interfaces[vlan_interface].pim.ipv4.dr_priority }}
+{%     endif %}
 {%     if vlan_interfaces[vlan_interface].pim.ipv4.local_interface is arista.avd.defined %}
    pim ipv4 local-interface {{ vlan_interfaces[vlan_interface].pim.ipv4.local_interface }}
 {%     endif %}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->

## Related Issue(s)

Fixes #1552

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Introduces a new key and templates (see linked issue):

```yaml
ethernet_interfaces:
  Ethernet1:
    pim:
      ipv4:
        dr_priority:  <0-429467295>
port_channel_interfaces:
  Port-Channel1:
    pim:
      ipv4:
        dr_priority:  <0-429467295>
vlan_interfaces:
  Vlan100:
    pim:
      ipv4:
        dr_priority:  <0-429467295>
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been rebased from devel before I start
- [X] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
