### PR TITLE
Fix(eos_validate_state): Failures on shutdown interfaces

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/interface_state.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/interface_state.yml
@@ -12,10 +12,18 @@
 
 - name: Validate Ethernet interfaces state
   assert:
-    that:
-      - interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.key].interfaceStatus == 'up'
-      - interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.key].lineProtocolStatus == 'up'
-    fail_msg: "interface status: {{ interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.key].interfaceStatus }} - line protocol status: {{ interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.key].lineProtocolStatus }}"
+    that: |
+      ( interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.key].interfaceStatus == 'up' and
+      interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.key].lineProtocolStatus == 'up' and
+      not ethernet_interfaces[ethernet_interface.key].shutdown
+      ) or
+      ( interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.key].interfaceStatus == 'adminDown' and
+      interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.key].lineProtocolStatus == 'down' and
+      ethernet_interfaces[ethernet_interface.key].shutdown
+      )
+    fail_msg: "interface shutdown: {{ ethernet_interfaces[ethernet_interface.key].shutdown }}
+      - interface status: {{ interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.key].interfaceStatus }}
+      - line protocol status: {{ interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.key].lineProtocolStatus }}"
     quiet: true
   loop: "{{ ethernet_interfaces | default({}, true) | dict2items }}"
   loop_control:
@@ -27,10 +35,18 @@
 
 - name: Validate Port-Channel interfaces state
   assert:
-    that:
-      - interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.key].interfaceStatus == 'up'
-      - interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.key].lineProtocolStatus == 'up'
-    fail_msg: "interface status: {{ interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.key].interfaceStatus }} - line protocol status: {{ interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.key].lineProtocolStatus }}"
+    that: |
+      ( interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.key].interfaceStatus == 'up' and
+      interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.key].lineProtocolStatus == 'up' and
+      not port_channel_interfaces[port_channel_interface.key].shutdown
+      ) or
+      ( interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.key].interfaceStatus == 'adminDown' and
+      interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.key].lineProtocolStatus == 'down' and
+      port_channel_interfaces[port_channel_interface.key].shutdown
+      )
+    fail_msg: "interface shutdown: {{ port_channel_interfaces[port_channel_interface.key].shutdown }}
+      - interface status: {{ interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.key].interfaceStatus }}
+      - line protocol status: {{ interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.key].lineProtocolStatus }}"
     quiet: true
   loop: "{{ port_channel_interfaces | default({}, true) | dict2items }}"
   loop_control:
@@ -42,10 +58,18 @@
 
 - name: Validate Vlan interfaces state
   assert:
-    that:
-      - interfaces_state.stdout[0].interfaceDescriptions[vlan_interface.key].interfaceStatus == 'up'
-      - interfaces_state.stdout[0].interfaceDescriptions[vlan_interface.key].lineProtocolStatus == 'up'
-    fail_msg: "interface status: {{ interfaces_state.stdout[0].interfaceDescriptions[vlan_interface.key].interfaceStatus }} - line protocol status: {{ interfaces_state.stdout[0].interfaceDescriptions[vlan_interface.key].lineProtocolStatus }}"
+    that: |
+      ( interfaces_state.stdout[0].interfaceDescriptions[vlan_interface.key].interfaceStatus == 'up' and
+      interfaces_state.stdout[0].interfaceDescriptions[vlan_interface.key].lineProtocolStatus == 'up' and
+      not vlan_interfaces[vlan_interface.key].shutdown
+      ) or
+      ( interfaces_state.stdout[0].interfaceDescriptions[vlan_interface.key].interfaceStatus == 'adminDown' and
+      interfaces_state.stdout[0].interfaceDescriptions[vlan_interface.key].lineProtocolStatus == 'down' and
+      vlan_interfaces[vlan_interface.key].shutdown
+      )
+    fail_msg: "interface shutdown: {{ vlan_interfaces[vlan_interface.key].shutdown }} -
+      interface status: {{ interfaces_state.stdout[0].interfaceDescriptions[vlan_interface.key].interfaceStatus }} -
+      line protocol status: {{ interfaces_state.stdout[0].interfaceDescriptions[vlan_interface.key].lineProtocolStatus }}"
     quiet: true
   loop: "{{ vlan_interfaces | default({}, true) | dict2items }}"
   loop_control:

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/interface_state.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/interface_state.yml
@@ -18,7 +18,7 @@
       not ethernet_interfaces[ethernet_interface.key].shutdown
       ) or
       ( interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.key].interfaceStatus == 'adminDown' and
-      interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.key].lineProtocolStatus == 'down' and
+      interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.key].lineProtocolStatus != 'up' and
       ethernet_interfaces[ethernet_interface.key].shutdown
       )
     fail_msg: "interface shutdown: {{ ethernet_interfaces[ethernet_interface.key].shutdown }} -
@@ -41,7 +41,7 @@
       not port_channel_interfaces[port_channel_interface.key].shutdown
       ) or
       ( interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.key].interfaceStatus == 'adminDown' and
-      interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.key].lineProtocolStatus == 'down' and
+      interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.key].lineProtocolStatus != 'up' and
       port_channel_interfaces[port_channel_interface.key].shutdown
       )
     fail_msg: "interface shutdown: {{ port_channel_interfaces[port_channel_interface.key].shutdown }} -
@@ -64,7 +64,7 @@
       not vlan_interfaces[vlan_interface.key].shutdown
       ) or
       ( interfaces_state.stdout[0].interfaceDescriptions[vlan_interface.key].interfaceStatus == 'adminDown' and
-      interfaces_state.stdout[0].interfaceDescriptions[vlan_interface.key].lineProtocolStatus == 'down' and
+      interfaces_state.stdout[0].interfaceDescriptions[vlan_interface.key].lineProtocolStatus != 'up' and
       vlan_interfaces[vlan_interface.key].shutdown
       )
     fail_msg: "interface shutdown: {{ vlan_interfaces[vlan_interface.key].shutdown }} -

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/interface_state.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/interface_state.yml
@@ -12,7 +12,7 @@
 
 - name: Validate Ethernet interfaces state
   assert:
-    that: |
+    that:
       ( interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.key].interfaceStatus == 'up' and
       interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.key].lineProtocolStatus == 'up' and
       not ethernet_interfaces[ethernet_interface.key].shutdown
@@ -21,9 +21,9 @@
       interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.key].lineProtocolStatus == 'down' and
       ethernet_interfaces[ethernet_interface.key].shutdown
       )
-    fail_msg: "interface shutdown: {{ ethernet_interfaces[ethernet_interface.key].shutdown }}
-      - interface status: {{ interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.key].interfaceStatus }}
-      - line protocol status: {{ interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.key].lineProtocolStatus }}"
+    fail_msg: "interface shutdown: {{ ethernet_interfaces[ethernet_interface.key].shutdown }} -
+      interface status: {{ interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.key].interfaceStatus }} -
+      line protocol status: {{ interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.key].lineProtocolStatus }}"
     quiet: true
   loop: "{{ ethernet_interfaces | default({}, true) | dict2items }}"
   loop_control:
@@ -35,7 +35,7 @@
 
 - name: Validate Port-Channel interfaces state
   assert:
-    that: |
+    that:
       ( interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.key].interfaceStatus == 'up' and
       interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.key].lineProtocolStatus == 'up' and
       not port_channel_interfaces[port_channel_interface.key].shutdown
@@ -44,9 +44,9 @@
       interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.key].lineProtocolStatus == 'down' and
       port_channel_interfaces[port_channel_interface.key].shutdown
       )
-    fail_msg: "interface shutdown: {{ port_channel_interfaces[port_channel_interface.key].shutdown }}
-      - interface status: {{ interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.key].interfaceStatus }}
-      - line protocol status: {{ interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.key].lineProtocolStatus }}"
+    fail_msg: "interface shutdown: {{ port_channel_interfaces[port_channel_interface.key].shutdown }} -
+      interface status: {{ interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.key].interfaceStatus }} -
+      line protocol status: {{ interfaces_state.stdout[0].interfaceDescriptions[port_channel_interface.key].lineProtocolStatus }}"
     quiet: true
   loop: "{{ port_channel_interfaces | default({}, true) | dict2items }}"
   loop_control:
@@ -58,7 +58,7 @@
 
 - name: Validate Vlan interfaces state
   assert:
-    that: |
+    that:
       ( interfaces_state.stdout[0].interfaceDescriptions[vlan_interface.key].interfaceStatus == 'up' and
       interfaces_state.stdout[0].interfaceDescriptions[vlan_interface.key].lineProtocolStatus == 'up' and
       not vlan_interfaces[vlan_interface.key].shutdown
@@ -84,7 +84,8 @@
     that:
       - interfaces_state.stdout[0].interfaceDescriptions.Vxlan1.interfaceStatus == 'up'
       - interfaces_state.stdout[0].interfaceDescriptions.Vxlan1.lineProtocolStatus == 'up'
-    fail_msg: "interface status: {{ interfaces_state.stdout[0].interfaceDescriptions.Vxlan1.interfaceStatus }} - line protocol status: {{ interfaces_state.stdout[0].interfaceDescriptions.Vxlan1.lineProtocolStatus }}"
+    fail_msg: "interface status: {{ interfaces_state.stdout[0].interfaceDescriptions.Vxlan1.interfaceStatus }} -
+      line protocol status: {{ interfaces_state.stdout[0].interfaceDescriptions.Vxlan1.lineProtocolStatus }}"
     quiet: true
   ignore_errors: "{{ eos_validate_state_validation_mode_loose }}"
   when: (vxlan_interface.Vxlan1 is arista.avd.defined)
@@ -97,7 +98,8 @@
     that:
       - interfaces_state.stdout[0].interfaceDescriptions[loopback_interface.key].interfaceStatus == 'up'
       - interfaces_state.stdout[0].interfaceDescriptions[loopback_interface.key].lineProtocolStatus == 'up'
-    fail_msg: "interface status: {{ interfaces_state.stdout[0].interfaceDescriptions[loopback_interface.key].interfaceStatus }} - line protocol status: {{ interfaces_state.stdout[0].interfaceDescriptions[loopback_interface.key].lineProtocolStatus }}"
+    fail_msg: "interface status: {{ interfaces_state.stdout[0].interfaceDescriptions[loopback_interface.key].interfaceStatus }} -
+      line protocol status: {{ interfaces_state.stdout[0].interfaceDescriptions[loopback_interface.key].lineProtocolStatus }}"
     quiet: true
   loop: "{{ loopback_interfaces | default({}, true) | dict2items }}"
   loop_control:

--- a/ansible_collections/arista/avd/roles/eos_validate_state/templates/generate_state_report_results.j2
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/templates/generate_state_report_results.j2
@@ -121,7 +121,7 @@ eos_validate_state_report:
 - id: {{ test_id.value }}
   device: "{{ node }}"
   test_category: "Interface State"
-  test_description: "Ethernet Interface Status & Line Protocol == \"up\""
+  test_description: "Ethernet Interface (Shutdown == \"False\" & Status == \"up\" & Line Protocol == \"up\") or (Shutdown == \"True\" & Status == \"adminDown\" & Line Protocol == \"down\")"
   test: "{{ result.ethernet_interface.key }} - {{ result.ethernet_interface.value.description | arista.avd.default('') }}"
 {%             if result.failed == false %}
   result: "PASS"
@@ -140,7 +140,7 @@ eos_validate_state_report:
 - id: {{ test_id.value }}
   device: "{{ node }}"
   test_category: "Interface State"
-  test_description: "Port-Channel Interface Status & Line Protocol == \"up\""
+  test_description: "Port-Channel Interface (Shutdown == \"False\" & Status == \"up\" & Line Protocol == \"up\") or (Shutdown == \"True\" & Status == \"adminDown\" & Line Protocol == \"down\")"
   test: "{{ result.port_channel_interface.key }} - {{ result.port_channel_interface.value.description | arista.avd.default('') }}"
 {%             if result.failed == false %}
   result: "PASS"
@@ -159,7 +159,7 @@ eos_validate_state_report:
 - id: {{ test_id.value }}
   device: "{{ node }}"
   test_category: "Interface State"
-  test_description: "Vlan Interface Status & Line Protocol == \"up\""
+  test_description: "Vlan Interface (Shutdown == \"False\" & Status == \"up\" & Line Protocol == \"up\") or (Shutdown == \"True\" & Status == \"adminDown\" & Line Protocol == \"down\")"
   test: "{{ result.vlan_interface.key }} - {{ result.vlan_interface.value.description | arista.avd.default('') }}"
 {%             if result.failed == false %}
   result: "PASS"

--- a/ansible_collections/arista/avd/roles/eos_validate_state/templates/generate_state_report_results.j2
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/templates/generate_state_report_results.j2
@@ -121,7 +121,11 @@ eos_validate_state_report:
 - id: {{ test_id.value }}
   device: "{{ node }}"
   test_category: "Interface State"
-  test_description: "Ethernet Interface (Shutdown == \"False\" & Status == \"up\" & Line Protocol == \"up\") or (Shutdown == \"True\" & Status == \"adminDown\" & Line Protocol != \"up\")"
+{%             if not result.ethernet_interface.value.shutdown %}
+  test_description: "Ethernet Interface & Line Protocol == \"up\""
+{%             else %}
+  test_description: "Ethernet Interface & Line Protocol == \"adminDown\""
+{%             endif %}
   test: "{{ result.ethernet_interface.key }} - {{ result.ethernet_interface.value.description | arista.avd.default('') }}"
 {%             if result.failed == false %}
   result: "PASS"
@@ -140,7 +144,11 @@ eos_validate_state_report:
 - id: {{ test_id.value }}
   device: "{{ node }}"
   test_category: "Interface State"
-  test_description: "Port-Channel Interface (Shutdown == \"False\" & Status == \"up\" & Line Protocol == \"up\") or (Shutdown == \"True\" & Status == \"adminDown\" & Line Protocol != \"up\")"
+{%             if not result.port_channel_interface.value.shutdown %}
+  test_description: "Port-Channel Interface & Line Protocol == \"up\""
+{%             else %}
+  test_description: "Port-Channel Interface & Line Protocol == \"adminDown\""
+{%             endif %}
   test: "{{ result.port_channel_interface.key }} - {{ result.port_channel_interface.value.description | arista.avd.default('') }}"
 {%             if result.failed == false %}
   result: "PASS"
@@ -159,7 +167,11 @@ eos_validate_state_report:
 - id: {{ test_id.value }}
   device: "{{ node }}"
   test_category: "Interface State"
-  test_description: "Vlan Interface (Shutdown == \"False\" & Status == \"up\" & Line Protocol == \"up\") or (Shutdown == \"True\" & Status == \"adminDown\" & Line Protocol != \"up\")"
+{%             if not result.vlan_interface.value.shutdown %}
+  test_description: "Vlan Interface & Line Protocol == \"up\""
+{%             else %}
+  test_description: "Vlan Interface & Line Protocol == \"adminDown\""
+{%             endif %}
   test: "{{ result.vlan_interface.key }} - {{ result.vlan_interface.value.description | arista.avd.default('') }}"
 {%             if result.failed == false %}
   result: "PASS"

--- a/ansible_collections/arista/avd/roles/eos_validate_state/templates/generate_state_report_results.j2
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/templates/generate_state_report_results.j2
@@ -121,7 +121,7 @@ eos_validate_state_report:
 - id: {{ test_id.value }}
   device: "{{ node }}"
   test_category: "Interface State"
-  test_description: "Ethernet Interface (Shutdown == \"False\" & Status == \"up\" & Line Protocol == \"up\") or (Shutdown == \"True\" & Status == \"adminDown\" & Line Protocol == \"down\")"
+  test_description: "Ethernet Interface (Shutdown == \"False\" & Status == \"up\" & Line Protocol == \"up\") or (Shutdown == \"True\" & Status == \"adminDown\" & Line Protocol != \"up\")"
   test: "{{ result.ethernet_interface.key }} - {{ result.ethernet_interface.value.description | arista.avd.default('') }}"
 {%             if result.failed == false %}
   result: "PASS"
@@ -140,7 +140,7 @@ eos_validate_state_report:
 - id: {{ test_id.value }}
   device: "{{ node }}"
   test_category: "Interface State"
-  test_description: "Port-Channel Interface (Shutdown == \"False\" & Status == \"up\" & Line Protocol == \"up\") or (Shutdown == \"True\" & Status == \"adminDown\" & Line Protocol == \"down\")"
+  test_description: "Port-Channel Interface (Shutdown == \"False\" & Status == \"up\" & Line Protocol == \"up\") or (Shutdown == \"True\" & Status == \"adminDown\" & Line Protocol != \"up\")"
   test: "{{ result.port_channel_interface.key }} - {{ result.port_channel_interface.value.description | arista.avd.default('') }}"
 {%             if result.failed == false %}
   result: "PASS"
@@ -159,7 +159,7 @@ eos_validate_state_report:
 - id: {{ test_id.value }}
   device: "{{ node }}"
   test_category: "Interface State"
-  test_description: "Vlan Interface (Shutdown == \"False\" & Status == \"up\" & Line Protocol == \"up\") or (Shutdown == \"True\" & Status == \"adminDown\" & Line Protocol == \"down\")"
+  test_description: "Vlan Interface (Shutdown == \"False\" & Status == \"up\" & Line Protocol == \"up\") or (Shutdown == \"True\" & Status == \"adminDown\" & Line Protocol != \"up\")"
   test: "{{ result.vlan_interface.key }} - {{ result.vlan_interface.value.description | arista.avd.default('') }}"
 {%             if result.failed == false %}
   result: "PASS"


### PR DESCRIPTION
## Change Summary

Changes to check interface state against the intended state. Today the validation code will simply check if a defined interface is up and fail if it is down. 

This change will take into account if the interface has been set to "enabled: false" and check accordingly.

## Related Issue(s)

none

## Component(s) name

`arista.avd.eos_validate_state`

## Proposed changes
If an interface is set to "enabled: true", the assert will check that an interface is up/up.

If an interface is set to "enabled: false", the assert will check that an interface is adminDown/down.

Otherwise the assert will fail.

This applies to ethernet, vlan and port-channel interfaces but here is an example from ethernet:

```
- name: Validate Ethernet interfaces state
  assert:
    that: |
      ( interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.key].interfaceStatus == 'up' and
      interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.key].lineProtocolStatus == 'up' and
      not ethernet_interfaces[ethernet_interface.key].shutdown
      ) or
      ( interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.key].interfaceStatus == 'adminDown' and
      interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.key].lineProtocolStatus == 'down' and
      ethernet_interfaces[ethernet_interface.key].shutdown
      )
    fail_msg: "interface shutdown: {{ ethernet_interfaces[ethernet_interface.key].shutdown }}
      - interface status: {{ interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.key].interfaceStatus }}
      - line protocol status: {{ interfaces_state.stdout[0].interfaceDescriptions[ethernet_interface.key].lineProtocolStatus }}"
```

## How to test
Code was tested with interfaces that are enabled but shutdown via the CLI, disabled but "no shut" in the CLI to test a fail. And enabled and "no shut" as expected in the CLI for a pass.

## Checklist

### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
