### PR TITLE
Feat(eos_cli_config_gen): dot1x-port-control

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -18,6 +18,8 @@
   - [MPLS Interfaces](#mpls-interfaces)
 - [Multicast](#multicast)
 - [Filters](#filters)
+- [DOT1X](#dot1x)
+  - [DOT1X Summary](#dot1x-summary)
 - [ACL](#acl)
 - [Quality Of Service](#quality-of-service)
 
@@ -92,6 +94,9 @@ interface Management1
 | Ethernet25 |  Molecule MAC | access | - | - | - | - |
 | Ethernet27 |  EVPN-Vxlan single-active redundancy | access | - | - | - | - |
 | Ethernet28 |  EVPN-MPLS multihoming | access | - | - | - | - |
+| Ethernet29 |  DOT1X Testing - auto phone true | access | - | - | - | - |
+| Ethernet30 |  DOT1X Testing - force-authorized phone false | access | - | - | - | - |
+| Ethernet31 |  DOT1X Testing - force-unauthorized - no phone | access | - | - | - | - |
 
 *Inherited from Port-Channel Interface
 
@@ -490,6 +495,23 @@ interface Ethernet28
       mpls tunnel flood filter time 100
       mpls shared index 100
       route-target import 00:00:01:02:03:05
+!
+interface Ethernet29
+   description DOT1X Testing - auto phone true
+   switchport
+   dot1x port-control auto
+   dot1x port-control force-authorized phone
+!
+interface Ethernet30
+   description DOT1X Testing - force-authorized phone false
+   switchport
+   dot1x port-control force-authorized
+   no dot1x port-control force-authorized phone
+!
+interface Ethernet31
+   description DOT1X Testing - force-unauthorized - no phone
+   switchport
+   dot1x port-control force-unauthorized
 ```
 
 # Routing
@@ -534,6 +556,19 @@ interface Ethernet28
 # Multicast
 
 # Filters
+
+# DOT1X
+
+## DOT1X Summary
+
+### DOT1X Interfaces
+
+| Interface | State | Phone State |
+| --------- | ----- | ----------- |
+| Ethernet29 | auto | True |
+| Ethernet30 | force-authorized | False |
+| Ethernet31 | force-unauthorized | - |
+
 
 # ACL
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -18,8 +18,8 @@
   - [MPLS Interfaces](#mpls-interfaces)
 - [Multicast](#multicast)
 - [Filters](#filters)
-- [DOT1X](#dot1x)
-  - [DOT1X Summary](#dot1x-summary)
+- [802.1X Port Security](#8021x-port-security)
+  - [802.1X Summary](#8021x-summary)
 - [ACL](#acl)
 - [Quality Of Service](#quality-of-service)
 
@@ -557,18 +557,17 @@ interface Ethernet31
 
 # Filters
 
-# DOT1X
+# 802.1X Port Security
 
-## DOT1X Summary
+## 802.1X Summary
 
-### DOT1X Interfaces
+### 802.1X Interfaces
 
 | Interface | State | Phone Force Authorized |
 | --------- | ----- | ----------- |
 | Ethernet29 | auto | True |
 | Ethernet30 | force-authorized | False |
 | Ethernet31 | force-unauthorized | - |
-
 
 # ACL
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -563,7 +563,7 @@ interface Ethernet31
 
 ### DOT1X Interfaces
 
-| Interface | State | Phone State |
+| Interface | State | Phone Force Authorized |
 | --------- | ----- | ----------- |
 | Ethernet29 | auto | True |
 | Ethernet30 | force-authorized | False |

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -564,7 +564,7 @@ interface Ethernet31
 ### 802.1X Interfaces
 
 | Interface | State | Phone Force Authorized |
-| --------- | ----- | ----------- |
+| --------- | ----- | ---------------------- |
 | Ethernet29 | auto | True |
 | Ethernet30 | force-authorized | False |
 | Ethernet31 | force-unauthorized | - |

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
@@ -301,6 +301,23 @@ interface Ethernet28
       mpls shared index 100
       route-target import 00:00:01:02:03:05
 !
+interface Ethernet29
+   description DOT1X Testing - auto phone true
+   switchport
+   dot1x port-control auto
+   dot1x port-control force-authorized phone
+!
+interface Ethernet30
+   description DOT1X Testing - force-authorized phone false
+   switchport
+   dot1x port-control force-authorized
+   no dot1x port-control force-authorized phone
+!
+interface Ethernet31
+   description DOT1X Testing - force-unauthorized - no phone
+   switchport
+   dot1x port-control force-unauthorized
+!
 interface Management1
    description oob_management
    vrf MGMT

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
@@ -402,3 +402,20 @@ ethernet_interfaces:
       mpls:
         shared_index: 100
         tunnel_flood_filter_time: 100
+
+  Ethernet29:
+    description: DOT1X Testing - auto phone true
+    dot1x:
+      port_control: auto
+      port_control_force_authorized_phone: true 
+
+  Ethernet30:
+    description: DOT1X Testing - force-authorized phone false
+    dot1x:
+      port_control: force-authorized
+      port_control_force_authorized_phone: false
+
+  Ethernet31:
+    description: DOT1X Testing - force-unauthorized - no phone
+    dot1x:
+      port_control: force-unauthorized

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
@@ -407,7 +407,7 @@ ethernet_interfaces:
     description: DOT1X Testing - auto phone true
     dot1x:
       port_control: auto
-      port_control_force_authorized_phone: true 
+      port_control_force_authorized_phone: true
 
   Ethernet30:
     description: DOT1X Testing - force-authorized phone false
@@ -419,3 +419,4 @@ ethernet_interfaces:
     description: DOT1X Testing - force-unauthorized - no phone
     dot1x:
       port_control: force-unauthorized
+      

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
@@ -419,4 +419,3 @@ ethernet_interfaces:
     description: DOT1X Testing - force-unauthorized - no phone
     dot1x:
       port_control: force-unauthorized
-      

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -571,12 +571,6 @@ dhcp_relay:
   tunnel_requests_disabled: < true | false >
 ```
 
-### DOT1X
-
-```yaml
-Global DOT1X to add later
-```
-
 ### EOS CLI
 
 ```yaml

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -31,6 +31,7 @@
     - [Router BFD](#router-bfd)
     - [Custom Templates](#custom-templates)
     - [DHCP Relay](#dhcp-relay)
+    - [DOT1X](#dot1x)
     - [EOS CLI](#eos-cli)
     - [Errdisable](#errdisable)
     - [Filters](#filters)
@@ -570,6 +571,12 @@ dhcp_relay:
   tunnel_requests_disabled: < true | false >
 ```
 
+### DOT1X
+
+```yaml
+Global DOT1X to add later
+```
+
 ### EOS CLI
 
 ```yaml
@@ -1075,6 +1082,9 @@ ethernet_interfaces:
       - from: < list of vlans as string (only one vlan if direction is "both") >
         to: < vlan_id >
         direction: < in | out | both | default -> both >
+    dot1x:
+      port_control: < "auto" | "force-authorized" | "force-unauthorized" >
+      port_control_force_authorized_phone: < true | false >
     # EOS CLI rendered directly on the ethernet interface in the final EOS configuration
     eos_cli: |
       < multiline eos cli >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -31,7 +31,6 @@
     - [Router BFD](#router-bfd)
     - [Custom Templates](#custom-templates)
     - [DHCP Relay](#dhcp-relay)
-    - [DOT1X](#dot1x)
     - [EOS CLI](#eos-cli)
     - [Errdisable](#errdisable)
     - [Filters](#filters)

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/dot1x.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/dot1x.j2
@@ -13,7 +13,7 @@
 
 ### DOT1X Interfaces
 
-| Interface | State | Phone State |
+| Interface | State | Phone Force Authorized |
 | --------- | ----- | ----------- |
 {%     for ethernet_interface in ethernet_interfaces_dot1x | arista.avd.natural_sort %}
 {%         set state = ethernet_interfaces[ethernet_interface].dot1x.port_control | arista.avd.default('-') %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/dot1x.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/dot1x.j2
@@ -1,0 +1,24 @@
+{# DOT1X Interfaces #}
+{% set ethernet_interfaces_dot1x = [] %}
+{% for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort %}
+{%     if ethernet_interfaces[ethernet_interface].dot1x is arista.avd.defined %}
+{%        do ethernet_interfaces_dot1x.append(ethernet_interface) %}
+{%     endif %}
+{% endfor %}
+{% if ethernet_interfaces_dot1x | length > 0 %}
+
+# DOT1X
+
+## DOT1X Summary
+
+### DOT1X Interfaces
+
+| Interface | State | Phone State |
+| --------- | ----- | ----------- |
+{%     for ethernet_interface in ethernet_interfaces_dot1x | arista.avd.natural_sort %}
+{%         set state = ethernet_interfaces[ethernet_interface].dot1x.port_control | arista.avd.default('-') %}
+{%         set phone_state = ethernet_interfaces[ethernet_interface].dot1x.port_control_force_authorized_phone | arista.avd.default('-') %}
+| {{ ethernet_interface }} | {{ state }} | {{ phone_state }} |
+{%     endfor %}
+
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/dot1x.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/dot1x.j2
@@ -14,7 +14,7 @@
 ### 802.1X Interfaces
 
 | Interface | State | Phone Force Authorized |
-| --------- | ----- | ----------- |
+| --------- | ----- | ---------------------- |
 {%     for ethernet_interface in ethernet_interfaces_dot1x %}
 {%         set state = ethernet_interface.dot1x.port_control | arista.avd.default('-') %}
 {%         set phone_state = ethernet_interface.dot1x.port_control_force_authorized_phone | arista.avd.default('-') %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/dot1x.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/dot1x.j2
@@ -2,7 +2,7 @@
 {% set ethernet_interfaces_dot1x = [] %}
 {% for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort %}
 {%     if ethernet_interfaces[ethernet_interface].dot1x is arista.avd.defined %}
-{%        do ethernet_interfaces_dot1x.append(ethernet_interface) %}
+{%         do ethernet_interfaces_dot1x.append(ethernet_interface) %}
 {%     endif %}
 {% endfor %}
 {% if ethernet_interfaces_dot1x | length > 0 %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/dot1x.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/dot1x.j2
@@ -1,24 +1,23 @@
 {# DOT1X Interfaces #}
 {% set ethernet_interfaces_dot1x = [] %}
-{% for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort %}
-{%     if ethernet_interfaces[ethernet_interface].dot1x is arista.avd.defined %}
+{% for ethernet_interface in ethernet_interfaces | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%     if ethernet_interface.dot1x is arista.avd.defined %}
 {%         do ethernet_interfaces_dot1x.append(ethernet_interface) %}
 {%     endif %}
 {% endfor %}
 {% if ethernet_interfaces_dot1x | length > 0 %}
 
-# DOT1X
+# 802.1X Port Security
 
-## DOT1X Summary
+## 802.1X Summary
 
-### DOT1X Interfaces
+### 802.1X Interfaces
 
 | Interface | State | Phone Force Authorized |
 | --------- | ----- | ----------- |
-{%     for ethernet_interface in ethernet_interfaces_dot1x | arista.avd.natural_sort %}
-{%         set state = ethernet_interfaces[ethernet_interface].dot1x.port_control | arista.avd.default('-') %}
-{%         set phone_state = ethernet_interfaces[ethernet_interface].dot1x.port_control_force_authorized_phone | arista.avd.default('-') %}
-| {{ ethernet_interface }} | {{ state }} | {{ phone_state }} |
+{%     for ethernet_interface in ethernet_interfaces_dot1x %}
+{%         set state = ethernet_interface.dot1x.port_control | arista.avd.default('-') %}
+{%         set phone_state = ethernet_interface.dot1x.port_control_force_authorized_phone | arista.avd.default('-') %}
+| {{ ethernet_interface.name }} | {{ state }} | {{ phone_state }} |
 {%     endfor %}
-
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-device-documentation.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-device-documentation.j2
@@ -196,6 +196,8 @@
 {% include 'documentation/match-lists.j2' %}
 {# as-paths #}
 {% include 'documentation/as-path.j2' %}
+{# dot1x #}
+{% include 'documentation/dot1x.j2' %}
 
 # ACL
 {## Standard Access-lists #}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -189,6 +189,16 @@ interface {{ ethernet_interface.name }}
       route-target import {{ ethernet_interface.evpn_ethernet_segment.route_target }}
 {%             endif %}
 {%         endif %}
+{%         if ethernet_interface.dot1x is arista.avd.defined %}
+{%             if ethernet_interface.dot1x.port_control is arista.avd.defined %}
+   dot1x port-control {{ ethernet_interface.dot1x.port_control }}
+{%             endif %}
+{%             if ethernet_interface.dot1x.port_control_force_authorized_phone is arista.avd.defined(true) %}
+   dot1x port-control force-authorized phone
+{%             elif ethernet_interface.dot1x.port_control_force_authorized_phone is arista.avd.defined(false) %}
+   no dot1x port-control force-authorized phone
+{%             endif %}
+{%         endif %}
 {%         if ethernet_interface.vrf is arista.avd.defined %}
    vrf {{ ethernet_interface.vrf }}
 {%         endif %}


### PR DESCRIPTION
## Change Summary

Adding Campus Dot1x Port Control Feature to ethernet interface
```
sw1(config-if-Et1)#dot1x port-control ?
  auto                Set port state to automatic
  force-authorized    Set port state to authorized
  force-unauthorized  Set port state to unauthorized
```

## Related Issue(s)

n/a

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test
Molecule testing with the following ethernet_interfaces.yml
```
  Ethernet29:
    description: DOT1X Testing - auto phone true
    dot1x:
      port_control: auto
      port_control_force_authorized_phone: true

  Ethernet30:
    description: DOT1X Testing - force-authorized phone false
    dot1x:
      port_control: force-authorized
      port_control_force_authorized_phone: false

  Ethernet31:
    description: DOT1X Testing - force-unauthorized - no phone
    dot1x:
      port_control: force-unauthorized
```

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
