### PR TITLE
Fix(eos_cli_config_gen): Allow no logging source-interface in VRFs

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/logging.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/logging.md
@@ -73,6 +73,7 @@ interface Management1
 | mgt | 10.10.10.7 | Default | UDP |
 | mgt | 30.30.30.7 | 100, 200 | TCP |
 | mgt | 40.40.40.7 | 300, 400 | UDP |
+| vrf_with_no_source_interface | 1.2.3.4 | Default | UDP |
 
 ### Logging Servers and Features Device Configuration
 
@@ -88,6 +89,7 @@ logging host 60.60.60.7 100 200
 logging vrf mgt host 10.10.10.7
 logging vrf mgt host 30.30.30.7 100 200 protocol tcp
 logging vrf mgt host 40.40.40.7 300 400
+logging vrf vrf_with_no_source_interface host 1.2.3.4
 logging source-interface Loopback0
 logging vrf mgt source-interface Management0
 ```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/logging.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/logging.cfg
@@ -12,6 +12,7 @@ logging host 60.60.60.7 100 200
 logging vrf mgt host 10.10.10.7
 logging vrf mgt host 30.30.30.7 100 200 protocol tcp
 logging vrf mgt host 40.40.40.7 300 400
+logging vrf vrf_with_no_source_interface host 1.2.3.4
 logging source-interface Loopback0
 logging vrf mgt source-interface Management0
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/logging.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/logging.yml
@@ -22,6 +22,10 @@ logging:
           ports:
             - 300
             - 400
+    vrf_with_no_source_interface:
+      hosts:
+        1.2.3.4:
+          protocol: udp
     default:
       source_interface: Loopback0
       hosts:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/logging.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/logging.j2
@@ -34,7 +34,7 @@ logging synchronous level {{ logging.synchronous.level | arista.avd.default("cri
 {%     for vrf in logging.vrfs | arista.avd.natural_sort %}
 {%         for host in logging.vrfs[vrf].hosts | arista.avd.natural_sort %}
 {%             set logging_host_cli = "logging" %}
-{%             if logging.vrfs[vrf].hosts is arista.avd.defined and vrf is not arista.avd.defined('default') %}
+{%             if vrf != "default" %}
 {%                 set logging_host_cli = logging_host_cli ~ " vrf " ~ vrf %}
 {%             endif %}
 {%             set logging_host_cli = logging_host_cli ~ " host " ~ host %}
@@ -66,11 +66,13 @@ logging source-interface {{ logging.source_interface }}
 {%     endif %}
 {%     for vrf in logging.vrfs | arista.avd.natural_sort %}
 {%         set logging_cli = "logging" %}
-{%         if logging.vrfs[vrf].source_interface is arista.avd.defined and vrf is not arista.avd.defined('default') %}
-{%             set logging_cli = logging_cli ~ " vrf " ~ vrf %}
-{%         endif %}
-{%         set logging_cli = logging_cli ~ " source-interface " ~ logging.vrfs[vrf].source_interface %}
+{%         if logging.vrfs[vrf].source_interface is arista.avd.defined %}
+{%             if vrf != "default" %}
+{%                 set logging_cli = logging_cli ~ " vrf " ~ vrf %}
+{%             endif %}
+{%             set logging_cli = logging_cli ~ " source-interface " ~ logging.vrfs[vrf].source_interface %}
 {{ logging_cli }}
+{%         endif %}
 {%     endfor %}
 {%     for match_list in logging.policy.match.match_lists | arista.avd.natural_sort %}
 logging policy match match-list {{ match_list }} {{ logging.policy.match.match_lists[match_list].action }}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Allow no logging source-interface in VRFs.

## Related Issue(s)

Fixes #1595 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->
Fixed logic in template, to ensure proper protection for undefined variables.
Added molecule coverage for this scenario.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Only expected change in molecule.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
