### PR TITLE
Fix(plugins): convert_dicts resolve corner case with dictionary with invalid value

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL1A.md
@@ -13,6 +13,7 @@
 - [Monitoring](#monitoring)
   - [TerminAttr Daemon](#terminattr-daemon)
   - [SNMP](#snmp)
+  - [SFlow](#sflow)
 - [Hardware TCAM Profile](#hardware-tcam-profile)
   - [Hardware TCAM configuration](#hardware-tcam-configuration)
 - [Spanning Tree](#spanning-tree)
@@ -193,6 +194,27 @@ daemon TerminAttr
 !
 snmp-server contact example@example.com
 snmp-server location EOS_DESIGNS_UNIT_TESTS DC1-BL1A
+```
+
+## SFlow
+
+### SFlow Summary
+
+| VRF | SFlow Source Interface | SFlow Destination | Port |
+| --- | ---------------------- | ----------------- | ---- |
+| OOB | - | 10.0.200.90 | 6343 |
+| OOB | - | 192.168.200.10 | 6343 |
+| OOB | Management1 | - | - |
+
+sFlow is disabled.
+
+### SFlow Device Configuration
+
+```eos
+!
+sflow vrf OOB destination 10.0.200.90
+sflow vrf OOB destination 192.168.200.10
+sflow vrf OOB source-interface Management1
 ```
 
 # Hardware TCAM Profile

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL1B.md
@@ -13,6 +13,7 @@
 - [Monitoring](#monitoring)
   - [TerminAttr Daemon](#terminattr-daemon)
   - [SNMP](#snmp)
+  - [SFlow](#sflow)
 - [Hardware TCAM Profile](#hardware-tcam-profile)
   - [Hardware TCAM configuration](#hardware-tcam-configuration)
 - [Spanning Tree](#spanning-tree)
@@ -191,6 +192,27 @@ daemon TerminAttr
 !
 snmp-server contact example@example.com
 snmp-server location EOS_DESIGNS_UNIT_TESTS DC1-BL1B
+```
+
+## SFlow
+
+### SFlow Summary
+
+| VRF | SFlow Source Interface | SFlow Destination | Port |
+| --- | ---------------------- | ----------------- | ---- |
+| OOB | - | 10.0.200.90 | 6343 |
+| OOB | - | 192.168.200.10 | 6343 |
+| OOB | Management1 | - | - |
+
+sFlow is disabled.
+
+### SFlow Device Configuration
+
+```eos
+!
+sflow vrf OOB destination 10.0.200.90
+sflow vrf OOB destination 192.168.200.10
+sflow vrf OOB source-interface Management1
 ```
 
 # Hardware TCAM Profile

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1A.cfg
@@ -17,6 +17,10 @@ ip name-server vrf MGMT 1.1.1.1
 ip name-server vrf MGMT 8.8.8.8
 ip name-server vrf MGMT 192.168.200.5
 !
+sflow vrf OOB destination 10.0.200.90
+sflow vrf OOB destination 192.168.200.10
+sflow vrf OOB source-interface Management1
+!
 snmp-server contact example@example.com
 snmp-server location EOS_DESIGNS_UNIT_TESTS DC1-BL1A
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1B.cfg
@@ -16,6 +16,10 @@ hostname DC1-BL1B
 ip name-server vrf MGMT 8.8.8.8
 ip name-server vrf MGMT 192.168.200.5
 !
+sflow vrf OOB destination 10.0.200.90
+sflow vrf OOB destination 192.168.200.10
+sflow vrf OOB source-interface Management1
+!
 snmp-server contact example@example.com
 snmp-server location EOS_DESIGNS_UNIT_TESTS DC1-BL1B
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
@@ -354,6 +354,14 @@ management_api_http:
     MGMT: {}
   enable_https: true
   default_services: false
+struct_cfg:
+  sflow:
+    vrfs:
+      OOB:
+        destinations:
+          192.168.200.10: None
+          10.0.200.90: None
+        source_interface: Management1
 ethernet_interfaces:
   Ethernet1:
     peer: DC1-SPINE1
@@ -559,4 +567,11 @@ vxlan_interface:
           vni: 21
         Tenant_C_WAN_Zone:
           vni: 31
+sflow:
+  vrfs:
+    OOB:
+      destinations:
+        192.168.200.10: None
+        10.0.200.90: None
+      source_interface: Management1
 ntp: null

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1B.yml
@@ -353,6 +353,14 @@ management_api_http:
     MGMT: {}
   enable_https: true
   default_services: false
+struct_cfg:
+  sflow:
+    vrfs:
+      OOB:
+        destinations:
+          192.168.200.10: None
+          10.0.200.90: None
+        source_interface: Management1
 ethernet_interfaces:
   Ethernet1:
     peer: DC1-SPINE1
@@ -546,4 +554,11 @@ vxlan_interface:
           vni: 21
         Tenant_C_WAN_Zone:
           vni: 31
+sflow:
+  vrfs:
+    OOB:
+      destinations:
+        192.168.200.10: None
+        10.0.200.90: None
+      source_interface: Management1
 ntp: null

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_FABRIC.yml
@@ -129,6 +129,15 @@ l3leaf:
         tenants: [ all ]
         tags: [ wan ]
         always_include_vrfs_in_tenants: [ 'Tenant_B' ]
+# Test cornercase in convert_dicts with keys that have no value
+      structured_config:
+        sflow:
+          vrfs:
+            OOB:
+              destinations:
+                192.168.200.10:
+                10.0.200.90:
+              source_interface: Management1
       nodes:
         DC1-BL1A:
           id: 6

--- a/ansible_collections/arista/avd/plugins/filter/convert_dicts.py
+++ b/ansible_collections/arista/avd/plugins/filter/convert_dicts.py
@@ -69,10 +69,7 @@ def convert_dicts(dictionary, primary_key="name", secondary_key=None):
     else:
         output = []
         for key in dictionary:
-            if dictionary[key] is None:
-                # Catch cornercase where dictionary has no value because of old data models
-                output.append({primary_key: key})
-            elif not isinstance(dictionary[key], dict):
+            if not isinstance(dictionary[key], dict):
                 # Not a nested dictionary, add secondary key for the values if secondary key is provided
                 if secondary_key is not None:
                     item = {}
@@ -80,7 +77,9 @@ def convert_dicts(dictionary, primary_key="name", secondary_key=None):
                     item.update({secondary_key: dictionary[key]})
                     output.append(item)
                 else:
-                    return dictionary
+                    # Catch cornercase where dictionary value is not a dict because of old data models
+                    # Ex <key>: "none" or <key>: null or <key>: "" will all be overwritten with {<primary_key>: <key>}
+                    output.append({primary_key: key})
             else:
                 item = dictionary[key].copy()
                 item.update({primary_key: key})

--- a/ansible_collections/arista/avd/tests/unit/filters/test_convert_dicts.py
+++ b/ansible_collections/arista/avd/tests/unit/filters/test_convert_dicts.py
@@ -39,15 +39,13 @@ class TestConvertDicts():
 
     def test_convert_dicts_with_listofdict_default(self):
         resp = convert_dicts(nested_list_of_dict)
-        assert resp == {'TEST1': [{'type': 'permit', 'extcommunities': '65000:65000'},
-                                  {'type': 'deny', 'extcommunities': '65002:65002'}],
-                        'TEST2': [{'type': 'deny', 'extcommunities': '65001:65001'}]}
+        assert resp == [{'name': 'TEST1'},
+                        {'name': 'TEST2'}]
 
     def test_convert_dicts_with_listofdict_primary_key(self):
         resp = convert_dicts(nested_list_of_dict, 'test')
-        assert resp == {'TEST1': [{'type': 'permit', 'extcommunities': '65000:65000'},
-                                  {'type': 'deny', 'extcommunities': '65002:65002'}],
-                        'TEST2': [{'type': 'deny', 'extcommunities': '65001:65001'}]}
+        assert resp == [{'test': 'TEST1'},
+                        {'test': 'TEST2'}]
 
     def test_convert_dicts_with_listofdict_secondary_key(self):
         resp = convert_dicts(nested_list_of_dict, secondary_key='types')
@@ -79,11 +77,11 @@ class TestConvertDicts():
 
     def test_convert_dicts_with_string_value_default(self):
         resp = convert_dicts(dict_with_string)
-        assert resp == dict_with_string
+        assert resp == [{'name': 'dict'}]
 
     def test_convert_dicts_with_string_value_primary_key(self):
         resp = convert_dicts(dict_with_string, 'test')
-        assert resp == dict_with_string
+        assert resp == [{'test': 'dict'}]
 
     def test_convert_dicts_with_string_value_secondary_key(self):
         resp = convert_dicts(dict_with_string, secondary_key='str')


### PR DESCRIPTION
## Change Summary

Fix logic in `convert_dicts` plugin to handle corner cases resolve corner case with dictionary with invalid value

## Component(s) name

`arista.avd.convert_dicts`

## How to test

See new molecule test case, triggering issue in eos_designs_unit_tests:

```yaml
# Test corner case in convert_dicts with keys that have no value
l3leaf:
  node_groups:
    DC1_BL1:
      structured_config:
        sflow:
          vrfs:
            OOB:
              destinations:
                192.168.200.10:
                10.0.200.90:
              source_interface: Management1
```
New Molecule output expected!


## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
