### PR TITLE
Feat(eos_designs): Support for reading network_services and connected_endpoints via lookups

### DIFF
--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -410,9 +410,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         timeout-minutes: 2
-      - name: Setup J2Lint
+      - name: Setup J2Lint and requirements
         timeout-minutes: 2
         run: |
+          pip install -r ansible_collections/arista/avd/requirements.txt
+          pip install -r ansible_collections/arista/avd/requirements-dev.txt
           pip install git+https://github.com/aristanetworks/j2lint.git
       - name: Run J2lint
         timeout-minutes: 2

--- a/ansible_collections/arista/avd/plugins/action/eos_designs_facts.py
+++ b/ansible_collections/arista/avd/plugins/action/eos_designs_facts.py
@@ -119,6 +119,7 @@ class ActionModule(ActionBase):
                     list_compress=list_compress,
                     natural_sort=natural_sort,
                     convert_dicts=convert_dicts,
+                    lookup_loader=lookup_loader,
                 )
             }
         return avd_switch_facts

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/connected-endpoints.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/connected-endpoints.md
@@ -12,11 +12,18 @@
 # Define connected endpoints keys, to define grouping of endpoints connecting to the fabric.
 # This provides the ability to define various keys of your choice to better organize/group your data.
 # This should be defined in top level group_var for the fabric.
+# Lookup source can be used to read data directly from an external source. Even with regular YAML files, this can speed up ansible runtime considerably.
 connected_endpoints_keys:
   < key_1 >:
     type: < type used for documentation >
   < key_2 >:
     type: < type used for documentation >
+    source: < "inventory" | "lookup" | default -> "inventory" >
+    lookup:
+      name: < name_of_lookup_plugin >
+      arguments: [ < lookup_plugin_argument1 >, < lookup_plugin_argument2 > ]
+      errors: < "strict" | "warn" | "ignore" | default -> "strict" >
+      data_format: < "yaml" | "json" | "raw" | default -> "raw" >
 ```
 
 ```yaml

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
@@ -15,9 +15,16 @@
 # Define network services keys, to define grouping of network services.
 # This provides the ability to define various keys of your choice to better organize/group your data.
 # This should be defined in top level group_var for the fabric.
+# Lookup source can be used to read data directly from an external source. Even with regular YAML files, this can speed up ansible runtime considerably.
 network_services_keys:
   - name: < key_1 >
   - name: < key_2 >
+    source: < "inventory" | "lookup" | default -> "inventory" >
+    lookup:
+      name: < name_of_lookup_plugin >
+      arguments: [ < lookup_plugin_argument1 >, < lookup_plugin_argument2 > ]
+      errors: < "strict" | "warn" | "ignore" | default -> "strict" >
+      data_format: < "yaml" | "json" | "raw" | default -> "raw" >
 ```
 
 ```yaml

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/logic.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/logic.j2
@@ -1,10 +1,26 @@
-{% for connected_endpoints_key in connected_endpoints_keys %}
-{%     set switch_connected_endpoints = hostvars[inventory_hostname][connected_endpoints_key] | arista.avd.default({}) %}
-{%     do connected_endpoints.update({ connected_endpoints_key: {} }) %}
-{%     for connected_endpoint in switch_connected_endpoints %}
-{%         set one_connected_endpoint = switch_connected_endpoints[connected_endpoint] %}
-{%         if one_connected_endpoint.adapters | selectattr('switches','arista.avd.contains',inventory_hostname) | length > 0 %}
-{%             do connected_endpoints[connected_endpoints_key].update({connected_endpoint: one_connected_endpoint}) %}
+{% for connected_endpoints_key in connected_endpoints_keys | arista.avd.convert_dicts('name') %}
+{%     if connected_endpoints_key.name is arista.avd.defined %}
+{%         if connected_endpoints_key.source | arista.avd.default('inventory') == 'inventory' %}
+{%             set connected_endpoints_data = lookup('ansible.builtin.vars', connected_endpoints_key.name, default=[]) %}
+{%         elif connected_endpoints_key.source is arista.avd.defined('lookup') and connected_endpoints_key.lookup.name is arista.avd.defined %}
+{%             set lookup_args = connected_endpoints_key.lookup.arguments | arista.avd.default([]) %}
+{%             set lookup_errors = connected_endpoints_key.lookup.errors | arista.avd.default('strict') %}
+{%             set lookup_data = lookup(connected_endpoints_key.lookup.name, *lookup_args, errors=lookup_errors) %}
+{%             if connected_endpoints_key.lookup.data_format is arista.avd.defined('yaml') %}
+{%                 set lookup_data = lookup_data | from_yaml %}
+{%             elif connected_endpoints_key.lookup.data_format is arista.avd.defined('json') %}
+{%                 set lookup_data = lookup_data | from_json %}
+{%             endif %}
+{%             if lookup_data[connected_endpoints_key.name] is arista.avd.defined(fail_action='error', var_name='Connected Endpoints Key ' ~ connected_endpoints_key.name) %}
+{%                 set connected_endpoints_data = lookup_data[connected_endpoints_key.name] %}
+{%             endif %}
 {%         endif %}
-{%     endfor %}
+{%         do connected_endpoints.update({ connected_endpoints_key.name: {} }) %}
+{%         for connected_endpoint in connected_endpoints_data | arista.avd.default([]) %}
+{%             set one_connected_endpoint = connected_endpoints_data[connected_endpoint] %}
+{%             if one_connected_endpoint.adapters | selectattr('switches','arista.avd.contains',inventory_hostname) | length > 0 %}
+{%                 do connected_endpoints[connected_endpoints_key.name].update({connected_endpoint: one_connected_endpoint}) %}
+{%             endif %}
+{%         endfor %}
+{%     endif %}
 {% endfor %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/logic.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/logic.j2
@@ -16,10 +16,26 @@
 {% endif %}
 {% set tmp_hostvars = hostvars[inventory_hostname] %}
 {% for network_services_key in network_services_keys | arista.avd.natural_sort('name') %}
-{%     if network_services_key.name is arista.avd.defined and tmp_hostvars[network_services_key.name] is arista.avd.defined %}
+{%     if network_services_key.name is arista.avd.defined %}
+{%         if network_services_key.source | arista.avd.default('inventory') == 'inventory' and tmp_hostvars[network_services_key.name] is arista.avd.defined %}
+{%             set network_services_data = tmp_hostvars[network_services_key.name] %}
+{%         elif network_services_key.source is arista.avd.defined('lookup') and network_services_key.lookup.name is arista.avd.defined %}
+{%             set lookup_args = network_services_key.lookup.arguments | arista.avd.default([]) %}
+{%             set lookup_errors = network_services_key.lookup.errors | arista.avd.default('strict') %}
+{%             set lookup_data = lookup(network_services_key.lookup.name, *lookup_args, errors=lookup_errors) %}
+{%             if network_services_key.lookup.data_format is arista.avd.defined('yaml') %}
+{%                 set lookup_data = lookup_data | from_yaml %}
+{%             elif network_services_key.lookup.data_format is arista.avd.defined('json') %}
+{%                 set lookup_data = lookup_data | from_json %}
+{%             endif %}
+{%             if lookup_data[network_services_key.name] is arista.avd.defined(fail_action='error', var_name='Network Services Key ' ~ network_services_key.name) %}
+{%                 set network_services_data = lookup_data[network_services_key.name] %}
+{%             endif %}
+{%         endif %}
 {#         tenants #}
-{%         for tenant in tmp_hostvars[network_services_key.name] | arista.avd.convert_dicts | arista.avd.natural_sort('name') %}
+{%         for tenant in network_services_data | arista.avd.convert_dicts | arista.avd.natural_sort('name') %}
 {%             if switch.filter_tenants is arista.avd.contains([tenant.name, "all"]) %}
+{%                 set switch_tenant = switch.tenants[tenant.name] %}
 {#                 vrfs #}
 {%                 set tmp_vrfs = [] %}
 {%                 for vrf in tenant.vrfs | arista.avd.convert_dicts | arista.avd.natural_sort('name') %}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Support for reading network_services and connected_endpoints via lookups

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
No expected changes to molecule yet.

I tested with this:
```yaml
connected_endpoints_keys:
  servers:
    type: server
    source: lookup
    lookup:
      name: file
      arguments:
        - "data_files/SERVERS.yml"
      data_filter: from_yaml

network_services_keys:
  - name: tenants
    source: lookup
    lookup:
      name: file
      arguments:
        - 'data_files/TENANTS.yml'
      data_filter: from_yaml
```
And moved the SERVERS and TENANTS files out of the `group_vars` in into a `data_files` folder.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been rebased from devel before I start
- [ ] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
