### PR TITLE
Feat(eos_cli_config_gen): Support bpduguard rate-limit

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/spanning-tree-bpdu.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/spanning-tree-bpdu.md
@@ -68,6 +68,8 @@ STP mode: **mstp**
 !
 no spanning-tree edge-port bpduguard default
 no spanning-tree edge-port bpdufilter default
+spanning-tree bpduguard rate-limit default
+spanning-tree bpduguard rate-limit count 100
 ```
 
 # Internal VLAN Allocation Policy

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/spanning-tree-bpdu.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/spanning-tree-bpdu.cfg
@@ -6,6 +6,8 @@ hostname spanning-tree-bpdu
 !
 no spanning-tree edge-port bpduguard default
 no spanning-tree edge-port bpdufilter default
+spanning-tree bpduguard rate-limit default
+spanning-tree bpduguard rate-limit count 100
 !
 no enable password
 no aaa root

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/spanning-tree-bpdu.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/spanning-tree-bpdu.yml
@@ -3,3 +3,6 @@ spanning_tree:
   edge_port:
     bpduguard_default: false
     bpdufilter_default: false
+  bpduguard_rate_limit:
+    default: true
+    count: 100

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -3290,6 +3290,9 @@ spanning_tree:
     bpdufilter_default: < true | false >
     bpduguard_default: < true | false >
   mode: < mstp | rstp | rapid-pvst | none >
+  bpduguard_rate_limit:
+    default: < true | false >
+    count: < integer >
   rstp_priority: < priority >
   mst:
     pvst_border: < true | false >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -3292,6 +3292,7 @@ spanning_tree:
   mode: < mstp | rstp | rapid-pvst | none >
   bpduguard_rate_limit:
     default: < true | false >
+    # Maximum number of BPDUs per timer interval
     count: < integer >
   rstp_priority: < priority >
   mst:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/spanning-tree.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/spanning-tree.j2
@@ -23,6 +23,16 @@ spanning-tree edge-port bpdufilter default
 {%     elif spanning_tree.edge_port.bpdufilter_default is arista.avd.defined(false) %}
 no spanning-tree edge-port bpdufilter default
 {%     endif %}
+{%     if spanning_tree.bpduguard_rate_limit is arista.avd.defined %}
+{%         if spanning_tree.bpduguard_rate_limit.default is arista.avd.defined(false) %}
+no spanning-tree bpduguard rate-limit default
+{%         elif spanning_tree.bpduguard_rate_limit.default is arista.avd.defined(true) %}
+spanning-tree bpduguard rate-limit default
+{%         endif %}
+{%         if spanning_tree.bpduguard_rate_limit.count is arista.avd.defined %}
+spanning-tree bpduguard rate-limit count {{ spanning_tree.bpduguard_rate_limit.count }}
+{%         endif %}
+{%     endif %}
 {%     if spanning_tree.mode is arista.avd.defined('mstp') %}
 {%         for mst_instance in spanning_tree.mst_instances | arista.avd.natural_sort %}
 {%             if spanning_tree.mst_instances[mst_instance].priority is arista.avd.defined %}


### PR DESCRIPTION
## Change Summary

Support bpduguard rate-limit knobs


## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

```yaml
spanning_tree:
  bpduguard_rate_limit:
    default: < true | false >
    count: < integer >
```
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test

Molecule
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
