### PR TITLE
Feat(eos_cli_config_gen): VRRP timer delay and IPv4 version options

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
@@ -143,12 +143,13 @@ interface Management1
 
 #### VRRP Details
 
-| Interface | VRRP-ID | Priority | Advertisement Interval | Preempt | Tracked Object Name(s) | Tracked Object Action(s) | IPv4 Virtual IP | IPv6 Virtual IP |
-| --------- | ------- | -------- | ---------------------- | --------| ---------------------- | ------------------------ | --------------- | ----------------|
-| Vlan333 | 1 | 105 | 2 | Enabled | ID1-TrackedObjectDecrement, ID1-TrackedObjectShutdown | Decrement 5, Shutdown | 192.0.2.1 | - |
-| Vlan333 | 2 | - | - | Enabled | ID2-TrackedObjectDecrement, ID2-TrackedObjectShutdown | Decrement 10, Shutdown | - | 2001:db8::1 |
-| Vlan667 | 1 | 105 | 2 | Enabled | - | - | 192.0.2.1 | - |
-| Vlan667 | 2 | - | - | Enabled | - | - | - | 2001:db8::1 |
+| Interface | VRRP-ID | Priority | Advertisement Interval | Preempt | Tracked Object Name(s) | Tracked Object Action(s) | IPv4 Virtual IP | IPv4 VRRP Version | IPv6 Virtual IP |
+| --------- | ------- | -------- | ---------------------- | --------| ---------------------- | ------------------------ | --------------- | ----------------- | --------------- |
+| Vlan333 | 1 | 105 | 2 | Enabled | ID1-TrackedObjectDecrement, ID1-TrackedObjectShutdown | Decrement 5, Shutdown | 192.0.2.1 | 2 | - |
+| Vlan333 | 2 | - | - | Enabled | ID2-TrackedObjectDecrement, ID2-TrackedObjectShutdown | Decrement 10, Shutdown | - | 2 | 2001:db8::1 |
+| Vlan333 | 3 | - | - | Enabled | - | - | 100.64.0.1 | 3 | - |
+| Vlan667 | 1 | 105 | 2 | Enabled | - | - | 192.0.2.1 | 2 | - |
+| Vlan667 | 2 | - | - | Enabled | - | - | - | 2 | 2001:db8::1 |
 
 ### VLAN Interfaces Device Configuration
 
@@ -278,6 +279,9 @@ interface Vlan333
    vrrp 2 ipv6 2001:db8::1
    vrrp 2 tracked-object ID2-TrackedObjectDecrement decrement 10
    vrrp 2 tracked-object ID2-TrackedObjectShutdown shutdown
+   vrrp 3 timers delay reload 900
+   vrrp 3 ipv4 100.64.0.1
+   vrrp 3 ipv4 version 3
 !
 interface Vlan501
    description SVI Description

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
@@ -136,6 +136,9 @@ interface Vlan333
    vrrp 2 ipv6 2001:db8::1
    vrrp 2 tracked-object ID2-TrackedObjectDecrement decrement 10
    vrrp 2 tracked-object ID2-TrackedObjectShutdown shutdown
+   vrrp 3 timers delay reload 900
+   vrrp 3 ipv4 100.64.0.1
+   vrrp 3 ipv4 version 3
 !
 interface Vlan501
    description SVI Description

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
@@ -286,3 +286,10 @@ vlan_interfaces:
             decrement: 10
           - name: ID2-TrackedObjectShutdown
             shutdown: true
+      - id: 3
+        timers:
+          delay:
+            reload: 900
+        ipv4:
+          address: 100.64.0.1
+          version: 3

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1469,6 +1469,9 @@ vlan_interfaces:
           delay:
             minimum: < integer >
             reload: < integer >
+        timers:
+          delay:
+            reload: < integer >
         tracked_object:
           - name: < tracked_object_name_1 >
             decrement: < decrement vrrp priority by 1-254 >
@@ -1478,6 +1481,7 @@ vlan_interfaces:
             shutdown: < true | false >
         ipv4:
           address: < virtual_ip_address >
+          version: < 2 | 3 >
         ipv6:
           address: < virtual_ip_address >
     # The below "vrrp" keys will be deprecated in AVD v4.0 - These should not be mixed with the new "vrrp_ids" key above to avoid conflicts.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vlan-interfaces.j2
@@ -82,8 +82,8 @@
 
 #### VRRP Details
 
-| Interface | VRRP-ID | Priority | Advertisement Interval | Preempt | Tracked Object Name(s) | Tracked Object Action(s) | IPv4 Virtual IP | IPv6 Virtual IP |
-| --------- | ------- | -------- | ---------------------- | --------| ---------------------- | ------------------------ | --------------- | ----------------|
+| Interface | VRRP-ID | Priority | Advertisement Interval | Preempt | Tracked Object Name(s) | Tracked Object Action(s) | IPv4 Virtual IP | IPv4 VRRP Version | IPv6 Virtual IP |
+| --------- | ------- | -------- | ---------------------- | --------| ---------------------- | ------------------------ | --------------- | ----------------- | --------------- |
 {%         for vlan_interface in vlan_interfaces_vrrp_details | arista.avd.natural_sort %}
 {%             for vrid in vlan_interfaces[vlan_interface].vrrp_ids if vrid.id is arista.avd.defined %}
 {%                 set row_id = vrid.id %}
@@ -108,8 +108,9 @@
 {%                     set row_tracked_object_action = row_tracked_object_action | join(", ") %}
 {%                 endif %}
 {%                 set row_ipv4_virt = vrid.ipv4.address | arista.avd.default('-') %}
+{%                 set row_ipv4_vers = vrid.ipv4.version | arista.avd.default('2') %}
 {%                 set row_ipv6_virt = vrid.ipv6.address | arista.avd.default('-') %}
-| {{ vlan_interface }} | {{ row_id }} | {{ row_prio_level }} | {{ row_ad_interval }} | {{ row_preempt }} | {{ row_tracked_object_name | arista.avd.default('-') }} | {{ row_tracked_object_action | arista.avd.default('-') }} | {{ row_ipv4_virt }} | {{ row_ipv6_virt }} |
+| {{ vlan_interface }} | {{ row_id }} | {{ row_prio_level }} | {{ row_ad_interval }} | {{ row_preempt }} | {{ row_tracked_object_name | arista.avd.default('-') }} | {{ row_tracked_object_action | arista.avd.default('-') }} | {{ row_ipv4_virt }} | {{ row_ipv4_vers }} | {{ row_ipv6_virt }} |
 {%             endfor %}
 {%         endfor %}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
@@ -195,8 +195,14 @@ interface {{ vlan_interface }}
 {%                 endif %}
    {{ delay_cli }}
 {%             endif %}
+{%             if vrid.timers.delay.reload is arista.avd.defined %}
+   vrrp {{ vrid.id }} timers delay reload {{ vrid.timers.delay.reload }}
+{%             endif %}
 {%             if vrid.ipv4.address is arista.avd.defined %}
    vrrp {{ vrid.id }} ipv4 {{ vrid.ipv4.address }}
+{%             endif %}
+{%             if vrid.ipv4.version is arista.avd.defined %}
+   vrrp {{ vrid.id }} ipv4 version {{ vrid.ipv4.version }}
 {%             endif %}
 {%             if vrid.ipv6.address is arista.avd.defined %}
    vrrp {{ vrid.id }} ipv6 {{ vrid.ipv6.address }}


### PR DESCRIPTION
## Change Summary

Add support for VRRP timer delay reload command per VRID

## Related Issue(s)

Fixes #1705 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

```yaml
# New improved "vrrp" data model to support multiple IDs
vrrp_ids:
  - id: < vrid >
    timers:
      delay:
        reload: < integer >
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
