### PR TITLE
Refactor(eos_cli_config_gen): Wildcard dict to list for event-handlers

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/event-handlers.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/event-handlers.yml
@@ -1,5 +1,5 @@
 event_handlers:
-  tracking:
+  - name: tracking
     action_type: bash
     action: /mnt/flash/tracking.sh
     delay: 300

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
@@ -2047,7 +2047,7 @@ monitor_connectivity:
 ```yaml
 ### Event Handler ###
 event_handlers:
-  < event_handler_name >:
+  - name: < event_handler_name >
     action_type: < Type of action. [bash, increment, log] >
     action: < Command to execute >
     delay: < Event-handler delay in seconds >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/event-handler.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/event-handler.j2
@@ -1,5 +1,5 @@
 {# eos - event-handler #}
-{% if event_handlers is defined and event_handlers is iterable %}
+{% if event_handlers is arista.avd.defined %}
 
 ## Event Handler
 
@@ -7,8 +7,8 @@
 
 | Handler | Action Type | Action | Trigger |
 | ------- | ----------- | ------ | ------- |
-{%     for handler in event_handlers | arista.avd.natural_sort %}
-| {{ handler }} | {{ event_handlers[handler].action_type }} | {{ event_handlers[handler].action }} | {{ event_handlers[handler].trigger }} |
+{%     for handler in event_handlers | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+| {{ handler.name }} | {{ handler.action_type }} | {{ handler.action }} | {{ handler.trigger }} |
 {%     endfor %}
 
 ### Event Handler Device Configuration

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/event-handler.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/event-handler.j2
@@ -1,21 +1,21 @@
 {# eos - Event handlers #}
 {% if event_handlers is arista.avd.defined %}
-{%     for handler in event_handlers %}
+{%     for handler in event_handlers | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
 !
-event-handler {{ handler }}
-{%         if event_handlers[handler].trigger is arista.avd.defined %}
-   trigger {{ event_handlers[handler].trigger }}
-{%             if event_handlers[handler].regex is arista.avd.defined %}
-      regex {{ event_handlers[handler].regex }}
+event-handler {{ handler.name }}
+{%         if handler.trigger is arista.avd.defined %}
+   trigger {{ handler.trigger }}
+{%             if handler.regex is arista.avd.defined %}
+      regex {{ handler.regex }}
 {%             endif %}
 {%         endif %}
-{%         if event_handlers[handler].action is arista.avd.defined and event_handlers[handler].action_type is arista.avd.defined %}
-   action {{ event_handlers[handler].action_type }} {{ event_handlers[handler].action }}
+{%         if handler.action is arista.avd.defined and handler.action_type is arista.avd.defined %}
+   action {{ handler.action_type }} {{ handler.action }}
 {%         endif %}
-{%         if event_handlers[handler].delay is arista.avd.defined %}
-   delay {{ event_handlers[handler].delay }}
+{%         if handler.delay is arista.avd.defined %}
+   delay {{ handler.delay }}
 {%         endif %}
-{%         if event_handlers[handler].asynchronous is arista.avd.defined(true) %}
+{%         if handler.asynchronous is arista.avd.defined(true) %}
    asynchronous
 {%         endif %}
 {%     endfor %}


### PR DESCRIPTION
## "Wildcard Keyed Dict" to "List of Dicts" Data model migration

<!-- Use this PR Title: Refactor(eos_cli_config_gen): Wildcard dict to list for `event-handlers` -->

## Data model key

`event-handlers`

## Checklist

### Contributor Checklist

- [x] Update `README_v4.0.md` with new data model
- [x] Update all `host_vars` under molecule scenario `eos_cli_config_gen_v4.0` with new data model
- [x] Update `templates/eos/< template >.j2` and `templates/documentation/< template >.j2`:
  - [x] Add `arista.avd.convert_dicts('<primary key>')` filter for loops previously using wildcard keys
  - [x] Update `arista.avd.natural_sort('<primary key>')` to sort on the primary key (if applicable)
- [x] Run molecule `cd ansible_collections/arista/avd/molecule ; make cli-4.0-schema`
  - [x] Verify no changes to generated configs/docs

### Reviewer Checklist

- Reviewer 1: Claus
  - [x] Verify data model changes
  - [x] Verify that all molecule `host_vars` under `eos_cli_config_gen_v4.0` has been updated to the new data model
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2: Tony
  - [x] Verify data model changes
  - [x] Verify that all molecule `host_vars` under `eos_cli_config_gen_v4.0` has been updated to the new data model
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
