### PR TITLE
Feat(eos_cli_config_gen): Add EngineID support to snmp-settings

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/snmp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/snmp.md
@@ -120,6 +120,14 @@ interface Management1
 | USER-READ | GRP-READ-ONLY | v3 | sha | aes |
 | USER-WRITE | GRP-READ-WRITE | v3 | sha | aes |
 
+### SNMP EngineID Configuration
+
+| Type | Name (Hex) | IP | Port |
+| ---- | ---------- | -- | ---- |
+| local | 617269737461 | - | - |
+| remote | 6172697374615F6970 | 1.1.1.1 | - |
+| remote | 6172697374615F706F7274 | 2.2.2.2 | 1337 |
+
 ### SNMP Device Configuration
 
 ```eos
@@ -138,6 +146,9 @@ snmp-server view VW-READ iso included
 snmp-server community SNMP-COMMUNITY-1 ro onur
 snmp-server community SNMP-COMMUNITY-2 view VW-READ rw ipv6 SNMP-MGMT SNMP-MGMT
 snmp-server community SNMP-COMMUNITY-3 ro
+snmp-server engineID local 617269737461
+snmp-server engineID remote 1.1.1.1 6172697374615F6970
+snmp-server engineID remote 2.2.2.2 udp-port 1337 6172697374615F706F7274
 snmp-server group GRP-READ-ONLY v3 priv read v3read
 snmp-server group GRP-READ-WRITE v3 auth read v3read write v3write
 snmp-server user USER-READ GRP-READ-ONLY v3 auth sha 7a07246a6e3467909098d01619e076adb4e2fe08 priv aes 7a07246a6e3467909098d01619e076ad

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/snmp.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/snmp.cfg
@@ -18,6 +18,9 @@ snmp-server view VW-READ iso included
 snmp-server community SNMP-COMMUNITY-1 ro onur
 snmp-server community SNMP-COMMUNITY-2 view VW-READ rw ipv6 SNMP-MGMT SNMP-MGMT
 snmp-server community SNMP-COMMUNITY-3 ro
+snmp-server engineID local 617269737461
+snmp-server engineID remote 1.1.1.1 6172697374615F6970
+snmp-server engineID remote 2.2.2.2 udp-port 1337 6172697374615F706F7274
 snmp-server group GRP-READ-ONLY v3 priv read v3read
 snmp-server group GRP-READ-WRITE v3 auth read v3read write v3write
 snmp-server user USER-READ GRP-READ-ONLY v3 auth sha 7a07246a6e3467909098d01619e076adb4e2fe08 priv aes 7a07246a6e3467909098d01619e076ad

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/snmp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/snmp.yml
@@ -15,6 +15,16 @@ snmp_server:
         name: SNMP-MGMT
       view: VW-READ
     SNMP-COMMUNITY-3:
+  engine_ids:
+    - type: local
+      name: 617269737461
+    - type: remote
+      name: 6172697374615F6970
+      ip: 1.1.1.1
+    - type: remote
+      name: 6172697374615F706F7274
+      ip: 2.2.2.2
+      port: 1337
   local_interfaces:
     Management1:
       vrf: MGMT

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -2354,6 +2354,11 @@ snmp_server:
       access_list_ipv6:
         name: < acl_ipv6_name >
       view: < view_name >
+  engine_ids:
+    - type: < local | remote >
+      name: < engine_name in hex >
+      ip: < hostname | ip of remote engine >
+      port: < udp-port of remote engine >
   ipv4_acls:
     - name: < ipv4-access-list >
       vrf: < vrf >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/snmp-settings.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/snmp-settings.j2
@@ -150,6 +150,20 @@
 | {{ row_user }} | {{ row_group }} | {{ row_version }} | {{ row_auth }} | {{ row_policy }} |
 {%         endfor %}
 {%     endif %}
+{%     if snmp_server.engine_ids is arista.avd.defined %}
+
+### SNMP EngineID Configuration
+
+| Type | Name (Hex) | IP | Port |
+| ---- | ---------- | -- | ---- |
+{%         for engine_id in snmp_server.engine_ids %}
+{%             set row_type = engine_id.type | arista.avd.default('-') %}
+{%             set row_name = engine_id.name | arista.avd.default('-') %}
+{%             set row_ip = engine_id.ip | arista.avd.default('-') %}
+{%             set row_port = engine_id.port | arista.avd.default('-') %}
+| {{ row_type }} | {{ row_name }} | {{ row_ip }} | {{ row_port }} |
+{%         endfor %}
+{%     endif %}
 
 ### SNMP Device Configuration
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/snmp-settings.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/snmp-settings.j2
@@ -71,6 +71,22 @@ snmp-server location {{ snmp_server.location }}
 {{ communities_cli }}
 {%         endfor %}
 {%     endif %}
+{%     if snmp_server.engine_ids is arista.avd.defined %}
+{%         for engine_id in snmp_server.engine_ids | arista.avd.natural_sort('type') %}
+{%             set engine_ids_cli = "snmp-server engineID " ~ engine_id.type %}
+{%             if engine_id.type is arista.avd.defined('local') and engine_id.name is arista.avd.defined %}
+{%                 set engine_ids_cli = engine_ids_cli ~ " " ~ engine_id.name %}
+{%             endif %}
+{%             if engine_id.type is arista.avd.defined('remote') and engine_id.name is arista.avd.defined and engine_id.ip is arista.avd.defined %}
+{%                 set engine_ids_cli = engine_ids_cli ~ " " ~ engine_id.ip %}
+{%                 if engine_id.port is arista.avd.defined %}
+{%                     set engine_ids_cli = engine_ids_cli ~ " udp-port " ~ engine_id.port %}
+{%                 endif %}
+{%                 set engine_ids_cli = engine_ids_cli ~ " " ~ engine_id.name %}
+{%             endif %}
+{{ engine_ids_cli }}
+{%         endfor %}
+{%     endif %}
 {%     if snmp_server.groups is arista.avd.defined %}
 {%         for group in snmp_server.groups %}
 {%             if group.name is arista.avd.defined %}


### PR DESCRIPTION
## Change Summary

Add options to configure remote and local EngineIDs in SNMP Settings

## Related Issue(s)

Fixes #<N/A>

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Allow to configure:
- Local EngineID
- Remote EngineID(s)

```
snmp_server:
<snip>
  engine_ids:
    - type: < local | remote >
      name: < engine_name in hex >
      ip: < hostname | ip of remote engine >
      port: < udp-port of remote engine >
</snip>
```

## How to test
Modified molecule test to include local and remote ID's

## Checklist

### User Checklist

- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
