### PR TITLE
Doc: Improve documentation, fix typo

### DIFF
--- a/ansible_collections/arista/avd/molecule/README.md
+++ b/ansible_collections/arista/avd/molecule/README.md
@@ -55,7 +55,7 @@ Testing for `eos_cli_config_gen` is part of [scenario `eos_cli_config_gen`](./eo
 When you update a template in `eos_cli_config_gen`, you should report a test case in molecule scenario [`ansible_collections/arista/avd/molecule/eos_cli_config_gen`](./eos_cli_config_gen/).
 
 1. Create or update a file related to updated section under `inventory/host_vars`
-2. If section is new, update inventory file to add a new host. Host SHALL be the name of your section and also file in your `host_vars`
+2. If the section is new, update the inventory file ([hosts.ini](eos_cli_config_gen/inventory/hosts.ini)) to add a new host. The host SHALL be the name of your section and also the `<filename>.yml` in your `host_vars`
 3. Run molecule scenario to generate artifacts:
 
 ```bash

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-topology.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-topology.md
@@ -196,7 +196,7 @@ defaults <- node_group <- node_group.node <- node
     # Uplink switches (list). | Required.
     uplink_switches: [ < uplink_switch_inventory_hostname 01 >, < uplink_switch_inventory_hostname 02 > ]
 
-    # Number of interfaces towards uplink switches | Optional
+    # Number of uplink switches | Optional
     max_uplink_switches: < integer >
 
     # Number of parallel links towards uplink switches | Optional

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-topology.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-topology.md
@@ -196,7 +196,9 @@ defaults <- node_group <- node_group.node <- node
     # Uplink switches (list). | Required.
     uplink_switches: [ < uplink_switch_inventory_hostname 01 >, < uplink_switch_inventory_hostname 02 > ]
 
-    # Number of uplink switches | Optional
+    # Maximum number of uplink switches. | Optional
+    # Changing this value may change IP Addressing on uplinks.
+    # Can be used to reserve IP space for future expansions.
     max_uplink_switches: < integer >
 
     # Number of parallel links towards uplink switches | Optional

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
@@ -30,7 +30,7 @@ network_services_keys:
 ```yaml
 # On mlag leafs, an SVI interface is defined per vrf, to establish iBGP peering. | Required (when mlag leafs in topology)
 # The SVI id will be derived from the base vlan defined: mlag_ibgp_peering_vrfs.base_vlan + (vrf_id or vrf_vni) - 1
-# Depending on the values of vrf_id / vrf_id it may be required to adjust the base_vlan to avoid overlaps or invalid vlan ids.
+# Depending on the values of vrf_id / vrf_vni it may be required to adjust the base_vlan to avoid overlaps or invalid vlan ids.
 # The SVI ip address derived from mlag_l3_peer_ipv4_pool is re-used across all iBGP peerings.
 mlag_ibgp_peering_vrfs:
   base_vlan: < 1-4000 | default -> 3000 >


### PR DESCRIPTION
## Change Summary

1. Improve description for `max_uplink_switch` as seems to be causing confusion across users. 
2. Fix typo on `mlag_ibgp_peering_vrfs` description
3. Improve molecule README more clear when you create a new feature.

## Related Issue(s)


## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

1. Improve description for `max_uplink_switch`.
 - **Current description:** `Number of interfaces towards uplink switches`.
 - **Proposed new description:** `Number of uplink switches`.

2. Fix typo `vrf_id / vrf_id` to `vrf_id / vrf_vni`. 
 

## How to test

Not required

## Checklist

### User Checklist

- N/A

### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
