### PR TITLE
Feat(eos_cli_config_gen): router_multicast rpf route

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-multicast.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-multicast.md
@@ -107,6 +107,8 @@ interface Management1
 !
 router multicast
    ipv4
+      rpf route 10.10.10.1/32 10.9.9.9 1
+      rpf route 10.10.10.2/32 Ethernet1
       counters rate period decay 300 seconds
       routing
       multipath deterministic router-id

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-multicast.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-multicast.md
@@ -98,8 +98,8 @@ interface Management1
 
 | Source Prefix | Next Hop | Administrative Distance |
 | ------------- | -------- | ----------------------- |
-| 10.10.10.1/32 | 10.9.9.9 | 1 |
-| 10.10.10.2/32 | - | 1 |
+| 10.10.10.1/32 | 10.9.9.9 | 2 |
+| 10.10.10.2/32 | Ethernet1 | - |
 
 ### IP Router Multicast VRFs
 
@@ -114,7 +114,7 @@ interface Management1
 !
 router multicast
    ipv4
-      rpf route 10.10.10.1/32 10.9.9.9 1
+      rpf route 10.10.10.1/32 10.9.9.9 2
       rpf route 10.10.10.2/32 Ethernet1
       counters rate period decay 300 seconds
       routing

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-multicast.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-multicast.md
@@ -94,6 +94,13 @@ interface Management1
 - Multipathing deterministically by selecting the same upstream router.
 - Software forwarding by the Software Forwarding Engine (SFE)
 
+### IP Router Multicast RPF Routes
+
+| Source Prefix | Next Hop | Administrative Distance |
+| ------------- | -------- | ----------------------- |
+| 10.10.10.1/32 | 10.9.9.9 | 1 |
+| 10.10.10.2/32 | - | 1 |
+
 ### IP Router Multicast VRFs
 
 | VRF Name | Multicast Routing |

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-multicast.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-multicast.md
@@ -99,7 +99,8 @@ interface Management1
 | Source Prefix | Next Hop | Administrative Distance |
 | ------------- | -------- | ----------------------- |
 | 10.10.10.1/32 | 10.9.9.9 | 2 |
-| 10.10.10.2/32 | Ethernet1 | - |
+| 10.10.10.1/32 | Ethernet1 | 1 |
+| 10.10.10.2/32 | Ethernet2 | - |
 
 ### IP Router Multicast VRFs
 
@@ -115,7 +116,8 @@ interface Management1
 router multicast
    ipv4
       rpf route 10.10.10.1/32 10.9.9.9 2
-      rpf route 10.10.10.2/32 Ethernet1
+      rpf route 10.10.10.1/32 Ethernet1 1
+      rpf route 10.10.10.2/32 Ethernet2
       counters rate period decay 300 seconds
       routing
       multipath deterministic router-id

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-multicast.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-multicast.cfg
@@ -15,7 +15,8 @@ interface Management1
 router multicast
    ipv4
       rpf route 10.10.10.1/32 10.9.9.9 2
-      rpf route 10.10.10.2/32 Ethernet1
+      rpf route 10.10.10.1/32 Ethernet1 1
+      rpf route 10.10.10.2/32 Ethernet2
       counters rate period decay 300 seconds
       routing
       multipath deterministic router-id

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-multicast.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-multicast.cfg
@@ -14,7 +14,7 @@ interface Management1
 !
 router multicast
    ipv4
-      rpf route 10.10.10.1/32 10.9.9.9 1
+      rpf route 10.10.10.1/32 10.9.9.9 2
       rpf route 10.10.10.2/32 Ethernet1
       counters rate period decay 300 seconds
       routing

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-multicast.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-multicast.cfg
@@ -14,6 +14,8 @@ interface Management1
 !
 router multicast
    ipv4
+      rpf route 10.10.10.1/32 10.9.9.9 1
+      rpf route 10.10.10.2/32 Ethernet1
       counters rate period decay 300 seconds
       routing
       multipath deterministic router-id

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-multicast.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-multicast.yml
@@ -6,7 +6,7 @@ router_multicast:
       routes:
         - subnet: 10.10.10.1/32
           nexthop_ip: 10.9.9.9
-          distance: 1
+          distance: 2
         - subnet: 10.10.10.2/32
           nexthop_interface: Ethernet1
     counters:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-multicast.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-multicast.yml
@@ -4,11 +4,21 @@ router_multicast:
   ipv4:
     rpf:
       routes:
+        - subnet: < IPv4 subnet / netmask >
+          destinations:
+            - nexthop: < ip | interface_name >
+              distance: < 1 - 255 >  # optional
+    rpf:
+      routes:
         - subnet: 10.10.10.1/32
-          nexthop_ip: 10.9.9.9
-          distance: 2
+          destinations:
+            - nexthop: 10.9.9.9
+              distance: 2
+            - nexthop: Ethernet1
+              distance: 1
         - subnet: 10.10.10.2/32
-          nexthop_interface: Ethernet1
+          destinations:
+            - nexthop: Ethernet2
     counters:
       rate_period_decay: 300
     routing: true

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-multicast.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-multicast.yml
@@ -2,6 +2,12 @@
 
 router_multicast:
   ipv4:
+    routes:
+      - subnet: "10.10.10.1/32"
+        nexthop_ip: 10.9.9.9
+        distance: 1
+      - subnet: "10.10.10.2/32"
+        nexthop_interface: Ethernet1
     counters:
       rate_period_decay: 300
     routing: true

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-multicast.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-multicast.yml
@@ -4,12 +4,6 @@ router_multicast:
   ipv4:
     rpf:
       routes:
-        - subnet: < IPv4 subnet / netmask >
-          destinations:
-            - nexthop: < ip | interface_name >
-              distance: < 1 - 255 >  # optional
-    rpf:
-      routes:
         - subnet: 10.10.10.1/32
           destinations:
             - nexthop: 10.9.9.9

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-multicast.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-multicast.yml
@@ -4,13 +4,13 @@ router_multicast:
   ipv4:
     rpf:
       routes:
-        - subnet: 10.10.10.1/32
+        - source_prefix: 10.10.10.1/32
           destinations:
             - nexthop: 10.9.9.9
               distance: 2
             - nexthop: Ethernet1
               distance: 1
-        - subnet: 10.10.10.2/32
+        - source_prefix: 10.10.10.2/32
           destinations:
             - nexthop: Ethernet2
     counters:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-multicast.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-multicast.yml
@@ -2,12 +2,13 @@
 
 router_multicast:
   ipv4:
-    routes:
-      - subnet: "10.10.10.1/32"
-        nexthop_ip: 10.9.9.9
-        distance: 1
-      - subnet: "10.10.10.2/32"
-        nexthop_interface: Ethernet1
+    rpf:
+      routes:
+        - subnet: 10.10.10.1/32
+          nexthop_ip: 10.9.9.9
+          distance: 1
+        - subnet: 10.10.10.2/32
+          nexthop_interface: Ethernet1
     counters:
       rate_period_decay: 300
     routing: true

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1974,9 +1974,9 @@ router_multicast:
     rpf:
       routes:
         - subnet: < IPv4 subnet / netmask >
-          nexthop_ip: < IPv4_network/Mask >
-          nexthop_interface: < interface >
-          distance: < 1 - 255 >  # optional
+          destinations:
+            - nexthop: < ip | interface_name >
+              distance: < 1 - 255 >  # optional
   vrfs:
     - name: < vrf_name >
       ipv4:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1993,9 +1993,9 @@ router_multicast:
     software_forwarding: < kernel | sfe >
     rpf:
       routes:
-        - subnet: < IPv4 subnet / netmask >
+        - source_prefix: < IPv4 subnet / netmask >
           destinations:
-            - nexthop: < ip | interface_name >
+            - nexthop: < nexthop_ip | interface_name >
               distance: < 1 - 255 >  # optional
   vrfs:
     - name: < vrf_name >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1971,6 +1971,12 @@ router_multicast:
     routing: < true | false >
     multipath: < none | deterministic | "deterministic color" | "deterministic router-id" >
     software_forwarding: < kernel | sfe >
+    rpf:
+      routes:
+        - subnet: < IPv4 subnet / netmask >
+          nexthop_ip: < IPv4_network/Mask >
+          nexthop_interface: < interface >
+          distance: < 1 - 255 >  # optional
   vrfs:
     - name: < vrf_name >
       ipv4:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-multicast.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-multicast.j2
@@ -30,9 +30,9 @@
 
 | Source Prefix | Next Hop | Administrative Distance |
 | ------------- | -------- | ----------------------- |
-{%         for rpf_route in router_multicast.ipv4.rpf.routes | arista.avd.natural_sort('subnet') if rpf_route.subnet is arista.avd.defined %}
+{%         for rpf_route in router_multicast.ipv4.rpf.routes | arista.avd.natural_sort('source_prefix') if rpf_route.source_prefix is arista.avd.defined %}
 {%             for destination in rpf_route.destinations | arista.avd.natural_sort('nexthop') if destination.nexthop is arista.avd.defined %}
-| {{ rpf_route.subnet }} | {{ destination.nexthop }} | {{ destination.distance | arista.avd.default('-') }} |
+| {{ rpf_route.source_prefix }} | {{ destination.nexthop }} | {{ destination.distance | arista.avd.default('-') }} |
 {%             endfor %}
 {%         endfor %}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-multicast.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-multicast.j2
@@ -30,7 +30,7 @@
 
 | Source Prefix | Next Hop | Administrative Distance |
 | ------------- | -------- | ----------------------- |
-{%         for rpf_route in router_multicast.ipv4.rpf.routes | arista.avd.natural_sort('subnet') if rpf_route.subnet is arista.avd.defined %}
+{%         for rpf_route in router_multicast.ipv4.rpf.routes | arista.avd.natural_sort('nexthop') if rpf_route.subnet is arista.avd.defined %}
 {%             for destination in rpf_route.destinations if destination.nexthop is arista.avd.defined %}
 | {{ rpf_route.subnet }} | {{ destination.nexthop }} | {{ destination.distance | arista.avd.default('-') }} |
 {%             endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-multicast.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-multicast.j2
@@ -30,13 +30,12 @@
 
 | Source Prefix | Next Hop IP | Next Hop Interface | Administrative Distance |
 | ------------- | ----------- | ------------------ | ----------------------- |
-{%         for rpf_route in router_multicast.ipv4.rpf.routes %}
+{%         for rpf_route in router_multicast.ipv4.rpf.routes | arista.avd.natural_sort('subnet') if rpf_route.subnet is arista.avd.defined %}
 {%             set nexthop_ip = rpf_route.nexthop_ip | arista.avd.default('-') %}
 {%             set nexthop_interface = rpf_route.interface | arista.avd.default('-') %}
 {%             set distance = static_rorpf_routeute.distance | arista.avd.default('1') %}
 | {{ rpf_route.subnet }} | {{ nexthop_ip }} | {{ nexthop_interface }} | {{ distance }} |
 {%         endfor %}
-
 {%     endif %}
 {%     if router_multicast.vrfs is arista.avd.defined %}
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-multicast.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-multicast.j2
@@ -24,6 +24,20 @@
 {%     elif router_multicast.ipv4.software_forwarding is arista.avd.defined('sfe') %}
 - Software forwarding by the Software Forwarding Engine (SFE)
 {%     endif %}
+{%     if router_multicast.rpf.routes is arista.avd.defined %}
+
+### IP Router Multicast RPF Routes
+
+| Source Prefix | Next Hop IP | Next Hop Interface | Administrative Distance |
+| ------------- | ----------- | ------------------ | ----------------------- |
+{%         for rpf_route in router_multicast.ipv4.rpf.routes %}
+{%             set nexthop_ip = rpf_route.nexthop_ip | arista.avd.default('-') %}
+{%             set nexthop_interface = rpf_route.interface | arista.avd.default('-') %}
+{%             set distance = static_rorpf_routeute.distance | arista.avd.default('1') %}
+| {{ rpf_route.subnet }} | {{ nexthop_ip }} | {{ nexthop_interface }} | {{ distance }} |
+{%         endfor %}
+
+{%     endif %}
 {%     if router_multicast.vrfs is arista.avd.defined %}
 
 ### IP Router Multicast VRFs

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-multicast.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-multicast.j2
@@ -30,8 +30,8 @@
 
 | Source Prefix | Next Hop | Administrative Distance |
 | ------------- | -------- | ----------------------- |
-{%         for rpf_route in router_multicast.ipv4.rpf.routes | arista.avd.natural_sort('nexthop') if rpf_route.subnet is arista.avd.defined %}
-{%             for destination in rpf_route.destinations if destination.nexthop is arista.avd.defined %}
+{%         for rpf_route in router_multicast.ipv4.rpf.routes | arista.avd.natural_sort('subnet') if rpf_route.subnet is arista.avd.defined %}
+{%             for destination in rpf_route.destinations | arista.avd.natural_sort('nexthop') if destination.nexthop is arista.avd.defined %}
 | {{ rpf_route.subnet }} | {{ destination.nexthop }} | {{ destination.distance | arista.avd.default('-') }} |
 {%             endfor %}
 {%         endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-multicast.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-multicast.j2
@@ -31,9 +31,9 @@
 | Source Prefix | Next Hop | Administrative Distance |
 | ------------- | -------- | ----------------------- |
 {%         for rpf_route in router_multicast.ipv4.rpf.routes | arista.avd.natural_sort('subnet') if rpf_route.subnet is arista.avd.defined %}
-{%             set nexthop = rpf_route.nexthop_ip | arista.avd.default(rpf_route.nexthop_interface, '-') %}
-{%             set distance = rpf_route.distance | arista.avd.default('-') %}
-| {{ rpf_route.subnet }} | {{ nexthop }} | {{ distance }} |
+{%             for destination in rpf_route.destinations if destination.nexthop is arista.avd.defined %}
+| {{ rpf_route.subnet }} | {{ destination.nexthop }} | {{ destination.distance | arista.avd.default('-') }} |
+{%             endfor %}
 {%         endfor %}
 {%     endif %}
 {%     if router_multicast.vrfs is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-multicast.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-multicast.j2
@@ -31,8 +31,8 @@
 | Source Prefix | Next Hop | Administrative Distance |
 | ------------- | -------- | ----------------------- |
 {%         for rpf_route in router_multicast.ipv4.rpf.routes | arista.avd.natural_sort('subnet') if rpf_route.subnet is arista.avd.defined %}
-{%             set nexthop = rpf_route.nexthop_ip | arista.avd.default(rpf_route.interface, '-') %}
-{%             set distance = rpf_route.distance | arista.avd.default('1') %}
+{%             set nexthop = rpf_route.nexthop_ip | arista.avd.default(rpf_route.nexthop_interface, '-') %}
+{%             set distance = rpf_route.distance | arista.avd.default('-') %}
 | {{ rpf_route.subnet }} | {{ nexthop }} | {{ distance }} |
 {%         endfor %}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-multicast.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-multicast.j2
@@ -24,17 +24,16 @@
 {%     elif router_multicast.ipv4.software_forwarding is arista.avd.defined('sfe') %}
 - Software forwarding by the Software Forwarding Engine (SFE)
 {%     endif %}
-{%     if router_multicast.rpf.routes is arista.avd.defined %}
+{%     if router_multicast.ipv4.rpf.routes is arista.avd.defined %}
 
 ### IP Router Multicast RPF Routes
 
-| Source Prefix | Next Hop IP | Next Hop Interface | Administrative Distance |
-| ------------- | ----------- | ------------------ | ----------------------- |
+| Source Prefix | Next Hop | Administrative Distance |
+| ------------- | -------- | ----------------------- |
 {%         for rpf_route in router_multicast.ipv4.rpf.routes | arista.avd.natural_sort('subnet') if rpf_route.subnet is arista.avd.defined %}
-{%             set nexthop_ip = rpf_route.nexthop_ip | arista.avd.default('-') %}
-{%             set nexthop_interface = rpf_route.interface | arista.avd.default('-') %}
-{%             set distance = static_rorpf_routeute.distance | arista.avd.default('1') %}
-| {{ rpf_route.subnet }} | {{ nexthop_ip }} | {{ nexthop_interface }} | {{ distance }} |
+{%             set nexthop = rpf_route.nexthop_ip | arista.avd.default(rpf_route.interface, '-') %}
+{%             set distance = rpf_route.distance | arista.avd.default('1') %}
+| {{ rpf_route.subnet }} | {{ nexthop }} | {{ distance }} |
 {%         endfor %}
 {%     endif %}
 {%     if router_multicast.vrfs is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-multicast.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-multicast.j2
@@ -5,16 +5,13 @@ router multicast
 {%     if router_multicast.ipv4 is arista.avd.defined %}
    ipv4
 {%         for rpf_route in router_multicast.ipv4.rpf.routes | arista.avd.natural_sort('subnet') if rpf_route.subnet is arista.avd.defined %}
-{%             set rpf_route_cli = "rpf route " ~ rpf_route.subnet ~ " " %}
-{%             if rpf_route.nexthop_ip is arista.avd.defined %}
-{%                 set rpf_route_cli = rpf_route_cli ~ rpf_route.nexthop_ip %}
-{%             elif rpf_route.nexthop_interface is arista.avd.defined %}
-{%                 set rpf_route_cli = rpf_route_cli ~ rpf_route.nexthop_interface %}
-{%             endif %}
-{%             if rpf_route.distance is arista.avd.defined %}
-{%                 set rpf_route_cli = rpf_route_cli ~ " " ~ rpf_route.distance %}
-{%             endif %}
+{%             for destination in rpf_route.destinations if destination.nexthop is arista.avd.defined %}
+{%                 set rpf_route_cli = "rpf route " ~ rpf_route.subnet ~ " " ~ destination.nexthop %}
+{%                 if destination.distance is arista.avd.defined %}
+{%                     set rpf_route_cli = rpf_route_cli ~ " " ~ destination.distance %}
+{%                 endif %}
       {{ rpf_route_cli }}
+{%             endfor %}
 {%         endfor %}
 {%         if router_multicast.ipv4.counters.rate_period_decay is arista.avd.defined %}
       counters rate period decay {{ router_multicast.ipv4.counters.rate_period_decay }} seconds

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-multicast.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-multicast.j2
@@ -4,9 +4,9 @@
 router multicast
 {%     if router_multicast.ipv4 is arista.avd.defined %}
    ipv4
-{%         for rpf_route in router_multicast.ipv4.rpf.routes | arista.avd.natural_sort('subnet') if rpf_route.subnet is arista.avd.defined %}
+{%         for rpf_route in router_multicast.ipv4.rpf.routes | arista.avd.natural_sort('source_prefix') if rpf_route.source_prefix is arista.avd.defined %}
 {%             for destination in rpf_route.destinations | arista.avd.natural_sort('nexthop') if destination.nexthop is arista.avd.defined %}
-{%                 set rpf_route_cli = "rpf route " ~ rpf_route.subnet ~ " " ~ destination.nexthop %}
+{%                 set rpf_route_cli = "rpf route " ~ rpf_route.source_prefix ~ " " ~ destination.nexthop %}
 {%                 if destination.distance is arista.avd.defined %}
 {%                     set rpf_route_cli = rpf_route_cli ~ " " ~ destination.distance %}
 {%                 endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-multicast.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-multicast.j2
@@ -4,7 +4,7 @@
 router multicast
 {%     if router_multicast.ipv4 is arista.avd.defined %}
    ipv4
-{%         for rpf_route in router_multicast.ipv4.rpf.routes | arista.avd.natural_sort('subnet') if rpf_route.subnet is arista.avd.defined %}
+{%         for rpf_route in router_multicast.ipv4.rpf.routes | arista.avd.natural_sort('nexthop') if rpf_route.subnet is arista.avd.defined %}
 {%             for destination in rpf_route.destinations if destination.nexthop is arista.avd.defined %}
 {%                 set rpf_route_cli = "rpf route " ~ rpf_route.subnet ~ " " ~ destination.nexthop %}
 {%                 if destination.distance is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-multicast.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-multicast.j2
@@ -4,6 +4,20 @@
 router multicast
 {%     if router_multicast.ipv4 is arista.avd.defined %}
    ipv4
+{%         if router_multicast.ipv4.rpf.routes is arista.avd.defined %}
+{%             for rpf_route in router_multicast.ipv4.rpf.routes %}
+{%                 set rpf_route_cli = "rpf route " ~ rpf_route.subnet ~ " " %}
+{%                 if rpf_route.nexthop_ip is arista.avd.defined %}
+{%                     set rpf_route_cli = rpf_route_cli ~ rpf_route.nexthop_ip %}
+{%                 elif rpf_route.nexthop_interface is arista.avd.defined %}
+{%                     set rpf_route_cli = rpf_route_cli ~ rpf_route.nexthop_interface %}
+{%                 endif %}
+{%                 if rpf_route.distance is arista.avd.defined %}
+{%                     set rpf_route_cli = rpf_route_cli ~ " " ~ rpf_route.distance %}
+{%                 endif %}
+      {{ rpf_route_cli }}
+{%             endfor %}
+{%         endif %}
 {%         if router_multicast.ipv4.counters.rate_period_decay is arista.avd.defined %}
       counters rate period decay {{ router_multicast.ipv4.counters.rate_period_decay }} seconds
 {%         endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-multicast.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-multicast.j2
@@ -4,8 +4,8 @@
 router multicast
 {%     if router_multicast.ipv4 is arista.avd.defined %}
    ipv4
-{%         for rpf_route in router_multicast.ipv4.rpf.routes | arista.avd.natural_sort('nexthop') if rpf_route.subnet is arista.avd.defined %}
-{%             for destination in rpf_route.destinations if destination.nexthop is arista.avd.defined %}
+{%         for rpf_route in router_multicast.ipv4.rpf.routes | arista.avd.natural_sort('subnet') if rpf_route.subnet is arista.avd.defined %}
+{%             for destination in rpf_route.destinations | arista.avd.natural_sort('nexthop') if destination.nexthop is arista.avd.defined %}
 {%                 set rpf_route_cli = "rpf route " ~ rpf_route.subnet ~ " " ~ destination.nexthop %}
 {%                 if destination.distance is arista.avd.defined %}
 {%                     set rpf_route_cli = rpf_route_cli ~ " " ~ destination.distance %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-multicast.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-multicast.j2
@@ -4,20 +4,18 @@
 router multicast
 {%     if router_multicast.ipv4 is arista.avd.defined %}
    ipv4
-{%         if router_multicast.ipv4.rpf.routes is arista.avd.defined %}
-{%             for rpf_route in router_multicast.ipv4.rpf.routes %}
-{%                 set rpf_route_cli = "rpf route " ~ rpf_route.subnet ~ " " %}
-{%                 if rpf_route.nexthop_ip is arista.avd.defined %}
-{%                     set rpf_route_cli = rpf_route_cli ~ rpf_route.nexthop_ip %}
-{%                 elif rpf_route.nexthop_interface is arista.avd.defined %}
-{%                     set rpf_route_cli = rpf_route_cli ~ rpf_route.nexthop_interface %}
-{%                 endif %}
-{%                 if rpf_route.distance is arista.avd.defined %}
-{%                     set rpf_route_cli = rpf_route_cli ~ " " ~ rpf_route.distance %}
-{%                 endif %}
+{%         for rpf_route in router_multicast.ipv4.rpf.routes | arista.avd.natural_sort('subnet') if rpf_route.subnet is arista.avd.defined %}
+{%             set rpf_route_cli = "rpf route " ~ rpf_route.subnet ~ " " %}
+{%             if rpf_route.nexthop_ip is arista.avd.defined %}
+{%                 set rpf_route_cli = rpf_route_cli ~ rpf_route.nexthop_ip %}
+{%             elif rpf_route.nexthop_interface is arista.avd.defined %}
+{%                 set rpf_route_cli = rpf_route_cli ~ rpf_route.nexthop_interface %}
+{%             endif %}
+{%             if rpf_route.distance is arista.avd.defined %}
+{%                 set rpf_route_cli = rpf_route_cli ~ " " ~ rpf_route.distance %}
+{%             endif %}
       {{ rpf_route_cli }}
-{%             endfor %}
-{%         endif %}
+{%         endfor %}
 {%         if router_multicast.ipv4.counters.rate_period_decay is arista.avd.defined %}
       counters rate period decay {{ router_multicast.ipv4.counters.rate_period_decay }} seconds
 {%         endif %}


### PR DESCRIPTION
## Change Summary

Add support for router_multicast rpf routes

## Related Issue(s)

Fixes #1671 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Add support for router_multicast rpf routes

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been rebased from devel before I start
- [X] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [X] My change requires a change to the documentation and documentation have been updated accordingly.
- [X] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
