### PR TITLE
Feat(eos_cli_config_gen): Support mlag primary-priority command

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mlag-configuration.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mlag-configuration.md
@@ -63,6 +63,7 @@ Heartbeat Interval is 5000 milliseconds.
 Dual primary detection is enabled. The detection delay is 5 seconds.
 Dual primary recovery delay for MLAG interfaces is 90 seconds.
 Dual primary recovery delay for NON-MLAG interfaces is 30 seconds.
+Mlag primary-priority is set to 5000
 
 ## MLAG Device Configuration
 
@@ -73,6 +74,7 @@ mlag configuration
    heartbeat-interval 5000
    local-interface Vlan4094
    peer-address 172.16.0.1
+   primary-priority 5000
    peer-link Port-Channel12
    dual-primary detection delay 5 action errdisable all-interfaces
    dual-primary recovery delay mlag 90 non-mlag 30

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/mlag-configuration.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/mlag-configuration.cfg
@@ -17,6 +17,7 @@ mlag configuration
    heartbeat-interval 5000
    local-interface Vlan4094
    peer-address 172.16.0.1
+   primary-priority 5000
    peer-link Port-Channel12
    dual-primary detection delay 5 action errdisable all-interfaces
    dual-primary recovery delay mlag 90 non-mlag 30

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/mlag-configuration.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/mlag-configuration.yml
@@ -9,3 +9,4 @@ mlag_configuration:
   dual_primary_recovery_delay_non_mlag: 30
   reload_delay_mlag: 400
   reload_delay_non_mlag: 450
+  primary_priority: 5000

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1888,7 +1888,6 @@ mlag_configuration:
   domain_id: < domain_id_name >
   heartbeat_interval: < milliseconds >
   local_interface: < interface_name >
-  primary_priority: < integer >
   peer_address: < IPv4_address >
   peer_address_heartbeat:
     peer_ip: < IPv4_address >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1888,6 +1888,7 @@ mlag_configuration:
   domain_id: < domain_id_name >
   heartbeat_interval: < milliseconds >
   local_interface: < interface_name >
+  primary_priority: < integer >
   peer_address: < IPv4_address >
   peer_address_heartbeat:
     peer_ip: < IPv4_address >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/mlag-configuration.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/mlag-configuration.j2
@@ -21,6 +21,9 @@ Dual primary recovery delay for NON-MLAG interfaces is {{ mlag_configuration.dua
 {%     else %}
 Dual primary detection is disabled.
 {%     endif %}
+{%     if mlag_configuration.primary_priority is arista.avd.defined %}
+Mlag primary-priority is set to {{ mlag_configuration.primary_priority }}
+{%     endif %}
 
 ## MLAG Device Configuration
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/mlag-configuration.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/mlag-configuration.j2
@@ -22,6 +22,9 @@ mlag configuration
    peer-address heartbeat {{ mlag_configuration.peer_address_heartbeat.peer_ip }}
 {%         endif %}
 {%     endif %}
+{%     if mlag_configuration.primary_priority is arista.avd.defined %}
+   primary-priority {{ mlag_configuration.primary_priority }}
+{%     endif %}
 {%     if mlag_configuration.peer_link is arista.avd.defined %}
    peer-link {{ mlag_configuration.peer_link }}
 {%     endif %}


### PR DESCRIPTION
## Change Summary

Add a knob to support mlag primary-priority command. This is not visible in the eos command line when ```?``` is typed in to command line but the switch takes the command when the full command is entered (tested it locally on a DUT). This command is needed to change the mlag priority on a primary mlag switch.

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

```
mlag_configuration:
  primary_priority: < integer >
```
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test

Molecule.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
