### PR TITLE
Feat(eos_cli_config_gen): Route redistribution under router isis

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis-new.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis-new.md
@@ -245,6 +245,16 @@ interface Vlan4094
 | Advertise Passive-only | True |
 | SR MPLS Enabled | True |
 
+### ISIS Route Redistribution
+
+| Route Type | Route-Map | Include Leaked |
+| ---------- | --------- | -------------- |
+| isis instance | RM-REDIS-ISIS-INSTANCE | - |
+| ospf internal | - | - |
+| ospf external | RM-OSPF-EXTERNAL-TO-ISIS | - |
+| ospf nssa-external | RM-OSPF-NSSA_EXT-TO-ISIS | True |
+| static | RM-STATIC-TO-ISIS | True |
+
 ### ISIS Interfaces Summary
 
 | Interface | ISIS Instance | ISIS Metric | Interface Mode |
@@ -254,6 +264,13 @@ interface Vlan4094
 | Vlan4093 | EVPN_UNDERLAY | 50 | point-to-point |
 | Loopback0 | EVPN_UNDERLAY | - | passive |
 | Loopback1 | EVPN_UNDERLAY | - | passive |
+
+### Prefix Segments
+
+| Prefix Segment | Index |
+| -------------- | ----- |
+| 155.2.1.1/32 | 211 |
+| 2001:cafe:155::/64 | 6211 |
 
 ### ISIS IPv4 Address Family Summary
 
@@ -265,6 +282,12 @@ interface Vlan4094
 | TI-LFA Level | level-2 |
 | TI-LFA SRLG Enabled | True |
 | TI-LFA SRLG Strict Mode | True |
+
+### Tunnel Source
+
+| Source Protocol | RCF |
+| --------------- | --- |
+| BGP Labeled-Unicast | lu_2_sr_pfx() |
 
 ### ISIS IPv6 Address Family Summary
 
@@ -282,6 +305,11 @@ interface Vlan4094
 router isis EVPN_UNDERLAY
    net 49.0001.0001.0001.0001.00
    is-type level-2
+   redistribute isis instance route-map RM-REDIS-ISIS-INSTANCE
+   redistribute ospf match internal
+   redistribute ospf match external route-map RM-OSPF-EXTERNAL-TO-ISIS
+   redistribute ospf include leaked match nssa-external route-map RM-OSPF-NSSA_EXT-TO-ISIS
+   redistribute static include leaked route-map RM-STATIC-TO-ISIS
    router-id ipv4 192.168.255.4
    log-adjacency-changes
    mpls ldp sync default
@@ -290,6 +318,7 @@ router isis EVPN_UNDERLAY
    !
    address-family ipv4 unicast
       maximum-paths 4
+      tunnel source-protocol bgp ipv4 labeled-unicast rcf lu_2_sr_pfx()
       fast-reroute ti-lfa mode link-protection level-2
       fast-reroute ti-lfa srlg strict
    !
@@ -300,6 +329,8 @@ router isis EVPN_UNDERLAY
    !
    segment-routing mpls
       no shutdown
+      prefix-segment 155.2.1.1/32 index 211
+      prefix-segment 2001:cafe:155::/64 index 6211
 ```
 
 # Multicast

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-isis-new.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-isis-new.cfg
@@ -68,6 +68,11 @@ interface Vlan4094
 router isis EVPN_UNDERLAY
    net 49.0001.0001.0001.0001.00
    is-type level-2
+   redistribute isis instance route-map RM-REDIS-ISIS-INSTANCE
+   redistribute ospf match internal
+   redistribute ospf match external route-map RM-OSPF-EXTERNAL-TO-ISIS
+   redistribute ospf include leaked match nssa-external route-map RM-OSPF-NSSA_EXT-TO-ISIS
+   redistribute static include leaked route-map RM-STATIC-TO-ISIS
    router-id ipv4 192.168.255.4
    log-adjacency-changes
    mpls ldp sync default
@@ -76,6 +81,7 @@ router isis EVPN_UNDERLAY
    !
    address-family ipv4 unicast
       maximum-paths 4
+      tunnel source-protocol bgp ipv4 labeled-unicast rcf lu_2_sr_pfx()
       fast-reroute ti-lfa mode link-protection level-2
       fast-reroute ti-lfa srlg strict
    !
@@ -86,5 +92,7 @@ router isis EVPN_UNDERLAY
    !
    segment-routing mpls
       no shutdown
+      prefix-segment 155.2.1.1/32 index 211
+      prefix-segment 2001:cafe:155::/64 index 6211
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-isis-new.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-isis-new.yml
@@ -17,6 +17,21 @@ router_isis:
     - Ethernet2
     - Vlan4093
     - Loopback1
+  redistribute_routes:
+    - source_protocol: static
+      include_leaked: True
+      route_map: RM-STATIC-TO-ISIS
+    - source_protocol: isis
+      route_map: RM-REDIS-ISIS-INSTANCE
+    - source_protocol: ospf
+      ospf_route_type: internal
+    - source_protocol: ospf
+      ospf_route_type: external
+      route_map: RM-OSPF-EXTERNAL-TO-ISIS
+    - source_protocol: ospf
+      include_leaked: True
+      ospf_route_type: nssa-external
+      route_map: RM-OSPF-NSSA_EXT-TO-ISIS
   address_family_ipv4:
     maximum_paths: 4
     fast_reroute_ti_lfa:
@@ -25,6 +40,9 @@ router_isis:
       srlg:
         enable: true
         strict: true
+    tunnel_source_labeled_unicast:
+      enable: True
+      rcf: lu_2_sr_pfx()
   address_family_ipv6:
     maximum_paths: 4
     fast_reroute_ti_lfa:
@@ -33,6 +51,11 @@ router_isis:
         enable: true
   segment_routing_mpls:
     enabled: true
+    prefix_segments:
+      - prefix: 155.2.1.1/32
+        index: 211
+      - prefix: 2001:cafe:155::/64
+        index: 6211
 
 ### Ethernet Interfaces ###
 ethernet_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-isis-new.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-isis-new.yml
@@ -41,7 +41,7 @@ router_isis:
         enable: true
         strict: true
     tunnel_source_labeled_unicast:
-      enable: True
+      enabled: True
       rcf: lu_2_sr_pfx()
   address_family_ipv6:
     maximum_paths: 4

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -3418,6 +3418,11 @@ router_isis:
   address_family: < List of Address Families >
   isis_af_defaults:
     - maximum-paths < Integer 1-128 >
+  redistribute_routes:
+    - source_protocol: < route_type >
+      route_map: < route_map_name >
+      include_leaked: < true | false >
+      ospf_route_type: < internal | external | nssa-external >
   address_family_ipv4:
     maximum_paths: < Integer 1-128 >
     fast_reroute_ti_lfa:
@@ -3426,6 +3431,9 @@ router_isis:
       srlg:
         enable: < true | false >
         strict: < true | false >
+    tunnel_source_labeled_unicast:
+      enable: < true | false >
+      rcf: < routing_control_function() >
   address_family_ipv6:
     maximum_paths: < Integer 1-128 >
     fast_reroute_ti_lfa:
@@ -3437,6 +3445,9 @@ router_isis:
   segment_routing_mpls:
     enabled: < true | false >
     router_id: < router_id >
+    prefix_segments:
+      - prefix: < IPv4_network/Mask | IPv6_network/Mask >
+        index: < integer >
 ```
 
 #### Router Traffic Engineering

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -3419,7 +3419,7 @@ router_isis:
   isis_af_defaults:
     - maximum-paths < Integer 1-128 >
   redistribute_routes:
-    - source_protocol: < route_type >
+    - source_protocol: < bgp | connected | isis | ospf | ospfv3 | static >
       route_map: < route_map_name >
       include_leaked: < true | false >
       # ospf_route_type is required with source_protocols 'ospf' and 'ospfv3'

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -3422,6 +3422,7 @@ router_isis:
     - source_protocol: < route_type >
       route_map: < route_map_name >
       include_leaked: < true | false >
+      # ospf_route_type is required with source_protocols 'ospf' and 'ospfv3'
       ospf_route_type: < internal | external | nssa-external >
   address_family_ipv4:
     maximum_paths: < Integer 1-128 >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -3433,7 +3433,7 @@ router_isis:
         enable: < true | false >
         strict: < true | false >
     tunnel_source_labeled_unicast:
-      enable: < true | false >
+      enabled: < true | false >
       rcf: < routing_control_function() >
   address_family_ipv6:
     maximum_paths: < Integer 1-128 >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
@@ -3050,6 +3050,11 @@ router_isis:
   address_family: < List of Address Families >
   isis_af_defaults:
     - maximum-paths < Integer 1-128 >
+  redistribute_routes:
+    - source_protocol: < route_type >
+      route_map: < route_map_name >
+      include_leaked: < true | false >
+      ospf_route_type: < internal | external | nssa-external >
   address_family_ipv4:
     maximum_paths: < Integer 1-128 >
     fast_reroute_ti_lfa:
@@ -3058,6 +3063,9 @@ router_isis:
       srlg:
         enable: < true | false >
         strict: < true | false >
+    tunnel_source_labeled_unicast:
+      enable: < true | false >
+      rcf: < routing_control_function() >
   address_family_ipv6:
     maximum_paths: < Integer 1-128 >
     fast_reroute_ti_lfa:
@@ -3069,6 +3077,9 @@ router_isis:
   segment_routing_mpls:
     enabled: < true | false >
     router_id: < router_id >
+    prefix_segments:
+      - prefix: < IPv4_network/Mask | IPv6_network/Mask >
+        index: < integer >
 ```
 
 #### Router Traffic Engineering

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
@@ -3051,9 +3051,10 @@ router_isis:
   isis_af_defaults:
     - maximum-paths < Integer 1-128 >
   redistribute_routes:
-    - source_protocol: < route_type >
+    - source_protocol: < bgp | connected | isis | ospf | ospfv3 | static >
       route_map: < route_map_name >
       include_leaked: < true | false >
+      # ospf_route_type is required with source_protocols 'ospf' and 'ospfv3'
       ospf_route_type: < internal | external | nssa-external >
   address_family_ipv4:
     maximum_paths: < Integer 1-128 >
@@ -3064,7 +3065,7 @@ router_isis:
         enable: < true | false >
         strict: < true | false >
     tunnel_source_labeled_unicast:
-      enable: < true | false >
+      enabled: < true | false >
       rcf: < routing_control_function() >
   address_family_ipv6:
     maximum_paths: < Integer 1-128 >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-isis.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-isis.j2
@@ -36,6 +36,29 @@
 {%     if router_isis.segment_routing_mpls.enabled is arista.avd.defined %}
 | SR MPLS Enabled | {{ router_isis.segment_routing_mpls.enabled }} |
 {%     endif %}
+{%     if router_isis.redistribute_routes is arista.avd.defined %}
+
+### ISIS Route Redistribution
+
+| Route Type | Route-Map | Include Leaked |
+| ---------- | --------- | -------------- |
+{%         for redistribute_route in router_isis.redistribute_routes | arista.avd.convert_dicts('source_protocol') | arista.avd.natural_sort('source_protocol') %}
+{%             set src_protocol = redistribute_route.source_protocol  | arista.avd.default('-') %}
+{%             set route_map = redistribute_route.route_map  | arista.avd.default('-') %}
+{%             if redistribute_route.source_protocol is arista.avd.defined('static') or redistribute_route.source_protocol is arista.avd.defined('connected') or redistribute_route.source_protocol is arista.avd.defined('ospf') %}
+{%                 set include_leaked = redistribute_route.include_leaked  | arista.avd.default('-') %}
+{%             else %}
+{%                 set include_leaked = include_leaked | arista.avd.default('-') %}
+{%             endif %}
+{%             if redistribute_route.source_protocol is arista.avd.defined('isis') %}
+{%                 set src_protocol = src_protocol ~ " instance" %}
+{%             endif %}
+{%             if redistribute_route.source_protocol is arista.avd.defined('ospf') or redistribute_route.source_protocol is arista.avd.defined('ospfv3') %}
+{%                 set src_protocol = src_protocol ~ " " ~ redistribute_route.ospf_route_type %}
+{%             endif %}
+| {{ src_protocol }} | {{ route_map }} | {{ include_leaked }} |
+{%         endfor %}
+{%     endif %}
 
 ### ISIS Interfaces Summary
 
@@ -110,6 +133,18 @@
 | {{ loopback_interface.name }} | {{ row_ipv4_index }} | {{ row_ipv6_index }} |
 {%         endfor %}
 {%     endif %}
+{%     if router_isis.segment_routing_mpls.prefix_segments is arista.avd.defined %}
+
+### Prefix Segments
+
+| Prefix Segment | Index |
+| -------------- | ----- |
+{%         for prefix_segment in router_isis.segment_routing_mpls.prefix_segments | arista.avd.convert_dicts('prefix') | arista.avd.natural_sort('prefix') %}
+{%             if prefix_segment.index is arista.avd.defined %}
+| {{ prefix_segment.prefix }} | {{ prefix_segment.index }} |
+{%             endif %}
+{%         endfor %}
+{%     endif %}
 {%     if router_isis.address_family_ipv4 is arista.avd.defined %}
 
 ### ISIS IPv4 Address Family Summary
@@ -132,6 +167,15 @@
 | TI-LFA SRLG Strict Mode | {{ router_isis.address_family_ipv4.fast_reroute_ti_lfa.srlg.strict }} |
 {%             endif %}
 {%         endif %}
+{%     endif %}
+{%     if router_isis.address_family_ipv4.tunnel_source_labeled_unicast.enable is arista.avd.defined(true) %}
+
+### Tunnel Source
+
+| Source Protocol | RCF |
+| --------------- | --- |
+{%         set rcf = router_isis.address_family_ipv4.tunnel_source_labeled_unicast.rcf  | arista.avd.default('-') %}
+| BGP Labeled-Unicast | {{ rcf }} |
 {%     endif %}
 {%     if router_isis.address_family_ipv6 is arista.avd.defined %}
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-isis.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-isis.j2
@@ -50,7 +50,7 @@
 {%             else %}
 {%                 set include_leaked = include_leaked | arista.avd.default('-') %}
 {%             endif %}
-{%             if redistribute_route.source_protocol is arista.avd.defined('isis') %}
+{%             if src_protocol == 'isis' %}
 {%                 set src_protocol = src_protocol ~ " instance" %}
 {%             endif %}
 {%             if redistribute_route.source_protocol is arista.avd.defined('ospf') or redistribute_route.source_protocol is arista.avd.defined('ospfv3') %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-isis.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-isis.j2
@@ -139,7 +139,7 @@
 
 | Prefix Segment | Index |
 | -------------- | ----- |
-{%         for prefix_segment in router_isis.segment_routing_mpls.prefix_segments | arista.avd.convert_dicts('prefix') | arista.avd.natural_sort('prefix') %}
+{%         for prefix_segment in router_isis.segment_routing_mpls.prefix_segments | arista.avd.natural_sort('prefix') %}
 {%             if prefix_segment.index is arista.avd.defined %}
 | {{ prefix_segment.prefix }} | {{ prefix_segment.index }} |
 {%             endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-isis.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-isis.j2
@@ -53,7 +53,7 @@
 {%             if src_protocol == 'isis' %}
 {%                 set src_protocol = src_protocol ~ " instance" %}
 {%             endif %}
-{%             if redistribute_route.source_protocol is arista.avd.defined('ospf') or redistribute_route.source_protocol is arista.avd.defined('ospfv3') %}
+{%             if src_protocol in ['ospf', 'ospfv3'] and redistribute_route.ospf_route_type is arista.avd.defined %}
 {%                 set src_protocol = src_protocol ~ " " ~ redistribute_route.ospf_route_type %}
 {%             endif %}
 | {{ src_protocol }} | {{ route_map }} | {{ include_leaked }} |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-isis.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-isis.j2
@@ -48,7 +48,7 @@
 {%             if src_protocol in ['static', 'connected', 'ospf'] %}
 {%                 set include_leaked = redistribute_route.include_leaked | arista.avd.default('-') %}
 {%             else %}
-{%                 set include_leaked = include_leaked | arista.avd.default('-') %}
+{%                 set include_leaked = '-' %}
 {%             endif %}
 {%             if src_protocol == 'isis' %}
 {%                 set src_protocol = src_protocol ~ " instance" %}
@@ -168,7 +168,7 @@
 {%             endif %}
 {%         endif %}
 {%     endif %}
-{%     if router_isis.address_family_ipv4.tunnel_source_labeled_unicast.enable is arista.avd.defined(true) %}
+{%     if router_isis.address_family_ipv4.tunnel_source_labeled_unicast.enabled is arista.avd.defined(true) %}
 
 ### Tunnel Source
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-isis.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-isis.j2
@@ -42,7 +42,7 @@
 
 | Route Type | Route-Map | Include Leaked |
 | ---------- | --------- | -------------- |
-{%         for redistribute_route in router_isis.redistribute_routes | arista.avd.convert_dicts('source_protocol') | arista.avd.natural_sort('source_protocol') %}
+{%         for redistribute_route in router_isis.redistribute_routes | arista.avd.natural_sort('source_protocol') %}
 {%             set src_protocol = redistribute_route.source_protocol | arista.avd.default('-') %}
 {%             set route_map = redistribute_route.route_map | arista.avd.default('-') %}
 {%             if redistribute_route.source_protocol is arista.avd.defined('static') or redistribute_route.source_protocol is arista.avd.defined('connected') or redistribute_route.source_protocol is arista.avd.defined('ospf') %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-isis.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-isis.j2
@@ -45,7 +45,7 @@
 {%         for redistribute_route in router_isis.redistribute_routes | arista.avd.natural_sort('source_protocol') %}
 {%             set src_protocol = redistribute_route.source_protocol | arista.avd.default('-') %}
 {%             set route_map = redistribute_route.route_map | arista.avd.default('-') %}
-{%             if redistribute_route.source_protocol is arista.avd.defined('static') or redistribute_route.source_protocol is arista.avd.defined('connected') or redistribute_route.source_protocol is arista.avd.defined('ospf') %}
+{%             if src_protocol in ['static', 'connected', 'ospf'] %}
 {%                 set include_leaked = redistribute_route.include_leaked | arista.avd.default('-') %}
 {%             else %}
 {%                 set include_leaked = include_leaked | arista.avd.default('-') %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-isis.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-isis.j2
@@ -43,10 +43,10 @@
 | Route Type | Route-Map | Include Leaked |
 | ---------- | --------- | -------------- |
 {%         for redistribute_route in router_isis.redistribute_routes | arista.avd.convert_dicts('source_protocol') | arista.avd.natural_sort('source_protocol') %}
-{%             set src_protocol = redistribute_route.source_protocol  | arista.avd.default('-') %}
-{%             set route_map = redistribute_route.route_map  | arista.avd.default('-') %}
+{%             set src_protocol = redistribute_route.source_protocol | arista.avd.default('-') %}
+{%             set route_map = redistribute_route.route_map | arista.avd.default('-') %}
 {%             if redistribute_route.source_protocol is arista.avd.defined('static') or redistribute_route.source_protocol is arista.avd.defined('connected') or redistribute_route.source_protocol is arista.avd.defined('ospf') %}
-{%                 set include_leaked = redistribute_route.include_leaked  | arista.avd.default('-') %}
+{%                 set include_leaked = redistribute_route.include_leaked | arista.avd.default('-') %}
 {%             else %}
 {%                 set include_leaked = include_leaked | arista.avd.default('-') %}
 {%             endif %}
@@ -174,7 +174,7 @@
 
 | Source Protocol | RCF |
 | --------------- | --- |
-{%         set rcf = router_isis.address_family_ipv4.tunnel_source_labeled_unicast.rcf  | arista.avd.default('-') %}
+{%         set rcf = router_isis.address_family_ipv4.tunnel_source_labeled_unicast.rcf | arista.avd.default('-') %}
 | BGP Labeled-Unicast | {{ rcf }} |
 {%     endif %}
 {%     if router_isis.address_family_ipv6 is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-isis.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-isis.j2
@@ -8,26 +8,34 @@ router isis {{ router_isis.instance }}
 {%     if router_isis.is_type is arista.avd.defined %}
    is-type {{ router_isis.is_type }}
 {%     endif %}
-{%     for redistribute_route in router_isis.redistribute_routes | arista.avd.convert_dicts('source_protocol') | arista.avd.natural_sort('source_protocol') %}
-{%         set redistribute_route_cli = "redistribute " ~ redistribute_route.source_protocol %}
-{%         if redistribute_route.source_protocol is arista.avd.defined('isis') %}
-{%             set redistribute_route_cli = redistribute_route_cli ~ " instance" %}
-{%         elif redistribute_route.source_protocol is arista.avd.defined('ospf') %}
-{%             if redistribute_route.include_leaked is arista.avd.defined(true) %}
-{%                 set redistribute_route_cli = redistribute_route_cli ~ " include leaked" %}
+{%     for redistribute_route in router_isis.redistribute_routes | arista.avd.natural_sort('source_protocol') %}
+{%         if redistribute_route.source_protocol is arista.avd.defined %}
+{%             set redistribute_route_cli = "redistribute " ~ redistribute_route.source_protocol %}
+{%             if redistribute_route.source_protocol == 'isis' %}
+{%                 set redistribute_route_cli = redistribute_route_cli ~ " instance" %}
+{%             elif redistribute_route.source_protocol == 'ospf' %}
+{%                 if redistribute_route.include_leaked is arista.avd.defined(true) %}
+{%                     set redistribute_route_cli = redistribute_route_cli ~ " include leaked" %}
+{%                 endif %}
+{%                 if redistribute_route.ospf_route_type is not arista.avd.defined %}
+{%                     continue %}
+{%                 endif %}
+{%                 set redistribute_route_cli = redistribute_route_cli ~ " match " ~ redistribute_route.ospf_route_type %}
+{%             elif redistribute_route.source_protocol == 'ospfv3' %}
+{%                 if redistribute_route.ospf_route_type is not arista.avd.defined %}
+{%                     continue %}
+{%                 endif %}
+{%                 set redistribute_route_cli = redistribute_route_cli ~ " match " ~ redistribute_route.ospf_route_type %}
+{%             elif redistribute_route.source_protocol in ['static', 'connected'] %}
+{%                 if redistribute_route.include_leaked is arista.avd.defined(true) %}
+{%                     set redistribute_route_cli = redistribute_route_cli ~ " include leaked" %}
+{%                 endif %}
 {%             endif %}
-{%             set redistribute_route_cli = redistribute_route_cli ~ " match " ~ redistribute_route.ospf_route_type %}
-{%         elif redistribute_route.source_protocol is arista.avd.defined('ospfv3') %}
-{%             set redistribute_route_cli = redistribute_route_cli ~ " match " ~ redistribute_route.ospf_route_type %}
-{%         elif redistribute_route.source_protocol is arista.avd.defined('static') or redistribute_route.source_protocol is arista.avd.defined('connected') %}
-{%             if redistribute_route.include_leaked is arista.avd.defined(true) %}
-{%                 set redistribute_route_cli = redistribute_route_cli ~ " include leaked" %}
+{%             if redistribute_route.route_map is arista.avd.defined %}
+{%                 set redistribute_route_cli = redistribute_route_cli ~ " route-map " ~ redistribute_route.route_map %}
 {%             endif %}
-{%         endif %}
-{%         if redistribute_route.route_map is arista.avd.defined %}
-{%             set redistribute_route_cli = redistribute_route_cli ~ " route-map " ~ redistribute_route.route_map %}
-{%         endif %}
    {{ redistribute_route_cli }}
+{%         endif %}
 {%     endfor %}
 {%     if router_isis.router_id is arista.avd.defined %}
    router-id ipv4 {{ router_isis.router_id }}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-isis.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-isis.j2
@@ -126,8 +126,8 @@ router isis {{ router_isis.instance }}
 {%         elif router_isis.segment_routing_mpls.enabled is arista.avd.defined(false) %}
       shutdown
 {%         endif %}
-{%         for prefix_segment in router_isis.segment_routing_mpls.prefix_segments | arista.avd.convert_dicts('prefix') | arista.avd.natural_sort('prefix') %}
-{%             if prefix_segment.index is arista.avd.defined %}
+{%         for prefix_segment in router_isis.segment_routing_mpls.prefix_segments | arista.avd.natural_sort('prefix') %}
+{%             if prefix_segment.prefix is arista.avd.defined and prefix_segment.index is arista.avd.defined %}
       prefix-segment {{ prefix_segment.prefix }} index {{ prefix_segment.index }}
 {%             endif %}
 {%         endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-isis.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-isis.j2
@@ -68,7 +68,7 @@ router isis {{ router_isis.instance }}
       maximum-paths {{ router_isis.address_family_ipv4.maximum_paths }}
 {%         endif %}
 {%         if router_isis.address_family_ipv4.tunnel_source_labeled_unicast.enable is arista.avd.defined(true) %}
-{%         set lu_cli = "tunnel source-protocol bgp ipv4 labeled-unicast" %}
+{%             set lu_cli = "tunnel source-protocol bgp ipv4 labeled-unicast" %}
 {%             if router_isis.address_family_ipv4.tunnel_source_labeled_unicast.rcf is arista.avd.defined %}
 {%                 set lu_cli = lu_cli ~ " rcf " ~ router_isis.address_family_ipv4.tunnel_source_labeled_unicast.rcf %}
 {%             endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-isis.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-isis.j2
@@ -75,7 +75,7 @@ router isis {{ router_isis.instance }}
 {%         if router_isis.address_family_ipv4.maximum_paths is arista.avd.defined %}
       maximum-paths {{ router_isis.address_family_ipv4.maximum_paths }}
 {%         endif %}
-{%         if router_isis.address_family_ipv4.tunnel_source_labeled_unicast.enable is arista.avd.defined(true) %}
+{%         if router_isis.address_family_ipv4.tunnel_source_labeled_unicast.enabled is arista.avd.defined(true) %}
 {%             set lu_cli = "tunnel source-protocol bgp ipv4 labeled-unicast" %}
 {%             if router_isis.address_family_ipv4.tunnel_source_labeled_unicast.rcf is arista.avd.defined %}
 {%                 set lu_cli = lu_cli ~ " rcf " ~ router_isis.address_family_ipv4.tunnel_source_labeled_unicast.rcf %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-isis.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-isis.j2
@@ -8,6 +8,27 @@ router isis {{ router_isis.instance }}
 {%     if router_isis.is_type is arista.avd.defined %}
    is-type {{ router_isis.is_type }}
 {%     endif %}
+{%     for redistribute_route in router_isis.redistribute_routes | arista.avd.convert_dicts('source_protocol') | arista.avd.natural_sort('source_protocol') %}
+{%         set redistribute_route_cli = "redistribute " ~ redistribute_route.source_protocol %}
+{%         if redistribute_route.source_protocol is arista.avd.defined('isis') %}
+{%             set redistribute_route_cli = redistribute_route_cli ~ " instance" %}
+{%         elif redistribute_route.source_protocol is arista.avd.defined('ospf') %}
+{%             if redistribute_route.include_leaked is arista.avd.defined(true) %}
+{%                 set redistribute_route_cli = redistribute_route_cli ~ " include leaked" %}
+{%             endif %}
+{%             set redistribute_route_cli = redistribute_route_cli ~ " match " ~ redistribute_route.ospf_route_type %}
+{%         elif redistribute_route.source_protocol is arista.avd.defined('ospfv3') %}
+{%             set redistribute_route_cli = redistribute_route_cli ~ " match " ~ redistribute_route.ospf_route_type %}
+{%         elif redistribute_route.source_protocol is arista.avd.defined('static') or redistribute_route.source_protocol is arista.avd.defined('connected') %}
+{%             if redistribute_route.include_leaked is arista.avd.defined(true) %}
+{%                 set redistribute_route_cli = redistribute_route_cli ~ " include leaked" %}
+{%             endif %}
+{%         endif %}
+{%         if redistribute_route.route_map is arista.avd.defined %}
+{%             set redistribute_route_cli = redistribute_route_cli ~ " route-map " ~ redistribute_route.route_map %}
+{%         endif %}
+   {{ redistribute_route_cli }}
+{%     endfor %}
 {%     if router_isis.router_id is arista.avd.defined %}
    router-id ipv4 {{ router_isis.router_id }}
 {%     endif %}
@@ -45,6 +66,13 @@ router isis {{ router_isis.instance }}
    address-family ipv4 unicast
 {%         if router_isis.address_family_ipv4.maximum_paths is arista.avd.defined %}
       maximum-paths {{ router_isis.address_family_ipv4.maximum_paths }}
+{%         endif %}
+{%         if router_isis.address_family_ipv4.tunnel_source_labeled_unicast.enable is arista.avd.defined(true) %}
+{%         set lu_cli = "tunnel source-protocol bgp ipv4 labeled-unicast" %}
+{%             if router_isis.address_family_ipv4.tunnel_source_labeled_unicast.rcf is arista.avd.defined %}
+{%                 set lu_cli = lu_cli ~ " rcf " ~ router_isis.address_family_ipv4.tunnel_source_labeled_unicast.rcf %}
+{%             endif %}
+      {{ lu_cli }}
 {%         endif %}
 {%         if router_isis.address_family_ipv4.fast_reroute_ti_lfa.mode is arista.avd.defined %}
 {%             set ti_lfa_cli = "fast-reroute ti-lfa mode " ~ router_isis.address_family_ipv4.fast_reroute_ti_lfa.mode %}
@@ -90,5 +118,10 @@ router isis {{ router_isis.instance }}
 {%         elif router_isis.segment_routing_mpls.enabled is arista.avd.defined(false) %}
       shutdown
 {%         endif %}
+{%         for prefix_segment in router_isis.segment_routing_mpls.prefix_segments | arista.avd.convert_dicts('prefix') | arista.avd.natural_sort('prefix') %}
+{%             if prefix_segment.index is arista.avd.defined %}
+      prefix-segment {{ prefix_segment.prefix }} index {{ prefix_segment.index }}
+{%             endif %}
+{%         endfor %}
 {%     endif %}
 {% endif %}


### PR DESCRIPTION
## Change Summary

Render route redistribution under router isis and generate prefix-segments under the segment-routing sub-configuration. Allow labeled-unicast redistribution as a tunnel-source.

## Related Issue(s)

Fixes #1809 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
```yaml
router_isis:
  redistribute_routes:
    - source_protocol: static
      include_leaked: True
      route_map: RM-STATIC-TO-ISIS
    - source_protocol: isis
      route_map: RM-REDIS-ISIS-INSTANCE
  address_family_ipv4:
    tunnel_source_labeled_unicast:
      enable: True
      rcf: lu_2_sr_pfx()
  segment_routing_mpls:
    enabled: true
    prefix_segments:
      - prefix: 155.2.1.1/32
        index: 211
      - prefix: 2001:cafe:155::/64
        index: 6211
```
## How to test
`molecule test --scenario-name eos_cli_config_gen`

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- [x] No breaking changes

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
