### PR TITLE
Fix(eos_cli_config_gen): Render error-correction encoding on port-channel members

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
@@ -103,6 +103,12 @@ interface Management1
 | Ethernet10/10 | 110 | *ISIS_TEST | *99 | *point-to-point | *level-2 | *True | *text |
  *Inherited from Port-Channel Interface
 
+#### Error Correction Encoding Interfaces
+
+| Interface | Enabled |
+| --------- | ------- |
+| Ethernet11/1 | fire-code<br>reed-solomon |
+
 ### Ethernet Interfaces Device Configuration
 
 ```eos
@@ -149,7 +155,9 @@ interface Ethernet10/10
    channel-group 110 mode active
 !
 interface Ethernet11/1
-   description LAG Member
+   description LAG Member with error_correction
+   error-correction encoding fire-code
+   error-correction encoding reed-solomon
    channel-group 111 mode active
 !
 interface Ethernet11/2

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
@@ -335,7 +335,9 @@ interface Ethernet10/10
    channel-group 110 mode active
 !
 interface Ethernet11/1
-   description LAG Member
+   description LAG Member with error_correction
+   error-correction encoding fire-code
+   error-correction encoding reed-solomon
    channel-group 111 mode active
 !
 interface Ethernet11/2

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
@@ -459,7 +459,10 @@ ethernet_interfaces:
       mode: active
 
   Ethernet11/1:
-    description: LAG Member
+    description: LAG Member with error_correction
+    error_correction_encoding:
+      fire_code: true
+      reed_solomon: true
     channel_group:
       id: 111
       mode: active

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -53,21 +53,21 @@ interface {{ ethernet_interface.name }}
 {%     if ethernet_interface.mac_security.profile is arista.avd.defined %}
    mac security profile {{ ethernet_interface.mac_security.profile }}
 {%     endif %}
-{%     if print_ethernet is arista.avd.defined(true) %}
-{%         if ethernet_interface.error_correction_encoding.enabled is arista.avd.defined(false) %}
+{%     if ethernet_interface.error_correction_encoding.enabled is arista.avd.defined(false) %}
    no error-correction encoding
-{%         else %}
-{%             if ethernet_interface.error_correction_encoding.fire_code is arista.avd.defined(true) %}
+{%     else %}
+{%         if ethernet_interface.error_correction_encoding.fire_code is arista.avd.defined(true) %}
    error-correction encoding fire-code
-{%             elif ethernet_interface.error_correction_encoding.fire_code is arista.avd.defined(false) %}
+{%         elif ethernet_interface.error_correction_encoding.fire_code is arista.avd.defined(false) %}
    no error-correction encoding fire-code
-{%             endif %}
-{%             if ethernet_interface.error_correction_encoding.reed_solomon is arista.avd.defined(true) %}
-   error-correction encoding reed-solomon
-{%             elif ethernet_interface.error_correction_encoding.reed_solomon is arista.avd.defined(false) %}
-   no error-correction encoding reed-solomon
-{%             endif %}
 {%         endif %}
+{%         if ethernet_interface.error_correction_encoding.reed_solomon is arista.avd.defined(true) %}
+   error-correction encoding reed-solomon
+{%         elif ethernet_interface.error_correction_encoding.reed_solomon is arista.avd.defined(false) %}
+   no error-correction encoding reed-solomon
+{%         endif %}
+{%     endif %}
+{%     if print_ethernet is arista.avd.defined(true) %}
 {%         if ethernet_interface.mode is arista.avd.defined('access') or ethernet_interface.mode is arista.avd.defined('dot1q-tunnel') %}
 {%             if ethernet_interface.vlans is arista.avd.defined %}
    switchport access vlan {{ ethernet_interface.vlans }}


### PR DESCRIPTION


## Change Summary

<!-- Enter short PR description -->
Render error correction encoding on port-channel members

## Related Issue(s)

`error-correction encoding` configuration is not rendered on port-channel members.

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
test case added to molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
