### PR TITLE
Doc: Remove CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ansible Collection For Arista Validated Designs - arista.avd
 
-![Arista AVD](https://img.shields.io/badge/Arista-AVD%20Automation-blue) ![collection version](https://img.shields.io/github/v/release/aristanetworks/ansible-avd) ![continuous integration](https://github.com/aristanetworks/ansible-avd/actions/workflows/continuous_integration.yml/badge.svg) ![License](https://img.shields.io/github/license/aristanetworks/ansible-avd)
+![Arista AVD](https://img.shields.io/badge/Arista-AVD%20Automation-blue) ![collection version](https://img.shields.io/github/v/release/aristanetworks/ansible-avd) ![License](https://img.shields.io/github/license/aristanetworks/ansible-avd)
 
 **Table of Contents:**
 


### PR DESCRIPTION
## Change Summary

- Remove the CI badge from ansible-avd GitHub README.md landing page.
- We will re-add this badge to represent the status of internal CI once ready!

## Component(s) name

ansible-avd GitHub README.md landing page

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
