### PR TITLE
Refactor(eos_cli_config_gen): Wildcard dict to list for standard_access_lists

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/acl.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/acl.yml
@@ -29,35 +29,35 @@ access_lists:
 
 ### Standard Access-Lists ###
 standard_access_lists:
-  ACL-API:
+  - name: ACL-API
     sequence_numbers:
-      10:
+      - sequence: 10
         action: "remark ACL to restrict access to switch API to CVP and Ansible"
-      20:
+      - sequence: 20
         action: "permit host 10.10.10.10"
-      30:
+      - sequence: 30
         action: "permit host 10.10.10.11"
-      40:
+      - sequence: 40
         action: "permit host 10.10.10.12"
-  ACL-SSH:
+  - name: ACL-SSH
     counters_per_entry: true
     sequence_numbers:
-      10:
+      - sequence: 10
         action: "remark ACL to restrict access RFC1918 addresses"
-      20:
+      - sequence: 20
         action: "permit 10.0.0.0/8"
-      30:
+      - sequence: 30
         action: "permit 172.16.0.0/12"
-      40:
+      - sequence: 40
         action: "permit 192.168.0.0/16"
-  ACL-SSH-VRF:
+  - name: ACL-SSH-VRF
     counters_per_entry: false
     sequence_numbers:
-      10:
+      - sequence: 10
         action: "remark ACL to restrict access RFC1918 addresses"
-      20:
+      - sequence: 20
         action: "permit 10.0.0.0/8"
-      30:
+      - sequence: 30
         action: "permit 172.16.0.0/12"
-      40:
+      - sequence: 40
         action: "permit 192.168.0.0/16"

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/management-api-http.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/management-api-http.yml
@@ -11,9 +11,9 @@ management_api_http:
 
 # Standard ACLs
 standard_access_lists:
-  ACL-API:
+  - name: ACL-API
     sequence_numbers:
-      10:
+      - sequence: 10
         action: "permit 10.0.0.0/8"
-      20:
+      - sequence: 20
         action: "permit 100.0.0.0/8"

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
@@ -285,16 +285,16 @@ ipv6_standard_access_lists:
 
 ```yaml
 standard_access_lists:
-  < access_list_name_1 >:
+  - name: < access_list_name_1 >
     counters_per_entry: < true | false >
     sequence_numbers:
-      < sequence_id_1 >:
+      - sequence: < sequence_id_1 >
         action: "< action as string >"
-      < sequence_id_2 >:
+      - sequence: < sequence_id_2 >
         action: "< action as string >"
-  < access_list_name_2 >:
+  - name: < access_list_name_2 >
     sequence_numbers:
-      < sequence_id_1 >:
+      - sequence: < sequence_id_1 >
         action: "< action as string >"
 ```
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/standard-access-lists.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/standard-access-lists.j2
@@ -1,20 +1,20 @@
-{% if standard_access_lists is defined and standard_access_lists is not none %}
+{% if standard_access_lists is arista.avd.defined %}
 
 ## Standard Access-lists
 
 ### Standard Access-lists Summary
 
-{%     for standard_access_list in standard_access_lists | arista.avd.natural_sort %}
-#### {{ standard_access_list }}
-{%         if standard_access_lists[standard_access_list].counters_per_entry is arista.avd.defined(true) %}
+{%     for standard_access_list in standard_access_lists | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+#### {{ standard_access_list.name }}
+{%         if standard_access_list.counters_per_entry is arista.avd.defined(true) %}
 
 ACL has counting mode `counters per-entry` enabled!
 {%         endif %}
 
 | Sequence | Action |
 | -------- | ------ |
-{%         for sequence in standard_access_lists[standard_access_list].sequence_numbers | arista.avd.natural_sort %}
-| {{ sequence }} | {{ standard_access_lists[standard_access_list].sequence_numbers[sequence].action }} |
+{%         for sequence in standard_access_list.sequence_numbers | arista.avd.convert_dicts('sequence') | arista.avd.natural_sort('sequence') %}
+| {{ sequence.sequence }} | {{ sequence.action }} |
 {%         endfor %}
 
 {%     endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/standard-access-lists.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/standard-access-lists.j2
@@ -1,13 +1,13 @@
 {# eos - standard access-lists #}
-{% for standard_access_list in standard_access_lists | arista.avd.natural_sort %}
+{% for standard_access_list in standard_access_lists | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
 !
-ip access-list standard {{ standard_access_list }}
-{%     if standard_access_lists[standard_access_list].counters_per_entry is arista.avd.defined(true) %}
+ip access-list standard {{ standard_access_list.name }}
+{%     if standard_access_list.counters_per_entry is arista.avd.defined(true) %}
    counters per-entry
 {%     endif %}
-{%     for sequence in standard_access_lists[standard_access_list].sequence_numbers | arista.avd.natural_sort %}
-{%         if standard_access_lists[standard_access_list].sequence_numbers[sequence].action is arista.avd.defined %}
-   {{ sequence }} {{ standard_access_lists[standard_access_list].sequence_numbers[sequence].action }}
+{%     for sequence in standard_access_list.sequence_numbers | arista.avd.convert_dicts('sequence') | arista.avd.natural_sort('sequence') %}
+{%         if sequence.action is arista.avd.defined %}
+   {{ sequence.sequence }} {{ sequence.action }}
 {%         endif %}
 {%     endfor %}
 {% endfor %}


### PR DESCRIPTION
## "Wildcard Keyed Dict" to "List of Dicts" Data model migration

<!-- Use this PR Title: Refactor(eos_cli_config_gen): Wildcard dict to list for `< data_model_key >` -->

## Data model key

`standard_access_lists`

## Checklist

### Contributor Checklist

- [ ] Update `README_v4.0.md` with new data model
- [ ] Update all `host_vars` under molecule scenario `eos_cli_config_gen_v4.0` with new data model
- [ ] Update `templates/eos/< template >.j2` and `templates/documentation/< template >.j2`:
  - [ ] Add `arista.avd.convert_dicts('<primary key>')` filter for loops previously using wildcard keys
  - [ ] Update `arista.avd.natural_sort('<primary key>')` to sort on the primary key (if applicable)
- [ ] Run molecule `cd ansible_collections/arista/avd/molecule ; make cli-4.0-schema`
  - [ ] Verify no changes to generated configs/docs

### Reviewer Checklist

- Reviewer 1:
  - [x] Verify data model changes
  - [x] Verify that all molecule `host_vars` under `eos_cli_config_gen_v4.0` has been updated to the new data model
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2:
  - [ ] Verify data model changes
  - [ ] Verify that all molecule `host_vars` under `eos_cli_config_gen_v4.0` has been updated to the new data model
  - [ ] Verify no changes to configs/docs on any molecule scenario
  - [ ] Verify that CI pass
