### PR TITLE
Refactor(eos_cli_config_gen): Wildcard dict to list for management_ssh

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/base.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/base.yml
@@ -42,7 +42,7 @@ management_ssh:
     per_host: 12
   enable: true
   vrfs:
-    mgt:
+    - name: mgt
       enable: true
 
 eos_cli: |

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/management-ssh-custom-cipher.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/management-ssh-custom-cipher.yml
@@ -21,5 +21,5 @@ management_ssh:
     limit: 55
   enable: true
   vrfs:
-    mgt:
+    - name: mgt
       enable: true

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/management-ssh.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/management-ssh.yml
@@ -9,6 +9,6 @@ management_ssh:
     per_host: 10
   enable: true
   vrfs:
-    mgt:
+    - name: mgt
       enable: true
   log_level: debug

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
@@ -1735,12 +1735,12 @@ management_security:
 ```yaml
 management_ssh:
   access_groups:
-    - name: < standard_acl_name_1 >:
-    - name: < standard_acl_name_2 >:
+    - name: < standard_acl_name_1 >
+    - name: < standard_acl_name_2 >
       vrf: < vrf name >
   ipv6_access_groups:
-    - name: < standard_acl_name_1 >:
-    - name: < standard_acl_name_2 >:
+    - name: < standard_acl_name_1 >
+    - name: < standard_acl_name_2 >
       vrf: < vrf name >
   idle_timeout: < 0-86400 in minutes >
   cipher:
@@ -1761,9 +1761,9 @@ management_ssh:
     limit: < 1-100 SSH Connections >
     per_host: < 1-20 max sessions from a host >
   vrfs:
-    < vrf_name_1 >:
+    - name: < vrf_name_1 >
       enable: < true | false >
-    < vrf_name_2 >:
+    - name: < vrf_name_2 >
       enable: < true | false >
   log_level: < SSH daemon log level >
 ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-ssh.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-ssh.j2
@@ -1,5 +1,5 @@
 {# Management SSH #}
-{% if management_ssh is defined and management_ssh is not none %}
+{% if management_ssh is arista.avd.defined %}
 
 ## Management SSH
 
@@ -55,13 +55,13 @@
 
 | VRF | Status |
 | --- | ------ |
-{%         for vrf in management_ssh.vrfs %}
-{%             if management_ssh.vrfs[vrf].enable %}
+{%         for vrf in management_ssh.vrfs | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%             if vrf.enable %}
 {%                 set status = 'Enabled' %}
 {%             else %}
 {%                 set status = 'Disabled' %}
 {%             endif %}
-| {{ vrf }} | {{ status }} |
+| {{ vrf.name }} | {{ status }} |
 {%         endfor %}
 {%     endif %}
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-ssh.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-ssh.j2
@@ -51,11 +51,11 @@ management ssh
 {%     if management_ssh.log_level is arista.avd.defined %}
    log-level {{ management_ssh.log_level }}
 {%     endif %}
-{%     for vrf in management_ssh.vrfs | arista.avd.natural_sort %}
-   vrf {{ vrf }}
-{%         if management_ssh.vrfs[vrf].enable is arista.avd.defined(true) %}
+{%     for vrf in management_ssh.vrfs | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+   vrf {{ vrf.name }}
+{%         if vrf.enable is arista.avd.defined(true) %}
       no shutdown
-{%         elif management_ssh.vrfs[vrf].enable is arista.avd.defined(false) %}
+{%         elif vrf.enable is arista.avd.defined(false) %}
       shutdown
 {%         endif %}
 {%     endfor %}


### PR DESCRIPTION
## "Wildcard Keyed Dict" to "List of Dicts" Data model migration

<!-- Use this PR Title: Refactor(eos_cli_config_gen): Wildcard dict to list for `< data_model_key >` -->

## Data model key

`< data_model_key >`

## Checklist

### Contributor Checklist

- [x] Update `README_v4.0.md` with new data model
- [x] Update all `host_vars` under molecule scenario `eos_cli_config_gen_v4.0` with new data model
- [x] Update `templates/eos/< template >.j2` and `templates/documentation/< template >.j2`:
  - [x] Add `arista.avd.convert_dicts('<primary key>')` filter for loops previously using wildcard keys
  - [x] Update `arista.avd.natural_sort('<primary key>')` to sort on the primary key (if applicable)
- [x] Run molecule `cd ansible_collections/arista/avd/molecule ; make cli-4.0-schema`
  - [x] Verify no changes to generated configs/docs

### Reviewer Checklist

- Reviewer 1: Claus
  - [x] Verify data model changes
  - [x] Verify that all molecule `host_vars` under `eos_cli_config_gen_v4.0` has been updated to the new data model
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2: Tony
  - [x] Verify data model changes
  - [x] Verify that all molecule `host_vars` under `eos_cli_config_gen_v4.0` has been updated to the new data model
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
