### PR TITLE
CI(requirements): Version cap on ansible-lint in requirements-dev.txt

### DIFF
--- a/ansible_collections/arista/avd/requirements-dev.txt
+++ b/ansible_collections/arista/avd/requirements-dev.txt
@@ -1,5 +1,5 @@
 ansible-core>=2.11.3,<2.13.0
-ansible-lint
+ansible-lint<6.0.0
 galaxy-importer>=0.3.1
 pycodestyle
 flake8


### PR DESCRIPTION
## Change Summary

- In v6.0.0 the prerun submodule in ansible-lint hast been renamed to _mockings
- With >v6.0.0 of ansible-lint, the documentation will not be rendered, because the prerun module is missing

## Component(s) name

Impact CI and Molecule

## Proposed changes
- Use ansible-lint <v6.0.0

## How to test
- Try to create documentation with ansible-lint > 6.0.0 vs < 6.0.0

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.

