### PR TITLE
Refactor(eos_cli_config_gen): Wildcard dict to list for vxlan_interface

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/vxlan-interface.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/vxlan-interface.yml
@@ -12,19 +12,19 @@ vxlan_interface:
         dscp_propagation_encapsulation: true
         map_dscp_to_traffic_class_decapsulation: true
       vlans:
-        110:
+        - id: 110
           vni: 10110
           multicast_group: 239.9.1.4
-        111:
+        - id: 111
           vni: 10111
           flood_vteps:
             - 10.1.1.10
             - 10.1.1.11
       vrfs:
-        Tenant_A_OP_Zone:
+        - name: Tenant_A_OP_Zone
           vni: 10
           multicast_group: 232.0.0.10
-        Tenant_A_WEB_Zone:
+        - name: Tenant_A_WEB_Zone
           vni: 11
       flood_vteps:
         - 10.1.0.10

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
@@ -1421,23 +1421,23 @@ vxlan_interface:
         dscp_propagation_encapsulation: < true | false >
         map_dscp_to_traffic_class_decapsulation: < true | false >
       vlans:
-        < vlan_id_1 >:
+        - id: < vlan_id_1 >
           vni: < vni_id_1 >
           multicast_group: < ip_multicast_group_address >
           flood_vteps:
             - < remote_vtep_1_ip_address >
             - < remote_vtep_2_ip_address >
-        < vlan_id_2 >:
+        - id: < vlan_id_2 >
           vni: < vni_id_2 >
           multicast_group: < ip_multicast_group_address >
           flood_vteps:
             - < remote_vtep_1_ip_address >
             - < remote_vtep_2_ip_address >
       vrfs:
-        < vrf_name_1 >:
+        - name: < vrf_name_1 >
           vni: < vni_id_3 >
           multicast_group: < ip_multicast_group_address >
-        < vrf_name_2 >:
+        - name: < vrf_name_2 >
           vni: < vni_id_4 >
           multicast_group: < ip_multicast_group_address >
       flood_vteps:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vxlan-interface.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vxlan-interface.j2
@@ -38,15 +38,15 @@
 
 | VLAN | VNI | Flood List | Multicast Group |
 | ---- | --- | ---------- | --------------- |
-{%         for vlan in vxlan_interface.Vxlan1.vxlan.vlans | arista.avd.natural_sort %}
-{%             set vlan_vni = vxlan_interface.Vxlan1.vxlan.vlans[vlan].vni | arista.avd.default('-') %}
-{%             set multicast_group = vxlan_interface.Vxlan1.vxlan.vlans[vlan].multicast_group | arista.avd.default('-') %}
-{%             if vxlan_interface.Vxlan1.vxlan.vlans[vlan].flood_vteps is arista.avd.defined %}
-{%                 set flood_list = vxlan_interface.Vxlan1.vxlan.vlans[vlan].flood_vteps | join('<br/>')  %}
+{%         for vlan in vxlan_interface.Vxlan1.vxlan.vlans | arista.avd.convert_dicts('id') | arista.avd.natural_sort('id') %}
+{%             set vlan_vni = vlan.vni | arista.avd.default('-') %}
+{%             set multicast_group = vlan.multicast_group | arista.avd.default('-') %}
+{%             if vlan.flood_vteps is arista.avd.defined %}
+{%                 set flood_list = vlan.flood_vteps | join('<br/>')  %}
 {%             else %}
 {%                 set flood_list = '-' %}
 {%             endif %}
-| {{ vlan }} | {{ vlan_vni }} | {{ flood_list }} | {{ multicast_group }} |
+| {{ vlan.id }} | {{ vlan_vni }} | {{ flood_list }} | {{ multicast_group }} |
 {%         endfor %}
 {%     endif %}
 {%     if vxlan_interface.Vxlan1.vxlan.vrfs is arista.avd.defined %}
@@ -55,10 +55,10 @@
 
 | VRF | VNI | Multicast Group |
 | ---- | --- | --------------- |
-{%         for vrf in vxlan_interface.Vxlan1.vxlan.vrfs | arista.avd.natural_sort %}
-{%             set vrf_vni = vxlan_interface.Vxlan1.vxlan.vrfs[vrf].vni | arista.avd.default('-') %}
-{%             set multicast_group = vxlan_interface.Vxlan1.vxlan.vrfs[vrf].multicast_group | arista.avd.default('-') %}
-| {{ vrf }} | {{ vrf_vni }} | {{ multicast_group }} |
+{%         for vrf in vxlan_interface.Vxlan1.vxlan.vrfs | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%             set vrf_vni = vrf.vni | arista.avd.default('-') %}
+{%             set multicast_group = vrf.multicast_group | arista.avd.default('-') %}
+| {{ vrf.name }} | {{ vrf_vni }} | {{ multicast_group }} |
 {%         endfor %}
 {%     endif %}
 {%     if vxlan_interface.Vxlan1.vxlan.flood_vteps is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vxlan-interface.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vxlan-interface.j2
@@ -18,15 +18,15 @@ interface Vxlan1
 {%     if vxlan_interface.Vxlan1.vxlan.flood_vtep_learned_data_plane is arista.avd.defined(true) %}
    vxlan flood vtep learned data-plane
 {%     endif %}
-{%     for vlan in vxlan_interface.Vxlan1.vxlan.vlans | arista.avd.natural_sort %}
-   vxlan vlan {{ vlan }} vni {{ vxlan_interface.Vxlan1.vxlan.vlans[vlan].vni }}
-{%         if vxlan_interface.Vxlan1.vxlan.vlans[vlan].flood_vteps is arista.avd.defined %}
-   vxlan vlan {{ vlan }} flood vtep {{ vxlan_interface.Vxlan1.vxlan.vlans[vlan].flood_vteps | join(' ') }}
+{%     for vlan in vxlan_interface.Vxlan1.vxlan.vlans | arista.avd.convert_dicts('id') | arista.avd.natural_sort('id') %}
+   vxlan vlan {{ vlan.id }} vni {{ vlan.vni }}
+{%         if vlan.flood_vteps is arista.avd.defined %}
+   vxlan vlan {{ vlan.id }} flood vtep {{ vlan.flood_vteps | join(' ') }}
 {%         endif %}
 {%     endfor %}
-{%     for vrf in vxlan_interface.Vxlan1.vxlan.vrfs | arista.avd.natural_sort %}
-{%         if vxlan_interface.Vxlan1.vxlan.vrfs[vrf].vni is arista.avd.defined %}
-   vxlan vrf {{ vrf }} vni {{ vxlan_interface.Vxlan1.vxlan.vrfs[vrf].vni }}
+{%     for vrf in vxlan_interface.Vxlan1.vxlan.vrfs | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%         if vrf.vni is arista.avd.defined %}
+   vxlan vrf {{ vrf.name }} vni {{ vrf.vni }}
 {%         endif %}
 {%     endfor %}
 {%     if vxlan_interface.Vxlan1.vxlan.mlag_source_interface is arista.avd.defined %}
@@ -45,11 +45,11 @@ interface Vxlan1
 {%     elif vxlan_interface.Vxlan1.vxlan.qos.map_dscp_to_traffic_class_decapsulation is arista.avd.defined(false) %}
    no vxlan qos map dscp to traffic-class decapsulation
 {%     endif %}
-{%     for vlan in vxlan_interface.Vxlan1.vxlan.vlans | arista.avd.natural_sort if vxlan_interface.Vxlan1.vxlan.vlans[vlan].multicast_group is arista.avd.defined %}
-   vxlan vlan {{ vlan }} multicast group {{ vxlan_interface.Vxlan1.vxlan.vlans[vlan].multicast_group }}
+{%     for vlan in vxlan_interface.Vxlan1.vxlan.vlans | arista.avd.convert_dicts('id') | arista.avd.natural_sort('id') if vlan.multicast_group is arista.avd.defined %}
+   vxlan vlan {{ vlan.id }} multicast group {{ vlan.multicast_group }}
 {%     endfor %}
-{%     for vrf in vxlan_interface.Vxlan1.vxlan.vrfs | arista.avd.natural_sort if vxlan_interface.Vxlan1.vxlan.vrfs[vrf].multicast_group is arista.avd.defined %}
-   vxlan vrf {{ vrf }} multicast group {{ vxlan_interface.Vxlan1.vxlan.vrfs[vrf].multicast_group }}
+{%     for vrf in vxlan_interface.Vxlan1.vxlan.vrfs | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') if vrf.multicast_group is arista.avd.defined %}
+   vxlan vrf {{ vrf.name }} multicast group {{ vrf.multicast_group }}
 {%     endfor %}
 {%     if  vxlan_interface.Vxlan1.eos_cli is arista.avd.defined %}
    {{ vxlan_interface.Vxlan1.eos_cli | indent(3, false) }}


### PR DESCRIPTION
## "Wildcard Keyed Dict" to "List of Dicts" Data model migration

<!-- Use this PR Title: Refactor(eos_cli_config_gen): Wildcard dict to list for `< data_model_key >` -->

## Data model key

`vxlan_interface`

## Checklist

### Contributor Checklist

- [x] Update `README_v4.0.md` with new data model
- [x] Update all `host_vars` under molecule scenario `eos_cli_config_gen_v4.0` with new data model
- [x] Update `templates/eos/< template >.j2` and `templates/documentation/< template >.j2`:
  - [x] Add `arista.avd.convert_dicts('<primary key>')` filter for loops previously using wildcard keys
  - [x] Update `arista.avd.natural_sort('<primary key>')` to sort on the primary key (if applicable)
- [x] Run molecule `cd ansible_collections/arista/avd/molecule ; make cli-4.0-schema`
  - [x] Verify no changes to generated configs/docs

### Reviewer Checklist

- Reviewer 1: Claus
  - [x] Verify data model changes
  - [x] Verify that all molecule `host_vars` under `eos_cli_config_gen_v4.0` has been updated to the new data model
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2: Tony
  - [x] Verify data model changes
  - [x] Verify that all molecule `host_vars` under `eos_cli_config_gen_v4.0` has been updated to the new data model
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
