### PR TITLE
Refactor(eos_designs): Wildcard dict to list platform_speed_groups

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/inventory/group_vars/DC1_FABRIC.yml
@@ -297,9 +297,12 @@ custom_structured_configuration_prefix: [ 'my_dci_', 'my_special_dci_', 'overrid
 
 # Set Hardware Speed Groups per platform
 platform_speed_groups:
-  7280R:             # Only setting speed-groups on 7280R platform, so only L3leaf should get this setting.
-    25G: [ 3, 2 ]    # Unsorted order, but we should sort output correctly.
-    10G: [ 1, 2, 4 ] # Duplicate speed-group 2. Since we sort on key first the result will be 25G for group 2
+  - name: 7280R            # Only setting speed-groups on 7280R platform, so only L3leaf should get this setting.
+    speeds:
+      - speed: 25G
+        speed_groups: [ 3, 2 ] # Unsorted order, but we should sort output correctly.
+      - speed: 10G
+        speed_groups: [ 1, 2, 4 ] # Duplicate speed-group 2. Since we sort on key first the result will be 25G for group 2
 
 # Set Aboot password with sha512 hash
 boot:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/inventory/group_vars/DC1_FABRIC.yml
@@ -297,7 +297,7 @@ custom_structured_configuration_prefix: [ 'my_dci_', 'my_special_dci_', 'overrid
 
 # Set Hardware Speed Groups per platform
 platform_speed_groups:
-  - name: 7280R            # Only setting speed-groups on 7280R platform, so only L3leaf should get this setting.
+  - platform: 7280R            # Only setting speed-groups on 7280R platform, so only L3leaf should get this setting.
     speeds:
       - speed: 25G
         speed_groups: [ 3, 2 ] # Unsorted order, but we should sort output correctly.

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/platform-settings-v4.0.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/platform-settings-v4.0.md
@@ -29,8 +29,10 @@ platform_settings:
 
 # Set Hardware Speed Groups per Platform
 platform_speed_groups:
-  < platform >:
-    < speed >: [ < speed_group >, < speed_group > ]
+  - name: < platform >
+    speeds:
+      -  speed: < speed >
+         speed_groups: [ < speed_group >, < speed_group > ]
 
 # Redundancy for chassis platforms with dual supervisors | Optional
 redundancy:

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/platform-settings-v4.0.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/platform-settings-v4.0.md
@@ -29,7 +29,7 @@ platform_settings:
 
 # Set Hardware Speed Groups per Platform
 platform_speed_groups:
-  - name: < platform >
+  - platform: < platform >
     speeds:
       -  speed: < speed >
          speed_groups: [ < speed_group >, < speed_group > ]

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/base/hardware.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/base/hardware.j2
@@ -3,12 +3,20 @@
 {# Using tmp variable to be able to sort final output and handle duplicate assignments gracefully #}
 {%     set tmp_speed_groups = {} %}
 {%     if switch.platform is arista.avd.defined %}
-{%         for speed in platform_speed_groups | arista.avd.convert_dicts('name', 'speeds') | arista.avd.natural_sort('name') | selectattr('name','arista.avd.defined',switch.platform) %}
-{%             for speed_group in speed.speeds | arista.avd.convert_dicts('speed', 'speed_groups') | arista.avd.natural_sort('speed') %}
-{%                 for group in speed_group.speed_groups %}
-{%                     do tmp_speed_groups.update({group: speed_group.speed}) %}
+{%         for platform_item in platform_speed_groups %}
+{# changing for avd_v4.0 #}
+{%             if "platform" in platform_item and "speeds" in platform_item %}
+{%                 set platform = platform_item %}
+{%             else %}
+{%                 set platform = {"platform": platform_item, "speeds": platform_speed_groups[platform_item]} %}
+{%             endif %}
+{%             if platform.platform == switch.platform %}
+{%                 for speed in platform.speeds | arista.avd.convert_dicts('speed', 'speed_groups') | arista.avd.natural_sort('speed') %}
+{%                     for speed_group in speed.speed_groups %}
+{%                         do tmp_speed_groups.update({speed_group: speed.speed}) %}
+{%                     endfor %}
 {%                 endfor %}
-{%             endfor %}
+{%             endif %}
 {%         endfor %}
 {%     endif %}
 {%     if tmp_speed_groups | arista.avd.natural_sort | length > 0 %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/base/hardware.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/base/hardware.j2
@@ -3,9 +3,11 @@
 {# Using tmp variable to be able to sort final output and handle duplicate assignments gracefully #}
 {%     set tmp_speed_groups = {} %}
 {%     if switch.platform is arista.avd.defined %}
-{%         for speed in platform_speed_groups[switch.platform] | arista.avd.natural_sort %}
-{%             for speed_group in platform_speed_groups[switch.platform][speed] | arista.avd.natural_sort %}
-{%                 do tmp_speed_groups.update({speed_group: speed}) %}
+{%         for speed in platform_speed_groups | arista.avd.convert_dicts('name', 'speeds') | arista.avd.natural_sort('name') | selectattr('name','arista.avd.defined',switch.platform) %}
+{%             for speed_group in speed.speeds | arista.avd.convert_dicts('speed', 'speed_groups') | arista.avd.natural_sort('speed') %}
+{%                 for group in speed_group.speed_groups %}
+{%                     do tmp_speed_groups.update({group: speed_group.speed}) %}
+{%                 endfor %}
 {%             endfor %}
 {%         endfor %}
 {%     endif %}


### PR DESCRIPTION
## "Wildcard Keyed Dict" to "List of Dicts" Data model migration

<!-- Use this PR Title: Refactor(eos_cli_config_gen): Wildcard dict to list for `< data_model_key >` -->

## Data model key

`platform_speed_groups`

## Checklist

### Contributor Checklist

- [x] Update `README_v4.0.md` with new data model
- [x] Update `templates/eos/< template >.j2` and `templates/documentation/< template >.j2`:
  - [x] Add `arista.avd.convert_dicts('<primary key>')` filter for loops previously using wildcard keys
  - [x] Update `arista.avd.natural_sort('<primary key>')` to sort on the primary key (if applicable)
 - [x] Verify no changes to generated configs/docs

### Reviewer Checklist

- Reviewer 1: Claus
  - [x] Verify data model changes
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2: Tony
  - [x] Verify data model changes
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
