### PR TITLE
Feat(eos_designs): Default value "all" for l2vlans.tags and svis.tags

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/evpn_services_l2_only_false.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/evpn_services_l2_only_false.md
@@ -200,6 +200,7 @@ vlan internal order ascending range 1006 1199
 | 150 | Tenant_A_WAN_Zone_1 | - |
 | 160 | Tenant_A_VMOTION | - |
 | 161 | Tenant_A_NFS | - |
+| 162 | Vlan_everywhere | - |
 | 210 | Tenant_B_OP_Zone_1 | - |
 | 211 | Tenant_B_OP_Zone_2 | - |
 | 250 | Tenant_B_WAN_Zone_1 | - |
@@ -249,6 +250,9 @@ vlan 160
 !
 vlan 161
    name Tenant_A_NFS
+!
+vlan 162
+   name Vlan_everywhere
 !
 vlan 210
    name Tenant_B_OP_Zone_1
@@ -505,6 +509,7 @@ interface Vlan350
 | 150 | 10150 | - | - |
 | 160 | 10160 | - | - |
 | 161 | 10161 | - | - |
+| 162 | 10162 | - | - |
 | 210 | 20210 | - | - |
 | 211 | 20211 | - | - |
 | 250 | 20250 | - | - |
@@ -547,6 +552,7 @@ interface Vxlan1
    vxlan vlan 150 vni 10150
    vxlan vlan 160 vni 10160
    vxlan vlan 161 vni 10161
+   vxlan vlan 162 vni 10162
    vxlan vlan 210 vni 20210
    vxlan vlan 211 vni 20211
    vxlan vlan 250 vni 20250
@@ -714,6 +720,7 @@ ip route vrf Tenant_A_APP_Zone 10.3.32.0/24 Vlan132 name VARP
 | Tenant_B_WAN_Zone | 192.168.255.109:21 | 21:21 | - | - | learned | 250 |
 | Tenant_C_OP_Zone | 192.168.255.109:30 | 30:30 | - | - | learned | 310-311 |
 | Tenant_C_WAN_Zone | 192.168.255.109:31 | 31:31 | - | - | learned | 350 |
+| Vlan_everywhere | 192.168.255.109:20162 | 20162:20162 | - | - | learned | 162 |
 
 ### Router BGP VRFs
 
@@ -814,6 +821,12 @@ router bgp 101
       route-target both 31:31
       redistribute learned
       vlan 350
+   !
+   vlan-aware-bundle Vlan_everywhere
+      rd 192.168.255.109:20162
+      route-target both 20162:20162
+      redistribute learned
+      vlan 162
    !
    address-family evpn
       neighbor EVPN-OVERLAY-PEERS activate

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/evpn_services_l2_only_false.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/evpn_services_l2_only_false.md
@@ -198,9 +198,10 @@ vlan internal order ascending range 1006 1199
 | 140 | Tenant_A_DB_BZone_1 | - |
 | 141 | Tenant_A_DB_Zone_2 | - |
 | 150 | Tenant_A_WAN_Zone_1 | - |
+| 151 | svi_with_no_tags | - |
 | 160 | Tenant_A_VMOTION | - |
 | 161 | Tenant_A_NFS | - |
-| 162 | Vlan_everywhere | - |
+| 162 | l2vlan_with_no_tags | - |
 | 210 | Tenant_B_OP_Zone_1 | - |
 | 211 | Tenant_B_OP_Zone_2 | - |
 | 250 | Tenant_B_WAN_Zone_1 | - |
@@ -245,6 +246,9 @@ vlan 141
 vlan 150
    name Tenant_A_WAN_Zone_1
 !
+vlan 151
+   name svi_with_no_tags
+!
 vlan 160
    name Tenant_A_VMOTION
 !
@@ -252,7 +256,7 @@ vlan 161
    name Tenant_A_NFS
 !
 vlan 162
-   name Vlan_everywhere
+   name l2vlan_with_no_tags
 !
 vlan 210
    name Tenant_B_OP_Zone_1
@@ -334,6 +338,7 @@ interface Loopback100
 | Vlan140 | Tenant_A_DB_BZone_1 | Tenant_A_DB_Zone | - | false |
 | Vlan141 | Tenant_A_DB_Zone_2 | Tenant_A_DB_Zone | - | false |
 | Vlan150 | Tenant_A_WAN_Zone_1 | Tenant_A_WAN_Zone | - | false |
+| Vlan151 | svi_with_no_tags | Tenant_A_WAN_Zone | - | false |
 | Vlan210 | Tenant_B_OP_Zone_1 | Tenant_B_OP_Zone | - | false |
 | Vlan211 | Tenant_B_OP_Zone_2 | Tenant_B_OP_Zone | - | false |
 | Vlan250 | Tenant_B_WAN_Zone_1 | Tenant_B_WAN_Zone | - | false |
@@ -356,6 +361,7 @@ interface Loopback100
 | Vlan140 |  Tenant_A_DB_Zone  |  -  |  10.1.40.1/24  |  -  |  -  |  -  |  -  |
 | Vlan141 |  Tenant_A_DB_Zone  |  -  |  10.1.41.1/24  |  -  |  -  |  -  |  -  |
 | Vlan150 |  Tenant_A_WAN_Zone  |  -  |  10.1.40.1/24  |  -  |  -  |  -  |  -  |
+| Vlan151 |  Tenant_A_WAN_Zone  |  -  |  10.1.51.1/24  |  -  |  -  |  -  |  -  |
 | Vlan210 |  Tenant_B_OP_Zone  |  -  |  10.2.10.1/24  |  -  |  -  |  -  |  -  |
 | Vlan211 |  Tenant_B_OP_Zone  |  -  |  10.2.11.1/24  |  -  |  -  |  -  |  -  |
 | Vlan250 |  Tenant_B_WAN_Zone  |  -  |  10.2.50.1/24  |  -  |  -  |  -  |  -  |
@@ -446,6 +452,12 @@ interface Vlan150
    ip ospf authentication-key 7 AQQvKeimxJu+uGQ/yYvv9w==
    ip address virtual 10.1.40.1/24
 !
+interface Vlan151
+   description svi_with_no_tags
+   no shutdown
+   vrf Tenant_A_WAN_Zone
+   ip address virtual 10.1.51.1/24
+!
 interface Vlan210
    description Tenant_B_OP_Zone_1
    no shutdown
@@ -507,6 +519,7 @@ interface Vlan350
 | 140 | 10140 | - | - |
 | 141 | 10141 | - | - |
 | 150 | 10150 | - | - |
+| 151 | 10151 | - | - |
 | 160 | 10160 | - | - |
 | 161 | 10161 | - | - |
 | 162 | 10162 | - | - |
@@ -550,6 +563,7 @@ interface Vxlan1
    vxlan vlan 140 vni 10140
    vxlan vlan 141 vni 10141
    vxlan vlan 150 vni 10150
+   vxlan vlan 151 vni 10151
    vxlan vlan 160 vni 10160
    vxlan vlan 161 vni 10161
    vxlan vlan 162 vni 10162
@@ -709,18 +723,18 @@ ip route vrf Tenant_A_APP_Zone 10.3.32.0/24 Vlan132 name VARP
 
 | VLAN Aware Bundle | Route-Distinguisher | Both Route-Target | Import Route Target | Export Route-Target | Redistribute | VLANs |
 | ----------------- | ------------------- | ----------------- | ------------------- | ------------------- | ------------ | ----- |
+| l2vlan_with_no_tags | 192.168.255.109:20162 | 20162:20162 | - | - | learned | 162 |
 | Tenant_A_APP_Zone | 192.168.255.109:12 | 12:12 | - | - | learned | 130-132 |
 | Tenant_A_DB_Zone | 192.168.255.109:13 | 13:13 | - | - | learned | 140-141 |
 | Tenant_A_NFS | 192.168.255.109:20161 | 20161:20161 | - | - | learned | 161 |
 | Tenant_A_OP_Zone | 192.168.255.109:9 | 9:9 | - | - | learned | 110-112 |
 | Tenant_A_VMOTION | 192.168.255.109:20160 | 20160:20160 | - | - | learned | 160 |
-| Tenant_A_WAN_Zone | 192.168.255.109:14 | 14:14 | - | - | learned | 150 |
+| Tenant_A_WAN_Zone | 192.168.255.109:14 | 14:14 | - | - | learned | 150-151 |
 | Tenant_A_WEB_Zone | 192.168.255.109:11 | 11:11 | - | - | learned | 120-121 |
 | Tenant_B_OP_Zone | 192.168.255.109:20 | 20:20 | - | - | learned | 210-211 |
 | Tenant_B_WAN_Zone | 192.168.255.109:21 | 21:21 | - | - | learned | 250 |
 | Tenant_C_OP_Zone | 192.168.255.109:30 | 30:30 | - | - | learned | 310-311 |
 | Tenant_C_WAN_Zone | 192.168.255.109:31 | 31:31 | - | - | learned | 350 |
-| Vlan_everywhere | 192.168.255.109:20162 | 20162:20162 | - | - | learned | 162 |
 
 ### Router BGP VRFs
 
@@ -756,6 +770,12 @@ router bgp 101
    neighbor UNDERLAY-PEERS maximum-routes 12000
    redistribute connected route-map RM-CONN-2-BGP
    !
+   vlan-aware-bundle l2vlan_with_no_tags
+      rd 192.168.255.109:20162
+      route-target both 20162:20162
+      redistribute learned
+      vlan 162
+   !
    vlan-aware-bundle Tenant_A_APP_Zone
       rd 192.168.255.109:12
       route-target both 12:12
@@ -790,7 +810,7 @@ router bgp 101
       rd 192.168.255.109:14
       route-target both 14:14
       redistribute learned
-      vlan 150
+      vlan 150-151
    !
    vlan-aware-bundle Tenant_A_WEB_Zone
       rd 192.168.255.109:11
@@ -821,12 +841,6 @@ router bgp 101
       route-target both 31:31
       redistribute learned
       vlan 350
-   !
-   vlan-aware-bundle Vlan_everywhere
-      rd 192.168.255.109:20162
-      route-target both 20162:20162
-      redistribute learned
-      vlan 162
    !
    address-family evpn
       neighbor EVPN-OVERLAY-PEERS activate

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/evpn_services_l2_only_true.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/evpn_services_l2_only_true.md
@@ -195,6 +195,7 @@ vlan internal order ascending range 1006 1199
 | 150 | Tenant_A_WAN_Zone_1 | - |
 | 160 | Tenant_A_VMOTION | - |
 | 161 | Tenant_A_NFS | - |
+| 162 | Vlan_everywhere | - |
 | 210 | Tenant_B_OP_Zone_1 | - |
 | 211 | Tenant_B_OP_Zone_2 | - |
 | 250 | Tenant_B_WAN_Zone_1 | - |
@@ -244,6 +245,9 @@ vlan 160
 !
 vlan 161
    name Tenant_A_NFS
+!
+vlan 162
+   name Vlan_everywhere
 !
 vlan 210
    name Tenant_B_OP_Zone_1
@@ -326,6 +330,7 @@ interface Loopback1
 | 150 | 10150 | - | - |
 | 160 | 10160 | - | - |
 | 161 | 10161 | - | - |
+| 162 | 10162 | - | - |
 | 210 | 20210 | - | - |
 | 211 | 20211 | - | - |
 | 250 | 20250 | - | - |
@@ -354,6 +359,7 @@ interface Vxlan1
    vxlan vlan 150 vni 10150
    vxlan vlan 160 vni 10160
    vxlan vlan 161 vni 10161
+   vxlan vlan 162 vni 10162
    vxlan vlan 210 vni 20210
    vxlan vlan 211 vni 20211
    vxlan vlan 250 vni 20250
@@ -468,6 +474,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | Tenant_B_WAN_Zone | 192.168.255.109:21 | 21:21 | - | - | learned | 250 |
 | Tenant_C_OP_Zone | 192.168.255.109:30 | 30:30 | - | - | learned | 310-311 |
 | Tenant_C_WAN_Zone | 192.168.255.109:31 | 31:31 | - | - | learned | 350 |
+| Vlan_everywhere | 192.168.255.109:20162 | 20162:20162 | - | - | learned | 162 |
 
 ### Router BGP Device Configuration
 
@@ -554,6 +561,12 @@ router bgp 101
       route-target both 31:31
       redistribute learned
       vlan 350
+   !
+   vlan-aware-bundle Vlan_everywhere
+      rd 192.168.255.109:20162
+      route-target both 20162:20162
+      redistribute learned
+      vlan 162
    !
    address-family evpn
       neighbor EVPN-OVERLAY-PEERS activate

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/evpn_services_l2_only_true.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/evpn_services_l2_only_true.md
@@ -193,9 +193,10 @@ vlan internal order ascending range 1006 1199
 | 140 | Tenant_A_DB_BZone_1 | - |
 | 141 | Tenant_A_DB_Zone_2 | - |
 | 150 | Tenant_A_WAN_Zone_1 | - |
+| 151 | svi_with_no_tags | - |
 | 160 | Tenant_A_VMOTION | - |
 | 161 | Tenant_A_NFS | - |
-| 162 | Vlan_everywhere | - |
+| 162 | l2vlan_with_no_tags | - |
 | 210 | Tenant_B_OP_Zone_1 | - |
 | 211 | Tenant_B_OP_Zone_2 | - |
 | 250 | Tenant_B_WAN_Zone_1 | - |
@@ -240,6 +241,9 @@ vlan 141
 vlan 150
    name Tenant_A_WAN_Zone_1
 !
+vlan 151
+   name svi_with_no_tags
+!
 vlan 160
    name Tenant_A_VMOTION
 !
@@ -247,7 +251,7 @@ vlan 161
    name Tenant_A_NFS
 !
 vlan 162
-   name Vlan_everywhere
+   name l2vlan_with_no_tags
 !
 vlan 210
    name Tenant_B_OP_Zone_1
@@ -328,6 +332,7 @@ interface Loopback1
 | 140 | 10140 | - | - |
 | 141 | 10141 | - | - |
 | 150 | 10150 | - | - |
+| 151 | 10151 | - | - |
 | 160 | 10160 | - | - |
 | 161 | 10161 | - | - |
 | 162 | 10162 | - | - |
@@ -357,6 +362,7 @@ interface Vxlan1
    vxlan vlan 140 vni 10140
    vxlan vlan 141 vni 10141
    vxlan vlan 150 vni 10150
+   vxlan vlan 151 vni 10151
    vxlan vlan 160 vni 10160
    vxlan vlan 161 vni 10161
    vxlan vlan 162 vni 10162
@@ -463,18 +469,18 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | VLAN Aware Bundle | Route-Distinguisher | Both Route-Target | Import Route Target | Export Route-Target | Redistribute | VLANs |
 | ----------------- | ------------------- | ----------------- | ------------------- | ------------------- | ------------ | ----- |
+| l2vlan_with_no_tags | 192.168.255.109:20162 | 20162:20162 | - | - | learned | 162 |
 | Tenant_A_APP_Zone | 192.168.255.109:12 | 12:12 | - | - | learned | 130-132 |
 | Tenant_A_DB_Zone | 192.168.255.109:13 | 13:13 | - | - | learned | 140-141 |
 | Tenant_A_NFS | 192.168.255.109:20161 | 20161:20161 | - | - | learned | 161 |
 | Tenant_A_OP_Zone | 192.168.255.109:9 | 9:9 | - | - | learned | 110-112 |
 | Tenant_A_VMOTION | 192.168.255.109:20160 | 20160:20160 | - | - | learned | 160 |
-| Tenant_A_WAN_Zone | 192.168.255.109:14 | 14:14 | - | - | learned | 150 |
+| Tenant_A_WAN_Zone | 192.168.255.109:14 | 14:14 | - | - | learned | 150-151 |
 | Tenant_A_WEB_Zone | 192.168.255.109:11 | 11:11 | - | - | learned | 120-121 |
 | Tenant_B_OP_Zone | 192.168.255.109:20 | 20:20 | - | - | learned | 210-211 |
 | Tenant_B_WAN_Zone | 192.168.255.109:21 | 21:21 | - | - | learned | 250 |
 | Tenant_C_OP_Zone | 192.168.255.109:30 | 30:30 | - | - | learned | 310-311 |
 | Tenant_C_WAN_Zone | 192.168.255.109:31 | 31:31 | - | - | learned | 350 |
-| Vlan_everywhere | 192.168.255.109:20162 | 20162:20162 | - | - | learned | 162 |
 
 ### Router BGP Device Configuration
 
@@ -495,6 +501,12 @@ router bgp 101
    neighbor UNDERLAY-PEERS send-community
    neighbor UNDERLAY-PEERS maximum-routes 12000
    redistribute connected route-map RM-CONN-2-BGP
+   !
+   vlan-aware-bundle l2vlan_with_no_tags
+      rd 192.168.255.109:20162
+      route-target both 20162:20162
+      redistribute learned
+      vlan 162
    !
    vlan-aware-bundle Tenant_A_APP_Zone
       rd 192.168.255.109:12
@@ -530,7 +542,7 @@ router bgp 101
       rd 192.168.255.109:14
       route-target both 14:14
       redistribute learned
-      vlan 150
+      vlan 150-151
    !
    vlan-aware-bundle Tenant_A_WEB_Zone
       rd 192.168.255.109:11
@@ -561,12 +573,6 @@ router bgp 101
       route-target both 31:31
       redistribute learned
       vlan 350
-   !
-   vlan-aware-bundle Vlan_everywhere
-      rd 192.168.255.109:20162
-      route-target both 20162:20162
-      redistribute learned
-      vlan 162
    !
    address-family evpn
       neighbor EVPN-OVERLAY-PEERS activate

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/mgmt_interface_default.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/mgmt_interface_default.md
@@ -216,6 +216,7 @@ vlan internal order ascending range 1006 1199
 | 150 | Tenant_A_WAN_Zone_1 | - |
 | 160 | Tenant_A_VMOTION | - |
 | 161 | Tenant_A_NFS | - |
+| 162 | Vlan_everywhere | - |
 | 210 | Tenant_B_OP_Zone_1 | - |
 | 211 | Tenant_B_OP_Zone_2 | - |
 | 250 | Tenant_B_WAN_Zone_1 | - |
@@ -265,6 +266,9 @@ vlan 160
 !
 vlan 161
    name Tenant_A_NFS
+!
+vlan 162
+   name Vlan_everywhere
 !
 vlan 210
    name Tenant_B_OP_Zone_1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/mgmt_interface_default.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/mgmt_interface_default.md
@@ -214,9 +214,10 @@ vlan internal order ascending range 1006 1199
 | 140 | Tenant_A_DB_BZone_1 | - |
 | 141 | Tenant_A_DB_Zone_2 | - |
 | 150 | Tenant_A_WAN_Zone_1 | - |
+| 151 | svi_with_no_tags | - |
 | 160 | Tenant_A_VMOTION | - |
 | 161 | Tenant_A_NFS | - |
-| 162 | Vlan_everywhere | - |
+| 162 | l2vlan_with_no_tags | - |
 | 210 | Tenant_B_OP_Zone_1 | - |
 | 211 | Tenant_B_OP_Zone_2 | - |
 | 250 | Tenant_B_WAN_Zone_1 | - |
@@ -261,6 +262,9 @@ vlan 141
 vlan 150
    name Tenant_A_WAN_Zone_1
 !
+vlan 151
+   name svi_with_no_tags
+!
 vlan 160
    name Tenant_A_VMOTION
 !
@@ -268,7 +272,7 @@ vlan 161
    name Tenant_A_NFS
 !
 vlan 162
-   name Vlan_everywhere
+   name l2vlan_with_no_tags
 !
 vlan 210
    name Tenant_B_OP_Zone_1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/mgmt_interface_fabric.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/mgmt_interface_fabric.md
@@ -216,6 +216,7 @@ vlan internal order ascending range 1006 1199
 | 150 | Tenant_A_WAN_Zone_1 | - |
 | 160 | Tenant_A_VMOTION | - |
 | 161 | Tenant_A_NFS | - |
+| 162 | Vlan_everywhere | - |
 | 210 | Tenant_B_OP_Zone_1 | - |
 | 211 | Tenant_B_OP_Zone_2 | - |
 | 250 | Tenant_B_WAN_Zone_1 | - |
@@ -265,6 +266,9 @@ vlan 160
 !
 vlan 161
    name Tenant_A_NFS
+!
+vlan 162
+   name Vlan_everywhere
 !
 vlan 210
    name Tenant_B_OP_Zone_1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/mgmt_interface_fabric.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/mgmt_interface_fabric.md
@@ -214,9 +214,10 @@ vlan internal order ascending range 1006 1199
 | 140 | Tenant_A_DB_BZone_1 | - |
 | 141 | Tenant_A_DB_Zone_2 | - |
 | 150 | Tenant_A_WAN_Zone_1 | - |
+| 151 | svi_with_no_tags | - |
 | 160 | Tenant_A_VMOTION | - |
 | 161 | Tenant_A_NFS | - |
-| 162 | Vlan_everywhere | - |
+| 162 | l2vlan_with_no_tags | - |
 | 210 | Tenant_B_OP_Zone_1 | - |
 | 211 | Tenant_B_OP_Zone_2 | - |
 | 250 | Tenant_B_WAN_Zone_1 | - |
@@ -261,6 +262,9 @@ vlan 141
 vlan 150
    name Tenant_A_WAN_Zone_1
 !
+vlan 151
+   name svi_with_no_tags
+!
 vlan 160
    name Tenant_A_VMOTION
 !
@@ -268,7 +272,7 @@ vlan 161
    name Tenant_A_NFS
 !
 vlan 162
-   name Vlan_everywhere
+   name l2vlan_with_no_tags
 !
 vlan 210
    name Tenant_B_OP_Zone_1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/mgmt_interface_host.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/mgmt_interface_host.md
@@ -231,9 +231,10 @@ vlan internal order ascending range 1006 1199
 | 140 | Tenant_A_DB_BZone_1 | - |
 | 141 | Tenant_A_DB_Zone_2 | - |
 | 150 | Tenant_A_WAN_Zone_1 | - |
+| 151 | svi_with_no_tags | - |
 | 160 | Tenant_A_VMOTION | - |
 | 161 | Tenant_A_NFS | - |
-| 162 | Vlan_everywhere | - |
+| 162 | l2vlan_with_no_tags | - |
 | 210 | Tenant_B_OP_Zone_1 | - |
 | 211 | Tenant_B_OP_Zone_2 | - |
 | 250 | Tenant_B_WAN_Zone_1 | - |
@@ -278,6 +279,9 @@ vlan 141
 vlan 150
    name Tenant_A_WAN_Zone_1
 !
+vlan 151
+   name svi_with_no_tags
+!
 vlan 160
    name Tenant_A_VMOTION
 !
@@ -285,7 +289,7 @@ vlan 161
    name Tenant_A_NFS
 !
 vlan 162
-   name Vlan_everywhere
+   name l2vlan_with_no_tags
 !
 vlan 210
    name Tenant_B_OP_Zone_1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/mgmt_interface_host.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/mgmt_interface_host.md
@@ -233,6 +233,7 @@ vlan internal order ascending range 1006 1199
 | 150 | Tenant_A_WAN_Zone_1 | - |
 | 160 | Tenant_A_VMOTION | - |
 | 161 | Tenant_A_NFS | - |
+| 162 | Vlan_everywhere | - |
 | 210 | Tenant_B_OP_Zone_1 | - |
 | 211 | Tenant_B_OP_Zone_2 | - |
 | 250 | Tenant_B_WAN_Zone_1 | - |
@@ -282,6 +283,9 @@ vlan 160
 !
 vlan 161
    name Tenant_A_NFS
+!
+vlan 162
+   name Vlan_everywhere
 !
 vlan 210
    name Tenant_B_OP_Zone_1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/mgmt_interface_platform.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/mgmt_interface_platform.md
@@ -231,9 +231,10 @@ vlan internal order ascending range 1006 1199
 | 140 | Tenant_A_DB_BZone_1 | - |
 | 141 | Tenant_A_DB_Zone_2 | - |
 | 150 | Tenant_A_WAN_Zone_1 | - |
+| 151 | svi_with_no_tags | - |
 | 160 | Tenant_A_VMOTION | - |
 | 161 | Tenant_A_NFS | - |
-| 162 | Vlan_everywhere | - |
+| 162 | l2vlan_with_no_tags | - |
 | 210 | Tenant_B_OP_Zone_1 | - |
 | 211 | Tenant_B_OP_Zone_2 | - |
 | 250 | Tenant_B_WAN_Zone_1 | - |
@@ -278,6 +279,9 @@ vlan 141
 vlan 150
    name Tenant_A_WAN_Zone_1
 !
+vlan 151
+   name svi_with_no_tags
+!
 vlan 160
    name Tenant_A_VMOTION
 !
@@ -285,7 +289,7 @@ vlan 161
    name Tenant_A_NFS
 !
 vlan 162
-   name Vlan_everywhere
+   name l2vlan_with_no_tags
 !
 vlan 210
    name Tenant_B_OP_Zone_1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/mgmt_interface_platform.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/mgmt_interface_platform.md
@@ -233,6 +233,7 @@ vlan internal order ascending range 1006 1199
 | 150 | Tenant_A_WAN_Zone_1 | - |
 | 160 | Tenant_A_VMOTION | - |
 | 161 | Tenant_A_NFS | - |
+| 162 | Vlan_everywhere | - |
 | 210 | Tenant_B_OP_Zone_1 | - |
 | 211 | Tenant_B_OP_Zone_2 | - |
 | 250 | Tenant_B_WAN_Zone_1 | - |
@@ -282,6 +283,9 @@ vlan 160
 !
 vlan 161
    name Tenant_A_NFS
+!
+vlan 162
+   name Vlan_everywhere
 !
 vlan 210
    name Tenant_B_OP_Zone_1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_false.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_false.cfg
@@ -68,6 +68,9 @@ vlan 160
 vlan 161
    name Tenant_A_NFS
 !
+vlan 162
+   name Vlan_everywhere
+!
 vlan 210
    name Tenant_B_OP_Zone_1
 !
@@ -254,6 +257,7 @@ interface Vxlan1
    vxlan vlan 150 vni 10150
    vxlan vlan 160 vni 10160
    vxlan vlan 161 vni 10161
+   vxlan vlan 162 vni 10162
    vxlan vlan 210 vni 20210
    vxlan vlan 211 vni 20211
    vxlan vlan 250 vni 20250
@@ -381,6 +385,12 @@ router bgp 101
       route-target both 31:31
       redistribute learned
       vlan 350
+   !
+   vlan-aware-bundle Vlan_everywhere
+      rd 192.168.255.109:20162
+      route-target both 20162:20162
+      redistribute learned
+      vlan 162
    !
    address-family evpn
       neighbor EVPN-OVERLAY-PEERS activate

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_false.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_false.cfg
@@ -62,6 +62,9 @@ vlan 141
 vlan 150
    name Tenant_A_WAN_Zone_1
 !
+vlan 151
+   name svi_with_no_tags
+!
 vlan 160
    name Tenant_A_VMOTION
 !
@@ -69,7 +72,7 @@ vlan 161
    name Tenant_A_NFS
 !
 vlan 162
-   name Vlan_everywhere
+   name l2vlan_with_no_tags
 !
 vlan 210
    name Tenant_B_OP_Zone_1
@@ -204,6 +207,12 @@ interface Vlan150
    ip ospf authentication-key 7 AQQvKeimxJu+uGQ/yYvv9w==
    ip address virtual 10.1.40.1/24
 !
+interface Vlan151
+   description svi_with_no_tags
+   no shutdown
+   vrf Tenant_A_WAN_Zone
+   ip address virtual 10.1.51.1/24
+!
 interface Vlan210
    description Tenant_B_OP_Zone_1
    no shutdown
@@ -255,6 +264,7 @@ interface Vxlan1
    vxlan vlan 140 vni 10140
    vxlan vlan 141 vni 10141
    vxlan vlan 150 vni 10150
+   vxlan vlan 151 vni 10151
    vxlan vlan 160 vni 10160
    vxlan vlan 161 vni 10161
    vxlan vlan 162 vni 10162
@@ -320,6 +330,12 @@ router bgp 101
    neighbor UNDERLAY-PEERS maximum-routes 12000
    redistribute connected route-map RM-CONN-2-BGP
    !
+   vlan-aware-bundle l2vlan_with_no_tags
+      rd 192.168.255.109:20162
+      route-target both 20162:20162
+      redistribute learned
+      vlan 162
+   !
    vlan-aware-bundle Tenant_A_APP_Zone
       rd 192.168.255.109:12
       route-target both 12:12
@@ -354,7 +370,7 @@ router bgp 101
       rd 192.168.255.109:14
       route-target both 14:14
       redistribute learned
-      vlan 150
+      vlan 150-151
    !
    vlan-aware-bundle Tenant_A_WEB_Zone
       rd 192.168.255.109:11
@@ -385,12 +401,6 @@ router bgp 101
       route-target both 31:31
       redistribute learned
       vlan 350
-   !
-   vlan-aware-bundle Vlan_everywhere
-      rd 192.168.255.109:20162
-      route-target both 20162:20162
-      redistribute learned
-      vlan 162
    !
    address-family evpn
       neighbor EVPN-OVERLAY-PEERS activate

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_true.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_true.cfg
@@ -68,6 +68,9 @@ vlan 160
 vlan 161
    name Tenant_A_NFS
 !
+vlan 162
+   name Vlan_everywhere
+!
 vlan 210
    name Tenant_B_OP_Zone_1
 !
@@ -115,6 +118,7 @@ interface Vxlan1
    vxlan vlan 150 vni 10150
    vxlan vlan 160 vni 10160
    vxlan vlan 161 vni 10161
+   vxlan vlan 162 vni 10162
    vxlan vlan 210 vni 20210
    vxlan vlan 211 vni 20211
    vxlan vlan 250 vni 20250
@@ -218,6 +222,12 @@ router bgp 101
       route-target both 31:31
       redistribute learned
       vlan 350
+   !
+   vlan-aware-bundle Vlan_everywhere
+      rd 192.168.255.109:20162
+      route-target both 20162:20162
+      redistribute learned
+      vlan 162
    !
    address-family evpn
       neighbor EVPN-OVERLAY-PEERS activate

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_true.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_true.cfg
@@ -62,6 +62,9 @@ vlan 141
 vlan 150
    name Tenant_A_WAN_Zone_1
 !
+vlan 151
+   name svi_with_no_tags
+!
 vlan 160
    name Tenant_A_VMOTION
 !
@@ -69,7 +72,7 @@ vlan 161
    name Tenant_A_NFS
 !
 vlan 162
-   name Vlan_everywhere
+   name l2vlan_with_no_tags
 !
 vlan 210
    name Tenant_B_OP_Zone_1
@@ -116,6 +119,7 @@ interface Vxlan1
    vxlan vlan 140 vni 10140
    vxlan vlan 141 vni 10141
    vxlan vlan 150 vni 10150
+   vxlan vlan 151 vni 10151
    vxlan vlan 160 vni 10160
    vxlan vlan 161 vni 10161
    vxlan vlan 162 vni 10162
@@ -157,6 +161,12 @@ router bgp 101
    neighbor UNDERLAY-PEERS maximum-routes 12000
    redistribute connected route-map RM-CONN-2-BGP
    !
+   vlan-aware-bundle l2vlan_with_no_tags
+      rd 192.168.255.109:20162
+      route-target both 20162:20162
+      redistribute learned
+      vlan 162
+   !
    vlan-aware-bundle Tenant_A_APP_Zone
       rd 192.168.255.109:12
       route-target both 12:12
@@ -191,7 +201,7 @@ router bgp 101
       rd 192.168.255.109:14
       route-target both 14:14
       redistribute learned
-      vlan 150
+      vlan 150-151
    !
    vlan-aware-bundle Tenant_A_WEB_Zone
       rd 192.168.255.109:11
@@ -222,12 +232,6 @@ router bgp 101
       route-target both 31:31
       redistribute learned
       vlan 350
-   !
-   vlan-aware-bundle Vlan_everywhere
-      rd 192.168.255.109:20162
-      route-target both 20162:20162
-      redistribute learned
-      vlan 162
    !
    address-family evpn
       neighbor EVPN-OVERLAY-PEERS activate

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_default.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_default.cfg
@@ -62,6 +62,9 @@ vlan 141
 vlan 150
    name Tenant_A_WAN_Zone_1
 !
+vlan 151
+   name svi_with_no_tags
+!
 vlan 160
    name Tenant_A_VMOTION
 !
@@ -69,7 +72,7 @@ vlan 161
    name Tenant_A_NFS
 !
 vlan 162
-   name Vlan_everywhere
+   name l2vlan_with_no_tags
 !
 vlan 210
    name Tenant_B_OP_Zone_1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_default.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_default.cfg
@@ -68,6 +68,9 @@ vlan 160
 vlan 161
    name Tenant_A_NFS
 !
+vlan 162
+   name Vlan_everywhere
+!
 vlan 210
    name Tenant_B_OP_Zone_1
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_fabric.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_fabric.cfg
@@ -62,6 +62,9 @@ vlan 141
 vlan 150
    name Tenant_A_WAN_Zone_1
 !
+vlan 151
+   name svi_with_no_tags
+!
 vlan 160
    name Tenant_A_VMOTION
 !
@@ -69,7 +72,7 @@ vlan 161
    name Tenant_A_NFS
 !
 vlan 162
-   name Vlan_everywhere
+   name l2vlan_with_no_tags
 !
 vlan 210
    name Tenant_B_OP_Zone_1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_fabric.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_fabric.cfg
@@ -68,6 +68,9 @@ vlan 160
 vlan 161
    name Tenant_A_NFS
 !
+vlan 162
+   name Vlan_everywhere
+!
 vlan 210
    name Tenant_B_OP_Zone_1
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_host.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_host.cfg
@@ -70,6 +70,9 @@ vlan 160
 vlan 161
    name Tenant_A_NFS
 !
+vlan 162
+   name Vlan_everywhere
+!
 vlan 210
    name Tenant_B_OP_Zone_1
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_host.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_host.cfg
@@ -64,6 +64,9 @@ vlan 141
 vlan 150
    name Tenant_A_WAN_Zone_1
 !
+vlan 151
+   name svi_with_no_tags
+!
 vlan 160
    name Tenant_A_VMOTION
 !
@@ -71,7 +74,7 @@ vlan 161
    name Tenant_A_NFS
 !
 vlan 162
-   name Vlan_everywhere
+   name l2vlan_with_no_tags
 !
 vlan 210
    name Tenant_B_OP_Zone_1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_platform.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_platform.cfg
@@ -70,6 +70,9 @@ vlan 160
 vlan 161
    name Tenant_A_NFS
 !
+vlan 162
+   name Vlan_everywhere
+!
 vlan 210
    name Tenant_B_OP_Zone_1
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_platform.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_platform.cfg
@@ -64,6 +64,9 @@ vlan 141
 vlan 150
    name Tenant_A_WAN_Zone_1
 !
+vlan 151
+   name svi_with_no_tags
+!
 vlan 160
    name Tenant_A_VMOTION
 !
@@ -71,7 +74,7 @@ vlan 161
    name Tenant_A_NFS
 !
 vlan 162
-   name Vlan_everywhere
+   name l2vlan_with_no_tags
 !
 vlan 210
    name Tenant_B_OP_Zone_1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_false.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_false.yml
@@ -173,7 +173,7 @@ router_bgp:
         - '14:14'
       redistribute_routes:
       - learned
-      vlan: 150
+      vlan: 150-151
     Tenant_A_WEB_Zone:
       rd: 192.168.255.109:11
       route_targets:
@@ -200,7 +200,7 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: 161
-    Vlan_everywhere:
+    l2vlan_with_no_tags:
       tenant: Tenant_A
       rd: 192.168.255.109:20162
       route_targets:
@@ -386,6 +386,9 @@ vlans:
   150:
     tenant: Tenant_A
     name: Tenant_A_WAN_Zone_1
+  151:
+    tenant: Tenant_A
+    name: svi_with_no_tags
   120:
     tenant: Tenant_A
     name: Tenant_A_WEB_Zone_1
@@ -400,7 +403,7 @@ vlans:
     name: Tenant_A_NFS
   162:
     tenant: Tenant_A
-    name: Vlan_everywhere
+    name: l2vlan_with_no_tags
   210:
     tenant: Tenant_B
     name: Tenant_B_OP_Zone_1
@@ -516,6 +519,12 @@ vlan_interfaces:
     ospf_cost: 100
     ospf_authentication: simple
     ospf_authentication_key: AQQvKeimxJu+uGQ/yYvv9w==
+  Vlan151:
+    tenant: Tenant_A
+    description: svi_with_no_tags
+    shutdown: false
+    vrf: Tenant_A_WAN_Zone
+    ip_address_virtual: 10.1.51.1/24
   Vlan120:
     tenant: Tenant_A
     tags:
@@ -614,6 +623,8 @@ vxlan_interface:
           vni: 10112
         150:
           vni: 10150
+        151:
+          vni: 10151
         120:
           vni: 10120
         121:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_false.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_false.yml
@@ -200,6 +200,15 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: 161
+    Vlan_everywhere:
+      tenant: Tenant_A
+      rd: 192.168.255.109:20162
+      route_targets:
+        both:
+        - 20162:20162
+      redistribute_routes:
+      - learned
+      vlan: 162
     Tenant_B_OP_Zone:
       rd: 192.168.255.109:20
       route_targets:
@@ -389,6 +398,9 @@ vlans:
   161:
     tenant: Tenant_A
     name: Tenant_A_NFS
+  162:
+    tenant: Tenant_A
+    name: Vlan_everywhere
   210:
     tenant: Tenant_B
     name: Tenant_B_OP_Zone_1
@@ -610,6 +622,8 @@ vxlan_interface:
           vni: 10160
         161:
           vni: 10161
+        162:
+          vni: 10162
         210:
           vni: 20210
         211:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_true.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_true.yml
@@ -89,6 +89,15 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: 161
+    Vlan_everywhere:
+      tenant: Tenant_A
+      rd: 192.168.255.109:20162
+      route_targets:
+        both:
+        - 20162:20162
+      redistribute_routes:
+      - learned
+      vlan: 162
     Tenant_B_OP_Zone:
       rd: 192.168.255.109:20
       route_targets:
@@ -237,6 +246,9 @@ vlans:
   161:
     tenant: Tenant_A
     name: Tenant_A_NFS
+  162:
+    tenant: Tenant_A
+    name: Vlan_everywhere
   210:
     tenant: Tenant_B
     name: Tenant_B_OP_Zone_1
@@ -293,6 +305,8 @@ vxlan_interface:
           vni: 10160
         161:
           vni: 10161
+        162:
+          vni: 10162
         210:
           vni: 20210
         211:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_true.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_true.yml
@@ -62,7 +62,7 @@ router_bgp:
         - '14:14'
       redistribute_routes:
       - learned
-      vlan: 150
+      vlan: 150-151
     Tenant_A_WEB_Zone:
       rd: 192.168.255.109:11
       route_targets:
@@ -89,7 +89,7 @@ router_bgp:
       redistribute_routes:
       - learned
       vlan: 161
-    Vlan_everywhere:
+    l2vlan_with_no_tags:
       tenant: Tenant_A
       rd: 192.168.255.109:20162
       route_targets:
@@ -234,6 +234,9 @@ vlans:
   150:
     tenant: Tenant_A
     name: Tenant_A_WAN_Zone_1
+  151:
+    tenant: Tenant_A
+    name: svi_with_no_tags
   120:
     tenant: Tenant_A
     name: Tenant_A_WEB_Zone_1
@@ -248,7 +251,7 @@ vlans:
     name: Tenant_A_NFS
   162:
     tenant: Tenant_A
-    name: Vlan_everywhere
+    name: l2vlan_with_no_tags
   210:
     tenant: Tenant_B
     name: Tenant_B_OP_Zone_1
@@ -297,6 +300,8 @@ vxlan_interface:
           vni: 10112
         150:
           vni: 10150
+        151:
+          vni: 10151
         120:
           vni: 10120
         121:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_default.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_default.yml
@@ -82,6 +82,9 @@ vlans:
   150:
     tenant: Tenant_A
     name: Tenant_A_WAN_Zone_1
+  151:
+    tenant: Tenant_A
+    name: svi_with_no_tags
   120:
     tenant: Tenant_A
     name: Tenant_A_WEB_Zone_1
@@ -96,7 +99,7 @@ vlans:
     name: Tenant_A_NFS
   162:
     tenant: Tenant_A
-    name: Vlan_everywhere
+    name: l2vlan_with_no_tags
   210:
     tenant: Tenant_B
     name: Tenant_B_OP_Zone_1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_default.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_default.yml
@@ -94,6 +94,9 @@ vlans:
   161:
     tenant: Tenant_A
     name: Tenant_A_NFS
+  162:
+    tenant: Tenant_A
+    name: Vlan_everywhere
   210:
     tenant: Tenant_B
     name: Tenant_B_OP_Zone_1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_fabric.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_fabric.yml
@@ -82,6 +82,9 @@ vlans:
   150:
     tenant: Tenant_A
     name: Tenant_A_WAN_Zone_1
+  151:
+    tenant: Tenant_A
+    name: svi_with_no_tags
   120:
     tenant: Tenant_A
     name: Tenant_A_WEB_Zone_1
@@ -96,7 +99,7 @@ vlans:
     name: Tenant_A_NFS
   162:
     tenant: Tenant_A
-    name: Vlan_everywhere
+    name: l2vlan_with_no_tags
   210:
     tenant: Tenant_B
     name: Tenant_B_OP_Zone_1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_fabric.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_fabric.yml
@@ -94,6 +94,9 @@ vlans:
   161:
     tenant: Tenant_A
     name: Tenant_A_NFS
+  162:
+    tenant: Tenant_A
+    name: Vlan_everywhere
   210:
     tenant: Tenant_B
     name: Tenant_B_OP_Zone_1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_host.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_host.yml
@@ -88,6 +88,9 @@ vlans:
   150:
     tenant: Tenant_A
     name: Tenant_A_WAN_Zone_1
+  151:
+    tenant: Tenant_A
+    name: svi_with_no_tags
   120:
     tenant: Tenant_A
     name: Tenant_A_WEB_Zone_1
@@ -102,7 +105,7 @@ vlans:
     name: Tenant_A_NFS
   162:
     tenant: Tenant_A
-    name: Vlan_everywhere
+    name: l2vlan_with_no_tags
   210:
     tenant: Tenant_B
     name: Tenant_B_OP_Zone_1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_host.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_host.yml
@@ -100,6 +100,9 @@ vlans:
   161:
     tenant: Tenant_A
     name: Tenant_A_NFS
+  162:
+    tenant: Tenant_A
+    name: Vlan_everywhere
   210:
     tenant: Tenant_B
     name: Tenant_B_OP_Zone_1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_platform.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_platform.yml
@@ -88,6 +88,9 @@ vlans:
   150:
     tenant: Tenant_A
     name: Tenant_A_WAN_Zone_1
+  151:
+    tenant: Tenant_A
+    name: svi_with_no_tags
   120:
     tenant: Tenant_A
     name: Tenant_A_WEB_Zone_1
@@ -102,7 +105,7 @@ vlans:
     name: Tenant_A_NFS
   162:
     tenant: Tenant_A
-    name: Vlan_everywhere
+    name: l2vlan_with_no_tags
   210:
     tenant: Tenant_B
     name: Tenant_B_OP_Zone_1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_platform.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_platform.yml
@@ -100,6 +100,9 @@ vlans:
   161:
     tenant: Tenant_A
     name: Tenant_A_NFS
+  162:
+    tenant: Tenant_A
+    name: Vlan_everywhere
   210:
     tenant: Tenant_B
     name: Tenant_B_OP_Zone_1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS.yml
@@ -217,6 +217,11 @@ tenants:
               cost: 100
               authentication: simple
               simple_auth_key: "AQQvKeimxJu+uGQ/yYvv9w=="
+          151:
+            name: svi_with_no_tags
+            enabled: True
+            ip_address_virtual: 10.1.51.1/24
+            # No "tags" defined - should render on switches with tag "all" or no tags
         additional_route_targets:
           - type: import
             address_family: vpn-ipv4
@@ -253,7 +258,7 @@ tenants:
         name: Tenant_A_NFS
         tags: ['opzone']
       162:
-        name: Vlan_everywhere
+        name: l2vlan_with_no_tags
         # No "tags" defined - should render on switches with tag "all" or no tags
   # Tenant_B Specific Information - VRFs / VLANs
   Tenant_B:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS.yml
@@ -252,6 +252,9 @@ tenants:
       161:
         name: Tenant_A_NFS
         tags: ['opzone']
+      162:
+        name: Vlan_everywhere
+        # No "tags" defined - should render on switches with tag "all" or no tags
   # Tenant_B Specific Information - VRFs / VLANs
   Tenant_B:
     mac_vrf_vni_base: 20000

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
@@ -223,6 +223,7 @@ svi_profiles:
 
             # Tags leveraged for networks services filtering. | Optional
             # Tags are matched against "filter.tags" defined under Fabric Topology variables
+            # Tags are also matched agains the "node_group" name under Fabric Topology variables
             tags: [ < tag_1 >, < tag_2 > | default -> all ]
 
             # Enable or disable interface

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
@@ -442,9 +442,9 @@ svi_profiles:
         # VLAN name | Required
         name: < description >
 
-        # Tags leveraged for networks services filtering. | Optional
+        # Tags leveraged for network services filtering. | Optional
         # Tags are matched against "filter.tags" defined under Fabric Topology variables
-        # Tags are also matched agains the "node_group" name under Fabric Topology variables
+        # Tags are also matched against the "node_group" name under Fabric Topology variables
         tags: [ < tag_1 >, < tag_2 > | default -> all ]
 
         # VXLAN | Optional - default true

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
@@ -223,7 +223,7 @@ svi_profiles:
 
             # Tags leveraged for networks services filtering. | Optional
             # Tags are matched against "filter.tags" defined under Fabric Topology variables
-            # Tags are also matched agains the "node_group" name under Fabric Topology variables
+            # Tags are also matched against the "node_group" name under Fabric Topology variables
             tags: [ < tag_1 >, < tag_2 > | default -> all ]
 
             # Enable or disable interface

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
@@ -221,8 +221,9 @@ svi_profiles:
             # SVI description. | Optional
             description: < description | Default -> vlan name >
 
-            # Tags leveraged for networks services filtering. | Required
-            tags: [ < tag_1 >, < tag_2 > ]
+            # Tags leveraged for networks services filtering. | Optional
+            # Tags are matched against "filter.tags" defined under Fabric Topology variables
+            tags: [ < tag_1 >, < tag_2 > | default -> all ]
 
             # Enable or disable interface
             enabled: < true | false >
@@ -437,11 +438,13 @@ svi_profiles:
         # The rt_override allows us to override this value and statically define it. | Optional
         rt_override: < 1-16777215 | default -> vni_override >
 
-        # VLAN name.
+        # VLAN name | Required
         name: < description >
 
-        # Tags leveraged for networks services filtering.
-        tags: [ < tag_1 >, < tag_2 > ]
+        # Tags leveraged for networks services filtering. | Optional
+        # Tags are matched against "filter.tags" defined under Fabric Topology variables
+        # Tags are also matched agains the "node_group" name under Fabric Topology variables
+        tags: [ < tag_1 >, < tag_2 > | default -> all ]
 
         # VXLAN | Optional - default true
         # Extend this L2VLAN over VXLAN

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/facts/switch/switch.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/facts/switch/switch.j2
@@ -457,7 +457,7 @@ switch:
 {%     set tmp_hostvars = hostvars[inventory_hostname] %}
 {%     for network_services_key in network_services_keys | arista.avd.natural_sort('name') %}
 {%         if network_services_key.name is arista.avd.defined and tmp_hostvars[network_services_key.name] is arista.avd.defined %}
-{%             for tenant in tmp_hostvars[network_services_key.name] | arista.avd.convert_dicts | arista.avd.natural_sort('name') if tenant.name in switch_filter_tenants or "all" in switch_filter_tenants %}
+{%             for tenant in tmp_hostvars[network_services_key.name] | arista.avd.convert_dicts | arista.avd.natural_sort('name') if switch_filter_tenants is arista.avd.contains([tenant.name, "all"]) %}
 {%                 set add_vrfs = {} %}
 {%                 for vrf in tenant.vrfs | arista.avd.convert_dicts | arista.avd.natural_sort('name') %}
 {%                     set add_svis = [] %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/facts/switch/switch.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/facts/switch/switch.j2
@@ -450,6 +450,10 @@ switch:
 {%     set leaf.vlans = []  %}
 {%     set leaf.tenants = {} %}
 {%     set leaf.pseudowires = [] %}
+{%     set match_tags = switch_filter_tags %}
+{%     if switch_data.group is arista.avd.defined %}
+{%         do match_tags.append(switch_data.group) %}
+{%     endif %}
 {%     set tmp_hostvars = hostvars[inventory_hostname] %}
 {%     for network_services_key in network_services_keys | arista.avd.natural_sort('name') %}
 {%         if network_services_key.name is arista.avd.defined and tmp_hostvars[network_services_key.name] is arista.avd.defined %}
@@ -458,13 +462,10 @@ switch:
 {%                 for vrf in tenant.vrfs | arista.avd.convert_dicts | arista.avd.natural_sort('name') %}
 {%                     set add_svis = [] %}
 {%                     for svi in vrf.svis | arista.avd.convert_dicts('id') | arista.avd.natural_sort('id') %}
-{%                         for svi_tag in tenants[tenant].vrfs[vrf].svis[svi].tags | arista.avd.default(['all']) | arista.avd.natural_sort %}
-{%                             if svi_tag in switch_filter_tags or switch_data.group is arista.avd.defined(svi_tag) or "all" in switch_filter_tags %}
-{%                                 do add_svis.append(svi.id) %}
-{%                                 do leaf.vlans.append(svi.id | int) %}
-{%                                 break %}
-{%                             endif %}
-{%                         endfor %}
+{%                         if "all" in switch_filter_tags or svi.tags | arista.avd.default(['all']) is arista.avd.contains(match_tags) %}
+{%                             do add_svis.append(svi.id) %}
+{%                             do leaf.vlans.append(svi.id | int) %}
+{%                         endif %}
 {%                     endfor %}
 {# Append VRF if we found SVIs #}
 {%                     if add_svis | length > 0 %}
@@ -483,13 +484,10 @@ switch:
 {%                 endfor %}
 {%                 set add_l2vlans = [] %}
 {%                 for l2vlan in tenant.l2vlans | arista.avd.convert_dicts('id') | arista.avd.natural_sort('id') %}
-{%                     for vlan_tag in tenants[tenant].l2vlans[l2vlan].tags | arista.avd.default(['all']) | arista.avd.natural_sort %}
-{%                         if vlan_tag in switch_filter_tags or switch_data.group is arista.avd.defined(vlan_tag) or "all" in switch_filter_tags %}
-{%                             do add_l2vlans.append(l2vlan.id) %}
-{%                             do leaf.vlans.append(l2vlan.id | int) %}
-{%                             break %}
-{%                         endif %}
-{%                     endfor %}
+{%                     if "all" in switch_filter_tags or l2vlan.tags | arista.avd.default(['all']) is arista.avd.contains(match_tags) %}
+{%                         do add_l2vlans.append(l2vlan.id) %}
+{%                         do leaf.vlans.append(l2vlan.id | int) %}
+{%                     endif %}
 {%                 endfor %}
 {%                 set add_point_to_point_services = [] %}
 {%                 for point_to_point_service in tenant.point_to_point_services | arista.avd.natural_sort %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/facts/switch/switch.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/facts/switch/switch.j2
@@ -458,7 +458,7 @@ switch:
 {%                 for vrf in tenant.vrfs | arista.avd.convert_dicts | arista.avd.natural_sort('name') %}
 {%                     set add_svis = [] %}
 {%                     for svi in vrf.svis | arista.avd.convert_dicts('id') | arista.avd.natural_sort('id') %}
-{%                         for svi_tag in svi.tags | arista.avd.natural_sort %}
+{%                         for svi_tag in tenants[tenant].vrfs[vrf].svis[svi].tags | arista.avd.default(['all']) | arista.avd.natural_sort %}
 {%                             if svi_tag in switch_filter_tags or switch_data.group is arista.avd.defined(svi_tag) or "all" in switch_filter_tags %}
 {%                                 do add_svis.append(svi.id) %}
 {%                                 do leaf.vlans.append(svi.id | int) %}
@@ -483,7 +483,7 @@ switch:
 {%                 endfor %}
 {%                 set add_l2vlans = [] %}
 {%                 for l2vlan in tenant.l2vlans | arista.avd.convert_dicts('id') | arista.avd.natural_sort('id') %}
-{%                     for vlan_tag in l2vlan.tags | arista.avd.natural_sort %}
+{%                     for vlan_tag in tenants[tenant].l2vlans[l2vlan].tags | arista.avd.default(['all']) | arista.avd.natural_sort %}
 {%                         if vlan_tag in switch_filter_tags or switch_data.group is arista.avd.defined(vlan_tag) or "all" in switch_filter_tags %}
 {%                             do add_l2vlans.append(l2vlan.id) %}
 {%                             do leaf.vlans.append(l2vlan.id | int) %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vlan-interfaces.j2
@@ -29,7 +29,7 @@ vlan_interfaces:
                                      svi_settings.name) %}
   Vlan{{ svi.id | int }}:
     tenant: {{ tenant.name }}
-    tags: {{ svi_settings.tags }}
+    tags: {{ svi_settings.tags | arista.avd.default }}
 {%             if svi_description is arista.avd.defined %}
     description: {{ svi_description }}
 {%             endif %}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Default value "all" for l2vlans.tags and svis.tags

## Related Issue(s)

Fixes #1087 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->
- Set default value for `l2vlans.<>.tags` and `svis.<>.tags` to `["all"]`. This will render vlans with no tags assigned on all switches with `all` or no tags defined. Basically allowing the user to ignore anything around tags, since they default to `["all"]` on both switches and vlans.
- Improve logic to avoid looping over tags in jinja.

This change is not breaking, since until this change we ignored the vlans if they did not have tags assigned.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

- Added molecule coverage for this scenario.
- No other changes in molecule.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
