### PR TITLE
Fix(eos_designs): Fix IPv6 static routes tenants

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2A.md
@@ -998,6 +998,7 @@ ip routing vrf Tenant_D_WAN_Zone
 | --- | ------------------ | ----------------------- | ------------------- | ----------------------------- | ----------------- | ----------------------------- | -------------- |
 | MGMT | 0.0.0.0/0 | 192.168.200.5 | - | 1 | - | - | - |
 | Tenant_D_OP_Zone | 0.0.0.0/0 | 10.3.11.4 | - | 1 | - | - | - |
+| Tenant_D_OP_Zone | 10.3.11.0/24 | - | Vlan411 | 1 | - | VARP | - |
 
 ### Static Routes Device Configuration
 
@@ -1005,6 +1006,7 @@ ip routing vrf Tenant_D_WAN_Zone
 !
 ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 ip route vrf Tenant_D_OP_Zone 0.0.0.0/0 10.3.11.4
+ip route vrf Tenant_D_OP_Zone 10.3.11.0/24 Vlan411 name VARP
 ```
 
 ## IPv6 Static Routes
@@ -1014,14 +1016,14 @@ ip route vrf Tenant_D_OP_Zone 0.0.0.0/0 10.3.11.4
 | VRF | Destination Prefix | Next Hop IP             | Exit interface      | Administrative Distance       | Tag               | Route Name                    | Metric         |
 | --- | ------------------ | ----------------------- | ------------------- | ----------------------------- | ----------------- | ----------------------------- | -------------- |
 | Tenant_D_OP_Zone | ::/0 | 2001:db8:311::4 | - | 1 | - | IPv6-test-2 | - |
-| Tenant_D_OP_Zone | 10.3.11.0/24 | - | Vlan411 | 1 | - | VARP | - |
+| Tenant_D_OP_Zone | 2001:db8:311::/64 | - | Vlan411 | 1 | - | VARPv6 | - |
 
 ### Static Routes Device Configuration
 
 ```eos
 !
 ipv6 route vrf Tenant_D_OP_Zone ::/0 2001:db8:311::4 name IPv6-test-2
-ipv6 route vrf Tenant_D_OP_Zone 10.3.11.0/24 Vlan411 name VARP
+ipv6 route vrf Tenant_D_OP_Zone 2001:db8:311::/64 Vlan411 name VARPv6
 ```
 
 ## Router BGP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2A.md
@@ -37,6 +37,7 @@
   - [IP Routing](#ip-routing)
   - [IPv6 Routing](#ipv6-routing)
   - [Static Routes](#static-routes)
+  - [IPv6 Static Routes](#ipv6-static-routes)
   - [Router BGP](#router-bgp)
 - [BFD](#bfd)
   - [Router BFD](#router-bfd)
@@ -997,8 +998,6 @@ ip routing vrf Tenant_D_WAN_Zone
 | --- | ------------------ | ----------------------- | ------------------- | ----------------------------- | ----------------- | ----------------------------- | -------------- |
 | MGMT | 0.0.0.0/0 | 192.168.200.5 | - | 1 | - | - | - |
 | Tenant_D_OP_Zone | 0.0.0.0/0 | 10.3.11.4 | - | 1 | - | - | - |
-| Tenant_D_OP_Zone | ::/0 | 2001:db8:311::4 | - | 1 | - | IPv6-test-2 | - |
-| Tenant_D_OP_Zone | 10.3.11.0/24 | - | Vlan411 | 1 | - | VARP | - |
 
 ### Static Routes Device Configuration
 
@@ -1006,8 +1005,23 @@ ip routing vrf Tenant_D_WAN_Zone
 !
 ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 ip route vrf Tenant_D_OP_Zone 0.0.0.0/0 10.3.11.4
-ip route vrf Tenant_D_OP_Zone ::/0 2001:db8:311::4 name IPv6-test-2
-ip route vrf Tenant_D_OP_Zone 10.3.11.0/24 Vlan411 name VARP
+```
+
+## IPv6 Static Routes
+
+### IPv6 Static Routes Summary
+
+| VRF | Destination Prefix | Next Hop IP             | Exit interface      | Administrative Distance       | Tag               | Route Name                    | Metric         |
+| --- | ------------------ | ----------------------- | ------------------- | ----------------------------- | ----------------- | ----------------------------- | -------------- |
+| Tenant_D_OP_Zone | ::/0 | 2001:db8:311::4 | - | 1 | - | IPv6-test-2 | - |
+| Tenant_D_OP_Zone | 10.3.11.0/24 | - | Vlan411 | 1 | - | VARP | - |
+
+### Static Routes Device Configuration
+
+```eos
+!
+ipv6 route vrf Tenant_D_OP_Zone ::/0 2001:db8:311::4 name IPv6-test-2
+ipv6 route vrf Tenant_D_OP_Zone 10.3.11.0/24 Vlan411 name VARP
 ```
 
 ## Router BGP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2B.md
@@ -998,6 +998,7 @@ ip routing vrf Tenant_D_WAN_Zone
 | --- | ------------------ | ----------------------- | ------------------- | ----------------------------- | ----------------- | ----------------------------- | -------------- |
 | MGMT | 0.0.0.0/0 | 192.168.200.5 | - | 1 | - | - | - |
 | Tenant_D_OP_Zone | 0.0.0.0/0 | 10.3.11.4 | - | 1 | - | - | - |
+| Tenant_D_OP_Zone | 10.3.11.0/24 | - | Vlan411 | 1 | - | VARP | - |
 
 ### Static Routes Device Configuration
 
@@ -1005,6 +1006,7 @@ ip routing vrf Tenant_D_WAN_Zone
 !
 ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 ip route vrf Tenant_D_OP_Zone 0.0.0.0/0 10.3.11.4
+ip route vrf Tenant_D_OP_Zone 10.3.11.0/24 Vlan411 name VARP
 ```
 
 ## IPv6 Static Routes
@@ -1014,14 +1016,14 @@ ip route vrf Tenant_D_OP_Zone 0.0.0.0/0 10.3.11.4
 | VRF | Destination Prefix | Next Hop IP             | Exit interface      | Administrative Distance       | Tag               | Route Name                    | Metric         |
 | --- | ------------------ | ----------------------- | ------------------- | ----------------------------- | ----------------- | ----------------------------- | -------------- |
 | Tenant_D_OP_Zone | ::/0 | 2001:db8:311::4 | - | 1 | - | IPv6-test-2 | - |
-| Tenant_D_OP_Zone | 10.3.11.0/24 | - | Vlan411 | 1 | - | VARP | - |
+| Tenant_D_OP_Zone | 2001:db8:311::/64 | - | Vlan411 | 1 | - | VARPv6 | - |
 
 ### Static Routes Device Configuration
 
 ```eos
 !
 ipv6 route vrf Tenant_D_OP_Zone ::/0 2001:db8:311::4 name IPv6-test-2
-ipv6 route vrf Tenant_D_OP_Zone 10.3.11.0/24 Vlan411 name VARP
+ipv6 route vrf Tenant_D_OP_Zone 2001:db8:311::/64 Vlan411 name VARPv6
 ```
 
 ## Router BGP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2B.md
@@ -37,6 +37,7 @@
   - [IP Routing](#ip-routing)
   - [IPv6 Routing](#ipv6-routing)
   - [Static Routes](#static-routes)
+  - [IPv6 Static Routes](#ipv6-static-routes)
   - [Router BGP](#router-bgp)
 - [BFD](#bfd)
   - [Router BFD](#router-bfd)
@@ -997,8 +998,6 @@ ip routing vrf Tenant_D_WAN_Zone
 | --- | ------------------ | ----------------------- | ------------------- | ----------------------------- | ----------------- | ----------------------------- | -------------- |
 | MGMT | 0.0.0.0/0 | 192.168.200.5 | - | 1 | - | - | - |
 | Tenant_D_OP_Zone | 0.0.0.0/0 | 10.3.11.4 | - | 1 | - | - | - |
-| Tenant_D_OP_Zone | ::/0 | 2001:db8:311::4 | - | 1 | - | IPv6-test-2 | - |
-| Tenant_D_OP_Zone | 10.3.11.0/24 | - | Vlan411 | 1 | - | VARP | - |
 
 ### Static Routes Device Configuration
 
@@ -1006,8 +1005,23 @@ ip routing vrf Tenant_D_WAN_Zone
 !
 ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 ip route vrf Tenant_D_OP_Zone 0.0.0.0/0 10.3.11.4
-ip route vrf Tenant_D_OP_Zone ::/0 2001:db8:311::4 name IPv6-test-2
-ip route vrf Tenant_D_OP_Zone 10.3.11.0/24 Vlan411 name VARP
+```
+
+## IPv6 Static Routes
+
+### IPv6 Static Routes Summary
+
+| VRF | Destination Prefix | Next Hop IP             | Exit interface      | Administrative Distance       | Tag               | Route Name                    | Metric         |
+| --- | ------------------ | ----------------------- | ------------------- | ----------------------------- | ----------------- | ----------------------------- | -------------- |
+| Tenant_D_OP_Zone | ::/0 | 2001:db8:311::4 | - | 1 | - | IPv6-test-2 | - |
+| Tenant_D_OP_Zone | 10.3.11.0/24 | - | Vlan411 | 1 | - | VARP | - |
+
+### Static Routes Device Configuration
+
+```eos
+!
+ipv6 route vrf Tenant_D_OP_Zone ::/0 2001:db8:311::4 name IPv6-test-2
+ipv6 route vrf Tenant_D_OP_Zone 10.3.11.0/24 Vlan411 name VARP
 ```
 
 ## Router BGP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/evpn_services_l2_only_false.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/evpn_services_l2_only_false.md
@@ -29,6 +29,7 @@
   - [IP Routing](#ip-routing)
   - [IPv6 Routing](#ipv6-routing)
   - [Static Routes](#static-routes)
+  - [IPv6 Static Routes](#ipv6-static-routes)
   - [Router BGP](#router-bgp)
 - [BFD](#bfd)
   - [Router BFD](#router-bfd)
@@ -795,7 +796,6 @@ ip routing vrf Tenant_D_WAN_Zone
 | MGMT | 0.0.0.0/0 | 192.168.200.5 | - | 1 | - | - | - |
 | Tenant_A_APP_Zone | 10.2.32.0/24 | - | Vlan132 | 1 | - | VARP | - |
 | Tenant_A_APP_Zone | 10.3.32.0/24 | - | Vlan132 | 1 | - | VARP | - |
-| Tenant_D_OP_Zone | 10.3.11.0/24 | - | Vlan411 | 1 | - | VARP | - |
 
 ### Static Routes Device Configuration
 
@@ -804,7 +804,21 @@ ip routing vrf Tenant_D_WAN_Zone
 ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 ip route vrf Tenant_A_APP_Zone 10.2.32.0/24 Vlan132 name VARP
 ip route vrf Tenant_A_APP_Zone 10.3.32.0/24 Vlan132 name VARP
-ip route vrf Tenant_D_OP_Zone 10.3.11.0/24 Vlan411 name VARP
+```
+
+## IPv6 Static Routes
+
+### IPv6 Static Routes Summary
+
+| VRF | Destination Prefix | Next Hop IP             | Exit interface      | Administrative Distance       | Tag               | Route Name                    | Metric         |
+| --- | ------------------ | ----------------------- | ------------------- | ----------------------------- | ----------------- | ----------------------------- | -------------- |
+| Tenant_D_OP_Zone | 10.3.11.0/24 | - | Vlan411 | 1 | - | VARP | - |
+
+### Static Routes Device Configuration
+
+```eos
+!
+ipv6 route vrf Tenant_D_OP_Zone 10.3.11.0/24 Vlan411 name VARP
 ```
 
 ## Router BGP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/evpn_services_l2_only_false.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/evpn_services_l2_only_false.md
@@ -796,6 +796,7 @@ ip routing vrf Tenant_D_WAN_Zone
 | MGMT | 0.0.0.0/0 | 192.168.200.5 | - | 1 | - | - | - |
 | Tenant_A_APP_Zone | 10.2.32.0/24 | - | Vlan132 | 1 | - | VARP | - |
 | Tenant_A_APP_Zone | 10.3.32.0/24 | - | Vlan132 | 1 | - | VARP | - |
+| Tenant_D_OP_Zone | 10.3.11.0/24 | - | Vlan411 | 1 | - | VARP | - |
 
 ### Static Routes Device Configuration
 
@@ -804,6 +805,7 @@ ip routing vrf Tenant_D_WAN_Zone
 ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 ip route vrf Tenant_A_APP_Zone 10.2.32.0/24 Vlan132 name VARP
 ip route vrf Tenant_A_APP_Zone 10.3.32.0/24 Vlan132 name VARP
+ip route vrf Tenant_D_OP_Zone 10.3.11.0/24 Vlan411 name VARP
 ```
 
 ## IPv6 Static Routes
@@ -812,13 +814,13 @@ ip route vrf Tenant_A_APP_Zone 10.3.32.0/24 Vlan132 name VARP
 
 | VRF | Destination Prefix | Next Hop IP             | Exit interface      | Administrative Distance       | Tag               | Route Name                    | Metric         |
 | --- | ------------------ | ----------------------- | ------------------- | ----------------------------- | ----------------- | ----------------------------- | -------------- |
-| Tenant_D_OP_Zone | 10.3.11.0/24 | - | Vlan411 | 1 | - | VARP | - |
+| Tenant_D_OP_Zone | 2001:db8:311::/64 | - | Vlan411 | 1 | - | VARPv6 | - |
 
 ### Static Routes Device Configuration
 
 ```eos
 !
-ipv6 route vrf Tenant_D_OP_Zone 10.3.11.0/24 Vlan411 name VARP
+ipv6 route vrf Tenant_D_OP_Zone 2001:db8:311::/64 Vlan411 name VARPv6
 ```
 
 ## Router BGP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
@@ -501,9 +501,10 @@ ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
 !
 ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 ip route vrf Tenant_D_OP_Zone 0.0.0.0/0 10.3.11.4
+ip route vrf Tenant_D_OP_Zone 10.3.11.0/24 Vlan411 name VARP
 !
 ipv6 route vrf Tenant_D_OP_Zone ::/0 2001:db8:311::4 name IPv6-test-2
-ipv6 route vrf Tenant_D_OP_Zone 10.3.11.0/24 Vlan411 name VARP
+ipv6 route vrf Tenant_D_OP_Zone 2001:db8:311::/64 Vlan411 name VARPv6
 !
 route-map RM-CONN-2-BGP permit 10
    match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
@@ -501,8 +501,9 @@ ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
 !
 ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 ip route vrf Tenant_D_OP_Zone 0.0.0.0/0 10.3.11.4
-ip route vrf Tenant_D_OP_Zone ::/0 2001:db8:311::4 name IPv6-test-2
-ip route vrf Tenant_D_OP_Zone 10.3.11.0/24 Vlan411 name VARP
+!
+ipv6 route vrf Tenant_D_OP_Zone ::/0 2001:db8:311::4 name IPv6-test-2
+ipv6 route vrf Tenant_D_OP_Zone 10.3.11.0/24 Vlan411 name VARP
 !
 route-map RM-CONN-2-BGP permit 10
    match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
@@ -501,9 +501,10 @@ ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
 !
 ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 ip route vrf Tenant_D_OP_Zone 0.0.0.0/0 10.3.11.4
+ip route vrf Tenant_D_OP_Zone 10.3.11.0/24 Vlan411 name VARP
 !
 ipv6 route vrf Tenant_D_OP_Zone ::/0 2001:db8:311::4 name IPv6-test-2
-ipv6 route vrf Tenant_D_OP_Zone 10.3.11.0/24 Vlan411 name VARP
+ipv6 route vrf Tenant_D_OP_Zone 2001:db8:311::/64 Vlan411 name VARPv6
 !
 route-map RM-CONN-2-BGP permit 10
    match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
@@ -501,8 +501,9 @@ ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
 !
 ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 ip route vrf Tenant_D_OP_Zone 0.0.0.0/0 10.3.11.4
-ip route vrf Tenant_D_OP_Zone ::/0 2001:db8:311::4 name IPv6-test-2
-ip route vrf Tenant_D_OP_Zone 10.3.11.0/24 Vlan411 name VARP
+!
+ipv6 route vrf Tenant_D_OP_Zone ::/0 2001:db8:311::4 name IPv6-test-2
+ipv6 route vrf Tenant_D_OP_Zone 10.3.11.0/24 Vlan411 name VARP
 !
 route-map RM-CONN-2-BGP permit 10
    match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_false.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_false.cfg
@@ -386,7 +386,8 @@ ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
 ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 ip route vrf Tenant_A_APP_Zone 10.2.32.0/24 Vlan132 name VARP
 ip route vrf Tenant_A_APP_Zone 10.3.32.0/24 Vlan132 name VARP
-ip route vrf Tenant_D_OP_Zone 10.3.11.0/24 Vlan411 name VARP
+!
+ipv6 route vrf Tenant_D_OP_Zone 10.3.11.0/24 Vlan411 name VARP
 !
 route-map RM-CONN-2-BGP permit 10
    match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_false.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_false.cfg
@@ -386,8 +386,9 @@ ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
 ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 ip route vrf Tenant_A_APP_Zone 10.2.32.0/24 Vlan132 name VARP
 ip route vrf Tenant_A_APP_Zone 10.3.32.0/24 Vlan132 name VARP
+ip route vrf Tenant_D_OP_Zone 10.3.11.0/24 Vlan411 name VARP
 !
-ipv6 route vrf Tenant_D_OP_Zone 10.3.11.0/24 Vlan411 name VARP
+ipv6 route vrf Tenant_D_OP_Zone 2001:db8:311::/64 Vlan411 name VARPv6
 !
 route-map RM-CONN-2-BGP permit 10
    match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
@@ -258,6 +258,10 @@ static_routes:
 - destination_address_prefix: 0.0.0.0/0
   vrf: Tenant_D_OP_Zone
   gateway: 10.3.11.4
+- destination_address_prefix: 10.3.11.0/24
+  vrf: Tenant_D_OP_Zone
+  name: VARP
+  interface: Vlan411
 service_routing_protocols_model: multi-agent
 ip_routing: true
 hardware:
@@ -885,9 +889,9 @@ ipv6_static_routes:
   vrf: Tenant_D_OP_Zone
   gateway: 2001:db8:311::4
   name: IPv6-test-2
-- destination_address_prefix: 10.3.11.0/24
+- destination_address_prefix: 2001:db8:311::/64
   vrf: Tenant_D_OP_Zone
-  name: VARP
+  name: VARPv6
   interface: Vlan411
 vxlan_interface:
   Vxlan1:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
@@ -258,14 +258,6 @@ static_routes:
 - destination_address_prefix: 0.0.0.0/0
   vrf: Tenant_D_OP_Zone
   gateway: 10.3.11.4
-- destination_address_prefix: ::/0
-  vrf: Tenant_D_OP_Zone
-  gateway: 2001:db8:311::4
-  name: IPv6-test-2
-- destination_address_prefix: 10.3.11.0/24
-  vrf: Tenant_D_OP_Zone
-  name: VARP
-  interface: Vlan411
 service_routing_protocols_model: multi-agent
 ip_routing: true
 hardware:
@@ -888,6 +880,15 @@ vlan_interfaces:
     ip_address_virtual: 10.4.12.254/24
     ipv6_address_virtual: 2001:db8:412::1/64
     mtu: 1560
+ipv6_static_routes:
+- destination_address_prefix: ::/0
+  vrf: Tenant_D_OP_Zone
+  gateway: 2001:db8:311::4
+  name: IPv6-test-2
+- destination_address_prefix: 10.3.11.0/24
+  vrf: Tenant_D_OP_Zone
+  name: VARP
+  interface: Vlan411
 vxlan_interface:
   Vxlan1:
     description: DC1-LEAF2A_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
@@ -258,6 +258,10 @@ static_routes:
 - destination_address_prefix: 0.0.0.0/0
   vrf: Tenant_D_OP_Zone
   gateway: 10.3.11.4
+- destination_address_prefix: 10.3.11.0/24
+  vrf: Tenant_D_OP_Zone
+  name: VARP
+  interface: Vlan411
 service_routing_protocols_model: multi-agent
 ip_routing: true
 hardware:
@@ -885,9 +889,9 @@ ipv6_static_routes:
   vrf: Tenant_D_OP_Zone
   gateway: 2001:db8:311::4
   name: IPv6-test-2
-- destination_address_prefix: 10.3.11.0/24
+- destination_address_prefix: 2001:db8:311::/64
   vrf: Tenant_D_OP_Zone
-  name: VARP
+  name: VARPv6
   interface: Vlan411
 vxlan_interface:
   Vxlan1:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
@@ -258,14 +258,6 @@ static_routes:
 - destination_address_prefix: 0.0.0.0/0
   vrf: Tenant_D_OP_Zone
   gateway: 10.3.11.4
-- destination_address_prefix: ::/0
-  vrf: Tenant_D_OP_Zone
-  gateway: 2001:db8:311::4
-  name: IPv6-test-2
-- destination_address_prefix: 10.3.11.0/24
-  vrf: Tenant_D_OP_Zone
-  name: VARP
-  interface: Vlan411
 service_routing_protocols_model: multi-agent
 ip_routing: true
 hardware:
@@ -888,6 +880,15 @@ vlan_interfaces:
     ip_address_virtual: 10.4.12.254/24
     ipv6_address_virtual: 2001:db8:412::1/64
     mtu: 1560
+ipv6_static_routes:
+- destination_address_prefix: ::/0
+  vrf: Tenant_D_OP_Zone
+  gateway: 2001:db8:311::4
+  name: IPv6-test-2
+- destination_address_prefix: 10.3.11.0/24
+  vrf: Tenant_D_OP_Zone
+  name: VARP
+  interface: Vlan411
 vxlan_interface:
   Vxlan1:
     description: DC1-LEAF2B_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_false.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_false.yml
@@ -298,6 +298,10 @@ static_routes:
   vrf: Tenant_A_APP_Zone
   name: VARP
   interface: Vlan132
+- destination_address_prefix: 10.3.11.0/24
+  vrf: Tenant_D_OP_Zone
+  name: VARP
+  interface: Vlan411
 service_routing_protocols_model: multi-agent
 ip_routing: true
 daemon_terminattr:
@@ -731,9 +735,9 @@ vlan_interfaces:
     ipv6_address_virtual: 2001:db8:412::1/64
     mtu: 1560
 ipv6_static_routes:
-- destination_address_prefix: 10.3.11.0/24
+- destination_address_prefix: 2001:db8:311::/64
   vrf: Tenant_D_OP_Zone
-  name: VARP
+  name: VARPv6
   interface: Vlan411
 vxlan_interface:
   Vxlan1:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_false.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_false.yml
@@ -298,10 +298,6 @@ static_routes:
   vrf: Tenant_A_APP_Zone
   name: VARP
   interface: Vlan132
-- destination_address_prefix: 10.3.11.0/24
-  vrf: Tenant_D_OP_Zone
-  name: VARP
-  interface: Vlan411
 service_routing_protocols_model: multi-agent
 ip_routing: true
 daemon_terminattr:
@@ -734,6 +730,11 @@ vlan_interfaces:
     ip_address_virtual: 10.4.12.254/24
     ipv6_address_virtual: 2001:db8:412::1/64
     mtu: 1560
+ipv6_static_routes:
+- destination_address_prefix: 10.3.11.0/24
+  vrf: Tenant_D_OP_Zone
+  name: VARP
+  interface: Vlan411
 vxlan_interface:
   Vxlan1:
     description: evpn_services_l2_only_false_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS.yml
@@ -324,7 +324,6 @@ tenants:
             enabled: True
             ip_address_virtual: 10.3.50.1/24
   Tenant_D:
-    ipv6_routing: true
     mac_vrf_vni_base: 40000
     vrfs:
       Tenant_D_OP_Zone:

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/static-routes.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/static-routes.j2
@@ -28,6 +28,7 @@ static_routes:
 {%             endfor %}
 {%         endif %}
 {%         if vrf.ipv6_static_routes is arista.avd.defined %}
+ipv6_static_routes:
 {%             for ipv6_static_route in vrf.ipv6_static_routes %}
 {%                 if inventory_hostname in ipv6_static_route.nodes | arista.avd.default([inventory_hostname]) %}
   - destination_address_prefix: {{ ipv6_static_route.destination_address_prefix }}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/static-routes.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/static-routes.j2
@@ -1,3 +1,53 @@
+ipv6_static_routes:
+{% for tenant in network_services_data.tenants %}
+{%     for vrf in tenant.vrfs %}
+{%         if vrf.ipv6_static_routes is arista.avd.defined %}
+{%             for ipv6_static_route in vrf.ipv6_static_routes %}
+{%                 if inventory_hostname in ipv6_static_route.nodes | arista.avd.default([inventory_hostname]) %}
+  - destination_address_prefix: {{ ipv6_static_route.destination_address_prefix }}
+    vrf: {{ vrf.name }}
+{%                     if ipv6_static_route.gateway is arista.avd.defined %}
+    gateway: {{ ipv6_static_route.gateway }}
+{%                     endif %}
+{%                     if ipv6_static_route.distance is arista.avd.defined %}
+    distance: {{ ipv6_static_route.distance }}
+{%                     endif %}
+{%                     if ipv6_static_route.tag is arista.avd.defined %}
+    tag: {{ ipv6_static_route.tag }}
+{%                     endif %}
+{%                     if ipv6_static_route.name is arista.avd.defined %}
+    name: {{ ipv6_static_route.name }}
+{%                     endif %}
+{%                     if ipv6_static_route.metric is arista.avd.defined %}
+    metric: {{ ipv6_static_route.metric }}
+{%                     endif %}
+{%                     if ipv6_static_route.interface is arista.avd.defined %}
+    interface: {{ ipv6_static_route.interface }}
+{%                     endif %}
+{%                 endif %}
+{%             endfor %}
+{%         endif %}
+{%         for svi in vrf.svis %}
+{# Detect if a svi_profile exists #}
+{# If exists, create a shortpath to access profile data #}
+{%             if svi.profile is arista.avd.defined %}
+{%                 set svi_profile = svi_profiles[svi.profile] | arista.avd.default() %}
+{%             endif %}
+{%             set svi_varpv6 = svi.ipv6_virtual_router_addresses | arista.avd.default(
+                              svi_profile.ipv6_virtual_router_addresses) %}
+{%             if svi_varpv6 is arista.avd.defined %}
+{# Detect if VARP addresses with prefixes exist and loop through the ip_address/prefix #}
+{# If the VARP address with prefix doesn't exist then it will loop through empty_list [], so config is not generated in this scenario #}
+{%                 for dest_addr_prefix in svi_varpv6 | ansible.netcommon.ipaddr(0) | ansible.netcommon.ipaddr('net') %}
+  - destination_address_prefix: {{ dest_addr_prefix }}
+    vrf: {{ vrf.name }}
+    name: "VARPv6"
+    interface: Vlan{{ svi.id | int }}
+{%                 endfor %}
+{%             endif %}
+{%         endfor %}
+{%     endfor %}
+{% endfor %}
 static_routes:
 {% for tenant in network_services_data.tenants %}
 {%     for vrf in tenant.vrfs %}
@@ -23,33 +73,6 @@ static_routes:
 {%                     endif %}
 {%                     if static_route.interface is arista.avd.defined %}
     interface: {{ static_route.interface }}
-{%                     endif %}
-{%                 endif %}
-{%             endfor %}
-{%         endif %}
-{%         if vrf.ipv6_static_routes is arista.avd.defined %}
-ipv6_static_routes:
-{%             for ipv6_static_route in vrf.ipv6_static_routes %}
-{%                 if inventory_hostname in ipv6_static_route.nodes | arista.avd.default([inventory_hostname]) %}
-  - destination_address_prefix: {{ ipv6_static_route.destination_address_prefix }}
-    vrf: {{ vrf.name }}
-{%                     if ipv6_static_route.gateway is arista.avd.defined %}
-    gateway: {{ ipv6_static_route.gateway }}
-{%                     endif %}
-{%                     if ipv6_static_route.distance is arista.avd.defined %}
-    distance: {{ ipv6_static_route.distance }}
-{%                     endif %}
-{%                     if ipv6_static_route.tag is arista.avd.defined %}
-    tag: {{ ipv6_static_route.tag }}
-{%                     endif %}
-{%                     if ipv6_static_route.name is arista.avd.defined %}
-    name: {{ ipv6_static_route.name }}
-{%                     endif %}
-{%                     if ipv6_static_route.metric is arista.avd.defined %}
-    metric: {{ ipv6_static_route.metric }}
-{%                     endif %}
-{%                     if ipv6_static_route.interface is arista.avd.defined %}
-    interface: {{ ipv6_static_route.interface }}
 {%                     endif %}
 {%                 endif %}
 {%             endfor %}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->

Small typo noticed after the ipv6_tenants PR got pulled in. This fixes the ipv6 route command, as it was printing it as ip route.

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

```
{%         if vrf.ipv6_static_routes is arista.avd.defined %}
ipv6_static_routes:
{%             for ipv6_static_route in vrf.ipv6_static_routes %}
```

Fixes

```
ip route vrf Tenant_D_OP_Zone ::/0 2001:db8:311::4 name IPv6-test-2
ip route vrf Tenant_D_OP_Zone 10.3.11.0/24 Vlan411 name VARP
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Molecule `eos_designs_test_units` also tested on customer's repo.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
