### PR TITLE
Fix(eos_cli_config_gen): dns config reorder

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/dns-ntp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/dns-ntp.md
@@ -55,7 +55,6 @@ interface Management1
 ### DNS Domain Device Configuration
 
 ```eos
-!
 dns domain test.local
 !
 ```
@@ -87,7 +86,6 @@ ip name-server vrf mgt 10.10.129.10
 ### DNS Domain Lookup Device Configuration
 
 ```eos
-!
 ip domain lookup vrf mgt source-interface Management0
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/dns-ntp.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/dns-ntp.cfg
@@ -3,11 +3,9 @@
 transceiver qsfp default-mode 4x10G
 !
 hostname dns-ntp
-!
 ip domain lookup vrf mgt source-interface Management0
 ip name-server vrf mgt 10.10.128.10
 ip name-server vrf mgt 10.10.129.10
-!
 dns domain test.local
 !
 ntp local-interface vrf mgt Management0

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/dns-ntp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/dns-ntp.md
@@ -55,7 +55,6 @@ interface Management1
 ### DNS Domain Device Configuration
 
 ```eos
-!
 dns domain test.local
 !
 ```
@@ -87,7 +86,6 @@ ip name-server vrf mgt 10.10.129.10
 ### DNS Domain Lookup Device Configuration
 
 ```eos
-!
 ip domain lookup vrf mgt source-interface Management0
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/dns-ntp.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/dns-ntp.cfg
@@ -3,11 +3,9 @@
 transceiver qsfp default-mode 4x10G
 !
 hostname dns-ntp
-!
 ip domain lookup vrf mgt source-interface Management0
 ip name-server vrf mgt 10.10.128.10
 ip name-server vrf mgt 10.10.129.10
-!
 dns domain test.local
 !
 ntp local-interface vrf mgt Management0

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2A.md
@@ -61,7 +61,6 @@
 ### Domain-list Device Configuration
 
 ```eos
-!
 ip domain-list structured-config.set.on.node
 ip domain-list structured-config.set.under.vrf.common-vrf
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
@@ -88,7 +88,6 @@ interface Management1
 ### Domain-list Device Configuration
 
 ```eos
-!
 ip domain-list structured-config.set.under.vrf.common-vrf
 !
 ```

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-LEAF1A.md
@@ -84,7 +84,6 @@ interface Management1
 ### Domain-list Device Configuration
 
 ```eos
-!
 ip domain-list structured-config.set.under.vrf.common-vrf
 !
 ```

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-LEAF1A.md
@@ -85,7 +85,6 @@ interface Management1
 ### Domain-list Device Configuration
 
 ```eos
-!
 ip domain-list structured-config.set.under.vrf.common-vrf
 !
 ```

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2A.cfg
@@ -7,7 +7,6 @@ transceiver qsfp default-mode 4x10G
 service routing protocols model multi-agent
 !
 hostname DC1-POD1-LEAF2A
-!
 ip domain-list structured-config.set.on.node
 ip domain-list structured-config.set.under.vrf.common-vrf
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2B.cfg
@@ -7,7 +7,6 @@ transceiver qsfp default-mode 4x10G
 service routing protocols model multi-agent
 !
 hostname DC1-POD1-LEAF2B
-!
 ip domain-list structured-config.set.under.vrf.common-vrf
 !
 snmp-server location TWODC_5STAGE_CLOS DC1 DC1_POD1 DC1-POD1-LEAF2B

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD2-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD2-LEAF1A.cfg
@@ -7,7 +7,6 @@ transceiver qsfp default-mode 4x10G
 service routing protocols model multi-agent
 !
 hostname DC1-POD2-LEAF1A
-!
 ip domain-list structured-config.set.under.vrf.common-vrf
 !
 snmp-server location TWODC_5STAGE_CLOS DC1 DC1_POD2 DC1-POD2-LEAF1A

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-LEAF1A.cfg
@@ -7,7 +7,6 @@ transceiver qsfp default-mode 4x10G
 service routing protocols model multi-agent
 !
 hostname DC2-POD1-LEAF1A
-!
 ip domain-list structured-config.set.under.vrf.common-vrf
 !
 snmp-server location TWODC_5STAGE_CLOS DC2 DC2_POD1 DC2-POD1-LEAF1A

--- a/ansible_collections/arista/avd/molecule/upgrade_eos_cli_config_gen/documentation/devices/dns-ntp.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_eos_cli_config_gen/documentation/devices/dns-ntp.md
@@ -55,7 +55,6 @@ interface Management1
 ### DNS Domain Device Configuration
 
 ```eos
-!
 dns domain test.local
 !
 ```
@@ -87,7 +86,6 @@ ip name-server vrf mgt 10.10.129.10
 ### DNS Domain Lookup Device Configuration
 
 ```eos
-!
 ip domain lookup vrf mgt source-interface Management0
 ```
 

--- a/ansible_collections/arista/avd/molecule/upgrade_eos_cli_config_gen/intended/configs/dns-ntp.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_eos_cli_config_gen/intended/configs/dns-ntp.cfg
@@ -3,11 +3,9 @@
 transceiver qsfp default-mode 4x10G
 !
 hostname dns-ntp
-!
 ip domain lookup vrf mgt source-interface Management0
 ip name-server vrf mgt 10.10.128.10
 ip name-server vrf mgt 10.10.129.10
-!
 dns domain test.local
 !
 ntp local-interface vrf mgt Management0

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/dns-domain.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/dns-domain.j2
@@ -1,5 +1,4 @@
 {# eos - dns domain #}
 {% if dns_domain is arista.avd.defined %}
-!
 dns domain {{ dns_domain }}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/domain-list.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/domain-list.j2
@@ -1,6 +1,5 @@
 {# eos - domain-list #}
 {% if domain_list is arista.avd.defined %}
-!
 {%     for domain in domain_list | arista.avd.natural_sort %}
 ip domain-list {{ domain }}
 {%     endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/domain-lookup.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/domain-lookup.j2
@@ -1,6 +1,5 @@
 {# eos - domain lookup #}
 {% if ip_domain_lookup is arista.avd.defined %}
-!
 {%     for source in ip_domain_lookup.source_interfaces | arista.avd.natural_sort %}
 {%         set ip_domain_cli = "ip domain lookup" %}
 {%         if ip_domain_lookup.source_interfaces[source].vrf is arista.avd.defined %}


### PR DESCRIPTION
## Change Summary

DNS config order/consolidation

## Related Issue(s)

Fixes #1572

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Similar to the other #1572 related PRs, this focuses on the order and config output to match closer to how EOS generates said config

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been rebased from devel before I start
- [X] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [X] My change requires a change to the documentation and documentation have been updated accordingly.
- [X] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
