### PR TITLE
Fix(eos_cli_config_gen): logging config order

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/logging.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/logging.md
@@ -78,18 +78,18 @@ interface Management1
 
 ```eos
 !
-logging console error
 logging buffered 1000000 warnings
 no logging trap
+logging console error
 logging synchronous level critical
-logging source-interface Loopback0
 logging host 20.20.20.7
 logging host 50.50.50.7 100 200 protocol tcp
 logging host 60.60.60.7 100 200
-logging vrf mgt source-interface Management0
 logging vrf mgt host 10.10.10.7
 logging vrf mgt host 30.30.30.7 100 200 protocol tcp
 logging vrf mgt host 40.40.40.7 300 400
+logging source-interface Loopback0
+logging vrf mgt source-interface Management0
 ```
 
 # Internal VLAN Allocation Policy

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/logging.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/logging.cfg
@@ -2,18 +2,18 @@
 !
 transceiver qsfp default-mode 4x10G
 !
-logging console error
 logging buffered 1000000 warnings
 no logging trap
+logging console error
 logging synchronous level critical
-logging source-interface Loopback0
 logging host 20.20.20.7
 logging host 50.50.50.7 100 200 protocol tcp
 logging host 60.60.60.7 100 200
-logging vrf mgt source-interface Management0
 logging vrf mgt host 10.10.10.7
 logging vrf mgt host 30.30.30.7 100 200 protocol tcp
 logging vrf mgt host 40.40.40.7 300 400
+logging source-interface Loopback0
+logging vrf mgt source-interface Management0
 !
 hostname logging
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/logging.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/logging.md
@@ -78,18 +78,18 @@ interface Management1
 
 ```eos
 !
-logging console error
 logging buffered 1000000 warnings
 no logging trap
+logging console error
 logging synchronous level critical
-logging source-interface Loopback0
 logging host 20.20.20.7
 logging host 50.50.50.7 100 200 protocol tcp
 logging host 60.60.60.7 100 200
-logging vrf mgt source-interface Management0
 logging vrf mgt host 10.10.10.7
 logging vrf mgt host 30.30.30.7 100 200 protocol tcp
 logging vrf mgt host 40.40.40.7 300 400
+logging source-interface Loopback0
+logging vrf mgt source-interface Management0
 ```
 
 # Internal VLAN Allocation Policy

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/logging.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/logging.cfg
@@ -2,18 +2,18 @@
 !
 transceiver qsfp default-mode 4x10G
 !
-logging console error
 logging buffered 1000000 warnings
 no logging trap
+logging console error
 logging synchronous level critical
-logging source-interface Loopback0
 logging host 20.20.20.7
 logging host 50.50.50.7 100 200 protocol tcp
 logging host 60.60.60.7 100 200
-logging vrf mgt source-interface Management0
 logging vrf mgt host 10.10.10.7
 logging vrf mgt host 30.30.30.7 100 200 protocol tcp
 logging vrf mgt host 40.40.40.7 300 400
+logging source-interface Loopback0
+logging vrf mgt source-interface Management0
 !
 hostname logging
 !

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/logging.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/logging.j2
@@ -1,16 +1,6 @@
 {# eos - logging #}
 {% if logging is arista.avd.defined %}
 !
-{%     if logging.console is arista.avd.defined('disabled') %}
-no logging console
-{%     elif logging.console is arista.avd.defined %}
-logging console {{ logging.console }}
-{%     endif %}
-{%     if logging.monitor is arista.avd.defined('disabled') %}
-no logging monitor
-{%     elif logging.monitor is arista.avd.defined %}
-logging monitor {{ logging.monitor }}
-{%     endif %}
 {%     if logging.buffered.level is arista.avd.defined('disabled') %}
 no logging buffered
 {%     elif logging.buffered.level is arista.avd.defined %}
@@ -26,11 +16,37 @@ no logging trap
 {%     elif logging.trap is arista.avd.defined %}
 logging trap {{ logging.trap }}
 {%     endif %}
+{%     if logging.console is arista.avd.defined('disabled') %}
+no logging console
+{%     elif logging.console is arista.avd.defined %}
+logging console {{ logging.console }}
+{%     endif %}
+{%     if logging.monitor is arista.avd.defined('disabled') %}
+no logging monitor
+{%     elif logging.monitor is arista.avd.defined %}
+logging monitor {{ logging.monitor }}
+{%     endif %}
 {%     if logging.synchronous.level is arista.avd.defined('disabled') %}
 no logging synchronous
 {%     elif logging.synchronous is arista.avd.defined %}
 logging synchronous level {{ logging.synchronous.level | arista.avd.default("critical") }}
 {%     endif %}
+{%     for vrf in logging.vrfs | arista.avd.natural_sort %}
+{%         for host in logging.vrfs[vrf].hosts | arista.avd.natural_sort %}
+{%             set logging_host_cli = "logging" %}
+{%             if logging.vrfs[vrf].hosts is arista.avd.defined and vrf is not arista.avd.defined('default') %}
+{%                 set logging_host_cli = logging_host_cli ~ " vrf " ~ vrf %}
+{%             endif %}
+{%             set logging_host_cli = logging_host_cli ~ " host " ~ host %}
+{%             if logging.vrfs[vrf].hosts[host].ports is arista.avd.defined() %}
+{%                 set logging_host_cli = logging_host_cli ~ ' ' ~ logging.vrfs[vrf].hosts[host].ports | join(' ') %}
+{%             endif %}
+{%             if logging.vrfs[vrf].hosts[host].protocol is arista.avd.defined() and logging.vrfs[vrf].hosts[host].protocol is not arista.avd.defined("udp") %}
+{%                 set logging_host_cli = logging_host_cli ~ " protocol " ~ logging.vrfs[vrf].hosts[host].protocol | lower %}
+{%             endif %}
+{{ logging_host_cli }}
+{%         endfor %}
+{%     endfor %}
 {%     if logging.format.timestamp is arista.avd.defined('high-resolution') %}
 logging format timestamp high-resolution
 {%     endif %}
@@ -55,20 +71,6 @@ logging source-interface {{ logging.source_interface }}
 {%         endif %}
 {%         set logging_cli = logging_cli ~ " source-interface " ~ logging.vrfs[vrf].source_interface %}
 {{ logging_cli }}
-{%         for host in logging.vrfs[vrf].hosts | arista.avd.natural_sort %}
-{%             set logging_host_cli = "logging" %}
-{%             if logging.vrfs[vrf].hosts is arista.avd.defined and vrf is not arista.avd.defined('default') %}
-{%                 set logging_host_cli = logging_host_cli ~ " vrf " ~ vrf %}
-{%             endif %}
-{%             set logging_host_cli = logging_host_cli ~ " host " ~ host %}
-{%             if logging.vrfs[vrf].hosts[host].ports is arista.avd.defined() %}
-{%                 set logging_host_cli = logging_host_cli ~ ' ' ~ logging.vrfs[vrf].hosts[host].ports | join(' ') %}
-{%             endif %}
-{%             if logging.vrfs[vrf].hosts[host].protocol is arista.avd.defined() and logging.vrfs[vrf].hosts[host].protocol is not arista.avd.defined("udp") %}
-{%                 set logging_host_cli = logging_host_cli ~ " protocol " ~ logging.vrfs[vrf].hosts[host].protocol | lower %}
-{%             endif %}
-{{ logging_host_cli }}
-{%         endfor %}
 {%     endfor %}
 {%     for match_list in logging.policy.match.match_lists | arista.avd.natural_sort %}
 logging policy match match-list {{ match_list }} {{ logging.policy.match.match_lists[match_list].action }}


### PR DESCRIPTION
## Change Summary

Part of the various changes for getting output config to reflect config order on box.

## Related Issue(s)

Fixes #1572

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Reorder logging configuration lines

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
