### PR TITLE
Refactor(eos_cli_config_gen): Wildcard dict to list for maintenance

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/maintenance.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/maintenance.yml
@@ -10,24 +10,24 @@ maintenance:
       shutdown:
         max_delay: 300
   bgp_profiles:
-    BP1:
+    - name: BP1
       initiator:
         route_map_inout: RM-MAINTENANCE
-    BP2:
+    - name: BP2
       initiator:
         route_map_inout: RM-MAINTENANCE2
-    BP3:
+    - name: BP3
       initiator:
         route_map_inout: RM-MAINTENANCE3
   unit_profiles:
-    UP1:
+    - name: UP1
       on_boot:
         duration: 900
-    UP2:
+    - name: UP2
       on_boot:
         duration: 600
   units:
-    UNIT1:
+    - name: UNIT1
       profile: UP1
       groups:
         bgp_groups:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
@@ -1579,15 +1579,15 @@ maintenance:
       shutdown:
         max_delay: < seconds >
   bgp_profiles:
-    < bgp_profile_1 >:
+    - name: < bgp_profile_1 >
       initiator:
         route_map_inout: < route_map >
   unit_profiles:
-    < unit_profile_1 >:
+    - name: < unit_profile_1 >
       on_boot:
         duration: < 300-3600 >
   units:
-    < unit_name_1 >:
+    - name: < unit_name_1 >
       quiesce: < true | false >
       profile: < unit_profile_1 >
       groups:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/maintenance.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/maintenance.j2
@@ -14,8 +14,8 @@ Default maintenance unit profile: **{{ maintenance.default_unit_profile | arista
 
 | BGP profile | Initiator route-map |
 | ----------- | ------------------- |
-{%     for bgp_profile in maintenance.bgp_profiles | arista.avd.natural_sort %}
-| {{ bgp_profile }} | {{ maintenance.bgp_profiles[bgp_profile].initiator.route_map_inout | arista.avd.default('SystemGenerated') }} |
+{%     for bgp_profile in maintenance.bgp_profiles | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+| {{ bgp_profile.name }} | {{ bgp_profile.initiator.route_map_inout | arista.avd.default('SystemGenerated') }} |
 {%     endfor %}
 
 | Interface profile | Rate monitoring load interval (s) | Rate monitoring threshold in/out (kbps) | Shutdown Max Delay |
@@ -29,20 +29,20 @@ Default maintenance unit profile: **{{ maintenance.default_unit_profile | arista
 
 | Unit profile | on-boot duration (s) |
 | ------------ | -------------------- |
-{%     for unit_profile in maintenance.unit_profiles | arista.avd.natural_sort %}
-| {{ unit_profile }} | {{ maintenance.unit_profiles[unit_profile].on_boot.duration | arista.avd.default('disabled') }} |
+{%     for unit_profile in maintenance.unit_profiles | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+| {{ unit_profile.name }} | {{ unit_profile.on_boot.duration | arista.avd.default('disabled') }} |
 {%     endfor %}
 
 ### Maintenance units
 
 | Unit | Interface groups | BGP groups | Unit profile | Quiesce |
 | ---- | ---------------- | ---------- | ------------ | ------- |
-{%     for unit in maintenance.units | arista.avd.natural_sort %}
-{%         set row_interface_groups = maintenance.units[unit].groups.interface_groups | arista.avd.default(['-']) | arista.avd.natural_sort | join('<br/>') %}
-{%         set row_bgp_groups = maintenance.units[unit].groups.bgp_groups | arista.avd.default(['-']) | arista.avd.natural_sort | join('<br/>') %}
-{%         set row_unit_profile = maintenance.units[unit].profile | arista.avd.default(maintenance.default_unit_profile, 'Default') %}
-{%         set row_quiesce = maintenance.units[unit].quiesce | arista.avd.default(false) | ternary('Yes', 'No') %}
-| {{ unit }} | {{ row_interface_groups }} | {{ row_bgp_groups }} | {{ row_unit_profile }} | {{ row_quiesce }} |
+{%     for unit in maintenance.units | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%         set row_interface_groups = unit.groups.interface_groups | arista.avd.default(['-']) | arista.avd.natural_sort | join('<br/>') %}
+{%         set row_bgp_groups = unit.groups.bgp_groups | arista.avd.default(['-']) | arista.avd.natural_sort | join('<br/>') %}
+{%         set row_unit_profile = unit.profile | arista.avd.default(maintenance.default_unit_profile, 'Default') %}
+{%         set row_quiesce = unit.quiesce | arista.avd.default(false) | ternary('Yes', 'No') %}
+| {{ unit.name }} | {{ row_interface_groups }} | {{ row_bgp_groups }} | {{ row_unit_profile }} | {{ row_quiesce }} |
 {%     endfor %}
 
 ### Maintenance configuration

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/maintenance.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/maintenance.j2
@@ -3,14 +3,14 @@
 {% if maintenance is arista.avd.defined %}
 !
 maintenance
-{%     for bgp_profile in maintenance.bgp_profiles | arista.avd.natural_sort %}
+{%     for bgp_profile in maintenance.bgp_profiles | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
 {%         if loop.index0 > 0 %}
    !
 {%         endif %}
 {%         set first_line = {'flag': False} %}
-   profile bgp {{ bgp_profile }}
-{%         if maintenance.bgp_profiles[bgp_profile].initiator.route_map_inout is arista.avd.defined %}
-      initiator route-map {{ maintenance.bgp_profiles[bgp_profile].initiator.route_map_inout }} inout
+   profile bgp {{ bgp_profile.name }}
+{%         if bgp_profile.initiator.route_map_inout is arista.avd.defined %}
+      initiator route-map {{ bgp_profile.initiator.route_map_inout }} inout
 {%         endif %}
 {%     endfor %}
 {%     if maintenance.default_bgp_profile is arista.avd.defined %}
@@ -41,34 +41,34 @@ maintenance
       shutdown max-delay {{ interface_profile.shutdown.max_delay }}
 {%         endif %}
 {%     endfor %}
-{%     for unit_profile in maintenance.unit_profiles | arista.avd.natural_sort %}
+{%     for unit_profile in maintenance.unit_profiles | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
 {%         if not first_line.flag %}
    !
 {%         endif %}
 {%         set first_line = {'flag': False} %}
-   profile unit {{ unit_profile }}
-{%         if maintenance.unit_profiles[unit_profile].on_boot.duration is arista.avd.defined %}
-      on-boot duration {{ maintenance.unit_profiles[unit_profile].on_boot.duration }}
+   profile unit {{ unit_profile.name }}
+{%         if unit_profile.on_boot.duration is arista.avd.defined %}
+      on-boot duration {{ unit_profile.on_boot.duration }}
 {%         endif %}
 {%     endfor %}
-{%     for unit in maintenance.units | arista.avd.natural_sort %}
+{%     for unit in maintenance.units | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
 {%         if not first_line.flag %}
    !
 {%         endif %}
 {%         set first_line = {'flag': False} %}
-   unit {{ unit }}
-{%         for bgp_group in maintenance.units[unit].groups.bgp_groups | arista.avd.natural_sort %}
+   unit {{ unit.name }}
+{%         for bgp_group in unit.groups.bgp_groups | arista.avd.natural_sort %}
       group bgp {{ bgp_group }}
 {%         endfor %}
-{%         for interface_group in maintenance.units[unit].groups.interface_groups | arista.avd.natural_sort %}
+{%         for interface_group in unit.groups.interface_groups | arista.avd.natural_sort %}
       group interface {{ interface_group }}
 {%         endfor %}
-{%         if maintenance.units[unit].profile is arista.avd.defined %}
-      profile unit {{ maintenance.units[unit].profile }}
+{%         if unit.profile is arista.avd.defined %}
+      profile unit {{ unit.profile }}
 {%         endif %}
-{%         if maintenance.units[unit].quiesce is arista.avd.defined(true) %}
+{%         if unit.quiesce is arista.avd.defined(true) %}
       quiesce
-{%         elif maintenance.units[unit].quiesce is arista.avd.defined(false) %}
+{%         elif unit.quiesce is arista.avd.defined(false) %}
       no quiesce
 {%         endif %}
 {%     endfor %}


### PR DESCRIPTION
## "Wildcard Keyed Dict" to "List of Dicts" Data model migration

<!-- Use this PR Title: Refactor(eos_cli_config_gen): Wildcard dict to list for `maintenance` -->

## Data model key

`maintenance`

## Checklist

### Contributor Checklist

- [x] Update `README_v4.0.md` with new data model
- [x] Update all `host_vars` under molecule scenario `eos_cli_config_gen_v4.0` with new data model
- [x] Update `templates/eos/< template >.j2` and `templates/documentation/< template >.j2`:
  - [x] Add `arista.avd.convert_dicts('<primary key>')` filter for loops previously using wildcard keys
  - [x] Update `arista.avd.natural_sort('<primary key>')` to sort on the primary key (if applicable)
- [x] Run molecule `cd ansible_collections/arista/avd/molecule ; make cli-4.0-schema`
  - [x] Verify no changes to generated configs/docs

### Reviewer Checklist

- Reviewer 1: Claus
  - [x] Verify data model changes
  - [x] Verify that all molecule `host_vars` under `eos_cli_config_gen_v4.0` has been updated to the new data model
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2: Tony
  - [x] Verify data model changes
  - [x] Verify that all molecule `host_vars` under `eos_cli_config_gen_v4.0` has been updated to the new data model
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
