### PR TITLE
Refactor(eos_cli_config_gen): Wildcard dict to list for snmp_server

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/snmp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/snmp.yml
@@ -3,23 +3,23 @@ snmp_server:
   contact: DC1_OPS
   location: DC1
   communities:
-    SNMP-COMMUNITY-1:
+    - name: SNMP-COMMUNITY-1
       access: ro
       access_list_ipv4:
         name: onur
-    SNMP-COMMUNITY-2:
+    - name: SNMP-COMMUNITY-2
       access: rw
       access_list_ipv4:
         name: SNMP-MGMT
       access_list_ipv6:
         name: SNMP-MGMT
       view: VW-READ
-    SNMP-COMMUNITY-3:
+    - name: SNMP-COMMUNITY-3
   local_interfaces:
-    Management1:
+    - name: Management1
       vrf: MGMT
-    Loopback0:
-    Loopback12:
+    - name: Loopback0
+    - name: Loopback12
       vrf: Tenant_A_APP_Zone
   ipv4_acls:
     - name: SNMP-MGMT

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
@@ -2139,14 +2139,14 @@ snmp_server:
   contact: < contact_name >
   location: < location >
   communities:
-    < community_name_1 >:
+    - name: < community_name_1 >
       access: < ro | rw >
       access_list_ipv4:
         name: < acl_ipv4_name >
       access_list_ipv6:
         name: < acl_ipv6_name >
       view: < view_name >
-    < community_name_2 >:
+    - name: < community_name_2 >
       access: < ro | rw >
       access_list_ipv4:
         name: < acl_ipv4_name >
@@ -2162,10 +2162,10 @@ snmp_server:
       vrf: < vrf >
     - name: < ipv6-access-list >
   local_interfaces:
-    < interface_name_1 >:
+    - name: < interface_name_1 >
       vrf: < vrf_name >
-    < interface_name_2 >:
-    < interface_name_3 >:
+    - name: < interface_name_2 >
+    - name: < interface_name_3 >
       vrf: < vrf_name >
   views:
     - name: < view_name >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/snmp-settings.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/snmp-settings.j2
@@ -44,8 +44,8 @@
 
 | Local Interface | VRF |
 | --------------- | --- |
-{%         for interface in snmp_server.local_interfaces %}
-| {{ interface }} | {{ snmp_server.local_interfaces[interface]['vrf'] | arista.avd.default('default') }} |
+{%         for interface in snmp_server.local_interfaces | arista.avd.convert_dicts('name') %}
+| {{ interface.name }} | {{ interface.vrf | arista.avd.default('default') }} |
 {%         endfor %}
 {%     endif %}
 {%     if snmp_server.vrfs is arista.avd.defined %}
@@ -111,12 +111,12 @@
 
 | Community | Access | Access List IPv4 | Access List IPv6 | View |
 | --------- | ------ | ---------------- | ---------------- | ---- |
-{%         for community in snmp_server.communities | arista.avd.natural_sort %}
-{%             set access = snmp_server.communities[community].access | arista.avd.default("ro") %}
-{%             set access_list_ipv4 = snmp_server.communities[community].access_list_ipv4.name | arista.avd.default("-") %}
-{%             set access_list_ipv6 = snmp_server.communities[community].access_list_ipv6.name | arista.avd.default("-") %}
-{%             set view = snmp_server.communities[community].view | arista.avd.default("-") %}
-| {{ community }} | {{ access }} | {{ access_list_ipv4 }} | {{ access_list_ipv6 }} | {{ view }} |
+{%         for community in snmp_server.communities | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%             set access = community.access | arista.avd.default("ro") %}
+{%             set access_list_ipv4 = community.access_list_ipv4.name | arista.avd.default("-") %}
+{%             set access_list_ipv6 = community.access_list_ipv6.name | arista.avd.default("-") %}
+{%             set view = community.view | arista.avd.default("-") %}
+| {{ community.name }} | {{ access }} | {{ access_list_ipv4 }} | {{ access_list_ipv6 }} | {{ view }} |
 {%         endfor %}
 {%     endif %}
 {%     if snmp_server.groups is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/snmp-settings.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/snmp-settings.j2
@@ -26,12 +26,12 @@ snmp-server location {{ snmp_server.location }}
 {%         endfor %}
 {%     endif %}
 {%     if snmp_server.local_interfaces is arista.avd.defined %}
-{%         for local_interface in snmp_server.local_interfaces %}
+{%         for local_interface in snmp_server.local_interfaces | arista.avd.convert_dicts('name') %}
 {%             set interface_snmp_cli = "snmp-server" %}
-{%             if snmp_server.local_interfaces[local_interface].vrf is arista.avd.defined %}
-{%                 set interface_snmp_cli = interface_snmp_cli ~ " vrf " ~ snmp_server.local_interfaces[local_interface].vrf %}
+{%             if local_interface.vrf is arista.avd.defined %}
+{%                 set interface_snmp_cli = interface_snmp_cli ~ " vrf " ~ local_interface.vrf %}
 {%             endif %}
-{%             set interface_snmp_cli = interface_snmp_cli ~ " local-interface " ~ local_interface %}
+{%             set interface_snmp_cli = interface_snmp_cli ~ " local-interface " ~ local_interface.name %}
 {{ interface_snmp_cli }}
 {%         endfor %}
 {%     endif %}
@@ -52,21 +52,21 @@ snmp-server location {{ snmp_server.location }}
 {%         endfor %}
 {%     endif %}
 {%     if snmp_server.communities is arista.avd.defined %}
-{%         for community in snmp_server.communities | arista.avd.natural_sort %}
-{%             set communities_cli = "snmp-server community " ~ community %}
-{%             if snmp_server.communities[community].view is arista.avd.defined %}
-{%                 set communities_cli = communities_cli ~ " view " ~ snmp_server.communities[community].view %}
+{%         for community in snmp_server.communities | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%             set communities_cli = "snmp-server community " ~ community.name %}
+{%             if community.view is arista.avd.defined %}
+{%                 set communities_cli = communities_cli ~ " view " ~ community.view %}
 {%             endif %}
-{%             if snmp_server.communities[community].access is arista.avd.defined %}
-{%                 set communities_cli = communities_cli ~ " " ~ snmp_server.communities[community].access %}
+{%             if community.access is arista.avd.defined %}
+{%                 set communities_cli = communities_cli ~ " " ~ community.access %}
 {%             else %}
 {%                 set communities_cli = communities_cli ~ " ro" %}
 {%             endif %}
-{%             if snmp_server.communities[community].access_list_ipv6 is arista.avd.defined %}
-{%                 set communities_cli = communities_cli ~ " ipv6 " ~ snmp_server.communities[community].access_list_ipv6.name %}
+{%             if community.access_list_ipv6 is arista.avd.defined %}
+{%                 set communities_cli = communities_cli ~ " ipv6 " ~ community.access_list_ipv6.name %}
 {%             endif %}
-{%             if snmp_server.communities[community].access_list_ipv4 is arista.avd.defined %}
-{%                 set communities_cli = communities_cli ~ " " ~ snmp_server.communities[community].access_list_ipv4.name %}
+{%             if community.access_list_ipv4 is arista.avd.defined %}
+{%                 set communities_cli = communities_cli ~ " " ~ community.access_list_ipv4.name %}
 {%             endif %}
 {{ communities_cli }}
 {%         endfor %}


### PR DESCRIPTION
## "Wildcard Keyed Dict" to "List of Dicts" Data model migration

<!-- Use this PR Title: Refactor(eos_cli_config_gen): Wildcard dict to list for `< data_model_key >` -->

## Data model key

`snmp_server`

## Checklist

### Contributor Checklist

- [x] Update `README_v4.0.md` with new data model
- [x] Update all `host_vars` under molecule scenario `eos_cli_config_gen_v4.0` with new data model
- [x] Update `templates/eos/< template >.j2` and `templates/documentation/< template >.j2`:
  - [x] Add `arista.avd.convert_dicts('<primary key>')` filter for loops previously using wildcard keys
  - [x] Update `arista.avd.natural_sort('<primary key>')` to sort on the primary key (if applicable)
- [x] Run molecule `cd ansible_collections/arista/avd/molecule ; make cli-4.0-schema`
  - [x] Verify no changes to generated configs/docs

### Reviewer Checklist

- Reviewer 1: Claus
  - [x] Verify data model changes
  - [x] Verify that all molecule `host_vars` under `eos_cli_config_gen_v4.0` has been updated to the new data model
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2: Tony
  - [x] Verify data model changes
  - [x] Verify that all molecule `host_vars` under `eos_cli_config_gen_v4.0` has been updated to the new data model
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
