### PR TITLE
Test(eos_designs): add event-handlers test

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-BL1A.md
@@ -14,6 +14,7 @@
   - [TerminAttr Daemon](#terminattr-daemon)
   - [SNMP](#snmp)
   - [SFlow](#sflow)
+  - [Event Handler](#event-handler)
 - [Hardware TCAM Profile](#hardware-tcam-profile)
   - [Hardware TCAM configuration](#hardware-tcam-configuration)
 - [Spanning Tree](#spanning-tree)
@@ -215,6 +216,25 @@ sFlow is disabled.
 sflow vrf OOB destination 10.0.200.90
 sflow vrf OOB destination 192.168.200.10
 sflow vrf OOB source-interface Management1
+```
+
+## Event Handler
+
+### Event Handler Summary
+
+| Handler | Action Type | Action | Trigger |
+| ------- | ----------- | ------ | ------- |
+| evpn-blacklist-recovery | bash | FastCli -p 15 -c "clear bgp evpn host-flap" | on-logging |
+
+### Event Handler Device Configuration
+
+```eos
+!
+event-handler evpn-blacklist-recovery
+   trigger on-logging
+      regex EVPN-3-BLACKLISTED_DUPLICATE_MAC
+   action bash FastCli -p 15 -c "clear bgp evpn host-flap"
+   delay 300
 ```
 
 # Hardware TCAM Profile

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1A.cfg
@@ -188,6 +188,12 @@ hardware tcam
 !
 ip virtual-router mac-address 00:dc:00:00:00:0a
 !
+event-handler evpn-blacklist-recovery
+   trigger on-logging
+      regex EVPN-3-BLACKLISTED_DUPLICATE_MAC
+   action bash FastCli -p 15 -c "clear bgp evpn host-flap"
+   delay 300
+!
 ip routing
 no ip routing vrf MGMT
 ip routing vrf Tenant_A_WAN_Zone

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
@@ -290,6 +290,14 @@ vlan_internal_order:
   range:
     beginning: 1006
     ending: 1199
+event_handlers:
+  evpn-blacklist-recovery:
+    action_type: bash
+    action: FastCli -p 15 -c "clear bgp evpn host-flap"
+    delay: 300
+    asynchronous: handler.asynchronous
+    trigger: on-logging
+    regex: EVPN-3-BLACKLISTED_DUPLICATE_MAC
 name_server:
   source:
     vrf: MGMT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/DC1-BL1A.yml
@@ -17,3 +17,13 @@ cvp_ingestauth_key: ""
 
 # Testing overlay loopback description override
 overlay_loopback_description: "MY_OVERLAY_LOOPBACK"
+
+# Testing event_handlers
+event_handlers:
+  evpn-blacklist-recovery:
+    action_type: bash
+    action: FastCli -p 15 -c "clear bgp evpn host-flap"
+    delay: 300
+    trigger: on-logging
+    regex: EVPN-3-BLACKLISTED_DUPLICATE_MAC
+    asynchronous: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-BL1A.yml
@@ -284,6 +284,14 @@ vlan_internal_order:
   range:
     beginning: 1006
     ending: 1199
+event_handlers:
+  evpn-blacklist-recovery:
+    action_type: bash
+    action: FastCli -p 15 -c "clear bgp evpn host-flap"
+    delay: 300
+    asynchronous: handler.asynchronous
+    trigger: on-logging
+    regex: EVPN-3-BLACKLISTED_DUPLICATE_MAC
 name_server:
   source:
     vrf: MGMT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/inventory/host_vars/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/inventory/host_vars/DC1-BL1A.yml
@@ -17,3 +17,13 @@ cvp_ingestauth_key: ""
 
 # Testing overlay loopback description override
 overlay_loopback_description: "MY_OVERLAY_LOOPBACK"
+
+# Testing event_handlers
+event_handlers:
+- name: evpn-blacklist-recovery
+  action_type: bash
+  action: FastCli -p 15 -c "clear bgp evpn host-flap"
+  delay: 300
+  trigger: on-logging
+  regex: EVPN-3-BLACKLISTED_DUPLICATE_MAC
+  asynchronous: true


### PR DESCRIPTION
* add test for eos_designs and eos_designs_v4.0
* confirm that the intended/structured_config output

## Change Summary

Following #1790, it was noticed that there was no test for event-handlers in `eos_designs` role. This PR adds a test for both 3.x and 4.0 version

## Related Issue(s)

No issue

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Leveraging the existing host_vars file for DC1-BL1A to add the variables

## How to test
These are tests

## Checklist

### User Checklist


### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
