### PR TITLE
Fix(eos_cli_config_gen): Remove sorting on class-maps in policy-maps type qos

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/policy-maps.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/policy-maps.md
@@ -148,11 +148,9 @@ policy-map type quality-of-service PM_REPLICATION_LD
    class CM_REPLICATION_LD_2
       set dscp af11
       set traffic-class 2
-   !
 !
 policy-map type quality-of-service PM_REPLICATION_LD2
    class CM_REPLICATION_LD
       set dscp af11
       set cos 4
-   !
 ```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/policy-maps.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/policy-maps.md
@@ -122,9 +122,9 @@ policy-map type pbr PM_PBR_BREAKOUT
 
 | class | Set | Value |
 | ----- | --- | ----- |
-| CM_REPLICATION_LD | drop_precedence | 1 |
 | CM_REPLICATION_LD | dscp | af11 |
 | CM_REPLICATION_LD | traffic_class | 2 |
+| CM_REPLICATION_LD | drop_precedence | 1 |
 | CM_REPLICATION_LD_2 | dscp | af11 |
 | CM_REPLICATION_LD_2 | traffic_class | 2 |
 
@@ -132,8 +132,8 @@ policy-map type pbr PM_PBR_BREAKOUT
 
 | class | Set | Value |
 | ----- | --- | ----- |
-| CM_REPLICATION_LD | cos | 4 |
 | CM_REPLICATION_LD | dscp | af11 |
+| CM_REPLICATION_LD | cos | 4 |
 
 ### QOS Policy Maps configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/qos.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/qos.md
@@ -327,13 +327,7 @@ class-map type qos match-any cmap_tc5_v6
 ```eos
 !
 policy-map type quality-of-service pmap_test1
-   class class-default
-      set traffic-class 1
-   !
    class cmap_tc0_v4
-      set traffic-class 0
-   !
-   class cmap_tc0_v6
       set traffic-class 0
    !
    class cmap_tc5_v4
@@ -341,6 +335,12 @@ policy-map type quality-of-service pmap_test1
    !
    class cmap_tc5_v6
       set traffic-class 5
+   !
+   class cmap_tc0_v6
+      set traffic-class 0
+   !
+   class class-default
+      set traffic-class 1
    !
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/qos.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/qos.md
@@ -316,11 +316,11 @@ class-map type qos match-any cmap_tc5_v6
 
 | class | Set | Value |
 | ----- | --- | ----- |
-| class-default | traffic_class | 1 |
 | cmap_tc0_v4 | traffic_class | 0 |
-| cmap_tc0_v6 | traffic_class | 0 |
 | cmap_tc5_v4 | traffic_class | 5 |
 | cmap_tc5_v6 | traffic_class | 5 |
+| cmap_tc0_v6 | traffic_class | 0 |
+| class-default | traffic_class | 1 |
 
 ### QOS Policy Maps configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/qos.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/qos.md
@@ -341,7 +341,6 @@ policy-map type quality-of-service pmap_test1
    !
    class class-default
       set traffic-class 1
-   !
 ```
 
 ## QOS Profiles

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/policy-maps.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/policy-maps.cfg
@@ -27,12 +27,10 @@ policy-map type quality-of-service PM_REPLICATION_LD
    class CM_REPLICATION_LD_2
       set dscp af11
       set traffic-class 2
-   !
 !
 policy-map type quality-of-service PM_REPLICATION_LD2
    class CM_REPLICATION_LD
       set dscp af11
       set cos 4
-   !
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/qos.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/qos.cfg
@@ -182,6 +182,5 @@ policy-map type quality-of-service pmap_test1
    !
    class class-default
       set traffic-class 1
-   !
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/qos.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/qos.cfg
@@ -168,13 +168,7 @@ class-map type qos match-any cmap_tc5_v6
    match ipv6 access-group acl_qos_tc5_v6
 !
 policy-map type quality-of-service pmap_test1
-   class class-default
-      set traffic-class 1
-   !
    class cmap_tc0_v4
-      set traffic-class 0
-   !
-   class cmap_tc0_v6
       set traffic-class 0
    !
    class cmap_tc5_v4
@@ -182,6 +176,12 @@ policy-map type quality-of-service pmap_test1
    !
    class cmap_tc5_v6
       set traffic-class 5
+   !
+   class cmap_tc0_v6
+      set traffic-class 0
+   !
+   class class-default
+      set traffic-class 1
    !
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/policy-maps.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/policy-maps.md
@@ -148,11 +148,9 @@ policy-map type quality-of-service PM_REPLICATION_LD
    class CM_REPLICATION_LD_2
       set dscp af11
       set traffic-class 2
-   !
 !
 policy-map type quality-of-service PM_REPLICATION_LD2
    class CM_REPLICATION_LD
       set dscp af11
       set cos 4
-   !
 ```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/policy-maps.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/policy-maps.md
@@ -122,9 +122,9 @@ policy-map type pbr PM_PBR_BREAKOUT
 
 | class | Set | Value |
 | ----- | --- | ----- |
-| CM_REPLICATION_LD | drop_precedence | 1 |
 | CM_REPLICATION_LD | dscp | af11 |
 | CM_REPLICATION_LD | traffic_class | 2 |
+| CM_REPLICATION_LD | drop_precedence | 1 |
 | CM_REPLICATION_LD_2 | dscp | af11 |
 | CM_REPLICATION_LD_2 | traffic_class | 2 |
 
@@ -132,8 +132,8 @@ policy-map type pbr PM_PBR_BREAKOUT
 
 | class | Set | Value |
 | ----- | --- | ----- |
-| CM_REPLICATION_LD | cos | 4 |
 | CM_REPLICATION_LD | dscp | af11 |
+| CM_REPLICATION_LD | cos | 4 |
 
 ### QOS Policy Maps configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/qos.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/qos.md
@@ -327,13 +327,7 @@ class-map type qos match-any cmap_tc5_v6
 ```eos
 !
 policy-map type quality-of-service pmap_test1
-   class class-default
-      set traffic-class 1
-   !
    class cmap_tc0_v4
-      set traffic-class 0
-   !
-   class cmap_tc0_v6
       set traffic-class 0
    !
    class cmap_tc5_v4
@@ -341,6 +335,12 @@ policy-map type quality-of-service pmap_test1
    !
    class cmap_tc5_v6
       set traffic-class 5
+   !
+   class cmap_tc0_v6
+      set traffic-class 0
+   !
+   class class-default
+      set traffic-class 1
    !
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/qos.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/qos.md
@@ -316,11 +316,11 @@ class-map type qos match-any cmap_tc5_v6
 
 | class | Set | Value |
 | ----- | --- | ----- |
-| class-default | traffic_class | 1 |
 | cmap_tc0_v4 | traffic_class | 0 |
-| cmap_tc0_v6 | traffic_class | 0 |
 | cmap_tc5_v4 | traffic_class | 5 |
 | cmap_tc5_v6 | traffic_class | 5 |
+| cmap_tc0_v6 | traffic_class | 0 |
+| class-default | traffic_class | 1 |
 
 ### QOS Policy Maps configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/qos.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/qos.md
@@ -341,7 +341,6 @@ policy-map type quality-of-service pmap_test1
    !
    class class-default
       set traffic-class 1
-   !
 ```
 
 ## QOS Profiles

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/policy-maps.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/policy-maps.cfg
@@ -27,12 +27,10 @@ policy-map type quality-of-service PM_REPLICATION_LD
    class CM_REPLICATION_LD_2
       set dscp af11
       set traffic-class 2
-   !
 !
 policy-map type quality-of-service PM_REPLICATION_LD2
    class CM_REPLICATION_LD
       set dscp af11
       set cos 4
-   !
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/qos.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/qos.cfg
@@ -182,6 +182,5 @@ policy-map type quality-of-service pmap_test1
    !
    class class-default
       set traffic-class 1
-   !
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/qos.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/qos.cfg
@@ -168,13 +168,7 @@ class-map type qos match-any cmap_tc5_v6
    match ipv6 access-group acl_qos_tc5_v6
 !
 policy-map type quality-of-service pmap_test1
-   class class-default
-      set traffic-class 1
-   !
    class cmap_tc0_v4
-      set traffic-class 0
-   !
-   class cmap_tc0_v6
       set traffic-class 0
    !
    class cmap_tc5_v4
@@ -182,6 +176,12 @@ policy-map type quality-of-service pmap_test1
    !
    class cmap_tc5_v6
       set traffic-class 5
+   !
+   class cmap_tc0_v6
+      set traffic-class 0
+   !
+   class class-default
+      set traffic-class 1
    !
 !
 end

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/policy-maps-qos.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/policy-maps-qos.j2
@@ -9,8 +9,8 @@
 
 | class | Set | Value |
 | ----- | --- | ----- |
-{%         for class in policy_maps.qos[policy_map].classes | arista.avd.natural_sort %}
-{%             for set in policy_maps.qos[policy_map].classes[class].set | arista.avd.natural_sort %}
+{%         for class in policy_maps.qos[policy_map].classes | arista.avd.default([]) %}
+{%             for set in policy_maps.qos[policy_map].classes[class].set | arista.avd.default([]) %}
 | {{ class }} | {{ set }} | {{ policy_maps.qos[policy_map].classes[class].set[set] }} |
 {%             endfor %}
 {%         endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/policy-maps-qos.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/policy-maps-qos.j2
@@ -4,14 +4,12 @@
 policy-map type quality-of-service {{ policy_map }}
 {%     for class in policy_maps.qos[policy_map].classes | arista.avd.default([]) %}
    class {{ class }}
-{%         if policy_maps.qos[policy_map].classes[class].set is arista.avd.defined %}
-{%             for set in policy_maps.qos[policy_map].classes[class].set %}
-{%                 set cli_set = set | replace('_','-') | lower %}
-{%                 if cli_set in ['cos', 'dscp', 'traffic-class', 'drop-precedence']  %}
+{%         for set in policy_maps.qos[policy_map].classes[class].set | arista.avd.default([]) %}
+{%             set cli_set = set | replace('_','-') | lower %}
+{%             if cli_set in ['cos', 'dscp', 'traffic-class', 'drop-precedence'] %}
       set {{ cli_set }} {{ policy_maps.qos[policy_map].classes[class].set[set] }}
-{%                 endif %}
-{%             endfor %}
+{%             endif %}
+{%         endfor %}
    !
-{%         endif %}
 {%     endfor %}
 {% endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/policy-maps-qos.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/policy-maps-qos.j2
@@ -2,7 +2,7 @@
 {% for policy_map in policy_maps.qos | arista.avd.natural_sort %}
 !
 policy-map type quality-of-service {{ policy_map }}
-{%     for class in policy_maps.qos[policy_map].classes | arista.avd.natural_sort %}
+{%     for class in policy_maps.qos[policy_map].classes | arista.avd.default([]) %}
    class {{ class }}
 {%         if policy_maps.qos[policy_map].classes[class].set is arista.avd.defined %}
 {%             for set in policy_maps.qos[policy_map].classes[class].set %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/policy-maps-qos.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/policy-maps-qos.j2
@@ -3,6 +3,9 @@
 !
 policy-map type quality-of-service {{ policy_map }}
 {%     for class in policy_maps.qos[policy_map].classes | arista.avd.default([]) %}
+{%         if loop.index > 1 %}
+   !
+{%         endif %}
    class {{ class }}
 {%         for set in policy_maps.qos[policy_map].classes[class].set | arista.avd.default([]) %}
 {%             set cli_set = set | replace('_','-') | lower %}
@@ -10,6 +13,5 @@ policy-map type quality-of-service {{ policy_map }}
       set {{ cli_set }} {{ policy_maps.qos[policy_map].classes[class].set[set] }}
 {%             endif %}
 {%         endfor %}
-   !
 {%     endfor %}
 {% endfor %}


### PR DESCRIPTION
## Change Summary

Remove sorting on class-maps in policy-maps type qos

## Related Issue(s)

Fixes #1610 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Replace `arista.avd.natural_sort` with `arista.avd.default([])`

## How to test

See molecule results

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
