### PR TITLE
Feat(eos_cli_config_gen): Add eos_cli for loopback_interfaces

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/loopbacks-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/loopbacks-interfaces.md
@@ -98,6 +98,10 @@ interface Management1
 interface Loopback0
    description EVPN_Overlay_Peering
    ip address 192.168.255.3/32
+   comment
+   Comment created from eos_cli under loopback_interfaces.Loopback0
+   EOF
+
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/loopbacks-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/loopbacks-interfaces.cfg
@@ -10,6 +10,10 @@ no aaa root
 interface Loopback0
    description EVPN_Overlay_Peering
    ip address 192.168.255.3/32
+   comment
+   Comment created from eos_cli under loopback_interfaces.Loopback0
+   EOF
+
 !
 interface Loopback1
    description VTEP_VXLAN_Tunnel_Source

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/loopbacks-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/loopbacks-interfaces.yml
@@ -2,6 +2,10 @@ loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
     ip_address: 192.168.255.3/32
+    eos_cli: |
+      comment
+      Comment created from eos_cli under loopback_interfaces.Loopback0
+      EOF
 
   Loopback1:
     description: VTEP_VXLAN_Tunnel_Source

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1195,6 +1195,9 @@ loopback_interfaces:
     mpls:
       ldp:
         interface: < true | false >
+    # EOS CLI rendered directly on the loopback interface in the final EOS configuration
+    eos_cli: |
+      < multiline eos cli >
 
   < Loopback_interface_2 >:
     description: < description >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/loopback-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/loopback-interfaces.j2
@@ -54,4 +54,7 @@ interface {{ loopback_interface.name }}
 {%     if loopback_interface.node_segment.ipv6_index is arista.avd.defined %}
    node-segment ipv6 index {{ loopback_interface.node_segment.ipv6_index }}
 {%     endif %}
+{%     if loopback_interface.eos_cli is arista.avd.defined %}
+   {{ loopback_interface.eos_cli | indent(3, false) }}
+{%     endif %}
 {% endfor %}


### PR DESCRIPTION
## Change Summary

Updated `eos_cli_config_gen`, added `eos_cli` for `loopback_interfaces`

## Related Issue(s)

Fixes #1701 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Updated `ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/loopback-interfaces.j2`
```jinja
+{%     if loopback_interface.eos_cli is arista.avd.defined %}
+   {{ loopback_interface.eos_cli | indent(3, false) }}
+{%     endif %}
```

## How to test
`molecule test --scenario-name eos_cli_config_gen`

also ran `make refresh-facts`

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
