### PR TITLE
Feat(eos_cli_config_gen): Add support for ebgp_multihop under bgp neighbors

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
@@ -110,6 +110,7 @@ interface Management1
 | 192.0.3.2 | 65433 | default | - | extended | 10000 | - | - | True (All) |
 | 192.0.3.3 | 65434 | default | - | standard | - | - | - | True |
 | 192.0.3.4 | 65435 | default | - | large | - | - | - | False |
+| 192.0.3.5 | 65436 | default | - | standard | 12000 | - | - | - |
 
 ### BGP Neighbor Interfaces
 
@@ -157,6 +158,11 @@ router bgp 65101
    neighbor 192.0.3.4 remote-as 65435
    no neighbor 192.0.3.4 rib-in pre-policy retain
    neighbor 192.0.3.4 send-community large
+   neighbor 192.0.3.5 remote-as 65436
+   neighbor 192.0.3.5 description test_ebgp_multihop
+   neighbor 192.0.3.5 ebgp-multihop 2
+   neighbor 192.0.3.5 send-community standard
+   neighbor 192.0.3.5 maximum-routes 12000
    aggregate-address 1.1.1.0/24 advertise-only
    aggregate-address 1.12.1.0/24 as-set summary-only attribute-map RM-ATTRIBUTE match-map RM-MATCH advertise-only
    aggregate-address 2.2.1.0/24

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-base.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-base.cfg
@@ -39,6 +39,11 @@ router bgp 65101
    neighbor 192.0.3.4 remote-as 65435
    no neighbor 192.0.3.4 rib-in pre-policy retain
    neighbor 192.0.3.4 send-community large
+   neighbor 192.0.3.5 remote-as 65436
+   neighbor 192.0.3.5 description test_ebgp_multihop
+   neighbor 192.0.3.5 ebgp-multihop 2
+   neighbor 192.0.3.5 send-community standard
+   neighbor 192.0.3.5 maximum-routes 12000
    aggregate-address 1.1.1.0/24 advertise-only
    aggregate-address 1.12.1.0/24 as-set summary-only attribute-map RM-ATTRIBUTE match-map RM-MATCH advertise-only
    aggregate-address 2.2.1.0/24

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-base.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-base.yml
@@ -96,6 +96,12 @@ router_bgp:
         enabled: false
       rib_in_pre_policy_retain:
         enabled: false
+    192.0.3.5:
+      remote_as: 65436
+      description: test_ebgp_multihop
+      send_community: standard
+      ebgp_multihop: 2
+      maximum_routes: 12000
   neighbor_interfaces:
     Ethernet2:
       peer_group: PG-FOO-v4

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-base.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-base.yml
@@ -98,7 +98,7 @@ router_bgp:
         enabled: false
     192.0.3.5:
       remote_as: 65436
-      description: test_ebgp_multihop_2
+      description: test_ebgp_multihop
       send_community: standard
       ebgp_multihop: 2
       maximum_routes: 12000

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-base.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-base.yml
@@ -98,7 +98,7 @@ router_bgp:
         enabled: false
     192.0.3.5:
       remote_as: 65436
-      description: test_ebgp_multihop
+      description: test_ebgp_multihop_2
       send_community: standard
       ebgp_multihop: 2
       maximum_routes: 12000

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -2607,6 +2607,7 @@ router_bgp:
       remote_as: < bgp_as >
       local_as: < bgp_as >
       description: "< description as string >"
+      ebgp_multihop: < integer >
       shutdown: < true | false >
       update_source: < interface >
       bfd: < true | false >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -155,6 +155,9 @@ router bgp {{ router_bgp.as }}
 {%         if router_bgp.neighbors[neighbor].description is arista.avd.defined %}
    neighbor {{ neighbor }} description {{ router_bgp.neighbors[neighbor].description }}
 {%         endif %}
+{%         if router_bgp.neighbors[neighbor].ebgp_multihop is arista.avd.defined %}
+   neighbor {{ neighbor }} ebgp-multihop {{ router_bgp.neighbors[neighbor].ebgp_multihop }}
+{%         endif %}
 {%         if router_bgp.neighbors[neighbor].update_source is arista.avd.defined %}
    neighbor {{ neighbor }} update-source {{ router_bgp.neighbors[neighbor].update_source }}
 {%         endif %}


### PR DESCRIPTION
## Change Summary

Currently we  don't support ebgp_multihop in the regular/plan bgp neighbor section, so I'm adding support for this.

## Related Issue(s)

Fixes # N/A

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
```
 neighbors:
    < IPv4_address_1 >:
      <snip>
      ebgp_multihop: < integer >
     </snip>
```

I've also updated the readme with the new setting. Please let me know if you think that adding this specifically to the doc makes sense.

## How to test
Added molecule testcase

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
