### PR TITLE
Refactor(eos_designs): Wildcard dict to list node_type_keys

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/inventory/group_vars/CORE_UNIT_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/inventory/group_vars/CORE_UNIT_TESTS.yml
@@ -1,6 +1,6 @@
 # Fabric node type keys
 node_type_keys:
-  core_router:
+  - name: core_router
     type: core_router
     default_evpn_role: none
     mpls_lsr: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/inventory/group_vars/CORE_UNIT_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/inventory/group_vars/CORE_UNIT_TESTS.yml
@@ -1,6 +1,6 @@
 # Fabric node type keys
 node_type_keys:
-  - name: core_router
+  - key: core_router
     type: core_router
     default_evpn_role: none
     mpls_lsr: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/inventory/group_vars/all.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/inventory/group_vars/all.yml
@@ -1,2 +1,59 @@
 ---
 root_dir: '{{ playbook_dir }}'
+
+
+default_node_type_keys:
+  "l3ls-evpn":
+    - key: spine
+      type: spine
+      default_evpn_role: server
+    - key: l3leaf
+      type: l3leaf
+      connected_endpoints: true
+      default_evpn_role: client
+      mlag_support: true
+      network_services:
+        l2: true
+        l3: true
+      vtep: true
+    - key: l2leaf
+      type: l2leaf
+      connected_endpoints: true
+      mlag_support: true
+      network_services:
+        l2: true
+      underlay_router: false
+      uplink_type: port-channel
+    - key: super_spine
+      type: super-spine
+    - key: overlay_controller
+      type: overlay-controller
+      default_evpn_role: server
+
+  "mpls":
+    - key: p
+      type: p
+      mpls_lsr: true
+      default_mpls_overlay_role: none
+      default_overlay_routing_protocol: ibgp
+      default_underlay_routing_protocol: isis-sr
+    - key: pe
+      type: pe
+      mpls_lsr: true
+      connected_endpoints: true
+      default_mpls_overlay_role: client
+      network_services:
+        l1: true
+        l2: true
+        l3: true
+      mpls_ler: true
+      default_overlay_routing_protocol: ibgp
+      default_underlay_routing_protocol: isis-sr
+      default_overlay_address_families: [ vpn-ipv4 ]
+    - key: rr
+      type: rr
+      mpls_lsr: true
+      default_mpls_overlay_role: server
+      default_overlay_routing_protocol: ibgp
+      default_underlay_routing_protocol: isis-sr
+      default_overlay_address_families: [ vpn-ipv4 ]

--- a/ansible_collections/arista/avd/plugins/module_utils/eos_designs_facts.py
+++ b/ansible_collections/arista/avd/plugins/module_utils/eos_designs_facts.py
@@ -125,32 +125,21 @@ class EosDesignsFacts:
         """
         switch.node_type_key fact set by finding a matching "type" in "node_type_keys" variable
         """
-        print("Inside")
-        node_type_keys = get(self._hostvars, "node_type_keys", required=True)
-        node_type_keys = self._convert_dicts(node_type_keys, 'name')
-        for node_type_key in node_type_keys:
-            for n in node_type_key:
-                # pass
-                # if 'type' in n:
-                if n['type'] == self.type:
-                    return n
-            # print('nodetype..', node_type_key )
-            # for key, value in node_type_key.items():
-            #     if value['type'] == self.type:
-            #         return key
-            # node_type = node_type_key.get('type', ['all'])
-            # if node_type == self.type:
-            #     return node_type_key.get('type')
-
-        # Not found
-        raise AristaAvdMissingVariableError(f"node_type_keys.<>.type=={type}")
+        return self._node_type_key_data['key']
 
     @cached_property
     def _node_type_key_data(self):
         """
         internal _node_type_key_data containing settings for this node_type.
         """
-        return get(self._hostvars, f"node_type_keys.{self.node_type_key}", required=True)
+        node_type_keys = get(self._hostvars, "node_type_keys", required=True)
+        node_type_keys = self._convert_dicts(node_type_keys, 'key')
+        for node_type in node_type_keys:
+            if node_type['type'] == self.type:
+                return node_type
+
+        # Not found
+        raise AristaAvdMissingVariableError(f"node_type_keys.<>.type=={type}")
 
     @cached_property
     def connected_endpoints(self):

--- a/ansible_collections/arista/avd/plugins/module_utils/eos_designs_facts.py
+++ b/ansible_collections/arista/avd/plugins/module_utils/eos_designs_facts.py
@@ -125,10 +125,22 @@ class EosDesignsFacts:
         """
         switch.node_type_key fact set by finding a matching "type" in "node_type_keys" variable
         """
+        print("Inside")
         node_type_keys = get(self._hostvars, "node_type_keys", required=True)
-        for key, value in node_type_keys.items():
-            if value['type'] == self.type:
-                return key
+        node_type_keys = self._convert_dicts(node_type_keys, 'name')
+        for node_type_key in node_type_keys:
+            for n in node_type_key:
+                # pass
+                # if 'type' in n:
+                if n['type'] == self.type:
+                    return n
+            # print('nodetype..', node_type_key )
+            # for key, value in node_type_key.items():
+            #     if value['type'] == self.type:
+            #         return key
+            # node_type = node_type_key.get('type', ['all'])
+            # if node_type == self.type:
+            #     return node_type_key.get('type')
 
         # Not found
         raise AristaAvdMissingVariableError(f"node_type_keys.<>.type=={type}")

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/node-types-v4.0.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/node-types-v4.0.md
@@ -9,7 +9,7 @@ The node type definition is done under `node_type_keys`. This dictionary defines
 # This allows for complete customization of the fabric layout.
 # This should be defined in top level group_var for the fabric.
 node_type_keys:
-  - name: <node_type_key>
+  - key: <node_type_key>
     # Required | The value of "type" set on each switch
     type: <type value matching this node_type_key>
 
@@ -160,10 +160,10 @@ The next output is structure example based on default definition:
 # Example
 # The below key/pair values are the role defaults.
 node_type_keys:
-  - name: spine
+  - key: spine
     type: spine
     default_evpn_role: server
-  - name: l3leaf
+  - key: l3leaf
     type: l3leaf
     connected_endpoints: true
     default_evpn_role: client
@@ -172,7 +172,7 @@ node_type_keys:
       l2: true
       l3: true
     vtep: true
-  - name: l2leaf:
+  - key: l2leaf:
     type: l2leaf
     connected_endpoints: true
     mlag_support: true
@@ -180,9 +180,9 @@ node_type_keys:
       l2: true
     underlay_router: false
     uplink_type: port-channel
-  - name: super_spine
+  - key: super_spine
     type: super-spine
-  - name: overlay_controller
+  - key: overlay_controller
     type: overlay-controller
 ```
 

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/node-types-v4.0.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/node-types-v4.0.md
@@ -9,7 +9,7 @@ The node type definition is done under `node_type_keys`. This dictionary defines
 # This allows for complete customization of the fabric layout.
 # This should be defined in top level group_var for the fabric.
 node_type_keys:
-  <node_type_key>:
+  - name: <node_type_key>
     # Required | The value of "type" set on each switch
     type: <type value matching this node_type_key>
 
@@ -160,10 +160,10 @@ The next output is structure example based on default definition:
 # Example
 # The below key/pair values are the role defaults.
 node_type_keys:
-  spine:
+  - name: spine
     type: spine
     default_evpn_role: server
-  l3leaf:
+  - name: l3leaf
     type: l3leaf
     connected_endpoints: true
     default_evpn_role: client
@@ -172,7 +172,7 @@ node_type_keys:
       l2: true
       l3: true
     vtep: true
-  l2leaf:
+  - name: l2leaf:
     type: l2leaf
     connected_endpoints: true
     mlag_support: true
@@ -180,9 +180,9 @@ node_type_keys:
       l2: true
     underlay_router: false
     uplink_type: port-channel
-  super_spine:
+  - name: super_spine
     type: super-spine
-  overlay_controller:
+  - name: overlay_controller
     type: overlay-controller
 ```
 

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/documentation/fabric-documentation.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/documentation/fabric-documentation.j2
@@ -1,3 +1,4 @@
+{% set node_types = node_type_keys | arista.avd.convert_dicts('key') | map(attribute="type") %}
 {% set fabric_switches = [] %}
 {% set topology_links = [] %}
 {% set uplink_ipv4_pools = [] %}
@@ -7,7 +8,7 @@
 {% set interfaces_done = [] %}
 {% for node in groups[fabric_name] | arista.avd.natural_sort %}
 {%     set node_hostvars = hostvars[node] %}
-{%     if node_hostvars.type | arista.avd.default('undefined') in node_type_keys | dict2items | map(attribute='value.type') | list %}
+{%     if node_hostvars.type | arista.avd.default('undefined') in node_types %}
 {# Populate network summaries #}
 {%         do uplink_ipv4_pools.append(node_hostvars.switch.uplink_ipv4_pool | arista.avd.default()) %}
 {%         do loopback_ipv4_pools.append(node_hostvars.switch.loopback_ipv4_pool | arista.avd.default()) %}
@@ -41,7 +42,7 @@
 {%         do fabric_switches.append(fabric_switch) %}
 {# Populate topology_links #}
 {%         for ethernet_interface in node_hostvars.ethernet_interfaces | arista.avd.natural_sort %}
-{%             if node_hostvars.ethernet_interfaces[ethernet_interface].peer_type | arista.avd.default('undefined') in node_type_keys | dict2items | map(attribute='value.type') | list + ['mlag_peer'] %}
+{%             if node_hostvars.ethernet_interfaces[ethernet_interface].peer_type | arista.avd.default('undefined') in node_types + ['mlag_peer'] %}
 {%                 do interfaces_done.append(node ~ "," ~ ethernet_interface) %}
 {%                 set peer = node_hostvars.ethernet_interfaces[ethernet_interface].peer %}
 {%                 set peer_interface = node_hostvars.ethernet_interfaces[ethernet_interface].peer_interface %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/documentation/fabric-p2p-links.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/documentation/fabric-p2p-links.j2
@@ -2,34 +2,36 @@ Type,Node,Node Interface,Leaf IP Address,Peer Type,Peer Node,Peer Interface,Peer
 {% set interfaces_done = [] %}
 {% for node in groups[fabric_name] | arista.avd.natural_sort %}
 {%     set node_hostvars = hostvars[node] %}
-{%     if node_hostvars.type | arista.avd.default('undefined') in node_type_keys | dict2items | map(attribute='value.type') | list %}
-{%         for ethernet_interface in node_hostvars.ethernet_interfaces | arista.avd.natural_sort %}
-{%             if node_hostvars.ethernet_interfaces[ethernet_interface].type is arista.avd.defined('routed') %}
-{%                 if node_hostvars.ethernet_interfaces[ethernet_interface].peer_type | arista.avd.default('undefined') in node_type_keys | dict2items | map(attribute='value.type') | list %}
-{%                     do interfaces_done.append(node ~ "," ~ ethernet_interface) %}
-{%                     set peer = node_hostvars.ethernet_interfaces[ethernet_interface].peer %}
-{%                     set peer_interface = node_hostvars.ethernet_interfaces[ethernet_interface].peer_interface %}
-{%                     if peer is arista.avd.defined and peer_interface is arista.avd.defined and peer ~ "," ~ peer_interface not in interfaces_done %}
-{%                         set csv_line = [] %}
-{%                         do csv_line.append(node_hostvars.type) %}
-{%                         do csv_line.append(node) %}
-{%                         do csv_line.append(ethernet_interface) %}
-{%                         do csv_line.append(node_hostvars.ethernet_interfaces[ethernet_interface].ip_address | arista.avd.default("")) %}
-{%                         do csv_line.append(node_hostvars.ethernet_interfaces[ethernet_interface].peer_type) %}
-{%                         do csv_line.append(peer) %}
-{%                         do csv_line.append(peer_interface) %}
-{%                         set peer_ip_address = "" %}
-{%                         set peer_hostvars = hostvars[peer] | arista.avd.default %}
-{%                         if peer_hostvars.ethernet_interfaces is arista.avd.defined %}
-{%                             if peer_hostvars.ethernet_interfaces[peer_interface] is arista.avd.defined %}
-{%                                 set peer_ip_address = peer_hostvars.ethernet_interfaces[peer_interface].ip_address | arista.avd.default("") %}
+{%     for node_type_key in node_type_keys | arista.avd.convert_dicts('name') %}
+{%         if node_hostvars.type | arista.avd.default('undefined') in node_type_key.name %}
+{%             for ethernet_intqerface in node_hostvars.ethernet_interfaces | arista.avd.natural_sort %}
+{%                 if node_hostvars.ethernet_interfaces[ethernet_interface].type is arista.avd.defined('routed') %}
+{%                     if node_hostvars.ethernet_interfaces[ethernet_interface].peer_type | arista.avd.default('undefined') in node_type_key.name | dict2items | map(attribute='value.type') | list %}
+{%                         do interfaces_done.append(node ~ "," ~ ethernet_interface) %}
+{%                         set peer = node_hostvars.ethernet_interfaces[ethernet_interface].peer %}
+{%                         set peer_interface = node_hostvars.ethernet_interfaces[ethernet_interface].peer_interface %}
+{%                         if peer is arista.avd.defined and peer_interface is arista.avd.defined and peer ~ "," ~ peer_interface not in interfaces_done %}
+{%                             set csv_line = [] %}
+{%                             do csv_line.append(node_hostvars.type) %}
+{%                             do csv_line.append(node) %}
+{%                             do csv_line.append(ethernet_interface) %}
+{%                             do csv_line.append(node_hostvars.ethernet_interfaces[ethernet_interface].ip_address | arista.avd.default("")) %}
+{%                             do csv_line.append(node_hostvars.ethernet_interfaces[ethernet_interface].peer_type) %}
+{%                             do csv_line.append(peer) %}
+{%                             do csv_line.append(peer_interface) %}
+{%                             set peer_ip_address = "" %}
+{%                             set peer_hostvars = hostvars[peer] | arista.avd.default %}
+{%                             if peer_hostvars.ethernet_interfaces is arista.avd.defined %}
+{%                                 if peer_hostvars.ethernet_interfaces[peer_interface] is arista.avd.defined %}
+{%                                     set peer_ip_address = peer_hostvars.ethernet_interfaces[peer_interface].ip_address | arista.avd.default("") %}
+{%                                 endif %}
 {%                             endif %}
-{%                         endif %}
-{%                         do csv_line.append(peer_ip_address) %}
+{%                             do csv_line.append(peer_ip_address) %}
 {{ csv_line | join(",") }}
+{%                         endif %}
 {%                     endif %}
 {%                 endif %}
-{%             endif %}
-{%         endfor %}
-{%     endif %}
+{%             endfor %}
+{%         endif %}
+{%     endfor %}
 {% endfor %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/documentation/fabric-p2p-links.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/documentation/fabric-p2p-links.j2
@@ -6,7 +6,7 @@ Type,Node,Node Interface,Leaf IP Address,Peer Type,Peer Node,Peer Interface,Peer
 {%     if node_hostvars.type | arista.avd.default('undefined') in node_types %}
 {%         for ethernet_interface in node_hostvars.ethernet_interfaces | arista.avd.natural_sort %}
 {%             if node_hostvars.ethernet_interfaces[ethernet_interface].type is arista.avd.defined('routed') %}
-{%                 if node_hostvars.ethernet_interfaces[ethernet_interface].peer_type in node_types %}
+{%                 if node_hostvars.ethernet_interfaces[ethernet_interface].peer_type | arista.avd.default('undefined') in node_types %}
 {%                     do interfaces_done.append(node ~ "," ~ ethernet_interface) %}
 {%                     set peer = node_hostvars.ethernet_interfaces[ethernet_interface].peer %}
 {%                     set peer_interface = node_hostvars.ethernet_interfaces[ethernet_interface].peer_interface %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/documentation/fabric-p2p-links.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/documentation/fabric-p2p-links.j2
@@ -1,37 +1,36 @@
 Type,Node,Node Interface,Leaf IP Address,Peer Type,Peer Node,Peer Interface,Peer IP Address
 {% set interfaces_done = [] %}
+{% set node_types = node_type_keys | arista.avd.convert_dicts('key') | map(attribute="type") %}
 {% for node in groups[fabric_name] | arista.avd.natural_sort %}
 {%     set node_hostvars = hostvars[node] %}
-{%     for node_type_key in node_type_keys | arista.avd.convert_dicts('name') %}
-{%         if node_hostvars.type | arista.avd.default('undefined') in node_type_key.name %}
-{%             for ethernet_intqerface in node_hostvars.ethernet_interfaces | arista.avd.natural_sort %}
-{%                 if node_hostvars.ethernet_interfaces[ethernet_interface].type is arista.avd.defined('routed') %}
-{%                     if node_hostvars.ethernet_interfaces[ethernet_interface].peer_type | arista.avd.default('undefined') in node_type_key.name | dict2items | map(attribute='value.type') | list %}
-{%                         do interfaces_done.append(node ~ "," ~ ethernet_interface) %}
-{%                         set peer = node_hostvars.ethernet_interfaces[ethernet_interface].peer %}
-{%                         set peer_interface = node_hostvars.ethernet_interfaces[ethernet_interface].peer_interface %}
-{%                         if peer is arista.avd.defined and peer_interface is arista.avd.defined and peer ~ "," ~ peer_interface not in interfaces_done %}
-{%                             set csv_line = [] %}
-{%                             do csv_line.append(node_hostvars.type) %}
-{%                             do csv_line.append(node) %}
-{%                             do csv_line.append(ethernet_interface) %}
-{%                             do csv_line.append(node_hostvars.ethernet_interfaces[ethernet_interface].ip_address | arista.avd.default("")) %}
-{%                             do csv_line.append(node_hostvars.ethernet_interfaces[ethernet_interface].peer_type) %}
-{%                             do csv_line.append(peer) %}
-{%                             do csv_line.append(peer_interface) %}
-{%                             set peer_ip_address = "" %}
-{%                             set peer_hostvars = hostvars[peer] | arista.avd.default %}
-{%                             if peer_hostvars.ethernet_interfaces is arista.avd.defined %}
-{%                                 if peer_hostvars.ethernet_interfaces[peer_interface] is arista.avd.defined %}
-{%                                     set peer_ip_address = peer_hostvars.ethernet_interfaces[peer_interface].ip_address | arista.avd.default("") %}
-{%                                 endif %}
+{%     if node_hostvars.type | arista.avd.default('undefined') in node_types %}
+{%         for ethernet_interface in node_hostvars.ethernet_interfaces | arista.avd.natural_sort %}
+{%             if node_hostvars.ethernet_interfaces[ethernet_interface].type is arista.avd.defined('routed') %}
+{%                 if node_hostvars.ethernet_interfaces[ethernet_interface].peer_type in node_types %}
+{%                     do interfaces_done.append(node ~ "," ~ ethernet_interface) %}
+{%                     set peer = node_hostvars.ethernet_interfaces[ethernet_interface].peer %}
+{%                     set peer_interface = node_hostvars.ethernet_interfaces[ethernet_interface].peer_interface %}
+{%                     if peer is arista.avd.defined and peer_interface is arista.avd.defined and peer ~ "," ~ peer_interface not in interfaces_done %}
+{%                         set csv_line = [] %}
+{%                         do csv_line.append(node_hostvars.type) %}
+{%                         do csv_line.append(node) %}
+{%                         do csv_line.append(ethernet_interface) %}
+{%                         do csv_line.append(node_hostvars.ethernet_interfaces[ethernet_interface].ip_address | arista.avd.default("")) %}
+{%                         do csv_line.append(node_hostvars.ethernet_interfaces[ethernet_interface].peer_type) %}
+{%                         do csv_line.append(peer) %}
+{%                         do csv_line.append(peer_interface) %}
+{%                         set peer_ip_address = "" %}
+{%                         set peer_hostvars = hostvars[peer] | arista.avd.default %}
+{%                         if peer_hostvars.ethernet_interfaces is arista.avd.defined %}
+{%                             if peer_hostvars.ethernet_interfaces[peer_interface] is arista.avd.defined %}
+{%                                 set peer_ip_address = peer_hostvars.ethernet_interfaces[peer_interface].ip_address | arista.avd.default("") %}
 {%                             endif %}
-{%                             do csv_line.append(peer_ip_address) %}
-{{ csv_line | join(",") }}
 {%                         endif %}
+{%                         do csv_line.append(peer_ip_address) %}
+{{ csv_line | join(",") }}
 {%                     endif %}
 {%                 endif %}
-{%             endfor %}
-{%         endif %}
-{%     endfor %}
+{%             endif %}
+{%         endfor %}
+{%     endif %}
 {% endfor %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/documentation/fabric-topology.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/documentation/fabric-topology.j2
@@ -1,7 +1,8 @@
 Node Type,Node,Node Interface,Peer Type,Peer Node,Peer Interface
+{% set node_types = node_type_keys | arista.avd.convert_dicts('key') | map(attribute="type") %}
 {% for node in groups[fabric_name] | arista.avd.natural_sort %}
 {%     set node_hostvars = hostvars[node] %}
-{%     if node_hostvars.type | arista.avd.default('undefined') in node_type_keys | dict2items | map(attribute='value.type') | list %}
+{%     if node_hostvars.type | arista.avd.default('undefined') in node_types %}
 {%         for ethernet_interface in node_hostvars.ethernet_interfaces | arista.avd.natural_sort %}
 {%             set csv_line = [] %}
 {%             do csv_line.append(node_hostvars.type) %}


### PR DESCRIPTION
## "Wildcard Keyed Dict" to "List of Dicts" Data model migration

<!-- Use this PR Title: Refactor(eos_cli_config_gen): Wildcard dict to list for `< data_model_key >` -->

## Data model key

`node_type_keys`

## Checklist

### Contributor Checklist

- [ ] Update `README_v4.0.md` with new data model
- [ ] Update `templates/eos/< template >.j2` and `templates/documentation/< template >.j2`:
  - [ ] Add `arista.avd.convert_dicts('<primary key>')` filter for loops previously using wildcard keys
  - [ ] Update `arista.avd.natural_sort('<primary key>')` to sort on the primary key (if applicable)
 - [ ] Verify no changes to generated configs/docs

### Reviewer Checklist

- Reviewer 1: Claus
  - [x] Verify data model changes
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2: Guillaume
  - [x] Verify data model changes
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
