### PR TITLE
Feat(eos_cli_config_gen): Support interfaces snmp trap link-change

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -234,6 +234,7 @@ interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE2_Ethernet2
    mtu 1500
    no switchport
+   no snmp trap link-change
    ip address 172.31.128.1/31
    ipv6 enable
    ipv6 address 2002:ABDC::1/64
@@ -249,6 +250,7 @@ interface Ethernet4
    shutdown
    mtu 9100
    switchport
+   snmp trap link-change
    ipv6 enable
    ipv6 address 2020::2020/64
    ipv6 address FE80:FEA::AB65/64 link-local

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
@@ -303,6 +303,7 @@ interface Port-Channel3
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
    switchport trunk group MLAG
+   no snmp trap link-change
    shape rate 200000 kbps
 !
 interface Port-Channel5
@@ -387,6 +388,7 @@ interface Port-Channel16
    switchport
    switchport trunk allowed vlan 110,201
    switchport mode trunk
+   snmp trap link-change
    mlag 16
    spanning-tree guard none
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
@@ -39,6 +39,7 @@ interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE2_Ethernet2
    mtu 1500
    no switchport
+   no snmp trap link-change
    ip address 172.31.128.1/31
    ipv6 enable
    ipv6 address 2002:ABDC::1/64
@@ -54,6 +55,7 @@ interface Ethernet4
    shutdown
    mtu 9100
    switchport
+   snmp trap link-change
    ipv6 enable
    ipv6 address 2020::2020/64
    ipv6 address FE80:FEA::AB65/64 link-local

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
@@ -14,6 +14,7 @@ interface Port-Channel3
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
    switchport trunk group MLAG
+   no snmp trap link-change
    shape rate 200000 kbps
 !
 interface Port-Channel5
@@ -98,6 +99,7 @@ interface Port-Channel16
    switchport
    switchport trunk allowed vlan 110,201
    switchport mode trunk
+   snmp trap link-change
    mlag 16
    spanning-tree guard none
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
@@ -61,6 +61,7 @@ ethernet_interfaces:
     mtu: 1500
     type: routed
     ip_address: 172.31.128.1/31
+    snmp_trap_link_change: false
     link_tracking_groups:
       - name: EVPN_MH_ES2
         direction: downstream
@@ -93,6 +94,7 @@ ethernet_interfaces:
     ipv6_nd_managed_config_flag: true
     ipv6_access_group_in: IPv6_ACL_IN
     ipv6_access_group_out: IPv6_ACL_OUT
+    snmp_trap_link_change: true
     priority_flow_control:
       enabled: true
     spanning_tree_guard: disabled

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
@@ -38,6 +38,7 @@ port_channel_interfaces:
     description: DC1_L2LEAF4_Po1
     vlans: 110,201
     mode: trunk
+    snmp_trap_link_change: true
     mlag: 16
     spanning_tree_guard: disabled
 
@@ -45,6 +46,7 @@ port_channel_interfaces:
     description: MLAG_PEER_DC1-LEAF1B_Po3
     vlans: "2-4094"
     mode: trunk
+    snmp_trap_link_change: false
     shape:
       rate: 200000 kbps
     trunk_groups:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -907,6 +907,7 @@ ethernet_interfaces:
     # l3dot1q and l2dot1q are used for sub-interfaces.
     # The parent interface should be defined as routed.
     type: < routed | switched | l3dot1q | l2dot1q >
+    snmp_trap_link_change: < true | false >
     vrf: < vrf_name >
     error_correction_encoding:
       enabled: < true | false | default -> true >
@@ -1074,6 +1075,7 @@ ethernet_interfaces:
         shared_index: < 1-1024 >
         tunnel_flood_filter_time: < integer >
       route_target: < EVPN Route Target for ESI with format xx:xx:xx:xx:xx:xx >
+    snmp_trap_link_change: < true | false >
     flowcontrol:
       received: < "received" | "send" | "on" >
     mac_security:
@@ -1240,6 +1242,7 @@ port_channel_interfaces:
     vlan_id: < 1-4094 >
     mode: < access | dot1q-tunnel | trunk | "trunk phone" >
     native_vlan: < native vlan number >
+    snmp_trap_link_change: < true | false >
     link_tracking_groups:
       - name: < group_name >
         direction: < upstream | downstream >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -199,6 +199,11 @@ interface {{ ethernet_interface.name }}
    no dot1x port-control force-authorized phone
 {%             endif %}
 {%         endif %}
+{%         if ethernet_interface.snmp_trap_link_change is arista.avd.defined(false) %}
+   no snmp trap link-change
+{%         elif ethernet_interface.snmp_trap_link_change is arista.avd.defined(true) %}
+   snmp trap link-change
+{%         endif %}
 {%         if ethernet_interface.vrf is arista.avd.defined %}
    vrf {{ ethernet_interface.vrf }}
 {%         endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
@@ -138,6 +138,11 @@ interface {{ port_channel_interface }}
       route-target import {{ port_channel_interfaces[port_channel_interface].rt }}
 {%         endif %}
 {%     endif %}
+{%     if port_channel_interfaces[port_channel_interface].snmp_trap_link_change is arista.avd.defined(false) %}
+   no snmp trap link-change
+{%     elif port_channel_interfaces[port_channel_interface].snmp_trap_link_change is arista.avd.defined(true) %}
+   snmp trap link-change
+{%     endif %}
 {%     if port_channel_interfaces[port_channel_interface].lacp_id is arista.avd.defined %}
    lacp system-id {{ port_channel_interfaces[port_channel_interface].lacp_id }}
 {%     endif %}


### PR DESCRIPTION
## Change Summary

Support AVD data model for interfaces snmp trap link-change
<!-- Enter short PR description -->

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Knob added under ethernet_interfaces and port_channel_interfaces:

```yaml
snmp_trap_link_change: < true | false >
```
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test

Molecule
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
