### PR TITLE
Feat(eos_cli_config_gen): Added support for CVX client

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-cvx.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-cvx.md
@@ -48,10 +48,11 @@ interface Management1
 ## Management CVX Summary
 
 | Shutdown | CVX Servers |
-| -------- | ------------- |
+| -------- | ----------- |
 | False | 10.90.224.188, 10.90.224.189, leaf1.atd.lab |
 
 ### Management CVX configuration
+
 ```eos
 !
 management cvx

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-cvx.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-cvx.md
@@ -48,7 +48,7 @@ interface Management1
 ## Management CVX Summary
 
 | Shutdown | CVX Servers |
-| ---------- | ------------- |
+| -------- | ------------- |
 | False | 10.90.224.188, 10.90.224.189, leaf1.atd.lab |
 
 ### Management CVX configuration

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-cvx.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-cvx.md
@@ -3,7 +3,7 @@
 
 - [Management](#management)
   - [Management Interfaces](#management-interfaces)
-  - [Management CVX](#management-cvx)
+  - [Management CVX Summary](#management-cvx-summary)
 - [Authentication](#authentication)
 - [Monitoring](#monitoring)
 - [Internal VLAN Allocation Policy](#internal-vlan-allocation-policy)
@@ -44,7 +44,12 @@ interface Management1
    vrf MGMT
    ip address 10.73.255.122/24
 ```
-## Management CVX
+
+## Management CVX Summary
+
+| Shutdown | CVX Servers |
+| ---------- | ------------- |
+| False | 10.90.224.188, 10.90.224.189, leaf1.atd.lab |
 
 ### Management CVX configuration
 ```eos
@@ -53,6 +58,7 @@ management cvx
    no shutdown
    server host 10.90.224.188
    server host 10.90.224.189
+   server host leaf1.atd.lab
 ```
 
 # Authentication

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-cvx.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-cvx.md
@@ -1,0 +1,102 @@
+# management-cvx
+# Table of Contents
+
+- [Management](#management)
+  - [Management Interfaces](#management-interfaces)
+  - [Management CVX](#management-cvx)
+- [Authentication](#authentication)
+- [Monitoring](#monitoring)
+- [Internal VLAN Allocation Policy](#internal-vlan-allocation-policy)
+  - [Internal VLAN Allocation Policy Summary](#internal-vlan-allocation-policy-summary)
+- [Interfaces](#interfaces)
+- [Routing](#routing)
+  - [IP Routing](#ip-routing)
+  - [IPv6 Routing](#ipv6-routing)
+- [Multicast](#multicast)
+- [Filters](#filters)
+- [ACL](#acl)
+- [Quality Of Service](#quality-of-service)
+
+# Management
+
+## Management Interfaces
+
+### Management Interfaces Summary
+
+#### IPv4
+
+| Management Interface | description | Type | VRF | IP Address | Gateway |
+| -------------------- | ----------- | ---- | --- | ---------- | ------- |
+| Management1 | oob_management | oob | MGMT | 10.73.255.122/24 | 10.73.255.2 |
+
+#### IPv6
+
+| Management Interface | description | Type | VRF | IPv6 Address | IPv6 Gateway |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ |
+| Management1 | oob_management | oob | MGMT | -  | - |
+
+### Management Interfaces Device Configuration
+
+```eos
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+```
+## Management CVX
+
+### Management CVX configuration
+```eos
+!
+management cvx
+   no shutdown
+   server host 10.90.224.188
+   server host 10.90.224.189
+```
+
+# Authentication
+
+# Monitoring
+
+# Internal VLAN Allocation Policy
+
+## Internal VLAN Allocation Policy Summary
+
+**Default Allocation Policy**
+
+| Policy Allocation | Range Beginning | Range Ending |
+| ------------------| --------------- | ------------ |
+| ascending | 1006 | 4094 |
+
+# Interfaces
+
+# Routing
+
+## IP Routing
+
+### IP Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | false |
+
+### IP Routing Device Configuration
+
+```eos
+```
+## IPv6 Routing
+
+### IPv6 Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | false |
+
+# Multicast
+
+# Filters
+
+# ACL
+
+# Quality Of Service

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-cvx.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-cvx.cfg
@@ -1,0 +1,20 @@
+!RANCID-CONTENT-TYPE: arista
+!
+transceiver qsfp default-mode 4x10G
+!
+hostname management-cvx
+!
+no enable password
+no aaa root
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+!
+management cvx
+   no shutdown
+   server host 10.90.224.188
+   server host 10.90.224.189
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-cvx.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-cvx.cfg
@@ -16,5 +16,6 @@ management cvx
    no shutdown
    server host 10.90.224.188
    server host 10.90.224.189
+   server host leaf1.atd.lab
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/management-cvx.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/management-cvx.yml
@@ -1,6 +1,7 @@
 ### MANAGEMENT CVX ###
 management_cvx:
   shutdown: false
-  server_host:
+  server_hosts:
   - 10.90.224.188
   - 10.90.224.189
+  - leaf1.atd.lab

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/management-cvx.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/management-cvx.yml
@@ -1,0 +1,6 @@
+### MANAGEMENT CVX ###
+management_cvx:
+  shutdown: false
+  server_host:
+  - 10.90.224.188
+  - 10.90.224.189

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
@@ -50,6 +50,7 @@ loopbacks-interfaces
 mac-address-table
 maintenance
 management-api-http
+management-cvx
 management-gnmi
 management-gnmi-new-flags
 management-console

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1776,10 +1776,11 @@ management_console:
 #### Management CVX
 ```yaml
 management_cvx:
-  shutdown: false
-  server_host:
-    - < IPv4_address >
-    - < IPv4_address >
+  shutdown: < true | false >
+  # List of Hostname(s) or IP Address(es) of CVX server(s)
+  server_hosts:
+    - < IP | hostname >
+    - < IP | hostname >
 ```
 
 #### Management Defaults

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1773,6 +1773,15 @@ management_console:
   idle_timeout: < 0-86400 in minutes >
 ```
 
+#### Management CVX
+```yaml
+management_cvx:
+  shutdown: false
+  server_host:
+    - < IPv4_address >
+    - < IPv4_address >
+```
+
 #### Management Defaults
 
 ```yaml

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-cvx.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-cvx.j2
@@ -1,6 +1,13 @@
 {# Management CVX #}
 {% if management_cvx is arista.avd.defined %}
-## Management CVX
+
+## Management CVX Summary
+
+| Shutdown | CVX Servers |
+| ---------- | ------------- |
+{%     set shut = management_cvx.shutdown | arista.avd.default('-') %}
+{%     set servers = management_cvx.server_hosts | arista.avd.default('-') | join(', ') %}
+| {{ shut }} | {{ servers }} |
 
 ### Management CVX configuration
 ```eos

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-cvx.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-cvx.j2
@@ -10,6 +10,7 @@
 | {{ shut }} | {{ servers }} |
 
 ### Management CVX configuration
+
 ```eos
 {%     include 'eos/management-cvx.j2' %}
 ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-cvx.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-cvx.j2
@@ -1,0 +1,9 @@
+{# Management CVX #}
+{% if management_cvx is arista.avd.defined %}
+## Management CVX
+
+### Management CVX configuration
+```eos
+{%      include 'eos/management-cvx.j2' %}
+```
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-cvx.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-cvx.j2
@@ -4,7 +4,7 @@
 ## Management CVX Summary
 
 | Shutdown | CVX Servers |
-| ---------- | ------------- |
+| -------- | ----------- |
 {%     set shut = management_cvx.shutdown | arista.avd.default('-') %}
 {%     set servers = management_cvx.server_hosts | arista.avd.default('-') | join(', ') %}
 | {{ shut }} | {{ servers }} |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-cvx.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-cvx.j2
@@ -11,6 +11,6 @@
 
 ### Management CVX configuration
 ```eos
-{%      include 'eos/management-cvx.j2' %}
+{%     include 'eos/management-cvx.j2' %}
 ```
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-device-documentation.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-device-documentation.j2
@@ -30,6 +30,8 @@
 {% include 'documentation/ip-ssh-client-source-interfaces.j2' %}
 {## Management API GNMI #}
 {% include 'documentation/management-api-gnmi.j2' %}
+{## Management CVX #}
+{% include 'documentation/management-cvx.j2' %}
 {# management Console #}
 {% include 'documentation/management-console.j2' %}
 {## Management API HTTP #}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
@@ -232,6 +232,8 @@
 {% include 'eos/management-api-http.j2' %}
 {# management console #}
 {% include 'eos/management-console.j2' %}
+{# management cvx #}
+{% include 'eos/management-cvx.j2' %}
 {# management defaults #}
 {% include 'eos/management-defaults.j2' %}
 {# management api gnmi #}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-cvx.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-cvx.j2
@@ -8,8 +8,8 @@ management cvx
    no shutdown
 {%     endif %}
 {%     if management_cvx.server_hosts is arista.avd.defined %}
-{%         for ip in management_cvx.server_hosts %}
-   server host {{ ip }}
+{%         for server_host in management_cvx.server_hosts | arista.avd.natural_sort %}
+   server host {{ server_host }}
 {%         endfor %}
 {%     endif %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-cvx.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-cvx.j2
@@ -9,5 +9,5 @@ management cvx
 {%     endif %}
 {%     for server_host in management_cvx.server_hosts | arista.avd.natural_sort %}
    server host {{ server_host }}
-{%         endfor %}
+{%     endfor %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-cvx.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-cvx.j2
@@ -4,12 +4,12 @@
 management cvx
 {%     if management_cvx.shutdown is arista.avd.defined(true) %}
    shutdown
-{%     else %}
+{%     elif management_cvx.shutdown is arista.avd.defined(false) %}
    no shutdown
 {%     endif %}
-{%     if management_cvx.server_host is arista.avd.defined %}
-{%         for ip in management_cvx.server_host %}
-   server host {{ip}}
+{%     if management_cvx.server_hosts is arista.avd.defined %}
+{%         for ip in management_cvx.server_hosts %}
+   server host {{ ip }}
 {%         endfor %}
 {%     endif %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-cvx.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-cvx.j2
@@ -1,0 +1,15 @@
+{# management cvx #}
+{% if management_cvx is arista.avd.defined %}
+!
+management cvx
+{%     if management_cvx.shutdown is arista.avd.defined(true) %}
+   shutdown
+{%     else %}
+   no shutdown
+{%     endif %}
+{%     if management_cvx.server_host is arista.avd.defined %}
+{%         for ip in management_cvx.server_host %}
+   server host {{ip}}
+{%         endfor %}
+{%     endif %}
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-cvx.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-cvx.j2
@@ -7,9 +7,7 @@ management cvx
 {%     elif management_cvx.shutdown is arista.avd.defined(false) %}
    no shutdown
 {%     endif %}
-{%     if management_cvx.server_hosts is arista.avd.defined %}
-{%         for server_host in management_cvx.server_hosts | arista.avd.natural_sort %}
+{%     for server_host in management_cvx.server_hosts | arista.avd.natural_sort %}
    server host {{ server_host }}
 {%         endfor %}
-{%     endif %}
 {% endif %}


### PR DESCRIPTION
## Change Summary

Added support for CVX client command

## Related Issue(s)

Fixes #1681 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Data Model
```
management_cvx:
  shutdown: false
  server_host:
    - < IPv4_address >
    - < IPv4_address >
```
Eg:
```
management_cvx:
  shutdown: false
  server_host:
  - 10.90.224.188
  - 10.90.224.189
```


## How to test
`molecule converge --scenario-name eos_cli_config_gen -- --limit management-cvx`

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
