### PR TITLE
Refactor(eos_designs): Set peer facts per device instead of shared

### DIFF
--- a/ansible_collections/arista/avd/plugins/modules/eos_designs_set_peer_facts.py
+++ b/ansible_collections/arista/avd/plugins/modules/eos_designs_set_peer_facts.py
@@ -44,7 +44,5 @@ EXAMPLES = r'''
   eos_designs_set_peer_facts:
     avd_topology_peers: True
     avd_overlay_peers: True
-  delegate_facts: True
-  delegate_to: "{{ ansible_play_hosts[0] }}"
   run_once: True
 '''

--- a/ansible_collections/arista/avd/roles/eos_designs/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/tasks/main.yml
@@ -32,8 +32,6 @@
   eos_designs_set_peer_facts:
     avd_topology_peers: True
     avd_overlay_peers: True
-  delegate_facts: True
-  delegate_to: "{{ ansible_play_hosts[0] }}"
   check_mode: no
   run_once: True
 

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/inband_management/parent-logic.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/inband_management/parent-logic.j2
@@ -2,7 +2,7 @@
 {% set inband_management_data.subnets = [] %}
 
 {# Add inband management variables defined on other devices pointing to this device #}
-{% set avd_topology_peers = hostvars[ansible_play_hosts[0]].ansible_facts.avd_topology_peers[inventory_hostname] | arista.avd.default([]) %}
+{% set avd_topology_peers = avd_topology_peers[inventory_hostname] | arista.avd.default([]) %}
 
 {% for peer in avd_topology_peers %}
 {%     set peer_facts = hostvars[peer] %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/logic-evpn-route-clients.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/logic-evpn-route-clients.j2
@@ -1,7 +1,7 @@
 {% if switch.evpn_role == "server" %}
 {%     set overlay_data.evpn_route_clients = {} %}
 {# #}
-{%     set avd_overlay_peers = hostvars[ansible_play_hosts[0]].ansible_facts.avd_overlay_peers[inventory_hostname] | arista.avd.default([]) %}
+{%     set avd_overlay_peers = avd_overlay_peers[inventory_hostname] | arista.avd.default([]) %}
 
 {# Parse switches pointing to us as evpn_route_server #}
 {%     for peer in avd_overlay_peers %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/underlay/logic.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/underlay/logic.j2
@@ -1,7 +1,7 @@
 {# Add underlay links defined on this device #}
 {% set underlay_data.links = topology.links | arista.avd.default({}) %}
 
-{% set avd_topology_peers = hostvars[ansible_play_hosts[0]].ansible_facts.avd_topology_peers[inventory_hostname] | arista.avd.default([]) %}
+{% set avd_topology_peers = avd_topology_peers[inventory_hostname] | arista.avd.default([]) %}
 
 {# Add underlay links defined on other devices pointing to this device #}
 {% for peer in avd_topology_peers %}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Set peer facts per device instead of shared

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->
Ansible set facts on _all_ devices when using `set_fact` or `yaml_templates_to_facts` in combination with `run_once` and _not_ using `delegate_to`.

This was not clear to me, when writing the original implementation of peer facts, so this PR simplifies the playbook and code a bit, by leveraging this behavior.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
No changes to any output
I have not been able to see any change to runtime, but welcome test results from others. (Run it a few times with devel vs this one and compare)

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
