### PR TITLE
Feat(eos_cli_config_gen): Support multiple VRRP VRID per interface

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
@@ -85,6 +85,7 @@ interface Management1
 | Vlan91 | PBR Description | default | - | true |
 | Vlan110 | PVLAN Primary with vlan mapping | Tenant_A | - | false |
 | Vlan501 | SVI Description | default | - | false |
+| Vlan667 | Multiple VRIDs | default | - | false |
 | Vlan1001 | SVI Description | Tenant_A | - | false |
 | Vlan1002 | SVI Description | Tenant_A | - | false |
 | Vlan2001 | SVI Description | Tenant_B | - | - |
@@ -117,6 +118,7 @@ interface Management1
 | Vlan91 |  default  |  -  |  -  |  -  |  -  |  -  |  -  |
 | Vlan110 |  Tenant_A  |  -  |  -  |  -  |  -  |  -  |  -  |
 | Vlan501 |  default  |  10.50.26.29/27  |  -  |  -  |  -  |  -  |  -  |
+| Vlan667 |  default  |  -  |  -  |  -  |  -  |  -  |  -  |
 | Vlan1001 |  Tenant_A  |  -  |  10.1.1.1/24  |  -  |  -  |  -  |  -  |
 | Vlan1002 |  Tenant_A  |  -  |  10.1.2.1/24  |  -  |  -  |  -  |  -  |
 | Vlan2001 |  Tenant_B  |  -  |  10.2.1.1/24  |  -  |  -  |  -  |  -  |
@@ -132,6 +134,7 @@ interface Management1
 | Vlan81 | Tenant_C | - | fc00:10:10:81::1/64 | - | - | - | - | - | - |
 | Vlan89 | default | 1b11:3a00:22b0:5200::15/64 | - | 1b11:3a00:22b0:5200::3 | - | - | true | - | - |
 | Vlan501 | default | 1b11:3a00:22b0:0088::207/127 | - | - | - | true | - | - | - |
+| Vlan667 | default | 2001:db8::2/64 | - | - | - | - | - | - | - |
 | Vlan1001 | Tenant_A | a1::1/64 | - | - | - | - | true | - | - |
 | Vlan1002 | Tenant_A | a2::1/64 | - | - | - | true | true | - | - |
 
@@ -252,6 +255,19 @@ interface Vlan501
    ip address 10.50.26.29/27
    ipv6 address 1b11:3a00:22b0:0088::207/127
    ipv6 nd ra disabled
+!
+interface Vlan667
+   description Multiple VRIDs
+   no shutdown
+   arp aging timeout 180
+   ipv6 enable
+   ipv6 address 2001:db8::2/64
+   ipv6 address fe80::2/64 link-local
+   vrrp 1 priority-level 105
+   vrrp 1 advertisement interval 2
+   vrrp 1 preempt delay minimum 30 reload 800
+   vrrp 1 ipv4 192.0.2.1
+   vrrp 2 ipv6 2001:db8::1
 !
 interface Vlan1001
    description SVI Description

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
@@ -125,6 +125,19 @@ interface Vlan501
    ipv6 address 1b11:3a00:22b0:0088::207/127
    ipv6 nd ra disabled
 !
+interface Vlan667
+   description Multiple VRIDs
+   no shutdown
+   arp aging timeout 180
+   ipv6 enable
+   ipv6 address 2001:db8::2/64
+   ipv6 address fe80::2/64 link-local
+   vrrp 1 priority-level 105
+   vrrp 1 advertisement interval 2
+   vrrp 1 preempt delay minimum 30 reload 800
+   vrrp 1 ipv4 192.0.2.1
+   vrrp 2 ipv6 2001:db8::1
+!
 interface Vlan1001
    description SVI Description
    no shutdown

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
@@ -221,3 +221,33 @@ vlan_interfaces:
     vrf: Tenant_A
     ip address: 10.0.101.1/24
     pvlan_mapping: 111-112
+
+
+# VRRP
+
+  Vlan667:
+    description: Multiple VRIDs
+    shutdown: false
+    arp_aging_timeout: 180
+    ip address: 192.0.2.2/25
+    ipv6_enable: true
+    ipv6_address: 2001:db8::2/64
+    ipv6_address_link_local: fe80::2/64
+    vrrp_ids:
+      - id: 1
+        priority_level: 105
+        advertisement:
+          interval: 2
+        preempt:
+          enabled: true
+          delay:
+            minimum: 30
+            reload: 800
+        ipv4:
+          address: 192.0.2.1
+      - id: 2
+        preempt:
+          enabled: true
+          delay:
+        ipv6:
+          address: 2001:db8::1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
@@ -222,7 +222,6 @@ vlan_interfaces:
     ip address: 10.0.101.1/24
     pvlan_mapping: 111-112
 
-
 # VRRP
 
   Vlan667:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1390,6 +1390,22 @@ vlan_interfaces:
     isis_network_point_to_point: < boolean >
     mtu: < mtu >
     no_autostate: < true | false >
+    # New improved "vrrp" data model to support multiple IDs
+    vrrp_ids:
+      - id: < vrid >
+        priority_level: < instance_priority >
+        advertisement:
+          interval: < advertisement_interval>
+        preempt:
+          enabled: < true | false >
+          delay:
+            minimum: < integer >
+            reload: < integer >
+        ipv4:
+          address: < virtual_ip_address >
+        ipv6:
+          address: < virtual_ip_address >
+    # The below "vrrp" keys will be deprecated in AVD v4.0 - These should not be mixed with the new "vrrp_ids" key above to avoid conflicts.
     vrrp:
       virtual_router: < virtual_router_id >
       priority: < instance_priority >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
@@ -156,6 +156,7 @@ interface {{ vlan_interface }}
 {%     if vlan_interfaces[vlan_interface].isis_network_point_to_point is arista.avd.defined(true) %}
    isis network point-to-point
 {%     endif %}
+{# The below "vrrp" keys will be deprecated in AVD v4.0 - These should not be mixed with the new "vrrp_ids" key above to avoid conflicts. #}
 {%     if vlan_interfaces[vlan_interface].vrrp.virtual_router is arista.avd.defined %}
 {%         if vlan_interfaces[vlan_interface].vrrp.priority is arista.avd.defined %}
    vrrp {{ vlan_interfaces[vlan_interface].vrrp.virtual_router }} priority-level {{ vlan_interfaces[vlan_interface].vrrp.priority }}
@@ -172,6 +173,35 @@ interface {{ vlan_interface }}
 {%         if vlan_interfaces[vlan_interface].vrrp.ipv6 is arista.avd.defined %}
    vrrp {{ vlan_interfaces[vlan_interface].vrrp.virtual_router }} ipv6 {{ vlan_interfaces[vlan_interface].vrrp.ipv6 }}
 {%         endif %}
+{%     endif %}
+{# New improved "vrrp" data model to support multiple IDs #}
+{%     if vlan_interfaces[vlan_interface].vrrp_ids is arista.avd.defined %}
+{%         for vrid in vlan_interfaces[vlan_interface].vrrp_ids | arista.avd.natural_sort('id') if vrid.id is arista.avd.defined %}
+{%             if vrid.priority_level is arista.avd.defined %}
+   vrrp {{ vrid.id }} priority-level {{ vrid.priority_level }}
+{%             endif %}
+{%             if vrid.advertisement.interval is arista.avd.defined %}
+   vrrp {{ vrid.id }} advertisement interval {{ vrid.advertisement.interval }}
+{%             endif %}
+{%             if vrid.preempt.enabled is arista.avd.defined(true) and (
+                  vrid.preempt.delay.minimum is arista.avd.defined or
+                  vrid.preempt.delay.reload is arista.avd.defined) %}
+{%                 set delay_cli = 'vrrp ' ~ vrid.id ~ ' preempt delay' %}
+{%                 if vrid.preempt.delay.minimum is arista.avd.defined %}
+{%                     set delay_cli = delay_cli ~ ' minimum ' ~ vrid.preempt.delay.minimum %}
+{%                 endif %}
+{%                 if vrid.preempt.delay.reload is arista.avd.defined %}
+{%                     set delay_cli = delay_cli ~ ' reload ' ~ vrid.preempt.delay.reload %}
+{%                 endif %}
+   {{ delay_cli }}
+{%             endif %}
+{%             if vrid.ipv4.address is arista.avd.defined %}
+   vrrp {{ vrid.id }} ipv4 {{ vrid.ipv4.address }}
+{%             endif %}
+{%             if vrid.ipv6.address is arista.avd.defined %}
+   vrrp {{ vrid.id }} ipv6 {{ vrid.ipv6.address }}
+{%             endif %}
+{%         endfor %}
 {%     endif %}
 {%     if vlan_interfaces[vlan_interface].ip_attached_host_route_export.distance is arista.avd.defined %}
    ip attached-host route export {{ vlan_interfaces[vlan_interface].ip_attached_host_route_export.distance }}


### PR DESCRIPTION
## Change Summary

Currently only one VRID can be specified per interface - EOS supports multiple VRIDs per interface.

## Related Issue(s)

Fixes #1636

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

```yaml
vlan_interfaces:
  < Vlan_id_1 >:
    # New improved "vrrp" data model to support multiple IDs
    vrrp_ids:
      - id: < vrid >
        priority_level: < instance_priority >
        advertisement:
          interval: < advertisement_interval>
        preempt:
          enabled: < true | false >
          delay:
            minimum: < minimum_preemption_delay >
            reload: < minimum_preemption_delay >
        ipv4:
          address: < virtual_ip_address >
        ipv6:
          address: < virtual_ip_address >
    # The below "vrrp" keys will be deprecated in AVD v4.0 - These should not be mixed with the new "vrrp_ids" key above to avoid conflicts.
    vrrp:
      virtual_router: < virtual_router_id >
      priority: < instance_priority >
      advertisement_interval: < advertisement_interval>
      preempt_delay_minimum: < minimum_preemption_delay >
      ipv4: < virtual_ip_address >
      ipv6: < virtual_ip_address >
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

molecule

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
