### PR TITLE
Feat(eos_config_deploy_cvp): support for !vault value in inventory file

### DIFF
--- a/ansible_collections/arista/avd/plugins/modules/inventory_to_container.py
+++ b/ansible_collections/arista/avd/plugins/modules/inventory_to_container.py
@@ -441,7 +441,7 @@ def main():
                 inventory_content = yaml.safe_load(stream)
             except yaml.YAMLError as exc:
                 raise AnsibleValidationError(
-                    f"Failed to parse inventory file, original exception:{exc}"
+                    "Failed to parse inventory file"
                 ) from exc
         result["CVP_TOPOLOGY"] = get_containers(inventory_content=inventory_content,
                                                 parent_container=parent_container,

--- a/ansible_collections/arista/avd/plugins/modules/inventory_to_container.py
+++ b/ansible_collections/arista/avd/plugins/modules/inventory_to_container.py
@@ -435,9 +435,11 @@ def main():
         inventory_content = ""
         with open(inventory_file, 'r', encoding='utf8') as stream:
             try:
+                # add a constructor to return "!VAULT" for inline vault variables
+                # to avoid the parse
+                yaml.SafeLoader.add_constructor("!vault", lambda _, __: "!VAULT")
                 inventory_content = yaml.safe_load(stream)
             except yaml.YAMLError as exc:
-                module.debug(exc)
                 raise AnsibleValidationError(
                     f"Failed to parse inventory file, original exception:{exc}"
                 ) from exc
@@ -460,7 +462,4 @@ def main():
 
 
 if __name__ == "__main__":
-    # add a constructor to return "!VAULT" for inline vault variables
-    # to avoid the parse
-    yaml.SafeLoader.add_constructor("!vault", lambda _, __: "!VAULT")
     main()

--- a/ansible_collections/arista/avd/plugins/modules/inventory_to_container.py
+++ b/ansible_collections/arista/avd/plugins/modules/inventory_to_container.py
@@ -19,6 +19,7 @@
 #
 
 from __future__ import (absolute_import, division, print_function)
+
 __metaclass__ = type
 
 DOCUMENTATION = r'''
@@ -96,9 +97,13 @@ import glob
 import os
 import traceback
 from ansible.module_utils.basic import AnsibleModule
+from ansible.errors import AnsibleError
+from ansible.parsing.yaml.objects import AnsibleVaultEncryptedUnicode
+
 TREELIB_IMP_ERR = None
 try:
     from treelib import Tree
+
     HAS_TREELIB = True
 except ImportError:
     HAS_TREELIB = False
@@ -106,6 +111,7 @@ except ImportError:
 YAML_IMP_ERR = None
 try:
     import yaml
+
     HAS_YAML = True
 except ImportError:
     HAS_YAML = False
@@ -157,7 +163,7 @@ def isIterable(testing_object=None):
         Object to test if it is iterable or not, by default None
     """
     try:
-        some_object_iterator = iter(testing_object)  # noqa # pylint: disable=unused-variable
+        iter(testing_object)  # noqa
         return True
     except TypeError as te:  # noqa # pylint: disable=unused-variable
         return False
@@ -433,7 +439,10 @@ def main():
                 inventory_content = yaml.safe_load(stream)
             except yaml.YAMLError as exc:
                 module.debug(exc)
-        result['CVP_TOPOLOGY'] = get_containers(inventory_content=inventory_content,
+                raise AnsibleError(
+                    f"Failed to parse inventory file, original exception:{exc}"
+                ) from exc
+        result["CVP_TOPOLOGY"] = get_containers(inventory_content=inventory_content,
                                                 parent_container=parent_container,
                                                 device_filter=module.params['device_filter'])
 
@@ -451,5 +460,17 @@ def main():
     module.exit_json(**result)
 
 
-if __name__ == '__main__':
+def construct_vault_encrypted_unicode(loader, node):
+    """
+    This construct is used to handle inline !vault variable when parsing
+    the inventory.
+
+    https://stackoverflow.com/a/69856812
+    """
+    value = loader.construct_scalar(node)
+    return AnsibleVaultEncryptedUnicode(value)
+
+
+if __name__ == "__main__":
+    yaml.SafeLoader.add_constructor("!vault", construct_vault_encrypted_unicode)
     main()

--- a/ansible_collections/arista/avd/plugins/modules/inventory_to_container.py
+++ b/ansible_collections/arista/avd/plugins/modules/inventory_to_container.py
@@ -97,11 +97,9 @@ import os
 import traceback
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.errors import AnsibleValidationError
-
 TREELIB_IMP_ERR = None
 try:
     from treelib import Tree
-
     HAS_TREELIB = True
 except ImportError:
     HAS_TREELIB = False
@@ -109,7 +107,6 @@ except ImportError:
 YAML_IMP_ERR = None
 try:
     import yaml
-
     HAS_YAML = True
 except ImportError:
     HAS_YAML = False

--- a/ansible_collections/arista/avd/plugins/modules/inventory_to_container.py
+++ b/ansible_collections/arista/avd/plugins/modules/inventory_to_container.py
@@ -19,7 +19,6 @@
 #
 
 from __future__ import (absolute_import, division, print_function)
-
 __metaclass__ = type
 
 DOCUMENTATION = r'''

--- a/ansible_collections/arista/avd/tests/inventory/inventory.yml
+++ b/ansible_collections/arista/avd/tests/inventory/inventory.yml
@@ -11,7 +11,8 @@ all:
           ansible_httpapi_host: 10.83.28.164
           ansible_host: 10.83.28.164
           ansible_user: ansible
-          ansible_password: ansible
+          ansible_password: !vault |
+              dummy_vault_value
           ansible_connection: httpapi
           ansible_httpapi_use_ssl: true
           ansible_httpapi_validate_certs: false

--- a/ansible_collections/arista/avd/tests/unit/modules/test_inventory_to_container.py
+++ b/ansible_collections/arista/avd/tests/unit/modules/test_inventory_to_container.py
@@ -9,6 +9,7 @@ import pytest
 import yaml
 import treelib
 import json
+from ansible.parsing.yaml.objects import AnsibleVaultEncryptedUnicode
 
 IS_ITERABLE_VALID = [
     ("string1", "string2", "string3", "string4"),
@@ -82,8 +83,20 @@ TREELIB_VALID_LEAF = "Leaf1"
 TREELIB_INVALID_LEAF = "DC1"
 
 
+def construct_vault_encrypted_unicode(loader, node):
+    """
+    This construct is used to handle inline !vault variable when parsing
+    the inventory.
+
+    https://stackoverflow.com/a/69856812
+    """
+    value = loader.construct_scalar(node)
+    return AnsibleVaultEncryptedUnicode(value)
+
+
 @pytest.fixture(scope="session")
 def inventory():
+    yaml.SafeLoader.add_constructor("!vault", construct_vault_encrypted_unicode)
     with open(INVENTORY_FILE, 'r', encoding='utf8') as stream:
         try:
             inventory_content = yaml.safe_load(stream)

--- a/ansible_collections/arista/avd/tests/unit/modules/test_inventory_to_container.py
+++ b/ansible_collections/arista/avd/tests/unit/modules/test_inventory_to_container.py
@@ -9,7 +9,6 @@ import pytest
 import yaml
 import treelib
 import json
-from ansible.parsing.yaml.objects import AnsibleVaultEncryptedUnicode
 
 IS_ITERABLE_VALID = [
     ("string1", "string2", "string3", "string4"),
@@ -83,20 +82,9 @@ TREELIB_VALID_LEAF = "Leaf1"
 TREELIB_INVALID_LEAF = "DC1"
 
 
-def construct_vault_encrypted_unicode(loader, node):
-    """
-    This construct is used to handle inline !vault variable when parsing
-    the inventory.
-
-    https://stackoverflow.com/a/69856812
-    """
-    value = loader.construct_scalar(node)
-    return AnsibleVaultEncryptedUnicode(value)
-
-
 @pytest.fixture(scope="session")
 def inventory():
-    yaml.SafeLoader.add_constructor("!vault", construct_vault_encrypted_unicode)
+    yaml.SafeLoader.add_constructor("!vault", lambda _, __: "!VAULT")
     with open(INVENTORY_FILE, 'r', encoding='utf8') as stream:
         try:
             inventory_content = yaml.safe_load(stream)


### PR DESCRIPTION
## Change Summary

This PR aims to fix the current silent failure behavior that occurs
when using inline !vault variable in the inventory file.

## Related Issue(s)

Fixes #1781

## Component(s) name

`arista.avd.eos_config_deploy_cvp`

## Proposed changes

### Current behavior:

When the inventory_to_container.py plugin tries to load such inventory,
the yaml safe_load function fails BUT the plugin catch the exception and
does not raise afterwards (only module.debug). The inventory_content
however is set to "" (empty string) which leads to an error in serialize
later on.

### Commit behavior:

* Introduce a special constructor when parsing via yaml to understand
  the `!vault` construct. This replaces the !vault values by
  AnsibleVaultEncryptedUnicode type in the parsed file which allows for
  the plugins to continue
* Change the behavior if another parsing error to raise an AnsibleError
  with the instruction rather than swallowing the Exception and failing
  later.
* Update the unit tests to use the same constructor


### Notes:

* the author tried to use decrypted vault values when parsing the
  inventory but it turns out to be difficult as the plugin does not
  receive the vault password when call from AVD `eos_config_deploy_cvp`
  and hence it would be require to add some logic to retrieve the vault
  password(s) to be able to decrypt the vault value.
  Given that the vault values are actually not required (as far as the
  author can see) - the decision to simply load the inventory with
  encoded vault values as AnsibleVaultEncryptedUnicode seems a good
  compromise.

## How to test

Run the unit tests

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
