### PR TITLE
Refactor(eos_cli_config_gen): Wildcard dict to list for ip_domain_lookup

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/dns-ntp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/dns-ntp.yml
@@ -1,7 +1,7 @@
 ### Domain Lookup ###
 ip_domain_lookup:
   source_interfaces:
-    Management0:
+    - name: Management0
       vrf: mgt
 
 ### Name Servers ###

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
@@ -1630,7 +1630,7 @@ name_server:
 ```yaml
 ip_domain_lookup:
   source_interfaces:
-    < source_interface_1 >:
+    - name: < source_interface_1 >
       vrf: < vrf_name >
 ```
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/domain-lookup.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/domain-lookup.j2
@@ -1,4 +1,4 @@
-{% if ip_domain_lookup is defined and ip_domain_lookup is not none %}
+{% if ip_domain_lookup is arista.avd.defined %}
 
 ## Domain Lookup
 
@@ -6,9 +6,9 @@
 
 | Source interface | vrf |
 | ---------------- | --- |
-{%     for source in ip_domain_lookup.source_interfaces | arista.avd.natural_sort %}
-{%         set vrf = ip_domain_lookup.source_interfaces[source].vrf | arista.avd.default('-') %}
-| {{ source }} | {{ vrf }} |
+{%     for source in ip_domain_lookup.source_interfaces | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%         set vrf = source.vrf | arista.avd.default('-') %}
+| {{ source.name }} | {{ vrf }} |
 {%     endfor %}
 
 ### DNS Domain Lookup Device Configuration

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/domain-lookup.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/domain-lookup.j2
@@ -1,11 +1,11 @@
 {# eos - domain lookup #}
 {% if ip_domain_lookup is arista.avd.defined %}
-{%     for source in ip_domain_lookup.source_interfaces | arista.avd.natural_sort %}
+{%     for source in ip_domain_lookup.source_interfaces | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
 {%         set ip_domain_cli = "ip domain lookup" %}
-{%         if ip_domain_lookup.source_interfaces[source].vrf is arista.avd.defined %}
-{%             set ip_domain_cli = ip_domain_cli ~ " vrf " ~ ip_domain_lookup.source_interfaces[source].vrf %}
+{%         if source.vrf is arista.avd.defined %}
+{%             set ip_domain_cli = ip_domain_cli ~ " vrf " ~ source.vrf %}
 {%         endif %}
-{%         set ip_domain_cli = ip_domain_cli ~ " source-interface " ~ source %}
+{%         set ip_domain_cli = ip_domain_cli ~ " source-interface " ~ source.name %}
 {{ ip_domain_cli }}
 {%     endfor %}
 {% endif %}


### PR DESCRIPTION
## "Wildcard Keyed Dict" to "List of Dicts" Data model migration

<!-- Use this PR Title: Refactor(eos_cli_config_gen): Wildcard dict to list for `< data_model_key >` -->

## Data model key

`< data_model_key >`

## Checklist

### Contributor Checklist

- [ ] Update `README_v4.0.md` with new data model
- [ ] Update all `host_vars` under molecule scenario `eos_cli_config_gen_v4.0` with new data model
- [ ] Update `templates/eos/< template >.j2` and `templates/documentation/< template >.j2`:
  - [ ] Add `arista.avd.convert_dicts('<primary key>')` filter for loops previously using wildcard keys
  - [ ] Update `arista.avd.natural_sort('<primary key>')` to sort on the primary key (if applicable)
- [ ] Run molecule `cd ansible_collections/arista/avd/molecule ; make cli-4.0-schema`
  - [ ] Verify no changes to generated configs/docs

### Reviewer Checklist

- Reviewer 1:
  - [x] Verify data model changes
  - [x] Verify that all molecule `host_vars` under `eos_cli_config_gen_v4.0` has been updated to the new data model
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2:
  - [ ] Verify data model changes
  - [ ] Verify that all molecule `host_vars` under `eos_cli_config_gen_v4.0` has been updated to the new data model
  - [ ] Verify no changes to configs/docs on any molecule scenario
  - [ ] Verify that CI pass
