### PR TITLE
Fix(eos_cli_config_gen): Ethernet Interface Config Order

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -201,11 +201,11 @@ interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet1
    mtu 1500
    no switchport
-   priority-flow-control on
-   priority-flow-control priority 5 drop
    ip address 172.31.255.1/31
    bfd interval 500 min-rx 500 multiplier 5
    bfd echo
+   priority-flow-control on
+   priority-flow-control priority 5 drop
    link tracking group EVPN_MH_ES1 upstream
    comment
    Comment created from eos_cli under ethernet_interfaces.Ethernet1
@@ -214,29 +214,29 @@ interface Ethernet1
 !
 interface Ethernet2
    description SRV-POD02_Eth1
-   switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
+   switchport
    priority-flow-control on
    priority-flow-control priority 5 no-drop
-   spanning-tree bpduguard disable
-   spanning-tree bpdufilter disable
    storm-control all level 10
    storm-control broadcast level pps 500
    storm-control unknown-unicast level 1
+   spanning-tree bpduguard disable
+   spanning-tree bpdufilter disable
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE2_Ethernet2
    mtu 1500
    no switchport
-   no priority-flow-control
-   spanning-tree guard root
    ip address 172.31.128.1/31
    ipv6 enable
    ipv6 address 2002:ABDC::1/64
    ipv6 nd prefix 2345:ABCD:3FE0::1/96 infinite 50 no-autoconfig
    ipv6 nd prefix 2345:ABCD:3FE0::2/96 50 infinite
    ipv6 nd prefix 2345:ABCD:3FE0::3/96 100000 no-autoconfig
+   no priority-flow-control
+   spanning-tree guard root
    link tracking group EVPN_MH_ES2 downstream
 !
 interface Ethernet4
@@ -244,8 +244,6 @@ interface Ethernet4
    shutdown
    mtu 9100
    switchport
-   priority-flow-control on
-   spanning-tree guard none
    ipv6 enable
    ipv6 address 2020::2020/64
    ipv6 address FE80:FEA::AB65/64 link-local
@@ -253,35 +251,37 @@ interface Ethernet4
    ipv6 nd managed-config-flag
    ipv6 access-group IPv6_ACL_IN in
    ipv6 access-group IPv6_ACL_OUT out
+   priority-flow-control on
+   spanning-tree guard none
 !
 interface Ethernet5
    description Molecule Routing
    no shutdown
    mtu 9100
    no switchport
-   spanning-tree guard loop
-   ip ospf network point-to-point
-   ip ospf area 100
    ip ospf cost 99
+   ip ospf network point-to-point
    ip ospf authentication message-digest
    ip ospf authentication-key 7 asfddja23452
+   ip ospf area 100
    ip ospf message-digest-key 1 sha512 7 asfddja23452
+   pim ipv4 sparse-mode
+   pim ipv4 dr-priority 200
    isis enable ISIS_TEST
    isis circuit-type level-2
    isis metric 99
-   isis network point-to-point
    no isis hello padding
+   isis network point-to-point
    isis authentication mode md5
    isis authentication key 7 asfddja23452
-   pim ipv4 sparse-mode
-   pim ipv4 dr-priority 200
+   spanning-tree guard loop
 !
 interface Ethernet6
    description SRV-POD02_Eth1
    logging event link-status
-   switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
+   switchport
    spanning-tree bpduguard enable
    spanning-tree bpdufilter enable
 !
@@ -292,24 +292,24 @@ interface Ethernet7
    switchport
    qos trust cos
    qos cos 5
-   spanning-tree portfast
-   spanning-tree bpduguard enable
-   spanning-tree bpdufilter enable
-   vmtracer vmware-esx
-   ptp enable
-   ptp announce interval 10
-   ptp announce timeout 30
-   ptp delay-req interval 20
-   ptp delay-mechanism p2p
-   ptp sync-message interval 5
-   ptp role master
-   ptp vlan all
-   ptp transport layer2
-   service-profile QoS
    storm-control all level 75
    storm-control broadcast level pps 10
    storm-control multicast level 50
    storm-control unknown-unicast level 10
+   ptp enable
+   ptp sync-message interval 5
+   ptp delay-mechanism p2p
+   ptp announce interval 10
+   ptp transport layer2
+   ptp announce timeout 30
+   ptp delay-req interval 20
+   ptp role master
+   ptp vlan all
+   service-profile QoS
+   spanning-tree portfast
+   spanning-tree bpduguard enable
+   spanning-tree bpdufilter enable
+   vmtracer vmware-esx
    transceiver media override 100gbase-ar4
 !
 interface Ethernet8
@@ -329,64 +329,64 @@ interface Ethernet9
    description interface_with_mpls_enabled
    no switchport
    ip address 172.31.128.9/31
-   mpls ip
    mpls ldp interface
+   mpls ip
 !
 interface Ethernet10
    description interface_with_mpls_disabled
    no switchport
    ip address 172.31.128.10/31
-   no mpls ip
    no mpls ldp interface
+   no mpls ip
 !
 interface Ethernet11
    description interface_in_mode_access_accepting_tagged_LACP
-   switchport
    switchport access vlan 200
    switchport mode access
+   switchport
    l2-protocol encapsulation dot1q vlan 200
 !
 interface Ethernet12
    description interface_with_dot1q_tunnel
-   switchport
    switchport access vlan 300
    switchport mode dot1q-tunnel
+   switchport
 !
 interface Ethernet13
    description interface_in_mode_access_with_voice
    no logging event link-status
-   switchport
    switchport trunk native vlan 100
    switchport phone vlan 70
    switchport phone trunk untagged
    switchport mode trunk phone
+   switchport
 !
 interface Ethernet14
    description SRV-POD02_Eth1
    logging event link-status
-   switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
+   switchport
 !
 interface Ethernet15
    description PVLAN Promiscuous Access - only one secondary
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
    switchport pvlan mapping 111
 !
 interface Ethernet16
    description PVLAN Promiscuous Trunk - vlan translation out
-   switchport
+   switchport vlan translation out 111-112 110
    switchport trunk allowed vlan 110-112
    switchport mode trunk
-   switchport vlan translation out 111-112 110
+   switchport
 !
 interface Ethernet17
    description PVLAN Secondary Trunk
-   switchport
    switchport trunk allowed vlan 110-112
    switchport mode trunk
+   switchport
    switchport trunk private-vlan secondary
 !
 interface Ethernet18
@@ -398,9 +398,9 @@ interface Ethernet18
 !
 interface Ethernet19
    description Switched port with no LLDP rx/tx
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
    no lldp transmit
    no lldp receive
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/lldp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/lldp.md
@@ -129,16 +129,16 @@ interface Ethernet1
 !
 interface Ethernet2
    description Switched port with no LLDP rx/tx
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
    no lldp transmit
 !
 interface Ethernet3
    description No special LLDP settings
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
 !
 interface Ethernet4
    description test

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mpls.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mpls.md
@@ -89,9 +89,9 @@ interface Management1
 interface Ethernet1
    no switchport
    ip address 192.168.100.1/31
-   mpls ip
-   mpls ldp interface
    mpls ldp igp sync
+   mpls ldp interface
+   mpls ip
 ```
 
 ## Loopback Interfaces

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
@@ -138,10 +138,10 @@ interface Ethernet10/3
 !
 interface Ethernet10/4
    description LAG Member LACP fallback
-   channel-group 104 mode active
-   switchport
    switchport trunk allowed vlan 100
    switchport mode trunk
+   switchport
+   channel-group 104 mode active
    spanning-tree portfast
 !
 interface Ethernet10/10
@@ -154,12 +154,12 @@ interface Ethernet11/1
 !
 interface Ethernet11/2
    description LAG Member LACP fallback LLDP ZTP VLAN
-   channel-group 112 mode active
-   switchport
    switchport trunk allowed vlan 112
    switchport mode trunk
-   spanning-tree portfast
+   switchport
+   channel-group 112 mode active
    lldp tlv transmit ztp vlan 112
+   spanning-tree portfast
 !
 interface Ethernet15
    description DC1-AGG03_Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ptp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ptp.md
@@ -121,15 +121,15 @@ ptp monitor threshold mean-path-delay 4321
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE2_Ethernet5
-   switchport
    switchport trunk allowed vlan 2,14
    switchport mode trunk
+   switchport
    ptp enable
-   ptp delay-mechanism e2e
    ptp sync-message interval 1
+   ptp delay-mechanism e2e
+   ptp transport layer2
    ptp role dynamic
    ptp vlan 2
-   ptp transport layer2
 !
 interface Ethernet5
    description DC1-AGG01_Ethernet1
@@ -141,13 +141,13 @@ interface Ethernet6
    no switchport
    ip address 172.31.255.15/31
    ptp enable
+   ptp sync-message interval 1
+   ptp delay-mechanism e2e
    ptp announce interval 3
+   ptp transport ipv4
    ptp announce timeout 9
    ptp delay-req interval -7
-   ptp delay-mechanism e2e
-   ptp sync-message interval 1
    ptp role dynamic
-   ptp transport ipv4
 ```
 
 ## Port-Channel Interfaces

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/qos.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/qos.md
@@ -97,9 +97,9 @@ interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet1
    mtu 1500
    no switchport
+   ip address 172.31.255.1/31
    qos trust dscp
    qos dscp 48
-   ip address 172.31.255.1/31
    service-profile test
 !
 interface Ethernet3
@@ -112,18 +112,18 @@ interface Ethernet4
 !
 interface Ethernet6
    description SRV-POD02_Eth1
-   switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
+   switchport
    qos trust cos
    qos cos 2
    service-profile experiment
 !
 interface Ethernet7
    description Test-with-policymap
-   switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
+   switchport
    service-profile qprof_testwithpolicy
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
@@ -82,10 +82,10 @@ interface Management1
 !
 interface Ethernet1
    no switchport
-   ip ospf network point-to-point
-   ip ospf area 0.0.0.1
    ip ospf cost 99
+   ip ospf network point-to-point
    ip ospf authentication message-digest
+   ip ospf area 0.0.0.1
    ip ospf message-digest-key 55 md5 7 ABCDEFGHIJKLMNOPQRSTUVWXYZ
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
@@ -11,11 +11,11 @@ interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet1
    mtu 1500
    no switchport
-   priority-flow-control on
-   priority-flow-control priority 5 drop
    ip address 172.31.255.1/31
    bfd interval 500 min-rx 500 multiplier 5
    bfd echo
+   priority-flow-control on
+   priority-flow-control priority 5 drop
    link tracking group EVPN_MH_ES1 upstream
    comment
    Comment created from eos_cli under ethernet_interfaces.Ethernet1
@@ -24,29 +24,29 @@ interface Ethernet1
 !
 interface Ethernet2
    description SRV-POD02_Eth1
-   switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
+   switchport
    priority-flow-control on
    priority-flow-control priority 5 no-drop
-   spanning-tree bpduguard disable
-   spanning-tree bpdufilter disable
    storm-control all level 10
    storm-control broadcast level pps 500
    storm-control unknown-unicast level 1
+   spanning-tree bpduguard disable
+   spanning-tree bpdufilter disable
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE2_Ethernet2
    mtu 1500
    no switchport
-   no priority-flow-control
-   spanning-tree guard root
    ip address 172.31.128.1/31
    ipv6 enable
    ipv6 address 2002:ABDC::1/64
    ipv6 nd prefix 2345:ABCD:3FE0::1/96 infinite 50 no-autoconfig
    ipv6 nd prefix 2345:ABCD:3FE0::2/96 50 infinite
    ipv6 nd prefix 2345:ABCD:3FE0::3/96 100000 no-autoconfig
+   no priority-flow-control
+   spanning-tree guard root
    link tracking group EVPN_MH_ES2 downstream
 !
 interface Ethernet4
@@ -54,8 +54,6 @@ interface Ethernet4
    shutdown
    mtu 9100
    switchport
-   priority-flow-control on
-   spanning-tree guard none
    ipv6 enable
    ipv6 address 2020::2020/64
    ipv6 address FE80:FEA::AB65/64 link-local
@@ -63,35 +61,37 @@ interface Ethernet4
    ipv6 nd managed-config-flag
    ipv6 access-group IPv6_ACL_IN in
    ipv6 access-group IPv6_ACL_OUT out
+   priority-flow-control on
+   spanning-tree guard none
 !
 interface Ethernet5
    description Molecule Routing
    no shutdown
    mtu 9100
    no switchport
-   spanning-tree guard loop
-   ip ospf network point-to-point
-   ip ospf area 100
    ip ospf cost 99
+   ip ospf network point-to-point
    ip ospf authentication message-digest
    ip ospf authentication-key 7 asfddja23452
+   ip ospf area 100
    ip ospf message-digest-key 1 sha512 7 asfddja23452
+   pim ipv4 sparse-mode
+   pim ipv4 dr-priority 200
    isis enable ISIS_TEST
    isis circuit-type level-2
    isis metric 99
-   isis network point-to-point
    no isis hello padding
+   isis network point-to-point
    isis authentication mode md5
    isis authentication key 7 asfddja23452
-   pim ipv4 sparse-mode
-   pim ipv4 dr-priority 200
+   spanning-tree guard loop
 !
 interface Ethernet6
    description SRV-POD02_Eth1
    logging event link-status
-   switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
+   switchport
    spanning-tree bpduguard enable
    spanning-tree bpdufilter enable
 !
@@ -102,24 +102,24 @@ interface Ethernet7
    switchport
    qos trust cos
    qos cos 5
-   spanning-tree portfast
-   spanning-tree bpduguard enable
-   spanning-tree bpdufilter enable
-   vmtracer vmware-esx
-   ptp enable
-   ptp announce interval 10
-   ptp announce timeout 30
-   ptp delay-req interval 20
-   ptp delay-mechanism p2p
-   ptp sync-message interval 5
-   ptp role master
-   ptp vlan all
-   ptp transport layer2
-   service-profile QoS
    storm-control all level 75
    storm-control broadcast level pps 10
    storm-control multicast level 50
    storm-control unknown-unicast level 10
+   ptp enable
+   ptp sync-message interval 5
+   ptp delay-mechanism p2p
+   ptp announce interval 10
+   ptp transport layer2
+   ptp announce timeout 30
+   ptp delay-req interval 20
+   ptp role master
+   ptp vlan all
+   service-profile QoS
+   spanning-tree portfast
+   spanning-tree bpduguard enable
+   spanning-tree bpdufilter enable
+   vmtracer vmware-esx
    transceiver media override 100gbase-ar4
 !
 interface Ethernet8
@@ -139,64 +139,64 @@ interface Ethernet9
    description interface_with_mpls_enabled
    no switchport
    ip address 172.31.128.9/31
-   mpls ip
    mpls ldp interface
+   mpls ip
 !
 interface Ethernet10
    description interface_with_mpls_disabled
    no switchport
    ip address 172.31.128.10/31
-   no mpls ip
    no mpls ldp interface
+   no mpls ip
 !
 interface Ethernet11
    description interface_in_mode_access_accepting_tagged_LACP
-   switchport
    switchport access vlan 200
    switchport mode access
+   switchport
    l2-protocol encapsulation dot1q vlan 200
 !
 interface Ethernet12
    description interface_with_dot1q_tunnel
-   switchport
    switchport access vlan 300
    switchport mode dot1q-tunnel
+   switchport
 !
 interface Ethernet13
    description interface_in_mode_access_with_voice
    no logging event link-status
-   switchport
    switchport trunk native vlan 100
    switchport phone vlan 70
    switchport phone trunk untagged
    switchport mode trunk phone
+   switchport
 !
 interface Ethernet14
    description SRV-POD02_Eth1
    logging event link-status
-   switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
+   switchport
 !
 interface Ethernet15
    description PVLAN Promiscuous Access - only one secondary
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
    switchport pvlan mapping 111
 !
 interface Ethernet16
    description PVLAN Promiscuous Trunk - vlan translation out
-   switchport
+   switchport vlan translation out 111-112 110
    switchport trunk allowed vlan 110-112
    switchport mode trunk
-   switchport vlan translation out 111-112 110
+   switchport
 !
 interface Ethernet17
    description PVLAN Secondary Trunk
-   switchport
    switchport trunk allowed vlan 110-112
    switchport mode trunk
+   switchport
    switchport trunk private-vlan secondary
 !
 interface Ethernet18
@@ -208,9 +208,9 @@ interface Ethernet18
 !
 interface Ethernet19
    description Switched port with no LLDP rx/tx
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
    no lldp transmit
    no lldp receive
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/lldp.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/lldp.cfg
@@ -23,16 +23,16 @@ interface Ethernet1
 !
 interface Ethernet2
    description Switched port with no LLDP rx/tx
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
    no lldp transmit
 !
 interface Ethernet3
    description No special LLDP settings
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
 !
 interface Ethernet4
    description test

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/mpls.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/mpls.cfg
@@ -10,9 +10,9 @@ no aaa root
 interface Ethernet1
    no switchport
    ip address 192.168.100.1/31
-   mpls ip
-   mpls ldp interface
    mpls ldp igp sync
+   mpls ldp interface
+   mpls ip
 !
 interface Loopback0
    ip address 192.168.1.1/32

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
@@ -322,10 +322,10 @@ interface Ethernet10/3
 !
 interface Ethernet10/4
    description LAG Member LACP fallback
-   channel-group 104 mode active
-   switchport
    switchport trunk allowed vlan 100
    switchport mode trunk
+   switchport
+   channel-group 104 mode active
    spanning-tree portfast
 !
 interface Ethernet10/10
@@ -338,12 +338,12 @@ interface Ethernet11/1
 !
 interface Ethernet11/2
    description LAG Member LACP fallback LLDP ZTP VLAN
-   channel-group 112 mode active
-   switchport
    switchport trunk allowed vlan 112
    switchport mode trunk
-   spanning-tree portfast
+   switchport
+   channel-group 112 mode active
    lldp tlv transmit ztp vlan 112
+   spanning-tree portfast
 !
 interface Ethernet15
    description DC1-AGG03_Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ptp.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ptp.cfg
@@ -35,15 +35,15 @@ interface Port-Channel5
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE2_Ethernet5
-   switchport
    switchport trunk allowed vlan 2,14
    switchport mode trunk
+   switchport
    ptp enable
-   ptp delay-mechanism e2e
    ptp sync-message interval 1
+   ptp delay-mechanism e2e
+   ptp transport layer2
    ptp role dynamic
    ptp vlan 2
-   ptp transport layer2
 !
 interface Ethernet5
    description DC1-AGG01_Ethernet1
@@ -55,13 +55,13 @@ interface Ethernet6
    no switchport
    ip address 172.31.255.15/31
    ptp enable
+   ptp sync-message interval 1
+   ptp delay-mechanism e2e
    ptp announce interval 3
+   ptp transport ipv4
    ptp announce timeout 9
    ptp delay-req interval -7
-   ptp delay-mechanism e2e
-   ptp sync-message interval 1
    ptp role dynamic
-   ptp transport ipv4
 !
 interface Management1
    description oob_management

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/qos.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/qos.cfg
@@ -99,9 +99,9 @@ interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet1
    mtu 1500
    no switchport
+   ip address 172.31.255.1/31
    qos trust dscp
    qos dscp 48
-   ip address 172.31.255.1/31
    service-profile test
 !
 interface Ethernet3
@@ -114,18 +114,18 @@ interface Ethernet4
 !
 interface Ethernet6
    description SRV-POD02_Eth1
-   switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
+   switchport
    qos trust cos
    qos cos 2
    service-profile experiment
 !
 interface Ethernet7
    description Test-with-policymap
-   switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
+   switchport
    service-profile qprof_testwithpolicy
 !
 interface Management1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-ospf.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-ospf.cfg
@@ -17,10 +17,10 @@ interface Port-Channel12
 !
 interface Ethernet1
    no switchport
-   ip ospf network point-to-point
-   ip ospf area 0.0.0.1
    ip ospf cost 99
+   ip ospf network point-to-point
    ip ospf authentication message-digest
+   ip ospf area 0.0.0.1
    ip ospf message-digest-key 55 md5 7 ABCDEFGHIJKLMNOPQRSTUVWXYZ
 !
 interface Loopback2

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/ethernet-interfaces.md
@@ -201,10 +201,10 @@ interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet1
    mtu 1500
    no switchport
-   priority-flow-control on
-   priority-flow-control priority 5 drop
    ip address 172.31.255.1/31
    bfd interval 500 min-rx 500 multiplier 5
+   priority-flow-control on
+   priority-flow-control priority 5 drop
    link tracking group EVPN_MH_ES1 upstream
    comment
    Comment created from eos_cli under ethernet_interfaces.Ethernet1
@@ -213,29 +213,29 @@ interface Ethernet1
 !
 interface Ethernet2
    description SRV-POD02_Eth1
-   switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
+   switchport
    priority-flow-control on
    priority-flow-control priority 5 no-drop
-   spanning-tree bpduguard disable
-   spanning-tree bpdufilter disable
    storm-control all level 10
    storm-control broadcast level pps 500
    storm-control unknown-unicast level 1
+   spanning-tree bpduguard disable
+   spanning-tree bpdufilter disable
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE2_Ethernet2
    mtu 1500
    no switchport
-   no priority-flow-control
-   spanning-tree guard root
    ip address 172.31.128.1/31
    ipv6 enable
    ipv6 address 2002:ABDC::1/64
    ipv6 nd prefix 2345:ABCD:3FE0::1/96 infinite 50 no-autoconfig
    ipv6 nd prefix 2345:ABCD:3FE0::2/96 50 infinite
    ipv6 nd prefix 2345:ABCD:3FE0::3/96 100000 no-autoconfig
+   no priority-flow-control
+   spanning-tree guard root
    link tracking group EVPN_MH_ES2 downstream
 !
 interface Ethernet4
@@ -243,8 +243,6 @@ interface Ethernet4
    shutdown
    mtu 9100
    switchport
-   priority-flow-control on
-   spanning-tree guard none
    ipv6 enable
    ipv6 address 2020::2020/64
    ipv6 address FE80:FEA::AB65/64 link-local
@@ -252,34 +250,36 @@ interface Ethernet4
    ipv6 nd managed-config-flag
    ipv6 access-group IPv6_ACL_IN in
    ipv6 access-group IPv6_ACL_OUT out
+   priority-flow-control on
+   spanning-tree guard none
 !
 interface Ethernet5
    description Molecule Routing
    no shutdown
    mtu 9100
    no switchport
-   spanning-tree guard loop
-   ip ospf network point-to-point
-   ip ospf area 100
    ip ospf cost 99
+   ip ospf network point-to-point
    ip ospf authentication message-digest
    ip ospf authentication-key 7 asfddja23452
+   ip ospf area 100
    ip ospf message-digest-key 1 sha512 7 asfddja23452
+   pim ipv4 sparse-mode
    isis enable ISIS_TEST
    isis circuit-type level-2
    isis metric 99
-   isis network point-to-point
    no isis hello padding
+   isis network point-to-point
    isis authentication mode md5
    isis authentication key 7 asfddja23452
-   pim ipv4 sparse-mode
+   spanning-tree guard loop
 !
 interface Ethernet6
    description SRV-POD02_Eth1
    logging event link-status
-   switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
+   switchport
    spanning-tree bpduguard enable
    spanning-tree bpdufilter enable
 !
@@ -290,24 +290,24 @@ interface Ethernet7
    switchport
    qos trust cos
    qos cos 5
-   spanning-tree portfast
-   spanning-tree bpduguard enable
-   spanning-tree bpdufilter enable
-   vmtracer vmware-esx
-   ptp enable
-   ptp announce interval 10
-   ptp announce timeout 30
-   ptp delay-req interval 20
-   ptp delay-mechanism p2p
-   ptp sync-message interval 5
-   ptp role master
-   ptp vlan all
-   ptp transport layer2
-   service-profile QoS
    storm-control all level 75
    storm-control broadcast level pps 10
    storm-control multicast level 50
    storm-control unknown-unicast level 10
+   ptp enable
+   ptp sync-message interval 5
+   ptp delay-mechanism p2p
+   ptp announce interval 10
+   ptp transport layer2
+   ptp announce timeout 30
+   ptp delay-req interval 20
+   ptp role master
+   ptp vlan all
+   service-profile QoS
+   spanning-tree portfast
+   spanning-tree bpduguard enable
+   spanning-tree bpdufilter enable
+   vmtracer vmware-esx
    transceiver media override 100gbase-ar4
 !
 interface Ethernet8
@@ -327,64 +327,64 @@ interface Ethernet9
    description interface_with_mpls_enabled
    no switchport
    ip address 172.31.128.9/31
-   mpls ip
    mpls ldp interface
+   mpls ip
 !
 interface Ethernet10
    description interface_with_mpls_disabled
    no switchport
    ip address 172.31.128.10/31
-   no mpls ip
    no mpls ldp interface
+   no mpls ip
 !
 interface Ethernet11
    description interface_in_mode_access_accepting_tagged_LACP
-   switchport
    switchport access vlan 200
    switchport mode access
+   switchport
    l2-protocol encapsulation dot1q vlan 200
 !
 interface Ethernet12
    description interface_with_dot1q_tunnel
-   switchport
    switchport access vlan 300
    switchport mode dot1q-tunnel
+   switchport
 !
 interface Ethernet13
    description interface_in_mode_access_with_voice
    no logging event link-status
-   switchport
    switchport trunk native vlan 100
    switchport phone vlan 70
    switchport phone trunk untagged
    switchport mode trunk phone
+   switchport
 !
 interface Ethernet14
    description SRV-POD02_Eth1
    logging event link-status
-   switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
+   switchport
 !
 interface Ethernet15
    description PVLAN Promiscuous Access - only one secondary
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
    switchport pvlan mapping 111
 !
 interface Ethernet16
    description PVLAN Promiscuous Trunk - vlan translation out
-   switchport
+   switchport vlan translation out 111-112 110
    switchport trunk allowed vlan 110-112
    switchport mode trunk
-   switchport vlan translation out 111-112 110
+   switchport
 !
 interface Ethernet17
    description PVLAN Secondary Trunk
-   switchport
    switchport trunk allowed vlan 110-112
    switchport mode trunk
+   switchport
    switchport trunk private-vlan secondary
 !
 interface Ethernet18
@@ -396,9 +396,9 @@ interface Ethernet18
 !
 interface Ethernet19
    description Switched port with no LLDP rx/tx
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
    no lldp transmit
    no lldp receive
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/lldp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/lldp.md
@@ -129,16 +129,16 @@ interface Ethernet1
 !
 interface Ethernet2
    description Switched port with no LLDP rx/tx
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
    no lldp transmit
 !
 interface Ethernet3
    description No special LLDP settings
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
 !
 interface Ethernet4
    description test

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/mpls.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/mpls.md
@@ -89,9 +89,9 @@ interface Management1
 interface Ethernet1
    no switchport
    ip address 192.168.100.1/31
-   mpls ip
-   mpls ldp interface
    mpls ldp igp sync
+   mpls ldp interface
+   mpls ip
 ```
 
 ## Loopback Interfaces

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/port-channel-interfaces.md
@@ -138,10 +138,10 @@ interface Ethernet10/3
 !
 interface Ethernet10/4
    description LAG Member LACP fallback
-   channel-group 104 mode active
-   switchport
    switchport trunk allowed vlan 100
    switchport mode trunk
+   switchport
+   channel-group 104 mode active
    spanning-tree portfast
 !
 interface Ethernet10/10
@@ -154,12 +154,12 @@ interface Ethernet11/1
 !
 interface Ethernet11/2
    description LAG Member LACP fallback LLDP ZTP VLAN
-   channel-group 112 mode active
-   switchport
    switchport trunk allowed vlan 112
    switchport mode trunk
-   spanning-tree portfast
+   switchport
+   channel-group 112 mode active
    lldp tlv transmit ztp vlan 112
+   spanning-tree portfast
 !
 interface Ethernet15
    description DC1-AGG03_Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/ptp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/ptp.md
@@ -121,15 +121,15 @@ ptp monitor threshold mean-path-delay 4321
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE2_Ethernet5
-   switchport
    switchport trunk allowed vlan 2,14
    switchport mode trunk
+   switchport
    ptp enable
-   ptp delay-mechanism e2e
    ptp sync-message interval 1
+   ptp delay-mechanism e2e
+   ptp transport layer2
    ptp role dynamic
    ptp vlan 2
-   ptp transport layer2
 !
 interface Ethernet5
    description DC1-AGG01_Ethernet1
@@ -141,13 +141,13 @@ interface Ethernet6
    no switchport
    ip address 172.31.255.15/31
    ptp enable
+   ptp sync-message interval 1
+   ptp delay-mechanism e2e
    ptp announce interval 3
+   ptp transport ipv4
    ptp announce timeout 9
    ptp delay-req interval -7
-   ptp delay-mechanism e2e
-   ptp sync-message interval 1
    ptp role dynamic
-   ptp transport ipv4
 ```
 
 ## Port-Channel Interfaces

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/qos.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/qos.md
@@ -97,9 +97,9 @@ interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet1
    mtu 1500
    no switchport
+   ip address 172.31.255.1/31
    qos trust dscp
    qos dscp 48
-   ip address 172.31.255.1/31
    service-profile test
 !
 interface Ethernet3
@@ -112,18 +112,18 @@ interface Ethernet4
 !
 interface Ethernet6
    description SRV-POD02_Eth1
-   switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
+   switchport
    qos trust cos
    qos cos 2
    service-profile experiment
 !
 interface Ethernet7
    description Test-with-policymap
-   switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
+   switchport
    service-profile qprof_testwithpolicy
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/router-ospf.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/router-ospf.md
@@ -82,10 +82,10 @@ interface Management1
 !
 interface Ethernet1
    no switchport
-   ip ospf network point-to-point
-   ip ospf area 0.0.0.1
    ip ospf cost 99
+   ip ospf network point-to-point
    ip ospf authentication message-digest
+   ip ospf area 0.0.0.1
    ip ospf message-digest-key 55 md5 7 ABCDEFGHIJKLMNOPQRSTUVWXYZ
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/ethernet-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/ethernet-interfaces.cfg
@@ -11,10 +11,10 @@ interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet1
    mtu 1500
    no switchport
-   priority-flow-control on
-   priority-flow-control priority 5 drop
    ip address 172.31.255.1/31
    bfd interval 500 min-rx 500 multiplier 5
+   priority-flow-control on
+   priority-flow-control priority 5 drop
    link tracking group EVPN_MH_ES1 upstream
    comment
    Comment created from eos_cli under ethernet_interfaces.Ethernet1
@@ -23,29 +23,29 @@ interface Ethernet1
 !
 interface Ethernet2
    description SRV-POD02_Eth1
-   switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
+   switchport
    priority-flow-control on
    priority-flow-control priority 5 no-drop
-   spanning-tree bpduguard disable
-   spanning-tree bpdufilter disable
    storm-control all level 10
    storm-control broadcast level pps 500
    storm-control unknown-unicast level 1
+   spanning-tree bpduguard disable
+   spanning-tree bpdufilter disable
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE2_Ethernet2
    mtu 1500
    no switchport
-   no priority-flow-control
-   spanning-tree guard root
    ip address 172.31.128.1/31
    ipv6 enable
    ipv6 address 2002:ABDC::1/64
    ipv6 nd prefix 2345:ABCD:3FE0::1/96 infinite 50 no-autoconfig
    ipv6 nd prefix 2345:ABCD:3FE0::2/96 50 infinite
    ipv6 nd prefix 2345:ABCD:3FE0::3/96 100000 no-autoconfig
+   no priority-flow-control
+   spanning-tree guard root
    link tracking group EVPN_MH_ES2 downstream
 !
 interface Ethernet4
@@ -53,8 +53,6 @@ interface Ethernet4
    shutdown
    mtu 9100
    switchport
-   priority-flow-control on
-   spanning-tree guard none
    ipv6 enable
    ipv6 address 2020::2020/64
    ipv6 address FE80:FEA::AB65/64 link-local
@@ -62,34 +60,36 @@ interface Ethernet4
    ipv6 nd managed-config-flag
    ipv6 access-group IPv6_ACL_IN in
    ipv6 access-group IPv6_ACL_OUT out
+   priority-flow-control on
+   spanning-tree guard none
 !
 interface Ethernet5
    description Molecule Routing
    no shutdown
    mtu 9100
    no switchport
-   spanning-tree guard loop
-   ip ospf network point-to-point
-   ip ospf area 100
    ip ospf cost 99
+   ip ospf network point-to-point
    ip ospf authentication message-digest
    ip ospf authentication-key 7 asfddja23452
+   ip ospf area 100
    ip ospf message-digest-key 1 sha512 7 asfddja23452
+   pim ipv4 sparse-mode
    isis enable ISIS_TEST
    isis circuit-type level-2
    isis metric 99
-   isis network point-to-point
    no isis hello padding
+   isis network point-to-point
    isis authentication mode md5
    isis authentication key 7 asfddja23452
-   pim ipv4 sparse-mode
+   spanning-tree guard loop
 !
 interface Ethernet6
    description SRV-POD02_Eth1
    logging event link-status
-   switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
+   switchport
    spanning-tree bpduguard enable
    spanning-tree bpdufilter enable
 !
@@ -100,24 +100,24 @@ interface Ethernet7
    switchport
    qos trust cos
    qos cos 5
-   spanning-tree portfast
-   spanning-tree bpduguard enable
-   spanning-tree bpdufilter enable
-   vmtracer vmware-esx
-   ptp enable
-   ptp announce interval 10
-   ptp announce timeout 30
-   ptp delay-req interval 20
-   ptp delay-mechanism p2p
-   ptp sync-message interval 5
-   ptp role master
-   ptp vlan all
-   ptp transport layer2
-   service-profile QoS
    storm-control all level 75
    storm-control broadcast level pps 10
    storm-control multicast level 50
    storm-control unknown-unicast level 10
+   ptp enable
+   ptp sync-message interval 5
+   ptp delay-mechanism p2p
+   ptp announce interval 10
+   ptp transport layer2
+   ptp announce timeout 30
+   ptp delay-req interval 20
+   ptp role master
+   ptp vlan all
+   service-profile QoS
+   spanning-tree portfast
+   spanning-tree bpduguard enable
+   spanning-tree bpdufilter enable
+   vmtracer vmware-esx
    transceiver media override 100gbase-ar4
 !
 interface Ethernet8
@@ -137,64 +137,64 @@ interface Ethernet9
    description interface_with_mpls_enabled
    no switchport
    ip address 172.31.128.9/31
-   mpls ip
    mpls ldp interface
+   mpls ip
 !
 interface Ethernet10
    description interface_with_mpls_disabled
    no switchport
    ip address 172.31.128.10/31
-   no mpls ip
    no mpls ldp interface
+   no mpls ip
 !
 interface Ethernet11
    description interface_in_mode_access_accepting_tagged_LACP
-   switchport
    switchport access vlan 200
    switchport mode access
+   switchport
    l2-protocol encapsulation dot1q vlan 200
 !
 interface Ethernet12
    description interface_with_dot1q_tunnel
-   switchport
    switchport access vlan 300
    switchport mode dot1q-tunnel
+   switchport
 !
 interface Ethernet13
    description interface_in_mode_access_with_voice
    no logging event link-status
-   switchport
    switchport trunk native vlan 100
    switchport phone vlan 70
    switchport phone trunk untagged
    switchport mode trunk phone
+   switchport
 !
 interface Ethernet14
    description SRV-POD02_Eth1
    logging event link-status
-   switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
+   switchport
 !
 interface Ethernet15
    description PVLAN Promiscuous Access - only one secondary
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
    switchport pvlan mapping 111
 !
 interface Ethernet16
    description PVLAN Promiscuous Trunk - vlan translation out
-   switchport
+   switchport vlan translation out 111-112 110
    switchport trunk allowed vlan 110-112
    switchport mode trunk
-   switchport vlan translation out 111-112 110
+   switchport
 !
 interface Ethernet17
    description PVLAN Secondary Trunk
-   switchport
    switchport trunk allowed vlan 110-112
    switchport mode trunk
+   switchport
    switchport trunk private-vlan secondary
 !
 interface Ethernet18
@@ -206,9 +206,9 @@ interface Ethernet18
 !
 interface Ethernet19
    description Switched port with no LLDP rx/tx
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
    no lldp transmit
    no lldp receive
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/lldp.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/lldp.cfg
@@ -23,16 +23,16 @@ interface Ethernet1
 !
 interface Ethernet2
    description Switched port with no LLDP rx/tx
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
    no lldp transmit
 !
 interface Ethernet3
    description No special LLDP settings
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
 !
 interface Ethernet4
    description test

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/mpls.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/mpls.cfg
@@ -10,9 +10,9 @@ no aaa root
 interface Ethernet1
    no switchport
    ip address 192.168.100.1/31
-   mpls ip
-   mpls ldp interface
    mpls ldp igp sync
+   mpls ldp interface
+   mpls ip
 !
 interface Loopback0
    ip address 192.168.1.1/32

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/port-channel-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/port-channel-interfaces.cfg
@@ -314,10 +314,10 @@ interface Ethernet10/3
 !
 interface Ethernet10/4
    description LAG Member LACP fallback
-   channel-group 104 mode active
-   switchport
    switchport trunk allowed vlan 100
    switchport mode trunk
+   switchport
+   channel-group 104 mode active
    spanning-tree portfast
 !
 interface Ethernet10/10
@@ -330,12 +330,12 @@ interface Ethernet11/1
 !
 interface Ethernet11/2
    description LAG Member LACP fallback LLDP ZTP VLAN
-   channel-group 112 mode active
-   switchport
    switchport trunk allowed vlan 112
    switchport mode trunk
-   spanning-tree portfast
+   switchport
+   channel-group 112 mode active
    lldp tlv transmit ztp vlan 112
+   spanning-tree portfast
 !
 interface Ethernet15
    description DC1-AGG03_Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/ptp.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/ptp.cfg
@@ -35,15 +35,15 @@ interface Port-Channel5
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE2_Ethernet5
-   switchport
    switchport trunk allowed vlan 2,14
    switchport mode trunk
+   switchport
    ptp enable
-   ptp delay-mechanism e2e
    ptp sync-message interval 1
+   ptp delay-mechanism e2e
+   ptp transport layer2
    ptp role dynamic
    ptp vlan 2
-   ptp transport layer2
 !
 interface Ethernet5
    description DC1-AGG01_Ethernet1
@@ -55,13 +55,13 @@ interface Ethernet6
    no switchport
    ip address 172.31.255.15/31
    ptp enable
+   ptp sync-message interval 1
+   ptp delay-mechanism e2e
    ptp announce interval 3
+   ptp transport ipv4
    ptp announce timeout 9
    ptp delay-req interval -7
-   ptp delay-mechanism e2e
-   ptp sync-message interval 1
    ptp role dynamic
-   ptp transport ipv4
 !
 interface Management1
    description oob_management

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/qos.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/qos.cfg
@@ -99,9 +99,9 @@ interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet1
    mtu 1500
    no switchport
+   ip address 172.31.255.1/31
    qos trust dscp
    qos dscp 48
-   ip address 172.31.255.1/31
    service-profile test
 !
 interface Ethernet3
@@ -114,18 +114,18 @@ interface Ethernet4
 !
 interface Ethernet6
    description SRV-POD02_Eth1
-   switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
+   switchport
    qos trust cos
    qos cos 2
    service-profile experiment
 !
 interface Ethernet7
    description Test-with-policymap
-   switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
+   switchport
    service-profile qprof_testwithpolicy
 !
 interface Management1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/router-ospf.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/router-ospf.cfg
@@ -17,10 +17,10 @@ interface Port-Channel12
 !
 interface Ethernet1
    no switchport
-   ip ospf network point-to-point
-   ip ospf area 0.0.0.1
    ip ospf cost 99
+   ip ospf network point-to-point
    ip ospf authentication message-digest
+   ip ospf area 0.0.0.1
    ip ospf message-digest-key 55 md5 7 ABCDEFGHIJKLMNOPQRSTUVWXYZ
 !
 interface Loopback2

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF1A.md
@@ -299,16 +299,16 @@ interface Ethernet4
 interface Ethernet6
    description server02_SINGLE_NODE_TRUNK_Eth1
    no shutdown
-   switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
+   switchport
 !
 interface Ethernet7
    description server02_SINGLE_NODE_Eth1
    no shutdown
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
 ```
 
 ## Loopback Interfaces

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-LEAF1A.cfg
@@ -77,16 +77,16 @@ interface Ethernet4
 interface Ethernet6
    description server02_SINGLE_NODE_TRUNK_Eth1
    no shutdown
-   switchport
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
+   switchport
 !
 interface Ethernet7
    description server02_SINGLE_NODE_Eth1
    no shutdown
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
 !
 interface Loopback0
    description EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/cvp/cv_server_configlets.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/cvp/cv_server_configlets.yml
@@ -352,61 +352,62 @@ CVP_CONFIGLETS:
     \   no switchport\n   ip address 172.31.255.5/31\n!\ninterface Ethernet4\n   description\
     \ P2P_LINK_TO_DC1-SPINE4_Ethernet1\n   no shutdown\n   mtu 1500\n   no switchport\n\
     \   ip address 172.31.255.7/31\n!\ninterface Ethernet6\n   description server02_SINGLE_NODE_TRUNK_Eth1\n\
-    \   no shutdown\n   switchport\n   switchport trunk allowed vlan 110-111,210-211\n\
-    \   switchport mode trunk\n!\ninterface Ethernet7\n   description server02_SINGLE_NODE_Eth1\n\
-    \   no shutdown\n   switchport\n   switchport access vlan 110\n   switchport mode\
-    \ access\n!\ninterface Loopback0\n   description EVPN_Overlay_Peering\n   no shutdown\n\
-    \   ip address 192.168.255.5/32\n!\ninterface Loopback1\n   description VTEP_VXLAN_Tunnel_Source\n\
-    \   no shutdown\n   ip address 192.168.254.5/32\n!\ninterface Management1\n  \
-    \ description oob_management\n   no shutdown\n   vrf MGMT\n   ip address 192.168.200.105/24\n\
-    !\ninterface Vlan120\n   description Tenant_A_WEB_Zone_1\n   no shutdown\n   vrf\
-    \ Tenant_A_WEB_Zone\n   ip helper-address 1.1.1.1 vrf TEST source-interface lo100\n\
-    \   ip address virtual 10.1.20.1/24\n!\ninterface Vlan121\n   description Tenant_A_WEBZone_2\n\
-    \   shutdown\n   mtu 1560\n   vrf Tenant_A_WEB_Zone\n   ip address virtual 10.1.10.254/24\n\
-    !\ninterface Vlan130\n   description Tenant_A_APP_Zone_1\n   no shutdown\n   vrf\
-    \ Tenant_A_APP_Zone\n   ip address virtual 10.1.30.1/24\n!\ninterface Vlan131\n\
-    \   description Tenant_A_APP_Zone_2\n   no shutdown\n   vrf Tenant_A_APP_Zone\n\
-    \   ip address virtual 10.1.31.1/24\n!\ninterface Vxlan1\n   description DC1-LEAF1A_VTEP\n\
-    \   vxlan source-interface Loopback1\n   vxlan udp-port 4789\n   vxlan vlan 120\
-    \ vni 10120\n   vxlan vlan 121 vni 10121\n   vxlan vlan 130 vni 10130\n   vxlan\
-    \ vlan 131 vni 10131\n   vxlan vrf Tenant_A_APP_Zone vni 12\n   vxlan vrf Tenant_A_WEB_Zone\
-    \ vni 11\n!\nip virtual-router mac-address 00:dc:00:00:00:0a\n!\nip routing\n\
-    no ip routing vrf MGMT\nip routing vrf Tenant_A_APP_Zone\nip routing vrf Tenant_A_WEB_Zone\n\
-    !\nip prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n   seq 10 permit 192.168.255.0/24\
-    \ eq 32\n   seq 20 permit 192.168.254.0/24 eq 32\n!\nip route vrf MGMT 0.0.0.0/0\
-    \ 192.168.200.5\n!\nroute-map RM-CONN-2-BGP permit 10\n   match ip address prefix-list\
-    \ PL-LOOPBACKS-EVPN-OVERLAY\n!\nrouter bfd\n   multihop interval 1200 min-rx 1200\
-    \ multiplier 3\n!\nrouter bgp 65101\n   router-id 192.168.255.5\n   no bgp default\
-    \ ipv4-unicast\n   distance bgp 20 200 200\n   maximum-paths 4 ecmp 4\n   neighbor\
-    \ EVPN-OVERLAY-PEERS peer group\n   neighbor EVPN-OVERLAY-PEERS update-source\
-    \ Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS\
-    \ ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n\
-    \   neighbor EVPN-OVERLAY-PEERS send-community\n   neighbor EVPN-OVERLAY-PEERS\
-    \ maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS peer group\n   neighbor IPv4-UNDERLAY-PEERS\
-    \ password 7 AQQvKeimxJu+uGQ/yYvv9w==\n   neighbor IPv4-UNDERLAY-PEERS send-community\n\
-    \   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000\n   neighbor 172.31.255.0\
-    \ peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.0 remote-as 65001\n \
-    \  neighbor 172.31.255.0 description DC1-SPINE1_Ethernet1\n   neighbor 172.31.255.2\
-    \ peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.2 remote-as 65001\n \
-    \  neighbor 172.31.255.2 description DC1-SPINE2_Ethernet1\n   neighbor 172.31.255.4\
-    \ peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.4 remote-as 65001\n \
-    \  neighbor 172.31.255.4 description DC1-SPINE3_Ethernet1\n   neighbor 172.31.255.6\
-    \ peer group IPv4-UNDERLAY-PEERS\n   neighbor 172.31.255.6 remote-as 65001\n \
-    \  neighbor 172.31.255.6 description DC1-SPINE4_Ethernet1\n   neighbor 192.168.255.1\
-    \ peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.1 remote-as 65001\n \
-    \  neighbor 192.168.255.1 description DC1-SPINE1\n   neighbor 192.168.255.2 peer\
-    \ group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.2 remote-as 65001\n   neighbor\
-    \ 192.168.255.2 description DC1-SPINE2\n   neighbor 192.168.255.3 peer group EVPN-OVERLAY-PEERS\n\
-    \   neighbor 192.168.255.3 remote-as 65001\n   neighbor 192.168.255.3 description\
-    \ DC1-SPINE3\n   neighbor 192.168.255.4 peer group EVPN-OVERLAY-PEERS\n   neighbor\
-    \ 192.168.255.4 remote-as 65001\n   neighbor 192.168.255.4 description DC1-SPINE4\n\
-    \   redistribute connected route-map RM-CONN-2-BGP\n   !\n   vlan-aware-bundle\
-    \ Tenant_A_APP_Zone\n      rd 192.168.255.5:12\n      route-target both 12:12\n\
-    \      redistribute learned\n      vlan 130-131\n   !\n   vlan-aware-bundle Tenant_A_WEB_Zone\n\
-    \      rd 192.168.255.5:11\n      route-target both 11:11\n      redistribute\
-    \ learned\n      vlan 120-121\n   !\n   address-family evpn\n      neighbor EVPN-OVERLAY-PEERS\
-    \ activate\n   !\n   address-family ipv4\n      no neighbor EVPN-OVERLAY-PEERS\
-    \ activate\n      neighbor IPv4-UNDERLAY-PEERS activate\n   !\n   vrf Tenant_A_APP_Zone\n\
+    \   no shutdown\n   switchport trunk allowed vlan 110-111,210-211\n   switchport\
+    \ mode trunk\n   switchport\n!\ninterface Ethernet7\n   description server02_SINGLE_NODE_Eth1\n\
+    \   no shutdown\n   switchport access vlan 110\n   switchport mode access\n  \
+    \ switchport\n!\ninterface Loopback0\n   description EVPN_Overlay_Peering\n  \
+    \ no shutdown\n   ip address 192.168.255.5/32\n!\ninterface Loopback1\n   description\
+    \ VTEP_VXLAN_Tunnel_Source\n   no shutdown\n   ip address 192.168.254.5/32\n!\n\
+    interface Management1\n   description oob_management\n   no shutdown\n   vrf MGMT\n\
+    \   ip address 192.168.200.105/24\n!\ninterface Vlan120\n   description Tenant_A_WEB_Zone_1\n\
+    \   no shutdown\n   vrf Tenant_A_WEB_Zone\n   ip helper-address 1.1.1.1 vrf TEST\
+    \ source-interface lo100\n   ip address virtual 10.1.20.1/24\n!\ninterface Vlan121\n\
+    \   description Tenant_A_WEBZone_2\n   shutdown\n   mtu 1560\n   vrf Tenant_A_WEB_Zone\n\
+    \   ip address virtual 10.1.10.254/24\n!\ninterface Vlan130\n   description Tenant_A_APP_Zone_1\n\
+    \   no shutdown\n   vrf Tenant_A_APP_Zone\n   ip address virtual 10.1.30.1/24\n\
+    !\ninterface Vlan131\n   description Tenant_A_APP_Zone_2\n   no shutdown\n   vrf\
+    \ Tenant_A_APP_Zone\n   ip address virtual 10.1.31.1/24\n!\ninterface Vxlan1\n\
+    \   description DC1-LEAF1A_VTEP\n   vxlan source-interface Loopback1\n   vxlan\
+    \ udp-port 4789\n   vxlan vlan 120 vni 10120\n   vxlan vlan 121 vni 10121\n  \
+    \ vxlan vlan 130 vni 10130\n   vxlan vlan 131 vni 10131\n   vxlan vrf Tenant_A_APP_Zone\
+    \ vni 12\n   vxlan vrf Tenant_A_WEB_Zone vni 11\n!\nip virtual-router mac-address\
+    \ 00:dc:00:00:00:0a\n!\nip routing\nno ip routing vrf MGMT\nip routing vrf Tenant_A_APP_Zone\n\
+    ip routing vrf Tenant_A_WEB_Zone\n!\nip prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n\
+    \   seq 10 permit 192.168.255.0/24 eq 32\n   seq 20 permit 192.168.254.0/24 eq\
+    \ 32\n!\nip route vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nroute-map RM-CONN-2-BGP\
+    \ permit 10\n   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n!\nrouter\
+    \ bfd\n   multihop interval 1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65101\n\
+    \   router-id 192.168.255.5\n   no bgp default ipv4-unicast\n   distance bgp 20\
+    \ 200 200\n   maximum-paths 4 ecmp 4\n   neighbor EVPN-OVERLAY-PEERS peer group\n\
+    \   neighbor EVPN-OVERLAY-PEERS update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS\
+    \ bfd\n   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS\
+    \ password 7 q+VNViP5i4rVjW1cxFv2wA==\n   neighbor EVPN-OVERLAY-PEERS send-community\n\
+    \   neighbor EVPN-OVERLAY-PEERS maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS\
+    \ peer group\n   neighbor IPv4-UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==\n\
+    \   neighbor IPv4-UNDERLAY-PEERS send-community\n   neighbor IPv4-UNDERLAY-PEERS\
+    \ maximum-routes 12000\n   neighbor 172.31.255.0 peer group IPv4-UNDERLAY-PEERS\n\
+    \   neighbor 172.31.255.0 remote-as 65001\n   neighbor 172.31.255.0 description\
+    \ DC1-SPINE1_Ethernet1\n   neighbor 172.31.255.2 peer group IPv4-UNDERLAY-PEERS\n\
+    \   neighbor 172.31.255.2 remote-as 65001\n   neighbor 172.31.255.2 description\
+    \ DC1-SPINE2_Ethernet1\n   neighbor 172.31.255.4 peer group IPv4-UNDERLAY-PEERS\n\
+    \   neighbor 172.31.255.4 remote-as 65001\n   neighbor 172.31.255.4 description\
+    \ DC1-SPINE3_Ethernet1\n   neighbor 172.31.255.6 peer group IPv4-UNDERLAY-PEERS\n\
+    \   neighbor 172.31.255.6 remote-as 65001\n   neighbor 172.31.255.6 description\
+    \ DC1-SPINE4_Ethernet1\n   neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS\n\
+    \   neighbor 192.168.255.1 remote-as 65001\n   neighbor 192.168.255.1 description\
+    \ DC1-SPINE1\n   neighbor 192.168.255.2 peer group EVPN-OVERLAY-PEERS\n   neighbor\
+    \ 192.168.255.2 remote-as 65001\n   neighbor 192.168.255.2 description DC1-SPINE2\n\
+    \   neighbor 192.168.255.3 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.3\
+    \ remote-as 65001\n   neighbor 192.168.255.3 description DC1-SPINE3\n   neighbor\
+    \ 192.168.255.4 peer group EVPN-OVERLAY-PEERS\n   neighbor 192.168.255.4 remote-as\
+    \ 65001\n   neighbor 192.168.255.4 description DC1-SPINE4\n   redistribute connected\
+    \ route-map RM-CONN-2-BGP\n   !\n   vlan-aware-bundle Tenant_A_APP_Zone\n    \
+    \  rd 192.168.255.5:12\n      route-target both 12:12\n      redistribute learned\n\
+    \      vlan 130-131\n   !\n   vlan-aware-bundle Tenant_A_WEB_Zone\n      rd 192.168.255.5:11\n\
+    \      route-target both 11:11\n      redistribute learned\n      vlan 120-121\n\
+    \   !\n   address-family evpn\n      neighbor EVPN-OVERLAY-PEERS activate\n  \
+    \ !\n   address-family ipv4\n      no neighbor EVPN-OVERLAY-PEERS activate\n \
+    \     neighbor IPv4-UNDERLAY-PEERS activate\n   !\n   vrf Tenant_A_APP_Zone\n\
     \      rd 192.168.255.5:12\n      route-target import evpn 12:12\n      route-target\
     \ export evpn 12:12\n      router-id 192.168.255.5\n      redistribute connected\n\
     \   !\n   vrf Tenant_A_WEB_Zone\n      rd 192.168.255.5:11\n      route-target\

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-SPINE1.md
@@ -158,8 +158,8 @@ vlan internal order ascending range 1006 1199
 interface Ethernet1
    description P2P_LINK_TO_DC1-SUPER-SPINE1_Ethernet1
    no shutdown
-   mac security profile MACSEC_PROFILE
    mtu 1500
+   mac security profile MACSEC_PROFILE
    no switchport
    ip address 172.16.11.1/31
    ptp enable
@@ -168,8 +168,8 @@ interface Ethernet1
 interface Ethernet2
    description P2P_LINK_TO_DC1-SUPER-SPINE2_Ethernet1
    no shutdown
-   mac security profile MACSEC_PROFILE
    mtu 1500
+   mac security profile MACSEC_PROFILE
    no switchport
    ip address 172.16.11.65/31
    ptp enable

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-SPINE2.md
@@ -183,8 +183,8 @@ vlan internal order ascending range 1006 1199
 interface Ethernet1
    description P2P_LINK_TO_DC1-SUPER-SPINE1_Ethernet2
    no shutdown
-   mac security profile MACSEC_PROFILE
    mtu 1500
+   mac security profile MACSEC_PROFILE
    no switchport
    ip address 172.16.11.3/31
    ptp enable
@@ -193,8 +193,8 @@ interface Ethernet1
 interface Ethernet2
    description P2P_LINK_TO_DC1-SUPER-SPINE2_Ethernet2
    no shutdown
-   mac security profile MACSEC_PROFILE
    mtu 1500
+   mac security profile MACSEC_PROFILE
    no switchport
    ip address 172.16.11.67/31
    ptp enable

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-SPINE1.md
@@ -183,8 +183,8 @@ vlan internal order ascending range 1006 1199
 interface Ethernet1
    description P2P_LINK_TO_DC1-SUPER-SPINE1_Ethernet3
    no shutdown
-   mac security profile MACSEC_PROFILE
    mtu 1500
+   mac security profile MACSEC_PROFILE
    no switchport
    ip address 172.16.12.1/31
    ptp enable
@@ -193,8 +193,8 @@ interface Ethernet1
 interface Ethernet2
    description P2P_LINK_TO_DC1-SUPER-SPINE2_Ethernet3
    no shutdown
-   mac security profile MACSEC_PROFILE
    mtu 1500
+   mac security profile MACSEC_PROFILE
    no switchport
    ip address 172.16.12.65/31
    ptp enable

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-SPINE2.md
@@ -182,8 +182,8 @@ vlan internal order ascending range 1006 1199
 interface Ethernet1
    description P2P_LINK_TO_DC1-SUPER-SPINE1_Ethernet4
    no shutdown
-   mac security profile MACSEC_PROFILE
    mtu 1500
+   mac security profile MACSEC_PROFILE
    no switchport
    ip address 172.16.12.3/31
    ptp enable
@@ -192,8 +192,8 @@ interface Ethernet1
 interface Ethernet2
    description P2P_LINK_TO_DC1-SUPER-SPINE2_Ethernet4
    no shutdown
-   mac security profile MACSEC_PROFILE
    mtu 1500
+   mac security profile MACSEC_PROFILE
    no switchport
    ip address 172.16.12.67/31
    ptp enable

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-SUPER-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-SUPER-SPINE1.md
@@ -154,8 +154,8 @@ vlan internal order ascending range 1006 1199
 interface Ethernet1
    description P2P_LINK_TO_DC1-POD1-SPINE1_Ethernet1
    no shutdown
-   mac security profile MACSEC_PROFILE
    mtu 1500
+   mac security profile MACSEC_PROFILE
    no switchport
    ip address 172.16.11.0/31
    ptp enable
@@ -164,8 +164,8 @@ interface Ethernet1
 interface Ethernet2
    description P2P_LINK_TO_DC1-POD1-SPINE2_Ethernet1
    no shutdown
-   mac security profile MACSEC_PROFILE
    mtu 1500
+   mac security profile MACSEC_PROFILE
    no switchport
    ip address 172.16.11.2/31
    ptp enable
@@ -174,8 +174,8 @@ interface Ethernet2
 interface Ethernet3
    description P2P_LINK_TO_DC1-POD2-SPINE1_Ethernet1
    no shutdown
-   mac security profile MACSEC_PROFILE
    mtu 1500
+   mac security profile MACSEC_PROFILE
    no switchport
    ip address 172.16.12.0/31
    ptp enable
@@ -184,8 +184,8 @@ interface Ethernet3
 interface Ethernet4
    description P2P_LINK_TO_DC1-POD2-SPINE2_Ethernet1
    no shutdown
-   mac security profile MACSEC_PROFILE
    mtu 1500
+   mac security profile MACSEC_PROFILE
    no switchport
    ip address 172.16.12.2/31
    ptp enable
@@ -202,8 +202,8 @@ interface Ethernet5
 interface Ethernet6
    description P2P_LINK_TO_DC2-SUPER-SPINE1_Ethernet4
    no shutdown
-   mac security profile MACSEC_PROFILE
    mtu 1499
+   mac security profile MACSEC_PROFILE
    no switchport
    ip address 11.1.2.0/31
    ptp enable

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-SUPER-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-SUPER-SPINE2.md
@@ -182,8 +182,8 @@ vlan internal order ascending range 1006 1199
 interface Ethernet1
    description P2P_LINK_TO_DC1-POD1-SPINE1_Ethernet2
    no shutdown
-   mac security profile MACSEC_PROFILE
    mtu 1500
+   mac security profile MACSEC_PROFILE
    no switchport
    ip address 172.16.11.64/31
    ptp enable
@@ -192,8 +192,8 @@ interface Ethernet1
 interface Ethernet2
    description P2P_LINK_TO_DC1-POD1-SPINE2_Ethernet2
    no shutdown
-   mac security profile MACSEC_PROFILE
    mtu 1500
+   mac security profile MACSEC_PROFILE
    no switchport
    ip address 172.16.11.66/31
    ptp enable
@@ -202,8 +202,8 @@ interface Ethernet2
 interface Ethernet3
    description P2P_LINK_TO_DC1-POD2-SPINE1_Ethernet2
    no shutdown
-   mac security profile MACSEC_PROFILE
    mtu 1500
+   mac security profile MACSEC_PROFILE
    no switchport
    ip address 172.16.12.64/31
    ptp enable
@@ -212,8 +212,8 @@ interface Ethernet3
 interface Ethernet4
    description P2P_LINK_TO_DC1-POD2-SPINE2_Ethernet2
    no shutdown
-   mac security profile MACSEC_PROFILE
    mtu 1500
+   mac security profile MACSEC_PROFILE
    no switchport
    ip address 172.16.12.66/31
    ptp enable

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-SUPER-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-SUPER-SPINE1.md
@@ -211,8 +211,8 @@ interface Ethernet3
 interface Ethernet4
    description P2P_LINK_TO_DC1-SUPER-SPINE1_Ethernet6
    no shutdown
-   mac security profile MACSEC_PROFILE
    mtu 1499
+   mac security profile MACSEC_PROFILE
    no switchport
    ip address 11.1.2.1/31
    ptp enable

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-SPINE1.cfg
@@ -22,8 +22,8 @@ vrf instance MGMT
 interface Ethernet1
    description P2P_LINK_TO_DC1-SUPER-SPINE1_Ethernet1
    no shutdown
-   mac security profile MACSEC_PROFILE
    mtu 1500
+   mac security profile MACSEC_PROFILE
    no switchport
    ip address 172.16.11.1/31
    ptp enable
@@ -32,8 +32,8 @@ interface Ethernet1
 interface Ethernet2
    description P2P_LINK_TO_DC1-SUPER-SPINE2_Ethernet1
    no shutdown
-   mac security profile MACSEC_PROFILE
    mtu 1500
+   mac security profile MACSEC_PROFILE
    no switchport
    ip address 172.16.11.65/31
    ptp enable

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-SPINE2.cfg
@@ -22,8 +22,8 @@ vrf instance MGMT
 interface Ethernet1
    description P2P_LINK_TO_DC1-SUPER-SPINE1_Ethernet2
    no shutdown
-   mac security profile MACSEC_PROFILE
    mtu 1500
+   mac security profile MACSEC_PROFILE
    no switchport
    ip address 172.16.11.3/31
    ptp enable
@@ -32,8 +32,8 @@ interface Ethernet1
 interface Ethernet2
    description P2P_LINK_TO_DC1-SUPER-SPINE2_Ethernet2
    no shutdown
-   mac security profile MACSEC_PROFILE
    mtu 1500
+   mac security profile MACSEC_PROFILE
    no switchport
    ip address 172.16.11.67/31
    ptp enable

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD2-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD2-SPINE1.cfg
@@ -22,8 +22,8 @@ vrf instance MGMT
 interface Ethernet1
    description P2P_LINK_TO_DC1-SUPER-SPINE1_Ethernet3
    no shutdown
-   mac security profile MACSEC_PROFILE
    mtu 1500
+   mac security profile MACSEC_PROFILE
    no switchport
    ip address 172.16.12.1/31
    ptp enable
@@ -32,8 +32,8 @@ interface Ethernet1
 interface Ethernet2
    description P2P_LINK_TO_DC1-SUPER-SPINE2_Ethernet3
    no shutdown
-   mac security profile MACSEC_PROFILE
    mtu 1500
+   mac security profile MACSEC_PROFILE
    no switchport
    ip address 172.16.12.65/31
    ptp enable

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD2-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD2-SPINE2.cfg
@@ -22,8 +22,8 @@ vrf instance MGMT
 interface Ethernet1
    description P2P_LINK_TO_DC1-SUPER-SPINE1_Ethernet4
    no shutdown
-   mac security profile MACSEC_PROFILE
    mtu 1500
+   mac security profile MACSEC_PROFILE
    no switchport
    ip address 172.16.12.3/31
    ptp enable
@@ -32,8 +32,8 @@ interface Ethernet1
 interface Ethernet2
    description P2P_LINK_TO_DC1-SUPER-SPINE2_Ethernet4
    no shutdown
-   mac security profile MACSEC_PROFILE
    mtu 1500
+   mac security profile MACSEC_PROFILE
    no switchport
    ip address 172.16.12.67/31
    ptp enable

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-SUPER-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-SUPER-SPINE1.cfg
@@ -22,8 +22,8 @@ vrf instance MGMT
 interface Ethernet1
    description P2P_LINK_TO_DC1-POD1-SPINE1_Ethernet1
    no shutdown
-   mac security profile MACSEC_PROFILE
    mtu 1500
+   mac security profile MACSEC_PROFILE
    no switchport
    ip address 172.16.11.0/31
    ptp enable
@@ -32,8 +32,8 @@ interface Ethernet1
 interface Ethernet2
    description P2P_LINK_TO_DC1-POD1-SPINE2_Ethernet1
    no shutdown
-   mac security profile MACSEC_PROFILE
    mtu 1500
+   mac security profile MACSEC_PROFILE
    no switchport
    ip address 172.16.11.2/31
    ptp enable
@@ -42,8 +42,8 @@ interface Ethernet2
 interface Ethernet3
    description P2P_LINK_TO_DC1-POD2-SPINE1_Ethernet1
    no shutdown
-   mac security profile MACSEC_PROFILE
    mtu 1500
+   mac security profile MACSEC_PROFILE
    no switchport
    ip address 172.16.12.0/31
    ptp enable
@@ -52,8 +52,8 @@ interface Ethernet3
 interface Ethernet4
    description P2P_LINK_TO_DC1-POD2-SPINE2_Ethernet1
    no shutdown
-   mac security profile MACSEC_PROFILE
    mtu 1500
+   mac security profile MACSEC_PROFILE
    no switchport
    ip address 172.16.12.2/31
    ptp enable
@@ -70,8 +70,8 @@ interface Ethernet5
 interface Ethernet6
    description P2P_LINK_TO_DC2-SUPER-SPINE1_Ethernet4
    no shutdown
-   mac security profile MACSEC_PROFILE
    mtu 1499
+   mac security profile MACSEC_PROFILE
    no switchport
    ip address 11.1.2.0/31
    ptp enable

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-SUPER-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-SUPER-SPINE2.cfg
@@ -22,8 +22,8 @@ vrf instance MGMT
 interface Ethernet1
    description P2P_LINK_TO_DC1-POD1-SPINE1_Ethernet2
    no shutdown
-   mac security profile MACSEC_PROFILE
    mtu 1500
+   mac security profile MACSEC_PROFILE
    no switchport
    ip address 172.16.11.64/31
    ptp enable
@@ -32,8 +32,8 @@ interface Ethernet1
 interface Ethernet2
    description P2P_LINK_TO_DC1-POD1-SPINE2_Ethernet2
    no shutdown
-   mac security profile MACSEC_PROFILE
    mtu 1500
+   mac security profile MACSEC_PROFILE
    no switchport
    ip address 172.16.11.66/31
    ptp enable
@@ -42,8 +42,8 @@ interface Ethernet2
 interface Ethernet3
    description P2P_LINK_TO_DC1-POD2-SPINE1_Ethernet2
    no shutdown
-   mac security profile MACSEC_PROFILE
    mtu 1500
+   mac security profile MACSEC_PROFILE
    no switchport
    ip address 172.16.12.64/31
    ptp enable
@@ -52,8 +52,8 @@ interface Ethernet3
 interface Ethernet4
    description P2P_LINK_TO_DC1-POD2-SPINE2_Ethernet2
    no shutdown
-   mac security profile MACSEC_PROFILE
    mtu 1500
+   mac security profile MACSEC_PROFILE
    no switchport
    ip address 172.16.12.66/31
    ptp enable

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-SUPER-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-SUPER-SPINE1.cfg
@@ -48,8 +48,8 @@ interface Ethernet3
 interface Ethernet4
    description P2P_LINK_TO_DC1-SUPER-SPINE1_Ethernet6
    no shutdown
-   mac security profile MACSEC_PROFILE
    mtu 1499
+   mac security profile MACSEC_PROFILE
    no switchport
    ip address 11.1.2.1/31
    ptp enable

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL1A.md
@@ -285,32 +285,32 @@ vlan 350
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet6
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.81/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet6
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.83/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet6
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.85/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet6
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.87/31
 !
@@ -321,10 +321,10 @@ interface Ethernet7
    no switchport
    vrf Tenant_A_WAN_Zone
    ip address 10.10.10.10/24
-   ip ospf network point-to-point
-   ip ospf area 0
    ip ospf cost 100
+   ip ospf network point-to-point
    ip ospf authentication message-digest
+   ip ospf area 0
    ip ospf message-digest-key 1 sha1 7 AQQvKeimxJu+uGQ/yYvv9w==
    ip ospf message-digest-key 2 sha512 7 AQQvKeimxJu+uGQ/yYvv9w==
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL1B.md
@@ -283,32 +283,32 @@ vlan 350
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet7
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.97/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet7
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.99/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet7
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.101/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet7
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.103/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL2A.md
@@ -303,32 +303,32 @@ vlan 350
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet8
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.113/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet8
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.115/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet8
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.117/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet8
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.119/31
 ```

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL2B.md
@@ -286,32 +286,32 @@ vlan 350
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet9
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.129/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet9
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.131/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet9
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.133/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet9
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.135/31
 ```

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF1A.md
@@ -296,32 +296,32 @@ vlan 132
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet1
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.1/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet1
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.3/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet1
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.5/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet1
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.7/31
 !
@@ -329,21 +329,21 @@ interface Ethernet6
    description server02_SINGLE_NODE_TRUNK_Eth1
    no shutdown
    l2 mtu 8000
-   switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   spanning-tree portfast
+   switchport
    storm-control all level 10
    storm-control broadcast level pps 100
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast
 !
 interface Ethernet7
    description server02_SINGLE_NODE_Eth1
    no shutdown
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
 ```
 
 ## Loopback Interfaces

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2A.md
@@ -363,32 +363,32 @@ vlan 311
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet2
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.17/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet2
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.19/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet2
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.21/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet2
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.23/31
 !
@@ -430,9 +430,9 @@ interface Ethernet20
 interface Ethernet21
    description ROUTER01_Eth0
    no shutdown
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
 ```
 
 ## Port-Channel Interfaces

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2B.md
@@ -363,32 +363,32 @@ vlan 311
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet3
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.33/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet3
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.35/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet3
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.37/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet3
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.39/31
 !
@@ -430,9 +430,9 @@ interface Ethernet20
 interface Ethernet21
    description ROUTER01_Eth1
    no shutdown
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
 ```
 
 ## Port-Channel Interfaces

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SPINE1.md
@@ -253,72 +253,72 @@ vlan internal order ascending range 1006 1199
 interface Ethernet1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet1
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.0/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-LEAF2A_Ethernet1
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.16/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-LEAF2B_Ethernet1
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.32/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SVC3A_Ethernet1
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.48/31
 !
 interface Ethernet5
    description P2P_LINK_TO_DC1-SVC3B_Ethernet1
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.64/31
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-BL1A_Ethernet1
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.80/31
 !
 interface Ethernet7
    description P2P_LINK_TO_DC1-BL1B_Ethernet1
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.96/31
 !
 interface Ethernet8
    description P2P_LINK_TO_DC1-BL2A_Ethernet1
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.112/31
 !
 interface Ethernet9
    description P2P_LINK_TO_DC1-BL2B_Ethernet1
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.128/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SPINE2.md
@@ -267,72 +267,72 @@ vlan internal order ascending range 1006 1199
 interface Ethernet1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet2
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.2/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-LEAF2A_Ethernet2
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.18/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-LEAF2B_Ethernet2
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.34/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SVC3A_Ethernet2
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.50/31
 !
 interface Ethernet5
    description P2P_LINK_TO_DC1-SVC3B_Ethernet2
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.66/31
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-BL1A_Ethernet2
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.82/31
 !
 interface Ethernet7
    description P2P_LINK_TO_DC1-BL1B_Ethernet2
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.98/31
 !
 interface Ethernet8
    description P2P_LINK_TO_DC1-BL2A_Ethernet2
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.114/31
 !
 interface Ethernet9
    description P2P_LINK_TO_DC1-BL2B_Ethernet2
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.130/31
 ```

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SPINE3.md
@@ -250,72 +250,72 @@ vlan internal order ascending range 1006 1199
 interface Ethernet1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet3
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.4/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-LEAF2A_Ethernet3
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.20/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-LEAF2B_Ethernet3
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.36/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SVC3A_Ethernet3
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.52/31
 !
 interface Ethernet5
    description P2P_LINK_TO_DC1-SVC3B_Ethernet3
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.68/31
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-BL1A_Ethernet3
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.84/31
 !
 interface Ethernet7
    description P2P_LINK_TO_DC1-BL1B_Ethernet3
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.100/31
 !
 interface Ethernet8
    description P2P_LINK_TO_DC1-BL2A_Ethernet3
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.116/31
 !
 interface Ethernet9
    description P2P_LINK_TO_DC1-BL2B_Ethernet3
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.132/31
 ```

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SPINE4.md
@@ -250,72 +250,72 @@ vlan internal order ascending range 1006 1199
 interface Ethernet1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet4
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.6/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-LEAF2A_Ethernet4
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.22/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-LEAF2B_Ethernet4
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.38/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SVC3A_Ethernet4
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.54/31
 !
 interface Ethernet5
    description P2P_LINK_TO_DC1-SVC3B_Ethernet4
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.70/31
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-BL1A_Ethernet4
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.86/31
 !
 interface Ethernet7
    description P2P_LINK_TO_DC1-BL1B_Ethernet4
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.102/31
 !
 interface Ethernet8
    description P2P_LINK_TO_DC1-BL2A_Ethernet4
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.118/31
 !
 interface Ethernet9
    description P2P_LINK_TO_DC1-BL2B_Ethernet4
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.134/31
 ```

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3A.md
@@ -508,32 +508,32 @@ vlan 4092
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet4
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.49/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet4
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.51/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet4
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.53/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet4
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.55/31
 !
@@ -568,45 +568,45 @@ interface Ethernet11
    description server04_inherit_all_from_profile_Eth1
    no shutdown
    l2 mtu 8000
-   switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   spanning-tree portfast
-   spanning-tree bpduguard disable
-   spanning-tree bpdufilter disable
+   switchport
    storm-control all level 10
    storm-control broadcast level pps 100
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast
+   spanning-tree bpduguard disable
+   spanning-tree bpdufilter disable
 !
 interface Ethernet12
    description server05_no_profile_Eth1
    no shutdown
-   switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   spanning-tree portfast
-   spanning-tree bpduguard disable
-   spanning-tree bpdufilter enable
+   switchport
    storm-control all level 10
    storm-control broadcast level pps 100
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast
+   spanning-tree bpduguard disable
+   spanning-tree bpdufilter enable
 !
 interface Ethernet13
    description server06_override_profile_Eth1
    no shutdown
    l2 mtu 8000
-   switchport
    switchport access vlan 210
    switchport mode access
-   spanning-tree portfast network
-   spanning-tree bpduguard enable
-   spanning-tree bpdufilter disable
+   switchport
    storm-control all level pps 20
    storm-control broadcast level 200
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast network
+   spanning-tree bpduguard enable
+   spanning-tree bpdufilter disable
 !
 interface Ethernet14
    description server07_inherit_all_from_profile_port_channel_Eth1
@@ -622,16 +622,16 @@ interface Ethernet16
    description server09_override_profile_no_port_channel_Eth1
    no shutdown
    l2 mtu 8000
-   switchport
    switchport access vlan 210
    switchport mode access
-   spanning-tree portfast network
-   spanning-tree bpduguard enable
-   spanning-tree bpdufilter disable
+   switchport
    storm-control all level pps 20
    storm-control broadcast level 200
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast network
+   spanning-tree bpduguard enable
+   spanning-tree bpdufilter disable
 !
 interface Ethernet17
    description server10_no_profile_port_channel_lacp_fallback_Eth1
@@ -654,16 +654,16 @@ interface Ethernet19
 interface Ethernet20
    description server13_disabled_interfaces_Eth1
    shutdown
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
 !
 interface Ethernet21
    description server14_explicitly_enabled_interfaces_Eth1
    no shutdown
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
 !
 interface Ethernet22
    description server15_port_channel_with_disabled_phy_interfaces_Eth1
@@ -683,9 +683,9 @@ interface Ethernet24
 interface Ethernet25
    description server18_monitoring_session_source_phys_interfaces_Eth1
    no shutdown
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
 !
 interface Ethernet26
    description server19_monitoring_session_destination_phys_Eth1
@@ -700,9 +700,9 @@ interface Ethernet27
 interface Ethernet28
    description server18_monitoring_session_source_phys_interface_Eth5
    no shutdown
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
 !
 interface Ethernet40
    description server20_monitoring_session_destination_phys_Eth1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3B.md
@@ -504,32 +504,32 @@ vlan 4092
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet5
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.65/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet5
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.67/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet5
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.69/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet5
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.71/31
 !
@@ -559,45 +559,45 @@ interface Ethernet11
    description server04_inherit_all_from_profile_Eth2
    no shutdown
    l2 mtu 8000
-   switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   spanning-tree portfast
-   spanning-tree bpduguard disable
-   spanning-tree bpdufilter disable
+   switchport
    storm-control all level 10
    storm-control broadcast level pps 100
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast
+   spanning-tree bpduguard disable
+   spanning-tree bpdufilter disable
 !
 interface Ethernet12
    description server05_no_profile_Eth2
    no shutdown
-   switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   spanning-tree portfast
-   spanning-tree bpduguard disable
-   spanning-tree bpdufilter enable
+   switchport
    storm-control all level 10
    storm-control broadcast level pps 100
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast
+   spanning-tree bpduguard disable
+   spanning-tree bpdufilter enable
 !
 interface Ethernet13
    description server06_override_profile_Eth2
    no shutdown
    l2 mtu 8000
-   switchport
    switchport access vlan 210
    switchport mode access
-   spanning-tree portfast network
-   spanning-tree bpduguard enable
-   spanning-tree bpdufilter disable
+   switchport
    storm-control all level pps 20
    storm-control broadcast level 200
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast network
+   spanning-tree bpduguard enable
+   spanning-tree bpdufilter disable
 !
 interface Ethernet14
    description server07_inherit_all_from_profile_port_channel_Eth2
@@ -613,16 +613,16 @@ interface Ethernet16
    description server09_override_profile_no_port_channel_Eth2
    no shutdown
    l2 mtu 8000
-   switchport
    switchport access vlan 210
    switchport mode access
-   spanning-tree portfast network
-   spanning-tree bpduguard enable
-   spanning-tree bpdufilter disable
+   switchport
    storm-control all level pps 20
    storm-control broadcast level 200
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast network
+   spanning-tree bpduguard enable
+   spanning-tree bpdufilter disable
 !
 interface Ethernet17
    description server10_no_profile_port_channel_lacp_fallback_Eth2
@@ -645,16 +645,16 @@ interface Ethernet19
 interface Ethernet20
    description server13_disabled_interfaces_Eth2
    shutdown
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
 !
 interface Ethernet21
    description server14_explicitly_enabled_interfaces_Eth2
    no shutdown
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
 !
 interface Ethernet22
    description server15_port_channel_with_disabled_phy_interfaces_Eth2
@@ -674,9 +674,9 @@ interface Ethernet24
 interface Ethernet25
    description server18_monitoring_session_source_phys_interfaces_Eth2
    no shutdown
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
 !
 interface Ethernet26
    description server19_monitoring_session_destination_phys_Eth2

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/MH-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/MH-LEAF2A.md
@@ -314,9 +314,9 @@ interface Ethernet2
 interface Ethernet10
    description ROUTER01_Eth1
    no shutdown
-   switchport
    switchport access vlan 310
    switchport mode access
+   switchport
    link tracking group Eth-conn-to-router downstream
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/core-1-isis-sr-ldp.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/core-1-isis-sr-ldp.md
@@ -152,126 +152,126 @@ vlan internal order ascending range 1006 1199
 interface Ethernet1
    description P2P_LINK_TO_core-2-ospf-ldp_Ethernet1
    no shutdown
-   speed forced 1000full
    mtu 1500
+   speed forced 1000full
    no switchport
    ip address unnumbered loopback0
    ipv6 enable
+   mpls ldp igp sync
+   mpls ldp interface
+   mpls ip
    isis enable CORE
    isis circuit-type level-2
    isis metric 60
-   isis network point-to-point
    no isis hello padding
+   isis network point-to-point
    isis authentication mode md5
    isis authentication key 7 $1c$sTNAlR6rKSw=
-   mpls ip
-   mpls ldp interface
-   mpls ldp igp sync
 !
 interface Ethernet2
    description P2P_LINK_TO_core-2-ospf-ldp_Ethernet2
    no shutdown
-   speed 100full
    mtu 1601
+   speed 100full
    no switchport
    ip address 100.123.123.2/31
+   mpls ldp igp sync
+   mpls ldp interface
+   mpls ip
+   service-profile test_qos_profile
    isis enable CORE
    isis circuit-type level-1
    isis metric 60
-   isis network point-to-point
    isis hello padding
-   service-profile test_qos_profile
-   mpls ip
-   mpls ldp interface
-   mpls ldp igp sync
+   isis network point-to-point
 !
 interface Ethernet3
    description P2P_LINK_TO_core-2-ospf-ldp_Ethernet3
    no shutdown
-   speed forced 1000full
    mtu 1500
+   speed forced 1000full
    no switchport
    ip address 100.64.48.4/31
    ipv6 enable
+   mpls ldp igp sync
+   mpls ldp interface
+   mpls ip
    isis enable CORE
    isis circuit-type level-2
    isis metric 60
-   isis network point-to-point
    no isis hello padding
+   isis network point-to-point
    isis authentication mode md5
    isis authentication key 7 $1c$sTNAlR6rKSw=
-   mpls ip
-   mpls ldp interface
-   mpls ldp igp sync
 !
 interface Ethernet4
    description P2P_LINK_TO_core-2-ospf-ldp_Ethernet4
    no shutdown
-   speed forced 1000full
    mtu 1500
+   speed forced 1000full
    no switchport
    ip address 100.64.48.6/31
    ipv6 enable
    isis enable CORE
    isis circuit-type level-2
    isis metric 60
-   isis network point-to-point
    no isis hello padding
+   isis network point-to-point
    isis authentication mode md5
    isis authentication key 7 $1c$sTNAlR6rKSw=
 !
 interface Ethernet5
    description P2P_LINK_TO_core-2-ospf-ldp_Ethernet5
    no shutdown
-   speed forced 1000full
    mtu 1500
+   speed forced 1000full
    no switchport
    ip address 100.64.48.8/31
    ipv6 enable
+   mpls ip
    isis enable CORE
    isis circuit-type level-2
    isis metric 60
-   isis network point-to-point
    no isis hello padding
+   isis network point-to-point
    isis authentication mode md5
    isis authentication key 7 $1c$sTNAlR6rKSw=
-   mpls ip
 !
 interface Ethernet6
    description P2P_LINK_TO_core-2-ospf-ldp_Ethernet6
    no shutdown
-   speed 100full
    mtu 1602
+   speed 100full
    no switchport
    ip address unnumbered loopback0
    ipv6 enable
+   mpls ldp igp sync
+   mpls ldp interface
+   mpls ip
+   service-profile test_qos_profile
    isis enable CORE
    isis circuit-type level-1-2
    isis metric 70
-   isis network point-to-point
    isis hello padding
+   isis network point-to-point
    isis authentication mode md5
    isis authentication key 7 $1c$sTNAlR6rKSw=
-   service-profile test_qos_profile
-   mpls ip
-   mpls ldp interface
-   mpls ldp igp sync
 !
 interface Ethernet10
    description P2P_LINK_TO_core-2-ospf-ldp_Ethernet10
    no shutdown
-   speed forced 1000full
    mtu 1500
+   speed forced 1000full
    no switchport
    ip address 100.64.48.12/31
+   mpls ldp igp sync
+   mpls ldp interface
+   mpls ip
    isis enable CORE
    isis circuit-type level-2
    isis metric 50
-   isis network point-to-point
    isis hello padding
-   mpls ip
-   mpls ldp interface
-   mpls ldp igp sync
+   isis network point-to-point
 !
 interface Ethernet12
    description P2P_LINK_TO_core-2-ospf-ldp_Port-Channel12

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/core-2-ospf-ldp.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/core-2-ospf-ldp.md
@@ -137,50 +137,50 @@ vlan internal order ascending range 1006 1199
 interface Ethernet1
    description P2P_LINK_TO_core-1-isis-sr-ldp_Ethernet1
    no shutdown
-   speed forced 1000full
    mtu 1500
+   speed forced 1000full
    no switchport
    ip address unnumbered loopback0
    ipv6 enable
+   mpls ldp igp sync
+   mpls ldp interface
+   mpls ip
    ip ospf network point-to-point
    ip ospf area 0.0.0.0
-   mpls ip
-   mpls ldp interface
-   mpls ldp igp sync
 !
 interface Ethernet2
    description P2P_LINK_TO_core-1-isis-sr-ldp_Ethernet2
    no shutdown
-   speed 100full
    mtu 1601
+   speed 100full
    no switchport
    ip address 100.123.123.3/31
+   mpls ldp igp sync
+   mpls ldp interface
+   mpls ip
    ip ospf network point-to-point
    ip ospf area 0.0.0.0
    service-profile test_qos_profile
-   mpls ip
-   mpls ldp interface
-   mpls ldp igp sync
 !
 interface Ethernet3
    description P2P_LINK_TO_core-1-isis-sr-ldp_Ethernet3
    no shutdown
-   speed forced 1000full
    mtu 1500
+   speed forced 1000full
    no switchport
    ip address 100.64.48.5/31
    ipv6 enable
+   mpls ldp igp sync
+   mpls ldp interface
+   mpls ip
    ip ospf network point-to-point
    ip ospf area 0.0.0.0
-   mpls ip
-   mpls ldp interface
-   mpls ldp igp sync
 !
 interface Ethernet4
    description P2P_LINK_TO_core-1-isis-sr-ldp_Ethernet4
    no shutdown
-   speed forced 1000full
    mtu 1500
+   speed forced 1000full
    no switchport
    ip address 100.64.48.7/31
    ipv6 enable
@@ -190,42 +190,42 @@ interface Ethernet4
 interface Ethernet5
    description P2P_LINK_TO_core-1-isis-sr-ldp_Ethernet5
    no shutdown
-   speed forced 1000full
    mtu 1500
+   speed forced 1000full
    no switchport
    ip address 100.64.48.9/31
    ipv6 enable
+   mpls ip
    ip ospf network point-to-point
    ip ospf area 0.0.0.0
-   mpls ip
 !
 interface Ethernet6
    description P2P_LINK_TO_core-1-isis-sr-ldp_Ethernet6
    no shutdown
-   speed 100full
    mtu 1602
+   speed 100full
    no switchport
    ip address unnumbered loopback0
    ipv6 enable
+   mpls ldp igp sync
+   mpls ldp interface
+   mpls ip
    ip ospf network point-to-point
    ip ospf area 0.0.0.0
    service-profile test_qos_profile
-   mpls ip
-   mpls ldp interface
-   mpls ldp igp sync
 !
 interface Ethernet10
    description P2P_LINK_TO_core-1-isis-sr-ldp_Ethernet10
    no shutdown
-   speed forced 1000full
    mtu 1500
+   speed forced 1000full
    no switchport
    ip address 100.64.48.13/31
+   mpls ldp igp sync
+   mpls ldp interface
+   mpls ip
    ip ospf network point-to-point
    ip ospf area 0.0.0.0
-   mpls ip
-   mpls ldp interface
-   mpls ldp igp sync
 !
 interface Ethernet12
    description P2P_LINK_TO_core-1-isis-sr-ldp_Port-Channel12

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1A.cfg
@@ -60,32 +60,32 @@ vrf instance Tenant_L3_VRF_Zone
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet6
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.81/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet6
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.83/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet6
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.85/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet6
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.87/31
 !
@@ -96,10 +96,10 @@ interface Ethernet7
    no switchport
    vrf Tenant_A_WAN_Zone
    ip address 10.10.10.10/24
-   ip ospf network point-to-point
-   ip ospf area 0
    ip ospf cost 100
+   ip ospf network point-to-point
    ip ospf authentication message-digest
+   ip ospf area 0
    ip ospf message-digest-key 1 sha1 7 AQQvKeimxJu+uGQ/yYvv9w==
    ip ospf message-digest-key 2 sha512 7 AQQvKeimxJu+uGQ/yYvv9w==
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1B.cfg
@@ -59,32 +59,32 @@ vrf instance Tenant_L3_VRF_Zone
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet7
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.97/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet7
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.99/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet7
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.101/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet7
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.103/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL2A.cfg
@@ -55,32 +55,32 @@ vrf instance Tenant_C_WAN_Zone
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet8
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.113/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet8
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.115/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet8
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.117/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet8
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.119/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL2B.cfg
@@ -53,32 +53,32 @@ vrf instance Tenant_C_WAN_Zone
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet9
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.129/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet9
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.131/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet9
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.133/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet9
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.135/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF1A.cfg
@@ -57,32 +57,32 @@ vrf instance Tenant_A_WEB_Zone
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet1
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.1/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet1
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.3/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet1
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.5/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet1
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.7/31
 !
@@ -90,21 +90,21 @@ interface Ethernet6
    description server02_SINGLE_NODE_TRUNK_Eth1
    no shutdown
    l2 mtu 8000
-   switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   spanning-tree portfast
+   switchport
    storm-control all level 10
    storm-control broadcast level pps 100
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast
 !
 interface Ethernet7
    description server02_SINGLE_NODE_Eth1
    no shutdown
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
 !
 interface Loopback0
    description EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
@@ -158,32 +158,32 @@ interface Port-Channel20
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet2
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.17/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet2
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.19/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet2
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.21/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet2
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.23/31
 !
@@ -225,9 +225,9 @@ interface Ethernet20
 interface Ethernet21
    description ROUTER01_Eth0
    no shutdown
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
 !
 interface Loopback0
    description EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
@@ -158,32 +158,32 @@ interface Port-Channel20
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet3
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.33/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet3
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.35/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet3
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.37/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet3
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.39/31
 !
@@ -225,9 +225,9 @@ interface Ethernet20
 interface Ethernet21
    description ROUTER01_Eth1
    no shutdown
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
 !
 interface Loopback0
    description EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SPINE1.cfg
@@ -34,72 +34,72 @@ vrf instance MGMT
 interface Ethernet1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet1
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.0/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-LEAF2A_Ethernet1
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.16/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-LEAF2B_Ethernet1
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.32/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SVC3A_Ethernet1
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.48/31
 !
 interface Ethernet5
    description P2P_LINK_TO_DC1-SVC3B_Ethernet1
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.64/31
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-BL1A_Ethernet1
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.80/31
 !
 interface Ethernet7
    description P2P_LINK_TO_DC1-BL1B_Ethernet1
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.96/31
 !
 interface Ethernet8
    description P2P_LINK_TO_DC1-BL2A_Ethernet1
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.112/31
 !
 interface Ethernet9
    description P2P_LINK_TO_DC1-BL2B_Ethernet1
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.128/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SPINE2.cfg
@@ -36,72 +36,72 @@ vrf instance MGMT
 interface Ethernet1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet2
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.2/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-LEAF2A_Ethernet2
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.18/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-LEAF2B_Ethernet2
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.34/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SVC3A_Ethernet2
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.50/31
 !
 interface Ethernet5
    description P2P_LINK_TO_DC1-SVC3B_Ethernet2
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.66/31
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-BL1A_Ethernet2
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.82/31
 !
 interface Ethernet7
    description P2P_LINK_TO_DC1-BL1B_Ethernet2
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.98/31
 !
 interface Ethernet8
    description P2P_LINK_TO_DC1-BL2A_Ethernet2
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.114/31
 !
 interface Ethernet9
    description P2P_LINK_TO_DC1-BL2B_Ethernet2
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.130/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SPINE3.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SPINE3.cfg
@@ -34,72 +34,72 @@ vrf instance MGMT
 interface Ethernet1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet3
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.4/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-LEAF2A_Ethernet3
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.20/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-LEAF2B_Ethernet3
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.36/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SVC3A_Ethernet3
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.52/31
 !
 interface Ethernet5
    description P2P_LINK_TO_DC1-SVC3B_Ethernet3
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.68/31
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-BL1A_Ethernet3
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.84/31
 !
 interface Ethernet7
    description P2P_LINK_TO_DC1-BL1B_Ethernet3
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.100/31
 !
 interface Ethernet8
    description P2P_LINK_TO_DC1-BL2A_Ethernet3
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.116/31
 !
 interface Ethernet9
    description P2P_LINK_TO_DC1-BL2B_Ethernet3
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.132/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SPINE4.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SPINE4.cfg
@@ -34,72 +34,72 @@ vrf instance MGMT
 interface Ethernet1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet4
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.6/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-LEAF2A_Ethernet4
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.22/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-LEAF2B_Ethernet4
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.38/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SVC3A_Ethernet4
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.54/31
 !
 interface Ethernet5
    description P2P_LINK_TO_DC1-SVC3B_Ethernet4
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.70/31
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-BL1A_Ethernet4
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.86/31
 !
 interface Ethernet7
    description P2P_LINK_TO_DC1-BL1B_Ethernet4
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.102/31
 !
 interface Ethernet8
    description P2P_LINK_TO_DC1-BL2A_Ethernet4
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.118/31
 !
 interface Ethernet9
    description P2P_LINK_TO_DC1-BL2B_Ethernet4
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.134/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3A.cfg
@@ -297,32 +297,32 @@ interface Port-Channel42
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet4
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.49/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet4
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.51/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet4
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.53/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet4
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.55/31
 !
@@ -357,45 +357,45 @@ interface Ethernet11
    description server04_inherit_all_from_profile_Eth1
    no shutdown
    l2 mtu 8000
-   switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   spanning-tree portfast
-   spanning-tree bpduguard disable
-   spanning-tree bpdufilter disable
+   switchport
    storm-control all level 10
    storm-control broadcast level pps 100
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast
+   spanning-tree bpduguard disable
+   spanning-tree bpdufilter disable
 !
 interface Ethernet12
    description server05_no_profile_Eth1
    no shutdown
-   switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   spanning-tree portfast
-   spanning-tree bpduguard disable
-   spanning-tree bpdufilter enable
+   switchport
    storm-control all level 10
    storm-control broadcast level pps 100
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast
+   spanning-tree bpduguard disable
+   spanning-tree bpdufilter enable
 !
 interface Ethernet13
    description server06_override_profile_Eth1
    no shutdown
    l2 mtu 8000
-   switchport
    switchport access vlan 210
    switchport mode access
-   spanning-tree portfast network
-   spanning-tree bpduguard enable
-   spanning-tree bpdufilter disable
+   switchport
    storm-control all level pps 20
    storm-control broadcast level 200
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast network
+   spanning-tree bpduguard enable
+   spanning-tree bpdufilter disable
 !
 interface Ethernet14
    description server07_inherit_all_from_profile_port_channel_Eth1
@@ -411,16 +411,16 @@ interface Ethernet16
    description server09_override_profile_no_port_channel_Eth1
    no shutdown
    l2 mtu 8000
-   switchport
    switchport access vlan 210
    switchport mode access
-   spanning-tree portfast network
-   spanning-tree bpduguard enable
-   spanning-tree bpdufilter disable
+   switchport
    storm-control all level pps 20
    storm-control broadcast level 200
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast network
+   spanning-tree bpduguard enable
+   spanning-tree bpdufilter disable
 !
 interface Ethernet17
    description server10_no_profile_port_channel_lacp_fallback_Eth1
@@ -443,16 +443,16 @@ interface Ethernet19
 interface Ethernet20
    description server13_disabled_interfaces_Eth1
    shutdown
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
 !
 interface Ethernet21
    description server14_explicitly_enabled_interfaces_Eth1
    no shutdown
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
 !
 interface Ethernet22
    description server15_port_channel_with_disabled_phy_interfaces_Eth1
@@ -472,9 +472,9 @@ interface Ethernet24
 interface Ethernet25
    description server18_monitoring_session_source_phys_interfaces_Eth1
    no shutdown
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
 !
 interface Ethernet26
    description server19_monitoring_session_destination_phys_Eth1
@@ -489,9 +489,9 @@ interface Ethernet27
 interface Ethernet28
    description server18_monitoring_session_source_phys_interface_Eth5
    no shutdown
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
 !
 interface Ethernet40
    description server20_monitoring_session_destination_phys_Eth1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3B.cfg
@@ -289,32 +289,32 @@ interface Port-Channel42
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet5
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.65/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet5
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.67/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet5
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.69/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet5
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.71/31
 !
@@ -344,45 +344,45 @@ interface Ethernet11
    description server04_inherit_all_from_profile_Eth2
    no shutdown
    l2 mtu 8000
-   switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   spanning-tree portfast
-   spanning-tree bpduguard disable
-   spanning-tree bpdufilter disable
+   switchport
    storm-control all level 10
    storm-control broadcast level pps 100
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast
+   spanning-tree bpduguard disable
+   spanning-tree bpdufilter disable
 !
 interface Ethernet12
    description server05_no_profile_Eth2
    no shutdown
-   switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   spanning-tree portfast
-   spanning-tree bpduguard disable
-   spanning-tree bpdufilter enable
+   switchport
    storm-control all level 10
    storm-control broadcast level pps 100
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast
+   spanning-tree bpduguard disable
+   spanning-tree bpdufilter enable
 !
 interface Ethernet13
    description server06_override_profile_Eth2
    no shutdown
    l2 mtu 8000
-   switchport
    switchport access vlan 210
    switchport mode access
-   spanning-tree portfast network
-   spanning-tree bpduguard enable
-   spanning-tree bpdufilter disable
+   switchport
    storm-control all level pps 20
    storm-control broadcast level 200
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast network
+   spanning-tree bpduguard enable
+   spanning-tree bpdufilter disable
 !
 interface Ethernet14
    description server07_inherit_all_from_profile_port_channel_Eth2
@@ -398,16 +398,16 @@ interface Ethernet16
    description server09_override_profile_no_port_channel_Eth2
    no shutdown
    l2 mtu 8000
-   switchport
    switchport access vlan 210
    switchport mode access
-   spanning-tree portfast network
-   spanning-tree bpduguard enable
-   spanning-tree bpdufilter disable
+   switchport
    storm-control all level pps 20
    storm-control broadcast level 200
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast network
+   spanning-tree bpduguard enable
+   spanning-tree bpdufilter disable
 !
 interface Ethernet17
    description server10_no_profile_port_channel_lacp_fallback_Eth2
@@ -430,16 +430,16 @@ interface Ethernet19
 interface Ethernet20
    description server13_disabled_interfaces_Eth2
    shutdown
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
 !
 interface Ethernet21
    description server14_explicitly_enabled_interfaces_Eth2
    no shutdown
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
 !
 interface Ethernet22
    description server15_port_channel_with_disabled_phy_interfaces_Eth2
@@ -459,9 +459,9 @@ interface Ethernet24
 interface Ethernet25
    description server18_monitoring_session_source_phys_interfaces_Eth2
    no shutdown
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
 !
 interface Ethernet26
    description server19_monitoring_session_destination_phys_Eth2

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MH-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MH-LEAF2A.cfg
@@ -65,9 +65,9 @@ interface Ethernet2
 interface Ethernet10
    description ROUTER01_Eth1
    no shutdown
-   switchport
    switchport access vlan 310
    switchport mode access
+   switchport
    link tracking group Eth-conn-to-router downstream
 !
 interface Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/core-1-isis-sr-ldp.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/core-1-isis-sr-ldp.cfg
@@ -36,126 +36,126 @@ interface Port-Channel12
 interface Ethernet1
    description P2P_LINK_TO_core-2-ospf-ldp_Ethernet1
    no shutdown
-   speed forced 1000full
    mtu 1500
+   speed forced 1000full
    no switchport
    ip address unnumbered loopback0
    ipv6 enable
+   mpls ldp igp sync
+   mpls ldp interface
+   mpls ip
    isis enable CORE
    isis circuit-type level-2
    isis metric 60
-   isis network point-to-point
    no isis hello padding
+   isis network point-to-point
    isis authentication mode md5
    isis authentication key 7 $1c$sTNAlR6rKSw=
-   mpls ip
-   mpls ldp interface
-   mpls ldp igp sync
 !
 interface Ethernet2
    description P2P_LINK_TO_core-2-ospf-ldp_Ethernet2
    no shutdown
-   speed 100full
    mtu 1601
+   speed 100full
    no switchport
    ip address 100.123.123.2/31
+   mpls ldp igp sync
+   mpls ldp interface
+   mpls ip
+   service-profile test_qos_profile
    isis enable CORE
    isis circuit-type level-1
    isis metric 60
-   isis network point-to-point
    isis hello padding
-   service-profile test_qos_profile
-   mpls ip
-   mpls ldp interface
-   mpls ldp igp sync
+   isis network point-to-point
 !
 interface Ethernet3
    description P2P_LINK_TO_core-2-ospf-ldp_Ethernet3
    no shutdown
-   speed forced 1000full
    mtu 1500
+   speed forced 1000full
    no switchport
    ip address 100.64.48.4/31
    ipv6 enable
+   mpls ldp igp sync
+   mpls ldp interface
+   mpls ip
    isis enable CORE
    isis circuit-type level-2
    isis metric 60
-   isis network point-to-point
    no isis hello padding
+   isis network point-to-point
    isis authentication mode md5
    isis authentication key 7 $1c$sTNAlR6rKSw=
-   mpls ip
-   mpls ldp interface
-   mpls ldp igp sync
 !
 interface Ethernet4
    description P2P_LINK_TO_core-2-ospf-ldp_Ethernet4
    no shutdown
-   speed forced 1000full
    mtu 1500
+   speed forced 1000full
    no switchport
    ip address 100.64.48.6/31
    ipv6 enable
    isis enable CORE
    isis circuit-type level-2
    isis metric 60
-   isis network point-to-point
    no isis hello padding
+   isis network point-to-point
    isis authentication mode md5
    isis authentication key 7 $1c$sTNAlR6rKSw=
 !
 interface Ethernet5
    description P2P_LINK_TO_core-2-ospf-ldp_Ethernet5
    no shutdown
-   speed forced 1000full
    mtu 1500
+   speed forced 1000full
    no switchport
    ip address 100.64.48.8/31
    ipv6 enable
+   mpls ip
    isis enable CORE
    isis circuit-type level-2
    isis metric 60
-   isis network point-to-point
    no isis hello padding
+   isis network point-to-point
    isis authentication mode md5
    isis authentication key 7 $1c$sTNAlR6rKSw=
-   mpls ip
 !
 interface Ethernet6
    description P2P_LINK_TO_core-2-ospf-ldp_Ethernet6
    no shutdown
-   speed 100full
    mtu 1602
+   speed 100full
    no switchport
    ip address unnumbered loopback0
    ipv6 enable
+   mpls ldp igp sync
+   mpls ldp interface
+   mpls ip
+   service-profile test_qos_profile
    isis enable CORE
    isis circuit-type level-1-2
    isis metric 70
-   isis network point-to-point
    isis hello padding
+   isis network point-to-point
    isis authentication mode md5
    isis authentication key 7 $1c$sTNAlR6rKSw=
-   service-profile test_qos_profile
-   mpls ip
-   mpls ldp interface
-   mpls ldp igp sync
 !
 interface Ethernet10
    description P2P_LINK_TO_core-2-ospf-ldp_Ethernet10
    no shutdown
-   speed forced 1000full
    mtu 1500
+   speed forced 1000full
    no switchport
    ip address 100.64.48.12/31
+   mpls ldp igp sync
+   mpls ldp interface
+   mpls ip
    isis enable CORE
    isis circuit-type level-2
    isis metric 50
-   isis network point-to-point
    isis hello padding
-   mpls ip
-   mpls ldp interface
-   mpls ldp igp sync
+   isis network point-to-point
 !
 interface Ethernet12
    description P2P_LINK_TO_core-2-ospf-ldp_Port-Channel12

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/core-2-ospf-ldp.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/core-2-ospf-ldp.cfg
@@ -31,50 +31,50 @@ interface Port-Channel12
 interface Ethernet1
    description P2P_LINK_TO_core-1-isis-sr-ldp_Ethernet1
    no shutdown
-   speed forced 1000full
    mtu 1500
+   speed forced 1000full
    no switchport
    ip address unnumbered loopback0
    ipv6 enable
+   mpls ldp igp sync
+   mpls ldp interface
+   mpls ip
    ip ospf network point-to-point
    ip ospf area 0.0.0.0
-   mpls ip
-   mpls ldp interface
-   mpls ldp igp sync
 !
 interface Ethernet2
    description P2P_LINK_TO_core-1-isis-sr-ldp_Ethernet2
    no shutdown
-   speed 100full
    mtu 1601
+   speed 100full
    no switchport
    ip address 100.123.123.3/31
+   mpls ldp igp sync
+   mpls ldp interface
+   mpls ip
    ip ospf network point-to-point
    ip ospf area 0.0.0.0
    service-profile test_qos_profile
-   mpls ip
-   mpls ldp interface
-   mpls ldp igp sync
 !
 interface Ethernet3
    description P2P_LINK_TO_core-1-isis-sr-ldp_Ethernet3
    no shutdown
-   speed forced 1000full
    mtu 1500
+   speed forced 1000full
    no switchport
    ip address 100.64.48.5/31
    ipv6 enable
+   mpls ldp igp sync
+   mpls ldp interface
+   mpls ip
    ip ospf network point-to-point
    ip ospf area 0.0.0.0
-   mpls ip
-   mpls ldp interface
-   mpls ldp igp sync
 !
 interface Ethernet4
    description P2P_LINK_TO_core-1-isis-sr-ldp_Ethernet4
    no shutdown
-   speed forced 1000full
    mtu 1500
+   speed forced 1000full
    no switchport
    ip address 100.64.48.7/31
    ipv6 enable
@@ -84,42 +84,42 @@ interface Ethernet4
 interface Ethernet5
    description P2P_LINK_TO_core-1-isis-sr-ldp_Ethernet5
    no shutdown
-   speed forced 1000full
    mtu 1500
+   speed forced 1000full
    no switchport
    ip address 100.64.48.9/31
    ipv6 enable
+   mpls ip
    ip ospf network point-to-point
    ip ospf area 0.0.0.0
-   mpls ip
 !
 interface Ethernet6
    description P2P_LINK_TO_core-1-isis-sr-ldp_Ethernet6
    no shutdown
-   speed 100full
    mtu 1602
+   speed 100full
    no switchport
    ip address unnumbered loopback0
    ipv6 enable
+   mpls ldp igp sync
+   mpls ldp interface
+   mpls ip
    ip ospf network point-to-point
    ip ospf area 0.0.0.0
    service-profile test_qos_profile
-   mpls ip
-   mpls ldp interface
-   mpls ldp igp sync
 !
 interface Ethernet10
    description P2P_LINK_TO_core-1-isis-sr-ldp_Ethernet10
    no shutdown
-   speed forced 1000full
    mtu 1500
+   speed forced 1000full
    no switchport
    ip address 100.64.48.13/31
+   mpls ldp igp sync
+   mpls ldp interface
+   mpls ip
    ip ospf network point-to-point
    ip ospf area 0.0.0.0
-   mpls ip
-   mpls ldp interface
-   mpls ldp igp sync
 !
 interface Ethernet12
    description P2P_LINK_TO_core-1-isis-sr-ldp_Port-Channel12

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -336,32 +336,32 @@ interface Ethernet10.200
 interface Ethernet41
    description CUSTOM_P2P_LINK_TO_DC1-SPINE1_Ethernet6
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.81/31
 !
 interface Ethernet42
    description CUSTOM_P2P_LINK_TO_DC1-SPINE2_Ethernet6
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.83/31
 !
 interface Ethernet43
    description CUSTOM_P2P_LINK_TO_DC1-SPINE3_Ethernet6
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.85/31
 !
 interface Ethernet44
    description CUSTOM_P2P_LINK_TO_DC1-SPINE4_Ethernet6
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.87/31
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -334,32 +334,32 @@ interface Ethernet10.200
 interface Ethernet45
    description CUSTOM_P2P_LINK_TO_DC1-SPINE1_Ethernet7
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.97/31
 !
 interface Ethernet46
    description CUSTOM_P2P_LINK_TO_DC1-SPINE2_Ethernet7
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.99/31
 !
 interface Ethernet47
    description CUSTOM_P2P_LINK_TO_DC1-SPINE3_Ethernet7
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.101/31
 !
 interface Ethernet48
    description CUSTOM_P2P_LINK_TO_DC1-SPINE4_Ethernet7
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.103/31
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -303,32 +303,32 @@ vlan 131
 interface Ethernet1
    description CUSTOM_P2P_LINK_TO_DC1-SPINE1_Ethernet1 no-monitor
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.1/31
 !
 interface Ethernet2
    description CUSTOM_P2P_LINK_TO_DC1-SPINE2_Ethernet1 no-monitor
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.3/31
 !
 interface Ethernet3
    description CUSTOM_P2P_LINK_TO_DC1-SPINE3_Ethernet1 no-monitor
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.5/31
 !
 interface Ethernet4
    description CUSTOM_P2P_LINK_TO_DC1-SPINE4_Ethernet1 no-monitor
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.7/31
 !
@@ -336,22 +336,22 @@ interface Ethernet6
    description CUSTOM_server02_SINGLE_NODE_TRUNK_Eth1
    no shutdown
    l2 mtu 8000
-   switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   spanning-tree portfast
-   spanning-tree bpdufilter enable
+   switchport
    storm-control all level 10
    storm-control broadcast level pps 100
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast
+   spanning-tree bpdufilter enable
 !
 interface Ethernet7
    description CUSTOM_server02_SINGLE_NODE_Eth1
    no shutdown
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
 ```
 
 ## Loopback Interfaces

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -375,32 +375,32 @@ vlan 311
 interface Ethernet1
    description CUSTOM_P2P_LINK_TO_DC1-SPINE1_Ethernet2
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.17/31
 !
 interface Ethernet2
    description CUSTOM_P2P_LINK_TO_DC1-SPINE2_Ethernet2
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.19/31
 !
 interface Ethernet3
    description CUSTOM_P2P_LINK_TO_DC1-SPINE3_Ethernet2
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.21/31
 !
 interface Ethernet4
    description CUSTOM_P2P_LINK_TO_DC1-SPINE4_Ethernet2
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.23/31
 !
@@ -447,9 +447,9 @@ interface Ethernet20
 interface Ethernet21
    description CUSTOM_ROUTER01_Eth0
    no shutdown
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
 ```
 
 ## Port-Channel Interfaces

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -375,32 +375,32 @@ vlan 311
 interface Ethernet1
    description CUSTOM_P2P_LINK_TO_DC1-SPINE1_Ethernet3
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.33/31
 !
 interface Ethernet2
    description CUSTOM_P2P_LINK_TO_DC1-SPINE2_Ethernet3
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.35/31
 !
 interface Ethernet3
    description CUSTOM_P2P_LINK_TO_DC1-SPINE3_Ethernet3
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.37/31
 !
 interface Ethernet4
    description CUSTOM_P2P_LINK_TO_DC1-SPINE4_Ethernet3
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.39/31
 !
@@ -447,9 +447,9 @@ interface Ethernet20
 interface Ethernet21
    description CUSTOM_ROUTER01_Eth1
    no shutdown
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
 ```
 
 ## Port-Channel Interfaces

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE1.md
@@ -247,56 +247,56 @@ vlan internal order ascending range 1006 1199
 interface Ethernet1
    description CUSTOM_P2P_LINK_TO_DC1-LEAF1A_Ethernet1
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.0/31
 !
 interface Ethernet2
    description CUSTOM_P2P_LINK_TO_DC1-LEAF2A_Ethernet1
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.16/31
 !
 interface Ethernet3
    description CUSTOM_P2P_LINK_TO_DC1-LEAF2B_Ethernet1
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.32/31
 !
 interface Ethernet4
    description CUSTOM_P2P_LINK_TO_DC1-SVC3A_Ethernet41
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.48/31
 !
 interface Ethernet5
    description CUSTOM_P2P_LINK_TO_DC1-SVC3B_Ethernet41
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.64/31
 !
 interface Ethernet6
    description CUSTOM_P2P_LINK_TO_DC1-BL1A_Ethernet41
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.80/31
 !
 interface Ethernet7
    description CUSTOM_P2P_LINK_TO_DC1-BL1B_Ethernet45
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.96/31
 ```

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE2.md
@@ -247,56 +247,56 @@ vlan internal order ascending range 1006 1199
 interface Ethernet1
    description CUSTOM_P2P_LINK_TO_DC1-LEAF1A_Ethernet2
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.2/31
 !
 interface Ethernet2
    description CUSTOM_P2P_LINK_TO_DC1-LEAF2A_Ethernet2
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.18/31
 !
 interface Ethernet3
    description CUSTOM_P2P_LINK_TO_DC1-LEAF2B_Ethernet2
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.34/31
 !
 interface Ethernet4
    description CUSTOM_P2P_LINK_TO_DC1-SVC3A_Ethernet42
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.50/31
 !
 interface Ethernet5
    description CUSTOM_P2P_LINK_TO_DC1-SVC3B_Ethernet42
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.66/31
 !
 interface Ethernet6
    description CUSTOM_P2P_LINK_TO_DC1-BL1A_Ethernet42
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.82/31
 !
 interface Ethernet7
    description CUSTOM_P2P_LINK_TO_DC1-BL1B_Ethernet46
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.98/31
 ```

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE3.md
@@ -247,56 +247,56 @@ vlan internal order ascending range 1006 1199
 interface Ethernet1
    description CUSTOM_P2P_LINK_TO_DC1-LEAF1A_Ethernet3
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.4/31
 !
 interface Ethernet2
    description CUSTOM_P2P_LINK_TO_DC1-LEAF2A_Ethernet3
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.20/31
 !
 interface Ethernet3
    description CUSTOM_P2P_LINK_TO_DC1-LEAF2B_Ethernet3
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.36/31
 !
 interface Ethernet4
    description CUSTOM_P2P_LINK_TO_DC1-SVC3A_Ethernet43
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.52/31
 !
 interface Ethernet5
    description CUSTOM_P2P_LINK_TO_DC1-SVC3B_Ethernet43
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.68/31
 !
 interface Ethernet6
    description CUSTOM_P2P_LINK_TO_DC1-BL1A_Ethernet43
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.84/31
 !
 interface Ethernet7
    description CUSTOM_P2P_LINK_TO_DC1-BL1B_Ethernet47
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.100/31
 ```

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE4.md
@@ -247,56 +247,56 @@ vlan internal order ascending range 1006 1199
 interface Ethernet1
    description CUSTOM_P2P_LINK_TO_DC1-LEAF1A_Ethernet4
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.6/31
 !
 interface Ethernet2
    description CUSTOM_P2P_LINK_TO_DC1-LEAF2A_Ethernet4
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.22/31
 !
 interface Ethernet3
    description CUSTOM_P2P_LINK_TO_DC1-LEAF2B_Ethernet4
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.38/31
 !
 interface Ethernet4
    description CUSTOM_P2P_LINK_TO_DC1-SVC3A_Ethernet44
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.54/31
 !
 interface Ethernet5
    description CUSTOM_P2P_LINK_TO_DC1-SVC3B_Ethernet44
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.70/31
 !
 interface Ethernet6
    description CUSTOM_P2P_LINK_TO_DC1-BL1A_Ethernet44
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.86/31
 !
 interface Ethernet7
    description CUSTOM_P2P_LINK_TO_DC1-BL1B_Ethernet48
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.102/31
 ```

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -485,42 +485,42 @@ interface Ethernet11
    description CUSTOM_server04_inherit_all_from_profile_Eth1
    no shutdown
    l2 mtu 8000
-   switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   spanning-tree portfast
-   spanning-tree bpdufilter enable
+   switchport
    storm-control all level 10
    storm-control broadcast level pps 100
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast
+   spanning-tree bpdufilter enable
 !
 interface Ethernet12
    description CUSTOM_server05_no_profile_Eth1
    no shutdown
-   switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   spanning-tree portfast
-   spanning-tree bpdufilter enable
+   switchport
    storm-control all level 10
    storm-control broadcast level pps 100
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast
+   spanning-tree bpdufilter enable
 !
 interface Ethernet13
    description CUSTOM_server06_override_profile_Eth1
    no shutdown
    l2 mtu 8000
-   switchport
    switchport access vlan 210
    switchport mode access
-   spanning-tree portfast network
-   spanning-tree bpduguard enable
+   switchport
    storm-control all level pps 20
    storm-control broadcast level 200
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast network
+   spanning-tree bpduguard enable
 !
 interface Ethernet14
    description CUSTOM_server07_inherit_all_from_profile_port_channel_Eth1
@@ -536,15 +536,15 @@ interface Ethernet16
    description CUSTOM_server09_override_profile_no_port_channel_Eth1
    no shutdown
    l2 mtu 8000
-   switchport
    switchport access vlan 210
    switchport mode access
-   spanning-tree portfast network
-   spanning-tree bpduguard enable
+   switchport
    storm-control all level pps 20
    storm-control broadcast level 200
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast network
+   spanning-tree bpduguard enable
 !
 interface Ethernet17
    description CUSTOM_server10_no_profile_port_channel_lacp_fallback_Eth1
@@ -567,16 +567,16 @@ interface Ethernet19
 interface Ethernet20
    description CUSTOM_server13_disabled_interfaces_Eth1
    shutdown
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
 !
 interface Ethernet21
    description CUSTOM_server14_explicitly_enabled_interfaces_Eth1
    no shutdown
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
 !
 interface Ethernet22
    description CUSTOM_server15_port_channel_disabled_interfaces_Eth1
@@ -586,32 +586,32 @@ interface Ethernet22
 interface Ethernet41
    description CUSTOM_P2P_LINK_TO_DC1-SPINE1_Ethernet4
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.49/31
 !
 interface Ethernet42
    description CUSTOM_P2P_LINK_TO_DC1-SPINE2_Ethernet4
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.51/31
 !
 interface Ethernet43
    description CUSTOM_P2P_LINK_TO_DC1-SPINE3_Ethernet4
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.53/31
 !
 interface Ethernet44
    description CUSTOM_P2P_LINK_TO_DC1-SPINE4_Ethernet4
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.55/31
 ```

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -485,42 +485,42 @@ interface Ethernet11
    description CUSTOM_server04_inherit_all_from_profile_Eth2
    no shutdown
    l2 mtu 8000
-   switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   spanning-tree portfast
-   spanning-tree bpdufilter enable
+   switchport
    storm-control all level 10
    storm-control broadcast level pps 100
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast
+   spanning-tree bpdufilter enable
 !
 interface Ethernet12
    description CUSTOM_server05_no_profile_Eth2
    no shutdown
-   switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   spanning-tree portfast
-   spanning-tree bpdufilter enable
+   switchport
    storm-control all level 10
    storm-control broadcast level pps 100
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast
+   spanning-tree bpdufilter enable
 !
 interface Ethernet13
    description CUSTOM_server06_override_profile_Eth2
    no shutdown
    l2 mtu 8000
-   switchport
    switchport access vlan 210
    switchport mode access
-   spanning-tree portfast network
-   spanning-tree bpduguard enable
+   switchport
    storm-control all level pps 20
    storm-control broadcast level 200
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast network
+   spanning-tree bpduguard enable
 !
 interface Ethernet14
    description CUSTOM_server07_inherit_all_from_profile_port_channel_Eth2
@@ -536,15 +536,15 @@ interface Ethernet16
    description CUSTOM_server09_override_profile_no_port_channel_Eth2
    no shutdown
    l2 mtu 8000
-   switchport
    switchport access vlan 210
    switchport mode access
-   spanning-tree portfast network
-   spanning-tree bpduguard enable
+   switchport
    storm-control all level pps 20
    storm-control broadcast level 200
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast network
+   spanning-tree bpduguard enable
 !
 interface Ethernet17
    description CUSTOM_server10_no_profile_port_channel_lacp_fallback_Eth2
@@ -567,16 +567,16 @@ interface Ethernet19
 interface Ethernet20
    description CUSTOM_server13_disabled_interfaces_Eth2
    shutdown
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
 !
 interface Ethernet21
    description CUSTOM_server14_explicitly_enabled_interfaces_Eth2
    no shutdown
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
 !
 interface Ethernet22
    description CUSTOM_server15_port_channel_disabled_interfaces_Eth2
@@ -586,32 +586,32 @@ interface Ethernet22
 interface Ethernet41
    description CUSTOM_P2P_LINK_TO_DC1-SPINE1_Ethernet5
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.65/31
 !
 interface Ethernet42
    description CUSTOM_P2P_LINK_TO_DC1-SPINE2_Ethernet5
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.67/31
 !
 interface Ethernet43
    description CUSTOM_P2P_LINK_TO_DC1-SPINE3_Ethernet5
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.69/31
 !
 interface Ethernet44
    description CUSTOM_P2P_LINK_TO_DC1-SPINE4_Ethernet5
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.71/31
 ```

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1A.cfg
@@ -107,32 +107,32 @@ interface Ethernet10.200
 interface Ethernet41
    description CUSTOM_P2P_LINK_TO_DC1-SPINE1_Ethernet6
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.81/31
 !
 interface Ethernet42
    description CUSTOM_P2P_LINK_TO_DC1-SPINE2_Ethernet6
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.83/31
 !
 interface Ethernet43
    description CUSTOM_P2P_LINK_TO_DC1-SPINE3_Ethernet6
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.85/31
 !
 interface Ethernet44
    description CUSTOM_P2P_LINK_TO_DC1-SPINE4_Ethernet6
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.87/31
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1B.cfg
@@ -106,32 +106,32 @@ interface Ethernet10.200
 interface Ethernet45
    description CUSTOM_P2P_LINK_TO_DC1-SPINE1_Ethernet7
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.97/31
 !
 interface Ethernet46
    description CUSTOM_P2P_LINK_TO_DC1-SPINE2_Ethernet7
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.99/31
 !
 interface Ethernet47
    description CUSTOM_P2P_LINK_TO_DC1-SPINE3_Ethernet7
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.101/31
 !
 interface Ethernet48
    description CUSTOM_P2P_LINK_TO_DC1-SPINE4_Ethernet7
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.103/31
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
@@ -65,32 +65,32 @@ vrf instance Tenant_A_WEB_Zone
 interface Ethernet1
    description CUSTOM_P2P_LINK_TO_DC1-SPINE1_Ethernet1 no-monitor
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.1/31
 !
 interface Ethernet2
    description CUSTOM_P2P_LINK_TO_DC1-SPINE2_Ethernet1 no-monitor
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.3/31
 !
 interface Ethernet3
    description CUSTOM_P2P_LINK_TO_DC1-SPINE3_Ethernet1 no-monitor
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.5/31
 !
 interface Ethernet4
    description CUSTOM_P2P_LINK_TO_DC1-SPINE4_Ethernet1 no-monitor
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.7/31
 !
@@ -98,22 +98,22 @@ interface Ethernet6
    description CUSTOM_server02_SINGLE_NODE_TRUNK_Eth1
    no shutdown
    l2 mtu 8000
-   switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   spanning-tree portfast
-   spanning-tree bpdufilter enable
+   switchport
    storm-control all level 10
    storm-control broadcast level pps 100
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast
+   spanning-tree bpdufilter enable
 !
 interface Ethernet7
    description CUSTOM_server02_SINGLE_NODE_Eth1
    no shutdown
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
 !
 interface Loopback0
    description CUSTOM_EVPN_Overlay_Peering_L3LEAF

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
@@ -165,32 +165,32 @@ interface Port-Channel20
 interface Ethernet1
    description CUSTOM_P2P_LINK_TO_DC1-SPINE1_Ethernet2
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.17/31
 !
 interface Ethernet2
    description CUSTOM_P2P_LINK_TO_DC1-SPINE2_Ethernet2
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.19/31
 !
 interface Ethernet3
    description CUSTOM_P2P_LINK_TO_DC1-SPINE3_Ethernet2
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.21/31
 !
 interface Ethernet4
    description CUSTOM_P2P_LINK_TO_DC1-SPINE4_Ethernet2
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.23/31
 !
@@ -237,9 +237,9 @@ interface Ethernet20
 interface Ethernet21
    description CUSTOM_ROUTER01_Eth0
    no shutdown
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
 !
 interface Loopback0
    description CUSTOM_EVPN_Overlay_Peering_L3LEAF

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
@@ -165,32 +165,32 @@ interface Port-Channel20
 interface Ethernet1
    description CUSTOM_P2P_LINK_TO_DC1-SPINE1_Ethernet3
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.33/31
 !
 interface Ethernet2
    description CUSTOM_P2P_LINK_TO_DC1-SPINE2_Ethernet3
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.35/31
 !
 interface Ethernet3
    description CUSTOM_P2P_LINK_TO_DC1-SPINE3_Ethernet3
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.37/31
 !
 interface Ethernet4
    description CUSTOM_P2P_LINK_TO_DC1-SPINE4_Ethernet3
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.39/31
 !
@@ -237,9 +237,9 @@ interface Ethernet20
 interface Ethernet21
    description CUSTOM_ROUTER01_Eth1
    no shutdown
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
 !
 interface Loopback0
    description CUSTOM_EVPN_Overlay_Peering_L3LEAF

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE1.cfg
@@ -36,56 +36,56 @@ vrf instance MGMT
 interface Ethernet1
    description CUSTOM_P2P_LINK_TO_DC1-LEAF1A_Ethernet1
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.0/31
 !
 interface Ethernet2
    description CUSTOM_P2P_LINK_TO_DC1-LEAF2A_Ethernet1
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.16/31
 !
 interface Ethernet3
    description CUSTOM_P2P_LINK_TO_DC1-LEAF2B_Ethernet1
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.32/31
 !
 interface Ethernet4
    description CUSTOM_P2P_LINK_TO_DC1-SVC3A_Ethernet41
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.48/31
 !
 interface Ethernet5
    description CUSTOM_P2P_LINK_TO_DC1-SVC3B_Ethernet41
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.64/31
 !
 interface Ethernet6
    description CUSTOM_P2P_LINK_TO_DC1-BL1A_Ethernet41
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.80/31
 !
 interface Ethernet7
    description CUSTOM_P2P_LINK_TO_DC1-BL1B_Ethernet45
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.96/31
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE2.cfg
@@ -36,56 +36,56 @@ vrf instance MGMT
 interface Ethernet1
    description CUSTOM_P2P_LINK_TO_DC1-LEAF1A_Ethernet2
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.2/31
 !
 interface Ethernet2
    description CUSTOM_P2P_LINK_TO_DC1-LEAF2A_Ethernet2
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.18/31
 !
 interface Ethernet3
    description CUSTOM_P2P_LINK_TO_DC1-LEAF2B_Ethernet2
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.34/31
 !
 interface Ethernet4
    description CUSTOM_P2P_LINK_TO_DC1-SVC3A_Ethernet42
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.50/31
 !
 interface Ethernet5
    description CUSTOM_P2P_LINK_TO_DC1-SVC3B_Ethernet42
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.66/31
 !
 interface Ethernet6
    description CUSTOM_P2P_LINK_TO_DC1-BL1A_Ethernet42
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.82/31
 !
 interface Ethernet7
    description CUSTOM_P2P_LINK_TO_DC1-BL1B_Ethernet46
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.98/31
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE3.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE3.cfg
@@ -36,56 +36,56 @@ vrf instance MGMT
 interface Ethernet1
    description CUSTOM_P2P_LINK_TO_DC1-LEAF1A_Ethernet3
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.4/31
 !
 interface Ethernet2
    description CUSTOM_P2P_LINK_TO_DC1-LEAF2A_Ethernet3
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.20/31
 !
 interface Ethernet3
    description CUSTOM_P2P_LINK_TO_DC1-LEAF2B_Ethernet3
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.36/31
 !
 interface Ethernet4
    description CUSTOM_P2P_LINK_TO_DC1-SVC3A_Ethernet43
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.52/31
 !
 interface Ethernet5
    description CUSTOM_P2P_LINK_TO_DC1-SVC3B_Ethernet43
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.68/31
 !
 interface Ethernet6
    description CUSTOM_P2P_LINK_TO_DC1-BL1A_Ethernet43
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.84/31
 !
 interface Ethernet7
    description CUSTOM_P2P_LINK_TO_DC1-BL1B_Ethernet47
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.100/31
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE4.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE4.cfg
@@ -36,56 +36,56 @@ vrf instance MGMT
 interface Ethernet1
    description CUSTOM_P2P_LINK_TO_DC1-LEAF1A_Ethernet4
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.6/31
 !
 interface Ethernet2
    description CUSTOM_P2P_LINK_TO_DC1-LEAF2A_Ethernet4
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.22/31
 !
 interface Ethernet3
    description CUSTOM_P2P_LINK_TO_DC1-LEAF2B_Ethernet4
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.38/31
 !
 interface Ethernet4
    description CUSTOM_P2P_LINK_TO_DC1-SVC3A_Ethernet44
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.54/31
 !
 interface Ethernet5
    description CUSTOM_P2P_LINK_TO_DC1-SVC3B_Ethernet44
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.70/31
 !
 interface Ethernet6
    description CUSTOM_P2P_LINK_TO_DC1-BL1A_Ethernet44
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.86/31
 !
 interface Ethernet7
    description CUSTOM_P2P_LINK_TO_DC1-BL1B_Ethernet48
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.102/31
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
@@ -301,42 +301,42 @@ interface Ethernet11
    description CUSTOM_server04_inherit_all_from_profile_Eth1
    no shutdown
    l2 mtu 8000
-   switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   spanning-tree portfast
-   spanning-tree bpdufilter enable
+   switchport
    storm-control all level 10
    storm-control broadcast level pps 100
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast
+   spanning-tree bpdufilter enable
 !
 interface Ethernet12
    description CUSTOM_server05_no_profile_Eth1
    no shutdown
-   switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   spanning-tree portfast
-   spanning-tree bpdufilter enable
+   switchport
    storm-control all level 10
    storm-control broadcast level pps 100
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast
+   spanning-tree bpdufilter enable
 !
 interface Ethernet13
    description CUSTOM_server06_override_profile_Eth1
    no shutdown
    l2 mtu 8000
-   switchport
    switchport access vlan 210
    switchport mode access
-   spanning-tree portfast network
-   spanning-tree bpduguard enable
+   switchport
    storm-control all level pps 20
    storm-control broadcast level 200
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast network
+   spanning-tree bpduguard enable
 !
 interface Ethernet14
    description CUSTOM_server07_inherit_all_from_profile_port_channel_Eth1
@@ -352,15 +352,15 @@ interface Ethernet16
    description CUSTOM_server09_override_profile_no_port_channel_Eth1
    no shutdown
    l2 mtu 8000
-   switchport
    switchport access vlan 210
    switchport mode access
-   spanning-tree portfast network
-   spanning-tree bpduguard enable
+   switchport
    storm-control all level pps 20
    storm-control broadcast level 200
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast network
+   spanning-tree bpduguard enable
 !
 interface Ethernet17
    description CUSTOM_server10_no_profile_port_channel_lacp_fallback_Eth1
@@ -383,16 +383,16 @@ interface Ethernet19
 interface Ethernet20
    description CUSTOM_server13_disabled_interfaces_Eth1
    shutdown
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
 !
 interface Ethernet21
    description CUSTOM_server14_explicitly_enabled_interfaces_Eth1
    no shutdown
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
 !
 interface Ethernet22
    description CUSTOM_server15_port_channel_disabled_interfaces_Eth1
@@ -402,32 +402,32 @@ interface Ethernet22
 interface Ethernet41
    description CUSTOM_P2P_LINK_TO_DC1-SPINE1_Ethernet4
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.49/31
 !
 interface Ethernet42
    description CUSTOM_P2P_LINK_TO_DC1-SPINE2_Ethernet4
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.51/31
 !
 interface Ethernet43
    description CUSTOM_P2P_LINK_TO_DC1-SPINE3_Ethernet4
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.53/31
 !
 interface Ethernet44
    description CUSTOM_P2P_LINK_TO_DC1-SPINE4_Ethernet4
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.55/31
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
@@ -301,42 +301,42 @@ interface Ethernet11
    description CUSTOM_server04_inherit_all_from_profile_Eth2
    no shutdown
    l2 mtu 8000
-   switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   spanning-tree portfast
-   spanning-tree bpdufilter enable
+   switchport
    storm-control all level 10
    storm-control broadcast level pps 100
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast
+   spanning-tree bpdufilter enable
 !
 interface Ethernet12
    description CUSTOM_server05_no_profile_Eth2
    no shutdown
-   switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   spanning-tree portfast
-   spanning-tree bpdufilter enable
+   switchport
    storm-control all level 10
    storm-control broadcast level pps 100
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast
+   spanning-tree bpdufilter enable
 !
 interface Ethernet13
    description CUSTOM_server06_override_profile_Eth2
    no shutdown
    l2 mtu 8000
-   switchport
    switchport access vlan 210
    switchport mode access
-   spanning-tree portfast network
-   spanning-tree bpduguard enable
+   switchport
    storm-control all level pps 20
    storm-control broadcast level 200
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast network
+   spanning-tree bpduguard enable
 !
 interface Ethernet14
    description CUSTOM_server07_inherit_all_from_profile_port_channel_Eth2
@@ -352,15 +352,15 @@ interface Ethernet16
    description CUSTOM_server09_override_profile_no_port_channel_Eth2
    no shutdown
    l2 mtu 8000
-   switchport
    switchport access vlan 210
    switchport mode access
-   spanning-tree portfast network
-   spanning-tree bpduguard enable
+   switchport
    storm-control all level pps 20
    storm-control broadcast level 200
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast network
+   spanning-tree bpduguard enable
 !
 interface Ethernet17
    description CUSTOM_server10_no_profile_port_channel_lacp_fallback_Eth2
@@ -383,16 +383,16 @@ interface Ethernet19
 interface Ethernet20
    description CUSTOM_server13_disabled_interfaces_Eth2
    shutdown
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
 !
 interface Ethernet21
    description CUSTOM_server14_explicitly_enabled_interfaces_Eth2
    no shutdown
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
 !
 interface Ethernet22
    description CUSTOM_server15_port_channel_disabled_interfaces_Eth2
@@ -402,32 +402,32 @@ interface Ethernet22
 interface Ethernet41
    description CUSTOM_P2P_LINK_TO_DC1-SPINE1_Ethernet5
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.65/31
 !
 interface Ethernet42
    description CUSTOM_P2P_LINK_TO_DC1-SPINE2_Ethernet5
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.67/31
 !
 interface Ethernet43
    description CUSTOM_P2P_LINK_TO_DC1-SPINE3_Ethernet5
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.69/31
 !
 interface Ethernet44
    description CUSTOM_P2P_LINK_TO_DC1-SPINE4_Ethernet5
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.71/31
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -316,22 +316,22 @@ interface Ethernet4
 interface Ethernet6
    description server02_SINGLE_NODE_TRUNK_Eth1
    no shutdown
-   switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   spanning-tree portfast
-   spanning-tree bpdufilter enable
+   switchport
    storm-control all level 10
    storm-control broadcast level pps 100
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast
+   spanning-tree bpdufilter enable
 !
 interface Ethernet7
    description server02_SINGLE_NODE_Eth1
    no shutdown
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
 ```
 
 ## Loopback Interfaces

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -492,41 +492,41 @@ interface Ethernet10
 interface Ethernet11
    description server04_inherit_all_from_profile_Eth1
    no shutdown
-   switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   spanning-tree portfast
-   spanning-tree bpdufilter enable
+   switchport
    storm-control all level 10
    storm-control broadcast level pps 100
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast
+   spanning-tree bpdufilter enable
 !
 interface Ethernet12
    description server05_no_profile_Eth1
    no shutdown
-   switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   spanning-tree portfast
-   spanning-tree bpdufilter enable
+   switchport
    storm-control all level 10
    storm-control broadcast level pps 100
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast
+   spanning-tree bpdufilter enable
 !
 interface Ethernet13
    description server06_override_profile_Eth1
    no shutdown
-   switchport
    switchport access vlan 210
    switchport mode access
-   spanning-tree portfast network
-   spanning-tree bpduguard enable
+   switchport
    storm-control all level pps 20
    storm-control broadcast level 200
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast network
+   spanning-tree bpduguard enable
 !
 interface Ethernet14
    description server07_inherit_all_from_profile_port_channel_Eth1
@@ -541,15 +541,15 @@ interface Ethernet15
 interface Ethernet16
    description server09_override_profile_no_port_channel_Eth1
    no shutdown
-   switchport
    switchport access vlan 210
    switchport mode access
-   spanning-tree portfast network
-   spanning-tree bpduguard enable
+   switchport
    storm-control all level pps 20
    storm-control broadcast level 200
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast network
+   spanning-tree bpduguard enable
 ```
 
 ## Port-Channel Interfaces

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -486,41 +486,41 @@ interface Ethernet8
 interface Ethernet11
    description server04_inherit_all_from_profile_Eth2
    no shutdown
-   switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   spanning-tree portfast
-   spanning-tree bpdufilter enable
+   switchport
    storm-control all level 10
    storm-control broadcast level pps 100
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast
+   spanning-tree bpdufilter enable
 !
 interface Ethernet12
    description server05_no_profile_Eth2
    no shutdown
-   switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   spanning-tree portfast
-   spanning-tree bpdufilter enable
+   switchport
    storm-control all level 10
    storm-control broadcast level pps 100
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast
+   spanning-tree bpdufilter enable
 !
 interface Ethernet13
    description server06_override_profile_Eth2
    no shutdown
-   switchport
    switchport access vlan 210
    switchport mode access
-   spanning-tree portfast network
-   spanning-tree bpduguard enable
+   switchport
    storm-control all level pps 20
    storm-control broadcast level 200
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast network
+   spanning-tree bpduguard enable
 !
 interface Ethernet14
    description server07_inherit_all_from_profile_port_channel_Eth2
@@ -535,15 +535,15 @@ interface Ethernet15
 interface Ethernet16
    description server09_override_profile_no_port_channel_Eth2
    no shutdown
-   switchport
    switchport access vlan 210
    switchport mode access
-   spanning-tree portfast network
-   spanning-tree bpduguard enable
+   switchport
    storm-control all level pps 20
    storm-control broadcast level 200
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast network
+   spanning-tree bpduguard enable
 ```
 
 ## Port-Channel Interfaces

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
@@ -79,22 +79,22 @@ interface Ethernet4
 interface Ethernet6
    description server02_SINGLE_NODE_TRUNK_Eth1
    no shutdown
-   switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   spanning-tree portfast
-   spanning-tree bpdufilter enable
+   switchport
    storm-control all level 10
    storm-control broadcast level pps 100
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast
+   spanning-tree bpdufilter enable
 !
 interface Ethernet7
    description server02_SINGLE_NODE_Eth1
    no shutdown
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
 !
 interface Loopback0
    description EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
@@ -255,41 +255,41 @@ interface Ethernet10
 interface Ethernet11
    description server04_inherit_all_from_profile_Eth1
    no shutdown
-   switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   spanning-tree portfast
-   spanning-tree bpdufilter enable
+   switchport
    storm-control all level 10
    storm-control broadcast level pps 100
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast
+   spanning-tree bpdufilter enable
 !
 interface Ethernet12
    description server05_no_profile_Eth1
    no shutdown
-   switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   spanning-tree portfast
-   spanning-tree bpdufilter enable
+   switchport
    storm-control all level 10
    storm-control broadcast level pps 100
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast
+   spanning-tree bpdufilter enable
 !
 interface Ethernet13
    description server06_override_profile_Eth1
    no shutdown
-   switchport
    switchport access vlan 210
    switchport mode access
-   spanning-tree portfast network
-   spanning-tree bpduguard enable
+   switchport
    storm-control all level pps 20
    storm-control broadcast level 200
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast network
+   spanning-tree bpduguard enable
 !
 interface Ethernet14
    description server07_inherit_all_from_profile_port_channel_Eth1
@@ -304,15 +304,15 @@ interface Ethernet15
 interface Ethernet16
    description server09_override_profile_no_port_channel_Eth1
    no shutdown
-   switchport
    switchport access vlan 210
    switchport mode access
-   spanning-tree portfast network
-   spanning-tree bpduguard enable
+   switchport
    storm-control all level pps 20
    storm-control broadcast level 200
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast network
+   spanning-tree bpduguard enable
 !
 interface Loopback0
    description EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
@@ -242,41 +242,41 @@ interface Ethernet8
 interface Ethernet11
    description server04_inherit_all_from_profile_Eth2
    no shutdown
-   switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   spanning-tree portfast
-   spanning-tree bpdufilter enable
+   switchport
    storm-control all level 10
    storm-control broadcast level pps 100
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast
+   spanning-tree bpdufilter enable
 !
 interface Ethernet12
    description server05_no_profile_Eth2
    no shutdown
-   switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   spanning-tree portfast
-   spanning-tree bpdufilter enable
+   switchport
    storm-control all level 10
    storm-control broadcast level pps 100
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast
+   spanning-tree bpdufilter enable
 !
 interface Ethernet13
    description server06_override_profile_Eth2
    no shutdown
-   switchport
    switchport access vlan 210
    switchport mode access
-   spanning-tree portfast network
-   spanning-tree bpduguard enable
+   switchport
    storm-control all level pps 20
    storm-control broadcast level 200
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast network
+   spanning-tree bpduguard enable
 !
 interface Ethernet14
    description server07_inherit_all_from_profile_port_channel_Eth2
@@ -291,15 +291,15 @@ interface Ethernet15
 interface Ethernet16
    description server09_override_profile_no_port_channel_Eth2
    no shutdown
-   switchport
    switchport access vlan 210
    switchport mode access
-   spanning-tree portfast network
-   spanning-tree bpduguard enable
+   switchport
    storm-control all level pps 20
    storm-control broadcast level 200
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast network
+   spanning-tree bpduguard enable
 !
 interface Loopback0
    description EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-SUPER-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC1-SUPER-SPINE1.md
@@ -198,8 +198,8 @@ interface Ethernet5
 interface Ethernet6
    description P2P_LINK_TO_DC2-SUPER-SPINE1_Ethernet4
    no shutdown
-   mac security profile MACSEC_PROFILE
    mtu 1499
+   mac security profile MACSEC_PROFILE
    no switchport
    ip address 11.1.2.0/31
    ptp enable

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC2-SUPER-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/documentation/devices/DC2-SUPER-SPINE1.md
@@ -211,8 +211,8 @@ interface Ethernet3
 interface Ethernet4
    description P2P_LINK_TO_DC1-SUPER-SPINE1_Ethernet6
    no shutdown
-   mac security profile MACSEC_PROFILE
    mtu 1499
+   mac security profile MACSEC_PROFILE
    no switchport
    ip address 11.1.2.1/31
    ptp enable

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/intended/configs/DC1-SUPER-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/intended/configs/DC1-SUPER-SPINE1.cfg
@@ -66,8 +66,8 @@ interface Ethernet5
 interface Ethernet6
    description P2P_LINK_TO_DC2-SUPER-SPINE1_Ethernet4
    no shutdown
-   mac security profile MACSEC_PROFILE
    mtu 1499
+   mac security profile MACSEC_PROFILE
    no switchport
    ip address 11.1.2.0/31
    ptp enable

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/intended/configs/DC2-SUPER-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos/intended/configs/DC2-SUPER-SPINE1.cfg
@@ -48,8 +48,8 @@ interface Ethernet3
 interface Ethernet4
    description P2P_LINK_TO_DC1-SUPER-SPINE1_Ethernet6
    no shutdown
-   mac security profile MACSEC_PROFILE
    mtu 1499
+   mac security profile MACSEC_PROFILE
    no switchport
    ip address 11.1.2.1/31
    ptp enable

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -336,32 +336,32 @@ interface Ethernet10.200
 interface Ethernet41
    description P2P_LINK_TO_DC1-SPINE1_Ethernet6
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.81/31
 !
 interface Ethernet42
    description P2P_LINK_TO_DC1-SPINE2_Ethernet6
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.83/31
 !
 interface Ethernet43
    description P2P_LINK_TO_DC1-SPINE3_Ethernet6
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.85/31
 !
 interface Ethernet44
    description P2P_LINK_TO_DC1-SPINE4_Ethernet6
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.87/31
 !

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -334,32 +334,32 @@ interface Ethernet10.200
 interface Ethernet45
    description P2P_LINK_TO_DC1-SPINE1_Ethernet7
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.97/31
 !
 interface Ethernet46
    description P2P_LINK_TO_DC1-SPINE2_Ethernet7
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.99/31
 !
 interface Ethernet47
    description P2P_LINK_TO_DC1-SPINE3_Ethernet7
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.101/31
 !
 interface Ethernet48
    description P2P_LINK_TO_DC1-SPINE4_Ethernet7
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.103/31
 !

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -291,32 +291,32 @@ vlan 131
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet1
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.1/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet1
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.3/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet1
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.5/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet1
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.7/31
 !
@@ -324,22 +324,22 @@ interface Ethernet6
    description server02_SINGLE_NODE_TRUNK_Eth1
    no shutdown
    l2 mtu 8000
-   switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   spanning-tree portfast
-   spanning-tree bpdufilter enable
+   switchport
    storm-control all level 10
    storm-control broadcast level pps 100
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast
+   spanning-tree bpdufilter enable
 !
 interface Ethernet7
    description server02_SINGLE_NODE_Eth1
    no shutdown
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
 ```
 
 ## Loopback Interfaces

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -359,32 +359,32 @@ vlan 311
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet2
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.17/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet2
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.19/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet2
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.21/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet2
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.23/31
 !
@@ -431,9 +431,9 @@ interface Ethernet20
 interface Ethernet21
    description ROUTER01_Eth0
    no shutdown
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
 ```
 
 ## Port-Channel Interfaces

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -359,32 +359,32 @@ vlan 311
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet3
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.33/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet3
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.35/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet3
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.37/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet3
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.39/31
 !
@@ -431,9 +431,9 @@ interface Ethernet20
 interface Ethernet21
    description ROUTER01_Eth1
    no shutdown
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
 ```
 
 ## Port-Channel Interfaces

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE1.md
@@ -247,56 +247,56 @@ vlan internal order ascending range 1006 1199
 interface Ethernet1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet1
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.0/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-LEAF2A_Ethernet1
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.16/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-LEAF2B_Ethernet1
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.32/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SVC3A_Ethernet41
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.48/31
 !
 interface Ethernet5
    description P2P_LINK_TO_DC1-SVC3B_Ethernet41
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.64/31
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-BL1A_Ethernet41
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.80/31
 !
 interface Ethernet7
    description P2P_LINK_TO_DC1-BL1B_Ethernet45
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.96/31
 ```

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE2.md
@@ -247,56 +247,56 @@ vlan internal order ascending range 1006 1199
 interface Ethernet1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet2
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.2/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-LEAF2A_Ethernet2
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.18/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-LEAF2B_Ethernet2
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.34/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SVC3A_Ethernet42
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.50/31
 !
 interface Ethernet5
    description P2P_LINK_TO_DC1-SVC3B_Ethernet42
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.66/31
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-BL1A_Ethernet42
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.82/31
 !
 interface Ethernet7
    description P2P_LINK_TO_DC1-BL1B_Ethernet46
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.98/31
 ```

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE3.md
@@ -247,56 +247,56 @@ vlan internal order ascending range 1006 1199
 interface Ethernet1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet3
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.4/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-LEAF2A_Ethernet3
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.20/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-LEAF2B_Ethernet3
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.36/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SVC3A_Ethernet43
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.52/31
 !
 interface Ethernet5
    description P2P_LINK_TO_DC1-SVC3B_Ethernet43
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.68/31
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-BL1A_Ethernet43
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.84/31
 !
 interface Ethernet7
    description P2P_LINK_TO_DC1-BL1B_Ethernet47
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.100/31
 ```

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SPINE4.md
@@ -247,56 +247,56 @@ vlan internal order ascending range 1006 1199
 interface Ethernet1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet4
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.6/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-LEAF2A_Ethernet4
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.22/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-LEAF2B_Ethernet4
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.38/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SVC3A_Ethernet44
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.54/31
 !
 interface Ethernet5
    description P2P_LINK_TO_DC1-SVC3B_Ethernet44
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.70/31
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-BL1A_Ethernet44
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.86/31
 !
 interface Ethernet7
    description P2P_LINK_TO_DC1-BL1B_Ethernet48
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.102/31
 ```

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -471,42 +471,42 @@ interface Ethernet11
    description server04_inherit_all_from_profile_Eth1
    no shutdown
    l2 mtu 8000
-   switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   spanning-tree portfast
-   spanning-tree bpdufilter enable
+   switchport
    storm-control all level 10
    storm-control broadcast level pps 100
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast
+   spanning-tree bpdufilter enable
 !
 interface Ethernet12
    description server05_no_profile_Eth1
    no shutdown
-   switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   spanning-tree portfast
-   spanning-tree bpdufilter enable
+   switchport
    storm-control all level 10
    storm-control broadcast level pps 100
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast
+   spanning-tree bpdufilter enable
 !
 interface Ethernet13
    description server06_override_profile_Eth1
    no shutdown
    l2 mtu 8000
-   switchport
    switchport access vlan 210
    switchport mode access
-   spanning-tree portfast network
-   spanning-tree bpduguard enable
+   switchport
    storm-control all level pps 20
    storm-control broadcast level 200
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast network
+   spanning-tree bpduguard enable
 !
 interface Ethernet14
    description server07_inherit_all_from_profile_port_channel_Eth1
@@ -522,15 +522,15 @@ interface Ethernet16
    description server09_override_profile_no_port_channel_Eth1
    no shutdown
    l2 mtu 8000
-   switchport
    switchport access vlan 210
    switchport mode access
-   spanning-tree portfast network
-   spanning-tree bpduguard enable
+   switchport
    storm-control all level pps 20
    storm-control broadcast level 200
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast network
+   spanning-tree bpduguard enable
 !
 interface Ethernet17
    description server10_no_profile_port_channel_lacp_fallback_Eth1
@@ -553,32 +553,32 @@ interface Ethernet19
 interface Ethernet41
    description P2P_LINK_TO_DC1-SPINE1_Ethernet4
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.49/31
 !
 interface Ethernet42
    description P2P_LINK_TO_DC1-SPINE2_Ethernet4
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.51/31
 !
 interface Ethernet43
    description P2P_LINK_TO_DC1-SPINE3_Ethernet4
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.53/31
 !
 interface Ethernet44
    description P2P_LINK_TO_DC1-SPINE4_Ethernet4
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.55/31
 ```

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -471,42 +471,42 @@ interface Ethernet11
    description server04_inherit_all_from_profile_Eth2
    no shutdown
    l2 mtu 8000
-   switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   spanning-tree portfast
-   spanning-tree bpdufilter enable
+   switchport
    storm-control all level 10
    storm-control broadcast level pps 100
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast
+   spanning-tree bpdufilter enable
 !
 interface Ethernet12
    description server05_no_profile_Eth2
    no shutdown
-   switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   spanning-tree portfast
-   spanning-tree bpdufilter enable
+   switchport
    storm-control all level 10
    storm-control broadcast level pps 100
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast
+   spanning-tree bpdufilter enable
 !
 interface Ethernet13
    description server06_override_profile_Eth2
    no shutdown
    l2 mtu 8000
-   switchport
    switchport access vlan 210
    switchport mode access
-   spanning-tree portfast network
-   spanning-tree bpduguard enable
+   switchport
    storm-control all level pps 20
    storm-control broadcast level 200
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast network
+   spanning-tree bpduguard enable
 !
 interface Ethernet14
    description server07_inherit_all_from_profile_port_channel_Eth2
@@ -522,15 +522,15 @@ interface Ethernet16
    description server09_override_profile_no_port_channel_Eth2
    no shutdown
    l2 mtu 8000
-   switchport
    switchport access vlan 210
    switchport mode access
-   spanning-tree portfast network
-   spanning-tree bpduguard enable
+   switchport
    storm-control all level pps 20
    storm-control broadcast level 200
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast network
+   spanning-tree bpduguard enable
 !
 interface Ethernet17
    description server10_no_profile_port_channel_lacp_fallback_Eth2
@@ -553,32 +553,32 @@ interface Ethernet19
 interface Ethernet41
    description P2P_LINK_TO_DC1-SPINE1_Ethernet5
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.65/31
 !
 interface Ethernet42
    description P2P_LINK_TO_DC1-SPINE2_Ethernet5
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.67/31
 !
 interface Ethernet43
    description P2P_LINK_TO_DC1-SPINE3_Ethernet5
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.69/31
 !
 interface Ethernet44
    description P2P_LINK_TO_DC1-SPINE4_Ethernet5
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.71/31
 ```

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1A.cfg
@@ -103,32 +103,32 @@ interface Ethernet10.200
 interface Ethernet41
    description P2P_LINK_TO_DC1-SPINE1_Ethernet6
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.81/31
 !
 interface Ethernet42
    description P2P_LINK_TO_DC1-SPINE2_Ethernet6
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.83/31
 !
 interface Ethernet43
    description P2P_LINK_TO_DC1-SPINE3_Ethernet6
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.85/31
 !
 interface Ethernet44
    description P2P_LINK_TO_DC1-SPINE4_Ethernet6
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.87/31
 !

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1B.cfg
@@ -102,32 +102,32 @@ interface Ethernet10.200
 interface Ethernet45
    description P2P_LINK_TO_DC1-SPINE1_Ethernet7
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.97/31
 !
 interface Ethernet46
    description P2P_LINK_TO_DC1-SPINE2_Ethernet7
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.99/31
 !
 interface Ethernet47
    description P2P_LINK_TO_DC1-SPINE3_Ethernet7
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.101/31
 !
 interface Ethernet48
    description P2P_LINK_TO_DC1-SPINE4_Ethernet7
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.103/31
 !

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
@@ -53,32 +53,32 @@ vrf instance Tenant_A_WEB_Zone
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet1
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.1/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet1
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.3/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet1
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.5/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet1
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.7/31
 !
@@ -86,22 +86,22 @@ interface Ethernet6
    description server02_SINGLE_NODE_TRUNK_Eth1
    no shutdown
    l2 mtu 8000
-   switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   spanning-tree portfast
-   spanning-tree bpdufilter enable
+   switchport
    storm-control all level 10
    storm-control broadcast level pps 100
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast
+   spanning-tree bpdufilter enable
 !
 interface Ethernet7
    description server02_SINGLE_NODE_Eth1
    no shutdown
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
 !
 interface Loopback0
    description EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
@@ -147,32 +147,32 @@ interface Port-Channel20
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet2
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.17/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet2
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.19/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet2
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.21/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet2
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.23/31
 !
@@ -219,9 +219,9 @@ interface Ethernet20
 interface Ethernet21
    description ROUTER01_Eth0
    no shutdown
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
 !
 interface Loopback0
    description EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
@@ -147,32 +147,32 @@ interface Port-Channel20
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet3
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.33/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-SPINE2_Ethernet3
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.35/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE3_Ethernet3
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.37/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SPINE4_Ethernet3
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.39/31
 !
@@ -219,9 +219,9 @@ interface Ethernet20
 interface Ethernet21
    description ROUTER01_Eth1
    no shutdown
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
 !
 interface Loopback0
    description EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE1.cfg
@@ -33,56 +33,56 @@ vrf instance MGMT
 interface Ethernet1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet1
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.0/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-LEAF2A_Ethernet1
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.16/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-LEAF2B_Ethernet1
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.32/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SVC3A_Ethernet41
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.48/31
 !
 interface Ethernet5
    description P2P_LINK_TO_DC1-SVC3B_Ethernet41
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.64/31
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-BL1A_Ethernet41
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.80/31
 !
 interface Ethernet7
    description P2P_LINK_TO_DC1-BL1B_Ethernet45
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.96/31
 !

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE2.cfg
@@ -33,56 +33,56 @@ vrf instance MGMT
 interface Ethernet1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet2
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.2/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-LEAF2A_Ethernet2
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.18/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-LEAF2B_Ethernet2
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.34/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SVC3A_Ethernet42
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.50/31
 !
 interface Ethernet5
    description P2P_LINK_TO_DC1-SVC3B_Ethernet42
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.66/31
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-BL1A_Ethernet42
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.82/31
 !
 interface Ethernet7
    description P2P_LINK_TO_DC1-BL1B_Ethernet46
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.98/31
 !

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE3.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE3.cfg
@@ -33,56 +33,56 @@ vrf instance MGMT
 interface Ethernet1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet3
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.4/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-LEAF2A_Ethernet3
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.20/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-LEAF2B_Ethernet3
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.36/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SVC3A_Ethernet43
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.52/31
 !
 interface Ethernet5
    description P2P_LINK_TO_DC1-SVC3B_Ethernet43
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.68/31
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-BL1A_Ethernet43
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.84/31
 !
 interface Ethernet7
    description P2P_LINK_TO_DC1-BL1B_Ethernet47
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.100/31
 !

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE4.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE4.cfg
@@ -33,56 +33,56 @@ vrf instance MGMT
 interface Ethernet1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet4
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.6/31
 !
 interface Ethernet2
    description P2P_LINK_TO_DC1-LEAF2A_Ethernet4
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.22/31
 !
 interface Ethernet3
    description P2P_LINK_TO_DC1-LEAF2B_Ethernet4
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.38/31
 !
 interface Ethernet4
    description P2P_LINK_TO_DC1-SVC3A_Ethernet44
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.54/31
 !
 interface Ethernet5
    description P2P_LINK_TO_DC1-SVC3B_Ethernet44
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.70/31
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-BL1A_Ethernet44
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.86/31
 !
 interface Ethernet7
    description P2P_LINK_TO_DC1-BL1B_Ethernet48
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.102/31
 !

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
@@ -281,42 +281,42 @@ interface Ethernet11
    description server04_inherit_all_from_profile_Eth1
    no shutdown
    l2 mtu 8000
-   switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   spanning-tree portfast
-   spanning-tree bpdufilter enable
+   switchport
    storm-control all level 10
    storm-control broadcast level pps 100
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast
+   spanning-tree bpdufilter enable
 !
 interface Ethernet12
    description server05_no_profile_Eth1
    no shutdown
-   switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   spanning-tree portfast
-   spanning-tree bpdufilter enable
+   switchport
    storm-control all level 10
    storm-control broadcast level pps 100
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast
+   spanning-tree bpdufilter enable
 !
 interface Ethernet13
    description server06_override_profile_Eth1
    no shutdown
    l2 mtu 8000
-   switchport
    switchport access vlan 210
    switchport mode access
-   spanning-tree portfast network
-   spanning-tree bpduguard enable
+   switchport
    storm-control all level pps 20
    storm-control broadcast level 200
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast network
+   spanning-tree bpduguard enable
 !
 interface Ethernet14
    description server07_inherit_all_from_profile_port_channel_Eth1
@@ -332,15 +332,15 @@ interface Ethernet16
    description server09_override_profile_no_port_channel_Eth1
    no shutdown
    l2 mtu 8000
-   switchport
    switchport access vlan 210
    switchport mode access
-   spanning-tree portfast network
-   spanning-tree bpduguard enable
+   switchport
    storm-control all level pps 20
    storm-control broadcast level 200
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast network
+   spanning-tree bpduguard enable
 !
 interface Ethernet17
    description server10_no_profile_port_channel_lacp_fallback_Eth1
@@ -363,32 +363,32 @@ interface Ethernet19
 interface Ethernet41
    description P2P_LINK_TO_DC1-SPINE1_Ethernet4
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.49/31
 !
 interface Ethernet42
    description P2P_LINK_TO_DC1-SPINE2_Ethernet4
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.51/31
 !
 interface Ethernet43
    description P2P_LINK_TO_DC1-SPINE3_Ethernet4
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.53/31
 !
 interface Ethernet44
    description P2P_LINK_TO_DC1-SPINE4_Ethernet4
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.55/31
 !

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
@@ -281,42 +281,42 @@ interface Ethernet11
    description server04_inherit_all_from_profile_Eth2
    no shutdown
    l2 mtu 8000
-   switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   spanning-tree portfast
-   spanning-tree bpdufilter enable
+   switchport
    storm-control all level 10
    storm-control broadcast level pps 100
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast
+   spanning-tree bpdufilter enable
 !
 interface Ethernet12
    description server05_no_profile_Eth2
    no shutdown
-   switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   spanning-tree portfast
-   spanning-tree bpdufilter enable
+   switchport
    storm-control all level 10
    storm-control broadcast level pps 100
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast
+   spanning-tree bpdufilter enable
 !
 interface Ethernet13
    description server06_override_profile_Eth2
    no shutdown
    l2 mtu 8000
-   switchport
    switchport access vlan 210
    switchport mode access
-   spanning-tree portfast network
-   spanning-tree bpduguard enable
+   switchport
    storm-control all level pps 20
    storm-control broadcast level 200
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast network
+   spanning-tree bpduguard enable
 !
 interface Ethernet14
    description server07_inherit_all_from_profile_port_channel_Eth2
@@ -332,15 +332,15 @@ interface Ethernet16
    description server09_override_profile_no_port_channel_Eth2
    no shutdown
    l2 mtu 8000
-   switchport
    switchport access vlan 210
    switchport mode access
-   spanning-tree portfast network
-   spanning-tree bpduguard enable
+   switchport
    storm-control all level pps 20
    storm-control broadcast level 200
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast network
+   spanning-tree bpduguard enable
 !
 interface Ethernet17
    description server10_no_profile_port_channel_lacp_fallback_Eth2
@@ -363,32 +363,32 @@ interface Ethernet19
 interface Ethernet41
    description P2P_LINK_TO_DC1-SPINE1_Ethernet5
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.65/31
 !
 interface Ethernet42
    description P2P_LINK_TO_DC1-SPINE2_Ethernet5
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.67/31
 !
 interface Ethernet43
    description P2P_LINK_TO_DC1-SPINE3_Ethernet5
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.69/31
 !
 interface Ethernet44
    description P2P_LINK_TO_DC1-SPINE4_Ethernet5
    no shutdown
-   speed forced 100gfull
    mtu 1500
+   speed forced 100gfull
    no switchport
    ip address 172.31.255.71/31
 !

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -316,22 +316,22 @@ interface Ethernet4
 interface Ethernet6
    description server02_SINGLE_NODE_TRUNK_Eth1
    no shutdown
-   switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   spanning-tree portfast
-   spanning-tree bpdufilter enable
+   switchport
    storm-control all level 10
    storm-control broadcast level pps 100
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast
+   spanning-tree bpdufilter enable
 !
 interface Ethernet7
    description server02_SINGLE_NODE_Eth1
    no shutdown
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
 ```
 
 ## Loopback Interfaces

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -492,41 +492,41 @@ interface Ethernet10
 interface Ethernet11
    description server04_inherit_all_from_profile_Eth1
    no shutdown
-   switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   spanning-tree portfast
-   spanning-tree bpdufilter enable
+   switchport
    storm-control all level 10
    storm-control broadcast level pps 100
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast
+   spanning-tree bpdufilter enable
 !
 interface Ethernet12
    description server05_no_profile_Eth1
    no shutdown
-   switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   spanning-tree portfast
-   spanning-tree bpdufilter enable
+   switchport
    storm-control all level 10
    storm-control broadcast level pps 100
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast
+   spanning-tree bpdufilter enable
 !
 interface Ethernet13
    description server06_override_profile_Eth1
    no shutdown
-   switchport
    switchport access vlan 210
    switchport mode access
-   spanning-tree portfast network
-   spanning-tree bpduguard enable
+   switchport
    storm-control all level pps 20
    storm-control broadcast level 200
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast network
+   spanning-tree bpduguard enable
 !
 interface Ethernet14
    description server07_inherit_all_from_profile_port_channel_Eth1
@@ -541,15 +541,15 @@ interface Ethernet15
 interface Ethernet16
    description server09_override_profile_no_port_channel_Eth1
    no shutdown
-   switchport
    switchport access vlan 210
    switchport mode access
-   spanning-tree portfast network
-   spanning-tree bpduguard enable
+   switchport
    storm-control all level pps 20
    storm-control broadcast level 200
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast network
+   spanning-tree bpduguard enable
 ```
 
 ## Port-Channel Interfaces

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -486,41 +486,41 @@ interface Ethernet8
 interface Ethernet11
    description server04_inherit_all_from_profile_Eth2
    no shutdown
-   switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   spanning-tree portfast
-   spanning-tree bpdufilter enable
+   switchport
    storm-control all level 10
    storm-control broadcast level pps 100
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast
+   spanning-tree bpdufilter enable
 !
 interface Ethernet12
    description server05_no_profile_Eth2
    no shutdown
-   switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   spanning-tree portfast
-   spanning-tree bpdufilter enable
+   switchport
    storm-control all level 10
    storm-control broadcast level pps 100
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast
+   spanning-tree bpdufilter enable
 !
 interface Ethernet13
    description server06_override_profile_Eth2
    no shutdown
-   switchport
    switchport access vlan 210
    switchport mode access
-   spanning-tree portfast network
-   spanning-tree bpduguard enable
+   switchport
    storm-control all level pps 20
    storm-control broadcast level 200
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast network
+   spanning-tree bpduguard enable
 !
 interface Ethernet14
    description server07_inherit_all_from_profile_port_channel_Eth2
@@ -535,15 +535,15 @@ interface Ethernet15
 interface Ethernet16
    description server09_override_profile_no_port_channel_Eth2
    no shutdown
-   switchport
    switchport access vlan 210
    switchport mode access
-   spanning-tree portfast network
-   spanning-tree bpduguard enable
+   switchport
    storm-control all level pps 20
    storm-control broadcast level 200
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast network
+   spanning-tree bpduguard enable
 ```
 
 ## Port-Channel Interfaces

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
@@ -79,22 +79,22 @@ interface Ethernet4
 interface Ethernet6
    description server02_SINGLE_NODE_TRUNK_Eth1
    no shutdown
-   switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   spanning-tree portfast
-   spanning-tree bpdufilter enable
+   switchport
    storm-control all level 10
    storm-control broadcast level pps 100
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast
+   spanning-tree bpdufilter enable
 !
 interface Ethernet7
    description server02_SINGLE_NODE_Eth1
    no shutdown
-   switchport
    switchport access vlan 110
    switchport mode access
+   switchport
 !
 interface Loopback0
    description EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
@@ -255,41 +255,41 @@ interface Ethernet10
 interface Ethernet11
    description server04_inherit_all_from_profile_Eth1
    no shutdown
-   switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   spanning-tree portfast
-   spanning-tree bpdufilter enable
+   switchport
    storm-control all level 10
    storm-control broadcast level pps 100
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast
+   spanning-tree bpdufilter enable
 !
 interface Ethernet12
    description server05_no_profile_Eth1
    no shutdown
-   switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   spanning-tree portfast
-   spanning-tree bpdufilter enable
+   switchport
    storm-control all level 10
    storm-control broadcast level pps 100
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast
+   spanning-tree bpdufilter enable
 !
 interface Ethernet13
    description server06_override_profile_Eth1
    no shutdown
-   switchport
    switchport access vlan 210
    switchport mode access
-   spanning-tree portfast network
-   spanning-tree bpduguard enable
+   switchport
    storm-control all level pps 20
    storm-control broadcast level 200
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast network
+   spanning-tree bpduguard enable
 !
 interface Ethernet14
    description server07_inherit_all_from_profile_port_channel_Eth1
@@ -304,15 +304,15 @@ interface Ethernet15
 interface Ethernet16
    description server09_override_profile_no_port_channel_Eth1
    no shutdown
-   switchport
    switchport access vlan 210
    switchport mode access
-   spanning-tree portfast network
-   spanning-tree bpduguard enable
+   switchport
    storm-control all level pps 20
    storm-control broadcast level 200
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast network
+   spanning-tree bpduguard enable
 !
 interface Loopback0
    description EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
@@ -242,41 +242,41 @@ interface Ethernet8
 interface Ethernet11
    description server04_inherit_all_from_profile_Eth2
    no shutdown
-   switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   spanning-tree portfast
-   spanning-tree bpdufilter enable
+   switchport
    storm-control all level 10
    storm-control broadcast level pps 100
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast
+   spanning-tree bpdufilter enable
 !
 interface Ethernet12
    description server05_no_profile_Eth2
    no shutdown
-   switchport
    switchport trunk allowed vlan 1-4094
    switchport mode trunk
-   spanning-tree portfast
-   spanning-tree bpdufilter enable
+   switchport
    storm-control all level 10
    storm-control broadcast level pps 100
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast
+   spanning-tree bpdufilter enable
 !
 interface Ethernet13
    description server06_override_profile_Eth2
    no shutdown
-   switchport
    switchport access vlan 210
    switchport mode access
-   spanning-tree portfast network
-   spanning-tree bpduguard enable
+   switchport
    storm-control all level pps 20
    storm-control broadcast level 200
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast network
+   spanning-tree bpduguard enable
 !
 interface Ethernet14
    description server07_inherit_all_from_profile_port_channel_Eth2
@@ -291,15 +291,15 @@ interface Ethernet15
 interface Ethernet16
    description server09_override_profile_no_port_channel_Eth2
    no shutdown
-   switchport
    switchport access vlan 210
    switchport mode access
-   spanning-tree portfast network
-   spanning-tree bpduguard enable
+   switchport
    storm-control all level pps 20
    storm-control broadcast level 200
    storm-control multicast level 1
    storm-control unknown-unicast level 2
+   spanning-tree portfast network
+   spanning-tree bpduguard enable
 !
 interface Loopback0
    description EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -1,50 +1,54 @@
 {# eos - Ethernet Interfaces #}
 {% for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort %}
-!
-interface {{ ethernet_interface }}
-{%     if ethernet_interfaces[ethernet_interface].description is arista.avd.defined %}
-   description {{ ethernet_interfaces[ethernet_interface].description }}
-{%     endif %}
-{%     if ethernet_interfaces[ethernet_interface].logging.event.link_status is arista.avd.defined(true) %}
-   logging event link-status
-{%     elif ethernet_interfaces[ethernet_interface].logging.event.link_status is arista.avd.defined(false) %}
-   no logging event link-status
-{%     endif %}
-{%     if ethernet_interfaces[ethernet_interface].shutdown is arista.avd.defined(true) %}
-   shutdown
-{%     elif ethernet_interfaces[ethernet_interface].shutdown is arista.avd.defined(false) %}
-   no shutdown
-{%     endif %}
-{%     if ethernet_interfaces[ethernet_interface].speed is arista.avd.defined %}
-   speed {{ ethernet_interfaces[ethernet_interface].speed }}
-{%     endif %}
-{%     if ethernet_interfaces[ethernet_interface].mac_security.profile is arista.avd.defined %}
-   mac security profile {{ ethernet_interfaces[ethernet_interface].mac_security.profile }}
-{%     endif %}
 {%     if ethernet_interfaces[ethernet_interface].channel_group.id is arista.avd.defined and ethernet_interfaces[ethernet_interface].channel_group.mode is arista.avd.defined %}
-   channel-group {{ ethernet_interfaces[ethernet_interface].channel_group.id }} mode {{ ethernet_interfaces[ethernet_interface].channel_group.mode }}
-{%         if ethernet_interfaces[ethernet_interface].lacp_port_priority is arista.avd.defined %}
-   lacp port-priority {{ ethernet_interfaces[ethernet_interface].lacp_port_priority }}
-{%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].lacp_timer.mode is arista.avd.defined %}
-   lacp timer {{ ethernet_interfaces[ethernet_interface].lacp_timer.mode }}
-{%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].lacp_timer.multiplier is arista.avd.defined %}
-   lacp timer multiplier {{ ethernet_interfaces[ethernet_interface].lacp_timer.multiplier }}
-{%         endif %}
 {%         if port_channel_interfaces['Port-Channel' ~ ethernet_interfaces[ethernet_interface].channel_group.id].lacp_fallback_mode is arista.avd.defined("individual") %}
 {%             set print_ethernet = true %}
 {%         endif %}
 {%     else %}
 {%         set print_ethernet = true %}
 {%     endif %}
+!
+interface {{ ethernet_interface }}
+{%     if print_ethernet is arista.avd.defined(true) %}
+{%         if ethernet_interfaces[ethernet_interface].profile is arista.avd.defined %}
+   profile {{ ethernet_interfaces[ethernet_interface].profile }}
+{%         endif %}
+{%     endif %}
+{%     if ethernet_interfaces[ethernet_interface].description is arista.avd.defined %}
+   description {{ ethernet_interfaces[ethernet_interface].description }}
+{%     endif %}
+{%     if ethernet_interfaces[ethernet_interface].shutdown is arista.avd.defined(true) %}
+   shutdown
+{%     elif ethernet_interfaces[ethernet_interface].shutdown is arista.avd.defined(false) %}
+   no shutdown
+{%     endif %}
 {%     if print_ethernet is arista.avd.defined(true) %}
 {%         if ethernet_interfaces[ethernet_interface].mtu is arista.avd.defined %}
    mtu {{ ethernet_interfaces[ethernet_interface].mtu }}
 {%         endif %}
+{%     endif %}
+{%     if ethernet_interfaces[ethernet_interface].logging.event.link_status is arista.avd.defined(true) %}
+   logging event link-status
+{%     elif ethernet_interfaces[ethernet_interface].logging.event.link_status is arista.avd.defined(false) %}
+   no logging event link-status
+{%     endif %}
+{%     if print_ethernet is arista.avd.defined(true) %}
+{%         if ethernet_interfaces[ethernet_interface].flowcontrol.received is arista.avd.defined %}
+   flowcontrol receive {{ ethernet_interfaces[ethernet_interface].flowcontrol.received }}
+{%         endif %}
+{%     endif %}
+{%     if ethernet_interfaces[ethernet_interface].speed is arista.avd.defined %}
+   speed {{ ethernet_interfaces[ethernet_interface].speed }}
+{%     endif %}
+{%     if print_ethernet is arista.avd.defined(true) %}
 {%         if ethernet_interfaces[ethernet_interface].l2_mtu is arista.avd.defined %}
    l2 mtu {{ ethernet_interfaces[ethernet_interface].l2_mtu }}
 {%         endif %}
+{%     endif %}
+{%     if ethernet_interfaces[ethernet_interface].mac_security.profile is arista.avd.defined %}
+   mac security profile {{ ethernet_interfaces[ethernet_interface].mac_security.profile }}
+{%     endif %}
+{%     if print_ethernet is arista.avd.defined(true) %}
 {%         if ethernet_interfaces[ethernet_interface].error_correction_encoding.enabled is arista.avd.defined(false) %}
    no error-correction encoding
 {%         else %}
@@ -59,6 +63,47 @@ interface {{ ethernet_interface }}
    no error-correction encoding reed-solomon
 {%             endif %}
 {%         endif %}
+{%         if ethernet_interfaces[ethernet_interface].mode is arista.avd.defined('access') or ethernet_interfaces[ethernet_interface].mode is arista.avd.defined('dot1q-tunnel') %}
+{%             if ethernet_interfaces[ethernet_interface].vlans is arista.avd.defined %}
+   switchport access vlan {{ ethernet_interfaces[ethernet_interface].vlans }}
+{%             endif %}
+{%         endif %}
+{%         if ethernet_interfaces[ethernet_interface].mode is arista.avd.defined('trunk') %}
+{%             if ethernet_interfaces[ethernet_interface].native_vlan is arista.avd.defined %}
+   switchport trunk native vlan {{ ethernet_interfaces[ethernet_interface].native_vlan }}
+{%             endif %}
+{%         endif %}
+{%         if ethernet_interfaces[ethernet_interface].mode is arista.avd.defined("trunk phone") and ethernet_interfaces[ethernet_interface].native_vlan %}
+   switchport trunk native vlan {{ ethernet_interfaces[ethernet_interface].native_vlan }}
+{%         endif %}
+{%         if ethernet_interfaces[ethernet_interface].phone.vlan is arista.avd.defined %}
+   switchport phone vlan {{ ethernet_interfaces[ethernet_interface].phone.vlan }}
+{%         endif %}
+{%         if ethernet_interfaces[ethernet_interface].phone.trunk is arista.avd.defined %}
+   switchport phone trunk {{ ethernet_interfaces[ethernet_interface].phone.trunk }}
+{%         endif %}
+{%         for vlan_translation in ethernet_interfaces[ethernet_interface].vlan_translations | arista.avd.natural_sort %}
+{%             if vlan_translation.from is arista.avd.defined and vlan_translation.to is arista.avd.defined %}
+{%                 set vlan_translation_cli = 'switchport vlan translation' %}
+{%                 if vlan_translation.direction | arista.avd.default in ['in', 'out'] %}
+{%                     set vlan_translation_cli = vlan_translation_cli ~ ' ' ~ vlan_translation.direction %}
+{%                 endif %}
+{%                 set vlan_translation_cli = vlan_translation_cli ~ ' ' ~ vlan_translation.from %}
+{%                 set vlan_translation_cli = vlan_translation_cli ~ ' ' ~ vlan_translation.to %}
+   {{ vlan_translation_cli }}
+{%             endif %}
+{%         endfor %}
+{%         if ethernet_interfaces[ethernet_interface].mode is arista.avd.defined('trunk') %}
+{%             if ethernet_interfaces[ethernet_interface].vlans is arista.avd.defined %}
+   switchport trunk allowed vlan {{ ethernet_interfaces[ethernet_interface].vlans }}
+{%             endif %}
+{%         endif %}
+{%         if ethernet_interfaces[ethernet_interface].mode is arista.avd.defined %}
+   switchport mode {{ ethernet_interfaces[ethernet_interface].mode }}
+{%         endif %}
+{%         for trunk_group in ethernet_interfaces[ethernet_interface].trunk_groups | arista.avd.natural_sort %}
+   switchport trunk group {{ trunk_group }}
+{%         endfor %}
 {%         if ethernet_interfaces[ethernet_interface].type is arista.avd.defined('routed') %}
    no switchport
 {%         elif ethernet_interfaces[ethernet_interface].type | arista.avd.default in ['l3dot1q', 'l2dot1q'] %}
@@ -92,37 +137,6 @@ interface {{ ethernet_interface }}
 {%         else %}
    switchport
 {%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].flowcontrol.received is arista.avd.defined %}
-   flowcontrol receive {{ ethernet_interfaces[ethernet_interface].flowcontrol.received }}
-{%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].mode is arista.avd.defined('access') or ethernet_interfaces[ethernet_interface].mode is arista.avd.defined('dot1q-tunnel') %}
-{%             if ethernet_interfaces[ethernet_interface].vlans is arista.avd.defined %}
-   switchport access vlan {{ ethernet_interfaces[ethernet_interface].vlans }}
-{%             endif %}
-{%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].mode is arista.avd.defined('trunk') %}
-{%             if ethernet_interfaces[ethernet_interface].vlans is arista.avd.defined %}
-   switchport trunk allowed vlan {{ ethernet_interfaces[ethernet_interface].vlans }}
-{%             endif %}
-{%             if ethernet_interfaces[ethernet_interface].native_vlan is arista.avd.defined %}
-   switchport trunk native vlan {{ ethernet_interfaces[ethernet_interface].native_vlan }}
-{%             endif %}
-{%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].mode is arista.avd.defined("trunk phone") and ethernet_interfaces[ethernet_interface].native_vlan %}
-   switchport trunk native vlan {{ ethernet_interfaces[ethernet_interface].native_vlan }}
-{%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].phone.vlan is arista.avd.defined %}
-   switchport phone vlan {{ ethernet_interfaces[ethernet_interface].phone.vlan }}
-{%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].phone.trunk is arista.avd.defined %}
-   switchport phone trunk {{ ethernet_interfaces[ethernet_interface].phone.trunk }}
-{%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].mode is arista.avd.defined %}
-   switchport mode {{ ethernet_interfaces[ethernet_interface].mode }}
-{%         endif %}
-{%         for trunk_group in ethernet_interfaces[ethernet_interface].trunk_groups | arista.avd.natural_sort %}
-   switchport trunk group {{ trunk_group }}
-{%         endfor %}
 {%         if ethernet_interfaces[ethernet_interface].trunk_private_vlan_secondary is arista.avd.defined(true) %}
    switchport trunk private-vlan secondary
 {%         elif ethernet_interfaces[ethernet_interface].trunk_private_vlan_secondary is arista.avd.defined(false) %}
@@ -131,17 +145,6 @@ interface {{ ethernet_interface }}
 {%         if ethernet_interfaces[ethernet_interface].pvlan_mapping is arista.avd.defined %}
    switchport pvlan mapping {{ ethernet_interfaces[ethernet_interface].pvlan_mapping }}
 {%         endif %}
-{%         for vlan_translation in ethernet_interfaces[ethernet_interface].vlan_translations | arista.avd.natural_sort %}
-{%             if vlan_translation.from is arista.avd.defined and vlan_translation.to is arista.avd.defined %}
-{%                 set vlan_translation_cli = 'switchport vlan translation' %}
-{%                 if vlan_translation.direction | arista.avd.default in ['in', 'out'] %}
-{%                     set vlan_translation_cli = vlan_translation_cli ~ ' ' ~ vlan_translation.direction %}
-{%                 endif %}
-{%                 set vlan_translation_cli = vlan_translation_cli ~ ' ' ~ vlan_translation.from %}
-{%                 set vlan_translation_cli = vlan_translation_cli ~ ' ' ~ vlan_translation.to %}
-   {{ vlan_translation_cli }}
-{%             endif %}
-{%         endfor %}
 {%         if ethernet_interfaces[ethernet_interface].l2_protocol.encapsulation_dot1q_vlan is arista.avd.defined %}
    l2-protocol encapsulation dot1q vlan {{ ethernet_interfaces[ethernet_interface].l2_protocol.encapsulation_dot1q_vlan }}
 {%         endif %}
@@ -186,55 +189,6 @@ interface {{ ethernet_interface }}
       route-target import {{ ethernet_interfaces[ethernet_interface].evpn_ethernet_segment.route_target }}
 {%             endif %}
 {%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].qos.trust is arista.avd.defined %}
-{%             if ethernet_interfaces[ethernet_interface].qos.trust == 'disabled' %}
-   no qos trust
-{%             else %}
-   qos trust {{ ethernet_interfaces[ethernet_interface].qos.trust }}
-{%             endif %}
-{%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].qos.dscp is arista.avd.defined %}
-   qos dscp {{ ethernet_interfaces[ethernet_interface].qos.dscp }}
-{%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].qos.cos is arista.avd.defined %}
-   qos cos {{ ethernet_interfaces[ethernet_interface].qos.cos }}
-{%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].priority_flow_control.enabled is arista.avd.defined(true) %}
-   priority-flow-control on
-{%         elif ethernet_interfaces[ethernet_interface].priority_flow_control.enabled is arista.avd.defined(false) %}
-   no priority-flow-control
-{%         endif %}
-{%         for priority_block in ethernet_interfaces[ethernet_interface].priority_flow_control.priorities | arista.avd.natural_sort %}
-{%             if priority_block.priority is arista.avd.defined %}
-{%                 if priority_block.no_drop is arista.avd.defined(true) %}
-   priority-flow-control priority {{ priority_block.priority }} no-drop
-{%                 elif priority_block.no_drop is arista.avd.defined(false) %}
-   priority-flow-control priority {{ priority_block.priority }} drop
-{%                 endif %}
-{%             endif %}
-{%         endfor %}
-{%         if ethernet_interfaces[ethernet_interface].spanning_tree_portfast is arista.avd.defined('edge') %}
-   spanning-tree portfast
-{%         elif ethernet_interfaces[ethernet_interface].spanning_tree_portfast is arista.avd.defined('network') %}
-   spanning-tree portfast network
-{%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].spanning_tree_bpduguard is arista.avd.defined(true) or ethernet_interfaces[ethernet_interface].spanning_tree_bpduguard is arista.avd.defined("enabled") %}
-   spanning-tree bpduguard enable
-{%         elif ethernet_interfaces[ethernet_interface].spanning_tree_bpduguard is arista.avd.defined("disabled") %}
-   spanning-tree bpduguard disable
-{%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].spanning_tree_bpdufilter is arista.avd.defined(true) or ethernet_interfaces[ethernet_interface].spanning_tree_bpdufilter is arista.avd.defined("enabled") %}
-   spanning-tree bpdufilter enable
-{%         elif ethernet_interfaces[ethernet_interface].spanning_tree_bpdufilter is arista.avd.defined("disabled") %}
-   spanning-tree bpdufilter disable
-{%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].spanning_tree_guard is arista.avd.defined %}
-{%             if ethernet_interfaces[ethernet_interface].spanning_tree_guard == 'disabled' %}
-   spanning-tree guard none
-{%             else %}
-   spanning-tree guard {{ ethernet_interfaces[ethernet_interface].spanning_tree_guard }}
-{%             endif %}
-{%         endif %}
 {%         if ethernet_interfaces[ethernet_interface].vrf is arista.avd.defined %}
    vrf {{ ethernet_interfaces[ethernet_interface].vrf }}
 {%         endif %}
@@ -248,6 +202,16 @@ interface {{ ethernet_interface }}
    ip address {{ ip_address_secondary }} secondary
 {%                 endfor %}
 {%             endif %}
+{%         endif %}
+{%         if ethernet_interfaces[ethernet_interface].bfd.interval is arista.avd.defined and
+              ethernet_interfaces[ethernet_interface].bfd.min_rx is arista.avd.defined and
+              ethernet_interfaces[ethernet_interface].bfd.multiplier is arista.avd.defined %}
+   bfd interval {{ ethernet_interfaces[ethernet_interface].bfd.interval }} min-rx {{ ethernet_interfaces[ethernet_interface].bfd.min_rx }} multiplier {{ ethernet_interfaces[ethernet_interface].bfd.multiplier }}
+{%         endif %}
+{%         if ethernet_interfaces[ethernet_interface].bfd.echo is arista.avd.defined(true) %}
+   bfd echo
+{%         elif ethernet_interfaces[ethernet_interface].bfd.echo is arista.avd.defined(false) %}
+   no bfd echo
 {%         endif %}
 {%         if ethernet_interfaces[ethernet_interface].ipv6_enable is arista.avd.defined(true) %}
    ipv6 enable
@@ -279,6 +243,37 @@ interface {{ ethernet_interface }}
    {{ ipv6_nd_prefix_cli }}
 {%             endfor %}
 {%         endif %}
+{%     endif %}
+{%     if ethernet_interfaces[ethernet_interface].channel_group.id is arista.avd.defined and ethernet_interfaces[ethernet_interface].channel_group.mode is arista.avd.defined %}
+   channel-group {{ ethernet_interfaces[ethernet_interface].channel_group.id }} mode {{ ethernet_interfaces[ethernet_interface].channel_group.mode }}
+{%         if ethernet_interfaces[ethernet_interface].lacp_timer.mode is arista.avd.defined %}
+   lacp timer {{ ethernet_interfaces[ethernet_interface].lacp_timer.mode }}
+{%         endif %}
+{%         if ethernet_interfaces[ethernet_interface].lacp_timer.multiplier is arista.avd.defined %}
+   lacp timer multiplier {{ ethernet_interfaces[ethernet_interface].lacp_timer.multiplier }}
+{%         endif %}
+{%         if ethernet_interfaces[ethernet_interface].lacp_port_priority is arista.avd.defined %}
+   lacp port-priority {{ ethernet_interfaces[ethernet_interface].lacp_port_priority }}
+{%         endif %}
+{%     endif %}
+{%     if print_ethernet is arista.avd.defined(true) %}
+{%         if ethernet_interfaces[ethernet_interface].mpls.ldp.igp_sync is arista.avd.defined(true) %}
+   mpls ldp igp sync
+{%         endif %}
+{%         if ethernet_interfaces[ethernet_interface].mpls.ldp.interface is arista.avd.defined(true) %}
+   mpls ldp interface
+{%         elif ethernet_interfaces[ethernet_interface].mpls.ldp.interface is arista.avd.defined(false) %}
+   no mpls ldp interface
+{%         endif %}
+{%         if ethernet_interfaces[ethernet_interface].lldp.transmit is arista.avd.defined(false) %}
+   no lldp transmit
+{%         endif %}
+{%         if ethernet_interfaces[ethernet_interface].lldp.receive is arista.avd.defined(false) %}
+   no lldp receive
+{%         endif %}
+{%         if ethernet_interfaces[ethernet_interface].lldp.ztp_vlan is arista.avd.defined %}
+   lldp tlv transmit ztp vlan {{ ethernet_interfaces[ethernet_interface].lldp.ztp_vlan }}
+{%         endif %}
 {%         if ethernet_interfaces[ethernet_interface].access_group_in is arista.avd.defined %}
    ip access-group {{ ethernet_interfaces[ethernet_interface].access_group_in }} in
 {%         endif %}
@@ -297,14 +292,16 @@ interface {{ ethernet_interface }}
 {%         if ethernet_interfaces[ethernet_interface].mac_access_group_out is arista.avd.defined %}
    mac access-group {{ ethernet_interfaces[ethernet_interface].mac_access_group_out }} out
 {%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].ospf_network_point_to_point is arista.avd.defined(true) %}
-   ip ospf network point-to-point
-{%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].ospf_area is arista.avd.defined %}
-   ip ospf area {{ ethernet_interfaces[ethernet_interface].ospf_area }}
+{%         if ethernet_interfaces[ethernet_interface].mpls.ip is arista.avd.defined(true) %}
+   mpls ip
+{%         elif ethernet_interfaces[ethernet_interface].mpls.ip is arista.avd.defined(false) %}
+   no mpls ip
 {%         endif %}
 {%         if ethernet_interfaces[ethernet_interface].ospf_cost is arista.avd.defined %}
    ip ospf cost {{ ethernet_interfaces[ethernet_interface].ospf_cost }}
+{%         endif %}
+{%         if ethernet_interfaces[ethernet_interface].ospf_network_point_to_point is arista.avd.defined(true) %}
+   ip ospf network point-to-point
 {%         endif %}
 {%         if ethernet_interfaces[ethernet_interface].ospf_authentication is arista.avd.defined('simple') %}
    ip ospf authentication
@@ -314,11 +311,92 @@ interface {{ ethernet_interface }}
 {%         if ethernet_interfaces[ethernet_interface].ospf_authentication_key is arista.avd.defined %}
    ip ospf authentication-key 7 {{ ethernet_interfaces[ethernet_interface].ospf_authentication_key }}
 {%         endif %}
+{%         if ethernet_interfaces[ethernet_interface].ospf_area is arista.avd.defined %}
+   ip ospf area {{ ethernet_interfaces[ethernet_interface].ospf_area }}
+{%         endif %}
 {%         for ospf_message_digest_key in ethernet_interfaces[ethernet_interface].ospf_message_digest_keys | arista.avd.natural_sort %}
 {%             if ethernet_interfaces[ethernet_interface].ospf_message_digest_keys[ospf_message_digest_key].hash_algorithm is arista.avd.defined and ethernet_interfaces[ethernet_interface].ospf_message_digest_keys[ospf_message_digest_key].key is arista.avd.defined %}
    ip ospf message-digest-key {{ ospf_message_digest_key }} {{ ethernet_interfaces[ethernet_interface].ospf_message_digest_keys[ospf_message_digest_key].hash_algorithm }} 7 {{ ethernet_interfaces[ethernet_interface].ospf_message_digest_keys[ospf_message_digest_key].key }}
 {%             endif %}
 {%         endfor %}
+{%         if ethernet_interfaces[ethernet_interface].pim.ipv4.sparse_mode is arista.avd.defined(true) %}
+   pim ipv4 sparse-mode
+{%         endif %}
+{%         if ethernet_interfaces[ethernet_interface].pim.ipv4.dr_priority is arista.avd.defined %}
+   pim ipv4 dr-priority {{ ethernet_interfaces[ethernet_interface].pim.ipv4.dr_priority }}
+{%         endif %}
+{%         if ethernet_interfaces[ethernet_interface].qos.trust is arista.avd.defined %}
+{%             if ethernet_interfaces[ethernet_interface].qos.trust == 'disabled' %}
+   no qos trust
+{%             else %}
+   qos trust {{ ethernet_interfaces[ethernet_interface].qos.trust }}
+{%             endif %}
+{%         endif %}
+{%         if ethernet_interfaces[ethernet_interface].qos.cos is arista.avd.defined %}
+   qos cos {{ ethernet_interfaces[ethernet_interface].qos.cos }}
+{%         endif %}
+{%         if ethernet_interfaces[ethernet_interface].qos.dscp is arista.avd.defined %}
+   qos dscp {{ ethernet_interfaces[ethernet_interface].qos.dscp }}
+{%         endif %}
+{%         if ethernet_interfaces[ethernet_interface].shape.rate is arista.avd.defined %}
+   shape rate {{ ethernet_interfaces[ethernet_interface].shape.rate }}
+{%         endif %}
+{%         if ethernet_interfaces[ethernet_interface].priority_flow_control.enabled is arista.avd.defined(true) %}
+   priority-flow-control on
+{%         elif ethernet_interfaces[ethernet_interface].priority_flow_control.enabled is arista.avd.defined(false) %}
+   no priority-flow-control
+{%         endif %}
+{%         for priority_block in ethernet_interfaces[ethernet_interface].priority_flow_control.priorities | arista.avd.natural_sort %}
+{%             if priority_block.priority is arista.avd.defined %}
+{%                 if priority_block.no_drop is arista.avd.defined(true) %}
+   priority-flow-control priority {{ priority_block.priority }} no-drop
+{%                 elif priority_block.no_drop is arista.avd.defined(false) %}
+   priority-flow-control priority {{ priority_block.priority }} drop
+{%                 endif %}
+{%             endif %}
+{%         endfor %}
+{%         for section in ethernet_interfaces[ethernet_interface].storm_control | arista.avd.natural_sort %}
+{%             if ethernet_interfaces[ethernet_interface].storm_control[section].level is arista.avd.defined %}
+{%                 if ethernet_interfaces[ethernet_interface].storm_control[section].unit is arista.avd.defined('pps') %}
+   storm-control {{ section | replace("_", "-") }} level pps {{ ethernet_interfaces[ethernet_interface].storm_control[section].level }}
+{%                 else %}
+   storm-control {{ section | replace("_", "-") }} level {{ ethernet_interfaces[ethernet_interface].storm_control[section].level }}
+{%                 endif %}
+{%             endif %}
+{%         endfor %}
+{%         if ethernet_interfaces[ethernet_interface].ptp.enable is arista.avd.defined(true) %}
+   ptp enable
+{%         endif %}
+{%         if ethernet_interfaces[ethernet_interface].ptp.sync_message.interval is arista.avd.defined %}
+   ptp sync-message interval {{ ethernet_interfaces[ethernet_interface].ptp.sync_message.interval }}
+{%         endif %}
+{%         if ethernet_interfaces[ethernet_interface].ptp.delay_mechanism is arista.avd.defined %}
+   ptp delay-mechanism {{ ethernet_interfaces[ethernet_interface].ptp.delay_mechanism }}
+{%         endif %}
+{%         if ethernet_interfaces[ethernet_interface].ptp.announce.interval is arista.avd.defined %}
+   ptp announce interval {{ ethernet_interfaces[ethernet_interface].ptp.announce.interval }}
+{%         endif %}
+{%         if ethernet_interfaces[ethernet_interface].ptp.transport is arista.avd.defined %}
+   ptp transport {{ ethernet_interfaces[ethernet_interface].ptp.transport }}
+{%         endif %}
+{%         if ethernet_interfaces[ethernet_interface].ptp.announce.timeout is arista.avd.defined %}
+   ptp announce timeout {{ ethernet_interfaces[ethernet_interface].ptp.announce.timeout }}
+{%         endif %}
+{%         if ethernet_interfaces[ethernet_interface].ptp.delay_req is arista.avd.defined %}
+   ptp delay-req interval {{ ethernet_interfaces[ethernet_interface].ptp.delay_req }}
+{%         endif %}
+{%         if ethernet_interfaces[ethernet_interface].ptp.role is arista.avd.defined %}
+   ptp role {{ ethernet_interfaces[ethernet_interface].ptp.role }}
+{%         endif %}
+{%         if ethernet_interfaces[ethernet_interface].ptp.vlan is arista.avd.defined %}
+   ptp vlan {{ ethernet_interfaces[ethernet_interface].ptp.vlan }}
+{%         endif %}
+{%         if ethernet_interfaces[ethernet_interface].service_policy.pbr.input is arista.avd.defined %}
+   service-policy type pbr input {{ ethernet_interfaces[ethernet_interface].service_policy.pbr.input }}
+{%         endif %}
+{%         if ethernet_interfaces[ethernet_interface].service_profile is arista.avd.defined %}
+   service-profile {{ ethernet_interfaces[ethernet_interface].service_profile }}
+{%         endif %}
 {%         if ethernet_interfaces[ethernet_interface].isis_enable is arista.avd.defined %}
    isis enable {{ ethernet_interfaces[ethernet_interface].isis_enable }}
 {%         endif %}
@@ -331,13 +409,13 @@ interface {{ ethernet_interface }}
 {%         if ethernet_interfaces[ethernet_interface].isis_passive is arista.avd.defined(true) %}
    isis passive
 {%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].isis_network_point_to_point is arista.avd.defined(true) %}
-   isis network point-to-point
-{%         endif %}
 {%         if ethernet_interfaces[ethernet_interface].isis_hello_padding is arista.avd.defined(false) %}
    no isis hello padding
 {%         elif ethernet_interfaces[ethernet_interface].isis_hello_padding is arista.avd.defined(true) %}
    isis hello padding
+{%         endif %}
+{%         if ethernet_interfaces[ethernet_interface].isis_network_point_to_point is arista.avd.defined(true) %}
+   isis network point-to-point
 {%         endif %}
 {%         if ethernet_interfaces[ethernet_interface].isis_authentication_mode is arista.avd.defined and
               ethernet_interfaces[ethernet_interface].isis_authentication_mode in ["text", "md5"] %}
@@ -346,94 +424,30 @@ interface {{ ethernet_interface }}
 {%         if ethernet_interfaces[ethernet_interface].isis_authentication_key is arista.avd.defined %}
    isis authentication key 7 {{ ethernet_interfaces[ethernet_interface].isis_authentication_key }}
 {%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].pim.ipv4.sparse_mode is arista.avd.defined(true) %}
-   pim ipv4 sparse-mode
+{%         if ethernet_interfaces[ethernet_interface].spanning_tree_portfast is arista.avd.defined('edge') %}
+   spanning-tree portfast
+{%         elif ethernet_interfaces[ethernet_interface].spanning_tree_portfast is arista.avd.defined('network') %}
+   spanning-tree portfast network
 {%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].pim.ipv4.dr_priority is arista.avd.defined %}
-   pim ipv4 dr-priority {{ ethernet_interfaces[ethernet_interface].pim.ipv4.dr_priority }}
+{%         if ethernet_interfaces[ethernet_interface].spanning_tree_bpduguard is arista.avd.defined(true) or ethernet_interfaces[ethernet_interface].spanning_tree_bpduguard is arista.avd.defined("enabled") %}
+   spanning-tree bpduguard enable
+{%         elif ethernet_interfaces[ethernet_interface].spanning_tree_bpduguard is arista.avd.defined("disabled") %}
+   spanning-tree bpduguard disable
+{%         endif %}
+{%         if ethernet_interfaces[ethernet_interface].spanning_tree_bpdufilter is arista.avd.defined(true) or ethernet_interfaces[ethernet_interface].spanning_tree_bpdufilter is arista.avd.defined("enabled") %}
+   spanning-tree bpdufilter enable
+{%         elif ethernet_interfaces[ethernet_interface].spanning_tree_bpdufilter is arista.avd.defined("disabled") %}
+   spanning-tree bpdufilter disable
+{%         endif %}
+{%         if ethernet_interfaces[ethernet_interface].spanning_tree_guard is arista.avd.defined %}
+{%             if ethernet_interfaces[ethernet_interface].spanning_tree_guard == 'disabled' %}
+   spanning-tree guard none
+{%             else %}
+   spanning-tree guard {{ ethernet_interfaces[ethernet_interface].spanning_tree_guard }}
+{%             endif %}
 {%         endif %}
 {%         if ethernet_interfaces[ethernet_interface].vmtracer is arista.avd.defined(true) %}
    vmtracer vmware-esx
-{%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].ptp.enable is arista.avd.defined(true) %}
-   ptp enable
-{%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].ptp.announce.interval is arista.avd.defined %}
-   ptp announce interval {{ ethernet_interfaces[ethernet_interface].ptp.announce.interval }}
-{%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].ptp.announce.timeout is arista.avd.defined %}
-   ptp announce timeout {{ ethernet_interfaces[ethernet_interface].ptp.announce.timeout }}
-{%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].ptp.delay_req is arista.avd.defined %}
-   ptp delay-req interval {{ ethernet_interfaces[ethernet_interface].ptp.delay_req }}
-{%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].ptp.delay_mechanism is arista.avd.defined %}
-   ptp delay-mechanism {{ ethernet_interfaces[ethernet_interface].ptp.delay_mechanism }}
-{%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].ptp.sync_message.interval is arista.avd.defined %}
-   ptp sync-message interval {{ ethernet_interfaces[ethernet_interface].ptp.sync_message.interval }}
-{%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].ptp.role is arista.avd.defined %}
-   ptp role {{ ethernet_interfaces[ethernet_interface].ptp.role }}
-{%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].ptp.vlan is arista.avd.defined %}
-   ptp vlan {{ ethernet_interfaces[ethernet_interface].ptp.vlan }}
-{%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].ptp.transport is arista.avd.defined %}
-   ptp transport {{ ethernet_interfaces[ethernet_interface].ptp.transport }}
-{%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].service_profile is arista.avd.defined %}
-   service-profile {{ ethernet_interfaces[ethernet_interface].service_profile }}
-{%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].profile is arista.avd.defined %}
-   profile {{ ethernet_interfaces[ethernet_interface].profile }}
-{%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].lldp.transmit is arista.avd.defined(false) %}
-   no lldp transmit
-{%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].lldp.receive is arista.avd.defined(false) %}
-   no lldp receive
-{%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].lldp.ztp_vlan is arista.avd.defined %}
-   lldp tlv transmit ztp vlan {{ ethernet_interfaces[ethernet_interface].lldp.ztp_vlan }}
-{%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].shape.rate is arista.avd.defined %}
-   shape rate {{ ethernet_interfaces[ethernet_interface].shape.rate }}
-{%         endif %}
-{%         for section in ethernet_interfaces[ethernet_interface].storm_control | arista.avd.natural_sort %}
-{%             if ethernet_interfaces[ethernet_interface].storm_control[section].level is arista.avd.defined %}
-{%                 if ethernet_interfaces[ethernet_interface].storm_control[section].unit is arista.avd.defined('pps') %}
-   storm-control {{ section | replace("_", "-") }} level pps {{ ethernet_interfaces[ethernet_interface].storm_control[section].level }}
-{%                 else %}
-   storm-control {{ section | replace("_", "-") }} level {{ ethernet_interfaces[ethernet_interface].storm_control[section].level }}
-{%                 endif %}
-{%             endif %}
-{%         endfor %}
-{%         if ethernet_interfaces[ethernet_interface].bfd.interval is arista.avd.defined and
-              ethernet_interfaces[ethernet_interface].bfd.min_rx is arista.avd.defined and
-              ethernet_interfaces[ethernet_interface].bfd.multiplier is arista.avd.defined %}
-   bfd interval {{ ethernet_interfaces[ethernet_interface].bfd.interval }} min-rx {{ ethernet_interfaces[ethernet_interface].bfd.min_rx }} multiplier {{ ethernet_interfaces[ethernet_interface].bfd.multiplier }}
-{%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].bfd.echo is arista.avd.defined(true) %}
-   bfd echo
-{%         elif ethernet_interfaces[ethernet_interface].bfd.echo is arista.avd.defined(false) %}
-   no bfd echo
-{%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].service_policy.pbr.input is arista.avd.defined %}
-   service-policy type pbr input {{ ethernet_interfaces[ethernet_interface].service_policy.pbr.input }}
-{%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].mpls.ip is arista.avd.defined(true) %}
-   mpls ip
-{%         elif ethernet_interfaces[ethernet_interface].mpls.ip is arista.avd.defined(false) %}
-   no mpls ip
-{%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].mpls.ldp.interface is arista.avd.defined(true) %}
-   mpls ldp interface
-{%         elif ethernet_interfaces[ethernet_interface].mpls.ldp.interface is arista.avd.defined(false) %}
-   no mpls ldp interface
-{%         endif %}
-{%         if ethernet_interfaces[ethernet_interface].mpls.ldp.igp_sync is arista.avd.defined(true) %}
-   mpls ldp igp sync
 {%         endif %}
 {%     endif %}
 {%     if ethernet_interfaces[ethernet_interface].transceiver.media.override is arista.avd.defined %}


### PR DESCRIPTION
## Change Summary

Part of the various changes for getting output config to reflect config order on box.

## Related Issue(s)

Fixes #1572 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Reorder various ethernet interface config

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been rebased from devel before I start
- [X] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [X] My change requires a change to the documentation and documentation have been updated accordingly.
- [X] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
