### PR TITLE
Feat(eos_designs): Custom name for underlay isis process

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-LSR1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-LSR1.md
@@ -153,9 +153,9 @@ vlan internal order ascending range 1006 1199
 
 | Interface | Channel Group | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type | Hello Padding | Authentication Mode |
 | --------- | ------------- | ------------- | ----------- | ---- | ----------------- | ------------- | ------------------- |
-| Ethernet1 | - | CORE | 60 | point-to-point | level-2 | False | md5 |
-| Ethernet3 | - | CORE | 60 | point-to-point | level-2 | False | md5 |
-| Ethernet4 | - | CORE | 60 | point-to-point | level-2 | False | md5 |
+| Ethernet1 | - | CUSTOM_NAME | 60 | point-to-point | level-2 | False | md5 |
+| Ethernet3 | - | CUSTOM_NAME | 60 | point-to-point | level-2 | False | md5 |
+| Ethernet4 | - | CUSTOM_NAME | 60 | point-to-point | level-2 | False | md5 |
 
 ### Ethernet Interfaces Device Configuration
 
@@ -172,7 +172,7 @@ interface Ethernet1
    mpls ldp igp sync
    mpls ldp interface
    mpls ip
-   isis enable CORE
+   isis enable CUSTOM_NAME
    isis circuit-type level-2
    isis metric 60
    no isis hello padding
@@ -191,7 +191,7 @@ interface Ethernet3
    mpls ldp igp sync
    mpls ldp interface
    mpls ip
-   isis enable CORE
+   isis enable CUSTOM_NAME
    isis circuit-type level-2
    isis metric 60
    no isis hello padding
@@ -210,7 +210,7 @@ interface Ethernet4
    mpls ldp igp sync
    mpls ldp interface
    mpls ip
-   isis enable CORE
+   isis enable CUSTOM_NAME
    isis circuit-type level-2
    isis metric 60
    no isis hello padding
@@ -239,7 +239,7 @@ interface Ethernet4
 
 | Interface | ISIS instance | ISIS metric | Interface mode |
 | --------- | ------------- | ----------- | -------------- |
-| Loopback0 | CORE | - | passive |
+| Loopback0 | CUSTOM_NAME | - | passive |
 
 ### Loopback Interfaces Device Configuration
 
@@ -250,7 +250,7 @@ interface Loopback0
    no shutdown
    ip address 100.70.0.3/32
    ipv6 address 2000:1234:ffff:ffff::3/128
-   isis enable CORE
+   isis enable CUSTOM_NAME
    isis passive
    mpls ldp interface
    node-segment ipv4 index 303
@@ -320,7 +320,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | Settings | Value |
 | -------- | ----- |
-| Instance | CORE |
+| Instance | CUSTOM_NAME |
 | Net-ID | 49.0001.0000.0000.0003.00 |
 | Type | level-2 |
 | Address Family | ipv4 unicast, ipv6 unicast |
@@ -335,10 +335,10 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | Interface | ISIS Instance | ISIS Metric | Interface Mode |
 | --------- | ------------- | ----------- | -------------- |
-| Ethernet1 | CORE | 60 | point-to-point |
-| Ethernet3 | CORE | 60 | point-to-point |
-| Ethernet4 | CORE | 60 | point-to-point |
-| Loopback0 | CORE | - | passive |
+| Ethernet1 | CUSTOM_NAME | 60 | point-to-point |
+| Ethernet3 | CUSTOM_NAME | 60 | point-to-point |
+| Ethernet4 | CUSTOM_NAME | 60 | point-to-point |
+| Loopback0 | CUSTOM_NAME | - | passive |
 
 ### ISIS Segment-routing Node-SID
 
@@ -350,7 +350,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 ```eos
 !
-router isis CORE
+router isis CUSTOM_NAME
    net 49.0001.0000.0000.0003.00
    is-type level-2
    router-id ipv4 100.70.0.3

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-LSR2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-LSR2.md
@@ -156,9 +156,9 @@ vlan internal order ascending range 1006 1199
 
 | Interface | Channel Group | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type | Hello Padding | Authentication Mode |
 | --------- | ------------- | ------------- | ----------- | ---- | ----------------- | ------------- | ------------------- |
-| Ethernet3 | - | CORE | 60 | point-to-point | level-2 | False | md5 |
-| Ethernet12 | 12 | *CORE | *60 | *point-to-point | *level-2 | *False | *md5 |
-| Ethernet13 | 12 | *CORE | *60 | *point-to-point | *level-2 | *False | *md5 |
+| Ethernet3 | - | CUSTOM_NAME | 60 | point-to-point | level-2 | False | md5 |
+| Ethernet12 | 12 | *CUSTOM_NAME | *60 | *point-to-point | *level-2 | *False | *md5 |
+| Ethernet13 | 12 | *CUSTOM_NAME | *60 | *point-to-point | *level-2 | *False | *md5 |
  *Inherited from Port-Channel Interface
 
 ### Ethernet Interfaces Device Configuration
@@ -176,7 +176,7 @@ interface Ethernet3
    mpls ldp igp sync
    mpls ldp interface
    mpls ip
-   isis enable CORE
+   isis enable CUSTOM_NAME
    isis circuit-type level-2
    isis metric 60
    no isis hello padding
@@ -214,7 +214,7 @@ interface Ethernet13
 
 | Interface | ISIS Instance | ISIS Metric | Mode | ISIS Circuit Type | Hello Padding | Authentication Mode |
 | --------- | ------------- | ----------- | ---- | ----------------- | ------------- | ------------------- |
-| Port-Channel12 | CORE | 60 | point-to-point | level-2 | False | md5 |
+| Port-Channel12 | CUSTOM_NAME | 60 | point-to-point | level-2 | False | md5 |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -230,7 +230,7 @@ interface Port-Channel12
    mpls ip
    mpls ldp interface
    mpls ldp igp sync
-   isis enable CORE
+   isis enable CUSTOM_NAME
    isis circuit-type level-2
    isis metric 60
    isis network point-to-point
@@ -259,7 +259,7 @@ interface Port-Channel12
 
 | Interface | ISIS instance | ISIS metric | Interface mode |
 | --------- | ------------- | ----------- | -------------- |
-| Loopback0 | CORE | - | passive |
+| Loopback0 | CUSTOM_NAME | - | passive |
 
 ### Loopback Interfaces Device Configuration
 
@@ -270,7 +270,7 @@ interface Loopback0
    no shutdown
    ip address 100.70.0.4/32
    ipv6 address 2000:1234:ffff:ffff::4/128
-   isis enable CORE
+   isis enable CUSTOM_NAME
    isis passive
    mpls ldp interface
    node-segment ipv4 index 304
@@ -340,7 +340,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | Settings | Value |
 | -------- | ----- |
-| Instance | CORE |
+| Instance | CUSTOM_NAME |
 | Net-ID | 49.0001.0000.0000.0004.00 |
 | Type | level-2 |
 | Address Family | ipv4 unicast, ipv6 unicast |
@@ -355,8 +355,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | Interface | ISIS Instance | ISIS Metric | Interface Mode |
 | --------- | ------------- | ----------- | -------------- |
-| Ethernet3 | CORE | 60 | point-to-point |
-| Loopback0 | CORE | - | passive |
+| Ethernet3 | CUSTOM_NAME | 60 | point-to-point |
+| Loopback0 | CUSTOM_NAME | - | passive |
 
 ### ISIS Segment-routing Node-SID
 
@@ -368,7 +368,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 ```eos
 !
-router isis CORE
+router isis CUSTOM_NAME
    net 49.0001.0000.0000.0004.00
    is-type level-2
    router-id ipv4 100.70.0.4

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE2-LSR1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE2-LSR1.cfg
@@ -26,7 +26,7 @@ interface Ethernet1
    mpls ldp igp sync
    mpls ldp interface
    mpls ip
-   isis enable CORE
+   isis enable CUSTOM_NAME
    isis circuit-type level-2
    isis metric 60
    no isis hello padding
@@ -45,7 +45,7 @@ interface Ethernet3
    mpls ldp igp sync
    mpls ldp interface
    mpls ip
-   isis enable CORE
+   isis enable CUSTOM_NAME
    isis circuit-type level-2
    isis metric 60
    no isis hello padding
@@ -64,7 +64,7 @@ interface Ethernet4
    mpls ldp igp sync
    mpls ldp interface
    mpls ip
-   isis enable CORE
+   isis enable CUSTOM_NAME
    isis circuit-type level-2
    isis metric 60
    no isis hello padding
@@ -77,7 +77,7 @@ interface Loopback0
    no shutdown
    ip address 100.70.0.3/32
    ipv6 address 2000:1234:ffff:ffff::3/128
-   isis enable CORE
+   isis enable CUSTOM_NAME
    isis passive
    mpls ldp interface
    node-segment ipv4 index 303
@@ -96,7 +96,7 @@ ipv6 unicast-routing
 !
 ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
-router isis CORE
+router isis CUSTOM_NAME
    net 49.0001.0000.0000.0003.00
    is-type level-2
    router-id ipv4 100.70.0.3

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE2-LSR2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE2-LSR2.cfg
@@ -25,7 +25,7 @@ interface Port-Channel12
    mpls ip
    mpls ldp interface
    mpls ldp igp sync
-   isis enable CORE
+   isis enable CUSTOM_NAME
    isis circuit-type level-2
    isis metric 60
    isis network point-to-point
@@ -44,7 +44,7 @@ interface Ethernet3
    mpls ldp igp sync
    mpls ldp interface
    mpls ip
-   isis enable CORE
+   isis enable CUSTOM_NAME
    isis circuit-type level-2
    isis metric 60
    no isis hello padding
@@ -67,7 +67,7 @@ interface Loopback0
    no shutdown
    ip address 100.70.0.4/32
    ipv6 address 2000:1234:ffff:ffff::4/128
-   isis enable CORE
+   isis enable CUSTOM_NAME
    isis passive
    mpls ldp interface
    node-segment ipv4 index 304
@@ -86,7 +86,7 @@ ipv6 unicast-routing
 !
 ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
-router isis CORE
+router isis CUSTOM_NAME
    net 49.0001.0000.0000.0004.00
    is-type level-2
    router-id ipv4 100.70.0.4

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-LSR1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-LSR1.yml
@@ -38,13 +38,13 @@ loopback_interfaces:
       ip: true
       ldp:
         interface: true
-    isis_enable: CORE
+    isis_enable: CUSTOM_NAME
     isis_passive: true
     node_segment:
       ipv4_index: 303
       ipv6_index: 303
 router_isis:
-  instance: CORE
+  instance: CUSTOM_NAME
   log_adjacency_changes: true
   net: 49.0001.0000.0000.0003.00
   router_id: 100.70.0.3
@@ -84,7 +84,7 @@ ethernet_interfaces:
     ip_address: 100.64.48.14/31
     speed: forced 40gfull
     ipv6_enable: true
-    isis_enable: CORE
+    isis_enable: CUSTOM_NAME
     isis_metric: 60
     isis_network_point_to_point: true
     isis_hello_padding: false
@@ -107,7 +107,7 @@ ethernet_interfaces:
     ip_address: 100.64.48.9/31
     speed: forced 40gfull
     ipv6_enable: true
-    isis_enable: CORE
+    isis_enable: CUSTOM_NAME
     isis_metric: 60
     isis_network_point_to_point: true
     isis_hello_padding: false
@@ -130,7 +130,7 @@ ethernet_interfaces:
     ip_address: 100.64.48.12/31
     speed: forced 40gfull
     ipv6_enable: true
-    isis_enable: CORE
+    isis_enable: CUSTOM_NAME
     isis_metric: 60
     isis_network_point_to_point: true
     isis_hello_padding: false

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-LSR2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-LSR2.yml
@@ -38,13 +38,13 @@ loopback_interfaces:
       ip: true
       ldp:
         interface: true
-    isis_enable: CORE
+    isis_enable: CUSTOM_NAME
     isis_passive: true
     node_segment:
       ipv4_index: 304
       ipv6_index: 304
 router_isis:
-  instance: CORE
+  instance: CUSTOM_NAME
   log_adjacency_changes: true
   net: 49.0001.0000.0000.0004.00
   router_id: 100.70.0.4
@@ -84,7 +84,7 @@ ethernet_interfaces:
     ip_address: 100.64.48.11/31
     speed: forced 40gfull
     ipv6_enable: true
-    isis_enable: CORE
+    isis_enable: CUSTOM_NAME
     isis_metric: 60
     isis_network_point_to_point: true
     isis_hello_padding: false
@@ -122,7 +122,7 @@ port_channel_interfaces:
     ip_address: 100.64.48.16/31
     speed: forced 40gfull
     ipv6_enable: true
-    isis_enable: CORE
+    isis_enable: CUSTOM_NAME
     isis_metric: 60
     isis_network_point_to_point: true
     isis_hello_padding: false

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/inventory/group_vars/SITE2_P_ROUTERS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/inventory/group_vars/SITE2_P_ROUTERS.yml
@@ -1,0 +1,2 @@
+---
+underlay_isis_instance_name: CUSTOM_NAME

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-variables.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-variables.md
@@ -41,6 +41,7 @@ isis_area_id: < isis area | default -> "49.0001" >
 # Additional underlay ISIS parameters | Optional.
 isis_default_is_type: < level-1-2, | level-1 | level-2 | default -> level-2 >
 isis_advertise_passive_only: < true | false | default -> false >
+underlay_isis_instance_name: < name >
 
 # ISIS TI-LFA parameters | Optional.
 isis_ti_lfa:

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-variables.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-variables.md
@@ -41,7 +41,7 @@ isis_area_id: < isis area | default -> "49.0001" >
 # Additional underlay ISIS parameters | Optional.
 isis_default_is_type: < level-1-2, | level-1 | level-2 | default -> level-2 >
 isis_advertise_passive_only: < true | false | default -> false >
-underlay_isis_instance_name: < name >
+underlay_isis_instance_name: < name | default -> "EVPN_UNDERLAY" for l3ls, "CORE" for mpls >
 
 # ISIS TI-LFA parameters | Optional.
 isis_ti_lfa:

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/facts/switch/switch.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/facts/switch/switch.j2
@@ -265,7 +265,9 @@ switch:
   is_type: {{ switch_is_type }}
 
 {# switch.isis_instance_name #}
-{%         if switch.mpls_lsr is arista.avd.defined(true) %}
+{%         if underlay_isis_instance_name is arista.avd.defined %}
+{%             set switch_isis_instance_name = underlay_isis_instance_name %}
+{%         elif switch.mpls_lsr is arista.avd.defined(true) %}
 {%             set switch_isis_instance_name = "CORE" %}
 {%         else %}
 {%             set switch_isis_instance_name = "EVPN_UNDERLAY" %}


### PR DESCRIPTION
## Change Summary

This PR proposes a custom naming variable for the underlay isis process:

```yaml
underlay_isis_instance_name: CUSTOM_NAME
```

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Adds new knob "underlay_isis_instance_name". 

## How to test
Tested with molecule

### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
