### PR TITLE
Feat(eos_cli_config_gen): OSPF redistribute include leaked support

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
@@ -206,14 +206,15 @@ interface Vlan24
 
 ### Router OSPF Router Redistribution
 
-| Process ID | Source Protocol | Route Map |
-| ---------- | --------------- | --------- |
-| 100 | connected | - |
-| 100 | static | - |
-| 100 | bgp | - |
-| 200 | connected | rm-ospf-connected |
-| 200 | static | rm-ospf-static |
-| 200 | bgp | rm-ospf-bgp |
+| Process ID | Source Protocol | Include Leaked | Route Map |
+| ---------- | --------------- | -------------- | --------- |
+| 100 | bgp | False | - |
+| 100 | connected | False | - |
+| 100 | static | False | - |
+| 200 | bgp | False | rm-ospf-bgp |
+| 200 | connected | False | rm-ospf-connected |
+| 200 | isis | True | - |
+| 200 | static | True | rm-ospf-static |
 
 ### Router OSPF Router Max-Metric
 
@@ -283,9 +284,9 @@ router ospf 100
    distribute-list route-map RM-OSPF-DIST-IN in
    max-lsa 12000
    default-information originate
-   redistribute static
-   redistribute connected
    redistribute bgp
+   redistribute connected
+   redistribute static
    auto-cost reference-bandwidth 100
    maximum-paths 10
    mpls ldp sync default
@@ -312,9 +313,10 @@ router ospf 200 vrf ospf_zone
    max-lsa 5
    timers lsa rx min interval 100
    default-information originate always
-   redistribute static route-map rm-ospf-static
-   redistribute connected route-map rm-ospf-connected
    redistribute bgp route-map rm-ospf-bgp
+   redistribute connected route-map rm-ospf-connected
+   redistribute isis include leaked
+   redistribute static include leaked route-map rm-ospf-static
 !
 router ospf 300
    max-metric router-lsa

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-ospf.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-ospf.cfg
@@ -53,9 +53,9 @@ router ospf 100
    distribute-list route-map RM-OSPF-DIST-IN in
    max-lsa 12000
    default-information originate
-   redistribute static
-   redistribute connected
    redistribute bgp
+   redistribute connected
+   redistribute static
    auto-cost reference-bandwidth 100
    maximum-paths 10
    mpls ldp sync default
@@ -82,9 +82,10 @@ router ospf 200 vrf ospf_zone
    max-lsa 5
    timers lsa rx min interval 100
    default-information originate always
-   redistribute static route-map rm-ospf-static
-   redistribute connected route-map rm-ospf-connected
    redistribute bgp route-map rm-ospf-bgp
+   redistribute connected route-map rm-ospf-connected
+   redistribute isis include leaked
+   redistribute static include leaked route-map rm-ospf-static
 !
 router ospf 300
    max-metric router-lsa

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-ospf.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-ospf.yml
@@ -68,11 +68,15 @@ router_ospf:
         always: true
       redistribute:
         static:
+          include_leaked: true
           route_map: rm-ospf-static
         connected:
+          include_leaked: false
           route_map: rm-ospf-connected
         bgp:
           route_map: rm-ospf-bgp
+        isis:
+          include_leaked: true
       areas:
         '0.0.0.2':
           filter:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/router-ospf.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/router-ospf.md
@@ -206,14 +206,15 @@ interface Vlan24
 
 ### Router OSPF Router Redistribution
 
-| Process ID | Source Protocol | Route Map |
-| ---------- | --------------- | --------- |
-| 100 | connected | - |
-| 100 | static | - |
-| 100 | bgp | - |
-| 200 | connected | rm-ospf-connected |
-| 200 | static | rm-ospf-static |
-| 200 | bgp | rm-ospf-bgp |
+| Process ID | Source Protocol | Include Leaked | Route Map |
+| ---------- | --------------- | -------------- | --------- |
+| 100 | bgp | False | - |
+| 100 | connected | False | - |
+| 100 | static | False | - |
+| 200 | bgp | False | rm-ospf-bgp |
+| 200 | connected | False | rm-ospf-connected |
+| 200 | isis | True | - |
+| 200 | static | True | rm-ospf-static |
 
 ### Router OSPF Router Max-Metric
 
@@ -283,9 +284,9 @@ router ospf 100
    distribute-list route-map RM-OSPF-DIST-IN in
    max-lsa 12000
    default-information originate
-   redistribute static
-   redistribute connected
    redistribute bgp
+   redistribute connected
+   redistribute static
    auto-cost reference-bandwidth 100
    maximum-paths 10
    mpls ldp sync default
@@ -312,9 +313,10 @@ router ospf 200 vrf ospf_zone
    max-lsa 5
    timers lsa rx min interval 100
    default-information originate always
-   redistribute static route-map rm-ospf-static
-   redistribute connected route-map rm-ospf-connected
    redistribute bgp route-map rm-ospf-bgp
+   redistribute connected route-map rm-ospf-connected
+   redistribute isis include leaked
+   redistribute static include leaked route-map rm-ospf-static
 !
 router ospf 300
    max-metric router-lsa

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/router-ospf.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/router-ospf.cfg
@@ -53,9 +53,9 @@ router ospf 100
    distribute-list route-map RM-OSPF-DIST-IN in
    max-lsa 12000
    default-information originate
-   redistribute static
-   redistribute connected
    redistribute bgp
+   redistribute connected
+   redistribute static
    auto-cost reference-bandwidth 100
    maximum-paths 10
    mpls ldp sync default
@@ -82,9 +82,10 @@ router ospf 200 vrf ospf_zone
    max-lsa 5
    timers lsa rx min interval 100
    default-information originate always
-   redistribute static route-map rm-ospf-static
-   redistribute connected route-map rm-ospf-connected
    redistribute bgp route-map rm-ospf-bgp
+   redistribute connected route-map rm-ospf-connected
+   redistribute isis include leaked
+   redistribute static include leaked route-map rm-ospf-static
 !
 router ospf 300
    max-metric router-lsa

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/router-ospf.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/router-ospf.yml
@@ -17,9 +17,9 @@ router_ospf:
       max_lsa: 12000
       default_information_originate:
       redistribute:
-        static:
-        connected:
-        bgp:
+        - source_protocol: static
+        - source_protocol: connected
+        - source_protocol: bgp
       auto_cost_reference_bandwidth: 100
       maximum_paths: 10
       mpls_ldp_sync_default: true
@@ -67,12 +67,16 @@ router_ospf:
       default_information_originate:
         always: true
       redistribute:
-        static:
+        - source_protocol: static
+          include_leaked: true
           route_map: rm-ospf-static
-        connected:
+        - source_protocol: connected
+          include_leaked: false
           route_map: rm-ospf-connected
-        bgp:
+        - source_protocol: bgp
           route_map: rm-ospf-bgp
+        - source_protocol: isis
+          include_leaked: true
       areas:
         - id: '0.0.0.2'
           filter:

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER1.md
@@ -514,9 +514,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 ### Router OSPF Router Redistribution
 
-| Process ID | Source Protocol | Route Map |
-| ---------- | --------------- | --------- |
-| 19 | bgp | - |
+| Process ID | Source Protocol | Include Leaked | Route Map |
+| ---------- | --------------- | -------------- | --------- |
+| 19 | bgp | False | - |
 
 ### OSPF Interfaces
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-LER1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-LER1.md
@@ -521,9 +521,9 @@ ip route vrf TENANT_B_INTRA 123.0.10.0/24 Ethernet6.10 123.1.1.3 name TENANT_B_S
 
 ### Router OSPF Router Redistribution
 
-| Process ID | Source Protocol | Route Map |
-| ---------- | --------------- | --------- |
-| 99 | bgp | - |
+| Process ID | Source Protocol | Include Leaked | Route Map |
+| ---------- | --------------- | -------------- | --------- |
+| 99 | bgp | False | - |
 
 ### OSPF Interfaces
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL1A.md
@@ -605,9 +605,9 @@ ip route vrf Tenant_A_WAN_Zone 10.3.4.0/24 1.2.3.4
 
 ### Router OSPF Router Redistribution
 
-| Process ID | Source Protocol | Route Map |
-| ---------- | --------------- | --------- |
-| 14 | bgp | - |
+| Process ID | Source Protocol | Include Leaked | Route Map |
+| ---------- | --------------- | -------------- | --------- |
+| 14 | bgp | False | - |
 
 ### OSPF Interfaces
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL1B.md
@@ -597,9 +597,9 @@ ip route vrf Tenant_A_WAN_Zone 10.3.4.0/24 1.2.3.4
 
 ### Router OSPF Router Redistribution
 
-| Process ID | Source Protocol | Route Map |
-| ---------- | --------------- | --------- |
-| 14 | bgp | - |
+| Process ID | Source Protocol | Include Leaked | Route Map |
+| ---------- | --------------- | -------------- | --------- |
+| 14 | bgp | False | - |
 
 ### OSPF Interfaces
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -3306,11 +3306,10 @@ router_ospf:
         - prefix: < summary_prefix_04 >
         - prefix: < summary_prefix_05 >
       redistribute:
-        static:
+        < route_type >:
+          include_leaked: < true | false >
           route_map: < route_map_name >
-        connected:
-          route_map: < route_map_name >
-        bgp:
+        < route_type >:
           route_map: < route_map_name >
       auto_cost_reference_bandwidth: < bandwidth in mbps >
       areas:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
@@ -2993,11 +2993,11 @@ router_ospf:
         - prefix: < summary_prefix_04 >
         - prefix: < summary_prefix_05 >
       redistribute:
-        static:
+        - source_protocol: < route_type >
+          include_leaked: < true | false >
           route_map: < route_map_name >
-        connected:
-          route_map: < route_map_name >
-        bgp:
+        - source_protocol: < route_type >
+          include_leaked: < true | false >
           route_map: < route_map_name >
       auto_cost_reference_bandwidth: < bandwidth in mbps >
       areas:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-ospf.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-ospf.j2
@@ -89,15 +89,9 @@
 {%         for process_id in router_ospf.process_ids | arista.avd.convert_dicts('id') | arista.avd.natural_sort('id') %}
 {%             for redistribute_route in process_id.redistribute | arista.avd.convert_dicts('source_protocol') | arista.avd.natural_sort('source_protocol') %}
 {%                 set source_protocol = redistribute_route.source_protocol %}
-{%                 if redistribute_route.include_leaked is arista.avd.defined(true) %}
-{%                     set include_leaked = "True" %}
-{%                 else %}
-{%                     set include_leaked = "False" %}
-{%                 endif %}
-{%                 if redistribute_route.route_map is arista.avd.defined %}
-{%                     set route_map = redistribute_route.route_map %}
-{%                 endif %}
-| {{ process_id.id }} | {{ source_protocol }} | {{ include_leaked }} | {{ route_map | arista.avd.default('-') }} |
+{%                 set include_leaked = redistribute_route.include_leaked | arista.avd.default(false) %}
+{%                 set route_map = redistribute_route.route_map | arista.avd.default('-') %}
+| {{ process_id.id }} | {{ source_protocol }} | {{ include_leaked }} | {{ route_map }} |
 {%             endfor %}
 {%         endfor %}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-ospf.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-ospf.j2
@@ -84,24 +84,21 @@
 
 ### Router OSPF Router Redistribution
 
-| Process ID | Source Protocol | Route Map |
-| ---------- | --------------- | --------- |
+| Process ID | Source Protocol | Include Leaked | Route Map |
+| ---------- | --------------- | -------------- | --------- |
 {%         for process_id in router_ospf.process_ids | arista.avd.convert_dicts('id') | arista.avd.natural_sort('id') %}
-{%             if process_id.redistribute is arista.avd.defined %}
-{%                 set source_protocols = [] %}
-{%                 if process_id.redistribute.connected is defined %}
-{%                     do source_protocols.append(('connected', process_id.redistribute.connected.route_map | arista.avd.default('-'))) %}
+{%             for redistribute_route in process_id.redistribute | arista.avd.convert_dicts('source_protocol') | arista.avd.natural_sort('source_protocol') %}
+{%                 set source_protocol = redistribute_route.source_protocol %}
+{%                 if redistribute_route.include_leaked is arista.avd.defined(true) %}
+{%                     set include_leaked = "True" %}
+{%                 else %}
+{%                     set include_leaked = "False" %}
 {%                 endif %}
-{%                 if process_id.redistribute.static is defined %}
-{%                     do source_protocols.append(('static', process_id.redistribute.static.route_map | arista.avd.default('-'))) %}
+{%                 if redistribute_route.route_map is arista.avd.defined %}
+{%                     set route_map = redistribute_route.route_map %}
 {%                 endif %}
-{%                 if process_id.redistribute.bgp is defined %}
-{%                     do source_protocols.append(('bgp', process_id.redistribute.bgp.route_map | arista.avd.default('-'))) %}
-{%                 endif %}
-{%                 for source_protocol in source_protocols %}
-| {{ process_id.id }} | {{ source_protocol[0] }} | {{ source_protocol[1] }} |
-{%                 endfor %}
-{%             endif %}
+| {{ process_id.id }} | {{ source_protocol }} | {{ include_leaked }} | {{ route_map | arista.avd.default('-') }} |
+{%             endfor %}
 {%         endfor %}
 {%     endif %}
 {# Max-Metric #}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-ospf.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-ospf.j2
@@ -121,7 +121,7 @@ router ospf {{ process_id.id }}
 {%             set redistribute_cli = redistribute_cli ~ " include leaked" %}
 {%         endif %}
 {%         if redistribute_route.route_map is arista.avd.defined %}
-{%             set redistribute_cli = redistribute_cli + " route-map " ~ redistribute_route.route_map %}
+{%             set redistribute_cli = redistribute_cli ~ " route-map " ~ redistribute_route.route_map %}
 {%         endif %}
    {{ redistribute_cli }}
 {%     endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-ospf.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-ospf.j2
@@ -115,27 +115,16 @@ router ospf {{ process_id.id }}
 {%         endif %}
    {{ default_information_originate_cli }}
 {%     endif %}
-{%     if process_id.redistribute.static is defined %}
-{%         set redistribute_static_cli = "redistribute static" %}
-{%         if process_id.redistribute.static.route_map is arista.avd.defined %}
-{%             set redistribute_static_cli = redistribute_static_cli ~ " route-map " ~  process_id.redistribute.static.route_map %}
+{%     for redistribute_route in process_id.redistribute | arista.avd.convert_dicts('source_protocol') | arista.avd.natural_sort('source_protocol') %}
+{%         set redistribute_cli = "redistribute " ~ redistribute_route.source_protocol %}
+{%         if redistribute_route.include_leaked is arista.avd.defined(true) %}
+{%           set redistribute_cli = redistribute_cli + " include leaked" %}
 {%         endif %}
-   {{ redistribute_static_cli }}
-{%     endif %}
-{%     if process_id.redistribute.connected is defined %}
-{%         set redistribute_connected_cli = "redistribute connected" %}
-{%         if process_id.redistribute.connected.route_map is arista.avd.defined %}
-{%             set redistribute_connected_cli = redistribute_connected_cli ~ " route-map " ~ process_id.redistribute.connected.route_map %}
+{%         if redistribute_route.route_map is arista.avd.defined %}
+{%           set redistribute_cli = redistribute_cli + " route-map " ~ redistribute_route.route_map %}
 {%         endif %}
-   {{ redistribute_connected_cli }}
-{%     endif %}
-{%     if process_id.redistribute.bgp is defined %}
-{%         set redistribute_bgp_cli = "redistribute bgp" %}
-{%         if process_id.redistribute.bgp.route_map is arista.avd.defined %}
-{%             set redistribute_bgp_cli = redistribute_bgp_cli ~ " route-map " ~ process_id.redistribute.bgp.route_map %}
-{%         endif %}
-   {{ redistribute_bgp_cli }}
-{%     endif %}
+   {{ redistribute_cli }}
+{%     endfor %}
 {%     if process_id.auto_cost_reference_bandwidth is arista.avd.defined %}
    auto-cost reference-bandwidth {{ process_id.auto_cost_reference_bandwidth }}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-ospf.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-ospf.j2
@@ -118,10 +118,10 @@ router ospf {{ process_id.id }}
 {%     for redistribute_route in process_id.redistribute | arista.avd.convert_dicts('source_protocol') | arista.avd.natural_sort('source_protocol') %}
 {%         set redistribute_cli = "redistribute " ~ redistribute_route.source_protocol %}
 {%         if redistribute_route.include_leaked is arista.avd.defined(true) %}
-{%           set redistribute_cli = redistribute_cli + " include leaked" %}
+{%             set redistribute_cli = redistribute_cli + " include leaked" %}
 {%         endif %}
 {%         if redistribute_route.route_map is arista.avd.defined %}
-{%           set redistribute_cli = redistribute_cli + " route-map " ~ redistribute_route.route_map %}
+{%             set redistribute_cli = redistribute_cli + " route-map " ~ redistribute_route.route_map %}
 {%         endif %}
    {{ redistribute_cli }}
 {%     endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-ospf.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-ospf.j2
@@ -118,7 +118,7 @@ router ospf {{ process_id.id }}
 {%     for redistribute_route in process_id.redistribute | arista.avd.convert_dicts('source_protocol') | arista.avd.natural_sort('source_protocol') %}
 {%         set redistribute_cli = "redistribute " ~ redistribute_route.source_protocol %}
 {%         if redistribute_route.include_leaked is arista.avd.defined(true) %}
-{%             set redistribute_cli = redistribute_cli + " include leaked" %}
+{%             set redistribute_cli = redistribute_cli ~ " include leaked" %}
 {%         endif %}
 {%         if redistribute_route.route_map is arista.avd.defined %}
 {%             set redistribute_cli = redistribute_cli + " route-map " ~ redistribute_route.route_map %}


### PR DESCRIPTION
## Change Summary

- Improve `router_ospf > process_id > redistribute` knob to be able to accept any supported source protocol. 
- Add knob to support `include leaked` routes in `router_ospf > process_id > redistribute`

## Related Issue(s)

Fixes #1766 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Current model today: 

```yaml
      redistribute:
        static:
          route_map: < route_map_name >
        connected:
          route_map: < route_map_name >
        bgp:
          route_map: < route_map_name >
```

Proposed model: 

```yaml
      redistribute:
        < route_type >:
          include_leaked: < true | false >
          route_map: < route_map_name >
        < route_type >:
          route_map: < route_map_name >
```

AVD 4.0 model:

```yaml
      redistribute:
        - source_protocol: < route_type >
          include_leaked: < true | false >
          route_map: < route_map_name >
        - source_protocol: < route_type >
          include_leaked: < true | false >
          route_map: < route_map_name >
```


## How to test

Molecule

## Checklist

### User Checklist

- N/A

### Repository Checklist

- [X] My code has been rebased from devel before I start
- [X] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [X] My change requires a change to the documentation and documentation have been updated accordingly.
- [X] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
