### PR TITLE
Feat(eos_cli_config_gen): Add BGP listen-range to VRF

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
@@ -104,11 +104,11 @@ interface Management1
 
 ### Router BGP Listen Ranges
 
-| Prefix | Peer-ID Include Router ID | Peer Group | Peer-Filter | Remote-AS |
-| ------ | ------------------------- | ---------- | ----------- | --------- |
-| 10.10.10.0/24 | - | my-peer-group1 | my-peer-filter | - |
-| 12.10.10.0/24 | True | my-peer-group3 | - | 65444 |
-| 13.10.10.0/24 | - | my-peer-group4 | my-peer-filter | - |
+| Prefix | Peer-ID Include Router ID | Peer Group | Peer-Filter | Remote-AS | VRF |
+| ------ | ------------------------- | ---------- | ----------- | --------- | --- |
+| 10.10.10.0/24 | - | my-peer-group1 | my-peer-filter | - | default |
+| 12.10.10.0/24 | True | my-peer-group3 | - | 65444 | default |
+| 13.10.10.0/24 | - | my-peer-group4 | my-peer-filter | - | default |
 
 ### BGP Neighbors
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vrf-lite.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vrf-lite.md
@@ -162,6 +162,7 @@ ip route vrf BLUE-C1 193.1.2.0/24 Null0
 | 101.0.3.2 | Inherited from peer group SEDI | BLUE-C1 | True | - | - | - | - | - |
 | 101.0.3.3 | - | BLUE-C1 | Inherited from peer group SEDI-shut | - | - | - | - | - |
 | 10.1.1.0 | Inherited from peer group OBS_WAN | RED-C1 | - | - | - | - | - | - |
+| 10.1.1.0 | Inherited from peer group OBS_WAN | YELLOW-C1 | - | - | - | - | - | - |
 
 ### Router BGP VRFs
 
@@ -169,6 +170,7 @@ ip route vrf BLUE-C1 193.1.2.0/24 Null0
 | --- | ------------------- | ------------ |
 | BLUE-C1 | 1.0.1.1:101 | static |
 | RED-C1 | 1.0.1.1:102 | - |
+| YELLOW-C1 | 1.0.1.1:103 | - |
 
 ### Router BGP Device Configuration
 
@@ -228,6 +230,13 @@ router bgp 65001
       neighbor 10.1.1.0 peer group OBS_WAN
       neighbor 10.1.1.0 prefix-list PL-BGP-DEFAULT-RED-IN-C1 in
       neighbor 10.1.1.0 prefix-list PL-BGP-DEFAULT-RED-OUT-C1 out
+   !
+   vrf YELLOW-C1
+      rd 1.0.1.1:103
+       bgp listen range 10.10.10.0/24 peer-group my-peer-group1 peer-filter my-peer-filter
+       bgp listen range 12.10.10.0/24 peer-id include router-id peer-group my-peer-group3 remote-as 65444
+       bgp listen range 13.10.10.0/24 peer-group my-peer-group4 peer-filter my-peer-filter
+      neighbor 10.1.1.0 peer group OBS_WAN
 ```
 
 # Multicast

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vrf-lite.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vrf-lite.md
@@ -120,6 +120,14 @@ ip route vrf BLUE-C1 193.1.2.0/24 Null0
 | graceful-restart restart-time 300 |
 | graceful-restart |
 
+### Router BGP Listen Ranges
+
+| Prefix | Peer-ID Include Router ID | Peer Group | Peer-Filter | Remote-AS | VRF |
+| ------ | ------------------------- | ---------- | ----------- | --------- | --- |
+| 10.10.10.0/24 | - | my-peer-group1 | my-peer-filter | - | YELLOW-C1 |
+| 12.10.10.0/24 | True | my-peer-group3 | - | 65444 | YELLOW-C1 |
+| 13.10.10.0/24 | - | my-peer-group4 | my-peer-filter | - | YELLOW-C1 |
+
 ### Router BGP Peer Groups
 
 #### OBS_WAN
@@ -233,9 +241,9 @@ router bgp 65001
    !
    vrf YELLOW-C1
       rd 1.0.1.1:103
-       bgp listen range 10.10.10.0/24 peer-group my-peer-group1 peer-filter my-peer-filter
-       bgp listen range 12.10.10.0/24 peer-id include router-id peer-group my-peer-group3 remote-as 65444
-       bgp listen range 13.10.10.0/24 peer-group my-peer-group4 peer-filter my-peer-filter
+      bgp listen range 10.10.10.0/24 peer-group my-peer-group1 peer-filter my-peer-filter
+      bgp listen range 12.10.10.0/24 peer-id include router-id peer-group my-peer-group3 remote-as 65444
+      bgp listen range 13.10.10.0/24 peer-group my-peer-group4 peer-filter my-peer-filter
       neighbor 10.1.1.0 peer group OBS_WAN
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-vrf-lite.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-vrf-lite.cfg
@@ -90,9 +90,9 @@ router bgp 65001
    !
    vrf YELLOW-C1
       rd 1.0.1.1:103
-       bgp listen range 10.10.10.0/24 peer-group my-peer-group1 peer-filter my-peer-filter
-       bgp listen range 12.10.10.0/24 peer-id include router-id peer-group my-peer-group3 remote-as 65444
-       bgp listen range 13.10.10.0/24 peer-group my-peer-group4 peer-filter my-peer-filter
+      bgp listen range 10.10.10.0/24 peer-group my-peer-group1 peer-filter my-peer-filter
+      bgp listen range 12.10.10.0/24 peer-id include router-id peer-group my-peer-group3 remote-as 65444
+      bgp listen range 13.10.10.0/24 peer-group my-peer-group4 peer-filter my-peer-filter
       neighbor 10.1.1.0 peer group OBS_WAN
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-vrf-lite.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-vrf-lite.cfg
@@ -87,5 +87,12 @@ router bgp 65001
       neighbor 10.1.1.0 peer group OBS_WAN
       neighbor 10.1.1.0 prefix-list PL-BGP-DEFAULT-RED-IN-C1 in
       neighbor 10.1.1.0 prefix-list PL-BGP-DEFAULT-RED-OUT-C1 out
+   !
+   vrf YELLOW-C1
+      rd 1.0.1.1:103
+       bgp listen range 10.10.10.0/24 peer-group my-peer-group1 peer-filter my-peer-filter
+       bgp listen range 12.10.10.0/24 peer-id include router-id peer-group my-peer-group3 remote-as 65444
+       bgp listen range 13.10.10.0/24 peer-group my-peer-group4 peer-filter my-peer-filter
+      neighbor 10.1.1.0 peer group OBS_WAN
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-vrf-lite.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-vrf-lite.yml
@@ -111,6 +111,29 @@ router_bgp:
           peer_group: OBS_WAN
           prefix_list_in: PL-BGP-DEFAULT-RED-IN-C1
           prefix_list_out: PL-BGP-DEFAULT-RED-OUT-C1
+    YELLOW-C1:
+      rd: 1.0.1.1:103
+      listen_ranges:
+          # should render
+        - prefix: 10.10.10.0/24
+          peer_group: my-peer-group1
+          peer_filter: my-peer-filter
+          # shouldnt render because neither peer-filter nor as-filter are defined
+        - prefix: 11.10.10.0/24
+          peer_group: my-peer-group2
+          # should render with remote-as filter
+        - prefix: 12.10.10.0/24
+          peer_id_include_router_id: true
+          peer_group: my-peer-group3
+          remote_as: 65444
+          # should render with peer-filter because of precedence
+        - prefix: 13.10.10.0/24
+          peer_group: my-peer-group4
+          peer_filter: my-peer-filter
+          remote_as: 65444
+      neighbors:
+        10.1.1.0:
+          peer_group: OBS_WAN
 
 static_routes:
   - vrf: BLUE-C1

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -3158,6 +3158,15 @@ router_bgp:
       networks:
         < prefix_ipv4 >:
           route_map: < route_map_name >
+      # New improved "listen_ranges" data model to support multiple listen ranges and additional filter capabilities
+      listen_ranges:
+        - prefix: < A.B.C.D/E | A:B:C:D:E:F:G:H/I >
+          # include router id as part of peer filter
+          peer_id_include_router_id: < true | false >
+          peer_group: < name of peer-group >
+          # peer_filter or remote_as is required but mutually exclusive. If both are defined, peer_filter takes precedence
+          peer_filter: < name of peer-filter >
+          remote_as: < remote ASN in plain or dot notation >
       neighbors:
         < neighbor_ip_address >:
           remote_as: < asn >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
@@ -44,17 +44,14 @@
 | {{ paths_cli }} |
 {%         endif %}
 {%     endif %}
-{# Check if neighbors or listen_ranges exist under router_bgp.vrfs #}
+{# Check if listen_ranges exist under router_bgp.vrfs #}
 {%     set temp = namespace() %}
-{%     set temp.bgp_vrf_neighbors = false %}
 {%     set temp.bgp_vrf_listen_ranges = false %}
 {%     if router_bgp.vrfs is arista.avd.defined %}
 {%         for vrf in router_bgp.vrfs | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
-{%             if vrf.neighbors is arista.avd.defined %}
-{%                 set temp.bgp_vrf_neighbors = true %}
-{%             endif %}
 {%             if vrf.listen_ranges is arista.avd.defined %}
 {%                 set temp.bgp_vrf_listen_ranges = true %}
+{%                 break %}
 {%             endif %}
 {%         endfor %}
 {%     endif %}
@@ -187,6 +184,16 @@
 {%                     endif %}
 {%                 endif %}
 | Maximum routes | {{ value }} |
+{%             endif %}
+{%         endfor %}
+{%     endif %}
+{%     set temp = namespace() %}
+{%     set temp.bgp_vrf_neighbors = false %}
+{%     if router_bgp.vrfs is arista.avd.defined %}
+{%         for vrf in router_bgp.vrfs | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%             if vrf.neighbors is arista.avd.defined %}
+{%                 set temp.bgp_vrf_neighbors = true %}
+{%                 break %}
 {%             endif %}
 {%         endfor %}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
@@ -44,21 +44,36 @@
 | {{ paths_cli }} |
 {%         endif %}
 {%     endif %}
-{%     if router_bgp.listen_ranges is arista.avd.defined %}
+{%     set temp = namespace() %}
+{%     set temp.bgp_vrf_neighbors = false %}
+{%     set temp.bgp_vrf_listen_ranges = false %}
+{%     if router_bgp.vrfs is arista.avd.defined %}
+{%         for vrf in router_bgp.vrfs | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%             if vrf.neighbors is arista.avd.defined %}
+{%                 set temp.bgp_vrf_neighbors = true %}
+{%             endif %}
+{%             if vrf.listen_ranges is arista.avd.defined %}
+{%                 set temp.bgp_vrf_listen_ranges = true %}
+{%             endif %}
+{%         endfor %}
+{%     endif %}
+{%     if router_bgp.listen_ranges is arista.avd.defined or temp.bgp_vrf_listen_ranges is arista.avd.defined(true) %}
 
 ### Router BGP Listen Ranges
 
-| Prefix | Peer-ID Include Router ID | Peer Group | Peer-Filter | Remote-AS |
-| ------ | ------------------------- | ---------- | ----------- | --------- |
-{%         for listen_range in router_bgp.listen_ranges | arista.avd.natural_sort('peer_group') if listen_range.peer_group is arista.avd.defined and listen_range.prefix is arista.avd.defined
-           and (listen_range.peer_filter is arista.avd.defined or listen_range.remote_as is arista.avd.defined) %}
-{%             if listen_range.peer_filter is arista.avd.defined %}
-{%                 set row_remote_as = "-" %}
-{%             elif listen_range.remote_as is arista.avd.defined %}
-{%                 set row_remote_as = listen_range.remote_as %}
-{%             endif %}
-| {{ listen_range.prefix }} | {{ listen_range.peer_id_include_router_id | arista.avd.default('-') }} | {{ listen_range.peer_group }} | {{ listen_range.peer_filter | arista.avd.default('-') }} | {{ row_remote_as }} |
-{%         endfor %}
+| Prefix | Peer-ID Include Router ID | Peer Group | Peer-Filter | Remote-AS | VRF |
+| ------ | ------------------------- | ---------- | ----------- | --------- | --- |
+{%         if router_bgp.listen_ranges is arista.avd.defined %}
+{%             for listen_range in router_bgp.listen_ranges | arista.avd.natural_sort('peer_group') if listen_range.peer_group is arista.avd.defined and listen_range.prefix is arista.avd.defined
+               and (listen_range.peer_filter is arista.avd.defined or listen_range.remote_as is arista.avd.defined) %}
+{%                 if listen_range.peer_filter is arista.avd.defined %}
+{%                     set row_remote_as = "-" %}
+{%                 elif listen_range.remote_as is arista.avd.defined %}
+{%                     set row_remote_as = listen_range.remote_as %}
+{%                 endif %}
+| {{ listen_range.prefix }} | {{ listen_range.peer_id_include_router_id | arista.avd.default('-') }} | {{ listen_range.peer_group }} | {{ listen_range.peer_filter | arista.avd.default('-') }} | {{ row_remote_as }} | {{ arista.avd.default('default') }} |
+{%             endfor %}
+{%         endif %}
 {%     endif %}
 {%     if router_bgp.peer_groups is arista.avd.defined %}
 
@@ -156,16 +171,6 @@
 {%                     endif %}
 {%                 endif %}
 | Maximum routes | {{ value }} |
-{%             endif %}
-{%         endfor %}
-{%     endif %}
-{%     set temp = namespace() %}
-{%     set temp.bgp_vrf_neighbors = false %}
-{%     if router_bgp.vrfs is arista.avd.defined %}
-{%         for vrf in router_bgp.vrfs | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
-{%             if vrf.neighbors is arista.avd.defined %}
-{%                 set temp.bgp_vrf_neighbors = true %}
-{%                 break %}
 {%             endif %}
 {%         endfor %}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
@@ -44,6 +44,7 @@
 | {{ paths_cli }} |
 {%         endif %}
 {%     endif %}
+{# Check if neighbors or listen_ranges exist under router_bgp.vrfs #}
 {%     set temp = namespace() %}
 {%     set temp.bgp_vrf_neighbors = false %}
 {%     set temp.bgp_vrf_listen_ranges = false %}
@@ -63,6 +64,7 @@
 
 | Prefix | Peer-ID Include Router ID | Peer Group | Peer-Filter | Remote-AS | VRF |
 | ------ | ------------------------- | ---------- | ----------- | --------- | --- |
+{# listen_ranges in vrf default #}
 {%         if router_bgp.listen_ranges is arista.avd.defined %}
 {%             for listen_range in router_bgp.listen_ranges | arista.avd.natural_sort('peer_group') if listen_range.peer_group is arista.avd.defined and listen_range.prefix is arista.avd.defined
                and (listen_range.peer_filter is arista.avd.defined or listen_range.remote_as is arista.avd.defined) %}
@@ -71,9 +73,23 @@
 {%                 elif listen_range.remote_as is arista.avd.defined %}
 {%                     set row_remote_as = listen_range.remote_as %}
 {%                 endif %}
-| {{ listen_range.prefix }} | {{ listen_range.peer_id_include_router_id | arista.avd.default('-') }} | {{ listen_range.peer_group }} | {{ listen_range.peer_filter | arista.avd.default('-') }} | {{ row_remote_as }} | {{ arista.avd.default('default') }} |
+| {{ listen_range.prefix }} | {{ listen_range.peer_id_include_router_id | arista.avd.default('-') }} | {{ listen_range.peer_group }} | {{ listen_range.peer_filter | arista.avd.default('-') }} | {{ row_remote_as }} | default |
 {%             endfor %}
 {%         endif %}
+{# listen_ranges under router_bgp.vrfs #}
+{%         for vrf in router_bgp.vrfs | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%             if vrf.listen_ranges is arista.avd.defined %}
+{%                 for listen_range in vrf.listen_ranges | arista.avd.natural_sort('peer_group') if listen_range.peer_group is arista.avd.defined and listen_range.prefix is arista.avd.defined
+                   and (listen_range.peer_filter is arista.avd.defined or listen_range.remote_as is arista.avd.defined) %}
+{%                     if listen_range.peer_filter is arista.avd.defined %}
+{%                         set row_remote_as = "-" %}
+{%                     elif listen_range.remote_as is arista.avd.defined %}
+{%                         set row_remote_as = listen_range.remote_as %}
+{%                     endif %}
+| {{ listen_range.prefix }} | {{ listen_range.peer_id_include_router_id | arista.avd.default('-') }} | {{ listen_range.peer_group }} | {{ listen_range.peer_filter | arista.avd.default('-') }} | {{ row_remote_as }} | {{ vrf.name }} |
+{%                 endfor %}
+{%             endif %}
+{%         endfor %}
 {%     endif %}
 {%     if router_bgp.peer_groups is arista.avd.defined %}
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -743,6 +743,22 @@ router bgp {{ router_bgp.as }}
 {%         if vrf.timers is arista.avd.defined %}
       timers bgp {{ vrf.timers }}
 {%         endif %}
+{%         if vrf.listen_ranges is arista.avd.defined %}
+{%             for listen_range in vrf.listen_ranges | arista.avd.natural_sort('peer_group') if listen_range.peer_group is arista.avd.defined and listen_range.prefix is arista.avd.defined
+                   and (listen_range.peer_filter is arista.avd.defined or listen_range.remote_as is arista.avd.defined) %}
+{%                 set listen_range_cli = "bgp listen range " ~ listen_range.prefix %}
+{%                 if listen_range.peer_id_include_router_id is arista.avd.defined(true) %}
+{%                     set listen_range_cli = listen_range_cli ~ " peer-id include router-id" %}
+{%                 endif %}
+{%                 set listen_range_cli = listen_range_cli ~ " peer-group " ~ listen_range.peer_group %}
+{%                 if listen_range.peer_filter is arista.avd.defined %}
+{%                     set listen_range_cli = listen_range_cli ~ " peer-filter " ~ listen_range.peer_filter %}
+{%                 elif listen_range.remote_as is arista.avd.defined %}
+{%                     set listen_range_cli = listen_range_cli ~ " remote-as " ~ listen_range.remote_as %}
+{%                 endif %}
+      {{ listen_range_cli }}
+{%             endfor %}
+{%         endif %}
 {%         for neighbor in vrf.neighbors | arista.avd.convert_dicts('ip_address') | arista.avd.natural_sort('ip_address') %}
 {%             if neighbor.remote_as is arista.avd.defined %}
       neighbor {{ neighbor.ip_address }} remote-as {{ neighbor.remote_as }}


### PR DESCRIPTION
## Change Summary

Allow configuration of listen_ranges within VRF context of BGP

## Related Issue(s)

Fixes #1088 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
- Combine checking for BGP neighbors and listen_ranges under BGP VRF
- Add extended listen_ranges DM to BGP VRF

```
router_bgp:
<snip>
  vrfs:
    < vrf_name_1 >:
      # New improved "listen_ranges" data model to support multiple listen ranges and additional filter capabilities
      listen_ranges:
        - prefix: < A.B.C.D/E | A:B:C:D:E:F:G:H/I >
          # include router id as part of peer filter
          peer_id_include_router_id: < true | false >
          peer_group: < name of peer-group >
          # peer_filter or remote_as is required but mutually exclusive. If both are defined, peer_filter takes precedence
          peer_filter: < name of peer-filter >
          remote_as: < remote ASN in plain or dot notation >
</snip>
```

## How to test
Extended molecule test

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
