### PR TITLE
Feat(eos_cli_config_gen): add support for FlexRoute compression and expansion of prefixes

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-routing-fib.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-routing-fib.md
@@ -1,0 +1,94 @@
+# ip-routing-fib
+# Table of Contents
+
+- [Management](#management)
+  - [Management Interfaces](#management-interfaces)
+- [Authentication](#authentication)
+- [Monitoring](#monitoring)
+- [Internal VLAN Allocation Policy](#internal-vlan-allocation-policy)
+  - [Internal VLAN Allocation Policy Summary](#internal-vlan-allocation-policy-summary)
+- [Interfaces](#interfaces)
+- [Routing](#routing)
+  - [IP Routing](#ip-routing)
+  - [IPv6 Routing](#ipv6-routing)
+- [Multicast](#multicast)
+- [Filters](#filters)
+- [ACL](#acl)
+- [Quality Of Service](#quality-of-service)
+
+# Management
+
+## Management Interfaces
+
+### Management Interfaces Summary
+
+#### IPv4
+
+| Management Interface | description | Type | VRF | IP Address | Gateway |
+| -------------------- | ----------- | ---- | --- | ---------- | ------- |
+| Management1 | oob_management | oob | MGMT | 10.73.255.122/24 | 10.73.255.2 |
+
+#### IPv6
+
+| Management Interface | description | Type | VRF | IPv6 Address | IPv6 Gateway |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ |
+| Management1 | oob_management | oob | MGMT | -  | - |
+
+### Management Interfaces Device Configuration
+
+```eos
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+```
+
+# Authentication
+
+# Monitoring
+
+# Internal VLAN Allocation Policy
+
+## Internal VLAN Allocation Policy Summary
+
+**Default Allocation Policy**
+
+| Policy Allocation | Range Beginning | Range Ending |
+| ------------------| --------------- | ------------ |
+| ascending | 1006 | 4094 |
+
+# Interfaces
+
+# Routing
+
+## IP Routing
+
+### IP Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | true |
+
+### IP Routing Device Configuration
+
+```eos
+!
+ip routing
+ip hardware fib optimize prefixes profile urpf-internet
+```
+## IPv6 Routing
+
+### IPv6 Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | false |
+
+# Multicast
+
+# Filters
+
+# ACL
+
+# Quality Of Service

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ip-routing-fib.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ip-routing-fib.cfg
@@ -1,0 +1,19 @@
+!RANCID-CONTENT-TYPE: arista
+!
+transceiver qsfp default-mode 4x10G
+!
+hostname ip-routing-fib
+!
+no enable password
+no aaa root
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+!
+ip routing
+ip hardware fib optimize prefixes profile urpf-internet
+ipv6 hardware fib optimize prefixes profile internet
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ip-routing-fib.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ip-routing-fib.yml
@@ -1,0 +1,14 @@
+### IP routing ###
+
+ip_routing: true
+ipv6_routing: true
+ip_hardware:
+  fib:
+    optimize:
+      prefixes:
+        profile: urpf-internet
+ipv6_hardware:
+  fib:
+    optimize:
+      prefixes:
+        profile: internet

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
@@ -32,6 +32,7 @@ ip-extended-community-lists
 ip-extended-community-lists-regexp
 ip-igmp-snooping-enable
 ip-routing
+ip-routing-fib
 ip-radius-source-interface
 ip-tacacs-source-interface
 ip-http-client-source-interface

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -65,6 +65,8 @@
     - [Internal VLAN Order](#internal-vlan-order)
     - [IP DHCP Relay](#ip-dhcp-relay)
     - [IP ICMP Redirect](#ip-icmp-redirect)
+    - [IP Hardware](#ip-hardware)
+    - [IPv6 Hardware](#ipv6-hardware)
     - [LACP](#lacp)
     - [Link Tracking Groups](#link-tracking-groups)
     - [LLDP](#lldp)
@@ -1480,6 +1482,26 @@ ip_dhcp_relay:
 ```yaml
 ip_icmp_redirect: < true | false >
 ipv6_icmp_redirect: < true | false >
+```
+
+### IP Hardware
+
+```yaml
+ip_hardware:
+  fib:
+    optimize:
+      prefixes:
+        profile: < internet | urpf-internet >
+```
+
+### IPv6 Hardware
+
+```yaml
+ipv6_hardware:
+  fib:
+    optimize:
+      prefixes:
+        profile: < internet >
 ```
 
 ### LACP

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-routing.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-routing.j2
@@ -9,6 +9,9 @@ no ip routing
 {% if ip_icmp_redirect is arista.avd.defined(false) %}
 no ip icmp redirect
 {% endif %}
+{% if ip_hardware.fib.optimize.prefixes.profile is arista.avd.defined %}
+ip hardware fib optimize prefixes profile {{ ip_hardware.fib.optimize.prefixes.profile }}
+{% endif %}
 {% for vrf in vrfs | arista.avd.natural_sort %}
 {%     if vrfs[vrf].ip_routing is arista.avd.defined(true) and vrf != 'default' %}
 ip routing vrf {{ vrf }}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ipv6-routing.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ipv6-routing.j2
@@ -17,3 +17,6 @@ ipv6 unicast-routing vrf {{ vrf }}
 {% if ipv6_icmp_redirect is arista.avd.defined(false) %}
 no ipv6 icmp redirect
 {% endif %}
+{% if ipv6_hardware.fib.optimize.prefixes.profile is arista.avd.defined %}
+ipv6 hardware fib optimize prefixes profile {{ ipv6_hardware.fib.optimize.prefixes.profile }}
+{% endif %}


### PR DESCRIPTION
## Change Summary

You can enable FlexRoute compression and expansion of prefixes. While these commands can be customized for different prefix lengths, Arista has included pre-defined 'internet' profiles for both IPv4 and IPv6 based on the current contents of the Internet routing table.

## Related Issue(s)

Fixes #1620

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

```yaml
ip_hardware:
  fib:
    optimize:
      prefix_profile: < internet | urpf-internet >
```

```yaml
ipv6_hardware:
  fib:
    optimize:
      prefix_profile: < internet >
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
