### PR TITLE
Feat(eos_cli_config_gen): Support Unicast and Multicast TX queues in qos profiles

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/qos.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/qos.md
@@ -357,9 +357,9 @@ QOS Profile: **experiment**
 | ----------- | ------------ | ----- | ---------- | ------------------ |
 | 2 | - | cos | - | test_qos_policy_v1 |
 
-**Tx-queues**
+**tx-queues**
 
-| Tx-queue | Bandwidth | Priority | Shape Rate |
+| tx-queue | Bandwidth | Priority | Shape Rate |
 | -------- | --------- | -------- | ---------- |
 | 3 | 30 | no priority | - |
 | 4 | 10 | - | - |
@@ -382,9 +382,9 @@ QOS Profile: **qprof_testwithpolicy**
 | ----------- | ------------ | ----- | ---------- | ------------------ |
 | - | - | - | - | pmap_test1 |
 
-**Tx-queues**
+**tx-queues**
 
-| Tx-queue | Bandwidth | Priority | Shape Rate |
+| tx-queue | Bandwidth | Priority | Shape Rate |
 | -------- | --------- | -------- | ---------- |
 | 0 | 1 | - | - |
 | 1 | 80 | - | - |
@@ -398,10 +398,34 @@ QOS Profile: **test**
 | ----------- | ------------ | ----- | ---------- | ------------------ |
 | - | 46 | dscp | 80 percent | - |
 
-**Tx-queues**
+**tx-queues**
 
-| Tx-queue | Bandwidth | Priority | Shape Rate |
+| tx-queue | Bandwidth | Priority | Shape Rate |
 | -------- | --------- | -------- | ---------- |
+| 1 | 50 | no priority | - |
+| 2 | 10 | priority strict | - |
+| 4 | 10 | - | - |
+
+QOS Profile: **uc_mc_queues_test**
+
+**Settings**
+
+| Default COS | Default DSCP | Trust | Shape Rate | QOS Service Policy |
+| ----------- | ------------ | ----- | ---------- | ------------------ |
+| - | - | - | - | - |
+
+**uc-tx-queues**
+
+| uc-tx-queue | Bandwidth | Priority | Shape Rate |
+| ----------- | --------- | -------- | ---------- |
+| 1 | 50 | no priority | - |
+| 2 | 10 | priority strict | - |
+| 4 | 10 | - | - |
+
+**mc-tx-queues**
+
+| mc-tx-queue | Bandwidth | Priority | Shape Rate |
+| ----------- | --------- | -------- | ---------- |
 | 1 | 50 | no priority | - |
 | 2 | 10 | priority strict | - |
 | 4 | 10 | - | - |
@@ -461,6 +485,30 @@ qos profile test
       priority strict
    !
    tx-queue 4
+      bandwidth guaranteed percent 10
+!
+qos profile uc_mc_queues_test
+   !
+   uc-tx-queue 1
+      bandwidth percent 50
+      no priority
+   !
+   uc-tx-queue 2
+      bandwidth percent 10
+      priority strict
+   !
+   uc-tx-queue 4
+      bandwidth guaranteed percent 10
+   !
+   mc-tx-queue 1
+      bandwidth percent 50
+      no priority
+   !
+   mc-tx-queue 2
+      bandwidth percent 10
+      priority strict
+   !
+   mc-tx-queue 4
       bandwidth guaranteed percent 10
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/qos.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/qos.md
@@ -357,14 +357,14 @@ QOS Profile: **experiment**
 | ----------- | ------------ | ----- | ---------- | ------------------ |
 | 2 | - | cos | - | test_qos_policy_v1 |
 
-**tx-queues**
+**TX Queues**
 
-| tx-queue | Bandwidth | Priority | Shape Rate |
-| -------- | --------- | -------- | ---------- |
-| 3 | 30 | no priority | - |
-| 4 | 10 | - | - |
-| 5 | 40 | - | - |
-| 7 | 30 | - | 40 percent |
+| TX queue | Type | Bandwidth | Priority | Shape Rate |
+| -------- | ---- | --------- | -------- | ---------- |
+| 3 | All | 30 | no priority | - |
+| 4 | All | 10 | - | - |
+| 5 | All | 40 | - | - |
+| 7 | All | 30 | - | 40 percent |
 
 QOS Profile: **no_qos_trust**
 
@@ -382,13 +382,13 @@ QOS Profile: **qprof_testwithpolicy**
 | ----------- | ------------ | ----- | ---------- | ------------------ |
 | - | - | - | - | pmap_test1 |
 
-**tx-queues**
+**TX Queues**
 
-| tx-queue | Bandwidth | Priority | Shape Rate |
-| -------- | --------- | -------- | ---------- |
-| 0 | 1 | - | - |
-| 1 | 80 | - | - |
-| 5 | 19 | no priority | - |
+| TX queue | Type | Bandwidth | Priority | Shape Rate |
+| -------- | ---- | --------- | -------- | ---------- |
+| 0 | All | 1 | - | - |
+| 1 | All | 80 | - | - |
+| 5 | All | 19 | no priority | - |
 
 QOS Profile: **test**
 
@@ -398,13 +398,13 @@ QOS Profile: **test**
 | ----------- | ------------ | ----- | ---------- | ------------------ |
 | - | 46 | dscp | 80 percent | - |
 
-**tx-queues**
+**TX Queues**
 
-| tx-queue | Bandwidth | Priority | Shape Rate |
-| -------- | --------- | -------- | ---------- |
-| 1 | 50 | no priority | - |
-| 2 | 10 | priority strict | - |
-| 4 | 10 | - | - |
+| TX queue | Type | Bandwidth | Priority | Shape Rate |
+| -------- | ---- | --------- | -------- | ---------- |
+| 1 | All | 50 | no priority | - |
+| 2 | All | 10 | priority strict | - |
+| 4 | All | 10 | - | - |
 
 QOS Profile: **uc_mc_queues_test**
 
@@ -414,21 +414,16 @@ QOS Profile: **uc_mc_queues_test**
 | ----------- | ------------ | ----- | ---------- | ------------------ |
 | - | - | - | - | - |
 
-**uc-tx-queues**
+**TX Queues**
 
-| uc-tx-queue | Bandwidth | Priority | Shape Rate |
-| ----------- | --------- | -------- | ---------- |
-| 1 | 50 | no priority | - |
-| 2 | 10 | priority strict | - |
-| 4 | 10 | - | - |
-
-**mc-tx-queues**
-
-| mc-tx-queue | Bandwidth | Priority | Shape Rate |
-| ----------- | --------- | -------- | ---------- |
-| 1 | 50 | no priority | - |
-| 2 | 10 | priority strict | - |
-| 4 | 10 | - | - |
+| TX queue | Type | Bandwidth | Priority | Shape Rate |
+| -------- | ---- | --------- | -------- | ---------- |
+| 1 | Unicast | 50 | no priority | - |
+| 2 | Unicast | 10 | priority strict | - |
+| 4 | Unicast | 10 | - | - |
+| 1 | Multicast | 50 | no priority | - |
+| 2 | Multicast | 10 | priority strict | - |
+| 4 | Multicast | 10 | - | - |
 
 ### QOS Profile Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/qos.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/qos.cfg
@@ -57,6 +57,30 @@ qos profile test
    tx-queue 4
       bandwidth guaranteed percent 10
 !
+qos profile uc_mc_queues_test
+   !
+   uc-tx-queue 1
+      bandwidth percent 50
+      no priority
+   !
+   uc-tx-queue 2
+      bandwidth percent 10
+      priority strict
+   !
+   uc-tx-queue 4
+      bandwidth guaranteed percent 10
+   !
+   mc-tx-queue 1
+      bandwidth percent 50
+      no priority
+   !
+   mc-tx-queue 2
+      bandwidth percent 10
+      priority strict
+   !
+   mc-tx-queue 4
+      bandwidth guaranteed percent 10
+!
 no aaa root
 no enable password
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/qos.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/qos.yml
@@ -63,6 +63,25 @@ qos_profiles:
         bandwidth_percent: 80
       0:
         bandwidth_percent: 1
+  uc_mc_queues_test:
+    uc_tx_queues:
+      1:
+        bandwidth_percent: 50
+        priority: 'no priority'
+      2:
+        bandwidth_percent: 10
+        priority: 'priority strict'
+      4:
+        bandwidth_guaranteed_percent: 10
+    mc_tx_queues:
+      1:
+        bandwidth_percent: 50
+        priority: 'no priority'
+      2:
+        bandwidth_percent: 10
+        priority: 'priority strict'
+      4:
+        bandwidth_guaranteed_percent: 10
 
 policy_maps:
   qos:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/qos.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/qos.md
@@ -357,9 +357,9 @@ QOS Profile: **experiment**
 | ----------- | ------------ | ----- | ---------- | ------------------ |
 | 2 | - | cos | - | test_qos_policy_v1 |
 
-**Tx-queues**
+**tx-queues**
 
-| Tx-queue | Bandwidth | Priority | Shape Rate |
+| tx-queue | Bandwidth | Priority | Shape Rate |
 | -------- | --------- | -------- | ---------- |
 | 3 | 30 | no priority | - |
 | 4 | 10 | - | - |
@@ -382,9 +382,9 @@ QOS Profile: **qprof_testwithpolicy**
 | ----------- | ------------ | ----- | ---------- | ------------------ |
 | - | - | - | - | pmap_test1 |
 
-**Tx-queues**
+**tx-queues**
 
-| Tx-queue | Bandwidth | Priority | Shape Rate |
+| tx-queue | Bandwidth | Priority | Shape Rate |
 | -------- | --------- | -------- | ---------- |
 | 0 | 1 | - | - |
 | 1 | 80 | - | - |
@@ -398,10 +398,34 @@ QOS Profile: **test**
 | ----------- | ------------ | ----- | ---------- | ------------------ |
 | - | 46 | dscp | 80 percent | - |
 
-**Tx-queues**
+**tx-queues**
 
-| Tx-queue | Bandwidth | Priority | Shape Rate |
+| tx-queue | Bandwidth | Priority | Shape Rate |
 | -------- | --------- | -------- | ---------- |
+| 1 | 50 | no priority | - |
+| 2 | 10 | priority strict | - |
+| 4 | 10 | - | - |
+
+QOS Profile: **uc_mc_queues_test**
+
+**Settings**
+
+| Default COS | Default DSCP | Trust | Shape Rate | QOS Service Policy |
+| ----------- | ------------ | ----- | ---------- | ------------------ |
+| - | - | - | - | - |
+
+**uc-tx-queues**
+
+| uc-tx-queue | Bandwidth | Priority | Shape Rate |
+| ----------- | --------- | -------- | ---------- |
+| 1 | 50 | no priority | - |
+| 2 | 10 | priority strict | - |
+| 4 | 10 | - | - |
+
+**mc-tx-queues**
+
+| mc-tx-queue | Bandwidth | Priority | Shape Rate |
+| ----------- | --------- | -------- | ---------- |
 | 1 | 50 | no priority | - |
 | 2 | 10 | priority strict | - |
 | 4 | 10 | - | - |
@@ -461,6 +485,30 @@ qos profile test
       priority strict
    !
    tx-queue 4
+      bandwidth guaranteed percent 10
+!
+qos profile uc_mc_queues_test
+   !
+   uc-tx-queue 1
+      bandwidth percent 50
+      no priority
+   !
+   uc-tx-queue 2
+      bandwidth percent 10
+      priority strict
+   !
+   uc-tx-queue 4
+      bandwidth guaranteed percent 10
+   !
+   mc-tx-queue 1
+      bandwidth percent 50
+      no priority
+   !
+   mc-tx-queue 2
+      bandwidth percent 10
+      priority strict
+   !
+   mc-tx-queue 4
       bandwidth guaranteed percent 10
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/qos.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/qos.md
@@ -357,14 +357,14 @@ QOS Profile: **experiment**
 | ----------- | ------------ | ----- | ---------- | ------------------ |
 | 2 | - | cos | - | test_qos_policy_v1 |
 
-**tx-queues**
+**TX Queues**
 
-| tx-queue | Bandwidth | Priority | Shape Rate |
-| -------- | --------- | -------- | ---------- |
-| 3 | 30 | no priority | - |
-| 4 | 10 | - | - |
-| 5 | 40 | - | - |
-| 7 | 30 | - | 40 percent |
+| TX queue | Type | Bandwidth | Priority | Shape Rate |
+| -------- | ---- | --------- | -------- | ---------- |
+| 3 | All | 30 | no priority | - |
+| 4 | All | 10 | - | - |
+| 5 | All | 40 | - | - |
+| 7 | All | 30 | - | 40 percent |
 
 QOS Profile: **no_qos_trust**
 
@@ -382,13 +382,13 @@ QOS Profile: **qprof_testwithpolicy**
 | ----------- | ------------ | ----- | ---------- | ------------------ |
 | - | - | - | - | pmap_test1 |
 
-**tx-queues**
+**TX Queues**
 
-| tx-queue | Bandwidth | Priority | Shape Rate |
-| -------- | --------- | -------- | ---------- |
-| 0 | 1 | - | - |
-| 1 | 80 | - | - |
-| 5 | 19 | no priority | - |
+| TX queue | Type | Bandwidth | Priority | Shape Rate |
+| -------- | ---- | --------- | -------- | ---------- |
+| 0 | All | 1 | - | - |
+| 1 | All | 80 | - | - |
+| 5 | All | 19 | no priority | - |
 
 QOS Profile: **test**
 
@@ -398,13 +398,13 @@ QOS Profile: **test**
 | ----------- | ------------ | ----- | ---------- | ------------------ |
 | - | 46 | dscp | 80 percent | - |
 
-**tx-queues**
+**TX Queues**
 
-| tx-queue | Bandwidth | Priority | Shape Rate |
-| -------- | --------- | -------- | ---------- |
-| 1 | 50 | no priority | - |
-| 2 | 10 | priority strict | - |
-| 4 | 10 | - | - |
+| TX queue | Type | Bandwidth | Priority | Shape Rate |
+| -------- | ---- | --------- | -------- | ---------- |
+| 1 | All | 50 | no priority | - |
+| 2 | All | 10 | priority strict | - |
+| 4 | All | 10 | - | - |
 
 QOS Profile: **uc_mc_queues_test**
 
@@ -414,21 +414,16 @@ QOS Profile: **uc_mc_queues_test**
 | ----------- | ------------ | ----- | ---------- | ------------------ |
 | - | - | - | - | - |
 
-**uc-tx-queues**
+**TX Queues**
 
-| uc-tx-queue | Bandwidth | Priority | Shape Rate |
-| ----------- | --------- | -------- | ---------- |
-| 1 | 50 | no priority | - |
-| 2 | 10 | priority strict | - |
-| 4 | 10 | - | - |
-
-**mc-tx-queues**
-
-| mc-tx-queue | Bandwidth | Priority | Shape Rate |
-| ----------- | --------- | -------- | ---------- |
-| 1 | 50 | no priority | - |
-| 2 | 10 | priority strict | - |
-| 4 | 10 | - | - |
+| TX queue | Type | Bandwidth | Priority | Shape Rate |
+| -------- | ---- | --------- | -------- | ---------- |
+| 1 | Unicast | 50 | no priority | - |
+| 2 | Unicast | 10 | priority strict | - |
+| 4 | Unicast | 10 | - | - |
+| 1 | Multicast | 50 | no priority | - |
+| 2 | Multicast | 10 | priority strict | - |
+| 4 | Multicast | 10 | - | - |
 
 ### QOS Profile Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/qos.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/qos.cfg
@@ -57,6 +57,30 @@ qos profile test
    tx-queue 4
       bandwidth guaranteed percent 10
 !
+qos profile uc_mc_queues_test
+   !
+   uc-tx-queue 1
+      bandwidth percent 50
+      no priority
+   !
+   uc-tx-queue 2
+      bandwidth percent 10
+      priority strict
+   !
+   uc-tx-queue 4
+      bandwidth guaranteed percent 10
+   !
+   mc-tx-queue 1
+      bandwidth percent 50
+      no priority
+   !
+   mc-tx-queue 2
+      bandwidth percent 10
+      priority strict
+   !
+   mc-tx-queue 4
+      bandwidth guaranteed percent 10
+!
 no aaa root
 no enable password
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/qos.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/qos.yml
@@ -63,6 +63,25 @@ qos_profiles:
         bandwidth_percent: 80
       0:
         bandwidth_percent: 1
+  uc_mc_queues_test:
+    uc_tx_queues:
+      1:
+        bandwidth_percent: 50
+        priority: 'no priority'
+      2:
+        bandwidth_percent: 10
+        priority: 'priority strict'
+      4:
+        bandwidth_guaranteed_percent: 10
+    mc_tx_queues:
+      1:
+        bandwidth_percent: 50
+        priority: 'no priority'
+      2:
+        bandwidth_percent: 10
+        priority: 'priority strict'
+      4:
+        bandwidth_guaranteed_percent: 10
 
 policy_maps:
   qos:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -2407,6 +2407,7 @@ policy_maps:
 #### QOS Profiles
 
 ```yaml
+# The below knobs are platform dependent
 qos_profiles:
   < profile-1 >:
     trust: < dscp | cos | disabled >
@@ -2420,14 +2421,27 @@ qos_profiles:
     tx_queues:
       < tx-queue-id >:
         bandwidth_percent: < value >
-        # The below knob is platform dependent
         bandwidth_guaranteed_percent: < value >
-        priority: < string >
+        priority: < "priority strict" | "no priority" >
         shape:
           rate: < "< rate > kbps" | "1-100 percent" | "< rate > pps" , supported options are platform dependent >
       < tx-queue-id >:
         bandwidth_percent: < value >
-        priority: < string >
+        priority: < "priority strict" | "no priority" >
+        shape:
+          rate: < "< rate > kbps" | "1-100 percent" | "< rate > pps" , supported options are platform dependent >
+    uc_tx_queues:
+      < uc-tx-queue-id >:
+        bandwidth_percent: < value >
+        bandwidth_guaranteed_percent: < value >
+        priority: < "priority strict" | "no priority" >
+        shape:
+          rate: < "< rate > kbps" | "1-100 percent" | "< rate > pps" , supported options are platform dependent >
+    mc_tx_queues:
+      < mc-tx-queue-id >:
+        bandwidth_percent: < value >
+        bandwidth_guaranteed_percent: < value >
+        priority: < "priority strict" | "no priority" >
         shape:
           rate: < "< rate > kbps" | "1-100 percent" | "< rate > pps" , supported options are platform dependent >
   < profile-2 >:
@@ -2437,10 +2451,10 @@ qos_profiles:
     tx_queues:
       < tx-queue-id >:
         bandwidth_percent: < value >
-        priority: < string >
+        priority: < "priority strict" | "no priority" >
       < tx-queue-id >:
         bandwidth_percent: < value >
-        priority: < string >
+        priority: < "priority strict" | "no priority" >
 ```
 
 #### Queue Monitor Length

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -84,6 +84,7 @@
       - [IP HTTP Client Source Interfaces](#ip-http-client-source-interfaces)
       - [Management GNMI](#management-gnmi)
       - [Management Console](#management-console)
+      - [Management Defaults](#management-defaults)
       - [Management Security](#management-security)
       - [Management SSH](#management-ssh)
       - [IP SSH Client Source Interfaces](#ip-ssh-client-source-interfaces)

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/qos-profiles.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/qos-profiles.j2
@@ -18,53 +18,45 @@ QOS Profile: **{{ profile }}**
 {%         set shape_rate = qos_profiles[profile].shape.rate | arista.avd.default('-') %}
 {%         set qos_sp = qos_profiles[profile].service_policy.type.qos_input | arista.avd.default('-') %}
 | {{ cos }} | {{ dscp }} | {{ trust }} | {{ shape_rate }} | {{ qos_sp }} |
-{%         if qos_profiles[profile].tx_queues is arista.avd.defined %}
+{%         if qos_profiles[profile].tx_queues is arista.avd.defined or qos_profiles[profile].uc_tx_queues is arista.avd.defined or qos_profiles[profile].mc_tx_queues is arista.avd.defined %}
 
-**tx-queues**
+**TX Queues**
 
-| tx-queue | Bandwidth | Priority | Shape Rate |
-| -------- | --------- | -------- | ---------- |
-{%             for tx_queue in qos_profiles[profile].tx_queues | arista.avd.natural_sort %}
-{%                 set queue = qos_profiles[profile].tx_queues[tx_queue] | arista.avd.default('-') %}
-{%                 set bw_percent = qos_profiles[profile].tx_queues[tx_queue].bandwidth_percent | arista.avd.default(
-                                    qos_profiles[profile].tx_queues[tx_queue].bandwidth_guaranteed_percent,
+| TX queue | Type | Bandwidth | Priority | Shape Rate |
+| -------- | ---- | --------- | -------- | ---------- |
+{%             if qos_profiles[profile].tx_queues is arista.avd.defined %}
+{%                 for tx_queue in qos_profiles[profile].tx_queues | arista.avd.natural_sort %}
+{%                     set type = "All" %}
+{%                     set bw_percent = qos_profiles[profile].tx_queues[tx_queue].bandwidth_percent | arista.avd.default(
+                                        qos_profiles[profile].tx_queues[tx_queue].bandwidth_guaranteed_percent,
                                     '-') %}
-{%                 set priority = qos_profiles[profile].tx_queues[tx_queue].priority | arista.avd.default('-') %}
-{%                 set shape_rate = qos_profiles[profile].tx_queues[tx_queue].shape.rate | arista.avd.default('-') %}
-| {{ tx_queue }} | {{ bw_percent }} | {{ priority }} | {{ shape_rate }} |
-{%             endfor %}
-{%         endif %}
-{%         if qos_profiles[profile].uc_tx_queues is arista.avd.defined %}
-
-**uc-tx-queues**
-
-| uc-tx-queue | Bandwidth | Priority | Shape Rate |
-| ----------- | --------- | -------- | ---------- |
-{%             for uc_tx_queue in qos_profiles[profile].uc_tx_queues | arista.avd.natural_sort %}
-{%                 set queue = qos_profiles[profile].uc_tx_queues[uc_tx_queue] | arista.avd.default('-') %}
-{%                 set bw_percent = qos_profiles[profile].uc_tx_queues[uc_tx_queue].bandwidth_percent | arista.avd.default(
-                                    qos_profiles[profile].uc_tx_queues[uc_tx_queue].bandwidth_guaranteed_percent,
-                                    '-') %}
-{%                 set priority = qos_profiles[profile].uc_tx_queues[uc_tx_queue].priority | arista.avd.default('-') %}
-{%                 set shape_rate = qos_profiles[profile].uc_tx_queues[uc_tx_queue].shape.rate | arista.avd.default('-') %}
-| {{ uc_tx_queue }} | {{ bw_percent }} | {{ priority }} | {{ shape_rate }} |
-{%             endfor %}
-{%         endif %}
-{%         if qos_profiles[profile].mc_tx_queues is arista.avd.defined %}
-
-**mc-tx-queues**
-
-| mc-tx-queue | Bandwidth | Priority | Shape Rate |
-| ----------- | --------- | -------- | ---------- |
-{%             for mc_tx_queue in qos_profiles[profile].mc_tx_queues | arista.avd.natural_sort %}
-{%                 set queue = qos_profiles[profile].mc_tx_queues[mc_tx_queue] | arista.avd.default('-') %}
-{%                 set bw_percent = qos_profiles[profile].mc_tx_queues[mc_tx_queue].bandwidth_percent | arista.avd.default(
-                                    qos_profiles[profile].mc_tx_queues[mc_tx_queue].bandwidth_guaranteed_percent,
-                                    '-') %}
-{%                 set priority = qos_profiles[profile].mc_tx_queues[mc_tx_queue].priority | arista.avd.default('-') %}
-{%                 set shape_rate = qos_profiles[profile].mc_tx_queues[mc_tx_queue].shape.rate | arista.avd.default('-') %}
-| {{ mc_tx_queue }} | {{ bw_percent }} | {{ priority }} | {{ shape_rate }} |
-{%             endfor %}
+{%                     set priority = qos_profiles[profile].tx_queues[tx_queue].priority | arista.avd.default('-') %}
+{%                     set shape_rate = qos_profiles[profile].tx_queues[tx_queue].shape.rate | arista.avd.default('-') %}
+| {{ tx_queue }} | {{ type }} | {{ bw_percent }} | {{ priority }} | {{ shape_rate }} |
+{%                 endfor %}
+{%             endif %}
+{%             if qos_profiles[profile].uc_tx_queues is arista.avd.defined %}
+{%                 for uc_tx_queue in qos_profiles[profile].uc_tx_queues | arista.avd.natural_sort %}
+{%                     set type = "Unicast" %}
+{%                     set bw_percent = qos_profiles[profile].uc_tx_queues[uc_tx_queue].bandwidth_percent | arista.avd.default(
+                                        qos_profiles[profile].uc_tx_queues[uc_tx_queue].bandwidth_guaranteed_percent,
+                                        '-') %}
+{%                     set priority = qos_profiles[profile].uc_tx_queues[uc_tx_queue].priority | arista.avd.default('-') %}
+{%                     set shape_rate = qos_profiles[profile].uc_tx_queues[uc_tx_queue].shape.rate | arista.avd.default('-') %}
+| {{ uc_tx_queue }} | {{ type }} | {{ bw_percent }} | {{ priority }} | {{ shape_rate }} |
+{%                 endfor %}
+{%             endif %}
+{%             if qos_profiles[profile].mc_tx_queues is arista.avd.defined %}
+{%                 for mc_tx_queue in qos_profiles[profile].mc_tx_queues | arista.avd.natural_sort %}
+{%                     set type = "Multicast" %}
+{%                     set bw_percent = qos_profiles[profile].mc_tx_queues[mc_tx_queue].bandwidth_percent | arista.avd.default(
+                                        qos_profiles[profile].mc_tx_queues[mc_tx_queue].bandwidth_guaranteed_percent,
+                                        '-') %}
+{%                     set priority = qos_profiles[profile].mc_tx_queues[mc_tx_queue].priority | arista.avd.default('-') %}
+{%                     set shape_rate = qos_profiles[profile].mc_tx_queues[mc_tx_queue].shape.rate | arista.avd.default('-') %}
+| {{ mc_tx_queue }} | {{ type }} | {{ bw_percent }} | {{ priority }} | {{ shape_rate }} |
+{%                 endfor %}
+{%             endif %}
 {%         endif %}
 {%     endfor %}
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/qos-profiles.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/qos-profiles.j2
@@ -20,9 +20,9 @@ QOS Profile: **{{ profile }}**
 | {{ cos }} | {{ dscp }} | {{ trust }} | {{ shape_rate }} | {{ qos_sp }} |
 {%         if qos_profiles[profile].tx_queues is arista.avd.defined %}
 
-**Tx-queues**
+**tx-queues**
 
-| Tx-queue | Bandwidth | Priority | Shape Rate |
+| tx-queue | Bandwidth | Priority | Shape Rate |
 | -------- | --------- | -------- | ---------- |
 {%             for tx_queue in qos_profiles[profile].tx_queues | arista.avd.natural_sort %}
 {%                 set queue = qos_profiles[profile].tx_queues[tx_queue] | arista.avd.default('-') %}
@@ -32,6 +32,38 @@ QOS Profile: **{{ profile }}**
 {%                 set priority = qos_profiles[profile].tx_queues[tx_queue].priority | arista.avd.default('-') %}
 {%                 set shape_rate = qos_profiles[profile].tx_queues[tx_queue].shape.rate | arista.avd.default('-') %}
 | {{ tx_queue }} | {{ bw_percent }} | {{ priority }} | {{ shape_rate }} |
+{%             endfor %}
+{%         endif %}
+{%         if qos_profiles[profile].uc_tx_queues is arista.avd.defined %}
+
+**uc-tx-queues**
+
+| uc-tx-queue | Bandwidth | Priority | Shape Rate |
+| ----------- | --------- | -------- | ---------- |
+{%             for uc_tx_queue in qos_profiles[profile].uc_tx_queues | arista.avd.natural_sort %}
+{%                 set queue = qos_profiles[profile].uc_tx_queues[uc_tx_queue] | arista.avd.default('-') %}
+{%                 set bw_percent = qos_profiles[profile].uc_tx_queues[uc_tx_queue].bandwidth_percent | arista.avd.default(
+                                    qos_profiles[profile].uc_tx_queues[uc_tx_queue].bandwidth_guaranteed_percent,
+                                    '-') %}
+{%                 set priority = qos_profiles[profile].uc_tx_queues[uc_tx_queue].priority | arista.avd.default('-') %}
+{%                 set shape_rate = qos_profiles[profile].uc_tx_queues[uc_tx_queue].shape.rate | arista.avd.default('-') %}
+| {{ uc_tx_queue }} | {{ bw_percent }} | {{ priority }} | {{ shape_rate }} |
+{%             endfor %}
+{%         endif %}
+{%         if qos_profiles[profile].mc_tx_queues is arista.avd.defined %}
+
+**mc-tx-queues**
+
+| mc-tx-queue | Bandwidth | Priority | Shape Rate |
+| ----------- | --------- | -------- | ---------- |
+{%             for mc_tx_queue in qos_profiles[profile].mc_tx_queues | arista.avd.natural_sort %}
+{%                 set queue = qos_profiles[profile].mc_tx_queues[mc_tx_queue] | arista.avd.default('-') %}
+{%                 set bw_percent = qos_profiles[profile].mc_tx_queues[mc_tx_queue].bandwidth_percent | arista.avd.default(
+                                    qos_profiles[profile].mc_tx_queues[mc_tx_queue].bandwidth_guaranteed_percent,
+                                    '-') %}
+{%                 set priority = qos_profiles[profile].mc_tx_queues[mc_tx_queue].priority | arista.avd.default('-') %}
+{%                 set shape_rate = qos_profiles[profile].mc_tx_queues[mc_tx_queue].shape.rate | arista.avd.default('-') %}
+| {{ mc_tx_queue }} | {{ bw_percent }} | {{ priority }} | {{ shape_rate }} |
 {%             endfor %}
 {%         endif %}
 {%     endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/qos-profiles.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/qos-profiles.j2
@@ -18,7 +18,9 @@ QOS Profile: **{{ profile }}**
 {%         set shape_rate = qos_profiles[profile].shape.rate | arista.avd.default('-') %}
 {%         set qos_sp = qos_profiles[profile].service_policy.type.qos_input | arista.avd.default('-') %}
 | {{ cos }} | {{ dscp }} | {{ trust }} | {{ shape_rate }} | {{ qos_sp }} |
-{%         if qos_profiles[profile].tx_queues is arista.avd.defined or qos_profiles[profile].uc_tx_queues is arista.avd.defined or qos_profiles[profile].mc_tx_queues is arista.avd.defined %}
+{%         if qos_profiles[profile].tx_queues is arista.avd.defined or
+              qos_profiles[profile].uc_tx_queues is arista.avd.defined or
+              qos_profiles[profile].mc_tx_queues is arista.avd.defined %}
 
 **TX Queues**
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/qos-profiles.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/qos-profiles.j2
@@ -36,4 +36,34 @@ qos profile {{ profile }}
       shape rate {{ qos_profiles[profile].tx_queues[tx_queue].shape.rate }}
 {%         endif %}
 {%     endfor %}
+{%     for uc_tx_queue in qos_profiles[profile].uc_tx_queues | arista.avd.natural_sort %}
+   !
+   uc-tx-queue {{ uc_tx_queue }}
+{%         if qos_profiles[profile].uc_tx_queues[uc_tx_queue].bandwidth_percent is arista.avd.defined %}
+      bandwidth percent {{ qos_profiles[profile].uc_tx_queues[uc_tx_queue].bandwidth_percent }}
+{%         elif qos_profiles[profile].uc_tx_queues[uc_tx_queue].bandwidth_guaranteed_percent is arista.avd.defined %}
+      bandwidth guaranteed percent {{ qos_profiles[profile].uc_tx_queues[uc_tx_queue].bandwidth_guaranteed_percent }}
+{%         endif %}
+{%         if qos_profiles[profile].uc_tx_queues[uc_tx_queue].priority is arista.avd.defined %}
+      {{ qos_profiles[profile].uc_tx_queues[uc_tx_queue].priority }}
+{%         endif %}
+{%         if qos_profiles[profile].uc_tx_queues[uc_tx_queue].shape.rate is arista.avd.defined %}
+      shape rate {{ qos_profiles[profile].uc_tx_queues[uc_tx_queue].shape.rate }}
+{%         endif %}
+{%     endfor %}
+{%     for mc_tx_queue in qos_profiles[profile].mc_tx_queues | arista.avd.natural_sort %}
+   !
+   mc-tx-queue {{ mc_tx_queue }}
+{%         if qos_profiles[profile].mc_tx_queues[mc_tx_queue].bandwidth_percent is arista.avd.defined %}
+      bandwidth percent {{ qos_profiles[profile].mc_tx_queues[mc_tx_queue].bandwidth_percent }}
+{%         elif qos_profiles[profile].mc_tx_queues[mc_tx_queue].bandwidth_guaranteed_percent is arista.avd.defined %}
+      bandwidth guaranteed percent {{ qos_profiles[profile].mc_tx_queues[mc_tx_queue].bandwidth_guaranteed_percent }}
+{%         endif %}
+{%         if qos_profiles[profile].mc_tx_queues[mc_tx_queue].priority is arista.avd.defined %}
+      {{ qos_profiles[profile].mc_tx_queues[mc_tx_queue].priority }}
+{%         endif %}
+{%         if qos_profiles[profile].mc_tx_queues[mc_tx_queue].shape.rate is arista.avd.defined %}
+      shape rate {{ qos_profiles[profile].mc_tx_queues[mc_tx_queue].shape.rate }}
+{%         endif %}
+{%     endfor %}
 {% endfor %}


### PR DESCRIPTION
## Change Summary

- Add support  for "uc|mc"-tx-queue in qos profiles
- Fix description on priorioty
- Fix missing `Management Defaults` heading in README.md

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

```yaml
qos_profiles:
  < profile-1 >:
    uc_tx_queues:
      < uc-tx-queue-id >:
        bandwidth_percent: < value >
        bandwidth_guaranteed_percent: < value >
        priority: < "priority strict" | "no priority" >
        shape:
          rate: < "< rate > kbps" | "1-100 percent" | "< rate > pps" , supported options are platform dependent >
    mc_tx_queues:
      < mc-tx-queue-id >:
        bandwidth_percent: < value >
        bandwidth_guaranteed_percent: < value >
        priority: < "priority strict" | "no priority" >
        shape:
          rate: < "< rate > kbps" | "1-100 percent" | "< rate > pps" , supported options are platform dependent >
```

## How to test

See Molecule results

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
