### PR TITLE
Fix(eos_designs): ipv6_underlay should not apply for l2 switches

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/DC1-L2LEAF1A.yml
@@ -1,0 +1,4 @@
+---
+# Test that having underlay_ipv6 will not require
+# loopback_ipv6_pool for devices that are not underlay_router
+underlay_ipv6: true

--- a/ansible_collections/arista/avd/plugins/module_utils/eos_designs_facts.py
+++ b/ansible_collections/arista/avd/plugins/module_utils/eos_designs_facts.py
@@ -869,14 +869,21 @@ class EosDesignsFacts:
         return None
 
     @cached_property
+    def underlay_ipv6(self):
+        if self.underlay_router is True:
+            return get(self._hostvars, "underlay_ipv6")
+        return None
+
+
+    @cached_property
     def loopback_ipv6_pool(self):
-        if get(self._hostvars, "underlay_ipv6") is True:
+        if self.underlay_ipv6 is True:
             return get(self._switch_data_combined, "loopback_ipv6_pool", required=True)
         return None
 
     @cached_property
     def loopback_ipv6_offset(self):
-        if get(self._hostvars, "underlay_ipv6") is True:
+        if self.underlay_ipv6 is True:
             return get(self._switch_data_combined, "loopback_ipv6_offset", default=0)
         return None
 
@@ -888,7 +895,7 @@ class EosDesignsFacts:
         Since some templates might contain certain legacy variables (switch_*),
         those are mapped from the switch.* model
         '''
-        if get(self._hostvars, "underlay_ipv6") is True:
+        if self.underlay_ipv6 is True:
             template_vars = {"ansible_search_path": self._ansible_search_path}
             # Copying __dict__ will expose all switch facts cached up until this function is run.
             # TODO: We should probably find and document a list of supported context variables instead.

--- a/ansible_collections/arista/avd/plugins/module_utils/eos_designs_facts.py
+++ b/ansible_collections/arista/avd/plugins/module_utils/eos_designs_facts.py
@@ -874,7 +874,6 @@ class EosDesignsFacts:
             return get(self._hostvars, "underlay_ipv6")
         return None
 
-
     @cached_property
     def loopback_ipv6_pool(self):
         if self.underlay_ipv6 is True:

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-variables.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-variables.md
@@ -31,7 +31,7 @@ underlay_rfc5549: < true | false | default -> false >
 
 # Enable IPv6 Address Family on underlay.
 # This feature allows IPv6 underlay routing protocol with RFC5549 addresses to be used along with IPv4 advertisements as VXLAN tunnel endpoints.
-# Requires "underlay_rfc5549: true" and "ipv6_loopback_pool" under the "Fabric Topology"
+# Requires "underlay_rfc5549: true" and "loopback_ipv6_pool" under the "Fabric Topology"
 underlay_ipv6: < true | false | default -> false >
 
 # Underlay OSFP | Required when < underlay_routing_protocol > == OSPF variants

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/base/routing.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/base/routing.j2
@@ -3,6 +3,6 @@ ip_routing: true
 {% if underlay_rfc5549 is arista.avd.defined(true) %}
 ipv6_unicast_routing: true
 ip_routing_ipv6_interfaces: true
-{% elif underlay_ipv6 is arista.avd.defined(true) %}
+{% elif switch.underlay_ipv6 is arista.avd.defined(true) %}
 ipv6_unicast_routing: true
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/mlag/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/mlag/router-bgp.j2
@@ -15,7 +15,7 @@ router_bgp:
 {%     if switch.mlag_ibgp_origin_incomplete == true %}
       route_map_in: RM-MLAG-PEER-IN
 {%     endif %}
-{%     if underlay_ipv6 is arista.avd.defined(true) %}
+{%     if switch.underlay_ipv6 is arista.avd.defined(true) %}
   address_family_ipv6:
     peer_groups:
       {{ switch.bgp_peer_groups.mlag_ipv4_underlay_peer.name }}:

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/underlay/ebgp/route-maps.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/underlay/ebgp/route-maps.j2
@@ -7,7 +7,7 @@ route_maps:
         match:
           - "ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY"
 {# SEQ 20 is set by inband management if applicable, so avoid setting that here #}
-{% if underlay_ipv6 is arista.avd.defined(true) %}
+{% if switch.underlay_ipv6 is arista.avd.defined(true) %}
       30:
         type: permit
         match:

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/underlay/ebgp/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/underlay/ebgp/router-bgp.j2
@@ -17,7 +17,7 @@ router_bgp:
         next_hop:
           address_family_ipv6_originate: true
 {% endif %}
-{% if underlay_ipv6 is arista.avd.defined(true) %}
+{% if switch.underlay_ipv6 is arista.avd.defined(true) %}
   address_family_ipv6:
     peer_groups:
       {{ switch.bgp_peer_groups.ipv4_underlay_peers.name }}:

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/underlay/interfaces/loopback-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/underlay/interfaces/loopback-interfaces.j2
@@ -25,7 +25,7 @@ loopback_interfaces:
 {%         if switch.underlay_routing_protocol in ["isis-sr", "isis-sr-ldp"] %}
     node_segment:
       ipv4_index: {{ switch.node_sid }}
-{%             if underlay_ipv6 is arista.avd.defined(true) %}
+{%             if switch.underlay_ipv6 is arista.avd.defined(true) %}
       ipv6_index: {{ switch.node_sid }}
 {%             endif %}
 {%         endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/underlay/isis-sr/router-isis.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/underlay/isis-sr/router-isis.j2
@@ -31,7 +31,7 @@ router_isis:
 {%     endif %}
 {% endif %}
 {% set isis_address_families = ["ipv4 unicast"] %}
-{% if underlay_ipv6 is arista.avd.defined(true) %}
+{% if switch.underlay_ipv6 is arista.avd.defined(true) %}
 {%     do isis_address_families.append("ipv6 unicast") %}
 {% endif %}
   address_family: {{ isis_address_families }}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/underlay/main.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/underlay/main.j2
@@ -15,7 +15,7 @@
 
 {%         include 'underlay/ebgp/prefix-lists.j2' %}
 
-{%         if underlay_ipv6 is arista.avd.defined(true) %}
+{%         if switch.underlay_ipv6 is arista.avd.defined(true) %}
 {%             include 'underlay/ebgp/ipv6-prefix-lists.j2' %}
 
 {%         endif %}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
`ipv6_underlay` should not apply for l2 switches

## Related Issue(s)

`ipv6_underlay` should not require `loopback_ipv6_pool` on l2-only switches (ex. l2leaf).

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

Implemented `switch.ipv6_underlay` set based on checks for `underlay_router` and `ipv6_underlay`.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Added molecule scenario for `l2leaf` with `ipv6_underlay: true`.
Verified failure
Applied fix
Verified no failure.
No other molecule changes.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
