### PR TITLE
Feat(eos_cli_config_gen): Hardware Accelerated Sflow

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/sflow.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/sflow.md
@@ -70,6 +70,10 @@ sFlow Sample Rate: 1000
 
 sFlow is enabled.
 
+sFlow hardware acceleration is enabled.
+
+sFlow hardware accelerated Sample Rate: 1024
+
 ### SFlow Device Configuration
 
 ```eos
@@ -86,6 +90,10 @@ sflow destination 10.6.75.61
 sflow destination 10.6.75.62 123
 sflow source-interface Management0
 sflow run
+sflow hardware acceleration
+sflow hardware acceleration sample 1024
+sflow hardware acceleration module Linecard2
+no sflow hardware acceleration module Linecard3
 ```
 
 # Internal VLAN Allocation Policy

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/sflow.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/sflow.md
@@ -92,6 +92,7 @@ sflow source-interface Management0
 sflow run
 sflow hardware acceleration
 sflow hardware acceleration sample 1024
+sflow hardware acceleration module Linecard1
 sflow hardware acceleration module Linecard2
 no sflow hardware acceleration module Linecard3
 ```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/sflow.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/sflow.md
@@ -75,6 +75,7 @@ sFlow hardware acceleration is enabled.
 sFlow hardware accelerated Sample Rate: 1024
 
 ### SFlow Hardware Accelerated Modules
+
 | Module | Acceleration Enabled |
 | ------ | -------------------- |
 | Linecard1 | True |

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/sflow.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/sflow.md
@@ -74,6 +74,13 @@ sFlow hardware acceleration is enabled.
 
 sFlow hardware accelerated Sample Rate: 1024
 
+### SFlow Hardware Accelerated Modules
+| Module | Acceleration Enabled |
+| ------ | -------------------- |
+| Linecard1 | True |
+| Linecard2 | True |
+| Linecard3 | False |
+
 ### SFlow Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/sflow.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/sflow.cfg
@@ -16,6 +16,10 @@ sflow destination 10.6.75.61
 sflow destination 10.6.75.62 123
 sflow source-interface Management0
 sflow run
+sflow hardware acceleration
+sflow hardware acceleration sample 1024
+sflow hardware acceleration module Linecard2
+no sflow hardware acceleration module Linecard3
 !
 no enable password
 no aaa root

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/sflow.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/sflow.cfg
@@ -18,6 +18,7 @@ sflow source-interface Management0
 sflow run
 sflow hardware acceleration
 sflow hardware acceleration sample 1024
+sflow hardware acceleration module Linecard1
 sflow hardware acceleration module Linecard2
 no sflow hardware acceleration module Linecard3
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/sflow.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/sflow.yml
@@ -24,3 +24,11 @@ sflow:
   sample: 1000
   dangerous: true
   run: true
+  hardware_acceleration:
+    enabled: true
+    sample: 1024
+    modules:
+      - name: Linecard2
+        enabled: true
+      - name: Linecard3
+        enabled: false

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/sflow.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/sflow.yml
@@ -28,6 +28,7 @@ sflow:
     enabled: true
     sample: 1024
     modules:
+      - name: Linecard1
       - name: Linecard2
         enabled: true
       - name: Linecard3

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -2225,11 +2225,11 @@ sflow:
   source_interface: < source_interface >
   run: < true | false >
   hardware_acceleration:
-    enabled: < true | false | default -> true >
+    enabled: < true | false >
     sample: < sample_rate >
     modules:
       - name: < module name >
-        enabled: < true | false >
+        enabled: < true | false | default -> true >
 ```
 
 #### SNMP Settings

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -2225,7 +2225,7 @@ sflow:
   source_interface: < source_interface >
   run: < true | false >
   hardware_acceleration:
-    enabled: < true | false >
+    enabled: < true | false | default -> true >
     sample: < sample_rate >
     modules:
       - name: < module name >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -2224,6 +2224,12 @@ sflow:
     < sflow_destination_ip_2 >:
   source_interface: < source_interface >
   run: < true | false >
+  hardware_acceleration:
+    enabled: < true | false >
+    sample: < sample_rate >
+    modules:
+      - name: < module name >
+        enabled: < true | false >
 ```
 
 #### SNMP Settings

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/sflow.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/sflow.j2
@@ -49,7 +49,18 @@ sFlow hardware acceleration is enabled.
 
 sFlow hardware accelerated Sample Rate: {{ sflow.hardware_acceleration.sample }}
 {%     endif %}
+{%     if sflow.hardware_acceleration.modules is arista.avd.defined and sflow.hardware_acceleration.modules | length > 0 %}
 
+### SFlow Hardware Accelerated Modules
+| Module | Acceleration Enabled |
+| ------ | -------------------- |
+{%         for module in sflow.hardware_acceleration.modules %}
+{%             if module.name is arista.avd.defined %}
+| {{ module.name }} | {{ module.enabled | arista.avd.default(true) }} |
+{%             endif %}
+{%         endfor %}
+
+{%     endif %}
 ### SFlow Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/sflow.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/sflow.j2
@@ -59,8 +59,8 @@ sFlow hardware accelerated Sample Rate: {{ sflow.hardware_acceleration.sample }}
 | {{ module.name }} | {{ module.enabled | arista.avd.default(true) }} |
 {%             endif %}
 {%         endfor %}
-
 {%     endif %}
+
 ### SFlow Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/sflow.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/sflow.j2
@@ -41,6 +41,14 @@ sFlow is enabled.
 
 sFlow is disabled.
 {%     endif %}
+{%     if sflow.hardware_acceleration.enabled is arista.avd.defined(true) %}
+
+sFlow hardware acceleration is enabled.
+{%     endif %}
+{%     if sflow.hardware_acceleration.sample is arista.avd.defined %}
+
+sFlow hardware accelerated Sample Rate: {{ sflow.hardware_acceleration.sample }}
+{%     endif %}
 
 ### SFlow Device Configuration
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/sflow.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/sflow.j2
@@ -52,6 +52,7 @@ sFlow hardware accelerated Sample Rate: {{ sflow.hardware_acceleration.sample }}
 {%     if sflow.hardware_acceleration.modules is arista.avd.defined and sflow.hardware_acceleration.modules | length > 0 %}
 
 ### SFlow Hardware Accelerated Modules
+
 | Module | Acceleration Enabled |
 | ------ | -------------------- |
 {%         for module in sflow.hardware_acceleration.modules %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/sflow.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/sflow.j2
@@ -34,4 +34,20 @@ sflow source-interface {{ sflow.source_interface }}
 {%     if sflow.run is arista.avd.defined(true) %}
 sflow run
 {%     endif %}
+{%     if sflow.hardware_acceleration.enabled is arista.avd.defined(true) %}
+sflow hardware acceleration
+{%     endif %}
+{%     if sflow.hardware_acceleration.sample is arista.avd.defined %}
+sflow hardware acceleration sample {{ sflow.hardware_acceleration.sample }}
+{%     endif %}
+{%     for module in sflow.hardware_acceleration.modules | arista.avd.natural_sort %}
+{%         if module.name is arista.avd.defined %}
+{%             if module.enabled is arista.avd.defined(false) %}
+{%                 set module_cli = "no sflow hardware acceleration module " ~ module.name %}
+{%             else %}
+{%                 set module_cli = "sflow hardware acceleration module " ~ module.name %}
+{%             endif %}
+{{ module_cli }}
+{%         endif %}
+{%     endfor %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/sflow.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/sflow.j2
@@ -40,7 +40,7 @@ sflow hardware acceleration
 {%     if sflow.hardware_acceleration.sample is arista.avd.defined %}
 sflow hardware acceleration sample {{ sflow.hardware_acceleration.sample }}
 {%     endif %}
-{%     for module in sflow.hardware_acceleration.modules | arista.avd.natural_sort %}
+{%     for module in sflow.hardware_acceleration.modules | arista.avd.natural_sort('name') %}
 {%         if module.name is arista.avd.defined %}
 {%             if module.enabled is arista.avd.defined(false) %}
 {%                 set module_cli = "no sflow hardware acceleration module " ~ module.name %}


### PR DESCRIPTION
## Change Summary

Adds sflow hardware-acceleration commands.

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

```yaml
sflow:
  hardware_acceleration:
    enabled: < true | false >
    sample: < sample rate >
    modules:
      - name: Linecard2
        enabled: < true | false >
```

### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
