### PR TITLE
Fix(plugins): Issue in convert_dicts with empty dictionary values

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/dns-ntp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/dns-ntp.md
@@ -81,11 +81,13 @@ ip name-server vrf mgt 10.10.129.10
 
 | Source interface | vrf |
 | ---------------- | --- |
+| Loopback0 | - |
 | Management0 | mgt |
 
 ### DNS Domain Lookup Device Configuration
 
 ```eos
+ip domain lookup source-interface Loopback0
 ip domain lookup vrf mgt source-interface Management0
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/dns-ntp.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/dns-ntp.cfg
@@ -3,6 +3,7 @@
 transceiver qsfp default-mode 4x10G
 !
 hostname dns-ntp
+ip domain lookup source-interface Loopback0
 ip domain lookup vrf mgt source-interface Management0
 ip name-server vrf mgt 10.10.128.10
 ip name-server vrf mgt 10.10.129.10

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/dns-ntp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/dns-ntp.yml
@@ -3,6 +3,9 @@ ip_domain_lookup:
   source_interfaces:
     Management0:
       vrf: mgt
+    Loopback0:
+    # Note there is no value here. This is valid with the current data model, but triggered an issue with convert_dicts filter.
+    # So this is added to ensure we catch regression.
 
 ### Name Servers ###
 name_server:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/dns-ntp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/dns-ntp.md
@@ -81,11 +81,13 @@ ip name-server vrf mgt 10.10.129.10
 
 | Source interface | vrf |
 | ---------------- | --- |
+| Loopback0 | - |
 | Management0 | mgt |
 
 ### DNS Domain Lookup Device Configuration
 
 ```eos
+ip domain lookup source-interface Loopback0
 ip domain lookup vrf mgt source-interface Management0
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/dns-ntp.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/dns-ntp.cfg
@@ -3,6 +3,7 @@
 transceiver qsfp default-mode 4x10G
 !
 hostname dns-ntp
+ip domain lookup source-interface Loopback0
 ip domain lookup vrf mgt source-interface Management0
 ip name-server vrf mgt 10.10.128.10
 ip name-server vrf mgt 10.10.129.10

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/dns-ntp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/dns-ntp.yml
@@ -3,6 +3,7 @@ ip_domain_lookup:
   source_interfaces:
     - name: Management0
       vrf: mgt
+    - name: Loopback0
 
 ### Name Servers ###
 name_server:

--- a/ansible_collections/arista/avd/plugins/filter/convert_dicts.py
+++ b/ansible_collections/arista/avd/plugins/filter/convert_dicts.py
@@ -54,7 +54,10 @@ def convert_dicts(dictionary, primary_key="name"):
     else:
         output = []
         for key in dictionary:
-            if not isinstance(dictionary[key], dict):
+            if dictionary[key] is None:
+                # Catch cornercase where dictionary has no value because of old data models
+                output.append({primary_key: key})
+            elif not isinstance(dictionary[key], dict):
                 # Not a nested dictionary, return the original
                 return dictionary
             else:


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Fix issue in convert_dicts with empty dictionary values

## Related Issue(s)

Some of the existing data models have optional keys inside nested dictionaries, so if none of the optional keys are set, the inner dictionary will not always be a dictionary, but instead the value `None`.

Example:
```yaml
ip_domain_lookup:
  source_interfaces:
    Management0:
      vrf: mgt
    Loopback0:
```

## Component(s) name

`arista.avd.convert_dicts`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

Catch if the inner value is `Null` and insert a dict with the primary key, instead of just returning the original dict as today.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

The update to `dns-ntp.yml` in this PR will fail with the old code.

```shell
TASK [arista.avd.eos_cli_config_gen : Generate eos intended configuration] *****
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ansible.errors.AnsibleUndefinedVariable: 'ansible.parsing.yaml.objects.AnsibleUnicode object' has no attribute 'name'
fatal: [dns-ntp -> localhost]: FAILED! => {"changed": false, "msg": "AnsibleUndefinedVariable: 'ansible.parsing.yaml.objects.AnsibleUnicode object' has no attribute 'name'"}
```

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
