### PR TITLE
Feat(eos_designs): Add ability to set mlag port-channel id

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3A.md
@@ -272,7 +272,7 @@ monitor session MonitoringSessionServer18WithDest truncate size 20
 
 | Domain-id | Local-interface | Peer-address | Peer-link |
 | --------- | --------------- | ------------ | --------- |
-| DC1_SVC3 | Vlan4092 | 10.255.252.7 | Port-Channel5 |
+| DC1_SVC3 | Vlan4092 | 10.255.252.7 | Port-Channel2000 |
 
 Dual primary detection is disabled.
 
@@ -284,7 +284,7 @@ mlag configuration
    domain-id DC1_SVC3
    local-interface Vlan4092
    peer-address 10.255.252.7
-   peer-link Port-Channel5
+   peer-link Port-Channel2000
    reload-delay mlag 300
    reload-delay non-mlag 330
 ```
@@ -481,8 +481,8 @@ vlan 4092
 
 | Interface | Description | Mode | VLANs | Native VLAN | Trunk Group | Channel-Group |
 | --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
-| Ethernet5 | MLAG_PEER_DC1-SVC3B_Ethernet5 | *trunk | *1-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 5 |
-| Ethernet6 | MLAG_PEER_DC1-SVC3B_Ethernet6 | *trunk | *1-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 5 |
+| Ethernet5 | MLAG_PEER_DC1-SVC3B_Ethernet5 | *trunk | *1-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 2000 |
+| Ethernet6 | MLAG_PEER_DC1-SVC3B_Ethernet6 | *trunk | *1-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 2000 |
 | Ethernet7 | DC1-L2LEAF2A_Ethernet1 | *trunk | *110-112,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350 | *- | *- | 7 |
 | Ethernet8 | DC1-L2LEAF2B_Ethernet1 | *trunk | *110-112,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350 | *- | *- | 7 |
 | Ethernet10 | server03_ESI_Eth1 | *trunk | *110-111,210-211 | *- | *- | 10 |
@@ -558,13 +558,13 @@ interface Ethernet5
    description MLAG_PEER_DC1-SVC3B_Ethernet5
    no shutdown
    speed 100g
-   channel-group 5 mode active
+   channel-group 2000 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-SVC3B_Ethernet6
    no shutdown
    speed 100g
-   channel-group 5 mode active
+   channel-group 2000 mode active
 !
 interface Ethernet7
    description DC1-L2LEAF2A_Ethernet1
@@ -740,7 +740,6 @@ interface Ethernet42
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel5 | MLAG_PEER_DC1-SVC3B_Po5 | switched | trunk | 1-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
 | Port-Channel7 | DC1_L2LEAF2_Po1 | switched | trunk | 110-112,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350 | - | - | - | - | 7 | - |
 | Port-Channel10 | server03_ESI_PortChanne1 | switched | trunk | 110-111,210-211 | - | - | - | - | 10 | - |
 | Port-Channel14 | server07_inherit_all_from_profile_port_channel_ALL_WITH_SECURITY_PORT_CHANNEL | switched | trunk | 1-4094 | - | - | - | - | 14 | - |
@@ -753,19 +752,11 @@ interface Ethernet42
 | Port-Channel24 | server17_port_channel_with_disabled_phy_and_po_interfaces_server17_port_channel_with_disabled_phy_and_po_interfaces | switched | access | 110 | - | - | - | - | 24 | - |
 | Port-Channel27 | server18_monitoring_session_source_po_server18_monitoring_session_source_po | switched | access | 110 | - | - | - | - | 27 | - |
 | Port-Channel42 | server21_monitoring_session_destination_po_server21_monitoring_session_destination_po | switched | access | 110 | - | - | - | - | 42 | - |
+| Port-Channel2000 | MLAG_PEER_DC1-SVC3B_Po2000 | switched | trunk | 1-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
 
 ```eos
-!
-interface Port-Channel5
-   description MLAG_PEER_DC1-SVC3B_Po5
-   no shutdown
-   switchport
-   switchport trunk allowed vlan 1-4094
-   switchport mode trunk
-   switchport trunk group LEAF_PEER_L3
-   switchport trunk group MLAG
 !
 interface Port-Channel7
    description DC1_L2LEAF2_Po1
@@ -898,6 +889,15 @@ interface Port-Channel42
    switchport
    switchport access vlan 110
    mlag 42
+!
+interface Port-Channel2000
+   description MLAG_PEER_DC1-SVC3B_Po2000
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 1-4094
+   switchport mode trunk
+   switchport trunk group LEAF_PEER_L3
+   switchport trunk group MLAG
 ```
 
 ## Loopback Interfaces

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3B.md
@@ -271,7 +271,7 @@ monitor session MonitoringSessionServer18WithDest truncate size 20
 
 | Domain-id | Local-interface | Peer-address | Peer-link |
 | --------- | --------------- | ------------ | --------- |
-| DC1_SVC3 | Vlan4092 | 10.255.252.6 | Port-Channel5 |
+| DC1_SVC3 | Vlan4092 | 10.255.252.6 | Port-Channel2000 |
 
 Dual primary detection is disabled.
 
@@ -283,7 +283,7 @@ mlag configuration
    domain-id DC1_SVC3
    local-interface Vlan4092
    peer-address 10.255.252.6
-   peer-link Port-Channel5
+   peer-link Port-Channel2000
    reload-delay mlag 300
    reload-delay non-mlag 330
 ```
@@ -480,8 +480,8 @@ vlan 4092
 
 | Interface | Description | Mode | VLANs | Native VLAN | Trunk Group | Channel-Group |
 | --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
-| Ethernet5 | MLAG_PEER_DC1-SVC3A_Ethernet5 | *trunk | *1-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 5 |
-| Ethernet6 | MLAG_PEER_DC1-SVC3A_Ethernet6 | *trunk | *1-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 5 |
+| Ethernet5 | MLAG_PEER_DC1-SVC3A_Ethernet5 | *trunk | *1-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 2000 |
+| Ethernet6 | MLAG_PEER_DC1-SVC3A_Ethernet6 | *trunk | *1-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 2000 |
 | Ethernet7 | DC1-L2LEAF2A_Ethernet2 | *trunk | *110-112,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350 | *- | *- | 7 |
 | Ethernet8 | DC1-L2LEAF2B_Ethernet2 | *trunk | *110-112,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350 | *- | *- | 7 |
 | Ethernet11 |  server04_inherit_all_from_profile_Eth2 | trunk | 1-4094 | - | - | - |
@@ -554,13 +554,13 @@ interface Ethernet5
    description MLAG_PEER_DC1-SVC3A_Ethernet5
    no shutdown
    speed 100g
-   channel-group 5 mode active
+   channel-group 2000 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-SVC3A_Ethernet6
    no shutdown
    speed 100g
-   channel-group 5 mode active
+   channel-group 2000 mode active
 !
 interface Ethernet7
    description DC1-L2LEAF2A_Ethernet2
@@ -719,7 +719,6 @@ interface Ethernet42
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel5 | MLAG_PEER_DC1-SVC3A_Po5 | switched | trunk | 1-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
 | Port-Channel7 | DC1_L2LEAF2_Po1 | switched | trunk | 110-112,120-121,130-131,140-141,150,160-161,210-211,250,310-311,350 | - | - | - | - | 7 | - |
 | Port-Channel14 | server07_inherit_all_from_profile_port_channel_ALL_WITH_SECURITY_PORT_CHANNEL | switched | trunk | 1-4094 | - | - | - | - | 14 | - |
 | Port-Channel15 | server08_no_profile_port_channel_server08_no_profile_port_channel | switched | trunk | 1-4094 | - | - | - | - | 15 | - |
@@ -731,19 +730,11 @@ interface Ethernet42
 | Port-Channel24 | server17_port_channel_with_disabled_phy_and_po_interfaces_server17_port_channel_with_disabled_phy_and_po_interfaces | switched | access | 110 | - | - | - | - | 24 | - |
 | Port-Channel27 | server18_monitoring_session_source_po_server18_monitoring_session_source_po | switched | access | 110 | - | - | - | - | 27 | - |
 | Port-Channel42 | server21_monitoring_session_destination_po_server21_monitoring_session_destination_po | switched | access | 110 | - | - | - | - | 42 | - |
+| Port-Channel2000 | MLAG_PEER_DC1-SVC3A_Po2000 | switched | trunk | 1-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
 
 ```eos
-!
-interface Port-Channel5
-   description MLAG_PEER_DC1-SVC3A_Po5
-   no shutdown
-   switchport
-   switchport trunk allowed vlan 1-4094
-   switchport mode trunk
-   switchport trunk group LEAF_PEER_L3
-   switchport trunk group MLAG
 !
 interface Port-Channel7
    description DC1_L2LEAF2_Po1
@@ -868,6 +859,15 @@ interface Port-Channel42
    switchport
    switchport access vlan 110
    mlag 42
+!
+interface Port-Channel2000
+   description MLAG_PEER_DC1-SVC3A_Po2000
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 1-4094
+   switchport mode trunk
+   switchport trunk group LEAF_PEER_L3
+   switchport trunk group MLAG
 ```
 
 ## Loopback Interfaces

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3A.cfg
@@ -155,15 +155,6 @@ vrf instance Tenant_C_OP_Zone
 !
 vrf instance Tenant_C_WAN_Zone
 !
-interface Port-Channel5
-   description MLAG_PEER_DC1-SVC3B_Po5
-   no shutdown
-   switchport
-   switchport trunk allowed vlan 1-4094
-   switchport mode trunk
-   switchport trunk group LEAF_PEER_L3
-   switchport trunk group MLAG
-!
 interface Port-Channel7
    description DC1_L2LEAF2_Po1
    no shutdown
@@ -296,6 +287,15 @@ interface Port-Channel42
    switchport access vlan 110
    mlag 42
 !
+interface Port-Channel2000
+   description MLAG_PEER_DC1-SVC3B_Po2000
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 1-4094
+   switchport mode trunk
+   switchport trunk group LEAF_PEER_L3
+   switchport trunk group MLAG
+!
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet4
    no shutdown
@@ -332,13 +332,13 @@ interface Ethernet5
    description MLAG_PEER_DC1-SVC3B_Ethernet5
    no shutdown
    speed 100g
-   channel-group 5 mode active
+   channel-group 2000 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-SVC3B_Ethernet6
    no shutdown
    speed 100g
-   channel-group 5 mode active
+   channel-group 2000 mode active
 !
 interface Ethernet7
    description DC1-L2LEAF2A_Ethernet1
@@ -779,7 +779,7 @@ mlag configuration
    domain-id DC1_SVC3
    local-interface Vlan4092
    peer-address 10.255.252.7
-   peer-link Port-Channel5
+   peer-link Port-Channel2000
    reload-delay mlag 300
    reload-delay non-mlag 330
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3B.cfg
@@ -155,15 +155,6 @@ vrf instance Tenant_C_OP_Zone
 !
 vrf instance Tenant_C_WAN_Zone
 !
-interface Port-Channel5
-   description MLAG_PEER_DC1-SVC3A_Po5
-   no shutdown
-   switchport
-   switchport trunk allowed vlan 1-4094
-   switchport mode trunk
-   switchport trunk group LEAF_PEER_L3
-   switchport trunk group MLAG
-!
 interface Port-Channel7
    description DC1_L2LEAF2_Po1
    no shutdown
@@ -288,6 +279,15 @@ interface Port-Channel42
    switchport access vlan 110
    mlag 42
 !
+interface Port-Channel2000
+   description MLAG_PEER_DC1-SVC3A_Po2000
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 1-4094
+   switchport mode trunk
+   switchport trunk group LEAF_PEER_L3
+   switchport trunk group MLAG
+!
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet5
    no shutdown
@@ -324,13 +324,13 @@ interface Ethernet5
    description MLAG_PEER_DC1-SVC3A_Ethernet5
    no shutdown
    speed 100g
-   channel-group 5 mode active
+   channel-group 2000 mode active
 !
 interface Ethernet6
    description MLAG_PEER_DC1-SVC3A_Ethernet6
    no shutdown
    speed 100g
-   channel-group 5 mode active
+   channel-group 2000 mode active
 !
 interface Ethernet7
    description DC1-L2LEAF2A_Ethernet2
@@ -753,7 +753,7 @@ mlag configuration
    domain-id DC1_SVC3
    local-interface Vlan4092
    peer-address 10.255.252.6
-   peer-link Port-Channel5
+   peer-link Port-Channel2000
    reload-delay mlag 300
    reload-delay non-mlag 330
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
@@ -752,8 +752,8 @@ vlan_interfaces:
     ip_address: 10.255.251.6/31
     mtu: 1500
 port_channel_interfaces:
-  Port-Channel5:
-    description: MLAG_PEER_DC1-SVC3B_Po5
+  Port-Channel2000:
+    description: MLAG_PEER_DC1-SVC3B_Po2000
     type: switched
     shutdown: false
     vlans: 1-4094
@@ -943,7 +943,7 @@ ethernet_interfaces:
     type: switched
     shutdown: false
     channel_group:
-      id: 5
+      id: 2000
       mode: active
     speed: 100g
   Ethernet6:
@@ -954,7 +954,7 @@ ethernet_interfaces:
     type: switched
     shutdown: false
     channel_group:
-      id: 5
+      id: 2000
       mode: active
     speed: 100g
   Ethernet1:
@@ -1392,7 +1392,7 @@ mlag_configuration:
   domain_id: DC1_SVC3
   local_interface: Vlan4092
   peer_address: 10.255.252.7
-  peer_link: Port-Channel5
+  peer_link: Port-Channel2000
   reload_delay_mlag: 300
   reload_delay_non_mlag: 330
 route_maps:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
@@ -752,8 +752,8 @@ vlan_interfaces:
     ip_address: 10.255.251.7/31
     mtu: 1500
 port_channel_interfaces:
-  Port-Channel5:
-    description: MLAG_PEER_DC1-SVC3A_Po5
+  Port-Channel2000:
+    description: MLAG_PEER_DC1-SVC3A_Po2000
     type: switched
     shutdown: false
     vlans: 1-4094
@@ -936,7 +936,7 @@ ethernet_interfaces:
     type: switched
     shutdown: false
     channel_group:
-      id: 5
+      id: 2000
       mode: active
     speed: 100g
   Ethernet6:
@@ -947,7 +947,7 @@ ethernet_interfaces:
     type: switched
     shutdown: false
     channel_group:
-      id: 5
+      id: 2000
       mode: active
     speed: 100g
   Ethernet1:
@@ -1357,7 +1357,7 @@ mlag_configuration:
   domain_id: DC1_SVC3
   local_interface: Vlan4092
   peer_address: 10.255.252.6
-  peer_link: Port-Channel5
+  peer_link: Port-Channel2000
   reload_delay_mlag: 300
   reload_delay_non_mlag: 330
 route_maps:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_FABRIC.yml
@@ -114,6 +114,7 @@ l3leaf:
     DC1_SVC3:
       platform: 7050SX3
       bgp_as: 65103
+      mlag_port_channel_id: 2000
       filter:
         tenants: [ Tenant_A, Tenant_B, Tenant_C ]
         tags: [ opzone, web, app, db, vmotion, nfs, wan ]

--- a/ansible_collections/arista/avd/plugins/module_utils/eos_designs_facts.py
+++ b/ansible_collections/arista/avd/plugins/module_utils/eos_designs_facts.py
@@ -991,6 +991,13 @@ class EosDesignsFacts:
         return None
 
     @cached_property
+    def mlag_port_channel_id(self):
+        if self.mlag is True:
+            default_mlag_port_channel_id = ''.join(re.findall(r'\d', self.mlag_interfaces[0]))
+            return get(self._switch_data_combined, "mlag_port_channel_id", default_mlag_port_channel_id)
+        return None
+
+    @cached_property
     def vtep_loopback_ipv4_pool(self):
         if self.vtep is True:
             return get(self._switch_data_combined, "vtep_loopback_ipv4_pool", required=True)

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-topology.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-topology.md
@@ -363,9 +363,10 @@ defaults <- node_group <- node_group.node <- node
     # MLAG interfaces speed | Optional and depends on mlag_interfaces to be defined
     mlag_interfaces_speed: < interface_speed | forced interface_speed | auto interface_speed >
 
-    # MLAG peer link port-channel id: | Optional; if not set, the mlag port-channel id
-    # is generated from the digits of the first interface present in 'mlag_interfaces'
-    mlag_port_channel_id: < 1-2000 > for EOS < 4.25.0F | < 1 - 999999 > for EOS >= 4.25.0F
+    # MLAG peer link port-channel id | Optional; if not set, the mlag port-channel id is
+    # generated based on the digits of the first interface present in 'mlag_interfaces'.
+    # Valid port-channel id numbers are < 1-2000 > for EOS < 4.25.0F and < 1 - 999999 > for EOS >= 4.25.0F.
+    mlag_port_channel_id: < integer >
 
     # Underlay L3 peering SVI interface id
     # If set to false or the same vlan as mlag_peer_vlan the mlag_peer_vlan will be used for L3 peering.

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-topology.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-topology.md
@@ -363,6 +363,10 @@ defaults <- node_group <- node_group.node <- node
     # MLAG interfaces speed | Optional and depends on mlag_interfaces to be defined
     mlag_interfaces_speed: < interface_speed | forced interface_speed | auto interface_speed >
 
+    # MLAG peer link port-channel id: | Optional; if not set, the mlag port-channel id
+    # is generated from the digits of the first interface present in 'mlag_interfaces'
+    mlag_port_channel_id: < 1-2000 > for EOS < 4.25.0F | < 1 - 999999 > for EOS >= 4.25.0F
+
     # Underlay L3 peering SVI interface id
     # If set to false or the same vlan as mlag_peer_vlan the mlag_peer_vlan will be used for L3 peering.
     mlag_peer_l3_vlan: < 0-4094 | false | default -> 4093 >

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/interface_descriptions/mlag/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/interface_descriptions/mlag/port-channel-interfaces.j2
@@ -1,1 +1,1 @@
-MLAG_PEER_{{ switch.mlag_peer }}_Po{{ mlag_port_channel_interface }}
+MLAG_PEER_{{ switch.mlag_peer }}_Po{{ switch.mlag_port_channel_id }}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/mlag/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/mlag/ethernet-interfaces.j2
@@ -10,7 +10,7 @@ ethernet_interfaces:
     type: switched
     shutdown: false
     channel_group:
-      id: {{ switch.mlag_interfaces[0] | regex_findall("\d") | join }}
+      id: {{ switch.mlag_port_channel_id }}
       mode: active
 {%         if switch.mlag_interfaces_speed is arista.avd.defined %}
     speed: {{ switch.mlag_interfaces_speed }}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/mlag/mlag-configuration.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/mlag/mlag-configuration.j2
@@ -11,7 +11,7 @@ mlag_configuration:
     vrf: {{ mgmt_interface_vrf }}
   dual_primary_detection_delay: 5
 {% endif %}
-  peer_link: Port-Channel{{ switch.mlag_interfaces[0] | regex_findall("\d") | join }}
+  peer_link: Port-Channel{{ switch.mlag_port_channel_id }}
 {% if switch.platform_settings.reload_delay.mlag is arista.avd.defined %}
   reload_delay_mlag: {{ switch.platform_settings.reload_delay.mlag }}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/mlag/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/mlag/port-channel-interfaces.j2
@@ -1,7 +1,6 @@
 {# Leaf mlag peer-link #}
-{% set mlag_port_channel_interface = switch.mlag_interfaces[0] | regex_findall("\d") | join %}
 port_channel_interfaces:
-  Port-Channel{{ mlag_port_channel_interface }}:
+  Port-Channel{{ switch.mlag_port_channel_id }}:
     description: "{% include switch.interface_descriptions.mlag_port_channel_interfaces %}"
     type: switched
     shutdown: false


### PR DESCRIPTION
## Change Summary

Gives users the ability to set the id of the port-channel used for the mlag peer link.

## Related Issue(s)

Fixes #1764

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Adding a field called `mlag_port_channel_id` which users can use in the node type defaults section or node group defaults section to set the mlag peer link port-channel id. If the key is not set, the default method of port-channel id generation is used.
<!--- Describe data model implemented for new features -->
Add a key called `mlag_port_channel_id` which can be set under node type defaults or node group defaults section.
```
< node_type_key >:
  mlag_port_channel_id: < 1-2000 > | Optional
  node_groups:
    <node_goup>:
      mlag_port_channel_id: < 1-2000 > | Optional
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
With an inventory consisting of a pair of 7280s serving as l3leafs and a pair of 7308s serving as a custom node type called splines,  I added the key the splines defaults section only.  MLAG came up on the spline switches, which had the mlag port-channel id manually set, and MLAG also came up on the leaf switches which did NOT have the mlag port-channel id manually set. Both configurations matched the expected output.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] My code has been rebased from devel before I start
- [ x ] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ x ] My change requires a change to the documentation and documentation have been updated accordingly.
- [ x ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
