### PR TITLE
Feat(eos_designs): Change bgp_peer_groups to lower-case

### DIFF
--- a/ansible_collections/arista/avd/docs/release-notes/3.x.x.md
+++ b/ansible_collections/arista/avd/docs/release-notes/3.x.x.md
@@ -2,6 +2,24 @@
 
 Documentation for AVD version `3.x.x` [available here](https://www.avd.sh/en/releases-v3.x.x/)
 
+## Release 3.4.0
+
+### Data model modifications (non-breaking)
+
+This section provides an overview of the data model that have ***changed*** from the previous release, but are backwards compatible.
+
+No changes are required for existing deployments.
+
+See the release notes and role documentation for all new additions.
+
+#### Changes to eos_designs role
+
+- __Fabric variables:__
+
+  - `bgp_peer_groups.IPv4_UNDERLAY_PEERS` has been renamed to `bgp_peer_groups.ipv4_underlay_peers` to avoid upper-case variables. The old key is still supported.
+  - `bgp_peer_groups.MLAG_IPv4_UNDERLAY_PEER` has been renamed to `bgp_peer_groups.mlag_ipv4_underlay_peer` to avoid upper-case variables. The old key is still supported.
+  - `bgp_peer_groups.EVPN_OVERLAY_PEERS` has been renamed to `bgp_peer_groups.evpn_overlay_peers` to avoid upper-case variables. The old key is still supported.
+
 ## Release 3.3.3
 
 ### Fixed issues

--- a/ansible_collections/arista/avd/molecule/dhcp_configuration/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/dhcp_configuration/inventory/group_vars/DC1_FABRIC.yml
@@ -26,11 +26,11 @@ vxlan_vlan_aware_bundles: true
 
 # bgp peer groups passwords
 bgp_peer_groups:
-  IPv4_UNDERLAY_PEERS:
+  ipv4_underlay_peers:
     password: "AQQvKeimxJu+uGQ/yYvv9w=="
-  EVPN_OVERLAY_PEERS:
+  evpn_overlay_peers:
     password: "q+VNViP5i4rVjW1cxFv2wA=="
-  MLAG_IPv4_UNDERLAY_PEER:
+  mlag_ipv4_underlay_peer:
     password: "vnEaG8gMeQf3d3cN6PktXQ=="
 
 # Spine Switches

--- a/ansible_collections/arista/avd/molecule/dhcp_provisionning/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/dhcp_provisionning/inventory/group_vars/DC1_FABRIC.yml
@@ -26,11 +26,11 @@ vxlan_vlan_aware_bundles: true
 
 # bgp peer groups passwords
 bgp_peer_groups:
-  IPv4_UNDERLAY_PEERS:
+  ipv4_underlay_peers:
     password: "AQQvKeimxJu+uGQ/yYvv9w=="
-  EVPN_OVERLAY_PEERS:
+  evpn_overlay_peers:
     password: "q+VNViP5i4rVjW1cxFv2wA=="
-  MLAG_IPv4_UNDERLAY_PEER:
+  mlag_ipv4_underlay_peer:
     password: "vnEaG8gMeQf3d3cN6PktXQ=="
 
 # Spine Switches

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/inventory/group_vars/DC1_FABRIC.yml
@@ -9,11 +9,11 @@ vxlan_vlan_aware_bundles: true
 
 # bgp peer groups passwords
 bgp_peer_groups:
-  IPv4_UNDERLAY_PEERS:
+  ipv4_underlay_peers:
     password: "AQQvKeimxJu+uGQ/yYvv9w=="
-  EVPN_OVERLAY_PEERS:
+  evpn_overlay_peers:
     password: "q+VNViP5i4rVjW1cxFv2wA=="
-  MLAG_IPv4_UNDERLAY_PEER:
+  mlag_ipv4_underlay_peer:
     password: "vnEaG8gMeQf3d3cN6PktXQ=="
 
 # Spine Switches

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/DC1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/DC1.yml
@@ -2,11 +2,11 @@
 dc_name: DC1
 
 bgp_peer_groups:
-  IPv4_UNDERLAY_PEERS:
+  ipv4_underlay_peers:
     password: "AQQvKeimxJu+uGQ/yYvv9w=="
-  EVPN_OVERLAY_PEERS:
+  evpn_overlay_peers:
     password: "q+VNViP5i4rVjW1cxFv2wA=="
-  MLAG_IPv4_UNDERLAY_PEER:
+  mlag_ipv4_underlay_peer:
     password: "vnEaG8gMeQf3d3cN6PktXQ=="
 
 super_spine:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_FABRIC.yml
@@ -9,12 +9,12 @@ evpn_vlan_aware_bundles: true
 
 # bgp peer groups passwords
 bgp_peer_groups:
-  IPv4_UNDERLAY_PEERS:
+  IPv4_UNDERLAY_PEERS: # Using legacy upper-case keys to test backwards-compatibility
     name: UNDERLAY-PEERS
     password: "AQQvKeimxJu+uGQ/yYvv9w=="
-  EVPN_OVERLAY_PEERS:
+  EVPN_OVERLAY_PEERS: # Using legacy upper-case keys to test backwards-compatibility
     password: "q+VNViP5i4rVjW1cxFv2wA=="
-  MLAG_IPv4_UNDERLAY_PEER:
+  MLAG_IPv4_UNDERLAY_PEER: # Using legacy upper-case keys to test backwards-compatibility
     name: MLAG-PEERS
     password: "vnEaG8gMeQf3d3cN6PktXQ=="
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
@@ -67,12 +67,12 @@ evpn_short_esi_prefix: "0000:1234:"
 
 # bgp peer groups passwords
 bgp_peer_groups:
-  IPv4_UNDERLAY_PEERS:
+  ipv4_underlay_peers:
     name: UNDERLAY-PEERS
     password: "AQQvKeimxJu+uGQ/yYvv9w=="
-  EVPN_OVERLAY_PEERS:
+  evpn_overlay_peers:
     password: "q+VNViP5i4rVjW1cxFv2wA=="
-  MLAG_IPv4_UNDERLAY_PEER:
+  mlag_ipv4_underlay_peer:
     name: MLAG-PEERS
     password: "vnEaG8gMeQf3d3cN6PktXQ=="
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/inventory/group_vars/DC1_FABRIC.yml
@@ -15,12 +15,12 @@ vxlan_vlan_aware_bundles: true
 
 # bgp peer groups passwords
 bgp_peer_groups:
-  IPv4_UNDERLAY_PEERS:
+  ipv4_underlay_peers:
     password: "AQQvKeimxJu+uGQ/yYvv9w=="
-  EVPN_OVERLAY_PEERS:
+  evpn_overlay_peers:
     name: OVERLAY-PEERS
     password: "q+VNViP5i4rVjW1cxFv2wA=="
-  MLAG_IPv4_UNDERLAY_PEER:
+  mlag_ipv4_underlay_peer:
     password: "vnEaG8gMeQf3d3cN6PktXQ=="
 
 # Spine Switches

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
@@ -24,11 +24,11 @@ bgp_ecmp: 10
 
 # bgp peer groups passwords
 bgp_peer_groups:
-  IPv4_UNDERLAY_PEERS:
+  ipv4_underlay_peers:
     password: "AQQvKeimxJu+uGQ/yYvv9w=="
-  EVPN_OVERLAY_PEERS:
+  evpn_overlay_peers:
     password: "q+VNViP5i4rVjW1cxFv2wA=="
-  MLAG_IPv4_UNDERLAY_PEER:
+  mlag_ipv4_underlay_peer:
     password: "vnEaG8gMeQf3d3cN6PktXQ=="
 
 # Spine Switches

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
@@ -21,12 +21,12 @@ evpn_hostflap_detection:
 
 # bgp peer groups passwords
 bgp_peer_groups:
-  IPv4_UNDERLAY_PEERS:
+  ipv4_underlay_peers:
     password: "AQQvKeimxJu+uGQ/yYvv9w=="
     name: "UNDERLAY_PEERS"
-  EVPN_OVERLAY_PEERS:
+  evpn_overlay_peers:
     password: "q+VNViP5i4rVjW1cxFv2wA=="
-  MLAG_IPv4_UNDERLAY_PEER:
+  mlag_ipv4_underlay_peer:
     name: "MLAG_PEER"
     password: "vnEaG8gMeQf3d3cN6PktXQ=="
 

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-variables.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-variables.md
@@ -80,12 +80,12 @@ bgp_peer_groups:
     password: "< encrypted password >"
    # Old mixed case key "MLAG_IPv4_UNDERLAY_PEER" is supported for backward-compatibility
   mlag_ipv4_underlay_peer:
-      name: < name of peer group | default -> MLAG-IPv4-UNDERLAY-PEER >
-      password: "< encrypted password >"
+    name: < name of peer group | default -> MLAG-IPv4-UNDERLAY-PEER >
+    password: "< encrypted password >"
    # Old upper case key "EVPN_OVERLAY_PEERS" is supported for backward-compatibility
   evpn_overlay_peers:
-      name: < name of peer group | default -> EVPN-OVERLAY-PEERS >
-      password: "< encrypted password >"
+    name: < name of peer group | default -> EVPN-OVERLAY-PEERS >
+    password: "< encrypted password >"
 
 # Enable vlan aware bundles for EVPN MAC-VRF | Required.
 # Old variable name vxlan_vlan_aware_bundles, supported for backward-compatibility.

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-variables.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-variables.md
@@ -78,11 +78,11 @@ bgp_peer_groups:
   ipv4_underlay_peers:
     name: < name of peer group | default -> IPv4-UNDERLAY-PEERS >
     password: "< encrypted password >"
-   # Old uppercase key "MLAG_IPv4_UNDERLAY_PEER" is supported for backward-compatibility
+   # Old mixed case key "MLAG_IPv4_UNDERLAY_PEER" is supported for backward-compatibility
   mlag_ipv4_underlay_peer:
       name: < name of peer group | default -> MLAG-IPv4-UNDERLAY-PEER >
       password: "< encrypted password >"
-   # Old uppercase key "EVPN_OVERLAY_PEERS" is supported for backward-compatibility
+   # Old upper case key "EVPN_OVERLAY_PEERS" is supported for backward-compatibility
   evpn_overlay_peers:
       name: < name of peer group | default -> EVPN-OVERLAY-PEERS >
       password: "< encrypted password >"

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-variables.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-variables.md
@@ -70,19 +70,20 @@ bgp_ecmp: < number_of_ecmp_paths | default -> 4 >
 # Set to a higher value to allow for very large and complex topologies.
 evpn_ebgp_multihop: < ebgp_multihop | default -> 3 >
 
-# BGP peer groups encrypted password
-# IPv4_UNDERLAY_PEERS and MLAG_IPv4_UNDERLAY_PEER | Optional
-# EVPN_OVERLAY_PEERS | Optional
+# BGP peer group names and encrypted password | Optional
 # Leverage an Arista EOS switch to generate the encrypted password using the correct peer group name.
 # Note that the name of the peer groups use '-' instead of '_' in EOS configuration.
 bgp_peer_groups:
-  IPv4_UNDERLAY_PEERS:
+   # Old mixed case key "IPv4_UNDERLAY_PEERS" is supported for backward-compatibility
+  ipv4_underlay_peers:
     name: < name of peer group | default -> IPv4-UNDERLAY-PEERS >
     password: "< encrypted password >"
-  MLAG_IPv4_UNDERLAY_PEER:
+   # Old uppercase key "MLAG_IPv4_UNDERLAY_PEER" is supported for backward-compatibility
+  mlag_ipv4_underlay_peer:
       name: < name of peer group | default -> MLAG-IPv4-UNDERLAY-PEER >
       password: "< encrypted password >"
-  EVPN_OVERLAY_PEERS:
+   # Old uppercase key "EVPN_OVERLAY_PEERS" is supported for backward-compatibility
+  evpn_overlay_peers:
       name: < name of peer group | default -> EVPN-OVERLAY-PEERS >
       password: "< encrypted password >"
 

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/core_interfaces/logic.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/core_interfaces/logic.j2
@@ -105,7 +105,7 @@
 {%                 set p2p_bgp_neighbor = namespace() %}
 {%                 set p2p_bgp_neighbor.remote_as = as[peer_index] %}
 {%                 set p2p_bgp_neighbor.description = p2p_interface.peer %}
-{%                 set p2p_bgp_neighbor.peer_group = bgp_peer_groups.IPv4_UNDERLAY_PEERS.name | arista.avd.default("IPv4-UNDERLAY-PEERS") %}
+{%                 set p2p_bgp_neighbor.peer_group = switch.bgp_peer_groups.ipv4_underlay_peers.name %}
 {%                 set p2p_bgp_neighbor.bfd = p2p_link.bfd | arista.avd.default(
                                               link_info.p2p_profile.bfd) %}
 {%                 if switch.bgp_as is arista.avd.defined and as[node_index] | string != switch.bgp_as %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/facts/switch/switch.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/facts/switch/switch.j2
@@ -223,13 +223,19 @@ switch:
   bgp_peer_groups:
     ipv4_underlay_peers:
       name: {{ bgp_peer_groups.ipv4_underlay_peers.name | arista.avd.default(bgp_peer_groups['IPv4_UNDERLAY_PEERS'].name, 'IPv4-UNDERLAY-PEERS') }}
-      password: {{ bgp_peer_groups.ipv4_underlay_peers.password | arista.avd.default(bgp_peer_groups['IPv4_UNDERLAY_PEERS'].password) }}
+      password: {{ bgp_peer_groups.ipv4_underlay_peers.password | arista.avd.default(bgp_peer_groups['IPv4_UNDERLAY_PEERS'].password) | to_json }}
     mlag_ipv4_underlay_peer:
       name: {{ bgp_peer_groups.mlag_ipv4_underlay_peer.name | arista.avd.default(bgp_peer_groups['MLAG_IPv4_UNDERLAY_PEER'].name, 'MLAG-IPv4-UNDERLAY-PEER') }}
-      password: {{ bgp_peer_groups.mlag_ipv4_underlay_peer.password | arista.avd.default(bgp_peer_groups['MLAG_IPv4_UNDERLAY_PEER'].password) }}
+      password: {{ bgp_peer_groups.mlag_ipv4_underlay_peer.password | arista.avd.default(bgp_peer_groups['MLAG_IPv4_UNDERLAY_PEER'].password) | to_json }}
     evpn_overlay_peers:
       name: {{ bgp_peer_groups.evpn_overlay_peers.name | arista.avd.default(bgp_peer_groups['EVPN_OVERLAY_PEERS'].name, 'EVPN-OVERLAY-PEERS') }}
-      password: {{ bgp_peer_groups.evpn_overlay_peers.password | arista.avd.default(bgp_peer_groups['EVPN_OVERLAY_PEERS'].password) }}
+      password: {{ bgp_peer_groups.evpn_overlay_peers.password | arista.avd.default(bgp_peer_groups['EVPN_OVERLAY_PEERS'].password) | to_json }}
+    mpls_overlay_peers:
+      name: {{ bgp_peer_groups.mpls_overlay_peers.name | arista.avd.default('MPLS-OVERLAY-PEERS') }}
+      password: {{ bgp_peer_groups.mpls_overlay_peers.password | arista.avd.default | to_json }}
+    rr_overlay_peers:
+      name: {{ bgp_peer_groups.rr_overlay_peers.name | arista.avd.default('RR-OVERLAY-PEERS') }}
+      password: {{ bgp_peer_groups.rr_overlay_peers.password | arista.avd.default | to_json }}
 
 {# switch.evpn_role #}
 {%     set switch_evpn_role = switch_data.combined.evpn_role | arista.avd.default(

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/facts/switch/switch.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/facts/switch/switch.j2
@@ -217,6 +217,25 @@ switch:
 {# switch.bgp_cluster_id #}
   bgp_cluster_id: {{ switch_data.combined.bgp_cluster_id | arista.avd.default() }}
 
+{# switch.bgp_peer_groups #}
+{# Keep support for old uppercase keys for backward-compatibility #}
+{# Using ['<name>'] style for upper-case keys, to avoid linting errors #}
+  bgp_peer_groups:
+    ipv4_underlay_peers:
+      name: {{ bgp_peer_groups.ipv4_underlay_peers.name | arista.avd.default(bgp_peer_groups['IPv4_UNDERLAY_PEERS'].name, 'IPv4-UNDERLAY-PEERS') }}
+      password: {{ bgp_peer_groups.ipv4_underlay_peers.password | arista.avd.default(bgp_peer_groups['IPv4_UNDERLAY_PEERS'].password) }}
+    mlag_ipv4_underlay_peer:
+      name: {{ bgp_peer_groups.mlag_ipv4_underlay_peer.name | arista.avd.default(bgp_peer_groups['MLAG_IPv4_UNDERLAY_PEER'].name, 'MLAG-IPv4-UNDERLAY-PEER') }}
+      password: {{ bgp_peer_groups.mlag_ipv4_underlay_peer.password | arista.avd.default(bgp_peer_groups['MLAG_IPv4_UNDERLAY_PEER'].password) }}
+    evpn_overlay_peers:
+      name: {{ bgp_peer_groups.evpn_overlay_peers.name | arista.avd.default(bgp_peer_groups['EVPN_OVERLAY_PEERS'].name, 'EVPN-OVERLAY-PEERS') }}
+      password: {{ bgp_peer_groups.evpn_overlay_peers.password | arista.avd.default(bgp_peer_groups['EVPN_OVERLAY_PEERS'].password) }}
+
+{# switch.evpn_role #}
+{%     set switch_evpn_role = switch_data.combined.evpn_role | arista.avd.default(
+                          switch.default_evpn_role) %}
+  evpn_role: {{ switch_evpn_role }}
+
 {# switch.evpn_route_servers #}
 {# For clients the default value for EVPN Route Servers is content of the uplink_switches variable set above. #}
 {%     if switch_evpn_role == "client" %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/l3_edge/logic.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/l3_edge/logic.j2
@@ -73,7 +73,7 @@
 {%                 set p2p_bgp_neighbor = namespace() %}
 {%                 set p2p_bgp_neighbor.remote_as = as[peer_index] %}
 {%                 set p2p_bgp_neighbor.description = p2p_interface.peer %}
-{%                 set p2p_bgp_neighbor.peer_group = bgp_peer_groups.IPv4_UNDERLAY_PEERS.name | arista.avd.default("IPv4-UNDERLAY-PEERS") %}
+{%                 set p2p_bgp_neighbor.peer_group = switch.bgp_peer_groups.ipv4_underlay_peers.name %}
 {%                 set p2p_bgp_neighbor.bfd = p2p_link.bfd | arista.avd.default(
                                               p2p_profile.bfd) %}
 {%                 if switch.bgp_as is arista.avd.defined and as[node_index] | string != switch.bgp_as %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/mlag/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/mlag/router-bgp.j2
@@ -1,15 +1,14 @@
-{# j2lint: disable=V1 #}
 {# MLAG iBGP peering #}
 {% if switch.mlag_l3 is arista.avd.defined(true) and switch.underlay_routing_protocol == "ebgp" %}
 router_bgp:
   peer_groups:
-    {{ bgp_peer_groups.MLAG_IPv4_UNDERLAY_PEER.name | arista.avd.default("MLAG-IPv4-UNDERLAY-PEER") }}:
+    {{ switch.bgp_peer_groups.mlag_ipv4_underlay_peer.name }}:
       type: ipv4
       remote_as: "{{ switch.bgp_as }}"
       next_hop_self: true
       description: {{ switch.mlag_peer }}
-{%     if bgp_peer_groups.MLAG_IPv4_UNDERLAY_PEER.password is arista.avd.defined() %}
-      password: "{{ bgp_peer_groups.MLAG_IPv4_UNDERLAY_PEER.password }}"
+{%     if switch.bgp_peer_groups.mlag_ipv4_underlay_peer.password is arista.avd.defined() %}
+      password: "{{ switch.bgp_peer_groups.mlag_ipv4_underlay_peer.password }}"
 {%     endif %}
       maximum_routes: 12000
       send_community: all
@@ -18,20 +17,20 @@ router_bgp:
 {%     endif %}
   address_family_ipv4:
     peer_groups:
-      {{ bgp_peer_groups.MLAG_IPv4_UNDERLAY_PEER.name | arista.avd.default("MLAG-IPv4-UNDERLAY-PEER") }}:
+      {{ switch.bgp_peer_groups.mlag_ipv4_underlay_peer.name }}:
         activate: true
 {%     if underlay_rfc5549 is arista.avd.defined(true) %}
         next_hop:
           address_family_ipv6_originate: true
   neighbor_interfaces:
     Vlan{{ switch.mlag_peer_l3_vlan | arista.avd.default(switch.mlag_peer_vlan) }}:
-      peer_group: {{ bgp_peer_groups.MLAG_IPv4_UNDERLAY_PEER.name | arista.avd.default("MLAG-IPv4-UNDERLAY-PEER") }}
+      peer_group: {{ switch.bgp_peer_groups.mlag_ipv4_underlay_peer.name }}
       remote_as: "{{ switch.bgp_as }}"
       description: {{ switch.mlag_peer }}
 {%     else %}
   neighbors:
     {{ switch.mlag_peer_l3_ip | arista.avd.default(switch.mlag_peer_ip) }}:
-      peer_group: {{ bgp_peer_groups.MLAG_IPv4_UNDERLAY_PEER.name | arista.avd.default("MLAG-IPv4-UNDERLAY-PEER") }}
+      peer_group: {{ switch.bgp_peer_groups.mlag_ipv4_underlay_peer.name }}
       description: {{ switch.mlag_peer }}
 {%     endif %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-default-vrf.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-default-vrf.j2
@@ -1,5 +1,5 @@
 {# router bgp default vrf configuration for evpn #}
   peer_groups:
-    {{ bgp_peer_groups["IPv4_UNDERLAY_PEERS"].name | arista.avd.default("IPv4-UNDERLAY-PEERS") }}:
+    {{ switch.bgp_peer_groups.ipv4_underlay_peers.name }}:
       type: ipv4
       route_map_out: RM-BGP-UNDERLAY-PEERS-OUT

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-vrfs.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-vrfs.j2
@@ -1,4 +1,3 @@
-{# j2lint: disable=V1 #}
 {# tenant router bgp VRFs #}
 {% if switch.network_services_l3 is arista.avd.defined(true) %}
 {%     set bgp_vrf = namespace() %}
@@ -58,7 +57,7 @@
                                                          true) %}
 {%                         if configure_mlag_ibgp_peering %}
         {{ switch.mlag_peer_l3_ip | arista.avd.default(switch.mlag_peer_ip) }}:
-          peer_group: {{ bgp_peer_groups.MLAG_IPv4_UNDERLAY_PEER.name | arista.avd.default("MLAG-IPv4-UNDERLAY-PEER") }}
+          peer_group: {{ switch.bgp_peer_groups.mlag_ipv4_underlay_peer.name }}
 {%                         endif %}
 {%                     endif %}
 {%                     for bgp_peer in vrf.bgp_peers %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/ebgp/address-family-evpn.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/ebgp/address-family-evpn.j2
@@ -1,7 +1,6 @@
-{# j2lint: disable=V1 #}
   address_family_evpn:
     peer_groups:
-      {{ bgp_peer_groups.EVPN_OVERLAY_PEERS.name | arista.avd.default("EVPN-OVERLAY-PEERS") }}:
+      {{ switch.bgp_peer_groups.evpn_overlay_peers.name }}:
         activate: true
 {% if switch.vtep_ip is arista.avd.defined and evpn_hostflap_detection is arista.avd.defined %}
     evpn_hostflap_detection:

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/ebgp/address-family-ipv4.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/ebgp/address-family-ipv4.j2
@@ -1,5 +1,4 @@
-{# j2lint: disable=V1 #}
   address_family_ipv4:
     peer_groups:
-      {{ bgp_peer_groups.EVPN_OVERLAY_PEERS.name | arista.avd.default("EVPN-OVERLAY-PEERS") }}:
+      {{ switch.bgp_peer_groups.evpn_overlay_peers.name }}:
         activate: false

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/ebgp/address-family-rtc.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/ebgp/address-family-rtc.j2
@@ -1,7 +1,6 @@
-{# j2lint: disable=V1 #}
   address_family_rtc:
     peer_groups:
-      {{ bgp_peer_groups.EVPN_OVERLAY_PEERS.name | arista.avd.default("EVPN-OVERLAY-PEERS") }}:
+      {{ switch.bgp_peer_groups.evpn_overlay_peers.name }}:
         activate: true
 {% if switch.evpn_role == "server" %}
         default_route_target:

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/ebgp/neighbors.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/ebgp/neighbors.j2
@@ -1,8 +1,7 @@
-{# j2lint: disable=V1 #}
   neighbors:
 {% for evpn_route_server in overlay_data.evpn_route_servers | arista.avd.natural_sort %}
     {{ overlay_data.evpn_route_servers[evpn_route_server].ip_address }}:
-      peer_group: {{ bgp_peer_groups.EVPN_OVERLAY_PEERS.name | arista.avd.default("EVPN-OVERLAY-PEERS") }}
+      peer_group: {{ switch.bgp_peer_groups.evpn_overlay_peers.name }}
       description: {{ evpn_route_server }}
       remote_as: "{{ overlay_data.evpn_route_servers[evpn_route_server].bgp_as }}"
 {%     if evpn_prevent_readvertise_to_server is arista.avd.defined(true) %}
@@ -11,7 +10,7 @@
 {% endfor %}
 {% for evpn_route_client in overlay_data.evpn_route_clients | arista.avd.natural_sort %}
     {{ overlay_data.evpn_route_clients[evpn_route_client].ip_address }}:
-      peer_group: {{ bgp_peer_groups.EVPN_OVERLAY_PEERS.name | arista.avd.default("EVPN-OVERLAY-PEERS") }}
+      peer_group: {{ switch.bgp_peer_groups.evpn_overlay_peers.name }}
       description: {{ evpn_route_client }}
       remote_as: "{{ overlay_data.evpn_route_clients[evpn_route_client].bgp_as }}"
 {% endfor %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/ebgp/peer-groups.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/ebgp/peer-groups.j2
@@ -1,12 +1,11 @@
-{# j2lint: disable=V1 #}
   peer_groups:
-    {{ bgp_peer_groups.EVPN_OVERLAY_PEERS.name | arista.avd.default("EVPN-OVERLAY-PEERS") }}:
+    {{ switch.bgp_peer_groups.evpn_overlay_peers.name }}:
       type: evpn
       update_source: Loopback0
       bfd: true
       ebgp_multihop: "{{ evpn_ebgp_multihop }}"
-{% if bgp_peer_groups.EVPN_OVERLAY_PEERS.password is arista.avd.defined() %}
-      password: "{{ bgp_peer_groups.EVPN_OVERLAY_PEERS.password }}"
+{% if bgp_peer_groups.evpn_overlay_peers.password is arista.avd.defined %}
+      password: "{{ bgp_peer_groups.evpn_overlay_peers.password }}"
 {% endif %}
       send_community: all
       maximum_routes: 0

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/ebgp/peer-groups.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/ebgp/peer-groups.j2
@@ -4,8 +4,8 @@
       update_source: Loopback0
       bfd: true
       ebgp_multihop: "{{ evpn_ebgp_multihop }}"
-{% if bgp_peer_groups.evpn_overlay_peers.password is arista.avd.defined %}
-      password: "{{ bgp_peer_groups.evpn_overlay_peers.password }}"
+{% if switch.bgp_peer_groups.evpn_overlay_peers.password is arista.avd.defined %}
+      password: "{{ switch.bgp_peer_groups.evpn_overlay_peers.password }}"
 {% endif %}
       send_community: all
       maximum_routes: 0

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/ibgp/peer-groups.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/ibgp/peer-groups.j2
@@ -1,4 +1,3 @@
-{# j2lint: disable=V1 #}
   peer_groups:
     {{ overlay_data.overlay_peer_group_name }}:
 {% if switch.mpls_overlay_role in ["server", "client"] %}
@@ -10,12 +9,12 @@
       remote_as: "{{ switch.bgp_as }}"
       bfd: true
 {% if switch.mpls_overlay_role in ["server", "client"] %}
-{%     if bgp_peer_groups.mpls_overlay_peers.password is arista.avd.defined() %}
+{%     if bgp_peer_groups.mpls_overlay_peers.password is arista.avd.defined %}
       password: "{{ bgp_peer_groups.mpls_overlay_peers.password }}"
 {%     endif %}
 {% else %}
-{%     if bgp_peer_groups.EVPN_OVERLAY_PEERS.password is arista.avd.defined() %}
-      password: "{{ bgp_peer_groups.EVPN_OVERLAY_PEERS.password }}"
+{%     if switch.bgp_peer_groups.evpn_overlay_peers.password is arista.avd.defined %}
+      password: "{{ bgp_peer_groups.evpn_overlay_peers.password }}"
 {%     endif %}
 {% endif %}
       send_community: all

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/ibgp/peer-groups.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/ibgp/peer-groups.j2
@@ -9,12 +9,12 @@
       remote_as: "{{ switch.bgp_as }}"
       bfd: true
 {% if switch.mpls_overlay_role in ["server", "client"] %}
-{%     if bgp_peer_groups.mpls_overlay_peers.password is arista.avd.defined %}
-      password: "{{ bgp_peer_groups.mpls_overlay_peers.password }}"
+{%     if switch.bgp_peer_groups.mpls_overlay_peers.password is arista.avd.defined %}
+      password: "{{ switch.bgp_peer_groups.mpls_overlay_peers.password }}"
 {%     endif %}
 {% else %}
 {%     if switch.bgp_peer_groups.evpn_overlay_peers.password is arista.avd.defined %}
-      password: "{{ bgp_peer_groups.evpn_overlay_peers.password }}"
+      password: "{{ switch.bgp_peer_groups.evpn_overlay_peers.password }}"
 {%     endif %}
 {% endif %}
       send_community: all
@@ -28,8 +28,8 @@
       update_source: Loopback0
       remote_as: "{{ bgp_as }}"
       bfd: true
-{%     if bgp_peer_groups.rr_overlay_peers.password is arista.avd.defined() %}
-      password: "{{ bgp_peer_groups.rr_overlay_peers.password }}"
+{%     if switch.bgp_peer_groups.rr_overlay_peers.password is arista.avd.defined() %}
+      password: "{{ switch.bgp_peer_groups.rr_overlay_peers.password }}"
       send_community: all
       maximum_routes: 0
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/ibgp/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/ibgp/router-bgp.j2
@@ -1,4 +1,3 @@
-{# j2lint: disable=V1 #}
 router_bgp:
 
 {% if switch.evpn_role == "server" or switch.mpls_overlay_role == "server" %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/main.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/main.j2
@@ -3,12 +3,12 @@
 {%     set overlay_data = namespace() %}
 {# Set peer group names for overlay peering #}
 {%     if switch.mpls_ler is arista.avd.defined(true) or switch.mpls_overlay_role == "server" %}
-{%         set overlay_data.overlay_peer_group_name = bgp_peer_groups.mpls_overlay_peers.name | arista.avd.default("MPLS-OVERLAY-PEERS") %}
+{%         set overlay_data.overlay_peer_group_name = switch.bgp_peer_groups.mpls_overlay_peers.name %}
 {%     else %}
-{%         set overlay_data.overlay_peer_group_name = bgp_peer_groups.EVPN_OVERLAY_PEERS.name | arista.avd.default("EVPN-OVERLAY-PEERS") %}
+{%         set overlay_data.overlay_peer_group_name = switch.bgp_peer_groups.evpn_overlay_peers.name %}
 {%     endif %}
 {%     if switch.mpls_overlay_role == "server" %}
-{%         set overlay_data.rr_peers_peer_group_name = bgp_peer_groups.rr_overlay_peers.name | arista.avd.default("RR-OVERLAY-PEERS") %}
+{%         set overlay_data.rr_peers_peer_group_name = switch.bgp_peer_groups.rr_overlay_peers.name %}
 {%     endif %}
 {%     if switch.mpls_overlay_role in ["client", "server"] %}
 {%         include 'overlay/logic-mpls-route-servers.j2' %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/underlay/ebgp/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/underlay/ebgp/router-bgp.j2
@@ -1,18 +1,17 @@
-{# j2lint: disable=V1 #}
 {# EBGP #}
 {## Underlay network peerings #}
 router_bgp:
   peer_groups:
-    {{ bgp_peer_groups.IPv4_UNDERLAY_PEERS.name | arista.avd.default("IPv4-UNDERLAY-PEERS") }}:
+    {{ switch.bgp_peer_groups.ipv4_underlay_peers.name }}:
       type: ipv4
-{% if bgp_peer_groups.IPv4_UNDERLAY_PEERS.password is arista.avd.defined() %}
-      password: "{{ bgp_peer_groups.IPv4_UNDERLAY_PEERS.password }}"
+{% if switch.bgp_peer_groups.ipv4_underlay_peers.password is arista.avd.defined() %}
+      password: "{{ switch.bgp_peer_groups.ipv4_underlay_peers.password }}"
 {% endif %}
       maximum_routes: 12000
       send_community: all
   address_family_ipv4:
     peer_groups:
-      {{ bgp_peer_groups.IPv4_UNDERLAY_PEERS.name | arista.avd.default("IPv4-UNDERLAY-PEERS") }}:
+      {{ switch.bgp_peer_groups.ipv4_underlay_peers.name }}:
         activate: true
 {% if underlay_rfc5549 is arista.avd.defined(true) %}
         next_hop:
@@ -28,7 +27,7 @@ router_bgp:
 {%     for link_interface in underlay_data.links | arista.avd.natural_sort if underlay_data.links[link_interface].type is arista.avd.defined('underlay_p2p') %}
 {%         set link = underlay_data.links[link_interface] %}
     {{ link_interface }}:
-      peer_group: {{ bgp_peer_groups.IPv4_UNDERLAY_PEERS.name | arista.avd.default("IPv4-UNDERLAY-PEERS") }}
+      peer_group: {{ switch.bgp_peer_groups.ipv4_underlay_peers.name }}
       remote_as: "{{ link.peer_bgp_as }}"
       description: {{ link.peer }}_{{ link.peer_interface }}
 {%     endfor %}
@@ -39,7 +38,7 @@ router_bgp:
 {%     for link_interface in underlay_data.links | arista.avd.natural_sort if underlay_data.links[link_interface].type is arista.avd.defined('underlay_p2p') %}
 {%         set link = underlay_data.links[link_interface] %}
     {{ link.peer_ip_address }}:
-      peer_group: {{ bgp_peer_groups.IPv4_UNDERLAY_PEERS.name | arista.avd.default("IPv4-UNDERLAY-PEERS") }}
+      peer_group: {{ switch.bgp_peer_groups.ipv4_underlay_peers.name }}
       remote_as: "{{ link.peer_bgp_as }}"
       description: {{ link.peer }}_{{ link.peer_interface }}
 {%         if link.bfd is arista.avd.defined %}

--- a/ansible_collections/arista/avd/tests/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/tests/inventory/group_vars/DC1_FABRIC.yml
@@ -9,11 +9,11 @@ evpn_vlan_aware_bundles: true
 
 # bgp peer groups passwords
 bgp_peer_groups:
-  IPv4_UNDERLAY_PEERS:
+  ipv4_underlay_peers:
     password: "AQQvKeimxJu+uGQ/yYvv9w=="
-  EVPN_OVERLAY_PEERS:
+  evpn_overlay_peers:
     password: "q+VNViP5i4rVjW1cxFv2wA=="
-  MLAG_IPv4_UNDERLAY_PEER:
+  mlag_ipv4_underlay_peer:
     password: "vnEaG8gMeQf3d3cN6PktXQ=="
 
 # Spine Switches


### PR DESCRIPTION
** Waiting for mpls design PR to merge, so we can cover those bgp peer groups with the new logic as well. **

## Change Summary

Change bgp_peer_groups to lower-case

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->
- [x] Change the datamodel for `bgp_peer_groups` to only use lower-case keys
- [x] Gather the logic and defaults in switch facts instead of distributed everywhere
- [x] Ensure changes are backward compatible
- [x] Update release notes with the data model change
- [x] Update readme
- [x] Update most molecule scenarios to the new standard, but keep some with the old style

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
No changes to molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
