### PR TITLE
Feat(eos_cli_config_gen): BGP VRF IPv4 RM support

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-v4-evpn.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-v4-evpn.md
@@ -318,6 +318,9 @@ router bgp 65101
       !
       address-family ipv4
          neighbor 10.2.3.4 activate
+         neighbor 10.2.3.4 route-map RM-10.2.3.4-SET-NEXT-HOP-OUT out
+         neighbor 10.2.3.5 activate
+         neighbor 10.2.3.5 route-map RM-10.2.3.5-SET-NEXT-HOP-IN in
          network 10.0.0.0/8
          network 100.64.0.0/10 route-map RM-10.2.3.4
    !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-v4-evpn.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-v4-evpn.cfg
@@ -110,6 +110,9 @@ router bgp 65101
       !
       address-family ipv4
          neighbor 10.2.3.4 activate
+         neighbor 10.2.3.4 route-map RM-10.2.3.4-SET-NEXT-HOP-OUT out
+         neighbor 10.2.3.5 activate
+         neighbor 10.2.3.5 route-map RM-10.2.3.5-SET-NEXT-HOP-IN in
          network 10.0.0.0/8
          network 100.64.0.0/10 route-map RM-10.2.3.4
    !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-v4-evpn.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-v4-evpn.yml
@@ -156,6 +156,10 @@ router_bgp:
           neighbors:
             10.2.3.4:
               activate: true
+              route_map_out: RM-10.2.3.4-SET-NEXT-HOP-OUT
+            10.2.3.5:
+              activate: true
+              route_map_in: RM-10.2.3.5-SET-NEXT-HOP-IN
           networks:
             10.0.0.0/8:
             100.64.0.0/10:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/router-bgp-v4-evpn.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/router-bgp-v4-evpn.md
@@ -313,6 +313,9 @@ router bgp 65101
       !
       address-family ipv4
          neighbor 10.2.3.4 activate
+         neighbor 10.2.3.4 route-map RM-10.2.3.4-SET-NEXT-HOP-OUT out
+         neighbor 10.2.3.5 activate
+         neighbor 10.2.3.5 route-map RM-10.2.3.5-SET-NEXT-HOP-IN in
          network 10.0.0.0/8
          network 100.64.0.0/10 route-map RM-10.2.3.4
    !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/router-bgp-v4-evpn.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/router-bgp-v4-evpn.cfg
@@ -107,6 +107,9 @@ router bgp 65101
       !
       address-family ipv4
          neighbor 10.2.3.4 activate
+         neighbor 10.2.3.4 route-map RM-10.2.3.4-SET-NEXT-HOP-OUT out
+         neighbor 10.2.3.5 activate
+         neighbor 10.2.3.5 route-map RM-10.2.3.5-SET-NEXT-HOP-IN in
          network 10.0.0.0/8
          network 100.64.0.0/10 route-map RM-10.2.3.4
    !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/router-bgp-v4-evpn.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/router-bgp-v4-evpn.yml
@@ -147,6 +147,10 @@ router_bgp:
           neighbors:
             - ip_address: 10.2.3.4
               activate: true
+              route_map_out: RM-10.2.3.4-SET-NEXT-HOP-OUT
+            - ip_address: 10.2.3.5
+              activate: true
+              route_map_in: RM-10.2.3.5-SET-NEXT-HOP-IN
           networks:
             - prefix: 10.0.0.0/8
             - prefix: 100.64.0.0/10

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -3189,8 +3189,8 @@ router_bgp:
           neighbors:
             < neighbor_ip_address >:
               activate: < true | false >
-              route_map_out: < route-map name >
-              route_map_in: < route-map name >
+              route_map_out: < route_map_name >
+              route_map_in: < route_map_name >
           networks:
             < prefix_address >:
               route_map: < route_map_name >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -3189,6 +3189,8 @@ router_bgp:
           neighbors:
             < neighbor_ip_address >:
               activate: < true | false >
+              route_map_out: < route-map name >
+              route_map_in: < route-map name >
           networks:
             < prefix_address >:
               route_map: < route_map_name >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
@@ -2907,8 +2907,8 @@ router_bgp:
           neighbors:
             - ip_address: < neighbor_ip_address >
               activate: < true | false >
-              route_map_out: < route-map name >
-              route_map_in: < route-map name >
+              route_map_out: < route_map_name >
+              route_map_in: < route_map_name >
           networks:
             - prefix: < prefix_address >
               route_map: < route_map_name >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
@@ -2907,6 +2907,8 @@ router_bgp:
           neighbors:
             - ip_address: < neighbor_ip_address >
               activate: < true | false >
+              route_map_out: < route-map name >
+              route_map_in: < route-map name >
           networks:
             - prefix: < prefix_address >
               route_map: < route_map_name >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -889,6 +889,12 @@ router bgp {{ router_bgp.as }}
 {%                 if neighbor.activate is arista.avd.defined(true) %}
          neighbor {{ neighbor.ip_address }} activate
 {%                 endif %}
+{%                 if neighbor.route_map_in is arista.avd.defined %}
+         neighbor {{ neighbor.ip_address }} route-map {{ neighbor.route_map_in }} in
+{%                 endif %}
+{%                 if neighbor.route_map_out is arista.avd.defined %}
+         neighbor {{ neighbor.ip_address }} route-map {{ neighbor.route_map_out }} out
+{%                 endif %}
 {%             endfor %}
 {%             for network in address_family.networks | arista.avd.convert_dicts('prefix') | arista.avd.natural_sort('prefix') %}
 {%                 set network_cli = "network " ~ network.prefix %}


### PR DESCRIPTION
Feat(eos_cli_config_gen): BGP VRF IPv4 RM support


## Change Summary

Support AVD data model for BGP VRF address-family IPv4 Route-maps

## Related Issue(s)

Fixes #1756 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Support for knob to apply route maps (in/out) under `router_bgp > vrfs > address_families > neighbor` :

```yaml
router_bgp:
  vrfs:
    <vrf>:
      address_families:
        < address_family >:
          neighbors:
            < neighbor_ip_address >:
              route_map_out: < route-map name >
              route_map_in: < route-map name >
```

## How to test

molecule

## Checklist

### User Checklist

- N/A

### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)