### PR TITLE
Fix(eos_cli_config_gen): no icmp redirect config order

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-routing.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-routing.md
@@ -81,9 +81,9 @@ interface Management1
 ```eos
 !
 no ip routing
+no ip icmp redirect
 ip routing vrf TEST1
 no ip routing vrf TEST2
-no ip icmp redirect
 ```
 ## IPv6 Routing
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ip-routing.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ip-routing.cfg
@@ -17,9 +17,9 @@ interface Management1
    ip address 10.73.255.122/24
 !
 no ip routing
+no ip icmp redirect
 ip routing vrf TEST1
 no ip routing vrf TEST2
-no ip icmp redirect
 !
 ipv6 unicast-routing
 ip routing ipv6 interfaces

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/ip-routing.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/ip-routing.md
@@ -15,7 +15,7 @@
   - [Internal VLAN Allocation Policy Summary](#internal-vlan-allocation-policy-summary)
 - [Interfaces](#interfaces)
 - [Routing](#routing)
-  - [IP Routing](#ip-routing-1)
+  - [IP Routing](#ip-routing)
     - [IP Routing Summary](#ip-routing-summary)
     - [IP Routing Device Configuration](#ip-routing-device-configuration)
   - [IPv6 Routing](#ipv6-routing)

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/ip-routing.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/ip-routing.md
@@ -1,16 +1,26 @@
 # ip-routing
 # Table of Contents
 
+- [ip-routing](#ip-routing)
+- [Table of Contents](#table-of-contents)
 - [Management](#management)
   - [Management Interfaces](#management-interfaces)
+    - [Management Interfaces Summary](#management-interfaces-summary)
+      - [IPv4](#ipv4)
+      - [IPv6](#ipv6)
+    - [Management Interfaces Device Configuration](#management-interfaces-device-configuration)
 - [Authentication](#authentication)
 - [Monitoring](#monitoring)
 - [Internal VLAN Allocation Policy](#internal-vlan-allocation-policy)
   - [Internal VLAN Allocation Policy Summary](#internal-vlan-allocation-policy-summary)
 - [Interfaces](#interfaces)
 - [Routing](#routing)
-  - [IP Routing](#ip-routing)
+  - [IP Routing](#ip-routing-1)
+    - [IP Routing Summary](#ip-routing-summary)
+    - [IP Routing Device Configuration](#ip-routing-device-configuration)
   - [IPv6 Routing](#ipv6-routing)
+    - [IPv6 Routing Summary](#ipv6-routing-summary)
+    - [IPv6 Routing Device Configuration](#ipv6-routing-device-configuration)
 - [Multicast](#multicast)
 - [Filters](#filters)
 - [ACL](#acl)
@@ -81,9 +91,9 @@ interface Management1
 ```eos
 !
 no ip routing
+no ip icmp redirect
 ip routing vrf TEST1
 no ip routing vrf TEST2
-no ip icmp redirect
 ```
 ## IPv6 Routing
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/ip-routing.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/ip-routing.md
@@ -1,14 +1,8 @@
 # ip-routing
 # Table of Contents
 
-- [ip-routing](#ip-routing)
-- [Table of Contents](#table-of-contents)
 - [Management](#management)
   - [Management Interfaces](#management-interfaces)
-    - [Management Interfaces Summary](#management-interfaces-summary)
-      - [IPv4](#ipv4)
-      - [IPv6](#ipv6)
-    - [Management Interfaces Device Configuration](#management-interfaces-device-configuration)
 - [Authentication](#authentication)
 - [Monitoring](#monitoring)
 - [Internal VLAN Allocation Policy](#internal-vlan-allocation-policy)
@@ -16,11 +10,7 @@
 - [Interfaces](#interfaces)
 - [Routing](#routing)
   - [IP Routing](#ip-routing)
-    - [IP Routing Summary](#ip-routing-summary)
-    - [IP Routing Device Configuration](#ip-routing-device-configuration)
   - [IPv6 Routing](#ipv6-routing)
-    - [IPv6 Routing Summary](#ipv6-routing-summary)
-    - [IPv6 Routing Device Configuration](#ipv6-routing-device-configuration)
 - [Multicast](#multicast)
 - [Filters](#filters)
 - [ACL](#acl)

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/ip-routing.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/ip-routing.cfg
@@ -17,9 +17,9 @@ interface Management1
    ip address 10.73.255.122/24
 !
 no ip routing
+no ip icmp redirect
 ip routing vrf TEST1
 no ip routing vrf TEST2
-no ip icmp redirect
 !
 ipv6 unicast-routing
 ip routing ipv6 interfaces

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-routing.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-routing.j2
@@ -6,6 +6,9 @@ ip routing
 !
 no ip routing
 {% endif %}
+{% if ip_icmp_redirect is arista.avd.defined(false) %}
+no ip icmp redirect
+{% endif %}
 {% for vrf in vrfs | arista.avd.natural_sort %}
 {%     if vrfs[vrf].ip_routing is arista.avd.defined(true) and vrf != 'default' %}
 ip routing vrf {{ vrf }}
@@ -13,6 +16,3 @@ ip routing vrf {{ vrf }}
 no ip routing vrf {{ vrf }}
 {%     endif %}
 {% endfor %}
-{% if ip_icmp_redirect is arista.avd.defined(false) %}
-no ip icmp redirect
-{% endif %}


### PR DESCRIPTION
## Change Summary

Part of the various changes for getting output config to reflect config order on box.

## Related Issue(s)

Fixes #1572

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Reorder no icmp redirect in the config

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been rebased from devel before I start
- [X] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [X] My change requires a change to the documentation and documentation have been updated accordingly.
- [X] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
