### PR TITLE
Refactor(eos_cli_config_gen): Wildcard dict to list for management-api-gnmi

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/management-gnmi.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/management-gnmi.yml
@@ -1,6 +1,6 @@
 management_api_gnmi:
   enable_vrfs:
-    MGMT:
+    - name: MGMT
       access_group: ACL-GNMI
-    MONITORING:
+    - name: MONITORING
   octa:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
@@ -1694,9 +1694,9 @@ ip_http_client_source_interfaces:
 ```yaml
 management_api_gnmi:
   enable_vrfs:
-    < vrf_name_1 >:
+    - name: < vrf_name_1 >
       access_group: < Standard IPv4 ACL name >
-    < vrf_name_2 >:
+    - name: < vrf_name_2 >
       access_group: < Standard IPv4 ACL name >
   octa:
 ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-api-gnmi.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-api-gnmi.j2
@@ -1,5 +1,5 @@
 {# Management API GNMI #}
-{% if management_api_gnmi is defined and management_api_gnmi is not none %}
+{% if management_api_gnmi is arista.avd.defined %}
 
 ## Management API GNMI
 
@@ -14,8 +14,8 @@
 
 | VRF with GNMI | OCTA |
 | ------------- | ---- |
-{%         for vrf in management_api_gnmi.enable_vrfs | arista.avd.natural_sort %}
-| {{ vrf }} | {{ octa }} |
+{%         for vrf in management_api_gnmi.enable_vrfs | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+| {{ vrf.name }} | {{ octa }} |
 {%         endfor %}
 {%     endif %}
 {# new table view using the new flags #}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-api-gnmi.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-api-gnmi.j2
@@ -2,15 +2,15 @@
 {% if management_api_gnmi is arista.avd.defined %}
 !
 management api gnmi
-{%     for vrf in management_api_gnmi.enable_vrfs | arista.avd.natural_sort %}
-{%         if vrf == 'default' %}
+{%     for vrf in management_api_gnmi.enable_vrfs | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%         if vrf.name == 'default' %}
    transport grpc default
 {%         else %}
-   transport grpc {{ vrf }}
-{%             if management_api_gnmi.enable_vrfs[vrf].access_group is arista.avd.defined %}
-      ip access-group {{ management_api_gnmi.enable_vrfs[vrf].access_group }}
+   transport grpc {{ vrf.name }}
+{%             if vrf.access_group is arista.avd.defined %}
+      ip access-group {{ vrf.access_group }}
 {%             endif %}
-      vrf {{ vrf }}
+      vrf {{ vrf.name }}
 {%         endif %}
 {%     endfor %}
 {%     if management_api_gnmi.octa is defined %}


### PR DESCRIPTION
## "Wildcard Keyed Dict" to "List of Dicts" Data model migration

<!-- Use this PR Title: Refactor(eos_cli_config_gen): Wildcard dict to list for `< data_model_key >` -->

## Data model key

`< data_model_key >`

## Checklist

### Contributor Checklist

- [ ] Update `README_v4.0.md` with new data model
- [ ] Update all `host_vars` under molecule scenario `eos_cli_config_gen_v4.0` with new data model
- [ ] Update `templates/eos/< template >.j2` and `templates/documentation/< template >.j2`:
  - [ ] Add `arista.avd.convert_dicts('<primary key>')` filter for loops previously using wildcard keys
  - [ ] Update `arista.avd.natural_sort('<primary key>')` to sort on the primary key (if applicable)
- [ ] Run molecule `cd ansible_collections/arista/avd/molecule ; make cli-4.0-schema`
  - [ ] Verify no changes to generated configs/docs

### Reviewer Checklist

- Reviewer 1:
  - [ ] Verify data model changes
  - [ ] Verify that all molecule `host_vars` under `eos_cli_config_gen_v4.0` has been updated to the new data model
  - [ ] Verify no changes to configs/docs on any molecule scenario
  - [ ] Verify that CI pass

- Reviewer 2:
  - [ ] Verify data model changes
  - [ ] Verify that all molecule `host_vars` under `eos_cli_config_gen_v4.0` has been updated to the new data model
  - [ ] Verify no changes to configs/docs on any molecule scenario
  - [ ] Verify that CI pass
