### PR TITLE
Fix(eos_cli_config_gen): router bgp config order

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
@@ -162,22 +162,22 @@ router bgp 65101
    aggregate-address 2.2.1.0/24
    !
    address-family ipv4
-      network 10.0.0.0/8
-      network 172.16.0.0/12
-      network 192.168.0.0/16 route-map RM-FOO-MATCH
       neighbor foo prefix-list PL-BAR-v4-IN in
       neighbor foo prefix-list PL-BAR-v4-OUT out
       neighbor foo default-originate route-map RM-FOO-MATCH always
       neighbor 192.0.2.1 prefix-list PL-FOO-v4-IN in
       neighbor 192.0.2.1 prefix-list PL-FOO-v4-OUT out
+      network 10.0.0.0/8
+      network 172.16.0.0/12
+      network 192.168.0.0/16 route-map RM-FOO-MATCH
    !
    address-family ipv6
-      network 2001:db8:100::/40
-      network 2001:db8:200::/40 route-map RM-BAR-MATCH
       neighbor baz prefix-list PL-BAR-v6-IN in
       neighbor baz prefix-list PL-BAR-v6-OUT out
       neighbor 2001:db8::1 prefix-list PL-FOO-v6-IN in
       neighbor 2001:db8::1 prefix-list PL-FOO-v6-OUT out
+      network 2001:db8:100::/40
+      network 2001:db8:200::/40 route-map RM-BAR-MATCH
       redistribute static route-map RM-IPV6-STATIC-TO-BGP
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-evpn.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-evpn.md
@@ -193,11 +193,11 @@ router bgp 65101
    neighbor EVPN-OVERLAY-PEERS remote-as 65001
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS allowas-in
    neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
    neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
    neighbor EVPN-OVERLAY-PEERS send-community
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
-   neighbor EVPN-OVERLAY-PEERS allowas-in
    neighbor MLAG-IPv4-UNDERLAY-PEER peer group
    neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65101
    neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
@@ -209,8 +209,8 @@ router bgp 65101
    neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS
    neighbor 192.168.255.1 allowas-in 5
    neighbor 192.168.255.2 peer group EVPN-OVERLAY-PEERS
-   neighbor 192.168.255.3 maximum-routes 52000 warning-limit 2000 warning-only
    neighbor 192.168.255.3 allowas-in 5
+   neighbor 192.168.255.3 maximum-routes 52000 warning-limit 2000 warning-only
    !
    vlan 2488
       rd 145.245.21.0:1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-v4-evpn.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-v4-evpn.md
@@ -297,8 +297,6 @@ router bgp 65101
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.3
-      network 10.0.0.0/8
-      network 100.64.0.0/10
       neighbor 10.2.3.4 remote-as 1234
       neighbor 10.2.3.4 local-as 123 no-prepend replace-as
       neighbor 10.2.3.4 description Tenant A BGP Peer
@@ -308,6 +306,8 @@ router bgp 65101
       neighbor 10.2.3.4 default-originate route-map RM-10.2.3.4-SET-NEXT-HOP-OUT always
       neighbor 10.2.3.4 route-map RM-10.2.3.4-SET-NEXT-HOP-OUT out
       neighbor 10.255.251.1 peer group MLAG-IPv4-UNDERLAY-PEER
+      network 10.0.0.0/8
+      network 100.64.0.0/10
       redistribute connected
       redistribute static
       !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vrf-lite.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vrf-lite.md
@@ -214,9 +214,9 @@ router bgp 65001
       neighbor 101.0.3.2 peer group SEDI
       neighbor 101.0.3.2 shutdown
       neighbor 101.0.3.3 peer group SEDI-shut
-      redistribute static
       aggregate-address 0.0.0.0/0 as-set summary-only attribute-map RM-BGP-AGG-APPLY-SET
       aggregate-address 193.1.0.0/16 as-set summary-only attribute-map RM-BGP-AGG-APPLY-SET
+      redistribute static
       !
       comment
       Comment created from eos_cli under router_bgp.vrfs.BLUE-C1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-base.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-base.cfg
@@ -44,22 +44,22 @@ router bgp 65101
    aggregate-address 2.2.1.0/24
    !
    address-family ipv4
-      network 10.0.0.0/8
-      network 172.16.0.0/12
-      network 192.168.0.0/16 route-map RM-FOO-MATCH
       neighbor foo prefix-list PL-BAR-v4-IN in
       neighbor foo prefix-list PL-BAR-v4-OUT out
       neighbor foo default-originate route-map RM-FOO-MATCH always
       neighbor 192.0.2.1 prefix-list PL-FOO-v4-IN in
       neighbor 192.0.2.1 prefix-list PL-FOO-v4-OUT out
+      network 10.0.0.0/8
+      network 172.16.0.0/12
+      network 192.168.0.0/16 route-map RM-FOO-MATCH
    !
    address-family ipv6
-      network 2001:db8:100::/40
-      network 2001:db8:200::/40 route-map RM-BAR-MATCH
       neighbor baz prefix-list PL-BAR-v6-IN in
       neighbor baz prefix-list PL-BAR-v6-OUT out
       neighbor 2001:db8::1 prefix-list PL-FOO-v6-IN in
       neighbor 2001:db8::1 prefix-list PL-FOO-v6-OUT out
+      network 2001:db8:100::/40
+      network 2001:db8:200::/40 route-map RM-BAR-MATCH
       redistribute static route-map RM-IPV6-STATIC-TO-BGP
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-evpn.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-evpn.cfg
@@ -23,11 +23,11 @@ router bgp 65101
    neighbor EVPN-OVERLAY-PEERS remote-as 65001
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS allowas-in
    neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
    neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
    neighbor EVPN-OVERLAY-PEERS send-community
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
-   neighbor EVPN-OVERLAY-PEERS allowas-in
    neighbor MLAG-IPv4-UNDERLAY-PEER peer group
    neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65101
    neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
@@ -39,8 +39,8 @@ router bgp 65101
    neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS
    neighbor 192.168.255.1 allowas-in 5
    neighbor 192.168.255.2 peer group EVPN-OVERLAY-PEERS
-   neighbor 192.168.255.3 maximum-routes 52000 warning-limit 2000 warning-only
    neighbor 192.168.255.3 allowas-in 5
+   neighbor 192.168.255.3 maximum-routes 52000 warning-limit 2000 warning-only
    !
    vlan 2488
       rd 145.245.21.0:1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-v4-evpn.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-v4-evpn.cfg
@@ -91,8 +91,6 @@ router bgp 65101
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.3
-      network 10.0.0.0/8
-      network 100.64.0.0/10
       neighbor 10.2.3.4 remote-as 1234
       neighbor 10.2.3.4 local-as 123 no-prepend replace-as
       neighbor 10.2.3.4 description Tenant A BGP Peer
@@ -102,6 +100,8 @@ router bgp 65101
       neighbor 10.2.3.4 default-originate route-map RM-10.2.3.4-SET-NEXT-HOP-OUT always
       neighbor 10.2.3.4 route-map RM-10.2.3.4-SET-NEXT-HOP-OUT out
       neighbor 10.255.251.1 peer group MLAG-IPv4-UNDERLAY-PEER
+      network 10.0.0.0/8
+      network 100.64.0.0/10
       redistribute connected
       redistribute static
       !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-vrf-lite.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-vrf-lite.cfg
@@ -73,9 +73,9 @@ router bgp 65001
       neighbor 101.0.3.2 peer group SEDI
       neighbor 101.0.3.2 shutdown
       neighbor 101.0.3.3 peer group SEDI-shut
-      redistribute static
       aggregate-address 0.0.0.0/0 as-set summary-only attribute-map RM-BGP-AGG-APPLY-SET
       aggregate-address 193.1.0.0/16 as-set summary-only attribute-map RM-BGP-AGG-APPLY-SET
+      redistribute static
       !
       comment
       Comment created from eos_cli under router_bgp.vrfs.BLUE-C1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/router-bgp-base.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/router-bgp-base.md
@@ -149,22 +149,22 @@ router bgp 65101
    aggregate-address 2.2.1.0/24
    !
    address-family ipv4
-      network 10.0.0.0/8
-      network 172.16.0.0/12
-      network 192.168.0.0/16 route-map RM-FOO-MATCH
       neighbor foo prefix-list PL-BAR-v4-IN in
       neighbor foo prefix-list PL-BAR-v4-OUT out
       neighbor foo default-originate route-map RM-FOO-MATCH always
       neighbor 192.0.2.1 prefix-list PL-FOO-v4-IN in
       neighbor 192.0.2.1 prefix-list PL-FOO-v4-OUT out
+      network 10.0.0.0/8
+      network 172.16.0.0/12
+      network 192.168.0.0/16 route-map RM-FOO-MATCH
    !
    address-family ipv6
-      network 2001:db8:100::/40
-      network 2001:db8:200::/40 route-map RM-BAR-MATCH
       neighbor baz prefix-list PL-BAR-v6-IN in
       neighbor baz prefix-list PL-BAR-v6-OUT out
       neighbor 2001:db8::1 prefix-list PL-FOO-v6-IN in
       neighbor 2001:db8::1 prefix-list PL-FOO-v6-OUT out
+      network 2001:db8:100::/40
+      network 2001:db8:200::/40 route-map RM-BAR-MATCH
       redistribute static route-map RM-IPV6-STATIC-TO-BGP
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/router-bgp-evpn.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/router-bgp-evpn.md
@@ -193,11 +193,11 @@ router bgp 65101
    neighbor EVPN-OVERLAY-PEERS remote-as 65001
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS allowas-in
    neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
    neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
    neighbor EVPN-OVERLAY-PEERS send-community
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
-   neighbor EVPN-OVERLAY-PEERS allowas-in
    neighbor MLAG-IPv4-UNDERLAY-PEER peer group
    neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65101
    neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
@@ -209,8 +209,8 @@ router bgp 65101
    neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS
    neighbor 192.168.255.1 allowas-in 5
    neighbor 192.168.255.2 peer group EVPN-OVERLAY-PEERS
-   neighbor 192.168.255.3 maximum-routes 52000 warning-limit 2000 warning-only
    neighbor 192.168.255.3 allowas-in 5
+   neighbor 192.168.255.3 maximum-routes 52000 warning-limit 2000 warning-only
    !
    vlan 2488
       rd 145.245.21.0:1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/router-bgp-v4-evpn.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/router-bgp-v4-evpn.md
@@ -297,8 +297,6 @@ router bgp 65101
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.3
-      network 10.0.0.0/8
-      network 100.64.0.0/10
       neighbor 10.2.3.4 remote-as 1234
       neighbor 10.2.3.4 local-as 123 no-prepend replace-as
       neighbor 10.2.3.4 description Tenant A BGP Peer
@@ -308,6 +306,8 @@ router bgp 65101
       neighbor 10.2.3.4 default-originate route-map RM-10.2.3.4-SET-NEXT-HOP-OUT always
       neighbor 10.2.3.4 route-map RM-10.2.3.4-SET-NEXT-HOP-OUT out
       neighbor 10.255.251.1 peer group MLAG-IPv4-UNDERLAY-PEER
+      network 10.0.0.0/8
+      network 100.64.0.0/10
       redistribute connected
       redistribute static
       !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/router-bgp-vrf-lite.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/router-bgp-vrf-lite.md
@@ -214,9 +214,9 @@ router bgp 65001
       neighbor 101.0.3.2 peer group SEDI
       neighbor 101.0.3.2 shutdown
       neighbor 101.0.3.3 peer group SEDI-shut
-      redistribute static
       aggregate-address 0.0.0.0/0 as-set summary-only attribute-map RM-BGP-AGG-APPLY-SET
       aggregate-address 193.1.0.0/16 as-set summary-only attribute-map RM-BGP-AGG-APPLY-SET
+      redistribute static
       !
       comment
       Comment created from eos_cli under router_bgp.vrfs.BLUE-C1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/router-bgp-base.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/router-bgp-base.cfg
@@ -38,22 +38,22 @@ router bgp 65101
    aggregate-address 2.2.1.0/24
    !
    address-family ipv4
-      network 10.0.0.0/8
-      network 172.16.0.0/12
-      network 192.168.0.0/16 route-map RM-FOO-MATCH
       neighbor foo prefix-list PL-BAR-v4-IN in
       neighbor foo prefix-list PL-BAR-v4-OUT out
       neighbor foo default-originate route-map RM-FOO-MATCH always
       neighbor 192.0.2.1 prefix-list PL-FOO-v4-IN in
       neighbor 192.0.2.1 prefix-list PL-FOO-v4-OUT out
+      network 10.0.0.0/8
+      network 172.16.0.0/12
+      network 192.168.0.0/16 route-map RM-FOO-MATCH
    !
    address-family ipv6
-      network 2001:db8:100::/40
-      network 2001:db8:200::/40 route-map RM-BAR-MATCH
       neighbor baz prefix-list PL-BAR-v6-IN in
       neighbor baz prefix-list PL-BAR-v6-OUT out
       neighbor 2001:db8::1 prefix-list PL-FOO-v6-IN in
       neighbor 2001:db8::1 prefix-list PL-FOO-v6-OUT out
+      network 2001:db8:100::/40
+      network 2001:db8:200::/40 route-map RM-BAR-MATCH
       redistribute static route-map RM-IPV6-STATIC-TO-BGP
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/router-bgp-evpn.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/router-bgp-evpn.cfg
@@ -23,11 +23,11 @@ router bgp 65101
    neighbor EVPN-OVERLAY-PEERS remote-as 65001
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS allowas-in
    neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
    neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
    neighbor EVPN-OVERLAY-PEERS send-community
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
-   neighbor EVPN-OVERLAY-PEERS allowas-in
    neighbor MLAG-IPv4-UNDERLAY-PEER peer group
    neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65101
    neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
@@ -39,8 +39,8 @@ router bgp 65101
    neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS
    neighbor 192.168.255.1 allowas-in 5
    neighbor 192.168.255.2 peer group EVPN-OVERLAY-PEERS
-   neighbor 192.168.255.3 maximum-routes 52000 warning-limit 2000 warning-only
    neighbor 192.168.255.3 allowas-in 5
+   neighbor 192.168.255.3 maximum-routes 52000 warning-limit 2000 warning-only
    !
    vlan 2488
       rd 145.245.21.0:1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/router-bgp-v4-evpn.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/router-bgp-v4-evpn.cfg
@@ -91,8 +91,6 @@ router bgp 65101
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.3
-      network 10.0.0.0/8
-      network 100.64.0.0/10
       neighbor 10.2.3.4 remote-as 1234
       neighbor 10.2.3.4 local-as 123 no-prepend replace-as
       neighbor 10.2.3.4 description Tenant A BGP Peer
@@ -102,6 +100,8 @@ router bgp 65101
       neighbor 10.2.3.4 default-originate route-map RM-10.2.3.4-SET-NEXT-HOP-OUT always
       neighbor 10.2.3.4 route-map RM-10.2.3.4-SET-NEXT-HOP-OUT out
       neighbor 10.255.251.1 peer group MLAG-IPv4-UNDERLAY-PEER
+      network 10.0.0.0/8
+      network 100.64.0.0/10
       redistribute connected
       redistribute static
       !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/router-bgp-vrf-lite.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/router-bgp-vrf-lite.cfg
@@ -73,9 +73,9 @@ router bgp 65001
       neighbor 101.0.3.2 peer group SEDI
       neighbor 101.0.3.2 shutdown
       neighbor 101.0.3.3 peer group SEDI-shut
-      redistribute static
       aggregate-address 0.0.0.0/0 as-set summary-only attribute-map RM-BGP-AGG-APPLY-SET
       aggregate-address 193.1.0.0/16 as-set summary-only attribute-map RM-BGP-AGG-APPLY-SET
+      redistribute static
       !
       comment
       Comment created from eos_cli under router_bgp.vrfs.BLUE-C1

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -68,6 +68,13 @@ router bgp {{ router_bgp.as }}
 {%         if router_bgp.peer_groups[peer_group].bfd is arista.avd.defined(true) %}
    neighbor {{ peer_group }} bfd
 {%         endif %}
+{%         if router_bgp.peer_groups[peer_group].allowas_in.enabled is arista.avd.defined(true) %}
+{%             set allowas_in_cli = "neighbor " ~ peer_group ~ " allowas-in" %}
+{%             if router_bgp.peer_groups[peer_group].allowas_in.times is arista.avd.defined %}
+{%                 set allowas_in_cli = allowas_in_cli ~ " " ~ router_bgp.peer_groups[peer_group].allowas_in.times %}
+{%             endif %}
+   {{ allowas_in_cli }}
+{%         endif %}
 {%         if router_bgp.peer_groups[peer_group].rib_in_pre_policy_retain.enabled is arista.avd.defined(true) %}
 {%             set neighbor_rib_in_pre_policy_retain_cli = "neighbor " ~ peer_group ~ " rib-in pre-policy retain" %}
 {%             if router_bgp.peer_groups[peer_group].rib_in_pre_policy_retain.all is arista.avd.defined(true) %}
@@ -108,13 +115,6 @@ router bgp {{ router_bgp.as }}
 {%                 set maximum_routes_cli = maximum_routes_cli ~ " warning-only" %}
 {%             endif %}
    {{ maximum_routes_cli }}
-{%         endif %}
-{%         if router_bgp.peer_groups[peer_group].allowas_in.enabled is arista.avd.defined(true) %}
-{%             set allowas_in_cli = "neighbor " ~ peer_group ~ " allowas-in" %}
-{%             if router_bgp.peer_groups[peer_group].allowas_in.times is arista.avd.defined %}
-{%                 set allowas_in_cli = allowas_in_cli ~ " " ~ router_bgp.peer_groups[peer_group].allowas_in.times %}
-{%             endif %}
-   {{ allowas_in_cli }}
 {%         endif %}
 {%         if router_bgp.peer_groups[peer_group].weight is arista.avd.defined %}
    neighbor {{ peer_group }} weight {{ router_bgp.peer_groups[peer_group].weight }}
@@ -160,6 +160,13 @@ router bgp {{ router_bgp.as }}
 {%         endif %}
 {%         if router_bgp.neighbors[neighbor].bfd is arista.avd.defined(true) %}
    neighbor {{ neighbor }} bfd
+{%         endif %}
+{%         if router_bgp.neighbors[neighbor].allowas_in.enabled is arista.avd.defined(true) %}
+{%             set allowas_in_cli = "neighbor " ~ neighbor ~ " allowas-in" %}
+{%             if router_bgp.neighbors[neighbor].allowas_in.times is arista.avd.defined %}
+{%                 set allowas_in_cli = allowas_in_cli ~ " " ~ router_bgp.neighbors[neighbor].allowas_in.times %}
+{%             endif %}
+   {{ allowas_in_cli }}
 {%         endif %}
 {%         if router_bgp.neighbors[neighbor].rib_in_pre_policy_retain.enabled is arista.avd.defined(true) %}
 {%             set neighbor_rib_in_pre_policy_retain_cli = "neighbor " ~ neighbor ~ " rib-in pre-policy retain" %}
@@ -210,13 +217,6 @@ router bgp {{ router_bgp.as }}
 {%                 set maximum_routes_cli = maximum_routes_cli ~ " warning-only" %}
 {%             endif %}
    {{ maximum_routes_cli }}
-{%         endif %}
-{%         if router_bgp.neighbors[neighbor].allowas_in.enabled is arista.avd.defined(true) %}
-{%             set allowas_in_cli = "neighbor " ~ neighbor ~ " allowas-in" %}
-{%             if router_bgp.neighbors[neighbor].allowas_in.times is arista.avd.defined %}
-{%                 set allowas_in_cli = allowas_in_cli ~ " " ~ router_bgp.neighbors[neighbor].allowas_in.times %}
-{%             endif %}
-   {{ allowas_in_cli }}
 {%         endif %}
 {%     endfor %}
 {%     for aggregate_address in router_bgp.aggregate_addresses | arista.avd.natural_sort %}
@@ -425,13 +425,6 @@ router bgp {{ router_bgp.as }}
 {%     if router_bgp.address_family_ipv4 is arista.avd.defined %}
    !
    address-family ipv4
-{%         for network in router_bgp.address_family_ipv4.networks | arista.avd.natural_sort %}
-{%             if router_bgp.address_family_ipv4.networks[network].route_map is arista.avd.defined %}
-      network {{ network }} route-map {{ router_bgp.address_family_ipv4.networks[network].route_map }}
-{%             else %}
-      network {{ network }}
-{%             endif %}
-{%         endfor %}
 {%         for peer_group in router_bgp.address_family_ipv4.peer_groups | arista.avd.natural_sort %}
 {%             if router_bgp.address_family_ipv4.peer_groups[peer_group].route_map_in is arista.avd.defined %}
       neighbor {{ peer_group }} route-map {{ router_bgp.address_family_ipv4.peer_groups[peer_group].route_map_in }} in
@@ -493,6 +486,13 @@ router bgp {{ router_bgp.as }}
       no neighbor {{ neighbor }} activate
 {%             endif %}
 {%         endfor %}
+{%         for network in router_bgp.address_family_ipv4.networks | arista.avd.natural_sort %}
+{%             if router_bgp.address_family_ipv4.networks[network].route_map is arista.avd.defined %}
+      network {{ network }} route-map {{ router_bgp.address_family_ipv4.networks[network].route_map }}
+{%             else %}
+      network {{ network }}
+{%             endif %}
+{%         endfor %}
 {%     endif %}
 {# address family ipv4 multicast activation #}
 {%     if router_bgp.address_family_ipv4_multicast is arista.avd.defined %}
@@ -536,13 +536,6 @@ router bgp {{ router_bgp.as }}
 {%     if router_bgp.address_family_ipv6 is arista.avd.defined %}
    !
    address-family ipv6
-{%         for network in router_bgp.address_family_ipv6.networks | arista.avd.natural_sort %}
-{%             if router_bgp.address_family_ipv6.networks[network].route_map is arista.avd.defined %}
-      network {{ network }} route-map {{ router_bgp.address_family_ipv6.networks[network].route_map }}
-{%             else %}
-      network {{ network }}
-{%             endif %}
-{%         endfor %}
 {%         for peer_group in router_bgp.address_family_ipv6.peer_groups | arista.avd.natural_sort %}
 {%             if router_bgp.address_family_ipv6.peer_groups[peer_group].route_map_in is arista.avd.defined %}
       neighbor {{ peer_group }} route-map {{ router_bgp.address_family_ipv6.peer_groups[peer_group].route_map_in }} in
@@ -579,6 +572,13 @@ router bgp {{ router_bgp.as }}
       neighbor {{ neighbor }} activate
 {%             elif router_bgp.address_family_ipv6.neighbors[neighbor].activate is arista.avd.defined(false) %}
       no neighbor {{ neighbor }} activate
+{%             endif %}
+{%         endfor %}
+{%         for network in router_bgp.address_family_ipv6.networks | arista.avd.natural_sort %}
+{%             if router_bgp.address_family_ipv6.networks[network].route_map is arista.avd.defined %}
+      network {{ network }} route-map {{ router_bgp.address_family_ipv6.networks[network].route_map }}
+{%             else %}
+      network {{ network }}
 {%             endif %}
 {%         endfor %}
 {%         for redistribute_route in router_bgp.address_family_ipv6.redistribute_routes | arista.avd.natural_sort %}
@@ -669,13 +669,6 @@ router bgp {{ router_bgp.as }}
 {%         if router_bgp.vrfs[vrf].timers is arista.avd.defined %}
       timers bgp {{ router_bgp.vrfs[vrf].timers }}
 {%         endif %}
-{%         for network in router_bgp.vrfs[vrf].networks | arista.avd.natural_sort %}
-{%             if router_bgp.vrfs[vrf].networks[network].route_map is arista.avd.defined %}
-      network {{ network }} route-map {{ router_bgp.vrfs[vrf].networks[network].route_map }}
-{%             else %}
-      network {{ network }}
-{%             endif %}
-{%         endfor %}
 {%         for neighbor in router_bgp.vrfs[vrf].neighbors | arista.avd.natural_sort %}
 {%             if router_bgp.vrfs[vrf].neighbors[neighbor].remote_as is arista.avd.defined %}
       neighbor {{ neighbor }} remote-as {{ router_bgp.vrfs[vrf].neighbors[neighbor].remote_as }}
@@ -710,6 +703,13 @@ router bgp {{ router_bgp.as }}
 {%             elif router_bgp.vrfs[vrf].neighbors[neighbor].bfd is arista.avd.defined(false) %}
       no neighbor {{ neighbor }} bfd
 {%             endif %}
+{%             if router_bgp.vrfs[vrf].neighbors[neighbor].allowas_in.enabled is arista.avd.defined(true) %}
+{%                 set allowas_in_cli = "neighbor " ~ neighbor ~ " allowas-in" %}
+{%                 if router_bgp.vrfs[vrf].neighbors[neighbor].allowas_in.times is arista.avd.defined %}
+{%                     set allowas_in_cli = allowas_in_cli ~ " " ~ router_bgp.vrfs[vrf].neighbors[neighbor].allowas_in.times %}
+{%                 endif %}
+      {{ allowas_in_cli }}
+{%             endif %}
 {%             if router_bgp.vrfs[vrf].neighbors[neighbor].rib_in_pre_policy_retain.enabled is arista.avd.defined(true) %}
 {%                 set neighbor_rib_in_pre_policy_retain_cli = "neighbor " ~ neighbor ~ " rib-in pre-policy retain" %}
 {%                 if router_bgp.vrfs[vrf].neighbors[neighbor].rib_in_pre_policy_retain.all is arista.avd.defined(true) %}
@@ -741,13 +741,6 @@ router bgp {{ router_bgp.as }}
 {%                 endif %}
       {{ maximum_routes_cli }}
 {%             endif %}
-{%             if router_bgp.vrfs[vrf].neighbors[neighbor].allowas_in.enabled is arista.avd.defined(true) %}
-{%                 set allowas_in_cli = "neighbor " ~ neighbor ~ " allowas-in" %}
-{%                 if router_bgp.vrfs[vrf].neighbors[neighbor].allowas_in.times is arista.avd.defined %}
-{%                     set allowas_in_cli = allowas_in_cli ~ " " ~ router_bgp.vrfs[vrf].neighbors[neighbor].allowas_in.times %}
-{%                 endif %}
-      {{ allowas_in_cli }}
-{%             endif %}
 {%             if router_bgp.vrfs[vrf].neighbors[neighbor].default_originate is arista.avd.defined %}
 {%                 set neighbor_default_originate_cli = "neighbor " ~ neighbor ~ " default-originate" %}
 {%                 if router_bgp.vrfs[vrf].neighbors[neighbor].default_originate.route_map is arista.avd.defined %}
@@ -774,12 +767,12 @@ router bgp {{ router_bgp.as }}
       neighbor {{ neighbor }} prefix-list {{ router_bgp.vrfs[vrf].neighbors[neighbor].prefix_list_out }} out
 {%             endif %}
 {%         endfor %}
-{%         for redistribute_route in router_bgp.vrfs[vrf].redistribute_routes | arista.avd.natural_sort %}
-{%             set redistribute_cli = "redistribute " ~ redistribute_route %}
-{%             if router_bgp.vrfs[vrf].redistribute_routes[redistribute_route].route_map is arista.avd.defined %}
-{%                 set redistribute_cli = redistribute_cli + " route-map " ~ router_bgp.vrfs[vrf].redistribute_routes[redistribute_route].route_map %}
+{%         for network in router_bgp.vrfs[vrf].networks | arista.avd.natural_sort %}
+{%             if router_bgp.vrfs[vrf].networks[network].route_map is arista.avd.defined %}
+      network {{ network }} route-map {{ router_bgp.vrfs[vrf].networks[network].route_map }}
+{%             else %}
+      network {{ network }}
 {%             endif %}
-      {{ redistribute_cli }}
 {%         endfor %}
 {%         for aggregate_address in router_bgp.vrfs[vrf].aggregate_addresses | arista.avd.natural_sort %}
 {%             set aggregate_address_cli = "aggregate-address " ~ aggregate_address %}
@@ -799,6 +792,13 @@ router bgp {{ router_bgp.as }}
 {%                 set aggregate_address_cli = aggregate_address_cli ~ " advertise-only" %}
 {%             endif %}
       {{ aggregate_address_cli }}
+{%         endfor %}
+{%         for redistribute_route in router_bgp.vrfs[vrf].redistribute_routes | arista.avd.natural_sort %}
+{%             set redistribute_cli = "redistribute " ~ redistribute_route %}
+{%             if router_bgp.vrfs[vrf].redistribute_routes[redistribute_route].route_map is arista.avd.defined %}
+{%                 set redistribute_cli = redistribute_cli + " route-map " ~ router_bgp.vrfs[vrf].redistribute_routes[redistribute_route].route_map %}
+{%             endif %}
+      {{ redistribute_cli }}
 {%         endfor %}
 {%         for  address_family in router_bgp.vrfs[vrf].address_families | arista.avd.natural_sort %}
       !


### PR DESCRIPTION
## Change Summary

Part of the various changes for getting output config to reflect config order on box.

## Related Issue(s)

Fixes #1572
## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Reorder configuration generation of router bgp configuration

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been rebased from devel before I start
- [X] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [X] My change requires a change to the documentation and documentation have been updated accordingly.
- [X] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
