### PR TITLE
Feat(eos_cli_config_gen): Support platfom sand qos-mapping

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/platform.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/platform.md
@@ -110,11 +110,22 @@ interface Management1
 | lag.mode | 512x32 |
 | multicast_replication.default | ingress |
 
+#### QOS Mapping
+
+| Traffic Class | To Network QOS |
+| ------------- | -------------- |
+| 0 | 0 |
+| 1 | 7 |
+| 2 | 15 |
+
 ## Platform Configuration
 
 ```eos
 !
 platform trident forwarding-table partition 2
+platform sand qos map traffic-class 0 to network-qos 0
+platform sand qos map traffic-class 1 to network-qos 7
+platform sand qos map traffic-class 2 to network-qos 15
 platform sand lag hardware-only
 platform sand lag mode 512x32
 platform sand forwarding mode arad

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/platform.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/platform.md
@@ -105,12 +105,12 @@ interface Management1
 
 | Settings | Value |
 | -------- | ----- |
-| forwarding_mode | arad |
-| lag.hardware_only | True |
-| lag.mode | 512x32 |
-| multicast_replication.default | ingress |
+| Forwarding Mode | arad |
+| Hardware Only Lag | True |
+| Lag Mode | 512x32 |
+| Default Multicast Replication | ingress |
 
-#### QOS Mapping
+#### Internal Network QOS Mapping
 
 | Traffic Class | To Network QOS |
 | ------------- | -------------- |

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/platform.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/platform.cfg
@@ -5,6 +5,9 @@ transceiver qsfp default-mode 4x10G
 hostname platform
 !
 platform trident forwarding-table partition 2
+platform sand qos map traffic-class 0 to network-qos 0
+platform sand qos map traffic-class 1 to network-qos 7
+platform sand qos map traffic-class 2 to network-qos 15
 platform sand lag hardware-only
 platform sand lag mode 512x32
 platform sand forwarding mode arad

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/platform.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/platform.yml
@@ -2,6 +2,13 @@ platform:
   trident:
     forwarding_table_partition: 2
   sand:
+    qos_maps:
+      - traffic_class: 0
+        to_network_qos: 0
+      - traffic_class: 1
+        to_network_qos: 7
+      - traffic_class: 2
+        to_network_qos: 15
     lag:
       hardware_only: true
       mode: "512x32"

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/platform.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/platform.md
@@ -105,10 +105,10 @@ interface Management1
 
 | Settings | Value |
 | -------- | ----- |
-| forwarding_mode | arad |
-| lag.hardware_only | True |
-| lag.mode | 512x32 |
-| multicast_replication.default | ingress |
+| Forwarding Mode | arad |
+| Hardware Only Lag | True |
+| Lag Mode | 512x32 |
+| Default Multicast Replication | ingress |
 
 ## Platform Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL1A.md
@@ -948,7 +948,7 @@ vrf instance Tenant_L3_VRF_Zone
 
 | Settings | Value |
 | -------- | ----- |
-| lag.hardware_only | True |
+| Hardware Only Lag | True |
 
 ## Platform Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL1B.md
@@ -938,7 +938,7 @@ vrf instance Tenant_L3_VRF_Zone
 
 | Settings | Value |
 | -------- | ----- |
-| lag.hardware_only | True |
+| Hardware Only Lag | True |
 
 ## Platform Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL2A.md
@@ -816,7 +816,7 @@ vrf instance Tenant_C_WAN_Zone
 
 | Settings | Value |
 | -------- | ----- |
-| lag.hardware_only | True |
+| Hardware Only Lag | True |
 
 ## Platform Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-CL1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-CL1A.md
@@ -983,7 +983,7 @@ vrf instance MGMT
 
 | Settings | Value |
 | -------- | ----- |
-| lag.hardware_only | True |
+| Hardware Only Lag | True |
 
 ## Platform Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-CL1B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-CL1B.md
@@ -983,7 +983,7 @@ vrf instance MGMT
 
 | Settings | Value |
 | -------- | ----- |
-| lag.hardware_only | True |
+| Hardware Only Lag | True |
 
 ## Platform Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2A.md
@@ -1196,7 +1196,7 @@ ip address virtual source-nat vrf Tenant_A_OP_Zone address 10.255.1.10
 
 | Settings | Value |
 | -------- | ----- |
-| lag.hardware_only | True |
+| Hardware Only Lag | True |
 
 ## Platform Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2B.md
@@ -1196,7 +1196,7 @@ ip address virtual source-nat vrf Tenant_A_OP_Zone address 10.255.1.11
 
 | Settings | Value |
 | -------- | ----- |
-| lag.hardware_only | True |
+| Hardware Only Lag | True |
 
 ## Platform Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SPINE2.md
@@ -683,7 +683,7 @@ vrf instance MGMT
 
 | Settings | Value |
 | -------- | ----- |
-| lag.hardware_only | True |
+| Hardware Only Lag | True |
 
 ## Platform Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/mgmt_interface_host.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/mgmt_interface_host.md
@@ -412,7 +412,7 @@ vrf instance MGMT
 
 | Settings | Value |
 | -------- | ----- |
-| lag.hardware_only | True |
+| Hardware Only Lag | True |
 
 ## Platform Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/mgmt_interface_platform.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/mgmt_interface_platform.md
@@ -412,7 +412,7 @@ vrf instance MGMT
 
 | Settings | Value |
 | -------- | ----- |
-| lag.hardware_only | True |
+| Hardware Only Lag | True |
 
 ## Platform Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -933,7 +933,7 @@ vrf instance Tenant_L3_VRF_Zone
 
 | Settings | Value |
 | -------- | ----- |
-| lag.hardware_only | True |
+| Hardware Only Lag | True |
 
 ## Platform Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -931,7 +931,7 @@ vrf instance Tenant_L3_VRF_Zone
 
 | Settings | Value |
 | -------- | ----- |
-| lag.hardware_only | True |
+| Hardware Only Lag | True |
 
 ## Platform Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -1245,7 +1245,7 @@ ip address virtual source-nat vrf Tenant_A_OP_Zone address 10.255.1.10
 
 | Settings | Value |
 | -------- | ----- |
-| lag.hardware_only | True |
+| Hardware Only Lag | True |
 
 ## Platform Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -1245,7 +1245,7 @@ ip address virtual source-nat vrf Tenant_A_OP_Zone address 10.255.1.11
 
 | Settings | Value |
 | -------- | ----- |
-| lag.hardware_only | True |
+| Hardware Only Lag | True |
 
 ## Platform Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -859,7 +859,7 @@ vrf instance Tenant_C_WAN_Zone
 
 | Settings | Value |
 | -------- | ----- |
-| lag.hardware_only | True |
+| Hardware Only Lag | True |
 
 ## Platform Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -840,7 +840,7 @@ vrf instance Tenant_C_WAN_Zone
 
 | Settings | Value |
 | -------- | ----- |
-| lag.hardware_only | True |
+| Hardware Only Lag | True |
 
 ## Platform Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -806,7 +806,7 @@ vrf instance Tenant_A_WEB_Zone
 
 | Settings | Value |
 | -------- | ----- |
-| lag.hardware_only | True |
+| Hardware Only Lag | True |
 
 ## Platform Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -1325,7 +1325,7 @@ ip address virtual source-nat vrf Tenant_A_OP_Zone address 10.255.1.6
 
 | Settings | Value |
 | -------- | ----- |
-| lag.hardware_only | True |
+| Hardware Only Lag | True |
 
 ## Platform Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -1325,7 +1325,7 @@ ip address virtual source-nat vrf Tenant_A_OP_Zone address 10.255.1.7
 
 | Settings | Value |
 | -------- | ----- |
-| lag.hardware_only | True |
+| Hardware Only Lag | True |
 
 ## Platform Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -1559,7 +1559,7 @@ ip address virtual source-nat vrf Tenant_A_OP_Zone address 10.255.1.8
 
 | Settings | Value |
 | -------- | ----- |
-| lag.hardware_only | True |
+| Hardware Only Lag | True |
 
 ## Platform Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -1544,7 +1544,7 @@ ip address virtual source-nat vrf Tenant_A_OP_Zone address 10.255.1.9
 
 | Settings | Value |
 | -------- | ----- |
-| lag.hardware_only | True |
+| Hardware Only Lag | True |
 
 ## Platform Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -940,7 +940,7 @@ vrf instance Tenant_L3_VRF_Zone
 
 | Settings | Value |
 | -------- | ----- |
-| lag.hardware_only | True |
+| Hardware Only Lag | True |
 
 ## Platform Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -938,7 +938,7 @@ vrf instance Tenant_L3_VRF_Zone
 
 | Settings | Value |
 | -------- | ----- |
-| lag.hardware_only | True |
+| Hardware Only Lag | True |
 
 ## Platform Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -1188,7 +1188,7 @@ ip address virtual source-nat vrf Tenant_A_OP_Zone address 10.255.1.10
 
 | Settings | Value |
 | -------- | ----- |
-| lag.hardware_only | True |
+| Hardware Only Lag | True |
 
 ## Platform Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -1188,7 +1188,7 @@ ip address virtual source-nat vrf Tenant_A_OP_Zone address 10.255.1.11
 
 | Settings | Value |
 | -------- | ----- |
-| lag.hardware_only | True |
+| Hardware Only Lag | True |
 
 ## Platform Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -863,7 +863,7 @@ vrf instance Tenant_C_WAN_Zone
 
 | Settings | Value |
 | -------- | ----- |
-| lag.hardware_only | True |
+| Hardware Only Lag | True |
 
 ## Platform Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -844,7 +844,7 @@ vrf instance Tenant_C_WAN_Zone
 
 | Settings | Value |
 | -------- | ----- |
-| lag.hardware_only | True |
+| Hardware Only Lag | True |
 
 ## Platform Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF1A.md
@@ -810,7 +810,7 @@ vrf instance Tenant_A_WEB_Zone
 
 | Settings | Value |
 | -------- | ----- |
-| lag.hardware_only | True |
+| Hardware Only Lag | True |
 
 ## Platform Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -1329,7 +1329,7 @@ ip address virtual source-nat vrf Tenant_A_OP_Zone address 10.255.1.6
 
 | Settings | Value |
 | -------- | ----- |
-| lag.hardware_only | True |
+| Hardware Only Lag | True |
 
 ## Platform Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -1329,7 +1329,7 @@ ip address virtual source-nat vrf Tenant_A_OP_Zone address 10.255.1.7
 
 | Settings | Value |
 | -------- | ----- |
-| lag.hardware_only | True |
+| Hardware Only Lag | True |
 
 ## Platform Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -1563,7 +1563,7 @@ ip address virtual source-nat vrf Tenant_A_OP_Zone address 10.255.1.8
 
 | Settings | Value |
 | -------- | ----- |
-| lag.hardware_only | True |
+| Hardware Only Lag | True |
 
 ## Platform Configuration
 

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -1548,7 +1548,7 @@ ip address virtual source-nat vrf Tenant_A_OP_Zone address 10.255.1.9
 
 | Settings | Value |
 | -------- | ----- |
-| lag.hardware_only | True |
+| Hardware Only Lag | True |
 
 ## Platform Configuration
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -817,7 +817,12 @@ tcam_profile:
 platform:
   trident:
     forwarding_table_partition: < partition >
+  # Most of the platform sand options are hardware dependant and optional
   sand:
+    # The traffic-class to network-qos mappings must be unique
+    qos_maps:
+      - traffic_class: < 0-7 >
+        to_network_qos: < 0-63 >
     lag:
       hardware_only: < true | false >
       mode: < mode | default -> 1024x16 >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -825,7 +825,7 @@ platform:
         to_network_qos: < 0-63 >
     lag:
       hardware_only: < true | false >
-      mode: < mode | default -> 1024x16 >
+      mode: < mode >
     forwarding_mode: < petraA | arad >
     multicast_replication:
       default: ingress

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/platform.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/platform.j2
@@ -20,7 +20,7 @@
 
 | Settings | Value |
 | -------- | ----- |
-{%             for sandsetting in platform.sand | arista.avd.natural_sort %}
+{%             for sandsetting in platform.sand | arista.avd.natural_sort if sandsetting not in ['qos_maps'] %}
 {%                 if sandsetting == 'lag' %}
 {%                     for lag_sandsetting in platform.sand.lag | arista.avd.natural_sort %}
 {%                         set lag_sandsettingmod = "lag." ~ lag_sandsetting %}
@@ -35,6 +35,18 @@
 | {{ sandsetting }} | {{ platform.sand[sandsetting] }} |
 {%                 endif %}
 {%             endfor %}
+{%             if platform.sand.qos_maps is arista.avd.defined %}
+
+#### QOS Mapping
+
+| Traffic Class | To Network QOS |
+| ------------- | -------------- |
+{%                 for qos_map in platform.sand.qos_maps | arista.avd.natural_sort('traffic_class') %}
+{%                     if qos_map.traffic_class is arista.avd.defined and qos_map.to_network_qos is arista.avd.defined %}
+| {{ qos_map.traffic_class }} | {{ qos_map.to_network_qos }} |
+{%                     endif %}
+{%                 endfor %}
+{%             endif %}
 {%         endif %}
 {%     endif %}
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/platform.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/platform.j2
@@ -20,24 +20,21 @@
 
 | Settings | Value |
 | -------- | ----- |
-{%             for sandsetting in platform.sand | arista.avd.natural_sort if sandsetting not in ['qos_maps'] %}
-{%                 if sandsetting == 'lag' %}
-{%                     for lag_sandsetting in platform.sand.lag | arista.avd.natural_sort %}
-{%                         set lag_sandsettingmod = "lag." ~ lag_sandsetting %}
-| {{ lag_sandsettingmod }} | {{ platform.sand.lag[lag_sandsetting] }} |
-{%                     endfor %}
-{%                 elif sandsetting == 'multicast_replication' %}
-{%                     for multicast_replication_sandsetting in platform.sand.multicast_replication | arista.avd.natural_sort %}
-{%                         set multicast_replication_sandsettingmod = "multicast_replication." ~ multicast_replication_sandsetting %}
-| {{ multicast_replication_sandsettingmod }} | {{ platform.sand.multicast_replication[multicast_replication_sandsetting] }} |
-{%                     endfor %}
-{%                 else %}
-| {{ sandsetting }} | {{ platform.sand[sandsetting] }} |
-{%                 endif %}
-{%             endfor %}
+{%             if platform.sand.forwarding_mode is arista.avd.defined %}
+| Forwarding Mode | {{ platform.sand.forwarding_mode }} |
+{%             endif %}
+{%             if platform.sand.lag.hardware_only is arista.avd.defined %}
+| Hardware Only Lag | {{ platform.sand.lag.hardware_only }} |
+{%             endif %}
+{%             if platform.sand.lag.mode is arista.avd.defined %}
+| Lag Mode | {{ platform.sand.lag.mode }} |
+{%             endif %}
+{%             if platform.sand.multicast_replication.default is arista.avd.defined %}
+| Default Multicast Replication | {{ platform.sand.multicast_replication.default }} |
+{%             endif %}
 {%             if platform.sand.qos_maps is arista.avd.defined %}
 
-#### QOS Mapping
+#### Internal Network QOS Mapping
 
 | Traffic Class | To Network QOS |
 | ------------- | -------------- |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/platform.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/platform.j2
@@ -4,16 +4,23 @@
 {%     if platform.trident.forwarding_table_partition is arista.avd.defined %}
 platform trident forwarding-table partition {{ platform.trident.forwarding_table_partition }}
 {%     endif %}
-{%     if platform.sand.lag.hardware_only is arista.avd.defined(true) %}
+{%     if platform.sand is arista.avd.defined %}
+{%         for qos_map in platform.sand.qos_maps | arista.avd.natural_sort('traffic_class') %}
+{%             if qos_map.traffic_class is arista.avd.defined and qos_map.to_network_qos is arista.avd.defined %}
+platform sand qos map traffic-class {{ qos_map.traffic_class }} to network-qos {{ qos_map.to_network_qos }}
+{%             endif %}
+{%         endfor %}
+{%         if platform.sand.lag.hardware_only is arista.avd.defined(true) %}
 platform sand lag hardware-only
-{%     endif %}
-{%     if platform.sand.lag.mode is arista.avd.defined %}
+{%         endif %}
+{%         if platform.sand.lag.mode is arista.avd.defined %}
 platform sand lag mode {{ platform.sand.lag.mode }}
-{%     endif %}
-{%     if platform.sand.forwarding_mode is arista.avd.defined %}
+{%         endif %}
+{%         if platform.sand.forwarding_mode is arista.avd.defined %}
 platform sand forwarding mode {{ platform.sand.forwarding_mode }}
-{%     endif %}
-{%     if platform.sand.multicast_replication.default is arista.avd.defined %}
+{%         endif %}
+{%         if platform.sand.multicast_replication.default is arista.avd.defined %}
 platform sand multicast replication default {{ platform.sand.multicast_replication.default }}
+{%         endif %}
 {%     endif %}
 {% endif %}


### PR DESCRIPTION
## Change Summary

Support platform sand qos-map commands in AVD.

<!-- Enter short PR description -->

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

```yaml
platform:
  sand:
    qos_maps:
      - traffic_class: < 0-7 >
        to_network_qos: < 0-63 >
```

<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test

molecule
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
