### PR TITLE
CI: Fix wrong key `helpers` in molecule vars

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
@@ -174,6 +174,9 @@ interface Vlan41
 interface Vlan42
    description SVI Description
    no shutdown
+   ip helper-address 10.10.64.150 source-interface Loopback0
+   ip helper-address 10.10.96.150 source-interface Loopback0
+   ip helper-address 10.10.96.151 source-interface Loopback0
    ip address virtual 10.10.42.1/24
 !
 interface Vlan75
@@ -234,6 +237,10 @@ interface Vlan88
 interface Vlan89
    description SVI Description
    no shutdown
+   ip helper-address 10.10.64.150 source-interface Loopback0
+   ip helper-address 10.10.96.101 source-interface Loopback0
+   ip helper-address 10.10.96.150 source-interface Loopback0
+   ip helper-address 10.10.96.151 source-interface Loopback0
    ip igmp
    ipv6 address 1b11:3a00:22b0:5200::15/64
    ipv6 nd managed-config-flag

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
@@ -32,6 +32,9 @@ interface Vlan41
 interface Vlan42
    description SVI Description
    no shutdown
+   ip helper-address 10.10.64.150 source-interface Loopback0
+   ip helper-address 10.10.96.150 source-interface Loopback0
+   ip helper-address 10.10.96.151 source-interface Loopback0
    ip address virtual 10.10.42.1/24
 !
 interface Vlan75
@@ -92,6 +95,10 @@ interface Vlan88
 interface Vlan89
    description SVI Description
    no shutdown
+   ip helper-address 10.10.64.150 source-interface Loopback0
+   ip helper-address 10.10.96.101 source-interface Loopback0
+   ip helper-address 10.10.96.150 source-interface Loopback0
+   ip helper-address 10.10.96.151 source-interface Loopback0
    ip igmp
    ipv6 address 1b11:3a00:22b0:5200::15/64
    ipv6 nd managed-config-flag

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
@@ -112,7 +112,7 @@ vlan_interfaces:
     description: SVI Description
     shutdown: false
     ip_address_virtual: 10.10.42.1/24
-    helpers:
+    ip_helpers:
       10.10.96.151:
         source_interface: Loopback0
       10.10.96.150:
@@ -197,7 +197,7 @@ vlan_interfaces:
         preferred_lifetime: infinite
         no_autoconfig_flag: true
     ipv6_virtual_router_address: 1b11:3a00:22b0:5200::3
-    helpers:
+    ip_helpers:
       10.10.96.101:
         source_interface: Loopback0
       10.10.96.151:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/vlan-interfaces.md
@@ -159,6 +159,9 @@ interface Vlan41
 interface Vlan42
    description SVI Description
    no shutdown
+   ip helper-address 10.10.64.150 source-interface Loopback0
+   ip helper-address 10.10.96.150 source-interface Loopback0
+   ip helper-address 10.10.96.151 source-interface Loopback0
    ip address virtual 10.10.42.1/24
 !
 interface Vlan75
@@ -218,6 +221,10 @@ interface Vlan88
 interface Vlan89
    description SVI Description
    no shutdown
+   ip helper-address 10.10.64.150 source-interface Loopback0
+   ip helper-address 10.10.96.101 source-interface Loopback0
+   ip helper-address 10.10.96.150 source-interface Loopback0
+   ip helper-address 10.10.96.151 source-interface Loopback0
    ip igmp
    ipv6 address 1b11:3a00:22b0:5200::15/64
    ipv6 nd managed-config-flag

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/vlan-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/vlan-interfaces.cfg
@@ -32,6 +32,9 @@ interface Vlan41
 interface Vlan42
    description SVI Description
    no shutdown
+   ip helper-address 10.10.64.150 source-interface Loopback0
+   ip helper-address 10.10.96.150 source-interface Loopback0
+   ip helper-address 10.10.96.151 source-interface Loopback0
    ip address virtual 10.10.42.1/24
 !
 interface Vlan75
@@ -91,6 +94,10 @@ interface Vlan88
 interface Vlan89
    description SVI Description
    no shutdown
+   ip helper-address 10.10.64.150 source-interface Loopback0
+   ip helper-address 10.10.96.101 source-interface Loopback0
+   ip helper-address 10.10.96.150 source-interface Loopback0
+   ip helper-address 10.10.96.151 source-interface Loopback0
    ip igmp
    ipv6 address 1b11:3a00:22b0:5200::15/64
    ipv6 nd managed-config-flag

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/vlan-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/vlan-interfaces.yml
@@ -110,7 +110,7 @@ vlan_interfaces:
     description: SVI Description
     shutdown: false
     ip_address_virtual: 10.10.42.1/24
-    helpers:
+    ip_helpers:
       10.10.96.151:
         source_interface: Loopback0
       10.10.96.150:
@@ -195,7 +195,7 @@ vlan_interfaces:
         preferred_lifetime: infinite
         no_autoconfig_flag: true
     ipv6_virtual_router_address: 1b11:3a00:22b0:5200::3
-    helpers:
+    ip_helpers:
       10.10.96.101:
         source_interface: Loopback0
       10.10.96.151:


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
CI: Fix wrong key `helpers` in molecule vars

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

Fix two SVIs defined with `helpers` instead of `ip_helpers`.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
