### PR TITLE
Refactor(eos_cli_config_gen): Wildcard dict to list for management_api_http

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/base.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/base.yml
@@ -15,7 +15,7 @@ management_api_http:
   enable_http: true
   enable_https: true
   enable_vrfs:
-    mgt:
+    - name: mgt
       access_group: ACL-API
 
 ### Management console ###

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/management-api-http.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/management-api-http.yml
@@ -4,9 +4,9 @@ management_api_http:
   enable_https: true
   https_ssl_profile: SSL_PROFILE
   enable_vrfs:
-    default:
+    - name: default
       access_group: ACL-API
-    MGMT:
+    - name: MGMT
       access_group: ACL-API
 
 # Standard ACLs

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
@@ -1667,10 +1667,10 @@ management_api_http:
   enable_https: < true | false >
   https_ssl_profile: < SSL Profile Name >
   enable_vrfs:
-    < vrf_name_1 >:
+    - name: < vrf_name_1 >
       access_group: < Standard IPv4 ACL name >
       ipv6_access_group: < Standard IPv6 ACL name >
-    < vrf_name_2 >:
+    - name: < vrf_name_2 >
       access_group: < Standard IPv4 ACL name >
       ipv6_access_group: < Standard IPv6 ACL name >
   protocol_https_certificate:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-api-http.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-api-http.j2
@@ -18,8 +18,8 @@ Management HTTPS is using the SSL profile {{ management_api_http.https_ssl_profi
 
 | VRF Name | IPv4 ACL | IPv6 ACL |
 | -------- | -------- | -------- |
-{%         for vrf in management_api_http.enable_vrfs | arista.avd.natural_sort %}
-| {{ vrf }} | {{ management_api_http.enable_vrfs[vrf].access_group | arista.avd.default('-') }} | {{ management_api_http.enable_vrfs[vrf].ipv6_access_group | arista.avd.default('-') }} |
+{%         for vrf in management_api_http.enable_vrfs | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+| {{ vrf.name }} | {{ vrf.access_group | arista.avd.default('-') }} | {{ vrf.ipv6_access_group | arista.avd.default('-') }} |
 {%         endfor %}
 {%     endif %}
 {%     if management_api_http.protocol_https_certificate.certificate is arista.avd.defined and management_api_http.protocol_https_certificate.private_key is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-api-http.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-api-http.j2
@@ -16,15 +16,15 @@ management api http-commands
    no protocol http
 {%     endif %}
    no shutdown
-{%     for vrf in management_api_http.enable_vrfs | arista.avd.natural_sort %}
+{%     for vrf in management_api_http.enable_vrfs | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
    !
-   vrf {{ vrf }}
+   vrf {{ vrf.name }}
       no shutdown
-{%         if management_api_http.enable_vrfs[vrf].access_group is arista.avd.defined %}
-      ip access-group {{ management_api_http.enable_vrfs[vrf].access_group }}
+{%         if vrf.access_group is arista.avd.defined %}
+      ip access-group {{ vrf.access_group }}
 {%         endif %}
-{%         if management_api_http.enable_vrfs[vrf].ipv6_access_group is arista.avd.defined %}
-      ipv6 access-group {{ management_api_http.enable_vrfs[vrf].ipv6_access_group }}
+{%         if vrf.ipv6_access_group is arista.avd.defined %}
+      ipv6 access-group {{ vrf.ipv6_access_group }}
 {%         endif %}
 {%     endfor %}
 {%     if management_api_http.protocol_https_certificate.certificate is arista.avd.defined and management_api_http.protocol_https_certificate.private_key is arista.avd.defined %}


### PR DESCRIPTION
## "Wildcard Keyed Dict" to "List of Dicts" Data model migration

<!-- Use this PR Title: Refactor(eos_cli_config_gen): Wildcard dict to list for `< data_model_key >` -->

## Data model key

`< data_model_key >`

## Checklist

### Contributor Checklist

- [x] Update `README_v4.0.md` with new data model
- [x] Update all `host_vars` under molecule scenario `eos_cli_config_gen_v4.0` with new data model
- [x] Update `templates/eos/< template >.j2` and `templates/documentation/< template >.j2`:
  - [x] Add `arista.avd.convert_dicts('<primary key>')` filter for loops previously using wildcard keys
  - [x] Update `arista.avd.natural_sort('<primary key>')` to sort on the primary key (if applicable)
- [x] Run molecule `cd ansible_collections/arista/avd/molecule ; make cli-4.0-schema`
  - [x] Verify no changes to generated configs/docs

### Reviewer Checklist

- Reviewer 1: Claus
  - [x] Verify data model changes
  - [x] Verify that all molecule `host_vars` under `eos_cli_config_gen_v4.0` has been updated to the new data model
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2: Tony
  - [x] Verify data model changes
  - [x] Verify that all molecule `host_vars` under `eos_cli_config_gen_v4.0` has been updated to the new data model
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
