### PR TITLE
Feat(eos_cli_config_gen): FlexRoute - add support for TCAM assisted ACLs #1656

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/hardware.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/hardware.cfg
@@ -4,6 +4,8 @@ transceiver qsfp default-mode 4x10G
 !
 hostname hardware
 !
+hardware access-list mechanism tcam
+!
 hardware speed-group 1 serdes 10g
 hardware speed-group 2 serdes 25g
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/hardware.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/hardware.yml
@@ -1,5 +1,7 @@
 ### Hardware ###
 hardware:
+  access_list:
+    mechanism: tcam
   speed_groups:
     1:
       serdes: 10g

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -817,6 +817,8 @@ redundancy:
 
 ```yaml
 hardware:
+  access_list:
+    mechanism: < algomatch | none | tcam >
   speed_groups:
     1:
       serdes: < 10g | 25g >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/hardware.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/hardware.j2
@@ -1,4 +1,8 @@
 {# eos - hardware settings #}
+{% if hardware.access_list.mechanism is arista.avd.defined %}
+!
+hardware access-list mechanism {{ hardware.access_list.mechanism }}
+{% endif %}
 {% if hardware.speed_groups is arista.avd.defined %}
 !
 {%     for speed_group in hardware.speed_groups %}


### PR DESCRIPTION
## Change Summary

From https://aristanetworks.force.com/AristaCommunity/s/article/inet-edge-config

Another optimization we recommend for edge deployments utilizing FlexRoute is to change the internal mechanism the switch router will use to implement Access-Control Lists. The hardware typically utilized in high-scale edge routing deployments supports Arista AlgoMatch technology, which is enabled by default. However, to ensure proper allocation of system resources, it is preferable at this time to change the implementation to leverage the system TCAM for ACLs.

## Related Issue(s)

Fixes #1656

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

```yaml
hardware:
  access_list:
    mechanism: < algomatch | none | tcam | default -> algomatch >
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Moelcule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
