### PR TITLE
Refactor(eos_cli_config_gen): Wildcard dict to list for vmtracer-sessions

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/vmtracer-sessions.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/vmtracer-sessions.yml
@@ -1,13 +1,13 @@
 ### vmtracer sessions ###
 
 vmtracer_sessions:
-  session_1:
+  - name: session_1
     url: "https://192.168.0.10"
     username: user1
     password: "encrypted_password"
     autovlan_disable: true
     source_interface: Management1
-  session_2:
+  - name: session_2
     url: "https://192.168.0.10"
     username: user1
     password: "encrypted_password"

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
@@ -2272,13 +2272,13 @@ system:
 
 ```yaml
 vmtracer_sessions:
-  < vmtracer_session_name_1 >:
+  - name: < vmtracer_session_name_1 >
     url: < url >
     username: < username >
     password: "< encrypted_password >"
     autovlan_disable: < true | false >
     source_interface: < interface_name >
-  < vmtracer_session_name_2 >:
+  - name: < vmtracer_session_name_2 >
     url: < url >
     username: < username >
     password: "< encrypted_password >"

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vmtracer-sessions.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vmtracer-sessions.j2
@@ -1,4 +1,4 @@
-{% if vmtracer_sessions is defined and vmtracer_sessions is not none %}
+{% if vmtracer_sessions is arista.avd.defined %}
 
 ## VM Tracer Sessions
 
@@ -6,13 +6,13 @@
 
 | Session | URL | Username | Autovlan | Source Interface |
 | ------- | --- | -------- | -------- | ---------------- |
-{%     for session in vmtracer_sessions | arista.avd.natural_sort %}
-{%         set url = vmtracer_sessions[session].url | arista.avd.default('-') %}
-{%         if vmtracer_sessions[session].autovlan_disable is arista.avd.defined and vmtracer_sessions[session].autovlan_disable == true %}
+{%     for session in vmtracer_sessions | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%         set url = session.url | arista.avd.default('-') %}
+{%         if session.autovlan_disable is arista.avd.defined and session.autovlan_disable == true %}
 {%             set autovlan = 'disabled' %}
 {%         endif %}
-{%         set source_interface = vmtracer_sessions[session].source_interface | arista.avd.default('-') %}
-| {{ session }} | {{ url }} | {{ vmtracer_sessions[session].username }} | {{ autovlan | arista.avd.default('enabled') }} | {{ source_interface }} |
+{%         set source_interface = session.source_interface | arista.avd.default('-') %}
+| {{ session.name }} | {{ url }} | {{ session.username }} | {{ autovlan | arista.avd.default('enabled') }} | {{ source_interface }} |
 {%     endfor %}
 
 ### VM Tracer Device Configuration

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vmtracer-sessions.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vmtracer-sessions.j2
@@ -8,11 +8,11 @@
 | ------- | --- | -------- | -------- | ---------------- |
 {%     for session in vmtracer_sessions | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
 {%         set url = session.url | arista.avd.default('-') %}
-{%         if session.autovlan_disable is arista.avd.defined and session.autovlan_disable == true %}
+{%         if session.autovlan_disable is arista.avd.defined(true) %}
 {%             set autovlan = 'disabled' %}
 {%         endif %}
 {%         set source_interface = session.source_interface | arista.avd.default('-') %}
-| {{ session.name }} | {{ url }} | {{ session.username }} | {{ autovlan | arista.avd.default('enabled') }} | {{ source_interface }} |
+| {{ session.name }} | {{ url }} | {{ session.username | arista.avd.default('-') }} | {{ autovlan | arista.avd.default('enabled') }} | {{ source_interface }} |
 {%     endfor %}
 
 ### VM Tracer Device Configuration

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vmtracer-sessions.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vmtracer-sessions.j2
@@ -1,20 +1,20 @@
 {# eos - vmtracer sessions #}
-{% for session in vmtracer_sessions | arista.avd.natural_sort %}
+{% for session in vmtracer_sessions | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
 !
-vmtracer session {{ session }}
-{%     if vmtracer_sessions[session].url is arista.avd.defined %}
-   url {{ vmtracer_sessions[session].url }}
+vmtracer session {{ session.name }}
+{%     if session.url is arista.avd.defined %}
+   url {{ session.url }}
 {%     endif %}
-{%     if vmtracer_sessions[session].username is arista.avd.defined %}
-   username {{ vmtracer_sessions[session].username }}
+{%     if session.username is arista.avd.defined %}
+   username {{ session.username }}
 {%     endif %}
-{%     if vmtracer_sessions[session].password is arista.avd.defined %}
-   password 7 {{ vmtracer_sessions[session].password }}
+{%     if session.password is arista.avd.defined %}
+   password 7 {{ session.password }}
 {%     endif %}
-{%     if vmtracer_sessions[session].autovlan_disable is arista.avd.defined(true) %}
+{%     if session.autovlan_disable is arista.avd.defined(true) %}
    autovlan disable
 {%     endif %}
-{%     if vmtracer_sessions[session].source_interface is arista.avd.defined %}
-   source-interface {{ vmtracer_sessions[session].source_interface }}
+{%     if session.source_interface is arista.avd.defined %}
+   source-interface {{ session.source_interface }}
 {%     endif %}
 {% endfor %}


### PR DESCRIPTION
## "Wildcard Keyed Dict" to "List of Dicts" Data model migration

<!-- Use this PR Title: Refactor(eos_cli_config_gen): Wildcard dict to list for `vmtracer-sessions` -->

## Data model key

`vmtracer-sessions`

## Checklist

### Contributor Checklist

- [x] Update `README_v4.0.md` with new data model
- [x] Update all `host_vars` under molecule scenario `eos_cli_config_gen_v4.0` with new data model
- [x] Update `templates/eos/< template >.j2` and `templates/documentation/< template >.j2`:
  - [x] Add `arista.avd.convert_dicts('<primary key>')` filter for loops previously using wildcard keys
  - [x] Update `arista.avd.natural_sort('<primary key>')` to sort on the primary key (if applicable)
- [x] Run molecule `cd ansible_collections/arista/avd/molecule ; make cli-4.0-schema`
  - [x] Verify no changes to generated configs/docs

### Reviewer Checklist

- Reviewer 1: Claus
  - [x] Verify data model changes
  - [x] Verify that all molecule `host_vars` under `eos_cli_config_gen_v4.0` has been updated to the new data model
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2: Tony
  - [x] Verify data model changes
  - [x] Verify that all molecule `host_vars` under `eos_cli_config_gen_v4.0` has been updated to the new data model
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
