### PR TITLE
Refactor(eos_cli_config_gen): Wildcard dict to list for `local_users`

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/aaa.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/aaa.yml
@@ -109,15 +109,15 @@ aaa_root:
 
 ### Local Users ###
 local_users:
-  admin:
+  - name: admin
     privilege: 15
     role: network-admin
     no_password: true
-  ansible:
+  - name: ansible
     privilege: 15
     role: network-admin
     sha512_password: $6$.I7/ZR/zlLIUv8fr$vR/JvLTbq5amMt6Y1SE4CKlPDv/AzJYlFYHkUZ17BDovm0Oi4aLdBULe1EmZ0Y9xKjVLMKpxCSKmlrAioDxbQ0
-  cvpadmin:
+  - name: cvpadmin
     privilege: 15
     role: network-admin
     sha512_password: $6$.I7/ZR/zlLIUv8fr$vR/JvLTbq5amMt6Y1SE4CKlPDv/AzJYlFYHkUZ17BDovm0Oi4aLdBULe1EmZ0Y9xKjVLMKpxCSKmlrAioDxbQ0

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
@@ -470,13 +470,13 @@ ip_tacacs_source_interfaces:
 
 ```yaml
 local_users:
-  < user_1 >:
+  - name: < user_1 >
     privilege: < 1-15 >
     role: < role >
     sha512_password: "< sha_512_password >"
     no_password: < true | do not configure a password for given username. sha512_password MUST not be defined for this user. >
     ssh_key: "< ssh_key_string >"
-  < user_2 >:
+  - name: < user_2 >
     privilege: < 1-15 >
     role: < role >
     sha512_password: "< sha_512_password >"

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/local-users.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/local-users.j2
@@ -1,5 +1,5 @@
 {# eos - local users #}
-{% if local_users is defined and local_users is not none %}
+{% if local_users is arista.avd.defined %}
 
 ## Local Users
 
@@ -7,8 +7,9 @@
 
 | User | Privilege | Role |
 | ---- | --------- | ---- |
-{%     for local_user in local_users | arista.avd.natural_sort %}
-| {{ local_user }} | {{ local_users[local_user].privilege }} | {% if local_users[local_user].role is defined %}{{ local_users[local_user].role }}{% else %} - {% endif %} |
+{%     for local_user in local_users | arista.avd.convert_dicts('name') |
+arista.avd.natural_sort('name') %}
+| {{ local_user }} | {{ local_user.privilege }} | {% if local_user.role is arista.avd.defined %}{{ local_user.role }}{% else %} - {% endif %} |
 {%     endfor %}
 
 ### Local Users Device Configuration

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/local-users.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/local-users.j2
@@ -7,9 +7,8 @@
 
 | User | Privilege | Role |
 | ---- | --------- | ---- |
-{%     for local_user in local_users | arista.avd.convert_dicts('name') |
-arista.avd.natural_sort('name') %}
-| {{ local_user }} | {{ local_user.privilege }} | {% if local_user.role is arista.avd.defined %}{{ local_user.role }}{% else %} - {% endif %} |
+{%     for local_user in local_users | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+| {{ local_user.name }} | {{ local_user.privilege }} | {% if local_user.role is arista.avd.defined %}{{ local_user.role }}{% else %} - {% endif %} |
 {%     endfor %}
 
 ### Local Users Device Configuration

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/local-users.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/local-users.j2
@@ -1,23 +1,24 @@
 {# eos - local users #}
 {% if local_users is arista.avd.defined %}
 !
-{%     for local_user in local_users | arista.avd.natural_sort %}
+{%     for local_user in local_users | arista.avd.convert_dicts('name') |
+arista.avd.natural_sort('name') %}
 {%         set local_user_cli = "username " ~ local_user %}
-{%         if local_users[local_user].privilege is arista.avd.defined %}
-{%             set local_user_cli = local_user_cli ~ " privilege " ~ local_users[local_user].privilege %}
+{%         if local_user.privilege is arista.avd.defined %}
+{%             set local_user_cli = local_user_cli ~ " privilege " ~ local_user.privilege %}
 {%         endif %}
-{%         if local_users[local_user].role is arista.avd.defined %}
-{%             set local_user_cli = local_user_cli ~ " role " ~ local_users[local_user].role %}
+{%         if local_user.role is arista.avd.defined %}
+{%             set local_user_cli = local_user_cli ~ " role " ~ local_user.role %}
 {%         endif %}
-{%         if local_users[local_user].sha512_password is arista.avd.defined %}
-{%             set local_user_cli = local_user_cli ~ " secret sha512 " ~ local_users[local_user].sha512_password %}
-{%         elif local_users[local_user].no_password is arista.avd.defined(true) %}
+{%         if local_user.sha512_password is arista.avd.defined %}
+{%             set local_user_cli = local_user_cli ~ " secret sha512 " ~ local_user.sha512_password %}
+{%         elif local_user.no_password is arista.avd.defined(true) %}
 {%             set local_user_cli = local_user_cli ~ " nopassword" %}
 {%         endif %}
 {{ local_user_cli }}
-{%         if local_users[local_user].ssh_key is arista.avd.defined %}
+{%         if local_user.ssh_key is arista.avd.defined %}
 {%             set local_ssh_key_cli = "username " ~ local_user %}
-{%             set local_ssh_key_cli = local_ssh_key_cli ~ " ssh-key " ~ local_users[local_user].ssh_key %}
+{%             set local_ssh_key_cli = local_ssh_key_cli ~ " ssh-key " ~ local_user.ssh_key %}
 {{ local_ssh_key_cli }}
 {%         endif %}
 {%     endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/local-users.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/local-users.j2
@@ -1,9 +1,8 @@
 {# eos - local users #}
 {% if local_users is arista.avd.defined %}
 !
-{%     for local_user in local_users | arista.avd.convert_dicts('name') |
-arista.avd.natural_sort('name') %}
-{%         set local_user_cli = "username " ~ local_user %}
+{%     for local_user in local_users | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%         set local_user_cli = "username " ~ local_user.name %}
 {%         if local_user.privilege is arista.avd.defined %}
 {%             set local_user_cli = local_user_cli ~ " privilege " ~ local_user.privilege %}
 {%         endif %}
@@ -17,7 +16,7 @@ arista.avd.natural_sort('name') %}
 {%         endif %}
 {{ local_user_cli }}
 {%         if local_user.ssh_key is arista.avd.defined %}
-{%             set local_ssh_key_cli = "username " ~ local_user %}
+{%             set local_ssh_key_cli = "username " ~ local_user.name %}
 {%             set local_ssh_key_cli = local_ssh_key_cli ~ " ssh-key " ~ local_user.ssh_key %}
 {{ local_ssh_key_cli }}
 {%         endif %}


### PR DESCRIPTION
## "Wildcard Keyed Dict" to "List of Dicts" Data model migration

## Data model key

`local_users`

## Checklist

### Contributor Checklist

- [x] Update `README_v4.0.md` with new data model
- [x] Update all `host_vars` under molecule scenario `eos_cli_config_gen_v4.0` with new data model
- [x] Update `templates/eos/local-users.j2` and `templates/documentation/local-users.j2`:
  - [x] Add `arista.avd.convert_dicts('name')` filter for loops previously using wildcard keys
  - [x] Update `arista.avd.natural_sort('name')` to sort on the primary key (if applicable)
- [x] Run molecule `cd ansible_collections/arista/avd ; molecule converge -s eos_cli_config_gen`
  - [x] Verify no changes to generated configs/docs
- [x] Run molecule `cd ansible_collections/arista/avd ; molecule converge -s eos_cli_config_gen_v4.0`
  - [x] Verify no changes to generated configs/docs

### Reviewer Checklist

- Reviewer 1 (@carlbuchmann ):
  - [x] Verify data model changes
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2:
  - [x] Verify data model changes
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
