### PR TITLE
Fix(eos_cli_config_gen): fix the dual-primary recovery delay if check

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/mlag-configuration.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/mlag-configuration.j2
@@ -27,10 +27,10 @@ mlag configuration
 {%     endif %}
 {%     if mlag_configuration.dual_primary_detection_delay is arista.avd.defined %}
    dual-primary detection delay {{ mlag_configuration.dual_primary_detection_delay }} action errdisable all-interfaces
-{%         if mlag_configuration.dual_primary_recovery_delay_mlag is arista.avd.defined and
-              mlag_configuration.dual_primary_recovery_delay_non_mlag is arista.avd.defined %}
+{%     endif %}
+{%     if mlag_configuration.dual_primary_recovery_delay_mlag is arista.avd.defined and
+          mlag_configuration.dual_primary_recovery_delay_non_mlag is arista.avd.defined %}
    dual-primary recovery delay mlag {{ mlag_configuration.dual_primary_recovery_delay_mlag }} non-mlag {{ mlag_configuration.dual_primary_recovery_delay_non_mlag }}
-{%         endif %}
 {%     endif %}
 {%     if mlag_configuration.reload_delay_mlag is arista.avd.defined %}
    reload-delay mlag {{ mlag_configuration.reload_delay_mlag }}


### PR DESCRIPTION
## Change Summary

The dual-primary recovery delay is embedded inside the dual-primary detection delay, which wasn't required. So the whole block was moved outside of the dual-primary detection delay if condition. This will enable the user to define only recovery delay even without defining detection delay if required.

## Related Issue(s)

Fixes #1529 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
No changes in data-model
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test
```molecule converge -s eos_cli_config_gen``` should not generate any artifacts
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

- [x] Check no new artifacts are generated
- [x] CI passed

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
