### PR TITLE
Refactor(eos_cli_config_gen): Wildcard dict to list for management_interfaces

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/group_vars/all.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/group_vars/all.yml
@@ -3,7 +3,7 @@ root_dir: '{{playbook_dir}}'
 is_for_test: true
 ### Management Interfaces ###
 management_interfaces:
-  Management1:
+  - name: Management1
     description: oob_management
     vrf: MGMT
     ip_address: 10.73.255.122/24

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/management-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/management-interfaces.yml
@@ -1,12 +1,12 @@
 ### Management Interfaces ###
 management_interfaces:
-  Management1:
+  - name: Management1
     description: oob_management
     vrf: MGMT
     ip_address: 10.73.255.122/24
     gateway: 10.73.255.2
     type: oob
-  Vlan123:
+  - name: Vlan123
     description: inband_management
     vrf: default
     ip_address: 10.73.0.123/24

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/router-isis-new.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/router-isis-new.yml
@@ -83,7 +83,7 @@ loopback_interfaces:
 
 ### Management Interfaces ###
 management_interfaces:
-  Management1:
+  - name: Management1
     description: oob_management
     vrf: MGMT
     ip_address: 10.73.254.11/24

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/router-isis.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/router-isis.yml
@@ -101,7 +101,7 @@ loopback_interfaces:
 
 ### Management Interfaces ###
 management_interfaces:
-  Management1:
+  - name: Management1
     description: oob_management
     vrf: MGMT
     ip_address: 10.73.254.11/24

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
@@ -1646,7 +1646,7 @@ domain_list:
 
 ```yaml
 management_interfaces:
-  < Management_interface_1 >:
+  - name: < Management_interface_1 >
     description: < description >
     shutdown: < true | false >
     vrf: < vrf_name >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-interfaces.j2
@@ -1,4 +1,4 @@
-{% if management_interfaces is defined and management_interfaces is not none %}
+{% if management_interfaces is arista.avd.defined %}
 
 ## Management Interfaces
 
@@ -8,20 +8,20 @@
 
 | Management Interface | description | Type | VRF | IP Address | Gateway |
 | -------------------- | ----------- | ---- | --- | ---------- | ------- |
-{%     for management_interface in management_interfaces | arista.avd.natural_sort %}
-{%         set vrf = management_interfaces[management_interface].vrf | arista.avd.default('default') %}
-| {{ management_interface }} | {{ management_interfaces[management_interface].description }} | {{ management_interfaces[management_interface].type | arista.avd.default('oob') }} | {{ vrf }} | {{ management_interfaces[management_interface].ip_address }} | {{ management_interfaces[management_interface].gateway }} |
+{%     for management_interface in management_interfaces | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%         set vrf = management_interface.vrf | arista.avd.default('default') %}
+| {{ management_interface.name }} | {{ management_interface.description }} | {{ management_interface.type | arista.avd.default('oob') }} | {{ vrf }} | {{ management_interface.ip_address }} | {{ management_interface.gateway }} |
 {%     endfor %}
 
 #### IPv6
 
 | Management Interface | description | Type | VRF | IPv6 Address | IPv6 Gateway |
 | -------------------- | ----------- | ---- | --- | ------------ | ------------ |
-{%     for management_interface in management_interfaces | arista.avd.natural_sort %}
-{%         set vrf = management_interfaces[management_interface].vrf | arista.avd.default('default') %}
-{%         set ipv6 = management_interfaces[management_interface].ipv6_address | arista.avd.default('-') %}
-{%         set ipv6_gateway = management_interfaces[management_interface].ipv6_gateway | arista.avd.default('-') %}
-| {{ management_interface }} | {{ management_interfaces[management_interface].description }} | {{ management_interfaces[management_interface].type | arista.avd.default('oob') }} | {{ vrf }} | {{ ipv6 }}  | {{ ipv6_gateway }} |
+{%     for management_interface in management_interfaces | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%         set vrf = management_interface.vrf | arista.avd.default('default') %}
+{%         set ipv6 = management_interface.ipv6_address | arista.avd.default('-') %}
+{%         set ipv6_gateway = management_interface.ipv6_gateway | arista.avd.default('-') %}
+| {{ management_interface.name }} | {{ management_interface.description }} | {{ management_interface.type | arista.avd.default('oob') }} | {{ vrf }} | {{ ipv6 }}  | {{ ipv6_gateway }} |
 {%     endfor %}
 
 ### Management Interfaces Device Configuration

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-interfaces.j2
@@ -1,25 +1,25 @@
 {# eos - Management Interfaces #}
-{% for management_interface in management_interfaces | arista.avd.natural_sort %}
+{% for management_interface in management_interfaces | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
 !
-interface {{ management_interface }}
-{%     if management_interfaces[management_interface].description is arista.avd.defined %}
-   description {{ management_interfaces[management_interface].description }}
+interface {{ management_interface.name }}
+{%     if management_interface.description is arista.avd.defined %}
+   description {{ management_interface.description }}
 {%     endif %}
-{%     if management_interfaces[management_interface].shutdown is arista.avd.defined(true) %}
+{%     if management_interface.shutdown is arista.avd.defined(true) %}
    shutdown
-{%     elif management_interfaces[management_interface].shutdown is arista.avd.defined(false) %}
+{%     elif management_interface.shutdown is arista.avd.defined(false) %}
    no shutdown
 {%     endif %}
-{%     if management_interfaces[management_interface].vrf is arista.avd.defined and management_interfaces[management_interface].vrf is ne 'default' %}
-   vrf {{ management_interfaces[management_interface].vrf }}
+{%     if management_interface.vrf is arista.avd.defined and management_interface.vrf is ne 'default' %}
+   vrf {{ management_interface.vrf }}
 {%     endif %}
-{%     if management_interfaces[management_interface].ip_address is arista.avd.defined %}
-   ip address {{ management_interfaces[management_interface].ip_address }}
+{%     if management_interface.ip_address is arista.avd.defined %}
+   ip address {{ management_interface.ip_address }}
 {%     endif %}
-{%     if management_interfaces[management_interface].ipv6_enable is arista.avd.defined(true) %}
+{%     if management_interface.ipv6_enable is arista.avd.defined(true) %}
    ipv6 enable
 {%     endif %}
-{%     if management_interfaces[management_interface].ipv6_address is arista.avd.defined %}
-   ipv6 address {{ management_interfaces[management_interface].ipv6_address }}
+{%     if management_interface.ipv6_address is arista.avd.defined %}
+   ipv6 address {{ management_interface.ipv6_address }}
 {%     endif %}
 {% endfor %}


### PR DESCRIPTION
## "Wildcard Keyed Dict" to "List of Dicts" Data model migration

<!-- Use this PR Title: Refactor(eos_cli_config_gen): Wildcard dict to list for `< data_model_key >` -->

## Data model key

`management_interfaces`

## Checklist

### Contributor Checklist

- [x] Update `README_v4.0.md` with new data model
- [x] Update all `host_vars` under molecule scenario `eos_cli_config_gen_v4.0` with new data model
- [x] Update `templates/eos/< template >.j2` and `templates/documentation/< template >.j2`:
  - [x] Add `arista.avd.convert_dicts('<primary key>')` filter for loops previously using wildcard keys
  - [x] Update `arista.avd.natural_sort('<primary key>')` to sort on the primary key (if applicable)
- [x] Run molecule `cd ansible_collections/arista/avd/molecule ; make cli-4.0-schema`
  - [x] Verify no changes to generated configs/docs

### Reviewer Checklist

- Reviewer 1: Claus
  - [x] Verify data model changes
  - [x] Verify that all molecule `host_vars` under `eos_cli_config_gen_v4.0` has been updated to the new data model
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2: Tony
  - [x] Verify data model changes
  - [x] Verify that all molecule `host_vars` under `eos_cli_config_gen_v4.0` has been updated to the new data model
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
