### PR TITLE
Refactor(eos_cli_config_gen): Wildcard dict to list for daemons

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/daemons.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/daemons.yml
@@ -1,7 +1,7 @@
 daemons:
-  ocprometheus:
+  - name: ocprometheus
     exec: "/usr/bin/ocprometheus -config /usr/bin/ocprometheus.yml -addr localhost:6042"
     enabled: true
-  random:
+  - name: random
     exec: "/usr/bin/random"
     enabled: false

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
@@ -2002,7 +2002,7 @@ You can either provide a list of IPs/FQDNs to target on-premise Cloudvision clus
 
 ```yaml
 daemons:
-  < daemon_name >:
+  - name: < daemon_name >
     exec: "< command to run as a daemon >"
     enabled: "< true | false | default -> true >"
 ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/daemons.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/daemons.j2
@@ -1,12 +1,12 @@
 {# eos - daemons #}
 {% if daemons is arista.avd.defined %}
-{%     for daemon in daemons %}
+{%     for daemon in daemons | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
 !
-daemon {{ daemon }}
-{%         if daemons[daemon].exec is arista.avd.defined %}
-   exec {{ daemons[daemon].exec }}
+daemon {{ daemon.name }}
+{%         if daemon.exec is arista.avd.defined %}
+   exec {{ daemon.exec }}
 {%         endif %}
-{%         if daemons[daemon].enabled is arista.avd.defined(false) %}
+{%         if daemon.enabled is arista.avd.defined(false) %}
    shutdown
 {%         else %}
    no shutdown


### PR DESCRIPTION
## "Wildcard Keyed Dict" to "List of Dicts" Data model migration

<!-- Use this PR Title: Refactor(eos_cli_config_gen): Wildcard dict to list for `daemons` -->

## Data model key

`daemons`

## Checklist

### Contributor Checklist

- [x] Update `README_v4.0.md` with new data model
- [x] Update all `host_vars` under molecule scenario `eos_cli_config_gen_v4.0` with new data model
- [x] Update `templates/eos/< template >.j2` and `templates/documentation/< template >.j2`:
  - [x] Add `arista.avd.convert_dicts('<primary key>')` filter for loops previously using wildcard keys
  - [x] Update `arista.avd.natural_sort('<primary key>')` to sort on the primary key (if applicable)
- [x] Run molecule `cd ansible_collections/arista/avd/molecule ; make cli-4.0-schema`
  - [x] Verify no changes to generated configs/docs

### Reviewer Checklist

- Reviewer 1: Claus
  - [x] Verify data model changes
  - [x] Verify that all molecule `host_vars` under `eos_cli_config_gen_v4.0` has been updated to the new data model
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2: Tony
  - [x] Verify data model changes
  - [x] Verify that all molecule `host_vars` under `eos_cli_config_gen_v4.0` has been updated to the new data model
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
