### PR TITLE
Refactor(eos_cli_config_gen): New data model for port-channel ESI variables

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
@@ -155,12 +155,12 @@ port_channel_interfaces:
 
   Port-Channel14:
     description: EVPN-MPLS multihoming
-    esi: "0000:0000:0000:0102:0305"
-    rt: "00:00:01:02:03:05"
     evpn_ethernet_segment:
+      identifier: "0000:0000:0000:0102:0305"
       mpls:
         shared_index: 100
         tunnel_flood_filter_time: 100
+      route_target: "00:00:01:02:03:05"
 
   Port-Channel17:
     description: PBR Description

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1353,6 +1353,7 @@ port_channel_interfaces:
     vlans: "< list of vlans as string >"
     mode: < access | dot1q-tunnel | trunk | "trunk phone" >
     evpn_ethernet_segment:
+      identifier: < EVPN Ethernet Segment Identifier (Type 1 format) >
       redundancy: < all-active | single-active >
       designated_forwarder_election:
         algorithm: < modulus | preference >
@@ -1365,6 +1366,8 @@ port_channel_interfaces:
       mpls:
         shared_index: < 1-1024 >
         tunnel_flood_filter_time: < integer >
+      route_target: < EVPN Route Target for ESI with format xx:xx:xx:xx:xx:xx >
+    # esi and rt to be deprecated in AVD 4.0, replaced by identifier and route_target under evpn_ethernet_segment.
     esi: < EVPN Ethernet Segment Identifier (Type 1 format) >
     rt: < EVPN Route Target for ESI with format xx:xx:xx:xx:xx:xx >
     lacp_id: < LACP ID with format xxxx.xxxx.xxxx >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1368,6 +1368,7 @@ port_channel_interfaces:
         tunnel_flood_filter_time: < integer >
       route_target: < EVPN Route Target for ESI with format xx:xx:xx:xx:xx:xx >
     # esi and rt to be deprecated in AVD 4.0, replaced by identifier and route_target under evpn_ethernet_segment.
+    # If both esi/rt and identifier/route_target are defined, new variables take precedence over old variables.
     esi: < EVPN Ethernet Segment Identifier (Type 1 format) >
     rt: < EVPN Route Target for ESI with format xx:xx:xx:xx:xx:xx >
     lacp_id: < LACP ID with format xxxx.xxxx.xxxx >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/port-channel-interfaces.j2
@@ -28,7 +28,7 @@
 {%             set lacp_fallback_timeout = port_channel_interface.lacp_fallback_timeout | arista.avd.default("-") %}
 {%             set lacp_fallback_mode = port_channel_interface.lacp_fallback_mode | arista.avd.default("-") %}
 {%             set mlag = port_channel_interface.mlag | arista.avd.default("-") %}
-{%             set esi = port_channel_interface.esi | arista.avd.default("-") %}
+{%             set esi = port_channel_interface.evpn_ethernet_segment.identifier | arista.avd.default(port_channel_interface.esi, "-") %}
 | {{ port_channel_interface.name }} | {{ description }} | {{ type }} | {{ mode }} | {{ vlans }} | {{ native_vlan }} | {{ l2.trunk_groups }} | {{ lacp_fallback_timeout }} | {{ lacp_fallback_mode }} | {{ mlag }} | {{ esi }} |
 {%         endif %}
 {%     endfor %}
@@ -159,9 +159,9 @@
 | Interface | Ethernet Segment Identifier | Multihoming Redundancy Mode | Route Target |
 | --------- | --------------------------- | --------------------------- | ------------ |
 {%         for evpn_es_po_interface in evpn_es_po_interfaces | arista.avd.natural_sort('name') %}
-{%             set esi = evpn_es_po_interface.esi | arista.avd.default("-") %}
+{%             set esi = evpn_es_po_interface.evpn_ethernet_segment.identifier | arista.avd.default(evpn_es_po_interface.esi, "-") %}
 {%             set redundancy = evpn_es_po_interface.evpn_ethernet_segment.redundancy | arista.avd.default("all-active") %}
-{%             set rt = evpn_es_po_interface.rt | arista.avd.default("-") %}
+{%             set rt = evpn_es_po_interface.evpn_ethernet_segment.route_target | arista.avd.default(evpn_es_po_interface.rt, "-") %}
 | {{ evpn_es_po_interface.name }} | {{ esi }} | {{ redundancy }} | {{ rt }} |
 {%         endfor %}
 {%         if evpn_dfe_po_interfaces | length > 0 %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
@@ -97,10 +97,10 @@ interface {{ port_channel_interface.name }}
 {%     if port_channel_interface.l2_protocol.encapsulation_dot1q_vlan is arista.avd.defined %}
    l2-protocol encapsulation dot1q vlan {{ port_channel_interface.l2_protocol.encapsulation_dot1q_vlan }}
 {%     endif %}
-{%     if port_channel_interface.esi is arista.avd.defined or port_channel_interface.evpn_ethernet_segment is arista.avd.defined %}
+{%     if port_channel_interface.evpn_ethernet_segment.identifier | arista.avd.default(port_channel_interface.esi) is arista.avd.defined or port_channel_interface.evpn_ethernet_segment is arista.avd.defined %}
    evpn ethernet-segment
-{%         if port_channel_interface.esi is arista.avd.defined %}
-      identifier {{ port_channel_interface.esi }}
+{%         if port_channel_interface.evpn_ethernet_segment.identifier | arista.avd.default(port_channel_interface.esi) is arista.avd.defined %}
+      identifier {{ port_channel_interface.evpn_ethernet_segment.identifier | arista.avd.default(port_channel_interface.esi) }}
 {%         endif %}
 {%         if port_channel_interface.evpn_ethernet_segment.redundancy is arista.avd.defined %}
       redundancy {{ port_channel_interface.evpn_ethernet_segment.redundancy }}
@@ -134,8 +134,8 @@ interface {{ port_channel_interface.name }}
 {%         if port_channel_interface.evpn_ethernet_segment.mpls.shared_index is arista.avd.defined %}
       mpls shared index {{ port_channel_interface.evpn_ethernet_segment.mpls.shared_index }}
 {%         endif %}
-{%         if port_channel_interface.rt is arista.avd.defined %}
-      route-target import {{ port_channel_interface.rt }}
+{%         if port_channel_interface.evpn_ethernet_segment.route_target | arista.avd.default(port_channel_interface.rt) is arista.avd.defined %}
+      route-target import {{ port_channel_interface.evpn_ethernet_segment.route_target | arista.avd.default(port_channel_interface.rt) }}
 {%         endif %}
 {%     endif %}
 {%     if port_channel_interface.snmp_trap_link_change is arista.avd.defined(false) %}


### PR DESCRIPTION
## Change Summary

Adds new data model for EVPN ESI variables on port-channel ethernet segments, with fallback to old model.

## Related Issue(s)

Fixes #1702 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

```yaml
port_channel_interfaces:
  < Port-Channel_interface >:
    evpn_ethernet_segment:
      identifier: < EVPN Ethernet Segment Identifier (Type 1 format) >
      route_target: < EVPN Route Target for ESI with format xx:xx:xx:xx:xx:xx >
```

## How to test
Tested with molecule

### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
