### PR TITLE
Fix(eos_cli_config_gen): Documentation template for IPv6 on port-channels

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/core-1-isis-sr-ldp.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/core-1-isis-sr-ldp.md
@@ -129,6 +129,9 @@ vlan internal order ascending range 1006 1199
 | Ethernet4 | P2P_LINK_TO_core-2-ospf-ldp_Ethernet4 | routed | - | - | default | 1500 | false | - | - | - | - |
 | Ethernet5 | P2P_LINK_TO_core-2-ospf-ldp_Ethernet5 | routed | - | - | default | 1500 | false | - | - | - | - |
 | Ethernet6 | P2P_LINK_TO_core-2-ospf-ldp_Ethernet6 | routed | - | - | default | 1602 | false | - | - | - | - |
+| Ethernet12 | P2P_LINK_TO_core-2-ospf-ldp_Port-Channel12 | *routed | 12 | *- | *default | *1500 | *false | *- | *- | *- | *- |
+| Ethernet13 | P2P_LINK_TO_core-2-ospf-ldp_Port-Channel12 | *routed | 12 | *- | *default | *1500 | *false | *- | *- | *- | *- |
+ *Inherited from Port-Channel Interface
 
 #### ISIS
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/core-2-ospf-ldp.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/core-2-ospf-ldp.md
@@ -129,6 +129,9 @@ vlan internal order ascending range 1006 1199
 | Ethernet4 | P2P_LINK_TO_core-1-isis-sr-ldp_Ethernet4 | routed | - | - | default | 1500 | false | - | - | - | - |
 | Ethernet5 | P2P_LINK_TO_core-1-isis-sr-ldp_Ethernet5 | routed | - | - | default | 1500 | false | - | - | - | - |
 | Ethernet6 | P2P_LINK_TO_core-1-isis-sr-ldp_Ethernet6 | routed | - | - | default | 1602 | false | - | - | - | - |
+| Ethernet12 | P2P_LINK_TO_core-1-isis-sr-ldp_Port-Channel12 | *routed | 12 | *- | *default | *1500 | *false | *- | *- | *- | *- |
+| Ethernet13 | P2P_LINK_TO_core-1-isis-sr-ldp_Port-Channel12 | *routed | 12 | *- | *default | *1500 | *false | *- | *- | *- | *- |
+ *Inherited from Port-Channel Interface
 
 ### Ethernet Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ethernet-interfaces.j2
@@ -234,7 +234,7 @@
 {%     for ethernet_interface in ethernet_interfaces | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
 {%         if ethernet_interface.type is defined
             and ethernet_interface.type in ['routed', 'l3dot1q']
-            and ethernet_interface.ipv6_address is arista.avd.defined or ethernet_interface.ipv6_enable is arista.avd.defined(true) %}
+            and (ethernet_interface.ipv6_address is arista.avd.defined or ethernet_interface.ipv6_enable is arista.avd.defined(true)) %}
 {%             set ethernet_interface_ipv6.configured = true %}
 {%         endif %}
 {%     endfor %}
@@ -244,7 +244,7 @@
 {%         for port_channel_interface in port_channel_interfaces | arista.avd.natural_sort %}
 {%             if port_channel_interfaces[port_channel_interface].type is defined
                 and port_channel_interfaces[port_channel_interface].type in ['routed', 'l3dot1q']
-                and port_channel_interfaces[port_channel_interface].ipv6_address is defined %}
+                and (port_channel_interfaces[port_channel_interface].ipv6_address is defined or port_channel_interfaces[port_channel_interface].ipv6_enable is arista.avd.defined(true)) %}
 {%                 set port_channel_interface_ipv6.configured = true %}
 {%             endif %}
 {%         endfor %}
@@ -258,19 +258,19 @@
 {%         for ethernet_interface in ethernet_interfaces | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
 {%             if ethernet_interface.channel_group.id is arista.avd.defined %}
 {%                 set port_channel_interface = 'Port-Channel' + ethernet_interface.channel_group.id | string %}
-{%                 if port_channel_interfaces[port_channel_interface].ipv6_address is arista.avd.defined or ethernet_interface.ipv6_enable is arista.avd.defined(true) %}
+{%                 if port_channel_interfaces[port_channel_interface].ipv6_address is arista.avd.defined or port_channel_interfaces[port_channel_interface].ipv6_enable is arista.avd.defined(true) %}
 {%                     set description = ethernet_interface.description | arista.avd.default("-") %}
-{%                     set type = port_channel_interfaces[port_channel_interface].type | arista.avd.default("*switchport") %}
+{%                     set type = port_channel_interfaces[port_channel_interface].type | arista.avd.default("switchport") %}
 {%                     set channel_group = ethernet_interface.channel_group.id | arista.avd.default("-") %}
 {%                     set ipv6_address = port_channel_interfaces[port_channel_interface].ipv6_address | arista.avd.default("-") %}
-{%                     set vrf = port_channel_interfaces[port_channel_interface].vrf | arista.avd.default("*default") %}
-{%                     set mtu = port_channel_interfaces[port_channel_interface].mtu | arista.avd.default("*-") %}
-{%                     set shutdown = port_channel_interfaces[port_channel_interface].shutdown | arista.avd.default("*-") %}
-{%                     set nd_ra_disabled = port_channel_interfaces[port_channel_interface].ipv6_nd_ra_disabled | arista.avd.default("*-") %}
-{%                     set managed_config_flag = port_channel_interfaces[port_channel_interface].ipv6_nd_managed_config_flag | arista.avd.default("*-") %}
-{%                     set ipv6_acl_in = port_channel_interfaces[port_channel_interface].ipv6_access_group_in | arista.avd.default("*-") %}
-{%                     set ipv6_acl_out = port_channel_interfaces[port_channel_interface].ipv6_access_group_out | arista.avd.default("*-") %}
-| {{ ethernet_interface.name }} | {{ description }} | *{{ type }} | {{ channel_group }} | *{{ ipv6_address }} | *{{ vrf }} | *{{ mtu }} | *{{ shutdown | lower }} | *{{ nd_ra_disabled | lower }} | {{ managed_config_flag | lower }} | *{{ ipv6_acl_in }} | *{{ ipv6_acl_out }} |
+{%                     set vrf = port_channel_interfaces[port_channel_interface].vrf | arista.avd.default("default") %}
+{%                     set mtu = port_channel_interfaces[port_channel_interface].mtu | arista.avd.default("-") %}
+{%                     set shutdown = port_channel_interfaces[port_channel_interface].shutdown | arista.avd.default("-") %}
+{%                     set nd_ra_disabled = port_channel_interfaces[port_channel_interface].ipv6_nd_ra_disabled | arista.avd.default("-") %}
+{%                     set managed_config_flag = port_channel_interfaces[port_channel_interface].ipv6_nd_managed_config_flag | arista.avd.default("-") %}
+{%                     set ipv6_acl_in = port_channel_interfaces[port_channel_interface].ipv6_access_group_in | arista.avd.default("-") %}
+{%                     set ipv6_acl_out = port_channel_interfaces[port_channel_interface].ipv6_access_group_out | arista.avd.default("-") %}
+| {{ ethernet_interface.name }} | {{ description }} | *{{ type }} | {{ channel_group }} | *{{ ipv6_address }} | *{{ vrf }} | *{{ mtu }} | *{{ shutdown | lower }} | *{{ nd_ra_disabled | lower }} | *{{ managed_config_flag | lower }} | *{{ ipv6_acl_in }} | *{{ ipv6_acl_out }} |
 {%                 endif %}
 {%             else %}
 {%                 if ethernet_interface.ipv6_address is arista.avd.defined or ethernet_interface.ipv6_enable is arista.avd.defined(true) %}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Fix Documentation template for IPv6 on port-channels

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->
- Include ethernet interfaces associated with port-channel with ipv6_enable but no address defined.
- Fix default values to avoid double stars

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Already covered in molecule, but was missed.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
