### PR TITLE
Fix(eos_cli_config_gen): vlan_interface virtual ip config order

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
@@ -274,11 +274,11 @@ interface Vlan1002
 interface Vlan2001
    description SVI Description
    vrf Tenant_B
+   ip address virtual 10.2.1.1/24
    comment
    Comment created from eos_cli under vlan_interfaces.Vlan2001
    EOF
 
-   ip address virtual 10.2.1.1/24
 !
 interface Vlan2002
    description SVI Description

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
@@ -143,19 +143,19 @@ interface Management1
 interface Vlan24
    description SVI Description
    no shutdown
-   ip address virtual 10.10.24.1/24
    ipv6 address 1b11:3a00:22b0:6::15/64
    ipv6 nd managed-config-flag
    ipv6 nd prefix 1b11:3a00:22b0:6::/64 infinite infinite no-autoconfig
    ipv6 virtual-router address 1b11:3a00:22b0:6::1
+   ip address virtual 10.10.24.1/24
 !
 interface Vlan41
    description SVI Description
    no shutdown
-   ip address virtual 10.10.41.1/24
    ip helper-address 10.10.64.150 source-interface Loopback0
    ip helper-address 10.10.96.150 source-interface Loopback0
    ip helper-address 10.10.96.151 source-interface Loopback0
+   ip address virtual 10.10.41.1/24
 !
 interface Vlan42
    description SVI Description
@@ -165,18 +165,18 @@ interface Vlan42
 interface Vlan75
    description SVI Description
    no shutdown
-   ip address virtual 10.10.75.1/24
    ipv6 address 1b11:3a00:22b0:1000::15/64
    ipv6 nd managed-config-flag
    ipv6 nd prefix 1b11:3a00:22b0:1000::/64 infinite infinite no-autoconfig
    ipv6 virtual-router address 1b11:3a00:22b0:1000::1
+   ip address virtual 10.10.75.1/24
 !
 interface Vlan81
    description IPv6 Virtual Address
    vrf Tenant_C
-   ip address virtual 10.10.81.1/24
    ipv6 enable
    ipv6 address virtual fc00:10:10:81::1/64
+   ip address virtual 10.10.81.1/24
 !
 interface Vlan83
    description SVI Description
@@ -219,7 +219,6 @@ interface Vlan88
 interface Vlan89
    description SVI Description
    no shutdown
-   ip address virtual 10.10.144.3/20
    ip igmp
    ipv6 address 1b11:3a00:22b0:5200::15/64
    ipv6 nd managed-config-flag
@@ -228,6 +227,7 @@ interface Vlan89
    pim ipv4 sparse-mode
    pim ipv4 local-interface Loopback0
    ipv6 virtual-router address 1b11:3a00:22b0:5200::3
+   ip address virtual 10.10.144.3/20
 !
 interface Vlan90
    description SVI Description
@@ -256,29 +256,29 @@ interface Vlan1001
    description SVI Description
    no shutdown
    vrf Tenant_A
-   ip address virtual 10.1.1.1/24
    ipv6 address a1::1/64
    ipv6 nd managed-config-flag
    ipv6 nd prefix a1::/64 infinite infinite no-autoconfig
+   ip address virtual 10.1.1.1/24
 !
 interface Vlan1002
    description SVI Description
    no shutdown
    vrf Tenant_A
-   ip address virtual 10.1.2.1/24
    ipv6 address a2::1/64
    ipv6 nd ra disabled
    ipv6 nd managed-config-flag
    ipv6 nd prefix a2::/64 infinite infinite no-autoconfig
+   ip address virtual 10.1.2.1/24
 !
 interface Vlan2001
    description SVI Description
    vrf Tenant_B
-   ip address virtual 10.2.1.1/24
    comment
    Comment created from eos_cli under vlan_interfaces.Vlan2001
    EOF
 
+   ip address virtual 10.2.1.1/24
 !
 interface Vlan2002
    description SVI Description

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
@@ -15,19 +15,19 @@ interface Management1
 interface Vlan24
    description SVI Description
    no shutdown
-   ip address virtual 10.10.24.1/24
    ipv6 address 1b11:3a00:22b0:6::15/64
    ipv6 nd managed-config-flag
    ipv6 nd prefix 1b11:3a00:22b0:6::/64 infinite infinite no-autoconfig
    ipv6 virtual-router address 1b11:3a00:22b0:6::1
+   ip address virtual 10.10.24.1/24
 !
 interface Vlan41
    description SVI Description
    no shutdown
-   ip address virtual 10.10.41.1/24
    ip helper-address 10.10.64.150 source-interface Loopback0
    ip helper-address 10.10.96.150 source-interface Loopback0
    ip helper-address 10.10.96.151 source-interface Loopback0
+   ip address virtual 10.10.41.1/24
 !
 interface Vlan42
    description SVI Description
@@ -37,18 +37,18 @@ interface Vlan42
 interface Vlan75
    description SVI Description
    no shutdown
-   ip address virtual 10.10.75.1/24
    ipv6 address 1b11:3a00:22b0:1000::15/64
    ipv6 nd managed-config-flag
    ipv6 nd prefix 1b11:3a00:22b0:1000::/64 infinite infinite no-autoconfig
    ipv6 virtual-router address 1b11:3a00:22b0:1000::1
+   ip address virtual 10.10.75.1/24
 !
 interface Vlan81
    description IPv6 Virtual Address
    vrf Tenant_C
-   ip address virtual 10.10.81.1/24
    ipv6 enable
    ipv6 address virtual fc00:10:10:81::1/64
+   ip address virtual 10.10.81.1/24
 !
 interface Vlan83
    description SVI Description
@@ -91,7 +91,6 @@ interface Vlan88
 interface Vlan89
    description SVI Description
    no shutdown
-   ip address virtual 10.10.144.3/20
    ip igmp
    ipv6 address 1b11:3a00:22b0:5200::15/64
    ipv6 nd managed-config-flag
@@ -100,6 +99,7 @@ interface Vlan89
    pim ipv4 sparse-mode
    pim ipv4 local-interface Loopback0
    ipv6 virtual-router address 1b11:3a00:22b0:5200::3
+   ip address virtual 10.10.144.3/20
 !
 interface Vlan90
    description SVI Description
@@ -128,29 +128,29 @@ interface Vlan1001
    description SVI Description
    no shutdown
    vrf Tenant_A
-   ip address virtual 10.1.1.1/24
    ipv6 address a1::1/64
    ipv6 nd managed-config-flag
    ipv6 nd prefix a1::/64 infinite infinite no-autoconfig
+   ip address virtual 10.1.1.1/24
 !
 interface Vlan1002
    description SVI Description
    no shutdown
    vrf Tenant_A
-   ip address virtual 10.1.2.1/24
    ipv6 address a2::1/64
    ipv6 nd ra disabled
    ipv6 nd managed-config-flag
    ipv6 nd prefix a2::/64 infinite infinite no-autoconfig
+   ip address virtual 10.1.2.1/24
 !
 interface Vlan2001
    description SVI Description
    vrf Tenant_B
-   ip address virtual 10.2.1.1/24
    comment
    Comment created from eos_cli under vlan_interfaces.Vlan2001
    EOF
 
+   ip address virtual 10.2.1.1/24
 !
 interface Vlan2002
    description SVI Description

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
@@ -146,11 +146,11 @@ interface Vlan1002
 interface Vlan2001
    description SVI Description
    vrf Tenant_B
+   ip address virtual 10.2.1.1/24
    comment
    Comment created from eos_cli under vlan_interfaces.Vlan2001
    EOF
 
-   ip address virtual 10.2.1.1/24
 !
 interface Vlan2002
    description SVI Description

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/vlan-interfaces.md
@@ -274,11 +274,11 @@ interface Vlan1002
 interface Vlan2001
    description SVI Description
    vrf Tenant_B
+   ip address virtual 10.2.1.1/24
    comment
    Comment created from eos_cli under vlan_interfaces.Vlan2001
    EOF
 
-   ip address virtual 10.2.1.1/24
 !
 interface Vlan2002
    description SVI Description

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/vlan-interfaces.md
@@ -143,19 +143,19 @@ interface Management1
 interface Vlan24
    description SVI Description
    no shutdown
-   ip address virtual 10.10.24.1/24
    ipv6 address 1b11:3a00:22b0:6::15/64
    ipv6 nd managed-config-flag
    ipv6 nd prefix 1b11:3a00:22b0:6::/64 infinite infinite no-autoconfig
    ipv6 virtual-router address 1b11:3a00:22b0:6::1
+   ip address virtual 10.10.24.1/24
 !
 interface Vlan41
    description SVI Description
    no shutdown
-   ip address virtual 10.10.41.1/24
    ip helper-address 10.10.64.150 source-interface Loopback0
    ip helper-address 10.10.96.150 source-interface Loopback0
    ip helper-address 10.10.96.151 source-interface Loopback0
+   ip address virtual 10.10.41.1/24
 !
 interface Vlan42
    description SVI Description
@@ -165,18 +165,18 @@ interface Vlan42
 interface Vlan75
    description SVI Description
    no shutdown
-   ip address virtual 10.10.75.1/24
    ipv6 address 1b11:3a00:22b0:1000::15/64
    ipv6 nd managed-config-flag
    ipv6 nd prefix 1b11:3a00:22b0:1000::/64 infinite infinite no-autoconfig
    ipv6 virtual-router address 1b11:3a00:22b0:1000::1
+   ip address virtual 10.10.75.1/24
 !
 interface Vlan81
    description IPv6 Virtual Address
    vrf Tenant_C
-   ip address virtual 10.10.81.1/24
    ipv6 enable
    ipv6 address virtual fc00:10:10:81::1/64
+   ip address virtual 10.10.81.1/24
 !
 interface Vlan83
    description SVI Description
@@ -219,7 +219,6 @@ interface Vlan88
 interface Vlan89
    description SVI Description
    no shutdown
-   ip address virtual 10.10.144.3/20
    ip igmp
    ipv6 address 1b11:3a00:22b0:5200::15/64
    ipv6 nd managed-config-flag
@@ -228,6 +227,7 @@ interface Vlan89
    pim ipv4 sparse-mode
    pim ipv4 local-interface Loopback0
    ipv6 virtual-router address 1b11:3a00:22b0:5200::3
+   ip address virtual 10.10.144.3/20
 !
 interface Vlan90
    description SVI Description
@@ -256,29 +256,29 @@ interface Vlan1001
    description SVI Description
    no shutdown
    vrf Tenant_A
-   ip address virtual 10.1.1.1/24
    ipv6 address a1::1/64
    ipv6 nd managed-config-flag
    ipv6 nd prefix a1::/64 infinite infinite no-autoconfig
+   ip address virtual 10.1.1.1/24
 !
 interface Vlan1002
    description SVI Description
    no shutdown
    vrf Tenant_A
-   ip address virtual 10.1.2.1/24
    ipv6 address a2::1/64
    ipv6 nd ra disabled
    ipv6 nd managed-config-flag
    ipv6 nd prefix a2::/64 infinite infinite no-autoconfig
+   ip address virtual 10.1.2.1/24
 !
 interface Vlan2001
    description SVI Description
    vrf Tenant_B
-   ip address virtual 10.2.1.1/24
    comment
    Comment created from eos_cli under vlan_interfaces.Vlan2001
    EOF
 
+   ip address virtual 10.2.1.1/24
 !
 interface Vlan2002
    description SVI Description

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/vlan-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/vlan-interfaces.cfg
@@ -15,19 +15,19 @@ interface Management1
 interface Vlan24
    description SVI Description
    no shutdown
-   ip address virtual 10.10.24.1/24
    ipv6 address 1b11:3a00:22b0:6::15/64
    ipv6 nd managed-config-flag
    ipv6 nd prefix 1b11:3a00:22b0:6::/64 infinite infinite no-autoconfig
    ipv6 virtual-router address 1b11:3a00:22b0:6::1
+   ip address virtual 10.10.24.1/24
 !
 interface Vlan41
    description SVI Description
    no shutdown
-   ip address virtual 10.10.41.1/24
    ip helper-address 10.10.64.150 source-interface Loopback0
    ip helper-address 10.10.96.150 source-interface Loopback0
    ip helper-address 10.10.96.151 source-interface Loopback0
+   ip address virtual 10.10.41.1/24
 !
 interface Vlan42
    description SVI Description
@@ -37,18 +37,18 @@ interface Vlan42
 interface Vlan75
    description SVI Description
    no shutdown
-   ip address virtual 10.10.75.1/24
    ipv6 address 1b11:3a00:22b0:1000::15/64
    ipv6 nd managed-config-flag
    ipv6 nd prefix 1b11:3a00:22b0:1000::/64 infinite infinite no-autoconfig
    ipv6 virtual-router address 1b11:3a00:22b0:1000::1
+   ip address virtual 10.10.75.1/24
 !
 interface Vlan81
    description IPv6 Virtual Address
    vrf Tenant_C
-   ip address virtual 10.10.81.1/24
    ipv6 enable
    ipv6 address virtual fc00:10:10:81::1/64
+   ip address virtual 10.10.81.1/24
 !
 interface Vlan83
    description SVI Description
@@ -91,7 +91,6 @@ interface Vlan88
 interface Vlan89
    description SVI Description
    no shutdown
-   ip address virtual 10.10.144.3/20
    ip igmp
    ipv6 address 1b11:3a00:22b0:5200::15/64
    ipv6 nd managed-config-flag
@@ -100,6 +99,7 @@ interface Vlan89
    pim ipv4 sparse-mode
    pim ipv4 local-interface Loopback0
    ipv6 virtual-router address 1b11:3a00:22b0:5200::3
+   ip address virtual 10.10.144.3/20
 !
 interface Vlan90
    description SVI Description
@@ -128,29 +128,29 @@ interface Vlan1001
    description SVI Description
    no shutdown
    vrf Tenant_A
-   ip address virtual 10.1.1.1/24
    ipv6 address a1::1/64
    ipv6 nd managed-config-flag
    ipv6 nd prefix a1::/64 infinite infinite no-autoconfig
+   ip address virtual 10.1.1.1/24
 !
 interface Vlan1002
    description SVI Description
    no shutdown
    vrf Tenant_A
-   ip address virtual 10.1.2.1/24
    ipv6 address a2::1/64
    ipv6 nd ra disabled
    ipv6 nd managed-config-flag
    ipv6 nd prefix a2::/64 infinite infinite no-autoconfig
+   ip address virtual 10.1.2.1/24
 !
 interface Vlan2001
    description SVI Description
    vrf Tenant_B
-   ip address virtual 10.2.1.1/24
    comment
    Comment created from eos_cli under vlan_interfaces.Vlan2001
    EOF
 
+   ip address virtual 10.2.1.1/24
 !
 interface Vlan2002
    description SVI Description

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/vlan-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/vlan-interfaces.cfg
@@ -146,11 +146,11 @@ interface Vlan1002
 interface Vlan2001
    description SVI Description
    vrf Tenant_B
+   ip address virtual 10.2.1.1/24
    comment
    Comment created from eos_cli under vlan_interfaces.Vlan2001
    EOF
 
-   ip address virtual 10.2.1.1/24
 !
 interface Vlan2002
    description SVI Description

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF1A.md
@@ -374,8 +374,8 @@ interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+   ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2A.md
@@ -577,15 +577,15 @@ interface Vlan111
    description Tenant_A_OP_Zone_2
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT source-interface lo100
+   ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+   ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2B.md
@@ -577,15 +577,15 @@ interface Vlan111
    description Tenant_A_OP_Zone_2
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT source-interface lo100
+   ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+   ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3A.md
@@ -622,15 +622,15 @@ interface Vlan111
    description Tenant_A_OP_Zone_2
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT source-interface lo100
+   ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+   ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3B.md
@@ -607,15 +607,15 @@ interface Vlan111
    description Tenant_A_OP_Zone_2
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT source-interface lo100
+   ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+   ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-LEAF1A.cfg
@@ -108,8 +108,8 @@ interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+   ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-LEAF2A.cfg
@@ -216,15 +216,15 @@ interface Vlan111
    description Tenant_A_OP_Zone_2
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT source-interface lo100
+   ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+   ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-LEAF2B.cfg
@@ -216,15 +216,15 @@ interface Vlan111
    description Tenant_A_OP_Zone_2
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT source-interface lo100
+   ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+   ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SVC3A.cfg
@@ -248,15 +248,15 @@ interface Vlan111
    description Tenant_A_OP_Zone_2
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT source-interface lo100
+   ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+   ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SVC3B.cfg
@@ -235,15 +235,15 @@ interface Vlan111
    description Tenant_A_OP_Zone_2
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT source-interface lo100
+   ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+   ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/cvp/cv_server_configlets.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/cvp/cv_server_configlets.yml
@@ -360,54 +360,53 @@ CVP_CONFIGLETS:
     \   no shutdown\n   ip address 192.168.254.5/32\n!\ninterface Management1\n  \
     \ description oob_management\n   no shutdown\n   vrf MGMT\n   ip address 192.168.200.105/24\n\
     !\ninterface Vlan120\n   description Tenant_A_WEB_Zone_1\n   no shutdown\n   vrf\
-    \ Tenant_A_WEB_Zone\n   ip address virtual 10.1.20.1/24\n   ip helper-address\
-    \ 1.1.1.1 vrf TEST source-interface lo100\n!\ninterface Vlan121\n   description\
-    \ Tenant_A_WEBZone_2\n   shutdown\n   mtu 1560\n   vrf Tenant_A_WEB_Zone\n   ip\
-    \ address virtual 10.1.10.254/24\n!\ninterface Vlan130\n   description Tenant_A_APP_Zone_1\n\
-    \   no shutdown\n   vrf Tenant_A_APP_Zone\n   ip address virtual 10.1.30.1/24\n\
-    !\ninterface Vlan131\n   description Tenant_A_APP_Zone_2\n   no shutdown\n   vrf\
-    \ Tenant_A_APP_Zone\n   ip address virtual 10.1.31.1/24\n!\ninterface Vxlan1\n\
-    \   description DC1-LEAF1A_VTEP\n   vxlan source-interface Loopback1\n   vxlan\
-    \ udp-port 4789\n   vxlan vlan 120 vni 10120\n   vxlan vlan 121 vni 10121\n  \
-    \ vxlan vlan 130 vni 10130\n   vxlan vlan 131 vni 10131\n   vxlan vrf Tenant_A_APP_Zone\
-    \ vni 12\n   vxlan vrf Tenant_A_WEB_Zone vni 11\n!\nip virtual-router mac-address\
-    \ 00:dc:00:00:00:0a\n!\nip routing\nno ip routing vrf MGMT\nip routing vrf Tenant_A_APP_Zone\n\
-    ip routing vrf Tenant_A_WEB_Zone\n!\nip prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n\
-    \   seq 10 permit 192.168.255.0/24 eq 32\n   seq 20 permit 192.168.254.0/24 eq\
-    \ 32\n!\nip route vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nroute-map RM-CONN-2-BGP\
-    \ permit 10\n   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n!\nrouter\
-    \ bfd\n   multihop interval 1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65101\n\
-    \   router-id 192.168.255.5\n   no bgp default ipv4-unicast\n   distance bgp 20\
-    \ 200 200\n   maximum-paths 4 ecmp 4\n   neighbor EVPN-OVERLAY-PEERS peer group\n\
-    \   neighbor EVPN-OVERLAY-PEERS update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS\
-    \ bfd\n   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS\
-    \ password 7 q+VNViP5i4rVjW1cxFv2wA==\n   neighbor EVPN-OVERLAY-PEERS send-community\n\
-    \   neighbor EVPN-OVERLAY-PEERS maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS\
-    \ peer group\n   neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==\n\
-    \   neighbor IPv4-UNDERLAY-PEERS send-community\n   neighbor IPv4-UNDERLAY-PEERS\
-    \ maximum-routes 12000\n   neighbor 172.31.255.0 peer group IPv4-UNDERLAY-PEERS\n\
-    \   neighbor 172.31.255.0 remote-as 65001\n   neighbor 172.31.255.0 description\
-    \ DC1-SPINE1_Ethernet1\n   neighbor 172.31.255.2 peer group IPv4-UNDERLAY-PEERS\n\
-    \   neighbor 172.31.255.2 remote-as 65001\n   neighbor 172.31.255.2 description\
-    \ DC1-SPINE2_Ethernet1\n   neighbor 172.31.255.4 peer group IPv4-UNDERLAY-PEERS\n\
-    \   neighbor 172.31.255.4 remote-as 65001\n   neighbor 172.31.255.4 description\
-    \ DC1-SPINE3_Ethernet1\n   neighbor 172.31.255.6 peer group IPv4-UNDERLAY-PEERS\n\
-    \   neighbor 172.31.255.6 remote-as 65001\n   neighbor 172.31.255.6 description\
-    \ DC1-SPINE4_Ethernet1\n   neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS\n\
-    \   neighbor 192.168.255.1 remote-as 65001\n   neighbor 192.168.255.1 description\
-    \ DC1-SPINE1\n   neighbor 192.168.255.2 peer group EVPN-OVERLAY-PEERS\n   neighbor\
-    \ 192.168.255.2 remote-as 65001\n   neighbor 192.168.255.2 description DC1-SPINE2\n\
-    \   neighbor 192.168.255.3 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.3\
-    \ remote-as 65001\n   neighbor 192.168.255.3 description DC1-SPINE3\n   neighbor\
-    \ 192.168.255.4 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.4 remote-as\
-    \ 65001\n   neighbor 192.168.255.4 description DC1-SPINE4\n   redistribute connected\
-    \ route-map RM-CONN-2-BGP\n   !\n   vlan-aware-bundle Tenant_A_APP_Zone\n    \
-    \  rd 192.168.255.5:12\n      route-target both 12:12\n      redistribute learned\n\
-    \      vlan 130-131\n   !\n   vlan-aware-bundle Tenant_A_WEB_Zone\n      rd 192.168.255.5:11\n\
-    \      route-target both 11:11\n      redistribute learned\n      vlan 120-121\n\
-    \   !\n   address-family evpn\n      neighbor EVPN-OVERLAY-PEERS activate\n  \
-    \ !\n   address-family ipv4\n      no neighbor EVPN-OVERLAY-PEERS activate\n \
-    \     neighbor IPv4-UNDERLAY-PEERS activate\n   !\n   vrf Tenant_A_APP_Zone\n\
+    \ Tenant_A_WEB_Zone\n   ip helper-address 1.1.1.1 vrf TEST source-interface lo100\n\
+    \   ip address virtual 10.1.20.1/24\n!\ninterface Vlan121\n   description Tenant_A_WEBZone_2\n\
+    \   shutdown\n   mtu 1560\n   vrf Tenant_A_WEB_Zone\n   ip address virtual 10.1.10.254/24\n\
+    !\ninterface Vlan130\n   description Tenant_A_APP_Zone_1\n   no shutdown\n   vrf\
+    \ Tenant_A_APP_Zone\n   ip address virtual 10.1.30.1/24\n!\ninterface Vlan131\n\
+    \   description Tenant_A_APP_Zone_2\n   no shutdown\n   vrf Tenant_A_APP_Zone\n\
+    \   ip address virtual 10.1.31.1/24\n!\ninterface Vxlan1\n   description DC1-LEAF1A_VTEP\n\
+    \   vxlan source-interface Loopback1\n   vxlan udp-port 4789\n   vxlan vlan 120\
+    \ vni 10120\n   vxlan vlan 121 vni 10121\n   vxlan vlan 130 vni 10130\n   vxlan\
+    \ vlan 131 vni 10131\n   vxlan vrf Tenant_A_APP_Zone vni 12\n   vxlan vrf Tenant_A_WEB_Zone\
+    \ vni 11\n!\nip virtual-router mac-address 00:dc:00:00:00:0a\n!\nip routing\n\
+    no ip routing vrf MGMT\nip routing vrf Tenant_A_APP_Zone\nip routing vrf Tenant_A_WEB_Zone\n\
+    !\nip prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n   seq 10 permit 192.168.255.0/24\
+    \ eq 32\n   seq 20 permit 192.168.254.0/24 eq 32\n!\nip route vrf MGMT 0.0.0.0/0\
+    \ 192.168.200.5\n!\nroute-map RM-CONN-2-BGP permit 10\n   match ip address prefix-list\
+    \ PL-LOOPBACKS-EVPN-OVERLAY\n!\nrouter bfd\n   multihop interval 1200 min-rx 1200\
+    \ multiplier 3\n!\nrouter bgp 65101\n   router-id 192.168.255.5\n   no bgp default\
+    \ ipv4-unicast\n   distance bgp 20 200 200\n   maximum-paths 4 ecmp 4\n   neighbor\
+    \ EVPN-OVERLAY-PEERS peer group\n   neighbor EVPN-OVERLAY-PEERS update-source\
+    \ Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS\
+    \ ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n\
+    \   neighbor EVPN-OVERLAY-PEERS send-community\n   neighbor EVPN-OVERLAY-PEERS\
+    \ maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS peer group\n   neighbor IPv4-UNDERLAY-PEERS\
+    \ password 7 AQQvKeimxJu+uGQ/yYvv9w==\n   neighbor IPv4-UNDERLAY-PEERS send-community\n\
+    \   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000\n   neighbor 172.31.255.0\
+    \ peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.0 remote-as 65001\n \
+    \  neighbor 172.31.255.0 description DC1-SPINE1_Ethernet1\n   neighbor 172.31.255.2\
+    \ peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.2 remote-as 65001\n \
+    \  neighbor 172.31.255.2 description DC1-SPINE2_Ethernet1\n   neighbor 172.31.255.4\
+    \ peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.4 remote-as 65001\n \
+    \  neighbor 172.31.255.4 description DC1-SPINE3_Ethernet1\n   neighbor 172.31.255.6\
+    \ peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.6 remote-as 65001\n \
+    \  neighbor 172.31.255.6 description DC1-SPINE4_Ethernet1\n   neighbor 192.168.255.1\
+    \ peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.1 remote-as 65001\n \
+    \  neighbor 192.168.255.1 description DC1-SPINE1\n   neighbor 192.168.255.2 peer\
+    \ group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.2 remote-as 65001\n   neighbor\
+    \ 192.168.255.2 description DC1-SPINE2\n   neighbor 192.168.255.3 peer group EVPN-OVERLAY-PEERS\n\
+    \   neighbor 192.168.255.3 remote-as 65001\n   neighbor 192.168.255.3 description\
+    \ DC1-SPINE3\n   neighbor 192.168.255.4 peer group EVPN-OVERLAY-PEERS\n   neighbor\
+    \ 192.168.255.4 remote-as 65001\n   neighbor 192.168.255.4 description DC1-SPINE4\n\
+    \   redistribute connected route-map RM-CONN-2-BGP\n   !\n   vlan-aware-bundle\
+    \ Tenant_A_APP_Zone\n      rd 192.168.255.5:12\n      route-target both 12:12\n\
+    \      redistribute learned\n      vlan 130-131\n   !\n   vlan-aware-bundle Tenant_A_WEB_Zone\n\
+    \      rd 192.168.255.5:11\n      route-target both 11:11\n      redistribute\
+    \ learned\n      vlan 120-121\n   !\n   address-family evpn\n      neighbor EVPN-OVERLAY-PEERS\
+    \ activate\n   !\n   address-family ipv4\n      no neighbor EVPN-OVERLAY-PEERS\
+    \ activate\n      neighbor IPv4-UNDERLAY-PEERS activate\n   !\n   vrf Tenant_A_APP_Zone\n\
     \      rd 192.168.255.5:12\n      route-target import evpn 12:12\n      route-target\
     \ export evpn 12:12\n      router-id 192.168.255.5\n      redistribute connected\n\
     \   !\n   vrf Tenant_A_WEB_Zone\n      rd 192.168.255.5:11\n      route-target\
@@ -470,10 +469,10 @@ CVP_CONFIGLETS:
     \ ip address 192.168.200.106/24\n!\ninterface Vlan110\n   description Tenant_A_OP_Zone_1\n\
     \   no shutdown\n   vrf Tenant_A_OP_Zone\n   ip address virtual 10.1.10.1/24\n\
     !\ninterface Vlan111\n   description Tenant_A_OP_Zone_2\n   no shutdown\n   vrf\
-    \ Tenant_A_OP_Zone\n   ip address virtual 10.1.11.1/24\n   ip helper-address 1.1.1.1\
-    \ vrf MGMT source-interface lo100\n!\ninterface Vlan120\n   description Tenant_A_WEB_Zone_1\n\
-    \   no shutdown\n   vrf Tenant_A_WEB_Zone\n   ip address virtual 10.1.20.1/24\n\
-    \   ip helper-address 1.1.1.1 vrf TEST source-interface lo100\n!\ninterface Vlan121\n\
+    \ Tenant_A_OP_Zone\n   ip helper-address 1.1.1.1 vrf MGMT source-interface lo100\n\
+    \   ip address virtual 10.1.11.1/24\n!\ninterface Vlan120\n   description Tenant_A_WEB_Zone_1\n\
+    \   no shutdown\n   vrf Tenant_A_WEB_Zone\n   ip helper-address 1.1.1.1 vrf TEST\
+    \ source-interface lo100\n   ip address virtual 10.1.20.1/24\n!\ninterface Vlan121\n\
     \   description Tenant_A_WEBZone_2\n   shutdown\n   mtu 1560\n   vrf Tenant_A_WEB_Zone\n\
     \   ip address virtual 10.1.10.254/24\n!\ninterface Vlan130\n   description Tenant_A_APP_Zone_1\n\
     \   no shutdown\n   vrf Tenant_A_APP_Zone\n   ip address virtual 10.1.30.1/24\n\
@@ -649,10 +648,10 @@ CVP_CONFIGLETS:
     \ ip address 192.168.200.107/24\n!\ninterface Vlan110\n   description Tenant_A_OP_Zone_1\n\
     \   no shutdown\n   vrf Tenant_A_OP_Zone\n   ip address virtual 10.1.10.1/24\n\
     !\ninterface Vlan111\n   description Tenant_A_OP_Zone_2\n   no shutdown\n   vrf\
-    \ Tenant_A_OP_Zone\n   ip address virtual 10.1.11.1/24\n   ip helper-address 1.1.1.1\
-    \ vrf MGMT source-interface lo100\n!\ninterface Vlan120\n   description Tenant_A_WEB_Zone_1\n\
-    \   no shutdown\n   vrf Tenant_A_WEB_Zone\n   ip address virtual 10.1.20.1/24\n\
-    \   ip helper-address 1.1.1.1 vrf TEST source-interface lo100\n!\ninterface Vlan121\n\
+    \ Tenant_A_OP_Zone\n   ip helper-address 1.1.1.1 vrf MGMT source-interface lo100\n\
+    \   ip address virtual 10.1.11.1/24\n!\ninterface Vlan120\n   description Tenant_A_WEB_Zone_1\n\
+    \   no shutdown\n   vrf Tenant_A_WEB_Zone\n   ip helper-address 1.1.1.1 vrf TEST\
+    \ source-interface lo100\n   ip address virtual 10.1.20.1/24\n!\ninterface Vlan121\n\
     \   description Tenant_A_WEBZone_2\n   shutdown\n   mtu 1560\n   vrf Tenant_A_WEB_Zone\n\
     \   ip address virtual 10.1.10.254/24\n!\ninterface Vlan130\n   description Tenant_A_APP_Zone_1\n\
     \   no shutdown\n   vrf Tenant_A_APP_Zone\n   ip address virtual 10.1.30.1/24\n\
@@ -1120,10 +1119,10 @@ CVP_CONFIGLETS:
     \ ip address 192.168.200.108/24\n!\ninterface Vlan110\n   description Tenant_A_OP_Zone_1\n\
     \   no shutdown\n   vrf Tenant_A_OP_Zone\n   ip address virtual 10.1.10.1/24\n\
     !\ninterface Vlan111\n   description Tenant_A_OP_Zone_2\n   no shutdown\n   vrf\
-    \ Tenant_A_OP_Zone\n   ip address virtual 10.1.11.1/24\n   ip helper-address 1.1.1.1\
-    \ vrf MGMT source-interface lo100\n!\ninterface Vlan120\n   description Tenant_A_WEB_Zone_1\n\
-    \   no shutdown\n   vrf Tenant_A_WEB_Zone\n   ip address virtual 10.1.20.1/24\n\
-    \   ip helper-address 1.1.1.1 vrf TEST source-interface lo100\n!\ninterface Vlan121\n\
+    \ Tenant_A_OP_Zone\n   ip helper-address 1.1.1.1 vrf MGMT source-interface lo100\n\
+    \   ip address virtual 10.1.11.1/24\n!\ninterface Vlan120\n   description Tenant_A_WEB_Zone_1\n\
+    \   no shutdown\n   vrf Tenant_A_WEB_Zone\n   ip helper-address 1.1.1.1 vrf TEST\
+    \ source-interface lo100\n   ip address virtual 10.1.20.1/24\n!\ninterface Vlan121\n\
     \   description Tenant_A_WEBZone_2\n   shutdown\n   mtu 1560\n   vrf Tenant_A_WEB_Zone\n\
     \   ip address virtual 10.1.10.254/24\n!\ninterface Vlan130\n   description Tenant_A_APP_Zone_1\n\
     \   no shutdown\n   vrf Tenant_A_APP_Zone\n   ip address virtual 10.1.30.1/24\n\
@@ -1332,10 +1331,10 @@ CVP_CONFIGLETS:
     \ ip address 192.168.200.109/24\n!\ninterface Vlan110\n   description Tenant_A_OP_Zone_1\n\
     \   no shutdown\n   vrf Tenant_A_OP_Zone\n   ip address virtual 10.1.10.1/24\n\
     !\ninterface Vlan111\n   description Tenant_A_OP_Zone_2\n   no shutdown\n   vrf\
-    \ Tenant_A_OP_Zone\n   ip address virtual 10.1.11.1/24\n   ip helper-address 1.1.1.1\
-    \ vrf MGMT source-interface lo100\n!\ninterface Vlan120\n   description Tenant_A_WEB_Zone_1\n\
-    \   no shutdown\n   vrf Tenant_A_WEB_Zone\n   ip address virtual 10.1.20.1/24\n\
-    \   ip helper-address 1.1.1.1 vrf TEST source-interface lo100\n!\ninterface Vlan121\n\
+    \ Tenant_A_OP_Zone\n   ip helper-address 1.1.1.1 vrf MGMT source-interface lo100\n\
+    \   ip address virtual 10.1.11.1/24\n!\ninterface Vlan120\n   description Tenant_A_WEB_Zone_1\n\
+    \   no shutdown\n   vrf Tenant_A_WEB_Zone\n   ip helper-address 1.1.1.1 vrf TEST\
+    \ source-interface lo100\n   ip address virtual 10.1.20.1/24\n!\ninterface Vlan121\n\
     \   description Tenant_A_WEBZone_2\n   shutdown\n   mtu 1560\n   vrf Tenant_A_WEB_Zone\n\
     \   ip address virtual 10.1.10.254/24\n!\ninterface Vlan130\n   description Tenant_A_APP_Zone_1\n\
     \   no shutdown\n   vrf Tenant_A_APP_Zone\n   ip address virtual 10.1.30.1/24\n\

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF1A.md
@@ -288,8 +288,8 @@ interface Vlan4085
    no shutdown
    mtu 1500
    ip address 172.21.110.2/24
-   ip virtual-router address 172.21.110.1
    ip attached-host route export 19
+   ip virtual-router address 172.21.110.1
 ```
 
 ## VXLAN Interface

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2A.md
@@ -576,11 +576,11 @@ interface Vlan112
    description Tenant_A_OP_Zone_3
    no shutdown
    vrf Common_VRF
-   ip address virtual 10.1.12.1/24
    comment
    Comment created from raw_eos_cli under SVI 112 in VRF Common_VRF
    EOF
 
+   ip address virtual 10.1.12.1/24
 !
 interface Vlan113
    description SVI_with_no_vxlan
@@ -611,8 +611,8 @@ interface Vlan4085
    no shutdown
    mtu 1500
    ip address 172.21.110.2/24
-   ip virtual-router address 172.21.110.1
    ip attached-host route export 19
+   ip virtual-router address 172.21.110.1
 !
 interface Vlan4094
    description MLAG_PEER

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2A.md
@@ -576,11 +576,11 @@ interface Vlan112
    description Tenant_A_OP_Zone_3
    no shutdown
    vrf Common_VRF
+   ip address virtual 10.1.12.1/24
    comment
    Comment created from raw_eos_cli under SVI 112 in VRF Common_VRF
    EOF
 
-   ip address virtual 10.1.12.1/24
 !
 interface Vlan113
    description SVI_with_no_vxlan

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
@@ -601,11 +601,11 @@ interface Vlan112
    description Tenant_A_OP_Zone_3
    no shutdown
    vrf Common_VRF
-   ip address virtual 10.1.12.1/24
    comment
    Comment created from raw_eos_cli under SVI 112 in VRF Common_VRF
    EOF
 
+   ip address virtual 10.1.12.1/24
 !
 interface Vlan113
    description SVI_with_no_vxlan
@@ -636,8 +636,8 @@ interface Vlan4085
    no shutdown
    mtu 1500
    ip address 172.21.110.3/24
-   ip virtual-router address 172.21.110.1
    ip attached-host route export 19
+   ip virtual-router address 172.21.110.1
 !
 interface Vlan4094
    description MLAG_PEER

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
@@ -601,11 +601,11 @@ interface Vlan112
    description Tenant_A_OP_Zone_3
    no shutdown
    vrf Common_VRF
+   ip address virtual 10.1.12.1/24
    comment
    Comment created from raw_eos_cli under SVI 112 in VRF Common_VRF
    EOF
 
-   ip address virtual 10.1.12.1/24
 !
 interface Vlan113
    description SVI_with_no_vxlan

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-LEAF1A.md
@@ -378,11 +378,11 @@ interface Vlan112
    description Tenant_A_OP_Zone_3
    no shutdown
    vrf Common_VRF
-   ip address virtual 10.1.12.1/24
    comment
    Comment created from raw_eos_cli under SVI 112 in VRF Common_VRF
    EOF
 
+   ip address virtual 10.1.12.1/24
 !
 interface Vlan113
    description SVI_with_no_vxlan

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-LEAF1A.md
@@ -378,11 +378,11 @@ interface Vlan112
    description Tenant_A_OP_Zone_3
    no shutdown
    vrf Common_VRF
+   ip address virtual 10.1.12.1/24
    comment
    Comment created from raw_eos_cli under SVI 112 in VRF Common_VRF
    EOF
 
-   ip address virtual 10.1.12.1/24
 !
 interface Vlan113
    description SVI_with_no_vxlan

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-LEAF1A.md
@@ -362,8 +362,8 @@ interface Vlan4092
    no shutdown
    mtu 1500
    ip address 172.21.210.2/24
-   ip virtual-router address 172.21.210.1
    ip attached-host route export 19
+   ip virtual-router address 172.21.210.1
 ```
 
 ## VXLAN Interface

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-LEAF2A.md
@@ -312,8 +312,8 @@ interface Vlan4092
    no shutdown
    mtu 1500
    ip address 172.21.210.2/24
-   ip virtual-router address 172.21.210.1
    ip attached-host route export 19
+   ip virtual-router address 172.21.210.1
 ```
 
 ## VXLAN Interface

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF1A.cfg
@@ -76,8 +76,8 @@ interface Vlan4085
    no shutdown
    mtu 1500
    ip address 172.21.110.2/24
-   ip virtual-router address 172.21.110.1
    ip attached-host route export 19
+   ip virtual-router address 172.21.110.1
 !
 interface Vxlan1
    description DC1-POD1-LEAF1A_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2A.cfg
@@ -271,11 +271,11 @@ interface Vlan112
    description Tenant_A_OP_Zone_3
    no shutdown
    vrf Common_VRF
+   ip address virtual 10.1.12.1/24
    comment
    Comment created from raw_eos_cli under SVI 112 in VRF Common_VRF
    EOF
 
-   ip address virtual 10.1.12.1/24
 !
 interface Vlan113
    description SVI_with_no_vxlan

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2A.cfg
@@ -271,11 +271,11 @@ interface Vlan112
    description Tenant_A_OP_Zone_3
    no shutdown
    vrf Common_VRF
-   ip address virtual 10.1.12.1/24
    comment
    Comment created from raw_eos_cli under SVI 112 in VRF Common_VRF
    EOF
 
+   ip address virtual 10.1.12.1/24
 !
 interface Vlan113
    description SVI_with_no_vxlan
@@ -306,8 +306,8 @@ interface Vlan4085
    no shutdown
    mtu 1500
    ip address 172.21.110.2/24
-   ip virtual-router address 172.21.110.1
    ip attached-host route export 19
+   ip virtual-router address 172.21.110.1
 !
 interface Vlan4094
    description MLAG_PEER

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2B.cfg
@@ -277,11 +277,11 @@ interface Vlan112
    description Tenant_A_OP_Zone_3
    no shutdown
    vrf Common_VRF
+   ip address virtual 10.1.12.1/24
    comment
    Comment created from raw_eos_cli under SVI 112 in VRF Common_VRF
    EOF
 
-   ip address virtual 10.1.12.1/24
 !
 interface Vlan113
    description SVI_with_no_vxlan

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2B.cfg
@@ -277,11 +277,11 @@ interface Vlan112
    description Tenant_A_OP_Zone_3
    no shutdown
    vrf Common_VRF
-   ip address virtual 10.1.12.1/24
    comment
    Comment created from raw_eos_cli under SVI 112 in VRF Common_VRF
    EOF
 
+   ip address virtual 10.1.12.1/24
 !
 interface Vlan113
    description SVI_with_no_vxlan
@@ -312,8 +312,8 @@ interface Vlan4085
    no shutdown
    mtu 1500
    ip address 172.21.110.3/24
-   ip virtual-router address 172.21.110.1
    ip attached-host route export 19
+   ip virtual-router address 172.21.110.1
 !
 interface Vlan4094
    description MLAG_PEER

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD2-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD2-LEAF1A.cfg
@@ -129,11 +129,11 @@ interface Vlan112
    description Tenant_A_OP_Zone_3
    no shutdown
    vrf Common_VRF
-   ip address virtual 10.1.12.1/24
    comment
    Comment created from raw_eos_cli under SVI 112 in VRF Common_VRF
    EOF
 
+   ip address virtual 10.1.12.1/24
 !
 interface Vlan113
    description SVI_with_no_vxlan

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD2-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD2-LEAF1A.cfg
@@ -129,11 +129,11 @@ interface Vlan112
    description Tenant_A_OP_Zone_3
    no shutdown
    vrf Common_VRF
+   ip address virtual 10.1.12.1/24
    comment
    Comment created from raw_eos_cli under SVI 112 in VRF Common_VRF
    EOF
 
-   ip address virtual 10.1.12.1/24
 !
 interface Vlan113
    description SVI_with_no_vxlan

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-LEAF1A.cfg
@@ -112,8 +112,8 @@ interface Vlan4092
    no shutdown
    mtu 1500
    ip address 172.21.210.2/24
-   ip virtual-router address 172.21.210.1
    ip attached-host route export 19
+   ip virtual-router address 172.21.210.1
 !
 interface Vxlan1
    description DC2-POD1-LEAF1A_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-LEAF2A.cfg
@@ -75,8 +75,8 @@ interface Vlan4092
    no shutdown
    mtu 1500
    ip address 172.21.210.2/24
-   ip virtual-router address 172.21.210.1
    ip attached-host route export 19
+   ip virtual-router address 172.21.210.1
 !
 interface Vxlan1
    description DC2-POD1-LEAF2A_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL1A.md
@@ -413,11 +413,11 @@ interface Vlan150
    description Tenant_A_WAN_Zone_1
    no shutdown
    vrf Tenant_A_WAN_Zone
-   ip address virtual 10.1.40.1/24
    ip ospf area 1
    ip ospf cost 100
    ip ospf authentication
    ip ospf authentication-key 7 AQQvKeimxJu+uGQ/yYvv9w==
+   ip address virtual 10.1.40.1/24
 !
 interface Vlan250
    description Tenant_B_WAN_Zone_1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL1B.md
@@ -405,11 +405,11 @@ interface Vlan150
    description Tenant_A_WAN_Zone_1
    no shutdown
    vrf Tenant_A_WAN_Zone
-   ip address virtual 10.1.40.1/24
    ip ospf area 1
    ip ospf cost 100
    ip ospf authentication
    ip ospf authentication-key 7 AQQvKeimxJu+uGQ/yYvv9w==
+   ip address virtual 10.1.40.1/24
 !
 interface Vlan250
    description Tenant_B_WAN_Zone_1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL2A.md
@@ -394,11 +394,11 @@ interface Vlan150
    description Tenant_A_WAN_Zone_1
    no shutdown
    vrf Tenant_A_WAN_Zone
-   ip address virtual 10.1.40.1/24
    ip ospf area 1
    ip ospf cost 100
    ip ospf authentication
    ip ospf authentication-key 7 AQQvKeimxJu+uGQ/yYvv9w==
+   ip address virtual 10.1.40.1/24
 !
 interface Vlan250
    description Tenant_B_WAN_Zone_1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL2B.md
@@ -377,11 +377,11 @@ interface Vlan150
    description Tenant_A_WAN_Zone_1
    no shutdown
    vrf Tenant_A_WAN_Zone
-   ip address virtual 10.1.40.1/24
    ip ospf area 1
    ip ospf cost 100
    ip ospf authentication
    ip ospf authentication-key 7 AQQvKeimxJu+uGQ/yYvv9w==
+   ip address virtual 10.1.40.1/24
 !
 interface Vlan250
    description Tenant_B_WAN_Zone_1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF1A.md
@@ -411,10 +411,10 @@ interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
+   ip helper-address 1.1.1.1 vrf TEST source-interface lo100
    ip address virtual 10.1.20.1/24
    ip address virtual 10.2.20.1/24 secondary
    ip address virtual 10.2.21.1/24 secondary
-   ip helper-address 1.1.1.1 vrf TEST source-interface lo100
 !
 interface Vlan121
    description Tenant_A_WEBZone_2

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2A.md
@@ -599,17 +599,17 @@ interface Vlan111
    description Tenant_A_OP_Zone_2
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT source-interface lo100
+   ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
+   ip helper-address 1.1.1.1 vrf TEST source-interface lo100
    ip address virtual 10.1.20.1/24
    ip address virtual 10.2.20.1/24 secondary
    ip address virtual 10.2.21.1/24 secondary
-   ip helper-address 1.1.1.1 vrf TEST source-interface lo100
 !
 interface Vlan121
    description Tenant_A_WEBZone_2

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2B.md
@@ -599,17 +599,17 @@ interface Vlan111
    description Tenant_A_OP_Zone_2
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT source-interface lo100
+   ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
+   ip helper-address 1.1.1.1 vrf TEST source-interface lo100
    ip address virtual 10.1.20.1/24
    ip address virtual 10.2.20.1/24 secondary
    ip address virtual 10.2.21.1/24 secondary
-   ip helper-address 1.1.1.1 vrf TEST source-interface lo100
 !
 interface Vlan121
    description Tenant_A_WEBZone_2

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3A.md
@@ -1007,17 +1007,17 @@ interface Vlan111
    description Tenant_A_OP_Zone_2
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT source-interface lo100
+   ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
+   ip helper-address 1.1.1.1 vrf TEST source-interface lo100
    ip address virtual 10.1.20.1/24
    ip address virtual 10.2.20.1/24 secondary
    ip address virtual 10.2.21.1/24 secondary
-   ip helper-address 1.1.1.1 vrf TEST source-interface lo100
 !
 interface Vlan121
    description Tenant_A_WEBZone_2
@@ -1054,11 +1054,11 @@ interface Vlan150
    description Tenant_A_WAN_Zone_1
    no shutdown
    vrf Tenant_A_WAN_Zone
-   ip address virtual 10.1.40.1/24
    ip ospf area 1
    ip ospf cost 100
    ip ospf authentication
    ip ospf authentication-key 7 AQQvKeimxJu+uGQ/yYvv9w==
+   ip address virtual 10.1.40.1/24
 !
 interface Vlan210
    description Tenant_B_OP_Zone_1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3B.md
@@ -977,17 +977,17 @@ interface Vlan111
    description Tenant_A_OP_Zone_2
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT source-interface lo100
+   ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
+   ip helper-address 1.1.1.1 vrf TEST source-interface lo100
    ip address virtual 10.1.20.1/24
    ip address virtual 10.2.20.1/24 secondary
    ip address virtual 10.2.21.1/24 secondary
-   ip helper-address 1.1.1.1 vrf TEST source-interface lo100
 !
 interface Vlan121
    description Tenant_A_WEBZone_2
@@ -1024,11 +1024,11 @@ interface Vlan150
    description Tenant_A_WAN_Zone_1
    no shutdown
    vrf Tenant_A_WAN_Zone
-   ip address virtual 10.1.40.1/24
    ip ospf area 1
    ip ospf cost 100
    ip ospf authentication
    ip ospf authentication-key 7 AQQvKeimxJu+uGQ/yYvv9w==
+   ip address virtual 10.1.40.1/24
 !
 interface Vlan210
    description Tenant_B_OP_Zone_1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/evpn_services_l2_only_false.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/evpn_services_l2_only_false.md
@@ -368,17 +368,17 @@ interface Vlan111
    description Tenant_A_OP_Zone_2
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT source-interface lo100
+   ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
+   ip helper-address 1.1.1.1 vrf TEST source-interface lo100
    ip address virtual 10.1.20.1/24
    ip address virtual 10.2.20.1/24 secondary
    ip address virtual 10.2.21.1/24 secondary
-   ip helper-address 1.1.1.1 vrf TEST source-interface lo100
 !
 interface Vlan121
    description Tenant_A_WEBZone_2
@@ -423,11 +423,11 @@ interface Vlan150
    description Tenant_A_WAN_Zone_1
    no shutdown
    vrf Tenant_A_WAN_Zone
-   ip address virtual 10.1.40.1/24
    ip ospf area 1
    ip ospf cost 100
    ip ospf authentication
    ip ospf authentication-key 7 AQQvKeimxJu+uGQ/yYvv9w==
+   ip address virtual 10.1.40.1/24
 !
 interface Vlan210
    description Tenant_B_OP_Zone_1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1A.cfg
@@ -146,11 +146,11 @@ interface Vlan150
    description Tenant_A_WAN_Zone_1
    no shutdown
    vrf Tenant_A_WAN_Zone
-   ip address virtual 10.1.40.1/24
    ip ospf area 1
    ip ospf cost 100
    ip ospf authentication
    ip ospf authentication-key 7 AQQvKeimxJu+uGQ/yYvv9w==
+   ip address virtual 10.1.40.1/24
 !
 interface Vlan250
    description Tenant_B_WAN_Zone_1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1B.cfg
@@ -139,11 +139,11 @@ interface Vlan150
    description Tenant_A_WAN_Zone_1
    no shutdown
    vrf Tenant_A_WAN_Zone
-   ip address virtual 10.1.40.1/24
    ip ospf area 1
    ip ospf cost 100
    ip ospf authentication
    ip ospf authentication-key 7 AQQvKeimxJu+uGQ/yYvv9w==
+   ip address virtual 10.1.40.1/24
 !
 interface Vlan250
    description Tenant_B_WAN_Zone_1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL2A.cfg
@@ -104,11 +104,11 @@ interface Vlan150
    description Tenant_A_WAN_Zone_1
    no shutdown
    vrf Tenant_A_WAN_Zone
-   ip address virtual 10.1.40.1/24
    ip ospf area 1
    ip ospf cost 100
    ip ospf authentication
    ip ospf authentication-key 7 AQQvKeimxJu+uGQ/yYvv9w==
+   ip address virtual 10.1.40.1/24
 !
 interface Vlan250
    description Tenant_B_WAN_Zone_1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL2B.cfg
@@ -102,11 +102,11 @@ interface Vlan150
    description Tenant_A_WAN_Zone_1
    no shutdown
    vrf Tenant_A_WAN_Zone
-   ip address virtual 10.1.40.1/24
    ip ospf area 1
    ip ospf cost 100
    ip ospf authentication
    ip ospf authentication-key 7 AQQvKeimxJu+uGQ/yYvv9w==
+   ip address virtual 10.1.40.1/24
 !
 interface Vlan250
    description Tenant_B_WAN_Zone_1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF1A.cfg
@@ -126,10 +126,10 @@ interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
+   ip helper-address 1.1.1.1 vrf TEST source-interface lo100
    ip address virtual 10.1.20.1/24
    ip address virtual 10.2.20.1/24 secondary
    ip address virtual 10.2.21.1/24 secondary
-   ip helper-address 1.1.1.1 vrf TEST source-interface lo100
 !
 interface Vlan121
    description Tenant_A_WEBZone_2

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
@@ -258,17 +258,17 @@ interface Vlan111
    description Tenant_A_OP_Zone_2
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT source-interface lo100
+   ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
+   ip helper-address 1.1.1.1 vrf TEST source-interface lo100
    ip address virtual 10.1.20.1/24
    ip address virtual 10.2.20.1/24 secondary
    ip address virtual 10.2.21.1/24 secondary
-   ip helper-address 1.1.1.1 vrf TEST source-interface lo100
 !
 interface Vlan121
    description Tenant_A_WEBZone_2

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
@@ -258,17 +258,17 @@ interface Vlan111
    description Tenant_A_OP_Zone_2
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT source-interface lo100
+   ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
+   ip helper-address 1.1.1.1 vrf TEST source-interface lo100
    ip address virtual 10.1.20.1/24
    ip address virtual 10.2.20.1/24 secondary
    ip address virtual 10.2.21.1/24 secondary
-   ip helper-address 1.1.1.1 vrf TEST source-interface lo100
 !
 interface Vlan121
    description Tenant_A_WEBZone_2

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3A.cfg
@@ -539,17 +539,17 @@ interface Vlan111
    description Tenant_A_OP_Zone_2
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT source-interface lo100
+   ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
+   ip helper-address 1.1.1.1 vrf TEST source-interface lo100
    ip address virtual 10.1.20.1/24
    ip address virtual 10.2.20.1/24 secondary
    ip address virtual 10.2.21.1/24 secondary
-   ip helper-address 1.1.1.1 vrf TEST source-interface lo100
 !
 interface Vlan121
    description Tenant_A_WEBZone_2
@@ -586,11 +586,11 @@ interface Vlan150
    description Tenant_A_WAN_Zone_1
    no shutdown
    vrf Tenant_A_WAN_Zone
-   ip address virtual 10.1.40.1/24
    ip ospf area 1
    ip ospf cost 100
    ip ospf authentication
    ip ospf authentication-key 7 AQQvKeimxJu+uGQ/yYvv9w==
+   ip address virtual 10.1.40.1/24
 !
 interface Vlan210
    description Tenant_B_OP_Zone_1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3B.cfg
@@ -514,17 +514,17 @@ interface Vlan111
    description Tenant_A_OP_Zone_2
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT source-interface lo100
+   ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
+   ip helper-address 1.1.1.1 vrf TEST source-interface lo100
    ip address virtual 10.1.20.1/24
    ip address virtual 10.2.20.1/24 secondary
    ip address virtual 10.2.21.1/24 secondary
-   ip helper-address 1.1.1.1 vrf TEST source-interface lo100
 !
 interface Vlan121
    description Tenant_A_WEBZone_2
@@ -561,11 +561,11 @@ interface Vlan150
    description Tenant_A_WAN_Zone_1
    no shutdown
    vrf Tenant_A_WAN_Zone
-   ip address virtual 10.1.40.1/24
    ip ospf area 1
    ip ospf cost 100
    ip ospf authentication
    ip ospf authentication-key 7 AQQvKeimxJu+uGQ/yYvv9w==
+   ip address virtual 10.1.40.1/24
 !
 interface Vlan210
    description Tenant_B_OP_Zone_1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_false.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_false.cfg
@@ -130,17 +130,17 @@ interface Vlan111
    description Tenant_A_OP_Zone_2
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT source-interface lo100
+   ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
+   ip helper-address 1.1.1.1 vrf TEST source-interface lo100
    ip address virtual 10.1.20.1/24
    ip address virtual 10.2.20.1/24 secondary
    ip address virtual 10.2.21.1/24 secondary
-   ip helper-address 1.1.1.1 vrf TEST source-interface lo100
 !
 interface Vlan121
    description Tenant_A_WEBZone_2
@@ -185,11 +185,11 @@ interface Vlan150
    description Tenant_A_WAN_Zone_1
    no shutdown
    vrf Tenant_A_WAN_Zone
-   ip address virtual 10.1.40.1/24
    ip ospf area 1
    ip ospf cost 100
    ip ospf authentication
    ip ospf authentication-key 7 AQQvKeimxJu+uGQ/yYvv9w==
+   ip address virtual 10.1.40.1/24
 !
 interface Vlan210
    description Tenant_B_OP_Zone_1

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -416,8 +416,8 @@ interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+   ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2
@@ -430,22 +430,22 @@ interface Vlan122
    description Tenant_a_WEB_DHCP_no_source_int_no_vrf
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.22.1/24
    ip helper-address 1.1.1.1
+   ip address virtual 10.1.22.1/24
 !
 interface Vlan123
    description Tenant_a_WEB_DHCP_source_int_no_vrf
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.23.1/24
    ip helper-address 1.1.1.1 source-interface lo100
+   ip address virtual 10.1.23.1/24
 !
 interface Vlan124
    description Tenant_a_WEB_DHCP_vrf_no_source_int
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.24.1/24
    ip helper-address 1.1.1.1 vrf TEST
+   ip address virtual 10.1.24.1/24
 !
 interface Vlan130
    description Tenant_A_APP_Zone_1

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -614,22 +614,22 @@ interface Vlan110
    description SVI 110 CUSTOM DESCRIPTION
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.10.1/24
    ip helper-address 1.2.3.4
+   ip address virtual 10.1.10.1/24
 !
 interface Vlan111
    description SVI 111 CUSTOM DESCRIPTION
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT source-interface lo100
+   ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+   ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2
@@ -642,22 +642,22 @@ interface Vlan122
    description Tenant_a_WEB_DHCP_no_source_int_no_vrf
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.22.1/24
    ip helper-address 1.1.1.1
+   ip address virtual 10.1.22.1/24
 !
 interface Vlan123
    description Tenant_a_WEB_DHCP_source_int_no_vrf
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.23.1/24
    ip helper-address 1.1.1.1 source-interface lo100
+   ip address virtual 10.1.23.1/24
 !
 interface Vlan124
    description Tenant_a_WEB_DHCP_vrf_no_source_int
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.24.1/24
    ip helper-address 1.1.1.1 vrf TEST
+   ip address virtual 10.1.24.1/24
 !
 interface Vlan130
    description Tenant_A_APP_Zone_1

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -614,22 +614,22 @@ interface Vlan110
    description SVI 110 CUSTOM DESCRIPTION
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.10.1/24
    ip helper-address 1.2.3.4
+   ip address virtual 10.1.10.1/24
 !
 interface Vlan111
    description SVI 111 CUSTOM DESCRIPTION
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT source-interface lo100
+   ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+   ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2
@@ -642,22 +642,22 @@ interface Vlan122
    description Tenant_a_WEB_DHCP_no_source_int_no_vrf
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.22.1/24
    ip helper-address 1.1.1.1
+   ip address virtual 10.1.22.1/24
 !
 interface Vlan123
    description Tenant_a_WEB_DHCP_source_int_no_vrf
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.23.1/24
    ip helper-address 1.1.1.1 source-interface lo100
+   ip address virtual 10.1.23.1/24
 !
 interface Vlan124
    description Tenant_a_WEB_DHCP_vrf_no_source_int
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.24.1/24
    ip helper-address 1.1.1.1 vrf TEST
+   ip address virtual 10.1.24.1/24
 !
 interface Vlan130
    description Tenant_A_APP_Zone_1

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -876,22 +876,22 @@ interface Vlan110
    description SVI 110 CUSTOM DESCRIPTION
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.10.1/24
    ip helper-address 1.2.3.4
+   ip address virtual 10.1.10.1/24
 !
 interface Vlan111
    description SVI 111 CUSTOM DESCRIPTION
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT source-interface lo100
+   ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+   ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2
@@ -904,22 +904,22 @@ interface Vlan122
    description Tenant_a_WEB_DHCP_no_source_int_no_vrf
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.22.1/24
    ip helper-address 1.1.1.1
+   ip address virtual 10.1.22.1/24
 !
 interface Vlan123
    description Tenant_a_WEB_DHCP_source_int_no_vrf
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.23.1/24
    ip helper-address 1.1.1.1 source-interface lo100
+   ip address virtual 10.1.23.1/24
 !
 interface Vlan124
    description Tenant_a_WEB_DHCP_vrf_no_source_int
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.24.1/24
    ip helper-address 1.1.1.1 vrf TEST
+   ip address virtual 10.1.24.1/24
 !
 interface Vlan130
    description Tenant_A_APP_Zone_1

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -876,22 +876,22 @@ interface Vlan110
    description SVI 110 CUSTOM DESCRIPTION
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.10.1/24
    ip helper-address 1.2.3.4
+   ip address virtual 10.1.10.1/24
 !
 interface Vlan111
    description SVI 111 CUSTOM DESCRIPTION
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT source-interface lo100
+   ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+   ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2
@@ -904,22 +904,22 @@ interface Vlan122
    description Tenant_a_WEB_DHCP_no_source_int_no_vrf
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.22.1/24
    ip helper-address 1.1.1.1
+   ip address virtual 10.1.22.1/24
 !
 interface Vlan123
    description Tenant_a_WEB_DHCP_source_int_no_vrf
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.23.1/24
    ip helper-address 1.1.1.1 source-interface lo100
+   ip address virtual 10.1.23.1/24
 !
 interface Vlan124
    description Tenant_a_WEB_DHCP_vrf_no_source_int
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.24.1/24
    ip helper-address 1.1.1.1 vrf TEST
+   ip address virtual 10.1.24.1/24
 !
 interface Vlan130
    description Tenant_A_APP_Zone_1

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
@@ -130,8 +130,8 @@ interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+   ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2
@@ -144,22 +144,22 @@ interface Vlan122
    description Tenant_a_WEB_DHCP_no_source_int_no_vrf
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.22.1/24
    ip helper-address 1.1.1.1
+   ip address virtual 10.1.22.1/24
 !
 interface Vlan123
    description Tenant_a_WEB_DHCP_source_int_no_vrf
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.23.1/24
    ip helper-address 1.1.1.1 source-interface lo100
+   ip address virtual 10.1.23.1/24
 !
 interface Vlan124
    description Tenant_a_WEB_DHCP_vrf_no_source_int
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.24.1/24
    ip helper-address 1.1.1.1 vrf TEST
+   ip address virtual 10.1.24.1/24
 !
 interface Vlan130
    description Tenant_A_APP_Zone_1

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
@@ -267,22 +267,22 @@ interface Vlan110
    description SVI 110 CUSTOM DESCRIPTION
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.10.1/24
    ip helper-address 1.2.3.4
+   ip address virtual 10.1.10.1/24
 !
 interface Vlan111
    description SVI 111 CUSTOM DESCRIPTION
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT source-interface lo100
+   ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+   ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2
@@ -295,22 +295,22 @@ interface Vlan122
    description Tenant_a_WEB_DHCP_no_source_int_no_vrf
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.22.1/24
    ip helper-address 1.1.1.1
+   ip address virtual 10.1.22.1/24
 !
 interface Vlan123
    description Tenant_a_WEB_DHCP_source_int_no_vrf
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.23.1/24
    ip helper-address 1.1.1.1 source-interface lo100
+   ip address virtual 10.1.23.1/24
 !
 interface Vlan124
    description Tenant_a_WEB_DHCP_vrf_no_source_int
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.24.1/24
    ip helper-address 1.1.1.1 vrf TEST
+   ip address virtual 10.1.24.1/24
 !
 interface Vlan130
    description Tenant_A_APP_Zone_1

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
@@ -267,22 +267,22 @@ interface Vlan110
    description SVI 110 CUSTOM DESCRIPTION
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.10.1/24
    ip helper-address 1.2.3.4
+   ip address virtual 10.1.10.1/24
 !
 interface Vlan111
    description SVI 111 CUSTOM DESCRIPTION
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT source-interface lo100
+   ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+   ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2
@@ -295,22 +295,22 @@ interface Vlan122
    description Tenant_a_WEB_DHCP_no_source_int_no_vrf
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.22.1/24
    ip helper-address 1.1.1.1
+   ip address virtual 10.1.22.1/24
 !
 interface Vlan123
    description Tenant_a_WEB_DHCP_source_int_no_vrf
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.23.1/24
    ip helper-address 1.1.1.1 source-interface lo100
+   ip address virtual 10.1.23.1/24
 !
 interface Vlan124
    description Tenant_a_WEB_DHCP_vrf_no_source_int
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.24.1/24
    ip helper-address 1.1.1.1 vrf TEST
+   ip address virtual 10.1.24.1/24
 !
 interface Vlan130
    description Tenant_A_APP_Zone_1

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
@@ -464,22 +464,22 @@ interface Vlan110
    description SVI 110 CUSTOM DESCRIPTION
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.10.1/24
    ip helper-address 1.2.3.4
+   ip address virtual 10.1.10.1/24
 !
 interface Vlan111
    description SVI 111 CUSTOM DESCRIPTION
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT source-interface lo100
+   ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+   ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2
@@ -492,22 +492,22 @@ interface Vlan122
    description Tenant_a_WEB_DHCP_no_source_int_no_vrf
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.22.1/24
    ip helper-address 1.1.1.1
+   ip address virtual 10.1.22.1/24
 !
 interface Vlan123
    description Tenant_a_WEB_DHCP_source_int_no_vrf
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.23.1/24
    ip helper-address 1.1.1.1 source-interface lo100
+   ip address virtual 10.1.23.1/24
 !
 interface Vlan124
    description Tenant_a_WEB_DHCP_vrf_no_source_int
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.24.1/24
    ip helper-address 1.1.1.1 vrf TEST
+   ip address virtual 10.1.24.1/24
 !
 interface Vlan130
    description Tenant_A_APP_Zone_1

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
@@ -464,22 +464,22 @@ interface Vlan110
    description SVI 110 CUSTOM DESCRIPTION
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.10.1/24
    ip helper-address 1.2.3.4
+   ip address virtual 10.1.10.1/24
 !
 interface Vlan111
    description SVI 111 CUSTOM DESCRIPTION
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT source-interface lo100
+   ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+   ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2
@@ -492,22 +492,22 @@ interface Vlan122
    description Tenant_a_WEB_DHCP_no_source_int_no_vrf
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.22.1/24
    ip helper-address 1.1.1.1
+   ip address virtual 10.1.22.1/24
 !
 interface Vlan123
    description Tenant_a_WEB_DHCP_source_int_no_vrf
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.23.1/24
    ip helper-address 1.1.1.1 source-interface lo100
+   ip address virtual 10.1.23.1/24
 !
 interface Vlan124
    description Tenant_a_WEB_DHCP_vrf_no_source_int
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.24.1/24
    ip helper-address 1.1.1.1 vrf TEST
+   ip address virtual 10.1.24.1/24
 !
 interface Vlan130
    description Tenant_A_APP_Zone_1

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -397,8 +397,8 @@ interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+   ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -638,15 +638,15 @@ interface Vlan111
    description Tenant_A_OP_Zone_2
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT source-interface lo100
+   ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+   ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -638,15 +638,15 @@ interface Vlan111
    description Tenant_A_OP_Zone_2
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT source-interface lo100
+   ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+   ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -752,15 +752,15 @@ interface Vlan111
    description Tenant_A_OP_Zone_2
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT source-interface lo100
+   ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+   ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -737,15 +737,15 @@ interface Vlan111
    description Tenant_A_OP_Zone_2
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT source-interface lo100
+   ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+   ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
@@ -116,8 +116,8 @@ interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+   ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
@@ -256,15 +256,15 @@ interface Vlan111
    description Tenant_A_OP_Zone_2
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT source-interface lo100
+   ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+   ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
@@ -256,15 +256,15 @@ interface Vlan111
    description Tenant_A_OP_Zone_2
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT source-interface lo100
+   ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+   ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
@@ -353,15 +353,15 @@ interface Vlan111
    description Tenant_A_OP_Zone_2
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT source-interface lo100
+   ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+   ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
@@ -340,15 +340,15 @@ interface Vlan111
    description Tenant_A_OP_Zone_2
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT source-interface lo100
+   ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+   ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF1A.md
@@ -288,8 +288,8 @@ interface Vlan4085
    no shutdown
    mtu 1500
    ip address 172.21.110.2/24
-   ip virtual-router address 172.21.110.1
    ip attached-host route export 19
+   ip virtual-router address 172.21.110.1
 ```
 
 ## VXLAN Interface

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2A.md
@@ -492,19 +492,19 @@ interface Vlan112
    description Tenant_A_OP_Zone_3
    no shutdown
    vrf Common_VRF
-   ip address virtual 10.1.12.1/24
    comment
    Comment created from raw_eos_cli under SVI 112 in VRF Common_VRF
    EOF
 
+   ip address virtual 10.1.12.1/24
 !
 interface Vlan4085
    description L2LEAF_INBAND_MGMT
    no shutdown
    mtu 1500
    ip address 172.21.110.2/24
-   ip virtual-router address 172.21.110.1
    ip attached-host route export 19
+   ip virtual-router address 172.21.110.1
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2A.md
@@ -492,11 +492,11 @@ interface Vlan112
    description Tenant_A_OP_Zone_3
    no shutdown
    vrf Common_VRF
+   ip address virtual 10.1.12.1/24
    comment
    Comment created from raw_eos_cli under SVI 112 in VRF Common_VRF
    EOF
 
-   ip address virtual 10.1.12.1/24
 !
 interface Vlan4085
    description L2LEAF_INBAND_MGMT

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
@@ -519,11 +519,11 @@ interface Vlan112
    description Tenant_A_OP_Zone_3
    no shutdown
    vrf Common_VRF
+   ip address virtual 10.1.12.1/24
    comment
    Comment created from raw_eos_cli under SVI 112 in VRF Common_VRF
    EOF
 
-   ip address virtual 10.1.12.1/24
 !
 interface Vlan4085
    description L2LEAF_INBAND_MGMT

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
@@ -519,19 +519,19 @@ interface Vlan112
    description Tenant_A_OP_Zone_3
    no shutdown
    vrf Common_VRF
-   ip address virtual 10.1.12.1/24
    comment
    Comment created from raw_eos_cli under SVI 112 in VRF Common_VRF
    EOF
 
+   ip address virtual 10.1.12.1/24
 !
 interface Vlan4085
    description L2LEAF_INBAND_MGMT
    no shutdown
    mtu 1500
    ip address 172.21.110.3/24
-   ip virtual-router address 172.21.110.1
    ip attached-host route export 19
+   ip virtual-router address 172.21.110.1
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-LEAF1A.md
@@ -317,11 +317,11 @@ interface Vlan112
    description Tenant_A_OP_Zone_3
    no shutdown
    vrf Common_VRF
+   ip address virtual 10.1.12.1/24
    comment
    Comment created from raw_eos_cli under SVI 112 in VRF Common_VRF
    EOF
 
-   ip address virtual 10.1.12.1/24
 ```
 
 ## VXLAN Interface

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-LEAF1A.md
@@ -317,11 +317,11 @@ interface Vlan112
    description Tenant_A_OP_Zone_3
    no shutdown
    vrf Common_VRF
-   ip address virtual 10.1.12.1/24
    comment
    Comment created from raw_eos_cli under SVI 112 in VRF Common_VRF
    EOF
 
+   ip address virtual 10.1.12.1/24
 ```
 
 ## VXLAN Interface

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-LEAF1A.md
@@ -329,8 +329,8 @@ interface Vlan4092
    no shutdown
    mtu 1500
    ip address 172.21.210.2/24
-   ip virtual-router address 172.21.210.1
    ip attached-host route export 19
+   ip virtual-router address 172.21.210.1
 ```
 
 ## VXLAN Interface

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF1A.cfg
@@ -76,8 +76,8 @@ interface Vlan4085
    no shutdown
    mtu 1500
    ip address 172.21.110.2/24
-   ip virtual-router address 172.21.110.1
    ip attached-host route export 19
+   ip virtual-router address 172.21.110.1
 !
 interface Vxlan1
    description DC1-POD1-LEAF1A_VTEP

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2A.cfg
@@ -215,19 +215,19 @@ interface Vlan112
    description Tenant_A_OP_Zone_3
    no shutdown
    vrf Common_VRF
-   ip address virtual 10.1.12.1/24
    comment
    Comment created from raw_eos_cli under SVI 112 in VRF Common_VRF
    EOF
 
+   ip address virtual 10.1.12.1/24
 !
 interface Vlan4085
    description L2LEAF_INBAND_MGMT
    no shutdown
    mtu 1500
    ip address 172.21.110.2/24
-   ip virtual-router address 172.21.110.1
    ip attached-host route export 19
+   ip virtual-router address 172.21.110.1
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2A.cfg
@@ -215,11 +215,11 @@ interface Vlan112
    description Tenant_A_OP_Zone_3
    no shutdown
    vrf Common_VRF
+   ip address virtual 10.1.12.1/24
    comment
    Comment created from raw_eos_cli under SVI 112 in VRF Common_VRF
    EOF
 
-   ip address virtual 10.1.12.1/24
 !
 interface Vlan4085
    description L2LEAF_INBAND_MGMT

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2B.cfg
@@ -222,19 +222,19 @@ interface Vlan112
    description Tenant_A_OP_Zone_3
    no shutdown
    vrf Common_VRF
-   ip address virtual 10.1.12.1/24
    comment
    Comment created from raw_eos_cli under SVI 112 in VRF Common_VRF
    EOF
 
+   ip address virtual 10.1.12.1/24
 !
 interface Vlan4085
    description L2LEAF_INBAND_MGMT
    no shutdown
    mtu 1500
    ip address 172.21.110.3/24
-   ip virtual-router address 172.21.110.1
    ip attached-host route export 19
+   ip virtual-router address 172.21.110.1
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2B.cfg
@@ -222,11 +222,11 @@ interface Vlan112
    description Tenant_A_OP_Zone_3
    no shutdown
    vrf Common_VRF
+   ip address virtual 10.1.12.1/24
    comment
    Comment created from raw_eos_cli under SVI 112 in VRF Common_VRF
    EOF
 
-   ip address virtual 10.1.12.1/24
 !
 interface Vlan4085
    description L2LEAF_INBAND_MGMT

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/intended/configs/DC1-POD2-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/intended/configs/DC1-POD2-LEAF1A.cfg
@@ -94,11 +94,11 @@ interface Vlan112
    description Tenant_A_OP_Zone_3
    no shutdown
    vrf Common_VRF
-   ip address virtual 10.1.12.1/24
    comment
    Comment created from raw_eos_cli under SVI 112 in VRF Common_VRF
    EOF
 
+   ip address virtual 10.1.12.1/24
 !
 interface Vxlan1
    description DC1-POD2-LEAF1A_VTEP

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/intended/configs/DC1-POD2-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/intended/configs/DC1-POD2-LEAF1A.cfg
@@ -94,11 +94,11 @@ interface Vlan112
    description Tenant_A_OP_Zone_3
    no shutdown
    vrf Common_VRF
+   ip address virtual 10.1.12.1/24
    comment
    Comment created from raw_eos_cli under SVI 112 in VRF Common_VRF
    EOF
 
-   ip address virtual 10.1.12.1/24
 !
 interface Vxlan1
    description DC1-POD2-LEAF1A_VTEP

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-LEAF1A.cfg
@@ -92,8 +92,8 @@ interface Vlan4092
    no shutdown
    mtu 1500
    ip address 172.21.210.2/24
-   ip virtual-router address 172.21.210.1
    ip attached-host route export 19
+   ip virtual-router address 172.21.210.1
 !
 interface Vxlan1
    description DC2-POD1-LEAF1A_VTEP

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -405,8 +405,8 @@ interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+   ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -598,15 +598,15 @@ interface Vlan111
    description Tenant_A_OP_Zone_2
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT source-interface lo100
+   ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+   ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -598,15 +598,15 @@ interface Vlan111
    description Tenant_A_OP_Zone_2
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT source-interface lo100
+   ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+   ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -837,15 +837,15 @@ interface Vlan111
    description Tenant_A_OP_Zone_2
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT source-interface lo100
+   ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+   ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -837,15 +837,15 @@ interface Vlan111
    description Tenant_A_OP_Zone_2
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT source-interface lo100
+   ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+   ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
@@ -123,8 +123,8 @@ interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+   ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
@@ -255,15 +255,15 @@ interface Vlan111
    description Tenant_A_OP_Zone_2
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT source-interface lo100
+   ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+   ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
@@ -255,15 +255,15 @@ interface Vlan111
    description Tenant_A_OP_Zone_2
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT source-interface lo100
+   ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+   ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
@@ -431,15 +431,15 @@ interface Vlan111
    description Tenant_A_OP_Zone_2
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT source-interface lo100
+   ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+   ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
@@ -431,15 +431,15 @@ interface Vlan111
    description Tenant_A_OP_Zone_2
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT source-interface lo100
+   ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+   ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -397,8 +397,8 @@ interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+   ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -638,15 +638,15 @@ interface Vlan111
    description Tenant_A_OP_Zone_2
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT source-interface lo100
+   ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+   ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -638,15 +638,15 @@ interface Vlan111
    description Tenant_A_OP_Zone_2
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT source-interface lo100
+   ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+   ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -752,15 +752,15 @@ interface Vlan111
    description Tenant_A_OP_Zone_2
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT source-interface lo100
+   ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+   ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -737,15 +737,15 @@ interface Vlan111
    description Tenant_A_OP_Zone_2
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT source-interface lo100
+   ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+   ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
@@ -116,8 +116,8 @@ interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+   ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
@@ -256,15 +256,15 @@ interface Vlan111
    description Tenant_A_OP_Zone_2
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT source-interface lo100
+   ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+   ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
@@ -256,15 +256,15 @@ interface Vlan111
    description Tenant_A_OP_Zone_2
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT source-interface lo100
+   ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+   ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
@@ -353,15 +353,15 @@ interface Vlan111
    description Tenant_A_OP_Zone_2
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT source-interface lo100
+   ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+   ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
@@ -340,15 +340,15 @@ interface Vlan111
    description Tenant_A_OP_Zone_2
    no shutdown
    vrf Tenant_A_OP_Zone
-   ip address virtual 10.1.11.1/24
    ip helper-address 1.1.1.1 vrf MGMT source-interface lo100
+   ip address virtual 10.1.11.1/24
 !
 interface Vlan120
    description Tenant_A_WEB_Zone_1
    no shutdown
    vrf Tenant_A_WEB_Zone
-   ip address virtual 10.1.20.1/24
    ip helper-address 1.1.1.1 vrf TEST source-interface lo100
+   ip address virtual 10.1.20.1/24
 !
 interface Vlan121
    description Tenant_A_WEBZone_2

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
@@ -189,9 +189,6 @@ interface {{ vlan_interface }}
 {%     if vlan_interfaces[vlan_interface].pvlan_mapping is arista.avd.defined %}
    pvlan mapping {{ vlan_interfaces[vlan_interface].pvlan_mapping }}
 {%     endif %}
-{%     if vlan_interfaces[vlan_interface].eos_cli is arista.avd.defined %}
-   {{ vlan_interfaces[vlan_interface].eos_cli | indent(3, false) }}
-{%     endif %}
 {%     if vlan_interfaces[vlan_interface].ip_virtual_router_addresses is arista.avd.defined %}
 {%         for ip_virtual_router_address in vlan_interfaces[vlan_interface].ip_virtual_router_addresses %}
    ip virtual-router address {{ ip_virtual_router_address }}
@@ -204,5 +201,8 @@ interface {{ vlan_interface }}
    ip address virtual {{ ip_address_virtual_secondary }} secondary
 {%             endfor %}
 {%         endif %}
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].eos_cli is arista.avd.defined %}
+   {{ vlan_interfaces[vlan_interface].eos_cli | indent(3, false) }}
 {%     endif %}
 {% endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
@@ -42,19 +42,6 @@ interface {{ vlan_interface }}
 {%             endfor %}
 {%         endif %}
 {%     endif %}
-{%     if vlan_interfaces[vlan_interface].ip_virtual_router_addresses is arista.avd.defined %}
-{%         for ip_virtual_router_address in vlan_interfaces[vlan_interface].ip_virtual_router_addresses %}
-   ip virtual-router address {{ ip_virtual_router_address }}
-{%         endfor %}
-{%     endif %}
-{%     if vlan_interfaces[vlan_interface].ip_address_virtual is arista.avd.defined %}
-   ip address virtual {{ vlan_interfaces[vlan_interface].ip_address_virtual }}
-{%         if vlan_interfaces[vlan_interface].ip_address_virtual_secondaries is arista.avd.defined %}
-{%             for ip_address_virtual_secondary in vlan_interfaces[vlan_interface].ip_address_virtual_secondaries %}
-   ip address virtual {{ ip_address_virtual_secondary }} secondary
-{%             endfor %}
-{%         endif %}
-{%     endif %}
 {%     for ip_helper in vlan_interfaces[vlan_interface].ip_helpers | arista.avd.natural_sort %}
 {%         set ip_helper_cli = "ip helper-address " ~ ip_helper %}
 {%         if vlan_interfaces[vlan_interface].ip_helpers[ip_helper].vrf is arista.avd.defined %}
@@ -204,5 +191,18 @@ interface {{ vlan_interface }}
 {%     endif %}
 {%     if vlan_interfaces[vlan_interface].eos_cli is arista.avd.defined %}
    {{ vlan_interfaces[vlan_interface].eos_cli | indent(3, false) }}
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].ip_virtual_router_addresses is arista.avd.defined %}
+{%         for ip_virtual_router_address in vlan_interfaces[vlan_interface].ip_virtual_router_addresses %}
+   ip virtual-router address {{ ip_virtual_router_address }}
+{%         endfor %}
+{%     endif %}
+{%     if vlan_interfaces[vlan_interface].ip_address_virtual is arista.avd.defined %}
+   ip address virtual {{ vlan_interfaces[vlan_interface].ip_address_virtual }}
+{%         if vlan_interfaces[vlan_interface].ip_address_virtual_secondaries is arista.avd.defined %}
+{%             for ip_address_virtual_secondary in vlan_interfaces[vlan_interface].ip_address_virtual_secondaries %}
+   ip address virtual {{ ip_address_virtual_secondary }} secondary
+{%             endfor %}
+{%         endif %}
 {%     endif %}
 {% endfor %}


### PR DESCRIPTION
## Change Summary

Part of the various changes for getting output config to reflect config order on box.

## Related Issue(s)

Fixes #1572

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Reorder `ip address virtual` and `ip virtual-router address` lines under vlan_interfaces.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
