### PR TITLE
Fix(eos_cli_config_gen): port_channel_interface mlag config order

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3A.md
@@ -798,9 +798,9 @@ interface Port-Channel17
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   mlag 17
    port-channel lacp fallback timeout 90
    port-channel lacp fallback static
+   mlag 17
    spanning-tree portfast
    spanning-tree bpduguard disable
    spanning-tree bpdufilter enable
@@ -815,9 +815,9 @@ interface Port-Channel18
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   mlag 18
    port-channel lacp fallback timeout 10
    port-channel lacp fallback static
+   mlag 18
    spanning-tree portfast
    spanning-tree bpduguard enable
    spanning-tree bpdufilter enable
@@ -832,9 +832,9 @@ interface Port-Channel19
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   mlag 19
    port-channel lacp fallback timeout 10
    port-channel lacp fallback static
+   mlag 19
    spanning-tree portfast
    spanning-tree bpduguard enable
    spanning-tree bpdufilter enable

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3B.md
@@ -768,9 +768,9 @@ interface Port-Channel17
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   mlag 17
    port-channel lacp fallback timeout 90
    port-channel lacp fallback static
+   mlag 17
    spanning-tree portfast
    spanning-tree bpduguard disable
    spanning-tree bpdufilter enable
@@ -785,9 +785,9 @@ interface Port-Channel18
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   mlag 18
    port-channel lacp fallback timeout 10
    port-channel lacp fallback static
+   mlag 18
    spanning-tree portfast
    spanning-tree bpduguard enable
    spanning-tree bpdufilter enable
@@ -802,9 +802,9 @@ interface Port-Channel19
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   mlag 19
    port-channel lacp fallback timeout 10
    port-channel lacp fallback static
+   mlag 19
    spanning-tree portfast
    spanning-tree bpduguard enable
    spanning-tree bpdufilter enable

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3A.cfg
@@ -211,9 +211,9 @@ interface Port-Channel17
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   mlag 17
    port-channel lacp fallback timeout 90
    port-channel lacp fallback static
+   mlag 17
    spanning-tree portfast
    spanning-tree bpduguard disable
    spanning-tree bpdufilter enable
@@ -228,9 +228,9 @@ interface Port-Channel18
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   mlag 18
    port-channel lacp fallback timeout 10
    port-channel lacp fallback static
+   mlag 18
    spanning-tree portfast
    spanning-tree bpduguard enable
    spanning-tree bpdufilter enable
@@ -245,9 +245,9 @@ interface Port-Channel19
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   mlag 19
    port-channel lacp fallback timeout 10
    port-channel lacp fallback static
+   mlag 19
    spanning-tree portfast
    spanning-tree bpduguard enable
    spanning-tree bpdufilter enable

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3B.cfg
@@ -203,9 +203,9 @@ interface Port-Channel17
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   mlag 17
    port-channel lacp fallback timeout 90
    port-channel lacp fallback static
+   mlag 17
    spanning-tree portfast
    spanning-tree bpduguard disable
    spanning-tree bpdufilter enable
@@ -220,9 +220,9 @@ interface Port-Channel18
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   mlag 18
    port-channel lacp fallback timeout 10
    port-channel lacp fallback static
+   mlag 18
    spanning-tree portfast
    spanning-tree bpduguard enable
    spanning-tree bpdufilter enable
@@ -237,9 +237,9 @@ interface Port-Channel19
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   mlag 19
    port-channel lacp fallback timeout 10
    port-channel lacp fallback static
+   mlag 19
    spanning-tree portfast
    spanning-tree bpduguard enable
    spanning-tree bpdufilter enable

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -700,9 +700,9 @@ interface Port-Channel17
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   mlag 17
    port-channel lacp fallback timeout 90
    port-channel lacp fallback static
+   mlag 17
    spanning-tree portfast
    spanning-tree bpdufilter enable
    storm-control all level 10
@@ -716,9 +716,9 @@ interface Port-Channel18
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   mlag 18
    port-channel lacp fallback timeout 10
    port-channel lacp fallback static
+   mlag 18
    spanning-tree portfast
    spanning-tree bpdufilter enable
    storm-control all level 10
@@ -732,9 +732,9 @@ interface Port-Channel19
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   mlag 19
    port-channel lacp fallback timeout 10
    port-channel lacp fallback static
+   mlag 19
    spanning-tree portfast
    spanning-tree bpdufilter enable
    storm-control all level 10

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -700,9 +700,9 @@ interface Port-Channel17
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   mlag 17
    port-channel lacp fallback timeout 90
    port-channel lacp fallback static
+   mlag 17
    spanning-tree portfast
    spanning-tree bpdufilter enable
    storm-control all level 10
@@ -716,9 +716,9 @@ interface Port-Channel18
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   mlag 18
    port-channel lacp fallback timeout 10
    port-channel lacp fallback static
+   mlag 18
    spanning-tree portfast
    spanning-tree bpdufilter enable
    storm-control all level 10
@@ -732,9 +732,9 @@ interface Port-Channel19
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   mlag 19
    port-channel lacp fallback timeout 10
    port-channel lacp fallback static
+   mlag 19
    spanning-tree portfast
    spanning-tree bpdufilter enable
    storm-control all level 10

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
@@ -223,9 +223,9 @@ interface Port-Channel17
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   mlag 17
    port-channel lacp fallback timeout 90
    port-channel lacp fallback static
+   mlag 17
    spanning-tree portfast
    spanning-tree bpdufilter enable
    storm-control all level 10
@@ -239,9 +239,9 @@ interface Port-Channel18
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   mlag 18
    port-channel lacp fallback timeout 10
    port-channel lacp fallback static
+   mlag 18
    spanning-tree portfast
    spanning-tree bpdufilter enable
    storm-control all level 10
@@ -255,9 +255,9 @@ interface Port-Channel19
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   mlag 19
    port-channel lacp fallback timeout 10
    port-channel lacp fallback static
+   mlag 19
    spanning-tree portfast
    spanning-tree bpdufilter enable
    storm-control all level 10

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
@@ -223,9 +223,9 @@ interface Port-Channel17
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   mlag 17
    port-channel lacp fallback timeout 90
    port-channel lacp fallback static
+   mlag 17
    spanning-tree portfast
    spanning-tree bpdufilter enable
    storm-control all level 10
@@ -239,9 +239,9 @@ interface Port-Channel18
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   mlag 18
    port-channel lacp fallback timeout 10
    port-channel lacp fallback static
+   mlag 18
    spanning-tree portfast
    spanning-tree bpdufilter enable
    storm-control all level 10
@@ -255,9 +255,9 @@ interface Port-Channel19
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   mlag 19
    port-channel lacp fallback timeout 10
    port-channel lacp fallback static
+   mlag 19
    spanning-tree portfast
    spanning-tree bpdufilter enable
    storm-control all level 10

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -666,9 +666,9 @@ interface Port-Channel17
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   mlag 17
    port-channel lacp fallback timeout 90
    port-channel lacp fallback static
+   mlag 17
    spanning-tree portfast
    spanning-tree bpdufilter enable
    storm-control all level 10
@@ -682,9 +682,9 @@ interface Port-Channel18
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   mlag 18
    port-channel lacp fallback timeout 10
    port-channel lacp fallback static
+   mlag 18
    spanning-tree portfast
    spanning-tree bpdufilter enable
    storm-control all level 10
@@ -698,9 +698,9 @@ interface Port-Channel19
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   mlag 19
    port-channel lacp fallback timeout 10
    port-channel lacp fallback static
+   mlag 19
    spanning-tree portfast
    spanning-tree bpdufilter enable
    storm-control all level 10

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -666,9 +666,9 @@ interface Port-Channel17
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   mlag 17
    port-channel lacp fallback timeout 90
    port-channel lacp fallback static
+   mlag 17
    spanning-tree portfast
    spanning-tree bpdufilter enable
    storm-control all level 10
@@ -682,9 +682,9 @@ interface Port-Channel18
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   mlag 18
    port-channel lacp fallback timeout 10
    port-channel lacp fallback static
+   mlag 18
    spanning-tree portfast
    spanning-tree bpdufilter enable
    storm-control all level 10
@@ -698,9 +698,9 @@ interface Port-Channel19
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   mlag 19
    port-channel lacp fallback timeout 10
    port-channel lacp fallback static
+   mlag 19
    spanning-tree portfast
    spanning-tree bpdufilter enable
    storm-control all level 10

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
@@ -210,9 +210,9 @@ interface Port-Channel17
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   mlag 17
    port-channel lacp fallback timeout 90
    port-channel lacp fallback static
+   mlag 17
    spanning-tree portfast
    spanning-tree bpdufilter enable
    storm-control all level 10
@@ -226,9 +226,9 @@ interface Port-Channel18
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   mlag 18
    port-channel lacp fallback timeout 10
    port-channel lacp fallback static
+   mlag 18
    spanning-tree portfast
    spanning-tree bpdufilter enable
    storm-control all level 10
@@ -242,9 +242,9 @@ interface Port-Channel19
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   mlag 19
    port-channel lacp fallback timeout 10
    port-channel lacp fallback static
+   mlag 19
    spanning-tree portfast
    spanning-tree bpdufilter enable
    storm-control all level 10

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
@@ -210,9 +210,9 @@ interface Port-Channel17
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   mlag 17
    port-channel lacp fallback timeout 90
    port-channel lacp fallback static
+   mlag 17
    spanning-tree portfast
    spanning-tree bpdufilter enable
    storm-control all level 10
@@ -226,9 +226,9 @@ interface Port-Channel18
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   mlag 18
    port-channel lacp fallback timeout 10
    port-channel lacp fallback static
+   mlag 18
    spanning-tree portfast
    spanning-tree bpdufilter enable
    storm-control all level 10
@@ -242,9 +242,9 @@ interface Port-Channel19
    switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   mlag 19
    port-channel lacp fallback timeout 10
    port-channel lacp fallback static
+   mlag 19
    spanning-tree portfast
    spanning-tree bpdufilter enable
    storm-control all level 10

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
@@ -97,9 +97,6 @@ interface {{ port_channel_interface }}
 {%     if port_channel_interfaces[port_channel_interface].l2_protocol.encapsulation_dot1q_vlan is arista.avd.defined %}
    l2-protocol encapsulation dot1q vlan {{ port_channel_interfaces[port_channel_interface].l2_protocol.encapsulation_dot1q_vlan }}
 {%     endif %}
-{%     if port_channel_interfaces[port_channel_interface].mlag is arista.avd.defined %}
-   mlag {{ port_channel_interfaces[port_channel_interface].mlag }}
-{%     endif %}
 {%     if port_channel_interfaces[port_channel_interface].esi is arista.avd.defined or port_channel_interfaces[port_channel_interface].evpn_ethernet_segment is arista.avd.defined %}
    evpn ethernet-segment
 {%         if port_channel_interfaces[port_channel_interface].esi is arista.avd.defined %}
@@ -149,6 +146,9 @@ interface {{ port_channel_interface }}
 {%     endif %}
 {%     if port_channel_interfaces[port_channel_interface].lacp_fallback_mode is arista.avd.defined %}
    port-channel lacp fallback {{ port_channel_interfaces[port_channel_interface].lacp_fallback_mode }}
+{%     endif %}
+{%     if port_channel_interfaces[port_channel_interface].mlag is arista.avd.defined %}
+   mlag {{ port_channel_interfaces[port_channel_interface].mlag }}
 {%     endif %}
 {%     if port_channel_interfaces[port_channel_interface].qos.trust is arista.avd.defined %}
 {%         if port_channel_interfaces[port_channel_interface].qos.trust == 'disabled' %}


### PR DESCRIPTION
## Change Summary

Part of the various changes for getting output config to reflect config order on box.

## Related Issue(s)

Fixes #1572

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Reorder  `mlag` line under portchannel_interfaces.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been rebased from devel before I start
- [X] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [X] My change requires a change to the documentation and documentation have been updated accordingly.
- [X] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
