### PR TITLE
Fix(eos_cli_config_gen): dhcp relay missing !

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/dhcp-relay.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/dhcp-relay.md
@@ -10,7 +10,7 @@
       - [IPv6](#ipv6)
     - [Management Interfaces Device Configuration](#management-interfaces-device-configuration)
 - [Authentication](#authentication)
-- [DHCP Relay](#dhcp-relay-1)
+- [DHCP Relay](#dhcp-relay)
   - [DHCP Relay Summary](#dhcp-relay-summary)
   - [DHCP Relay Configuration](#dhcp-relay-configuration)
 - [Monitoring](#monitoring)

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/dhcp-relay.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/dhcp-relay.md
@@ -1,14 +1,8 @@
 # dhcp-relay
 # Table of Contents
 
-- [dhcp-relay](#dhcp-relay)
-- [Table of Contents](#table-of-contents)
 - [Management](#management)
   - [Management Interfaces](#management-interfaces)
-    - [Management Interfaces Summary](#management-interfaces-summary)
-      - [IPv4](#ipv4)
-      - [IPv6](#ipv6)
-    - [Management Interfaces Device Configuration](#management-interfaces-device-configuration)
 - [Authentication](#authentication)
 - [DHCP Relay](#dhcp-relay)
   - [DHCP Relay Summary](#dhcp-relay-summary)
@@ -19,10 +13,7 @@
 - [Interfaces](#interfaces)
 - [Routing](#routing)
   - [IP Routing](#ip-routing)
-    - [IP Routing Summary](#ip-routing-summary)
-    - [IP Routing Device Configuration](#ip-routing-device-configuration)
   - [IPv6 Routing](#ipv6-routing)
-    - [IPv6 Routing Summary](#ipv6-routing-summary)
 - [Multicast](#multicast)
 - [Filters](#filters)
 - [ACL](#acl)

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/dhcp-relay.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/dhcp-relay.md
@@ -1,10 +1,16 @@
 # dhcp-relay
 # Table of Contents
 
+- [dhcp-relay](#dhcp-relay)
+- [Table of Contents](#table-of-contents)
 - [Management](#management)
   - [Management Interfaces](#management-interfaces)
+    - [Management Interfaces Summary](#management-interfaces-summary)
+      - [IPv4](#ipv4)
+      - [IPv6](#ipv6)
+    - [Management Interfaces Device Configuration](#management-interfaces-device-configuration)
 - [Authentication](#authentication)
-- [DHCP Relay](#dhcp-relay)
+- [DHCP Relay](#dhcp-relay-1)
   - [DHCP Relay Summary](#dhcp-relay-summary)
   - [DHCP Relay Configuration](#dhcp-relay-configuration)
 - [Monitoring](#monitoring)
@@ -13,7 +19,10 @@
 - [Interfaces](#interfaces)
 - [Routing](#routing)
   - [IP Routing](#ip-routing)
+    - [IP Routing Summary](#ip-routing-summary)
+    - [IP Routing Device Configuration](#ip-routing-device-configuration)
   - [IPv6 Routing](#ipv6-routing)
+    - [IPv6 Routing Summary](#ipv6-routing-summary)
 - [Multicast](#multicast)
 - [Filters](#filters)
 - [ACL](#acl)
@@ -63,6 +72,7 @@ interface Management1
 ## DHCP Relay Configuration
 
 ```eos
+!
 dhcp relay
    server dhcp-relay-server1
    server dhcp-relay-server2

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/dhcp-relay.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/dhcp-relay.cfg
@@ -1,4 +1,5 @@
 !RANCID-CONTENT-TYPE: arista
+!
 dhcp relay
    server dhcp-relay-server1
    server dhcp-relay-server2

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/dhcp-relay.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/dhcp-relay.md
@@ -10,7 +10,7 @@
       - [IPv6](#ipv6)
     - [Management Interfaces Device Configuration](#management-interfaces-device-configuration)
 - [Authentication](#authentication)
-- [DHCP Relay](#dhcp-relay-1)
+- [DHCP Relay](#dhcp-relay)
   - [DHCP Relay Summary](#dhcp-relay-summary)
   - [DHCP Relay Configuration](#dhcp-relay-configuration)
 - [Monitoring](#monitoring)

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/dhcp-relay.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/dhcp-relay.md
@@ -1,14 +1,8 @@
 # dhcp-relay
 # Table of Contents
 
-- [dhcp-relay](#dhcp-relay)
-- [Table of Contents](#table-of-contents)
 - [Management](#management)
   - [Management Interfaces](#management-interfaces)
-    - [Management Interfaces Summary](#management-interfaces-summary)
-      - [IPv4](#ipv4)
-      - [IPv6](#ipv6)
-    - [Management Interfaces Device Configuration](#management-interfaces-device-configuration)
 - [Authentication](#authentication)
 - [DHCP Relay](#dhcp-relay)
   - [DHCP Relay Summary](#dhcp-relay-summary)
@@ -19,10 +13,7 @@
 - [Interfaces](#interfaces)
 - [Routing](#routing)
   - [IP Routing](#ip-routing)
-    - [IP Routing Summary](#ip-routing-summary)
-    - [IP Routing Device Configuration](#ip-routing-device-configuration)
   - [IPv6 Routing](#ipv6-routing)
-    - [IPv6 Routing Summary](#ipv6-routing-summary)
 - [Multicast](#multicast)
 - [Filters](#filters)
 - [ACL](#acl)

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/dhcp-relay.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/dhcp-relay.md
@@ -1,10 +1,16 @@
 # dhcp-relay
 # Table of Contents
 
+- [dhcp-relay](#dhcp-relay)
+- [Table of Contents](#table-of-contents)
 - [Management](#management)
   - [Management Interfaces](#management-interfaces)
+    - [Management Interfaces Summary](#management-interfaces-summary)
+      - [IPv4](#ipv4)
+      - [IPv6](#ipv6)
+    - [Management Interfaces Device Configuration](#management-interfaces-device-configuration)
 - [Authentication](#authentication)
-- [DHCP Relay](#dhcp-relay)
+- [DHCP Relay](#dhcp-relay-1)
   - [DHCP Relay Summary](#dhcp-relay-summary)
   - [DHCP Relay Configuration](#dhcp-relay-configuration)
 - [Monitoring](#monitoring)
@@ -13,7 +19,10 @@
 - [Interfaces](#interfaces)
 - [Routing](#routing)
   - [IP Routing](#ip-routing)
+    - [IP Routing Summary](#ip-routing-summary)
+    - [IP Routing Device Configuration](#ip-routing-device-configuration)
   - [IPv6 Routing](#ipv6-routing)
+    - [IPv6 Routing Summary](#ipv6-routing-summary)
 - [Multicast](#multicast)
 - [Filters](#filters)
 - [ACL](#acl)
@@ -63,6 +72,7 @@ interface Management1
 ## DHCP Relay Configuration
 
 ```eos
+!
 dhcp relay
    server dhcp-relay-server1
    server dhcp-relay-server2

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/dhcp-relay.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/dhcp-relay.cfg
@@ -1,4 +1,5 @@
 !RANCID-CONTENT-TYPE: arista
+!
 dhcp relay
    server dhcp-relay-server1
    server dhcp-relay-server2

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/dhcp-relay.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/dhcp-relay.j2
@@ -1,4 +1,5 @@
 {% if dhcp_relay is arista.avd.defined %}
+!
 dhcp relay
 {%     for server in dhcp_relay.servers | arista.avd.natural_sort %}
    server {{ server }}


### PR DESCRIPTION
## Change Summary

Part of the various changes for getting output config to reflect config order on box.

## Related Issue(s)

Fixes #1572

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

```
!
dhcp relay
```

## How to test


## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
