### PR TITLE
Refactor(eos_cli_config_gen): Wildcard dict to list for `prefix_lists`

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/prefix-lists.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/prefix-lists.yml
@@ -1,16 +1,16 @@
 ### IPv4 Prefix-Lists ###
 prefix_lists:
-  PL-LOOPBACKS-EVPN-OVERLAY:
+  - name: PL-LOOPBACKS-EVPN-OVERLAY
     sequence_numbers:
-      10:
+      - sequence: 10
         action: "permit 192.168.255.0/24 eq 32"
-      20:
+      - sequence: 20
         action: "permit 192.168.254.0/24 eq 32"
 
 
 ### IPv6 Prefix-lists ###
 ipv6_prefix_lists:
-  PL-IPV6-LOOPBACKS:
+  - name: PL-IPV6-LOOPBACKS
     sequence_numbers:
-      10:
+      - sequence: 10
         action: permit 1b11:3a00:22b0:0082::/64 eq 128

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/router-bgp-vrf-lite.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/router-bgp-vrf-lite.yml
@@ -1,15 +1,15 @@
 prefix_lists:
-  PL-BGP-DEFAULT-BLUE-C1:
+  - name: PL-BGP-DEFAULT-BLUE-C1
     sequence_numbers:
-      10:
+      - sequence: 10
         action: permit 0.0.0.0/0 le 1
-  PL-BGP-DEFAULT-RED-OUT-C1:
+  - name: PL-BGP-DEFAULT-RED-OUT-C1
     sequence_numbers:
-      10:
+      - sequence: 10
         action: permit 10.0.0.0/8
-  PL-BGP-DEFAULT-RED-IN-C1:
+  - name: PL-BGP-DEFAULT-RED-IN-C1
     sequence_numbers:
-      10:
+      - sequence: 10
         action: permit 0.0.0.0/0
 
 route_maps:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
@@ -615,15 +615,15 @@ errdisable:
 
 ```yaml
 prefix_lists:
-  < prefix_list_name_1 >:
+  - name: < prefix_list_name_1 >
     sequence_numbers:
-      < sequence_id_1 >:
+      - sequence: < sequence_id_1 >
         action: "< action as string >"
-      < sequence_id_2 >:
+      - sequence: < sequence_id_2 >
         action: "< action as string >"
-  < prefix_list_name_2 >:
+  - name: < prefix_list_name_2 >
     sequence_numbers:
-      < sequence_id_1 >:
+      - sequence: < sequence_id_1 >
         action: "< action as string >"
 ```
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
@@ -631,15 +631,15 @@ prefix_lists:
 
 ```yaml
 ipv6_prefix_lists:
-  < ipv6_prefix_list_name_1 >:
+  - name: < ipv6_prefix_list_name_1 >
     sequence_numbers:
-      < sequence_id_1 >:
+      - sequence: < sequence_id_1 >
         action: "< action as string >"
-      < sequence_id_2 >:
+      - sequence: < sequence_id_2 >
         action: "< action as string >"
-  < ipv6_prefix_list_name_2 >:
+  - name: < ipv6_prefix_list_name_2 >
     sequence_numbers:
-      < sequence_id_1 >:
+      - sequence: < sequence_id_1 >
         action: "< action as string >"
 ```
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ipv6-prefix-lists.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ipv6-prefix-lists.j2
@@ -4,14 +4,12 @@
 
 ### IPv6 Prefix-lists Summary
 
-{%     for ipv6_prefix_list in ipv6_prefix_lists | arista.avd.convert_dicts('name') |
-arista.avd.natural_sort('name') %}
+{%     for ipv6_prefix_list in ipv6_prefix_lists | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
 #### {{ ipv6_prefix_list.name }}
 
 | Sequence | Action |
 | -------- | ------ |
-{%         for sequence in ipv6_prefix_list.sequence_numbers | arista.avd.convert_dicts('sequence') |
-arista.avd.natural_sort('sequence') %}
+{%         for sequence in ipv6_prefix_list.sequence_numbers | arista.avd.convert_dicts('sequence') | arista.avd.natural_sort('sequence') %}
 | {{ sequence.sequence }} | {{ sequence.action }} |
 {%         endfor %}
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ipv6-prefix-lists.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ipv6-prefix-lists.j2
@@ -1,16 +1,18 @@
-{% if ipv6_prefix_lists is defined and ipv6_prefix_lists is not none %}
+{% if ipv6_prefix_lists is arista.avd.defined %}
 
 ## IPv6 Prefix-lists
 
 ### IPv6 Prefix-lists Summary
 
-{%     for ipv6_prefix_list in ipv6_prefix_lists | arista.avd.natural_sort %}
-#### {{ ipv6_prefix_list }}
+{%     for ipv6_prefix_list in ipv6_prefix_lists | arista.avd.convert_dicts('name') |
+arista.avd.natural_sort('name') %}
+#### {{ ipv6_prefix_list.name }}
 
 | Sequence | Action |
 | -------- | ------ |
-{%         for sequence in ipv6_prefix_lists[ipv6_prefix_list].sequence_numbers | arista.avd.natural_sort %}
-| {{ sequence }} | {{ ipv6_prefix_lists[ipv6_prefix_list].sequence_numbers[sequence].action }} |
+{%         for sequence in ipv6_prefix_list.sequence_numbers | arista.avd.convert_dicts('sequence') |
+arista.avd.natural_sort('sequence') %}
+| {{ sequence.sequence }} | {{ sequence.action }} |
 {%         endfor %}
 
 {%     endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/prefix-lists.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/prefix-lists.j2
@@ -4,14 +4,12 @@
 
 ### Prefix-lists Summary
 
-{%     for prefix_list in prefix_lists | arista.avd.convert_dicts('name') |
-arista.avd.natural_sort('name') %}
+{%     for prefix_list in prefix_lists | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
 #### {{ prefix_list.name }}
 
 | Sequence | Action |
 | -------- | ------ |
-{%         for sequence in prefix_list.sequence_numbers | arista.avd.convert_dicts('sequence') |
-arista.avd.natural_sort('sequence') %}
+{%         for sequence in prefix_list.sequence_numbers | arista.avd.convert_dicts('sequence') | arista.avd.natural_sort('sequence') %}
 | {{ sequence.sequence }} | {{ sequence.action }} |
 {%         endfor %}
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/prefix-lists.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/prefix-lists.j2
@@ -1,16 +1,18 @@
-{% if prefix_lists is defined and prefix_lists is not none %}
+{% if prefix_lists is arista.avd.defined %}
 
 ## Prefix-lists
 
 ### Prefix-lists Summary
 
-{%     for prefix_list in prefix_lists | arista.avd.natural_sort %}
-#### {{ prefix_list }}
+{%     for prefix_list in prefix_lists | arista.avd.convert_dicts('name') |
+arista.avd.natural_sort('name') %}
+#### {{ prefix_list.name }}
 
 | Sequence | Action |
 | -------- | ------ |
-{%         for sequence in prefix_lists[prefix_list].sequence_numbers | arista.avd.natural_sort %}
-| {{ sequence }} | {{ prefix_lists[prefix_list].sequence_numbers[sequence].action }} |
+{%         for sequence in prefix_list.sequence_numbers | arista.avd.convert_dicts('sequence') |
+arista.avd.natural_sort('sequence') %}
+| {{ sequence.sequence }} | {{ sequence.action }} |
 {%         endfor %}
 
 {%     endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ipv6-prefix-lists.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ipv6-prefix-lists.j2
@@ -1,10 +1,8 @@
 {# eos - ipv6-prefix-lists #}
-{% for ipv6_prefix_list in ipv6_prefix_lists | arista.avd.convert_dicts('name') |
-arista.avd.natural_sort('name') %}
+{% for ipv6_prefix_list in ipv6_prefix_lists | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
 !
 ipv6 prefix-list {{ ipv6_prefix_list.name }}
-{%     for sequence in ipv6_prefix_list.sequence_numbers | arista.avd.convert_dicts('sequence') |
-arista.avd.natural_sort('sequence') %}
+{%     for sequence in ipv6_prefix_list.sequence_numbers | arista.avd.convert_dicts('sequence') | arista.avd.natural_sort('sequence') %}
 {%         if sequence.action is arista.avd.defined %}
    seq {{ sequence.sequence }} {{ sequence.action }}
 {%         endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ipv6-prefix-lists.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ipv6-prefix-lists.j2
@@ -1,10 +1,12 @@
 {# eos - ipv6-prefix-lists #}
-{% for ipv6_prefix_list in ipv6_prefix_lists | arista.avd.natural_sort %}
+{% for ipv6_prefix_list in ipv6_prefix_lists | arista.avd.convert_dicts('name') |
+arista.avd.natural_sort('name') %}
 !
-ipv6 prefix-list {{ ipv6_prefix_list }}
-{%     for sequence in ipv6_prefix_lists[ipv6_prefix_list].sequence_numbers | arista.avd.natural_sort %}
-{%         if ipv6_prefix_lists[ipv6_prefix_list].sequence_numbers[sequence].action is arista.avd.defined %}
-   seq {{ sequence }} {{ ipv6_prefix_lists[ipv6_prefix_list].sequence_numbers[sequence].action }}
+ipv6 prefix-list {{ ipv6_prefix_list.name }}
+{%     for sequence in ipv6_prefix_list.sequence_numbers | arista.avd.convert_dicts('sequence') |
+arista.avd.natural_sort('sequence') %}
+{%         if sequence.action is arista.avd.defined %}
+   seq {{ sequence.sequence }} {{ sequence.action }}
 {%         endif %}
 {%     endfor %}
 {% endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/prefix-lists.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/prefix-lists.j2
@@ -1,10 +1,8 @@
 {# eos - prefix-lists #}
-{% for prefix_list in prefix_lists | arista.avd.convert_dicts('name') |
-arista.avd.natural_sort('name') %}
+{% for prefix_list in prefix_lists | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
 !
 ip prefix-list {{ prefix_list.name }}
-{%     for sequence in prefix_list.sequence_numbers | arista.avd.convert_dicts('sequence') |
-arista.avd.natural_sort('sequence') %}
+{%     for sequence in prefix_list.sequence_numbers | arista.avd.convert_dicts('sequence') | arista.avd.natural_sort('sequence') %}
 {%         if sequence.action is arista.avd.defined %}
    seq {{ sequence.sequence }} {{ sequence.action }}
 {%         endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/prefix-lists.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/prefix-lists.j2
@@ -1,10 +1,12 @@
 {# eos - prefix-lists #}
-{% for prefix_list in prefix_lists | arista.avd.natural_sort %}
+{% for prefix_list in prefix_lists | arista.avd.convert_dicts('name') |
+arista.avd.natural_sort('name') %}
 !
-ip prefix-list {{ prefix_list }}
-{%     for sequence in prefix_lists[prefix_list].sequence_numbers | arista.avd.natural_sort %}
-{%         if prefix_lists[prefix_list].sequence_numbers[sequence].action is arista.avd.defined %}
-   seq {{ sequence }} {{ prefix_lists[prefix_list].sequence_numbers[sequence].action }}
+ip prefix-list {{ prefix_list.name }}
+{%     for sequence in prefix_list.sequence_numbers | arista.avd.convert_dicts('sequence') |
+arista.avd.natural_sort('sequence') %}
+{%         if sequence.action is arista.avd.defined %}
+   seq {{ sequence.sequence }} {{ sequence.action }}
 {%         endif %}
 {%     endfor %}
 {% endfor %}


### PR DESCRIPTION
## "Wildcard Keyed Dict" to "List of Dicts" Data model migration

<!-- Use this PR Title: Refactor(eos_cli_config_gen): Wildcard dict to list for `< data_model_key >` -->

## Data model key

`prefix_lists`

## Checklist

### Contributor Checklist

- [x] Update `README_v4.0.md` with new data model
- [x] Update all `host_vars` under molecule scenario `eos_cli_config_gen_v4.0` with new data model
- [x] Update `templates/eos/< template >.j2` and `templates/documentation/< template >.j2`:
  - [x] Add `arista.avd.convert_dicts('<primary key>')` filter for loops previously using wildcard keys
  - [x] Update `arista.avd.natural_sort('<primary key>')` to sort on the primary key (if applicable)
- [x] Run molecule `cd ansible_collections/arista/avd ; molecule converge -s eos_cli_config_gen`
  - [x] Verify no changes to generated configs/docs
- [x] Run molecule `cd ansible_collections/arista/avd ; molecule converge -s eos_cli_config_gen_v4.0`
  - [x] Verify no changes to generated configs/docs

### Reviewer Checklist

- Reviewer 1 (@ClausHolbechArista):
  - [x] Verify data model changes
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [ ] Verify that CI pass

- Reviewer 2:
  - [x] Verify data model changes
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
