### PR TITLE
Feat(eos_cli_config_gen): Add support for authenticating only ntp servers

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/dns-ntp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/dns-ntp.md
@@ -108,10 +108,27 @@ ip domain lookup vrf mgt source-interface Management0
 | 10.10.111.1 | mgt | True | - | - | - | - | - | - | - |
 | 10.10.111.2 | mgt | - | - | - | - | - | - | - | - |
 
+#### NTP Authentication
+
+- Authentication enabled (Servers only)
+
+- Trusted Keys: 1-2
+
+#### NTP Authentication Keys
+
+| ID | Algoritm |
+| -- | -------- |
+| 1 | md5 |
+| 2 | sha1 |
+
 ### NTP Device Configuration
 
 ```eos
 !
+ntp authentication-key 1 md5 044F0E151B
+ntp authentication-key 2 sha1 15060E1F10
+ntp trusted-key 1-2
+ntp authenticate servers
 ntp local-interface vrf mgt Management0
 ntp server vrf mgt 10.10.111.1 prefer
 ntp server vrf mgt 10.10.111.2

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/dns-ntp.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/dns-ntp.cfg
@@ -9,6 +9,10 @@ ip name-server vrf mgt 10.10.128.10
 ip name-server vrf mgt 10.10.129.10
 dns domain test.local
 !
+ntp authentication-key 1 md5 044F0E151B
+ntp authentication-key 2 sha1 15060E1F10
+ntp trusted-key 1-2
+ntp authenticate servers
 ntp local-interface vrf mgt Management0
 ntp server vrf mgt 10.10.111.1 prefer
 ntp server vrf mgt 10.10.111.2

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/dns-ntp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/dns-ntp.yml
@@ -31,10 +31,10 @@ ntp:
       vrf: mgt
   authenticate_servers_only: true
   authentication_keys:
-  - id: 1
-    hash_algorithm: "md5"
-    key: "044F0E151B"
-  - id: 2
-    hash_algorithm: "sha1"
-    key: "15060E1F10"
+    - id: 1
+      hash_algorithm: "md5"
+      key: "044F0E151B"
+    - id: 2
+      hash_algorithm: "sha1"
+      key: "15060E1F10"
   trusted_keys: "1-2"

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/dns-ntp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/dns-ntp.yml
@@ -29,3 +29,12 @@ ntp:
       vrf: mgt
     - name: 10.10.111.2
       vrf: mgt
+  authenticate_servers_only: true
+  authentication_keys:
+  - id: 1
+    hash_algorithm: "md5"
+    key: "044F0E151B"
+  - id: 2
+    hash_algorithm: "sha1"
+    key: "15060E1F10"
+  trusted_keys: "1-2"

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ntp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ntp.yml
@@ -4,24 +4,24 @@ ntp:
     name: lo1
     vrf: default
   servers:
-  - name: 2.2.2.55
-  - name: 10.1.1.1
-  - name: ie.pool.ntp.org
-    iburst: true
-    burst: false
-    key: 1
-  - name: 10.1.1.2
-    preferred: true
-  - name: 20.20.20.1
-    key: 2
-  - name: 1.2.3.4
-    local_interface: lo0
+    - name: 2.2.2.55
+    - name: 10.1.1.1
+    - name: ie.pool.ntp.org
+      iburst: true
+      burst: false
+      key: 1
+    - name: 10.1.1.2
+      preferred: true
+    - name: 20.20.20.1
+      key: 2
+    - name: 1.2.3.4
+      local_interface: lo0
   authenticate: true
   authentication_keys:
-  - id: 1
-    hash_algorithm: "md5"
-    key: "044F0E151B"
-  - id: 2
-    hash_algorithm: "sha1"
-    key: "15060E1F10"
+    - id: 1
+      hash_algorithm: "md5"
+      key: "044F0E151B"
+    - id: 2
+      hash_algorithm: "sha1"
+      key: "15060E1F10"
   trusted_keys: "1-2"

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -2038,6 +2038,7 @@ ntp:
       version: < 1 - 4 >
       vrf: < vrf_name >
   authenticate: <true | false >
+  authenticate_servers_only: < true | false >
   authentication_keys:
     - id: < key_identifier | 1-65534 >
       hash_algorithm: < md5 | sha1 >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ntp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ntp.j2
@@ -40,7 +40,10 @@
           or ntp.authentication_keys is arista.avd.defined %}
 
 #### NTP Authentication
-{%         if ntp.authenticate is arista.avd.defined(true) %}
+{%         if ntp.authenticate_servers_only is arista.avd.defined(true) %}
+
+- Authentication enabled (Servers only)
+{%         elif ntp.authenticate is arista.avd.defined(true) %}
 
 - Authentication enabled
 {%         endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ntp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ntp.j2
@@ -11,7 +11,9 @@ ntp authentication-key {{ authentication_key.id }} {{ authentication_key.hash_al
 {%     if ntp.trusted_keys is arista.avd.defined %}
 ntp trusted-key {{ ntp.trusted_keys }}
 {%     endif %}
-{%     if ntp.authenticate is arista.avd.defined(true) %}
+{%     if ntp.authenticate_servers_only is arista.avd.defined(true) %}
+ntp authenticate servers
+{%     elif ntp.authenticate is arista.avd.defined(true) %}
 ntp authenticate
 {%     endif %}
 {%     if ntp.local_interface.name is arista.avd.defined %}


### PR DESCRIPTION

## Change Summary

Add support for authenticating only ntp servers.

CLI:
```shell
ntp authenticate servers
```

## Related Issue(s)

Fixes #1783

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Add `authenticate_servers_only` to existing ntp data model.

```yaml
ntp:
  local_interface:
    name: Management0
    vrf: mgt
  servers:
    - name: 10.10.111.1
      preferred: True
      vrf: mgt
    - name: 10.10.111.2
      vrf: mgt
  authenticate_servers_only: true
  authentication_keys:
  - id: 1
    hash_algorithm: "md5"
    key: "044F0E151B"
  - id: 2
    hash_algorithm: "sha1"
    key: "15060E1F10"
  trusted_keys: "1-2"
```


## How to test

Ran `molecule test --scenario-name eos_cli_config_gen`

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
