### PR TITLE
Feat(eos_designs): RFC5549 for MLAG iBGP in VRF

### DIFF
--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -595,7 +595,7 @@ interface Loopback100
 
 | Interface | VRF | IP Address | IP Address Virtual | IP Router Virtual Address | VRRP | ACL In | ACL Out |
 | --------- | --- | ---------- | ------------------ | ------------------------- | ---- | ------ | ------- |
-| Vlan2 |  Tenant_C_OP_Zone  |  10.255.251.2/31  |  -  |  -  |  -  |  -  |  -  |
+| Vlan2 |  Tenant_C_OP_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
 | Vlan110 |  Tenant_A_OP_Zone  |  -  |  10.1.10.1/24  |  -  |  -  |  -  |  -  |
 | Vlan111 |  Tenant_A_OP_Zone  |  -  |  10.1.11.1/24  |  -  |  -  |  -  |  -  |
 | Vlan120 |  Tenant_A_WEB_Zone  |  -  |  10.1.20.1/24  |  -  |  -  |  -  |  -  |
@@ -608,11 +608,11 @@ interface Loopback100
 | Vlan211 |  Tenant_B_OP_Zone  |  -  |  10.2.11.1/24  |  -  |  -  |  -  |  -  |
 | Vlan310 |  Tenant_C_OP_Zone  |  -  |  10.3.10.1/24  |  -  |  -  |  -  |  -  |
 | Vlan311 |  Tenant_C_OP_Zone  |  -  |  10.3.11.1/24  |  -  |  -  |  -  |  -  |
-| Vlan3009 |  Tenant_A_OP_Zone  |  10.255.251.2/31  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3010 |  Tenant_A_WEB_Zone  |  10.255.251.2/31  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3011 |  Tenant_A_APP_Zone  |  10.255.251.2/31  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3012 |  Tenant_A_DB_Zone  |  10.255.251.2/31  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3019 |  Tenant_B_OP_Zone  |  10.255.251.2/31  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3009 |  Tenant_A_OP_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3010 |  Tenant_A_WEB_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3011 |  Tenant_A_APP_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3012 |  Tenant_A_DB_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3019 |  Tenant_B_OP_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
 | Vlan4093 |  default  |  -  |  -  |  -  |  -  |  -  |  -  |
 | Vlan4094 |  default  |  10.255.252.2/31  |  -  |  -  |  -  |  -  |  -  |
 
@@ -625,7 +625,7 @@ interface Vlan2
    no shutdown
    mtu 1500
    vrf Tenant_C_OP_Zone
-   ip address 10.255.251.2/31
+   ipv6 enable
 !
 interface Vlan110
    description Tenant_A_OP_Zone_1
@@ -707,35 +707,35 @@ interface Vlan3009
    no shutdown
    mtu 1500
    vrf Tenant_A_OP_Zone
-   ip address 10.255.251.2/31
+   ipv6 enable
 !
 interface Vlan3010
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_WEB_Zone
-   ip address 10.255.251.2/31
+   ipv6 enable
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_APP_Zone
-   ip address 10.255.251.2/31
+   ipv6 enable
 !
 interface Vlan3012
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_DB_Zone
-   ip address 10.255.251.2/31
+   ipv6 enable
 !
 interface Vlan3019
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone
    no shutdown
    mtu 1500
    vrf Tenant_B_OP_Zone
-   ip address 10.255.251.2/31
+   ipv6 enable
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
@@ -964,12 +964,6 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | 192.168.255.2 | 65001 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - |
 | 192.168.255.3 | 65001 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - |
 | 192.168.255.4 | 65001 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - |
-| 10.255.251.3 | Inherited from peer group MLAG_PEER | Tenant_A_APP_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - |
-| 10.255.251.3 | Inherited from peer group MLAG_PEER | Tenant_A_DB_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - |
-| 10.255.251.3 | Inherited from peer group MLAG_PEER | Tenant_A_OP_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - |
-| 10.255.251.3 | Inherited from peer group MLAG_PEER | Tenant_A_WEB_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - |
-| 10.255.251.3 | Inherited from peer group MLAG_PEER | Tenant_B_OP_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - |
-| 10.255.251.3 | Inherited from peer group MLAG_PEER | Tenant_C_OP_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - |
 
 ### BGP Neighbor Interfaces
 
@@ -1130,7 +1124,6 @@ router bgp 65102
       route-target import evpn 12:12
       route-target export evpn 12:12
       router-id 192.168.255.6
-      neighbor 10.255.251.3 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1138,7 +1131,6 @@ router bgp 65102
       route-target import evpn 13:13
       route-target export evpn 13:13
       router-id 192.168.255.6
-      neighbor 10.255.251.3 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1146,7 +1138,6 @@ router bgp 65102
       route-target import evpn 10:10
       route-target export evpn 10:10
       router-id 192.168.255.6
-      neighbor 10.255.251.3 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1154,7 +1145,6 @@ router bgp 65102
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.6
-      neighbor 10.255.251.3 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1162,7 +1152,6 @@ router bgp 65102
       route-target import evpn 20:20
       route-target export evpn 20:20
       router-id 192.168.255.6
-      neighbor 10.255.251.3 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1170,7 +1159,6 @@ router bgp 65102
       route-target import evpn 30:30
       route-target export evpn 30:30
       router-id 192.168.255.6
-      neighbor 10.255.251.3 peer group MLAG_PEER
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -974,6 +974,12 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | Ethernet3 | default | UNDERLAY_PEERS | 65001 | - |
 | Ethernet4 | default | UNDERLAY_PEERS | 65001 | - |
 | Vlan4093 | default | MLAG_PEER | 65102 | - |
+| Vlan3011 | Tenant_A_APP_Zone | MLAG_PEER | 65102 | - |
+| Vlan3012 | Tenant_A_DB_Zone | MLAG_PEER | 65102 | - |
+| Vlan3009 | Tenant_A_OP_Zone | MLAG_PEER | 65102 | - |
+| Vlan3010 | Tenant_A_WEB_Zone | MLAG_PEER | 65102 | - |
+| Vlan3019 | Tenant_B_OP_Zone | MLAG_PEER | 65102 | - |
+| Vlan2 | Tenant_C_OP_Zone | MLAG_PEER | 65102 | - |
 
 ### Router BGP EVPN Address Family
 
@@ -1124,6 +1130,7 @@ router bgp 65102
       route-target import evpn 12:12
       route-target export evpn 12:12
       router-id 192.168.255.6
+      neighbor interface Vlan3011 peer-group MLAG_PEER remote-as 65102
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1131,6 +1138,7 @@ router bgp 65102
       route-target import evpn 13:13
       route-target export evpn 13:13
       router-id 192.168.255.6
+      neighbor interface Vlan3012 peer-group MLAG_PEER remote-as 65102
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1138,6 +1146,7 @@ router bgp 65102
       route-target import evpn 10:10
       route-target export evpn 10:10
       router-id 192.168.255.6
+      neighbor interface Vlan3009 peer-group MLAG_PEER remote-as 65102
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1145,6 +1154,7 @@ router bgp 65102
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.6
+      neighbor interface Vlan3010 peer-group MLAG_PEER remote-as 65102
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1152,6 +1162,7 @@ router bgp 65102
       route-target import evpn 20:20
       route-target export evpn 20:20
       router-id 192.168.255.6
+      neighbor interface Vlan3019 peer-group MLAG_PEER remote-as 65102
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1159,6 +1170,7 @@ router bgp 65102
       route-target import evpn 30:30
       route-target export evpn 30:30
       router-id 192.168.255.6
+      neighbor interface Vlan2 peer-group MLAG_PEER remote-as 65102
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -595,7 +595,7 @@ interface Loopback100
 
 | Interface | VRF | IP Address | IP Address Virtual | IP Router Virtual Address | VRRP | ACL In | ACL Out |
 | --------- | --- | ---------- | ------------------ | ------------------------- | ---- | ------ | ------- |
-| Vlan2 |  Tenant_C_OP_Zone  |  10.255.251.3/31  |  -  |  -  |  -  |  -  |  -  |
+| Vlan2 |  Tenant_C_OP_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
 | Vlan110 |  Tenant_A_OP_Zone  |  -  |  10.1.10.1/24  |  -  |  -  |  -  |  -  |
 | Vlan111 |  Tenant_A_OP_Zone  |  -  |  10.1.11.1/24  |  -  |  -  |  -  |  -  |
 | Vlan120 |  Tenant_A_WEB_Zone  |  -  |  10.1.20.1/24  |  -  |  -  |  -  |  -  |
@@ -608,11 +608,11 @@ interface Loopback100
 | Vlan211 |  Tenant_B_OP_Zone  |  -  |  10.2.11.1/24  |  -  |  -  |  -  |  -  |
 | Vlan310 |  Tenant_C_OP_Zone  |  -  |  10.3.10.1/24  |  -  |  -  |  -  |  -  |
 | Vlan311 |  Tenant_C_OP_Zone  |  -  |  10.3.11.1/24  |  -  |  -  |  -  |  -  |
-| Vlan3009 |  Tenant_A_OP_Zone  |  10.255.251.3/31  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3010 |  Tenant_A_WEB_Zone  |  10.255.251.3/31  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3011 |  Tenant_A_APP_Zone  |  10.255.251.3/31  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3012 |  Tenant_A_DB_Zone  |  10.255.251.3/31  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3019 |  Tenant_B_OP_Zone  |  10.255.251.3/31  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3009 |  Tenant_A_OP_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3010 |  Tenant_A_WEB_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3011 |  Tenant_A_APP_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3012 |  Tenant_A_DB_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3019 |  Tenant_B_OP_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
 | Vlan4093 |  default  |  -  |  -  |  -  |  -  |  -  |  -  |
 | Vlan4094 |  default  |  10.255.252.3/31  |  -  |  -  |  -  |  -  |  -  |
 
@@ -625,7 +625,7 @@ interface Vlan2
    no shutdown
    mtu 1500
    vrf Tenant_C_OP_Zone
-   ip address 10.255.251.3/31
+   ipv6 enable
 !
 interface Vlan110
    description Tenant_A_OP_Zone_1
@@ -707,35 +707,35 @@ interface Vlan3009
    no shutdown
    mtu 1500
    vrf Tenant_A_OP_Zone
-   ip address 10.255.251.3/31
+   ipv6 enable
 !
 interface Vlan3010
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_WEB_Zone
-   ip address 10.255.251.3/31
+   ipv6 enable
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_APP_Zone
-   ip address 10.255.251.3/31
+   ipv6 enable
 !
 interface Vlan3012
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_DB_Zone
-   ip address 10.255.251.3/31
+   ipv6 enable
 !
 interface Vlan3019
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone
    no shutdown
    mtu 1500
    vrf Tenant_B_OP_Zone
-   ip address 10.255.251.3/31
+   ipv6 enable
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
@@ -964,12 +964,6 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | 192.168.255.2 | 65001 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - |
 | 192.168.255.3 | 65001 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - |
 | 192.168.255.4 | 65001 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - |
-| 10.255.251.2 | Inherited from peer group MLAG_PEER | Tenant_A_APP_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - |
-| 10.255.251.2 | Inherited from peer group MLAG_PEER | Tenant_A_DB_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - |
-| 10.255.251.2 | Inherited from peer group MLAG_PEER | Tenant_A_OP_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - |
-| 10.255.251.2 | Inherited from peer group MLAG_PEER | Tenant_A_WEB_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - |
-| 10.255.251.2 | Inherited from peer group MLAG_PEER | Tenant_B_OP_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - |
-| 10.255.251.2 | Inherited from peer group MLAG_PEER | Tenant_C_OP_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - |
 
 ### BGP Neighbor Interfaces
 
@@ -1130,7 +1124,6 @@ router bgp 65102
       route-target import evpn 12:12
       route-target export evpn 12:12
       router-id 192.168.255.7
-      neighbor 10.255.251.2 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1138,7 +1131,6 @@ router bgp 65102
       route-target import evpn 13:13
       route-target export evpn 13:13
       router-id 192.168.255.7
-      neighbor 10.255.251.2 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1146,7 +1138,6 @@ router bgp 65102
       route-target import evpn 10:10
       route-target export evpn 10:10
       router-id 192.168.255.7
-      neighbor 10.255.251.2 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1154,7 +1145,6 @@ router bgp 65102
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.7
-      neighbor 10.255.251.2 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1162,7 +1152,6 @@ router bgp 65102
       route-target import evpn 20:20
       route-target export evpn 20:20
       router-id 192.168.255.7
-      neighbor 10.255.251.2 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1170,7 +1159,6 @@ router bgp 65102
       route-target import evpn 30:30
       route-target export evpn 30:30
       router-id 192.168.255.7
-      neighbor 10.255.251.2 peer group MLAG_PEER
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -974,6 +974,12 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | Ethernet3 | default | UNDERLAY_PEERS | 65001 | - |
 | Ethernet4 | default | UNDERLAY_PEERS | 65001 | - |
 | Vlan4093 | default | MLAG_PEER | 65102 | - |
+| Vlan3011 | Tenant_A_APP_Zone | MLAG_PEER | 65102 | - |
+| Vlan3012 | Tenant_A_DB_Zone | MLAG_PEER | 65102 | - |
+| Vlan3009 | Tenant_A_OP_Zone | MLAG_PEER | 65102 | - |
+| Vlan3010 | Tenant_A_WEB_Zone | MLAG_PEER | 65102 | - |
+| Vlan3019 | Tenant_B_OP_Zone | MLAG_PEER | 65102 | - |
+| Vlan2 | Tenant_C_OP_Zone | MLAG_PEER | 65102 | - |
 
 ### Router BGP EVPN Address Family
 
@@ -1124,6 +1130,7 @@ router bgp 65102
       route-target import evpn 12:12
       route-target export evpn 12:12
       router-id 192.168.255.7
+      neighbor interface Vlan3011 peer-group MLAG_PEER remote-as 65102
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1131,6 +1138,7 @@ router bgp 65102
       route-target import evpn 13:13
       route-target export evpn 13:13
       router-id 192.168.255.7
+      neighbor interface Vlan3012 peer-group MLAG_PEER remote-as 65102
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1138,6 +1146,7 @@ router bgp 65102
       route-target import evpn 10:10
       route-target export evpn 10:10
       router-id 192.168.255.7
+      neighbor interface Vlan3009 peer-group MLAG_PEER remote-as 65102
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1145,6 +1154,7 @@ router bgp 65102
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.7
+      neighbor interface Vlan3010 peer-group MLAG_PEER remote-as 65102
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1152,6 +1162,7 @@ router bgp 65102
       route-target import evpn 20:20
       route-target export evpn 20:20
       router-id 192.168.255.7
+      neighbor interface Vlan3019 peer-group MLAG_PEER remote-as 65102
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1159,6 +1170,7 @@ router bgp 65102
       route-target import evpn 30:30
       route-target export evpn 30:30
       router-id 192.168.255.7
+      neighbor interface Vlan2 peer-group MLAG_PEER remote-as 65102
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF3A.md
@@ -887,6 +887,12 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | ------------------ | --- | ---------- | --------- | ----------- |
 | Ethernet1 | default | UNDERLAY_PEERS | 65001 | - |
 | Vlan4093 | default | MLAG_PEER | 65106 | - |
+| Vlan3011 | Tenant_A_APP_Zone | MLAG_PEER | 65106 | - |
+| Vlan3012 | Tenant_A_DB_Zone | MLAG_PEER | 65106 | - |
+| Vlan3009 | Tenant_A_OP_Zone | MLAG_PEER | 65106 | - |
+| Vlan3010 | Tenant_A_WEB_Zone | MLAG_PEER | 65106 | - |
+| Vlan3019 | Tenant_B_OP_Zone | MLAG_PEER | 65106 | - |
+| Vlan2 | Tenant_C_OP_Zone | MLAG_PEER | 65106 | - |
 
 ### Router BGP EVPN Address Family
 
@@ -1029,6 +1035,7 @@ router bgp 65106
       route-target import evpn 12:12
       route-target export evpn 12:12
       router-id 192.168.255.12
+      neighbor interface Vlan3011 peer-group MLAG_PEER remote-as 65106
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1036,6 +1043,7 @@ router bgp 65106
       route-target import evpn 13:13
       route-target export evpn 13:13
       router-id 192.168.255.12
+      neighbor interface Vlan3012 peer-group MLAG_PEER remote-as 65106
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1043,6 +1051,7 @@ router bgp 65106
       route-target import evpn 10:10
       route-target export evpn 10:10
       router-id 192.168.255.12
+      neighbor interface Vlan3009 peer-group MLAG_PEER remote-as 65106
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1050,6 +1059,7 @@ router bgp 65106
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.12
+      neighbor interface Vlan3010 peer-group MLAG_PEER remote-as 65106
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1057,6 +1067,7 @@ router bgp 65106
       route-target import evpn 20:20
       route-target export evpn 20:20
       router-id 192.168.255.12
+      neighbor interface Vlan3019 peer-group MLAG_PEER remote-as 65106
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1064,6 +1075,7 @@ router bgp 65106
       route-target import evpn 30:30
       route-target export evpn 30:30
       router-id 192.168.255.12
+      neighbor interface Vlan2 peer-group MLAG_PEER remote-as 65106
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF3A.md
@@ -514,7 +514,7 @@ interface Loopback100
 
 | Interface | VRF | IP Address | IP Address Virtual | IP Router Virtual Address | VRRP | ACL In | ACL Out |
 | --------- | --- | ---------- | ------------------ | ------------------------- | ---- | ------ | ------- |
-| Vlan2 |  Tenant_C_OP_Zone  |  10.255.251.14/31  |  -  |  -  |  -  |  -  |  -  |
+| Vlan2 |  Tenant_C_OP_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
 | Vlan110 |  Tenant_A_OP_Zone  |  -  |  10.1.10.1/24  |  -  |  -  |  -  |  -  |
 | Vlan111 |  Tenant_A_OP_Zone  |  -  |  10.1.11.1/24  |  -  |  -  |  -  |  -  |
 | Vlan120 |  Tenant_A_WEB_Zone  |  -  |  10.1.20.1/24  |  -  |  -  |  -  |  -  |
@@ -527,11 +527,11 @@ interface Loopback100
 | Vlan211 |  Tenant_B_OP_Zone  |  -  |  10.2.11.1/24  |  -  |  -  |  -  |  -  |
 | Vlan310 |  Tenant_C_OP_Zone  |  -  |  10.3.10.1/24  |  -  |  -  |  -  |  -  |
 | Vlan311 |  Tenant_C_OP_Zone  |  -  |  10.3.11.1/24  |  -  |  -  |  -  |  -  |
-| Vlan3009 |  Tenant_A_OP_Zone  |  10.255.251.14/31  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3010 |  Tenant_A_WEB_Zone  |  10.255.251.14/31  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3011 |  Tenant_A_APP_Zone  |  10.255.251.14/31  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3012 |  Tenant_A_DB_Zone  |  10.255.251.14/31  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3019 |  Tenant_B_OP_Zone  |  10.255.251.14/31  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3009 |  Tenant_A_OP_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3010 |  Tenant_A_WEB_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3011 |  Tenant_A_APP_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3012 |  Tenant_A_DB_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3019 |  Tenant_B_OP_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
 | Vlan4093 |  default  |  -  |  -  |  -  |  -  |  -  |  -  |
 | Vlan4094 |  default  |  10.255.252.14/31  |  -  |  -  |  -  |  -  |  -  |
 
@@ -544,7 +544,7 @@ interface Vlan2
    no shutdown
    mtu 1500
    vrf Tenant_C_OP_Zone
-   ip address 10.255.251.14/31
+   ipv6 enable
 !
 interface Vlan110
    description Tenant_A_OP_Zone_1
@@ -626,35 +626,35 @@ interface Vlan3009
    no shutdown
    mtu 1500
    vrf Tenant_A_OP_Zone
-   ip address 10.255.251.14/31
+   ipv6 enable
 !
 interface Vlan3010
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_WEB_Zone
-   ip address 10.255.251.14/31
+   ipv6 enable
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_APP_Zone
-   ip address 10.255.251.14/31
+   ipv6 enable
 !
 interface Vlan3012
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_DB_Zone
-   ip address 10.255.251.14/31
+   ipv6 enable
 !
 interface Vlan3019
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone
    no shutdown
    mtu 1500
    vrf Tenant_B_OP_Zone
-   ip address 10.255.251.14/31
+   ipv6 enable
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
@@ -880,12 +880,6 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | Neighbor | Remote AS | VRF | Shutdown | Send-community | Maximum-routes | Allowas-in | BFD | RIB Pre-Policy Retain |
 | -------- | --------- | --- | -------- | -------------- | -------------- | ---------- | --- | --------------------- |
 | 2001:1::5 | 65001 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - |
-| 10.255.251.15 | Inherited from peer group MLAG_PEER | Tenant_A_APP_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - |
-| 10.255.251.15 | Inherited from peer group MLAG_PEER | Tenant_A_DB_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - |
-| 10.255.251.15 | Inherited from peer group MLAG_PEER | Tenant_A_OP_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - |
-| 10.255.251.15 | Inherited from peer group MLAG_PEER | Tenant_A_WEB_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - |
-| 10.255.251.15 | Inherited from peer group MLAG_PEER | Tenant_B_OP_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - |
-| 10.255.251.15 | Inherited from peer group MLAG_PEER | Tenant_C_OP_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - |
 
 ### BGP Neighbor Interfaces
 
@@ -1035,7 +1029,6 @@ router bgp 65106
       route-target import evpn 12:12
       route-target export evpn 12:12
       router-id 192.168.255.12
-      neighbor 10.255.251.15 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1043,7 +1036,6 @@ router bgp 65106
       route-target import evpn 13:13
       route-target export evpn 13:13
       router-id 192.168.255.12
-      neighbor 10.255.251.15 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1051,7 +1043,6 @@ router bgp 65106
       route-target import evpn 10:10
       route-target export evpn 10:10
       router-id 192.168.255.12
-      neighbor 10.255.251.15 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1059,7 +1050,6 @@ router bgp 65106
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.12
-      neighbor 10.255.251.15 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1067,7 +1057,6 @@ router bgp 65106
       route-target import evpn 20:20
       route-target export evpn 20:20
       router-id 192.168.255.12
-      neighbor 10.255.251.15 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1075,7 +1064,6 @@ router bgp 65106
       route-target import evpn 30:30
       route-target export evpn 30:30
       router-id 192.168.255.12
-      neighbor 10.255.251.15 peer group MLAG_PEER
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF3B.md
@@ -514,7 +514,7 @@ interface Loopback100
 
 | Interface | VRF | IP Address | IP Address Virtual | IP Router Virtual Address | VRRP | ACL In | ACL Out |
 | --------- | --- | ---------- | ------------------ | ------------------------- | ---- | ------ | ------- |
-| Vlan2 |  Tenant_C_OP_Zone  |  10.255.251.15/31  |  -  |  -  |  -  |  -  |  -  |
+| Vlan2 |  Tenant_C_OP_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
 | Vlan110 |  Tenant_A_OP_Zone  |  -  |  10.1.10.1/24  |  -  |  -  |  -  |  -  |
 | Vlan111 |  Tenant_A_OP_Zone  |  -  |  10.1.11.1/24  |  -  |  -  |  -  |  -  |
 | Vlan120 |  Tenant_A_WEB_Zone  |  -  |  10.1.20.1/24  |  -  |  -  |  -  |  -  |
@@ -527,11 +527,11 @@ interface Loopback100
 | Vlan211 |  Tenant_B_OP_Zone  |  -  |  10.2.11.1/24  |  -  |  -  |  -  |  -  |
 | Vlan310 |  Tenant_C_OP_Zone  |  -  |  10.3.10.1/24  |  -  |  -  |  -  |  -  |
 | Vlan311 |  Tenant_C_OP_Zone  |  -  |  10.3.11.1/24  |  -  |  -  |  -  |  -  |
-| Vlan3009 |  Tenant_A_OP_Zone  |  10.255.251.15/31  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3010 |  Tenant_A_WEB_Zone  |  10.255.251.15/31  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3011 |  Tenant_A_APP_Zone  |  10.255.251.15/31  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3012 |  Tenant_A_DB_Zone  |  10.255.251.15/31  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3019 |  Tenant_B_OP_Zone  |  10.255.251.15/31  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3009 |  Tenant_A_OP_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3010 |  Tenant_A_WEB_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3011 |  Tenant_A_APP_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3012 |  Tenant_A_DB_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3019 |  Tenant_B_OP_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
 | Vlan4093 |  default  |  -  |  -  |  -  |  -  |  -  |  -  |
 | Vlan4094 |  default  |  10.255.252.15/31  |  -  |  -  |  -  |  -  |  -  |
 
@@ -544,7 +544,7 @@ interface Vlan2
    no shutdown
    mtu 1500
    vrf Tenant_C_OP_Zone
-   ip address 10.255.251.15/31
+   ipv6 enable
 !
 interface Vlan110
    description Tenant_A_OP_Zone_1
@@ -626,35 +626,35 @@ interface Vlan3009
    no shutdown
    mtu 1500
    vrf Tenant_A_OP_Zone
-   ip address 10.255.251.15/31
+   ipv6 enable
 !
 interface Vlan3010
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_WEB_Zone
-   ip address 10.255.251.15/31
+   ipv6 enable
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_APP_Zone
-   ip address 10.255.251.15/31
+   ipv6 enable
 !
 interface Vlan3012
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_DB_Zone
-   ip address 10.255.251.15/31
+   ipv6 enable
 !
 interface Vlan3019
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone
    no shutdown
    mtu 1500
    vrf Tenant_B_OP_Zone
-   ip address 10.255.251.15/31
+   ipv6 enable
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
@@ -880,12 +880,6 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | Neighbor | Remote AS | VRF | Shutdown | Send-community | Maximum-routes | Allowas-in | BFD | RIB Pre-Policy Retain |
 | -------- | --------- | --- | -------- | -------------- | -------------- | ---------- | --- | --------------------- |
 | 2001:1::5 | 65001 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - |
-| 10.255.251.14 | Inherited from peer group MLAG_PEER | Tenant_A_APP_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - |
-| 10.255.251.14 | Inherited from peer group MLAG_PEER | Tenant_A_DB_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - |
-| 10.255.251.14 | Inherited from peer group MLAG_PEER | Tenant_A_OP_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - |
-| 10.255.251.14 | Inherited from peer group MLAG_PEER | Tenant_A_WEB_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - |
-| 10.255.251.14 | Inherited from peer group MLAG_PEER | Tenant_B_OP_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - |
-| 10.255.251.14 | Inherited from peer group MLAG_PEER | Tenant_C_OP_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - |
 
 ### BGP Neighbor Interfaces
 
@@ -1035,7 +1029,6 @@ router bgp 65106
       route-target import evpn 12:12
       route-target export evpn 12:12
       router-id 192.168.255.13
-      neighbor 10.255.251.14 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1043,7 +1036,6 @@ router bgp 65106
       route-target import evpn 13:13
       route-target export evpn 13:13
       router-id 192.168.255.13
-      neighbor 10.255.251.14 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1051,7 +1043,6 @@ router bgp 65106
       route-target import evpn 10:10
       route-target export evpn 10:10
       router-id 192.168.255.13
-      neighbor 10.255.251.14 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1059,7 +1050,6 @@ router bgp 65106
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.13
-      neighbor 10.255.251.14 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1067,7 +1057,6 @@ router bgp 65106
       route-target import evpn 20:20
       route-target export evpn 20:20
       router-id 192.168.255.13
-      neighbor 10.255.251.14 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1075,7 +1064,6 @@ router bgp 65106
       route-target import evpn 30:30
       route-target export evpn 30:30
       router-id 192.168.255.13
-      neighbor 10.255.251.14 peer group MLAG_PEER
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF3B.md
@@ -887,6 +887,12 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | ------------------ | --- | ---------- | --------- | ----------- |
 | Ethernet1 | default | UNDERLAY_PEERS | 65001 | - |
 | Vlan4093 | default | MLAG_PEER | 65106 | - |
+| Vlan3011 | Tenant_A_APP_Zone | MLAG_PEER | 65106 | - |
+| Vlan3012 | Tenant_A_DB_Zone | MLAG_PEER | 65106 | - |
+| Vlan3009 | Tenant_A_OP_Zone | MLAG_PEER | 65106 | - |
+| Vlan3010 | Tenant_A_WEB_Zone | MLAG_PEER | 65106 | - |
+| Vlan3019 | Tenant_B_OP_Zone | MLAG_PEER | 65106 | - |
+| Vlan2 | Tenant_C_OP_Zone | MLAG_PEER | 65106 | - |
 
 ### Router BGP EVPN Address Family
 
@@ -1029,6 +1035,7 @@ router bgp 65106
       route-target import evpn 12:12
       route-target export evpn 12:12
       router-id 192.168.255.13
+      neighbor interface Vlan3011 peer-group MLAG_PEER remote-as 65106
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1036,6 +1043,7 @@ router bgp 65106
       route-target import evpn 13:13
       route-target export evpn 13:13
       router-id 192.168.255.13
+      neighbor interface Vlan3012 peer-group MLAG_PEER remote-as 65106
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1043,6 +1051,7 @@ router bgp 65106
       route-target import evpn 10:10
       route-target export evpn 10:10
       router-id 192.168.255.13
+      neighbor interface Vlan3009 peer-group MLAG_PEER remote-as 65106
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1050,6 +1059,7 @@ router bgp 65106
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.13
+      neighbor interface Vlan3010 peer-group MLAG_PEER remote-as 65106
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1057,6 +1067,7 @@ router bgp 65106
       route-target import evpn 20:20
       route-target export evpn 20:20
       router-id 192.168.255.13
+      neighbor interface Vlan3019 peer-group MLAG_PEER remote-as 65106
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1064,6 +1075,7 @@ router bgp 65106
       route-target import evpn 30:30
       route-target export evpn 30:30
       router-id 192.168.255.13
+      neighbor interface Vlan2 peer-group MLAG_PEER remote-as 65106
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF4A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF4A.md
@@ -887,6 +887,12 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | ------------------ | --- | ---------- | --------- | ----------- |
 | Ethernet1 | default | UNDERLAY_PEERS | 65001 | - |
 | Vlan4093 | default | MLAG_PEER | 65107 | - |
+| Vlan3011 | Tenant_A_APP_Zone | MLAG_PEER | 65107 | - |
+| Vlan3012 | Tenant_A_DB_Zone | MLAG_PEER | 65107 | - |
+| Vlan3009 | Tenant_A_OP_Zone | MLAG_PEER | 65107 | - |
+| Vlan3010 | Tenant_A_WEB_Zone | MLAG_PEER | 65107 | - |
+| Vlan3019 | Tenant_B_OP_Zone | MLAG_PEER | 65107 | - |
+| Vlan2 | Tenant_C_OP_Zone | MLAG_PEER | 65107 | - |
 
 ### Router BGP EVPN Address Family
 
@@ -1029,6 +1035,7 @@ router bgp 65107
       route-target import evpn 12:12
       route-target export evpn 12:12
       router-id 192.168.255.14
+      neighbor interface Vlan3011 peer-group MLAG_PEER remote-as 65107
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1036,6 +1043,7 @@ router bgp 65107
       route-target import evpn 13:13
       route-target export evpn 13:13
       router-id 192.168.255.14
+      neighbor interface Vlan3012 peer-group MLAG_PEER remote-as 65107
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1043,6 +1051,7 @@ router bgp 65107
       route-target import evpn 10:10
       route-target export evpn 10:10
       router-id 192.168.255.14
+      neighbor interface Vlan3009 peer-group MLAG_PEER remote-as 65107
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1050,6 +1059,7 @@ router bgp 65107
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.14
+      neighbor interface Vlan3010 peer-group MLAG_PEER remote-as 65107
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1057,6 +1067,7 @@ router bgp 65107
       route-target import evpn 20:20
       route-target export evpn 20:20
       router-id 192.168.255.14
+      neighbor interface Vlan3019 peer-group MLAG_PEER remote-as 65107
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1064,6 +1075,7 @@ router bgp 65107
       route-target import evpn 30:30
       route-target export evpn 30:30
       router-id 192.168.255.14
+      neighbor interface Vlan2 peer-group MLAG_PEER remote-as 65107
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF4A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF4A.md
@@ -514,7 +514,7 @@ interface Loopback100
 
 | Interface | VRF | IP Address | IP Address Virtual | IP Router Virtual Address | VRRP | ACL In | ACL Out |
 | --------- | --- | ---------- | ------------------ | ------------------------- | ---- | ------ | ------- |
-| Vlan2 |  Tenant_C_OP_Zone  |  10.255.251.18/31  |  -  |  -  |  -  |  -  |  -  |
+| Vlan2 |  Tenant_C_OP_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
 | Vlan110 |  Tenant_A_OP_Zone  |  -  |  10.1.10.1/24  |  -  |  -  |  -  |  -  |
 | Vlan111 |  Tenant_A_OP_Zone  |  -  |  10.1.11.1/24  |  -  |  -  |  -  |  -  |
 | Vlan120 |  Tenant_A_WEB_Zone  |  -  |  10.1.20.1/24  |  -  |  -  |  -  |  -  |
@@ -527,11 +527,11 @@ interface Loopback100
 | Vlan211 |  Tenant_B_OP_Zone  |  -  |  10.2.11.1/24  |  -  |  -  |  -  |  -  |
 | Vlan310 |  Tenant_C_OP_Zone  |  -  |  10.3.10.1/24  |  -  |  -  |  -  |  -  |
 | Vlan311 |  Tenant_C_OP_Zone  |  -  |  10.3.11.1/24  |  -  |  -  |  -  |  -  |
-| Vlan3009 |  Tenant_A_OP_Zone  |  10.255.251.18/31  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3010 |  Tenant_A_WEB_Zone  |  10.255.251.18/31  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3011 |  Tenant_A_APP_Zone  |  10.255.251.18/31  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3012 |  Tenant_A_DB_Zone  |  10.255.251.18/31  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3019 |  Tenant_B_OP_Zone  |  10.255.251.18/31  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3009 |  Tenant_A_OP_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3010 |  Tenant_A_WEB_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3011 |  Tenant_A_APP_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3012 |  Tenant_A_DB_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3019 |  Tenant_B_OP_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
 | Vlan4093 |  default  |  -  |  -  |  -  |  -  |  -  |  -  |
 | Vlan4094 |  default  |  10.255.252.18/31  |  -  |  -  |  -  |  -  |  -  |
 
@@ -544,7 +544,7 @@ interface Vlan2
    no shutdown
    mtu 1500
    vrf Tenant_C_OP_Zone
-   ip address 10.255.251.18/31
+   ipv6 enable
 !
 interface Vlan110
    description Tenant_A_OP_Zone_1
@@ -626,35 +626,35 @@ interface Vlan3009
    no shutdown
    mtu 1500
    vrf Tenant_A_OP_Zone
-   ip address 10.255.251.18/31
+   ipv6 enable
 !
 interface Vlan3010
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_WEB_Zone
-   ip address 10.255.251.18/31
+   ipv6 enable
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_APP_Zone
-   ip address 10.255.251.18/31
+   ipv6 enable
 !
 interface Vlan3012
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_DB_Zone
-   ip address 10.255.251.18/31
+   ipv6 enable
 !
 interface Vlan3019
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone
    no shutdown
    mtu 1500
    vrf Tenant_B_OP_Zone
-   ip address 10.255.251.18/31
+   ipv6 enable
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
@@ -880,12 +880,6 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | Neighbor | Remote AS | VRF | Shutdown | Send-community | Maximum-routes | Allowas-in | BFD | RIB Pre-Policy Retain |
 | -------- | --------- | --- | -------- | -------------- | -------------- | ---------- | --- | --------------------- |
 | 192.168.255.6 | 65001 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - |
-| 10.255.251.19 | Inherited from peer group MLAG_PEER | Tenant_A_APP_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - |
-| 10.255.251.19 | Inherited from peer group MLAG_PEER | Tenant_A_DB_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - |
-| 10.255.251.19 | Inherited from peer group MLAG_PEER | Tenant_A_OP_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - |
-| 10.255.251.19 | Inherited from peer group MLAG_PEER | Tenant_A_WEB_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - |
-| 10.255.251.19 | Inherited from peer group MLAG_PEER | Tenant_B_OP_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - |
-| 10.255.251.19 | Inherited from peer group MLAG_PEER | Tenant_C_OP_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - |
 
 ### BGP Neighbor Interfaces
 
@@ -1035,7 +1029,6 @@ router bgp 65107
       route-target import evpn 12:12
       route-target export evpn 12:12
       router-id 192.168.255.14
-      neighbor 10.255.251.19 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1043,7 +1036,6 @@ router bgp 65107
       route-target import evpn 13:13
       route-target export evpn 13:13
       router-id 192.168.255.14
-      neighbor 10.255.251.19 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1051,7 +1043,6 @@ router bgp 65107
       route-target import evpn 10:10
       route-target export evpn 10:10
       router-id 192.168.255.14
-      neighbor 10.255.251.19 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1059,7 +1050,6 @@ router bgp 65107
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.14
-      neighbor 10.255.251.19 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1067,7 +1057,6 @@ router bgp 65107
       route-target import evpn 20:20
       route-target export evpn 20:20
       router-id 192.168.255.14
-      neighbor 10.255.251.19 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1075,7 +1064,6 @@ router bgp 65107
       route-target import evpn 30:30
       route-target export evpn 30:30
       router-id 192.168.255.14
-      neighbor 10.255.251.19 peer group MLAG_PEER
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF4B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF4B.md
@@ -887,6 +887,12 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | ------------------ | --- | ---------- | --------- | ----------- |
 | Ethernet1 | default | UNDERLAY_PEERS | 65001 | - |
 | Vlan4093 | default | MLAG_PEER | 65107 | - |
+| Vlan3011 | Tenant_A_APP_Zone | MLAG_PEER | 65107 | - |
+| Vlan3012 | Tenant_A_DB_Zone | MLAG_PEER | 65107 | - |
+| Vlan3009 | Tenant_A_OP_Zone | MLAG_PEER | 65107 | - |
+| Vlan3010 | Tenant_A_WEB_Zone | MLAG_PEER | 65107 | - |
+| Vlan3019 | Tenant_B_OP_Zone | MLAG_PEER | 65107 | - |
+| Vlan2 | Tenant_C_OP_Zone | MLAG_PEER | 65107 | - |
 
 ### Router BGP EVPN Address Family
 
@@ -1029,6 +1035,7 @@ router bgp 65107
       route-target import evpn 12:12
       route-target export evpn 12:12
       router-id 192.168.255.15
+      neighbor interface Vlan3011 peer-group MLAG_PEER remote-as 65107
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1036,6 +1043,7 @@ router bgp 65107
       route-target import evpn 13:13
       route-target export evpn 13:13
       router-id 192.168.255.15
+      neighbor interface Vlan3012 peer-group MLAG_PEER remote-as 65107
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1043,6 +1051,7 @@ router bgp 65107
       route-target import evpn 10:10
       route-target export evpn 10:10
       router-id 192.168.255.15
+      neighbor interface Vlan3009 peer-group MLAG_PEER remote-as 65107
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1050,6 +1059,7 @@ router bgp 65107
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.15
+      neighbor interface Vlan3010 peer-group MLAG_PEER remote-as 65107
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1057,6 +1067,7 @@ router bgp 65107
       route-target import evpn 20:20
       route-target export evpn 20:20
       router-id 192.168.255.15
+      neighbor interface Vlan3019 peer-group MLAG_PEER remote-as 65107
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1064,6 +1075,7 @@ router bgp 65107
       route-target import evpn 30:30
       route-target export evpn 30:30
       router-id 192.168.255.15
+      neighbor interface Vlan2 peer-group MLAG_PEER remote-as 65107
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF4B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF4B.md
@@ -514,7 +514,7 @@ interface Loopback100
 
 | Interface | VRF | IP Address | IP Address Virtual | IP Router Virtual Address | VRRP | ACL In | ACL Out |
 | --------- | --- | ---------- | ------------------ | ------------------------- | ---- | ------ | ------- |
-| Vlan2 |  Tenant_C_OP_Zone  |  10.255.251.19/31  |  -  |  -  |  -  |  -  |  -  |
+| Vlan2 |  Tenant_C_OP_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
 | Vlan110 |  Tenant_A_OP_Zone  |  -  |  10.1.10.1/24  |  -  |  -  |  -  |  -  |
 | Vlan111 |  Tenant_A_OP_Zone  |  -  |  10.1.11.1/24  |  -  |  -  |  -  |  -  |
 | Vlan120 |  Tenant_A_WEB_Zone  |  -  |  10.1.20.1/24  |  -  |  -  |  -  |  -  |
@@ -527,11 +527,11 @@ interface Loopback100
 | Vlan211 |  Tenant_B_OP_Zone  |  -  |  10.2.11.1/24  |  -  |  -  |  -  |  -  |
 | Vlan310 |  Tenant_C_OP_Zone  |  -  |  10.3.10.1/24  |  -  |  -  |  -  |  -  |
 | Vlan311 |  Tenant_C_OP_Zone  |  -  |  10.3.11.1/24  |  -  |  -  |  -  |  -  |
-| Vlan3009 |  Tenant_A_OP_Zone  |  10.255.251.19/31  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3010 |  Tenant_A_WEB_Zone  |  10.255.251.19/31  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3011 |  Tenant_A_APP_Zone  |  10.255.251.19/31  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3012 |  Tenant_A_DB_Zone  |  10.255.251.19/31  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3019 |  Tenant_B_OP_Zone  |  10.255.251.19/31  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3009 |  Tenant_A_OP_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3010 |  Tenant_A_WEB_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3011 |  Tenant_A_APP_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3012 |  Tenant_A_DB_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3019 |  Tenant_B_OP_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
 | Vlan4093 |  default  |  -  |  -  |  -  |  -  |  -  |  -  |
 | Vlan4094 |  default  |  10.255.252.19/31  |  -  |  -  |  -  |  -  |  -  |
 
@@ -544,7 +544,7 @@ interface Vlan2
    no shutdown
    mtu 1500
    vrf Tenant_C_OP_Zone
-   ip address 10.255.251.19/31
+   ipv6 enable
 !
 interface Vlan110
    description Tenant_A_OP_Zone_1
@@ -626,35 +626,35 @@ interface Vlan3009
    no shutdown
    mtu 1500
    vrf Tenant_A_OP_Zone
-   ip address 10.255.251.19/31
+   ipv6 enable
 !
 interface Vlan3010
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_WEB_Zone
-   ip address 10.255.251.19/31
+   ipv6 enable
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_APP_Zone
-   ip address 10.255.251.19/31
+   ipv6 enable
 !
 interface Vlan3012
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_DB_Zone
-   ip address 10.255.251.19/31
+   ipv6 enable
 !
 interface Vlan3019
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone
    no shutdown
    mtu 1500
    vrf Tenant_B_OP_Zone
-   ip address 10.255.251.19/31
+   ipv6 enable
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
@@ -880,12 +880,6 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | Neighbor | Remote AS | VRF | Shutdown | Send-community | Maximum-routes | Allowas-in | BFD | RIB Pre-Policy Retain |
 | -------- | --------- | --- | -------- | -------------- | -------------- | ---------- | --- | --------------------- |
 | 192.168.255.6 | 65001 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - |
-| 10.255.251.18 | Inherited from peer group MLAG_PEER | Tenant_A_APP_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - |
-| 10.255.251.18 | Inherited from peer group MLAG_PEER | Tenant_A_DB_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - |
-| 10.255.251.18 | Inherited from peer group MLAG_PEER | Tenant_A_OP_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - |
-| 10.255.251.18 | Inherited from peer group MLAG_PEER | Tenant_A_WEB_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - |
-| 10.255.251.18 | Inherited from peer group MLAG_PEER | Tenant_B_OP_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - |
-| 10.255.251.18 | Inherited from peer group MLAG_PEER | Tenant_C_OP_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - |
 
 ### BGP Neighbor Interfaces
 
@@ -1035,7 +1029,6 @@ router bgp 65107
       route-target import evpn 12:12
       route-target export evpn 12:12
       router-id 192.168.255.15
-      neighbor 10.255.251.18 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1043,7 +1036,6 @@ router bgp 65107
       route-target import evpn 13:13
       route-target export evpn 13:13
       router-id 192.168.255.15
-      neighbor 10.255.251.18 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1051,7 +1043,6 @@ router bgp 65107
       route-target import evpn 10:10
       route-target export evpn 10:10
       router-id 192.168.255.15
-      neighbor 10.255.251.18 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1059,7 +1050,6 @@ router bgp 65107
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.15
-      neighbor 10.255.251.18 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1067,7 +1057,6 @@ router bgp 65107
       route-target import evpn 20:20
       route-target export evpn 20:20
       router-id 192.168.255.15
-      neighbor 10.255.251.18 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1075,7 +1064,6 @@ router bgp 65107
       route-target import evpn 30:30
       route-target export evpn 30:30
       router-id 192.168.255.15
-      neighbor 10.255.251.18 peer group MLAG_PEER
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -703,7 +703,7 @@ interface Loopback100
 
 | Interface | VRF | IP Address | IP Address Virtual | IP Router Virtual Address | VRRP | ACL In | ACL Out |
 | --------- | --- | ---------- | ------------------ | ------------------------- | ---- | ------ | ------- |
-| Vlan2 |  Tenant_C_OP_Zone  |  10.255.251.6/31  |  -  |  -  |  -  |  -  |  -  |
+| Vlan2 |  Tenant_C_OP_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
 | Vlan110 |  Tenant_A_OP_Zone  |  -  |  10.1.10.1/24  |  -  |  -  |  -  |  -  |
 | Vlan111 |  Tenant_A_OP_Zone  |  -  |  10.1.11.1/24  |  -  |  -  |  -  |  -  |
 | Vlan120 |  Tenant_A_WEB_Zone  |  -  |  10.1.20.1/24  |  -  |  -  |  -  |  -  |
@@ -719,14 +719,14 @@ interface Loopback100
 | Vlan310 |  Tenant_C_OP_Zone  |  -  |  10.3.10.1/24  |  -  |  -  |  -  |  -  |
 | Vlan311 |  Tenant_C_OP_Zone  |  -  |  10.3.11.1/24  |  -  |  -  |  -  |  -  |
 | Vlan350 |  Tenant_C_WAN_Zone  |  -  |  10.3.50.1/24  |  -  |  -  |  -  |  -  |
-| Vlan3009 |  Tenant_A_OP_Zone  |  10.255.251.6/31  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3010 |  Tenant_A_WEB_Zone  |  10.255.251.6/31  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3011 |  Tenant_A_APP_Zone  |  10.255.251.6/31  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3012 |  Tenant_A_DB_Zone  |  10.255.251.6/31  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3013 |  Tenant_A_WAN_Zone  |  10.255.251.6/31  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3019 |  Tenant_B_OP_Zone  |  10.255.251.6/31  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3020 |  Tenant_B_WAN_Zone  |  10.255.251.6/31  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3030 |  Tenant_C_WAN_Zone  |  10.255.251.6/31  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3009 |  Tenant_A_OP_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3010 |  Tenant_A_WEB_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3011 |  Tenant_A_APP_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3012 |  Tenant_A_DB_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3013 |  Tenant_A_WAN_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3019 |  Tenant_B_OP_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3020 |  Tenant_B_WAN_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3030 |  Tenant_C_WAN_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
 | Vlan4093 |  default  |  -  |  -  |  -  |  -  |  -  |  -  |
 | Vlan4094 |  default  |  10.255.252.6/31  |  -  |  -  |  -  |  -  |  -  |
 
@@ -739,7 +739,7 @@ interface Vlan2
    no shutdown
    mtu 1500
    vrf Tenant_C_OP_Zone
-   ip address 10.255.251.6/31
+   ipv6 enable
 !
 interface Vlan110
    description Tenant_A_OP_Zone_1
@@ -839,56 +839,56 @@ interface Vlan3009
    no shutdown
    mtu 1500
    vrf Tenant_A_OP_Zone
-   ip address 10.255.251.6/31
+   ipv6 enable
 !
 interface Vlan3010
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_WEB_Zone
-   ip address 10.255.251.6/31
+   ipv6 enable
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_APP_Zone
-   ip address 10.255.251.6/31
+   ipv6 enable
 !
 interface Vlan3012
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_DB_Zone
-   ip address 10.255.251.6/31
+   ipv6 enable
 !
 interface Vlan3013
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_WAN_Zone
-   ip address 10.255.251.6/31
+   ipv6 enable
 !
 interface Vlan3019
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone
    no shutdown
    mtu 1500
    vrf Tenant_B_OP_Zone
-   ip address 10.255.251.6/31
+   ipv6 enable
 !
 interface Vlan3020
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone
    no shutdown
    mtu 1500
    vrf Tenant_B_WAN_Zone
-   ip address 10.255.251.6/31
+   ipv6 enable
 !
 interface Vlan3030
    description MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone
    no shutdown
    mtu 1500
    vrf Tenant_C_WAN_Zone
-   ip address 10.255.251.6/31
+   ipv6 enable
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
@@ -1138,15 +1138,6 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | 192.168.255.2 | 65001 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - |
 | 192.168.255.3 | 65001 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - |
 | 192.168.255.4 | 65001 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - |
-| 10.255.251.7 | Inherited from peer group MLAG_PEER | Tenant_A_APP_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - |
-| 10.255.251.7 | Inherited from peer group MLAG_PEER | Tenant_A_DB_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - |
-| 10.255.251.7 | Inherited from peer group MLAG_PEER | Tenant_A_OP_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - |
-| 10.255.251.7 | Inherited from peer group MLAG_PEER | Tenant_A_WAN_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - |
-| 10.255.251.7 | Inherited from peer group MLAG_PEER | Tenant_A_WEB_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - |
-| 10.255.251.7 | Inherited from peer group MLAG_PEER | Tenant_B_OP_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - |
-| 10.255.251.7 | Inherited from peer group MLAG_PEER | Tenant_B_WAN_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - |
-| 10.255.251.7 | Inherited from peer group MLAG_PEER | Tenant_C_OP_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - |
-| 10.255.251.7 | Inherited from peer group MLAG_PEER | Tenant_C_WAN_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - |
 
 ### BGP Neighbor Interfaces
 
@@ -1331,7 +1322,6 @@ router bgp 65103
       route-target import evpn 12:12
       route-target export evpn 12:12
       router-id 192.168.255.8
-      neighbor 10.255.251.7 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1339,7 +1329,6 @@ router bgp 65103
       route-target import evpn 13:13
       route-target export evpn 13:13
       router-id 192.168.255.8
-      neighbor 10.255.251.7 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1347,7 +1336,6 @@ router bgp 65103
       route-target import evpn 10:10
       route-target export evpn 10:10
       router-id 192.168.255.8
-      neighbor 10.255.251.7 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -1355,7 +1343,6 @@ router bgp 65103
       route-target import evpn 14:14
       route-target export evpn 14:14
       router-id 192.168.255.8
-      neighbor 10.255.251.7 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1363,7 +1350,6 @@ router bgp 65103
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.8
-      neighbor 10.255.251.7 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1371,7 +1357,6 @@ router bgp 65103
       route-target import evpn 20:20
       route-target export evpn 20:20
       router-id 192.168.255.8
-      neighbor 10.255.251.7 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -1379,7 +1364,6 @@ router bgp 65103
       route-target import evpn 21:21
       route-target export evpn 21:21
       router-id 192.168.255.8
-      neighbor 10.255.251.7 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1387,7 +1371,6 @@ router bgp 65103
       route-target import evpn 30:30
       route-target export evpn 30:30
       router-id 192.168.255.8
-      neighbor 10.255.251.7 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -1395,7 +1378,6 @@ router bgp 65103
       route-target import evpn 31:31
       route-target export evpn 31:31
       router-id 192.168.255.8
-      neighbor 10.255.251.7 peer group MLAG_PEER
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -1148,6 +1148,15 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | Ethernet3 | default | UNDERLAY_PEERS | 65001 | - |
 | Ethernet4 | default | UNDERLAY_PEERS | 65001 | - |
 | Vlan4093 | default | MLAG_PEER | 65103 | - |
+| Vlan3011 | Tenant_A_APP_Zone | MLAG_PEER | 65103 | - |
+| Vlan3012 | Tenant_A_DB_Zone | MLAG_PEER | 65103 | - |
+| Vlan3009 | Tenant_A_OP_Zone | MLAG_PEER | 65103 | - |
+| Vlan3013 | Tenant_A_WAN_Zone | MLAG_PEER | 65103 | - |
+| Vlan3010 | Tenant_A_WEB_Zone | MLAG_PEER | 65103 | - |
+| Vlan3019 | Tenant_B_OP_Zone | MLAG_PEER | 65103 | - |
+| Vlan3020 | Tenant_B_WAN_Zone | MLAG_PEER | 65103 | - |
+| Vlan2 | Tenant_C_OP_Zone | MLAG_PEER | 65103 | - |
+| Vlan3030 | Tenant_C_WAN_Zone | MLAG_PEER | 65103 | - |
 
 ### Router BGP EVPN Address Family
 
@@ -1322,6 +1331,7 @@ router bgp 65103
       route-target import evpn 12:12
       route-target export evpn 12:12
       router-id 192.168.255.8
+      neighbor interface Vlan3011 peer-group MLAG_PEER remote-as 65103
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1329,6 +1339,7 @@ router bgp 65103
       route-target import evpn 13:13
       route-target export evpn 13:13
       router-id 192.168.255.8
+      neighbor interface Vlan3012 peer-group MLAG_PEER remote-as 65103
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1336,6 +1347,7 @@ router bgp 65103
       route-target import evpn 10:10
       route-target export evpn 10:10
       router-id 192.168.255.8
+      neighbor interface Vlan3009 peer-group MLAG_PEER remote-as 65103
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -1343,6 +1355,7 @@ router bgp 65103
       route-target import evpn 14:14
       route-target export evpn 14:14
       router-id 192.168.255.8
+      neighbor interface Vlan3013 peer-group MLAG_PEER remote-as 65103
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1350,6 +1363,7 @@ router bgp 65103
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.8
+      neighbor interface Vlan3010 peer-group MLAG_PEER remote-as 65103
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1357,6 +1371,7 @@ router bgp 65103
       route-target import evpn 20:20
       route-target export evpn 20:20
       router-id 192.168.255.8
+      neighbor interface Vlan3019 peer-group MLAG_PEER remote-as 65103
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -1364,6 +1379,7 @@ router bgp 65103
       route-target import evpn 21:21
       route-target export evpn 21:21
       router-id 192.168.255.8
+      neighbor interface Vlan3020 peer-group MLAG_PEER remote-as 65103
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1371,6 +1387,7 @@ router bgp 65103
       route-target import evpn 30:30
       route-target export evpn 30:30
       router-id 192.168.255.8
+      neighbor interface Vlan2 peer-group MLAG_PEER remote-as 65103
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -1378,6 +1395,7 @@ router bgp 65103
       route-target import evpn 31:31
       route-target export evpn 31:31
       router-id 192.168.255.8
+      neighbor interface Vlan3030 peer-group MLAG_PEER remote-as 65103
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -688,7 +688,7 @@ interface Loopback100
 
 | Interface | VRF | IP Address | IP Address Virtual | IP Router Virtual Address | VRRP | ACL In | ACL Out |
 | --------- | --- | ---------- | ------------------ | ------------------------- | ---- | ------ | ------- |
-| Vlan2 |  Tenant_C_OP_Zone  |  10.255.251.7/31  |  -  |  -  |  -  |  -  |  -  |
+| Vlan2 |  Tenant_C_OP_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
 | Vlan110 |  Tenant_A_OP_Zone  |  -  |  10.1.10.1/24  |  -  |  -  |  -  |  -  |
 | Vlan111 |  Tenant_A_OP_Zone  |  -  |  10.1.11.1/24  |  -  |  -  |  -  |  -  |
 | Vlan120 |  Tenant_A_WEB_Zone  |  -  |  10.1.20.1/24  |  -  |  -  |  -  |  -  |
@@ -704,14 +704,14 @@ interface Loopback100
 | Vlan310 |  Tenant_C_OP_Zone  |  -  |  10.3.10.1/24  |  -  |  -  |  -  |  -  |
 | Vlan311 |  Tenant_C_OP_Zone  |  -  |  10.3.11.1/24  |  -  |  -  |  -  |  -  |
 | Vlan350 |  Tenant_C_WAN_Zone  |  -  |  10.3.50.1/24  |  -  |  -  |  -  |  -  |
-| Vlan3009 |  Tenant_A_OP_Zone  |  10.255.251.7/31  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3010 |  Tenant_A_WEB_Zone  |  10.255.251.7/31  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3011 |  Tenant_A_APP_Zone  |  10.255.251.7/31  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3012 |  Tenant_A_DB_Zone  |  10.255.251.7/31  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3013 |  Tenant_A_WAN_Zone  |  10.255.251.7/31  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3019 |  Tenant_B_OP_Zone  |  10.255.251.7/31  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3020 |  Tenant_B_WAN_Zone  |  10.255.251.7/31  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3030 |  Tenant_C_WAN_Zone  |  10.255.251.7/31  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3009 |  Tenant_A_OP_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3010 |  Tenant_A_WEB_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3011 |  Tenant_A_APP_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3012 |  Tenant_A_DB_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3013 |  Tenant_A_WAN_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3019 |  Tenant_B_OP_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3020 |  Tenant_B_WAN_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3030 |  Tenant_C_WAN_Zone  |  -  |  -  |  -  |  -  |  -  |  -  |
 | Vlan4093 |  default  |  -  |  -  |  -  |  -  |  -  |  -  |
 | Vlan4094 |  default  |  10.255.252.7/31  |  -  |  -  |  -  |  -  |  -  |
 
@@ -724,7 +724,7 @@ interface Vlan2
    no shutdown
    mtu 1500
    vrf Tenant_C_OP_Zone
-   ip address 10.255.251.7/31
+   ipv6 enable
 !
 interface Vlan110
    description Tenant_A_OP_Zone_1
@@ -824,56 +824,56 @@ interface Vlan3009
    no shutdown
    mtu 1500
    vrf Tenant_A_OP_Zone
-   ip address 10.255.251.7/31
+   ipv6 enable
 !
 interface Vlan3010
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_WEB_Zone
-   ip address 10.255.251.7/31
+   ipv6 enable
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_APP_Zone
-   ip address 10.255.251.7/31
+   ipv6 enable
 !
 interface Vlan3012
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_DB_Zone
-   ip address 10.255.251.7/31
+   ipv6 enable
 !
 interface Vlan3013
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_WAN_Zone
-   ip address 10.255.251.7/31
+   ipv6 enable
 !
 interface Vlan3019
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone
    no shutdown
    mtu 1500
    vrf Tenant_B_OP_Zone
-   ip address 10.255.251.7/31
+   ipv6 enable
 !
 interface Vlan3020
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone
    no shutdown
    mtu 1500
    vrf Tenant_B_WAN_Zone
-   ip address 10.255.251.7/31
+   ipv6 enable
 !
 interface Vlan3030
    description MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone
    no shutdown
    mtu 1500
    vrf Tenant_C_WAN_Zone
-   ip address 10.255.251.7/31
+   ipv6 enable
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
@@ -1123,15 +1123,6 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | 192.168.255.2 | 65001 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - |
 | 192.168.255.3 | 65001 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - |
 | 192.168.255.4 | 65001 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - |
-| 10.255.251.6 | Inherited from peer group MLAG_PEER | Tenant_A_APP_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - |
-| 10.255.251.6 | Inherited from peer group MLAG_PEER | Tenant_A_DB_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - |
-| 10.255.251.6 | Inherited from peer group MLAG_PEER | Tenant_A_OP_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - |
-| 10.255.251.6 | Inherited from peer group MLAG_PEER | Tenant_A_WAN_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - |
-| 10.255.251.6 | Inherited from peer group MLAG_PEER | Tenant_A_WEB_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - |
-| 10.255.251.6 | Inherited from peer group MLAG_PEER | Tenant_B_OP_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - |
-| 10.255.251.6 | Inherited from peer group MLAG_PEER | Tenant_B_WAN_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - |
-| 10.255.251.6 | Inherited from peer group MLAG_PEER | Tenant_C_OP_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - |
-| 10.255.251.6 | Inherited from peer group MLAG_PEER | Tenant_C_WAN_Zone | - | Inherited from peer group MLAG_PEER | Inherited from peer group MLAG_PEER | - | - | - |
 
 ### BGP Neighbor Interfaces
 
@@ -1316,7 +1307,6 @@ router bgp 65103
       route-target import evpn 12:12
       route-target export evpn 12:12
       router-id 192.168.255.9
-      neighbor 10.255.251.6 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1324,7 +1314,6 @@ router bgp 65103
       route-target import evpn 13:13
       route-target export evpn 13:13
       router-id 192.168.255.9
-      neighbor 10.255.251.6 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1332,7 +1321,6 @@ router bgp 65103
       route-target import evpn 10:10
       route-target export evpn 10:10
       router-id 192.168.255.9
-      neighbor 10.255.251.6 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -1340,7 +1328,6 @@ router bgp 65103
       route-target import evpn 14:14
       route-target export evpn 14:14
       router-id 192.168.255.9
-      neighbor 10.255.251.6 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1348,7 +1335,6 @@ router bgp 65103
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.9
-      neighbor 10.255.251.6 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1356,7 +1342,6 @@ router bgp 65103
       route-target import evpn 20:20
       route-target export evpn 20:20
       router-id 192.168.255.9
-      neighbor 10.255.251.6 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -1364,7 +1349,6 @@ router bgp 65103
       route-target import evpn 21:21
       route-target export evpn 21:21
       router-id 192.168.255.9
-      neighbor 10.255.251.6 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1372,7 +1356,6 @@ router bgp 65103
       route-target import evpn 30:30
       route-target export evpn 30:30
       router-id 192.168.255.9
-      neighbor 10.255.251.6 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -1380,7 +1363,6 @@ router bgp 65103
       route-target import evpn 31:31
       route-target export evpn 31:31
       router-id 192.168.255.9
-      neighbor 10.255.251.6 peer group MLAG_PEER
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -1133,6 +1133,15 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | Ethernet3 | default | UNDERLAY_PEERS | 65001 | - |
 | Ethernet4 | default | UNDERLAY_PEERS | 65001 | - |
 | Vlan4093 | default | MLAG_PEER | 65103 | - |
+| Vlan3011 | Tenant_A_APP_Zone | MLAG_PEER | 65103 | - |
+| Vlan3012 | Tenant_A_DB_Zone | MLAG_PEER | 65103 | - |
+| Vlan3009 | Tenant_A_OP_Zone | MLAG_PEER | 65103 | - |
+| Vlan3013 | Tenant_A_WAN_Zone | MLAG_PEER | 65103 | - |
+| Vlan3010 | Tenant_A_WEB_Zone | MLAG_PEER | 65103 | - |
+| Vlan3019 | Tenant_B_OP_Zone | MLAG_PEER | 65103 | - |
+| Vlan3020 | Tenant_B_WAN_Zone | MLAG_PEER | 65103 | - |
+| Vlan2 | Tenant_C_OP_Zone | MLAG_PEER | 65103 | - |
+| Vlan3030 | Tenant_C_WAN_Zone | MLAG_PEER | 65103 | - |
 
 ### Router BGP EVPN Address Family
 
@@ -1307,6 +1316,7 @@ router bgp 65103
       route-target import evpn 12:12
       route-target export evpn 12:12
       router-id 192.168.255.9
+      neighbor interface Vlan3011 peer-group MLAG_PEER remote-as 65103
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1314,6 +1324,7 @@ router bgp 65103
       route-target import evpn 13:13
       route-target export evpn 13:13
       router-id 192.168.255.9
+      neighbor interface Vlan3012 peer-group MLAG_PEER remote-as 65103
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1321,6 +1332,7 @@ router bgp 65103
       route-target import evpn 10:10
       route-target export evpn 10:10
       router-id 192.168.255.9
+      neighbor interface Vlan3009 peer-group MLAG_PEER remote-as 65103
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -1328,6 +1340,7 @@ router bgp 65103
       route-target import evpn 14:14
       route-target export evpn 14:14
       router-id 192.168.255.9
+      neighbor interface Vlan3013 peer-group MLAG_PEER remote-as 65103
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1335,6 +1348,7 @@ router bgp 65103
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.9
+      neighbor interface Vlan3010 peer-group MLAG_PEER remote-as 65103
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1342,6 +1356,7 @@ router bgp 65103
       route-target import evpn 20:20
       route-target export evpn 20:20
       router-id 192.168.255.9
+      neighbor interface Vlan3019 peer-group MLAG_PEER remote-as 65103
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -1349,6 +1364,7 @@ router bgp 65103
       route-target import evpn 21:21
       route-target export evpn 21:21
       router-id 192.168.255.9
+      neighbor interface Vlan3020 peer-group MLAG_PEER remote-as 65103
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1356,6 +1372,7 @@ router bgp 65103
       route-target import evpn 30:30
       route-target export evpn 30:30
       router-id 192.168.255.9
+      neighbor interface Vlan2 peer-group MLAG_PEER remote-as 65103
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -1363,6 +1380,7 @@ router bgp 65103
       route-target import evpn 31:31
       route-target export evpn 31:31
       router-id 192.168.255.9
+      neighbor interface Vlan3030 peer-group MLAG_PEER remote-as 65103
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
@@ -244,7 +244,7 @@ interface Vlan2
    no shutdown
    mtu 1500
    vrf Tenant_C_OP_Zone
-   ip address 10.255.251.2/31
+   ipv6 enable
 !
 interface Vlan110
    description Tenant_A_OP_Zone_1
@@ -326,35 +326,35 @@ interface Vlan3009
    no shutdown
    mtu 1500
    vrf Tenant_A_OP_Zone
-   ip address 10.255.251.2/31
+   ipv6 enable
 !
 interface Vlan3010
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_WEB_Zone
-   ip address 10.255.251.2/31
+   ipv6 enable
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_APP_Zone
-   ip address 10.255.251.2/31
+   ipv6 enable
 !
 interface Vlan3012
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_DB_Zone
-   ip address 10.255.251.2/31
+   ipv6 enable
 !
 interface Vlan3019
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone
    no shutdown
    mtu 1500
    vrf Tenant_B_OP_Zone
-   ip address 10.255.251.2/31
+   ipv6 enable
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
@@ -545,7 +545,6 @@ router bgp 65102
       route-target import evpn 12:12
       route-target export evpn 12:12
       router-id 192.168.255.6
-      neighbor 10.255.251.3 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -553,7 +552,6 @@ router bgp 65102
       route-target import evpn 13:13
       route-target export evpn 13:13
       router-id 192.168.255.6
-      neighbor 10.255.251.3 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -561,7 +559,6 @@ router bgp 65102
       route-target import evpn 10:10
       route-target export evpn 10:10
       router-id 192.168.255.6
-      neighbor 10.255.251.3 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -569,7 +566,6 @@ router bgp 65102
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.6
-      neighbor 10.255.251.3 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -577,7 +573,6 @@ router bgp 65102
       route-target import evpn 20:20
       route-target export evpn 20:20
       router-id 192.168.255.6
-      neighbor 10.255.251.3 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -585,7 +580,6 @@ router bgp 65102
       route-target import evpn 30:30
       route-target export evpn 30:30
       router-id 192.168.255.6
-      neighbor 10.255.251.3 peer group MLAG_PEER
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
@@ -545,6 +545,7 @@ router bgp 65102
       route-target import evpn 12:12
       route-target export evpn 12:12
       router-id 192.168.255.6
+      neighbor interface Vlan3011 peer-group MLAG_PEER remote-as 65102
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -552,6 +553,7 @@ router bgp 65102
       route-target import evpn 13:13
       route-target export evpn 13:13
       router-id 192.168.255.6
+      neighbor interface Vlan3012 peer-group MLAG_PEER remote-as 65102
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -559,6 +561,7 @@ router bgp 65102
       route-target import evpn 10:10
       route-target export evpn 10:10
       router-id 192.168.255.6
+      neighbor interface Vlan3009 peer-group MLAG_PEER remote-as 65102
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -566,6 +569,7 @@ router bgp 65102
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.6
+      neighbor interface Vlan3010 peer-group MLAG_PEER remote-as 65102
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -573,6 +577,7 @@ router bgp 65102
       route-target import evpn 20:20
       route-target export evpn 20:20
       router-id 192.168.255.6
+      neighbor interface Vlan3019 peer-group MLAG_PEER remote-as 65102
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -580,6 +585,7 @@ router bgp 65102
       route-target import evpn 30:30
       route-target export evpn 30:30
       router-id 192.168.255.6
+      neighbor interface Vlan2 peer-group MLAG_PEER remote-as 65102
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
@@ -545,6 +545,7 @@ router bgp 65102
       route-target import evpn 12:12
       route-target export evpn 12:12
       router-id 192.168.255.7
+      neighbor interface Vlan3011 peer-group MLAG_PEER remote-as 65102
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -552,6 +553,7 @@ router bgp 65102
       route-target import evpn 13:13
       route-target export evpn 13:13
       router-id 192.168.255.7
+      neighbor interface Vlan3012 peer-group MLAG_PEER remote-as 65102
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -559,6 +561,7 @@ router bgp 65102
       route-target import evpn 10:10
       route-target export evpn 10:10
       router-id 192.168.255.7
+      neighbor interface Vlan3009 peer-group MLAG_PEER remote-as 65102
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -566,6 +569,7 @@ router bgp 65102
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.7
+      neighbor interface Vlan3010 peer-group MLAG_PEER remote-as 65102
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -573,6 +577,7 @@ router bgp 65102
       route-target import evpn 20:20
       route-target export evpn 20:20
       router-id 192.168.255.7
+      neighbor interface Vlan3019 peer-group MLAG_PEER remote-as 65102
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -580,6 +585,7 @@ router bgp 65102
       route-target import evpn 30:30
       route-target export evpn 30:30
       router-id 192.168.255.7
+      neighbor interface Vlan2 peer-group MLAG_PEER remote-as 65102
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
@@ -244,7 +244,7 @@ interface Vlan2
    no shutdown
    mtu 1500
    vrf Tenant_C_OP_Zone
-   ip address 10.255.251.3/31
+   ipv6 enable
 !
 interface Vlan110
    description Tenant_A_OP_Zone_1
@@ -326,35 +326,35 @@ interface Vlan3009
    no shutdown
    mtu 1500
    vrf Tenant_A_OP_Zone
-   ip address 10.255.251.3/31
+   ipv6 enable
 !
 interface Vlan3010
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_WEB_Zone
-   ip address 10.255.251.3/31
+   ipv6 enable
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_APP_Zone
-   ip address 10.255.251.3/31
+   ipv6 enable
 !
 interface Vlan3012
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_DB_Zone
-   ip address 10.255.251.3/31
+   ipv6 enable
 !
 interface Vlan3019
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone
    no shutdown
    mtu 1500
    vrf Tenant_B_OP_Zone
-   ip address 10.255.251.3/31
+   ipv6 enable
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
@@ -545,7 +545,6 @@ router bgp 65102
       route-target import evpn 12:12
       route-target export evpn 12:12
       router-id 192.168.255.7
-      neighbor 10.255.251.2 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -553,7 +552,6 @@ router bgp 65102
       route-target import evpn 13:13
       route-target export evpn 13:13
       router-id 192.168.255.7
-      neighbor 10.255.251.2 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -561,7 +559,6 @@ router bgp 65102
       route-target import evpn 10:10
       route-target export evpn 10:10
       router-id 192.168.255.7
-      neighbor 10.255.251.2 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -569,7 +566,6 @@ router bgp 65102
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.7
-      neighbor 10.255.251.2 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -577,7 +573,6 @@ router bgp 65102
       route-target import evpn 20:20
       route-target export evpn 20:20
       router-id 192.168.255.7
-      neighbor 10.255.251.2 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -585,7 +580,6 @@ router bgp 65102
       route-target import evpn 30:30
       route-target export evpn 30:30
       router-id 192.168.255.7
-      neighbor 10.255.251.2 peer group MLAG_PEER
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF3A.cfg
@@ -173,7 +173,7 @@ interface Vlan2
    no shutdown
    mtu 1500
    vrf Tenant_C_OP_Zone
-   ip address 10.255.251.14/31
+   ipv6 enable
 !
 interface Vlan110
    description Tenant_A_OP_Zone_1
@@ -255,35 +255,35 @@ interface Vlan3009
    no shutdown
    mtu 1500
    vrf Tenant_A_OP_Zone
-   ip address 10.255.251.14/31
+   ipv6 enable
 !
 interface Vlan3010
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_WEB_Zone
-   ip address 10.255.251.14/31
+   ipv6 enable
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_APP_Zone
-   ip address 10.255.251.14/31
+   ipv6 enable
 !
 interface Vlan3012
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_DB_Zone
-   ip address 10.255.251.14/31
+   ipv6 enable
 !
 interface Vlan3019
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone
    no shutdown
    mtu 1500
    vrf Tenant_B_OP_Zone
-   ip address 10.255.251.14/31
+   ipv6 enable
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
@@ -472,7 +472,6 @@ router bgp 65106
       route-target import evpn 12:12
       route-target export evpn 12:12
       router-id 192.168.255.12
-      neighbor 10.255.251.15 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -480,7 +479,6 @@ router bgp 65106
       route-target import evpn 13:13
       route-target export evpn 13:13
       router-id 192.168.255.12
-      neighbor 10.255.251.15 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -488,7 +486,6 @@ router bgp 65106
       route-target import evpn 10:10
       route-target export evpn 10:10
       router-id 192.168.255.12
-      neighbor 10.255.251.15 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -496,7 +493,6 @@ router bgp 65106
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.12
-      neighbor 10.255.251.15 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -504,7 +500,6 @@ router bgp 65106
       route-target import evpn 20:20
       route-target export evpn 20:20
       router-id 192.168.255.12
-      neighbor 10.255.251.15 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -512,7 +507,6 @@ router bgp 65106
       route-target import evpn 30:30
       route-target export evpn 30:30
       router-id 192.168.255.12
-      neighbor 10.255.251.15 peer group MLAG_PEER
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF3A.cfg
@@ -472,6 +472,7 @@ router bgp 65106
       route-target import evpn 12:12
       route-target export evpn 12:12
       router-id 192.168.255.12
+      neighbor interface Vlan3011 peer-group MLAG_PEER remote-as 65106
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -479,6 +480,7 @@ router bgp 65106
       route-target import evpn 13:13
       route-target export evpn 13:13
       router-id 192.168.255.12
+      neighbor interface Vlan3012 peer-group MLAG_PEER remote-as 65106
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -486,6 +488,7 @@ router bgp 65106
       route-target import evpn 10:10
       route-target export evpn 10:10
       router-id 192.168.255.12
+      neighbor interface Vlan3009 peer-group MLAG_PEER remote-as 65106
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -493,6 +496,7 @@ router bgp 65106
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.12
+      neighbor interface Vlan3010 peer-group MLAG_PEER remote-as 65106
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -500,6 +504,7 @@ router bgp 65106
       route-target import evpn 20:20
       route-target export evpn 20:20
       router-id 192.168.255.12
+      neighbor interface Vlan3019 peer-group MLAG_PEER remote-as 65106
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -507,6 +512,7 @@ router bgp 65106
       route-target import evpn 30:30
       route-target export evpn 30:30
       router-id 192.168.255.12
+      neighbor interface Vlan2 peer-group MLAG_PEER remote-as 65106
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF3B.cfg
@@ -472,6 +472,7 @@ router bgp 65106
       route-target import evpn 12:12
       route-target export evpn 12:12
       router-id 192.168.255.13
+      neighbor interface Vlan3011 peer-group MLAG_PEER remote-as 65106
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -479,6 +480,7 @@ router bgp 65106
       route-target import evpn 13:13
       route-target export evpn 13:13
       router-id 192.168.255.13
+      neighbor interface Vlan3012 peer-group MLAG_PEER remote-as 65106
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -486,6 +488,7 @@ router bgp 65106
       route-target import evpn 10:10
       route-target export evpn 10:10
       router-id 192.168.255.13
+      neighbor interface Vlan3009 peer-group MLAG_PEER remote-as 65106
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -493,6 +496,7 @@ router bgp 65106
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.13
+      neighbor interface Vlan3010 peer-group MLAG_PEER remote-as 65106
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -500,6 +504,7 @@ router bgp 65106
       route-target import evpn 20:20
       route-target export evpn 20:20
       router-id 192.168.255.13
+      neighbor interface Vlan3019 peer-group MLAG_PEER remote-as 65106
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -507,6 +512,7 @@ router bgp 65106
       route-target import evpn 30:30
       route-target export evpn 30:30
       router-id 192.168.255.13
+      neighbor interface Vlan2 peer-group MLAG_PEER remote-as 65106
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF3B.cfg
@@ -173,7 +173,7 @@ interface Vlan2
    no shutdown
    mtu 1500
    vrf Tenant_C_OP_Zone
-   ip address 10.255.251.15/31
+   ipv6 enable
 !
 interface Vlan110
    description Tenant_A_OP_Zone_1
@@ -255,35 +255,35 @@ interface Vlan3009
    no shutdown
    mtu 1500
    vrf Tenant_A_OP_Zone
-   ip address 10.255.251.15/31
+   ipv6 enable
 !
 interface Vlan3010
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_WEB_Zone
-   ip address 10.255.251.15/31
+   ipv6 enable
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_APP_Zone
-   ip address 10.255.251.15/31
+   ipv6 enable
 !
 interface Vlan3012
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_DB_Zone
-   ip address 10.255.251.15/31
+   ipv6 enable
 !
 interface Vlan3019
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone
    no shutdown
    mtu 1500
    vrf Tenant_B_OP_Zone
-   ip address 10.255.251.15/31
+   ipv6 enable
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
@@ -472,7 +472,6 @@ router bgp 65106
       route-target import evpn 12:12
       route-target export evpn 12:12
       router-id 192.168.255.13
-      neighbor 10.255.251.14 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -480,7 +479,6 @@ router bgp 65106
       route-target import evpn 13:13
       route-target export evpn 13:13
       router-id 192.168.255.13
-      neighbor 10.255.251.14 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -488,7 +486,6 @@ router bgp 65106
       route-target import evpn 10:10
       route-target export evpn 10:10
       router-id 192.168.255.13
-      neighbor 10.255.251.14 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -496,7 +493,6 @@ router bgp 65106
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.13
-      neighbor 10.255.251.14 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -504,7 +500,6 @@ router bgp 65106
       route-target import evpn 20:20
       route-target export evpn 20:20
       router-id 192.168.255.13
-      neighbor 10.255.251.14 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -512,7 +507,6 @@ router bgp 65106
       route-target import evpn 30:30
       route-target export evpn 30:30
       router-id 192.168.255.13
-      neighbor 10.255.251.14 peer group MLAG_PEER
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF4A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF4A.cfg
@@ -173,7 +173,7 @@ interface Vlan2
    no shutdown
    mtu 1500
    vrf Tenant_C_OP_Zone
-   ip address 10.255.251.18/31
+   ipv6 enable
 !
 interface Vlan110
    description Tenant_A_OP_Zone_1
@@ -255,35 +255,35 @@ interface Vlan3009
    no shutdown
    mtu 1500
    vrf Tenant_A_OP_Zone
-   ip address 10.255.251.18/31
+   ipv6 enable
 !
 interface Vlan3010
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_WEB_Zone
-   ip address 10.255.251.18/31
+   ipv6 enable
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_APP_Zone
-   ip address 10.255.251.18/31
+   ipv6 enable
 !
 interface Vlan3012
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_DB_Zone
-   ip address 10.255.251.18/31
+   ipv6 enable
 !
 interface Vlan3019
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone
    no shutdown
    mtu 1500
    vrf Tenant_B_OP_Zone
-   ip address 10.255.251.18/31
+   ipv6 enable
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
@@ -472,7 +472,6 @@ router bgp 65107
       route-target import evpn 12:12
       route-target export evpn 12:12
       router-id 192.168.255.14
-      neighbor 10.255.251.19 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -480,7 +479,6 @@ router bgp 65107
       route-target import evpn 13:13
       route-target export evpn 13:13
       router-id 192.168.255.14
-      neighbor 10.255.251.19 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -488,7 +486,6 @@ router bgp 65107
       route-target import evpn 10:10
       route-target export evpn 10:10
       router-id 192.168.255.14
-      neighbor 10.255.251.19 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -496,7 +493,6 @@ router bgp 65107
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.14
-      neighbor 10.255.251.19 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -504,7 +500,6 @@ router bgp 65107
       route-target import evpn 20:20
       route-target export evpn 20:20
       router-id 192.168.255.14
-      neighbor 10.255.251.19 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -512,7 +507,6 @@ router bgp 65107
       route-target import evpn 30:30
       route-target export evpn 30:30
       router-id 192.168.255.14
-      neighbor 10.255.251.19 peer group MLAG_PEER
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF4A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF4A.cfg
@@ -472,6 +472,7 @@ router bgp 65107
       route-target import evpn 12:12
       route-target export evpn 12:12
       router-id 192.168.255.14
+      neighbor interface Vlan3011 peer-group MLAG_PEER remote-as 65107
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -479,6 +480,7 @@ router bgp 65107
       route-target import evpn 13:13
       route-target export evpn 13:13
       router-id 192.168.255.14
+      neighbor interface Vlan3012 peer-group MLAG_PEER remote-as 65107
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -486,6 +488,7 @@ router bgp 65107
       route-target import evpn 10:10
       route-target export evpn 10:10
       router-id 192.168.255.14
+      neighbor interface Vlan3009 peer-group MLAG_PEER remote-as 65107
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -493,6 +496,7 @@ router bgp 65107
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.14
+      neighbor interface Vlan3010 peer-group MLAG_PEER remote-as 65107
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -500,6 +504,7 @@ router bgp 65107
       route-target import evpn 20:20
       route-target export evpn 20:20
       router-id 192.168.255.14
+      neighbor interface Vlan3019 peer-group MLAG_PEER remote-as 65107
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -507,6 +512,7 @@ router bgp 65107
       route-target import evpn 30:30
       route-target export evpn 30:30
       router-id 192.168.255.14
+      neighbor interface Vlan2 peer-group MLAG_PEER remote-as 65107
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF4B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF4B.cfg
@@ -173,7 +173,7 @@ interface Vlan2
    no shutdown
    mtu 1500
    vrf Tenant_C_OP_Zone
-   ip address 10.255.251.19/31
+   ipv6 enable
 !
 interface Vlan110
    description Tenant_A_OP_Zone_1
@@ -255,35 +255,35 @@ interface Vlan3009
    no shutdown
    mtu 1500
    vrf Tenant_A_OP_Zone
-   ip address 10.255.251.19/31
+   ipv6 enable
 !
 interface Vlan3010
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_WEB_Zone
-   ip address 10.255.251.19/31
+   ipv6 enable
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_APP_Zone
-   ip address 10.255.251.19/31
+   ipv6 enable
 !
 interface Vlan3012
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_DB_Zone
-   ip address 10.255.251.19/31
+   ipv6 enable
 !
 interface Vlan3019
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone
    no shutdown
    mtu 1500
    vrf Tenant_B_OP_Zone
-   ip address 10.255.251.19/31
+   ipv6 enable
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
@@ -472,7 +472,6 @@ router bgp 65107
       route-target import evpn 12:12
       route-target export evpn 12:12
       router-id 192.168.255.15
-      neighbor 10.255.251.18 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -480,7 +479,6 @@ router bgp 65107
       route-target import evpn 13:13
       route-target export evpn 13:13
       router-id 192.168.255.15
-      neighbor 10.255.251.18 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -488,7 +486,6 @@ router bgp 65107
       route-target import evpn 10:10
       route-target export evpn 10:10
       router-id 192.168.255.15
-      neighbor 10.255.251.18 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -496,7 +493,6 @@ router bgp 65107
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.15
-      neighbor 10.255.251.18 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -504,7 +500,6 @@ router bgp 65107
       route-target import evpn 20:20
       route-target export evpn 20:20
       router-id 192.168.255.15
-      neighbor 10.255.251.18 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -512,7 +507,6 @@ router bgp 65107
       route-target import evpn 30:30
       route-target export evpn 30:30
       router-id 192.168.255.15
-      neighbor 10.255.251.18 peer group MLAG_PEER
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF4B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF4B.cfg
@@ -472,6 +472,7 @@ router bgp 65107
       route-target import evpn 12:12
       route-target export evpn 12:12
       router-id 192.168.255.15
+      neighbor interface Vlan3011 peer-group MLAG_PEER remote-as 65107
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -479,6 +480,7 @@ router bgp 65107
       route-target import evpn 13:13
       route-target export evpn 13:13
       router-id 192.168.255.15
+      neighbor interface Vlan3012 peer-group MLAG_PEER remote-as 65107
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -486,6 +488,7 @@ router bgp 65107
       route-target import evpn 10:10
       route-target export evpn 10:10
       router-id 192.168.255.15
+      neighbor interface Vlan3009 peer-group MLAG_PEER remote-as 65107
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -493,6 +496,7 @@ router bgp 65107
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.15
+      neighbor interface Vlan3010 peer-group MLAG_PEER remote-as 65107
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -500,6 +504,7 @@ router bgp 65107
       route-target import evpn 20:20
       route-target export evpn 20:20
       router-id 192.168.255.15
+      neighbor interface Vlan3019 peer-group MLAG_PEER remote-as 65107
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -507,6 +512,7 @@ router bgp 65107
       route-target import evpn 30:30
       route-target export evpn 30:30
       router-id 192.168.255.15
+      neighbor interface Vlan2 peer-group MLAG_PEER remote-as 65107
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
@@ -341,7 +341,7 @@ interface Vlan2
    no shutdown
    mtu 1500
    vrf Tenant_C_OP_Zone
-   ip address 10.255.251.6/31
+   ipv6 enable
 !
 interface Vlan110
    description Tenant_A_OP_Zone_1
@@ -441,56 +441,56 @@ interface Vlan3009
    no shutdown
    mtu 1500
    vrf Tenant_A_OP_Zone
-   ip address 10.255.251.6/31
+   ipv6 enable
 !
 interface Vlan3010
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_WEB_Zone
-   ip address 10.255.251.6/31
+   ipv6 enable
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_APP_Zone
-   ip address 10.255.251.6/31
+   ipv6 enable
 !
 interface Vlan3012
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_DB_Zone
-   ip address 10.255.251.6/31
+   ipv6 enable
 !
 interface Vlan3013
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_WAN_Zone
-   ip address 10.255.251.6/31
+   ipv6 enable
 !
 interface Vlan3019
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone
    no shutdown
    mtu 1500
    vrf Tenant_B_OP_Zone
-   ip address 10.255.251.6/31
+   ipv6 enable
 !
 interface Vlan3020
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone
    no shutdown
    mtu 1500
    vrf Tenant_B_WAN_Zone
-   ip address 10.255.251.6/31
+   ipv6 enable
 !
 interface Vlan3030
    description MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone
    no shutdown
    mtu 1500
    vrf Tenant_C_WAN_Zone
-   ip address 10.255.251.6/31
+   ipv6 enable
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
@@ -708,7 +708,6 @@ router bgp 65103
       route-target import evpn 12:12
       route-target export evpn 12:12
       router-id 192.168.255.8
-      neighbor 10.255.251.7 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -716,7 +715,6 @@ router bgp 65103
       route-target import evpn 13:13
       route-target export evpn 13:13
       router-id 192.168.255.8
-      neighbor 10.255.251.7 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -724,7 +722,6 @@ router bgp 65103
       route-target import evpn 10:10
       route-target export evpn 10:10
       router-id 192.168.255.8
-      neighbor 10.255.251.7 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -732,7 +729,6 @@ router bgp 65103
       route-target import evpn 14:14
       route-target export evpn 14:14
       router-id 192.168.255.8
-      neighbor 10.255.251.7 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -740,7 +736,6 @@ router bgp 65103
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.8
-      neighbor 10.255.251.7 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -748,7 +743,6 @@ router bgp 65103
       route-target import evpn 20:20
       route-target export evpn 20:20
       router-id 192.168.255.8
-      neighbor 10.255.251.7 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -756,7 +750,6 @@ router bgp 65103
       route-target import evpn 21:21
       route-target export evpn 21:21
       router-id 192.168.255.8
-      neighbor 10.255.251.7 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -764,7 +757,6 @@ router bgp 65103
       route-target import evpn 30:30
       route-target export evpn 30:30
       router-id 192.168.255.8
-      neighbor 10.255.251.7 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -772,7 +764,6 @@ router bgp 65103
       route-target import evpn 31:31
       route-target export evpn 31:31
       router-id 192.168.255.8
-      neighbor 10.255.251.7 peer group MLAG_PEER
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
@@ -708,6 +708,7 @@ router bgp 65103
       route-target import evpn 12:12
       route-target export evpn 12:12
       router-id 192.168.255.8
+      neighbor interface Vlan3011 peer-group MLAG_PEER remote-as 65103
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -715,6 +716,7 @@ router bgp 65103
       route-target import evpn 13:13
       route-target export evpn 13:13
       router-id 192.168.255.8
+      neighbor interface Vlan3012 peer-group MLAG_PEER remote-as 65103
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -722,6 +724,7 @@ router bgp 65103
       route-target import evpn 10:10
       route-target export evpn 10:10
       router-id 192.168.255.8
+      neighbor interface Vlan3009 peer-group MLAG_PEER remote-as 65103
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -729,6 +732,7 @@ router bgp 65103
       route-target import evpn 14:14
       route-target export evpn 14:14
       router-id 192.168.255.8
+      neighbor interface Vlan3013 peer-group MLAG_PEER remote-as 65103
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -736,6 +740,7 @@ router bgp 65103
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.8
+      neighbor interface Vlan3010 peer-group MLAG_PEER remote-as 65103
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -743,6 +748,7 @@ router bgp 65103
       route-target import evpn 20:20
       route-target export evpn 20:20
       router-id 192.168.255.8
+      neighbor interface Vlan3019 peer-group MLAG_PEER remote-as 65103
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -750,6 +756,7 @@ router bgp 65103
       route-target import evpn 21:21
       route-target export evpn 21:21
       router-id 192.168.255.8
+      neighbor interface Vlan3020 peer-group MLAG_PEER remote-as 65103
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -757,6 +764,7 @@ router bgp 65103
       route-target import evpn 30:30
       route-target export evpn 30:30
       router-id 192.168.255.8
+      neighbor interface Vlan2 peer-group MLAG_PEER remote-as 65103
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -764,6 +772,7 @@ router bgp 65103
       route-target import evpn 31:31
       route-target export evpn 31:31
       router-id 192.168.255.8
+      neighbor interface Vlan3030 peer-group MLAG_PEER remote-as 65103
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
@@ -328,7 +328,7 @@ interface Vlan2
    no shutdown
    mtu 1500
    vrf Tenant_C_OP_Zone
-   ip address 10.255.251.7/31
+   ipv6 enable
 !
 interface Vlan110
    description Tenant_A_OP_Zone_1
@@ -428,56 +428,56 @@ interface Vlan3009
    no shutdown
    mtu 1500
    vrf Tenant_A_OP_Zone
-   ip address 10.255.251.7/31
+   ipv6 enable
 !
 interface Vlan3010
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_WEB_Zone
-   ip address 10.255.251.7/31
+   ipv6 enable
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_APP_Zone
-   ip address 10.255.251.7/31
+   ipv6 enable
 !
 interface Vlan3012
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_DB_Zone
-   ip address 10.255.251.7/31
+   ipv6 enable
 !
 interface Vlan3013
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_WAN_Zone
-   ip address 10.255.251.7/31
+   ipv6 enable
 !
 interface Vlan3019
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone
    no shutdown
    mtu 1500
    vrf Tenant_B_OP_Zone
-   ip address 10.255.251.7/31
+   ipv6 enable
 !
 interface Vlan3020
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone
    no shutdown
    mtu 1500
    vrf Tenant_B_WAN_Zone
-   ip address 10.255.251.7/31
+   ipv6 enable
 !
 interface Vlan3030
    description MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone
    no shutdown
    mtu 1500
    vrf Tenant_C_WAN_Zone
-   ip address 10.255.251.7/31
+   ipv6 enable
 !
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
@@ -695,7 +695,6 @@ router bgp 65103
       route-target import evpn 12:12
       route-target export evpn 12:12
       router-id 192.168.255.9
-      neighbor 10.255.251.6 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -703,7 +702,6 @@ router bgp 65103
       route-target import evpn 13:13
       route-target export evpn 13:13
       router-id 192.168.255.9
-      neighbor 10.255.251.6 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -711,7 +709,6 @@ router bgp 65103
       route-target import evpn 10:10
       route-target export evpn 10:10
       router-id 192.168.255.9
-      neighbor 10.255.251.6 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -719,7 +716,6 @@ router bgp 65103
       route-target import evpn 14:14
       route-target export evpn 14:14
       router-id 192.168.255.9
-      neighbor 10.255.251.6 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -727,7 +723,6 @@ router bgp 65103
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.9
-      neighbor 10.255.251.6 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -735,7 +730,6 @@ router bgp 65103
       route-target import evpn 20:20
       route-target export evpn 20:20
       router-id 192.168.255.9
-      neighbor 10.255.251.6 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -743,7 +737,6 @@ router bgp 65103
       route-target import evpn 21:21
       route-target export evpn 21:21
       router-id 192.168.255.9
-      neighbor 10.255.251.6 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -751,7 +744,6 @@ router bgp 65103
       route-target import evpn 30:30
       route-target export evpn 30:30
       router-id 192.168.255.9
-      neighbor 10.255.251.6 peer group MLAG_PEER
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -759,7 +751,6 @@ router bgp 65103
       route-target import evpn 31:31
       route-target export evpn 31:31
       router-id 192.168.255.9
-      neighbor 10.255.251.6 peer group MLAG_PEER
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
@@ -695,6 +695,7 @@ router bgp 65103
       route-target import evpn 12:12
       route-target export evpn 12:12
       router-id 192.168.255.9
+      neighbor interface Vlan3011 peer-group MLAG_PEER remote-as 65103
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -702,6 +703,7 @@ router bgp 65103
       route-target import evpn 13:13
       route-target export evpn 13:13
       router-id 192.168.255.9
+      neighbor interface Vlan3012 peer-group MLAG_PEER remote-as 65103
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -709,6 +711,7 @@ router bgp 65103
       route-target import evpn 10:10
       route-target export evpn 10:10
       router-id 192.168.255.9
+      neighbor interface Vlan3009 peer-group MLAG_PEER remote-as 65103
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -716,6 +719,7 @@ router bgp 65103
       route-target import evpn 14:14
       route-target export evpn 14:14
       router-id 192.168.255.9
+      neighbor interface Vlan3013 peer-group MLAG_PEER remote-as 65103
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -723,6 +727,7 @@ router bgp 65103
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.9
+      neighbor interface Vlan3010 peer-group MLAG_PEER remote-as 65103
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -730,6 +735,7 @@ router bgp 65103
       route-target import evpn 20:20
       route-target export evpn 20:20
       router-id 192.168.255.9
+      neighbor interface Vlan3019 peer-group MLAG_PEER remote-as 65103
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -737,6 +743,7 @@ router bgp 65103
       route-target import evpn 21:21
       route-target export evpn 21:21
       router-id 192.168.255.9
+      neighbor interface Vlan3020 peer-group MLAG_PEER remote-as 65103
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -744,6 +751,7 @@ router bgp 65103
       route-target import evpn 30:30
       route-target export evpn 30:30
       router-id 192.168.255.9
+      neighbor interface Vlan2 peer-group MLAG_PEER remote-as 65103
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -751,6 +759,7 @@ router bgp 65103
       route-target import evpn 31:31
       route-target export evpn 31:31
       router-id 192.168.255.9
+      neighbor interface Vlan3030 peer-group MLAG_PEER remote-as 65103
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -100,9 +100,11 @@ router_bgp:
         export:
           evpn:
           - '12:12'
-      neighbors:
-        10.255.251.3:
+      neighbor_interfaces:
+        Vlan3011:
           peer_group: MLAG_PEER
+          remote_as: '65102'
+          description: DC1-LEAF2B
       redistribute_routes:
       - connected
     Tenant_A_DB_Zone:
@@ -115,9 +117,11 @@ router_bgp:
         export:
           evpn:
           - '13:13'
-      neighbors:
-        10.255.251.3:
+      neighbor_interfaces:
+        Vlan3012:
           peer_group: MLAG_PEER
+          remote_as: '65102'
+          description: DC1-LEAF2B
       redistribute_routes:
       - connected
     Tenant_A_OP_Zone:
@@ -130,9 +134,11 @@ router_bgp:
         export:
           evpn:
           - '10:10'
-      neighbors:
-        10.255.251.3:
+      neighbor_interfaces:
+        Vlan3009:
           peer_group: MLAG_PEER
+          remote_as: '65102'
+          description: DC1-LEAF2B
       redistribute_routes:
       - connected
     Tenant_A_WEB_Zone:
@@ -145,9 +151,11 @@ router_bgp:
         export:
           evpn:
           - '11:11'
-      neighbors:
-        10.255.251.3:
+      neighbor_interfaces:
+        Vlan3010:
           peer_group: MLAG_PEER
+          remote_as: '65102'
+          description: DC1-LEAF2B
       redistribute_routes:
       - connected
     Tenant_B_OP_Zone:
@@ -160,9 +168,11 @@ router_bgp:
         export:
           evpn:
           - '20:20'
-      neighbors:
-        10.255.251.3:
+      neighbor_interfaces:
+        Vlan3019:
           peer_group: MLAG_PEER
+          remote_as: '65102'
+          description: DC1-LEAF2B
       redistribute_routes:
       - connected
     Tenant_C_OP_Zone:
@@ -175,9 +185,11 @@ router_bgp:
         export:
           evpn:
           - '30:30'
-      neighbors:
-        10.255.251.3:
+      neighbor_interfaces:
+        Vlan2:
           peer_group: MLAG_PEER
+          remote_as: '65102'
+          description: DC1-LEAF2B
       redistribute_routes:
       - connected
   vlan_aware_bundles:
@@ -448,7 +460,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone'
     vrf: Tenant_A_APP_Zone
-    ip_address: 10.255.251.2/31
+    ipv6_enable: true
     mtu: 1500
   Vlan140:
     tenant: Tenant_A
@@ -473,7 +485,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone'
     vrf: Tenant_A_DB_Zone
-    ip_address: 10.255.251.2/31
+    ipv6_enable: true
     mtu: 1500
   Vlan110:
     tenant: Tenant_A
@@ -501,7 +513,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone'
     vrf: Tenant_A_OP_Zone
-    ip_address: 10.255.251.2/31
+    ipv6_enable: true
     mtu: 1500
   Vlan120:
     tenant: Tenant_A
@@ -531,7 +543,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone'
     vrf: Tenant_A_WEB_Zone
-    ip_address: 10.255.251.2/31
+    ipv6_enable: true
     mtu: 1500
   Vlan210:
     tenant: Tenant_B
@@ -555,7 +567,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone'
     vrf: Tenant_B_OP_Zone
-    ip_address: 10.255.251.2/31
+    ipv6_enable: true
     mtu: 1500
   Vlan310:
     tenant: Tenant_C
@@ -579,7 +591,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone'
     vrf: Tenant_C_OP_Zone
-    ip_address: 10.255.251.2/31
+    ipv6_enable: true
     mtu: 1500
 port_channel_interfaces:
   Port-Channel5:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -100,9 +100,11 @@ router_bgp:
         export:
           evpn:
           - '12:12'
-      neighbors:
-        10.255.251.2:
+      neighbor_interfaces:
+        Vlan3011:
           peer_group: MLAG_PEER
+          remote_as: '65102'
+          description: DC1-LEAF2A
       redistribute_routes:
       - connected
     Tenant_A_DB_Zone:
@@ -115,9 +117,11 @@ router_bgp:
         export:
           evpn:
           - '13:13'
-      neighbors:
-        10.255.251.2:
+      neighbor_interfaces:
+        Vlan3012:
           peer_group: MLAG_PEER
+          remote_as: '65102'
+          description: DC1-LEAF2A
       redistribute_routes:
       - connected
     Tenant_A_OP_Zone:
@@ -130,9 +134,11 @@ router_bgp:
         export:
           evpn:
           - '10:10'
-      neighbors:
-        10.255.251.2:
+      neighbor_interfaces:
+        Vlan3009:
           peer_group: MLAG_PEER
+          remote_as: '65102'
+          description: DC1-LEAF2A
       redistribute_routes:
       - connected
     Tenant_A_WEB_Zone:
@@ -145,9 +151,11 @@ router_bgp:
         export:
           evpn:
           - '11:11'
-      neighbors:
-        10.255.251.2:
+      neighbor_interfaces:
+        Vlan3010:
           peer_group: MLAG_PEER
+          remote_as: '65102'
+          description: DC1-LEAF2A
       redistribute_routes:
       - connected
     Tenant_B_OP_Zone:
@@ -160,9 +168,11 @@ router_bgp:
         export:
           evpn:
           - '20:20'
-      neighbors:
-        10.255.251.2:
+      neighbor_interfaces:
+        Vlan3019:
           peer_group: MLAG_PEER
+          remote_as: '65102'
+          description: DC1-LEAF2A
       redistribute_routes:
       - connected
     Tenant_C_OP_Zone:
@@ -175,9 +185,11 @@ router_bgp:
         export:
           evpn:
           - '30:30'
-      neighbors:
-        10.255.251.2:
+      neighbor_interfaces:
+        Vlan2:
           peer_group: MLAG_PEER
+          remote_as: '65102'
+          description: DC1-LEAF2A
       redistribute_routes:
       - connected
   vlan_aware_bundles:
@@ -448,7 +460,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone'
     vrf: Tenant_A_APP_Zone
-    ip_address: 10.255.251.3/31
+    ipv6_enable: true
     mtu: 1500
   Vlan140:
     tenant: Tenant_A
@@ -473,7 +485,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone'
     vrf: Tenant_A_DB_Zone
-    ip_address: 10.255.251.3/31
+    ipv6_enable: true
     mtu: 1500
   Vlan110:
     tenant: Tenant_A
@@ -501,7 +513,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone'
     vrf: Tenant_A_OP_Zone
-    ip_address: 10.255.251.3/31
+    ipv6_enable: true
     mtu: 1500
   Vlan120:
     tenant: Tenant_A
@@ -531,7 +543,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone'
     vrf: Tenant_A_WEB_Zone
-    ip_address: 10.255.251.3/31
+    ipv6_enable: true
     mtu: 1500
   Vlan210:
     tenant: Tenant_B
@@ -555,7 +567,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone'
     vrf: Tenant_B_OP_Zone
-    ip_address: 10.255.251.3/31
+    ipv6_enable: true
     mtu: 1500
   Vlan310:
     tenant: Tenant_C
@@ -579,7 +591,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone'
     vrf: Tenant_C_OP_Zone
-    ip_address: 10.255.251.3/31
+    ipv6_enable: true
     mtu: 1500
 port_channel_interfaces:
   Port-Channel5:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF3A.yml
@@ -82,9 +82,11 @@ router_bgp:
         export:
           evpn:
           - '12:12'
-      neighbors:
-        10.255.251.15:
+      neighbor_interfaces:
+        Vlan3011:
           peer_group: MLAG_PEER
+          remote_as: '65106'
+          description: DC1-LEAF3B
       redistribute_routes:
       - connected
     Tenant_A_DB_Zone:
@@ -97,9 +99,11 @@ router_bgp:
         export:
           evpn:
           - '13:13'
-      neighbors:
-        10.255.251.15:
+      neighbor_interfaces:
+        Vlan3012:
           peer_group: MLAG_PEER
+          remote_as: '65106'
+          description: DC1-LEAF3B
       redistribute_routes:
       - connected
     Tenant_A_OP_Zone:
@@ -112,9 +116,11 @@ router_bgp:
         export:
           evpn:
           - '10:10'
-      neighbors:
-        10.255.251.15:
+      neighbor_interfaces:
+        Vlan3009:
           peer_group: MLAG_PEER
+          remote_as: '65106'
+          description: DC1-LEAF3B
       redistribute_routes:
       - connected
     Tenant_A_WEB_Zone:
@@ -127,9 +133,11 @@ router_bgp:
         export:
           evpn:
           - '11:11'
-      neighbors:
-        10.255.251.15:
+      neighbor_interfaces:
+        Vlan3010:
           peer_group: MLAG_PEER
+          remote_as: '65106'
+          description: DC1-LEAF3B
       redistribute_routes:
       - connected
     Tenant_B_OP_Zone:
@@ -142,9 +150,11 @@ router_bgp:
         export:
           evpn:
           - '20:20'
-      neighbors:
-        10.255.251.15:
+      neighbor_interfaces:
+        Vlan3019:
           peer_group: MLAG_PEER
+          remote_as: '65106'
+          description: DC1-LEAF3B
       redistribute_routes:
       - connected
     Tenant_C_OP_Zone:
@@ -157,9 +167,11 @@ router_bgp:
         export:
           evpn:
           - '30:30'
-      neighbors:
-        10.255.251.15:
+      neighbor_interfaces:
+        Vlan2:
           peer_group: MLAG_PEER
+          remote_as: '65106'
+          description: DC1-LEAF3B
       redistribute_routes:
       - connected
   vlan_aware_bundles:
@@ -430,7 +442,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone'
     vrf: Tenant_A_APP_Zone
-    ip_address: 10.255.251.14/31
+    ipv6_enable: true
     mtu: 1500
   Vlan140:
     tenant: Tenant_A
@@ -455,7 +467,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone'
     vrf: Tenant_A_DB_Zone
-    ip_address: 10.255.251.14/31
+    ipv6_enable: true
     mtu: 1500
   Vlan110:
     tenant: Tenant_A
@@ -483,7 +495,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone'
     vrf: Tenant_A_OP_Zone
-    ip_address: 10.255.251.14/31
+    ipv6_enable: true
     mtu: 1500
   Vlan120:
     tenant: Tenant_A
@@ -513,7 +525,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone'
     vrf: Tenant_A_WEB_Zone
-    ip_address: 10.255.251.14/31
+    ipv6_enable: true
     mtu: 1500
   Vlan210:
     tenant: Tenant_B
@@ -537,7 +549,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone'
     vrf: Tenant_B_OP_Zone
-    ip_address: 10.255.251.14/31
+    ipv6_enable: true
     mtu: 1500
   Vlan310:
     tenant: Tenant_C
@@ -561,7 +573,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone'
     vrf: Tenant_C_OP_Zone
-    ip_address: 10.255.251.14/31
+    ipv6_enable: true
     mtu: 1500
 port_channel_interfaces:
   Port-Channel5:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF3B.yml
@@ -82,9 +82,11 @@ router_bgp:
         export:
           evpn:
           - '12:12'
-      neighbors:
-        10.255.251.14:
+      neighbor_interfaces:
+        Vlan3011:
           peer_group: MLAG_PEER
+          remote_as: '65106'
+          description: DC1-LEAF3A
       redistribute_routes:
       - connected
     Tenant_A_DB_Zone:
@@ -97,9 +99,11 @@ router_bgp:
         export:
           evpn:
           - '13:13'
-      neighbors:
-        10.255.251.14:
+      neighbor_interfaces:
+        Vlan3012:
           peer_group: MLAG_PEER
+          remote_as: '65106'
+          description: DC1-LEAF3A
       redistribute_routes:
       - connected
     Tenant_A_OP_Zone:
@@ -112,9 +116,11 @@ router_bgp:
         export:
           evpn:
           - '10:10'
-      neighbors:
-        10.255.251.14:
+      neighbor_interfaces:
+        Vlan3009:
           peer_group: MLAG_PEER
+          remote_as: '65106'
+          description: DC1-LEAF3A
       redistribute_routes:
       - connected
     Tenant_A_WEB_Zone:
@@ -127,9 +133,11 @@ router_bgp:
         export:
           evpn:
           - '11:11'
-      neighbors:
-        10.255.251.14:
+      neighbor_interfaces:
+        Vlan3010:
           peer_group: MLAG_PEER
+          remote_as: '65106'
+          description: DC1-LEAF3A
       redistribute_routes:
       - connected
     Tenant_B_OP_Zone:
@@ -142,9 +150,11 @@ router_bgp:
         export:
           evpn:
           - '20:20'
-      neighbors:
-        10.255.251.14:
+      neighbor_interfaces:
+        Vlan3019:
           peer_group: MLAG_PEER
+          remote_as: '65106'
+          description: DC1-LEAF3A
       redistribute_routes:
       - connected
     Tenant_C_OP_Zone:
@@ -157,9 +167,11 @@ router_bgp:
         export:
           evpn:
           - '30:30'
-      neighbors:
-        10.255.251.14:
+      neighbor_interfaces:
+        Vlan2:
           peer_group: MLAG_PEER
+          remote_as: '65106'
+          description: DC1-LEAF3A
       redistribute_routes:
       - connected
   vlan_aware_bundles:
@@ -430,7 +442,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone'
     vrf: Tenant_A_APP_Zone
-    ip_address: 10.255.251.15/31
+    ipv6_enable: true
     mtu: 1500
   Vlan140:
     tenant: Tenant_A
@@ -455,7 +467,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone'
     vrf: Tenant_A_DB_Zone
-    ip_address: 10.255.251.15/31
+    ipv6_enable: true
     mtu: 1500
   Vlan110:
     tenant: Tenant_A
@@ -483,7 +495,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone'
     vrf: Tenant_A_OP_Zone
-    ip_address: 10.255.251.15/31
+    ipv6_enable: true
     mtu: 1500
   Vlan120:
     tenant: Tenant_A
@@ -513,7 +525,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone'
     vrf: Tenant_A_WEB_Zone
-    ip_address: 10.255.251.15/31
+    ipv6_enable: true
     mtu: 1500
   Vlan210:
     tenant: Tenant_B
@@ -537,7 +549,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone'
     vrf: Tenant_B_OP_Zone
-    ip_address: 10.255.251.15/31
+    ipv6_enable: true
     mtu: 1500
   Vlan310:
     tenant: Tenant_C
@@ -561,7 +573,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone'
     vrf: Tenant_C_OP_Zone
-    ip_address: 10.255.251.15/31
+    ipv6_enable: true
     mtu: 1500
 port_channel_interfaces:
   Port-Channel5:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF4A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF4A.yml
@@ -82,9 +82,11 @@ router_bgp:
         export:
           evpn:
           - '12:12'
-      neighbors:
-        10.255.251.19:
+      neighbor_interfaces:
+        Vlan3011:
           peer_group: MLAG_PEER
+          remote_as: '65107'
+          description: DC1-LEAF4B
       redistribute_routes:
       - connected
     Tenant_A_DB_Zone:
@@ -97,9 +99,11 @@ router_bgp:
         export:
           evpn:
           - '13:13'
-      neighbors:
-        10.255.251.19:
+      neighbor_interfaces:
+        Vlan3012:
           peer_group: MLAG_PEER
+          remote_as: '65107'
+          description: DC1-LEAF4B
       redistribute_routes:
       - connected
     Tenant_A_OP_Zone:
@@ -112,9 +116,11 @@ router_bgp:
         export:
           evpn:
           - '10:10'
-      neighbors:
-        10.255.251.19:
+      neighbor_interfaces:
+        Vlan3009:
           peer_group: MLAG_PEER
+          remote_as: '65107'
+          description: DC1-LEAF4B
       redistribute_routes:
       - connected
     Tenant_A_WEB_Zone:
@@ -127,9 +133,11 @@ router_bgp:
         export:
           evpn:
           - '11:11'
-      neighbors:
-        10.255.251.19:
+      neighbor_interfaces:
+        Vlan3010:
           peer_group: MLAG_PEER
+          remote_as: '65107'
+          description: DC1-LEAF4B
       redistribute_routes:
       - connected
     Tenant_B_OP_Zone:
@@ -142,9 +150,11 @@ router_bgp:
         export:
           evpn:
           - '20:20'
-      neighbors:
-        10.255.251.19:
+      neighbor_interfaces:
+        Vlan3019:
           peer_group: MLAG_PEER
+          remote_as: '65107'
+          description: DC1-LEAF4B
       redistribute_routes:
       - connected
     Tenant_C_OP_Zone:
@@ -157,9 +167,11 @@ router_bgp:
         export:
           evpn:
           - '30:30'
-      neighbors:
-        10.255.251.19:
+      neighbor_interfaces:
+        Vlan2:
           peer_group: MLAG_PEER
+          remote_as: '65107'
+          description: DC1-LEAF4B
       redistribute_routes:
       - connected
   vlan_aware_bundles:
@@ -430,7 +442,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone'
     vrf: Tenant_A_APP_Zone
-    ip_address: 10.255.251.18/31
+    ipv6_enable: true
     mtu: 1500
   Vlan140:
     tenant: Tenant_A
@@ -455,7 +467,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone'
     vrf: Tenant_A_DB_Zone
-    ip_address: 10.255.251.18/31
+    ipv6_enable: true
     mtu: 1500
   Vlan110:
     tenant: Tenant_A
@@ -483,7 +495,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone'
     vrf: Tenant_A_OP_Zone
-    ip_address: 10.255.251.18/31
+    ipv6_enable: true
     mtu: 1500
   Vlan120:
     tenant: Tenant_A
@@ -513,7 +525,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone'
     vrf: Tenant_A_WEB_Zone
-    ip_address: 10.255.251.18/31
+    ipv6_enable: true
     mtu: 1500
   Vlan210:
     tenant: Tenant_B
@@ -537,7 +549,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone'
     vrf: Tenant_B_OP_Zone
-    ip_address: 10.255.251.18/31
+    ipv6_enable: true
     mtu: 1500
   Vlan310:
     tenant: Tenant_C
@@ -561,7 +573,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone'
     vrf: Tenant_C_OP_Zone
-    ip_address: 10.255.251.18/31
+    ipv6_enable: true
     mtu: 1500
 port_channel_interfaces:
   Port-Channel5:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF4B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF4B.yml
@@ -82,9 +82,11 @@ router_bgp:
         export:
           evpn:
           - '12:12'
-      neighbors:
-        10.255.251.18:
+      neighbor_interfaces:
+        Vlan3011:
           peer_group: MLAG_PEER
+          remote_as: '65107'
+          description: DC1-LEAF4A
       redistribute_routes:
       - connected
     Tenant_A_DB_Zone:
@@ -97,9 +99,11 @@ router_bgp:
         export:
           evpn:
           - '13:13'
-      neighbors:
-        10.255.251.18:
+      neighbor_interfaces:
+        Vlan3012:
           peer_group: MLAG_PEER
+          remote_as: '65107'
+          description: DC1-LEAF4A
       redistribute_routes:
       - connected
     Tenant_A_OP_Zone:
@@ -112,9 +116,11 @@ router_bgp:
         export:
           evpn:
           - '10:10'
-      neighbors:
-        10.255.251.18:
+      neighbor_interfaces:
+        Vlan3009:
           peer_group: MLAG_PEER
+          remote_as: '65107'
+          description: DC1-LEAF4A
       redistribute_routes:
       - connected
     Tenant_A_WEB_Zone:
@@ -127,9 +133,11 @@ router_bgp:
         export:
           evpn:
           - '11:11'
-      neighbors:
-        10.255.251.18:
+      neighbor_interfaces:
+        Vlan3010:
           peer_group: MLAG_PEER
+          remote_as: '65107'
+          description: DC1-LEAF4A
       redistribute_routes:
       - connected
     Tenant_B_OP_Zone:
@@ -142,9 +150,11 @@ router_bgp:
         export:
           evpn:
           - '20:20'
-      neighbors:
-        10.255.251.18:
+      neighbor_interfaces:
+        Vlan3019:
           peer_group: MLAG_PEER
+          remote_as: '65107'
+          description: DC1-LEAF4A
       redistribute_routes:
       - connected
     Tenant_C_OP_Zone:
@@ -157,9 +167,11 @@ router_bgp:
         export:
           evpn:
           - '30:30'
-      neighbors:
-        10.255.251.18:
+      neighbor_interfaces:
+        Vlan2:
           peer_group: MLAG_PEER
+          remote_as: '65107'
+          description: DC1-LEAF4A
       redistribute_routes:
       - connected
   vlan_aware_bundles:
@@ -430,7 +442,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone'
     vrf: Tenant_A_APP_Zone
-    ip_address: 10.255.251.19/31
+    ipv6_enable: true
     mtu: 1500
   Vlan140:
     tenant: Tenant_A
@@ -455,7 +467,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone'
     vrf: Tenant_A_DB_Zone
-    ip_address: 10.255.251.19/31
+    ipv6_enable: true
     mtu: 1500
   Vlan110:
     tenant: Tenant_A
@@ -483,7 +495,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone'
     vrf: Tenant_A_OP_Zone
-    ip_address: 10.255.251.19/31
+    ipv6_enable: true
     mtu: 1500
   Vlan120:
     tenant: Tenant_A
@@ -513,7 +525,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone'
     vrf: Tenant_A_WEB_Zone
-    ip_address: 10.255.251.19/31
+    ipv6_enable: true
     mtu: 1500
   Vlan210:
     tenant: Tenant_B
@@ -537,7 +549,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone'
     vrf: Tenant_B_OP_Zone
-    ip_address: 10.255.251.19/31
+    ipv6_enable: true
     mtu: 1500
   Vlan310:
     tenant: Tenant_C
@@ -561,7 +573,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone'
     vrf: Tenant_C_OP_Zone
-    ip_address: 10.255.251.19/31
+    ipv6_enable: true
     mtu: 1500
 port_channel_interfaces:
   Port-Channel5:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -100,9 +100,11 @@ router_bgp:
         export:
           evpn:
           - '12:12'
-      neighbors:
-        10.255.251.7:
+      neighbor_interfaces:
+        Vlan3011:
           peer_group: MLAG_PEER
+          remote_as: '65103'
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_A_DB_Zone:
@@ -115,9 +117,11 @@ router_bgp:
         export:
           evpn:
           - '13:13'
-      neighbors:
-        10.255.251.7:
+      neighbor_interfaces:
+        Vlan3012:
           peer_group: MLAG_PEER
+          remote_as: '65103'
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_A_OP_Zone:
@@ -130,9 +134,11 @@ router_bgp:
         export:
           evpn:
           - '10:10'
-      neighbors:
-        10.255.251.7:
+      neighbor_interfaces:
+        Vlan3009:
           peer_group: MLAG_PEER
+          remote_as: '65103'
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_A_WAN_Zone:
@@ -145,9 +151,11 @@ router_bgp:
         export:
           evpn:
           - '14:14'
-      neighbors:
-        10.255.251.7:
+      neighbor_interfaces:
+        Vlan3013:
           peer_group: MLAG_PEER
+          remote_as: '65103'
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_A_WEB_Zone:
@@ -160,9 +168,11 @@ router_bgp:
         export:
           evpn:
           - '11:11'
-      neighbors:
-        10.255.251.7:
+      neighbor_interfaces:
+        Vlan3010:
           peer_group: MLAG_PEER
+          remote_as: '65103'
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_B_OP_Zone:
@@ -175,9 +185,11 @@ router_bgp:
         export:
           evpn:
           - '20:20'
-      neighbors:
-        10.255.251.7:
+      neighbor_interfaces:
+        Vlan3019:
           peer_group: MLAG_PEER
+          remote_as: '65103'
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_B_WAN_Zone:
@@ -190,9 +202,11 @@ router_bgp:
         export:
           evpn:
           - '21:21'
-      neighbors:
-        10.255.251.7:
+      neighbor_interfaces:
+        Vlan3020:
           peer_group: MLAG_PEER
+          remote_as: '65103'
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_C_OP_Zone:
@@ -205,9 +219,11 @@ router_bgp:
         export:
           evpn:
           - '30:30'
-      neighbors:
-        10.255.251.7:
+      neighbor_interfaces:
+        Vlan2:
           peer_group: MLAG_PEER
+          remote_as: '65103'
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
     Tenant_C_WAN_Zone:
@@ -220,9 +236,11 @@ router_bgp:
         export:
           evpn:
           - '31:31'
-      neighbors:
-        10.255.251.7:
+      neighbor_interfaces:
+        Vlan3030:
           peer_group: MLAG_PEER
+          remote_as: '65103'
+          description: DC1-SVC3B
       redistribute_routes:
       - connected
   vlan_aware_bundles:
@@ -550,7 +568,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone'
     vrf: Tenant_A_APP_Zone
-    ip_address: 10.255.251.6/31
+    ipv6_enable: true
     mtu: 1500
   Vlan140:
     tenant: Tenant_A
@@ -575,7 +593,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone'
     vrf: Tenant_A_DB_Zone
-    ip_address: 10.255.251.6/31
+    ipv6_enable: true
     mtu: 1500
   Vlan110:
     tenant: Tenant_A
@@ -603,7 +621,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone'
     vrf: Tenant_A_OP_Zone
-    ip_address: 10.255.251.6/31
+    ipv6_enable: true
     mtu: 1500
   Vlan150:
     tenant: Tenant_A
@@ -619,7 +637,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone'
     vrf: Tenant_A_WAN_Zone
-    ip_address: 10.255.251.6/31
+    ipv6_enable: true
     mtu: 1500
   Vlan120:
     tenant: Tenant_A
@@ -649,7 +667,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone'
     vrf: Tenant_A_WEB_Zone
-    ip_address: 10.255.251.6/31
+    ipv6_enable: true
     mtu: 1500
   Vlan210:
     tenant: Tenant_B
@@ -673,7 +691,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone'
     vrf: Tenant_B_OP_Zone
-    ip_address: 10.255.251.6/31
+    ipv6_enable: true
     mtu: 1500
   Vlan250:
     tenant: Tenant_B
@@ -689,7 +707,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone'
     vrf: Tenant_B_WAN_Zone
-    ip_address: 10.255.251.6/31
+    ipv6_enable: true
     mtu: 1500
   Vlan310:
     tenant: Tenant_C
@@ -713,7 +731,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone'
     vrf: Tenant_C_OP_Zone
-    ip_address: 10.255.251.6/31
+    ipv6_enable: true
     mtu: 1500
   Vlan350:
     tenant: Tenant_C
@@ -729,7 +747,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone'
     vrf: Tenant_C_WAN_Zone
-    ip_address: 10.255.251.6/31
+    ipv6_enable: true
     mtu: 1500
 port_channel_interfaces:
   Port-Channel5:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -100,9 +100,11 @@ router_bgp:
         export:
           evpn:
           - '12:12'
-      neighbors:
-        10.255.251.6:
+      neighbor_interfaces:
+        Vlan3011:
           peer_group: MLAG_PEER
+          remote_as: '65103'
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_A_DB_Zone:
@@ -115,9 +117,11 @@ router_bgp:
         export:
           evpn:
           - '13:13'
-      neighbors:
-        10.255.251.6:
+      neighbor_interfaces:
+        Vlan3012:
           peer_group: MLAG_PEER
+          remote_as: '65103'
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_A_OP_Zone:
@@ -130,9 +134,11 @@ router_bgp:
         export:
           evpn:
           - '10:10'
-      neighbors:
-        10.255.251.6:
+      neighbor_interfaces:
+        Vlan3009:
           peer_group: MLAG_PEER
+          remote_as: '65103'
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_A_WAN_Zone:
@@ -145,9 +151,11 @@ router_bgp:
         export:
           evpn:
           - '14:14'
-      neighbors:
-        10.255.251.6:
+      neighbor_interfaces:
+        Vlan3013:
           peer_group: MLAG_PEER
+          remote_as: '65103'
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_A_WEB_Zone:
@@ -160,9 +168,11 @@ router_bgp:
         export:
           evpn:
           - '11:11'
-      neighbors:
-        10.255.251.6:
+      neighbor_interfaces:
+        Vlan3010:
           peer_group: MLAG_PEER
+          remote_as: '65103'
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_B_OP_Zone:
@@ -175,9 +185,11 @@ router_bgp:
         export:
           evpn:
           - '20:20'
-      neighbors:
-        10.255.251.6:
+      neighbor_interfaces:
+        Vlan3019:
           peer_group: MLAG_PEER
+          remote_as: '65103'
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_B_WAN_Zone:
@@ -190,9 +202,11 @@ router_bgp:
         export:
           evpn:
           - '21:21'
-      neighbors:
-        10.255.251.6:
+      neighbor_interfaces:
+        Vlan3020:
           peer_group: MLAG_PEER
+          remote_as: '65103'
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_C_OP_Zone:
@@ -205,9 +219,11 @@ router_bgp:
         export:
           evpn:
           - '30:30'
-      neighbors:
-        10.255.251.6:
+      neighbor_interfaces:
+        Vlan2:
           peer_group: MLAG_PEER
+          remote_as: '65103'
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
     Tenant_C_WAN_Zone:
@@ -220,9 +236,11 @@ router_bgp:
         export:
           evpn:
           - '31:31'
-      neighbors:
-        10.255.251.6:
+      neighbor_interfaces:
+        Vlan3030:
           peer_group: MLAG_PEER
+          remote_as: '65103'
+          description: DC1-SVC3A
       redistribute_routes:
       - connected
   vlan_aware_bundles:
@@ -550,7 +568,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone'
     vrf: Tenant_A_APP_Zone
-    ip_address: 10.255.251.7/31
+    ipv6_enable: true
     mtu: 1500
   Vlan140:
     tenant: Tenant_A
@@ -575,7 +593,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone'
     vrf: Tenant_A_DB_Zone
-    ip_address: 10.255.251.7/31
+    ipv6_enable: true
     mtu: 1500
   Vlan110:
     tenant: Tenant_A
@@ -603,7 +621,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone'
     vrf: Tenant_A_OP_Zone
-    ip_address: 10.255.251.7/31
+    ipv6_enable: true
     mtu: 1500
   Vlan150:
     tenant: Tenant_A
@@ -619,7 +637,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone'
     vrf: Tenant_A_WAN_Zone
-    ip_address: 10.255.251.7/31
+    ipv6_enable: true
     mtu: 1500
   Vlan120:
     tenant: Tenant_A
@@ -649,7 +667,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone'
     vrf: Tenant_A_WEB_Zone
-    ip_address: 10.255.251.7/31
+    ipv6_enable: true
     mtu: 1500
   Vlan210:
     tenant: Tenant_B
@@ -673,7 +691,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone'
     vrf: Tenant_B_OP_Zone
-    ip_address: 10.255.251.7/31
+    ipv6_enable: true
     mtu: 1500
   Vlan250:
     tenant: Tenant_B
@@ -689,7 +707,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone'
     vrf: Tenant_B_WAN_Zone
-    ip_address: 10.255.251.7/31
+    ipv6_enable: true
     mtu: 1500
   Vlan310:
     tenant: Tenant_C
@@ -713,7 +731,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone'
     vrf: Tenant_C_OP_Zone
-    ip_address: 10.255.251.7/31
+    ipv6_enable: true
     mtu: 1500
   Vlan350:
     tenant: Tenant_C
@@ -729,7 +747,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone'
     vrf: Tenant_C_WAN_Zone
-    ip_address: 10.255.251.7/31
+    ipv6_enable: true
     mtu: 1500
 port_channel_interfaces:
   Port-Channel5:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
@@ -10,6 +10,8 @@ fabric_name: DC1_FABRIC
 
 # Point to Point Underlay with IPv6 Unumberred
 underlay_rfc5549: true
+overlay_mlag_rfc5549: true
+
 overlay_routing_protocol_address_family: ipv4
 
 # Enable vlan aware bundles

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-variables.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-variables.md
@@ -29,6 +29,10 @@ overlay_routing_protocol: < EBGP | IBGP | default for l3ls-evpn -> EBGP >
 # Requires "underlay_routing_protocol: EBGP"
 underlay_rfc5549: < true | false | default -> false >
 
+# MLAG iBGP in VRFs with RFC 5549(eBGP), i.e. IPv6 Unnumbered.
+# Requires "underlay_rfc5549: true"
+overlay_mlag_rfc5549: < true | false | default -> false >
+
 # Enable IPv6 Address Family on underlay.
 # This feature allows IPv6 underlay routing protocol with RFC5549 addresses to be used along with IPv4 advertisements as VXLAN tunnel endpoints.
 # Requires "underlay_rfc5549: true" and "loopback_ipv6_pool" under the "Fabric Topology"

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-variables.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-variables.md
@@ -29,7 +29,7 @@ overlay_routing_protocol: < EBGP | IBGP | default for l3ls-evpn -> EBGP >
 # Requires "underlay_routing_protocol: EBGP"
 underlay_rfc5549: < true | false | default -> false >
 
-# MLAG iBGP in VRFs with RFC 5549(eBGP), i.e. IPv6 Unnumbered.
+# Enable RFC 5549(iBGP) i.e. IPv6 Unnumbered for MLAG iBGP connections.
 # Requires "underlay_rfc5549: true"
 overlay_mlag_rfc5549: < true | false | default -> false >
 

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-vrfs.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-vrfs.j2
@@ -50,15 +50,25 @@
       route_targets:
         import: {{ route_targets.import | to_json }}
         export: {{ route_targets.export | to_json }}
-      neighbors:
+{%                     set configure_mlag_ibgp_peering = false %}
 {%                     if switch.mlag_l3 is arista.avd.defined(true) %}
 {%                         set configure_mlag_ibgp_peering = vrf.enable_mlag_ibgp_peering_vrfs | arista.avd.default(
-                                                         tenant.enable_mlag_ibgp_peering_vrfs,
-                                                         true) %}
-{%                         if configure_mlag_ibgp_peering %}
+                                                 tenant.enable_mlag_ibgp_peering_vrfs,
+                                                 true) %}
+{%                     endif %}
+{%                     if configure_mlag_ibgp_peering and underlay_rfc5549 is arista.avd.defined(true) and underlay_ipv6 is arista.avd.defined(true) %}
+{%                         set vrf_id_int = vrf.vrf_id | arista.avd.default(vrf.vrf_vni) | int %}
+      neighbor_interfaces:
+        Vlan{{ vrf.mlag_ibgp_peering_vlan | arista.avd.default(mlag_ibgp_peering_vrfs.base_vlan + (vrf_id_int - 1)) }}:
+          peer_group: {{ switch.bgp_peer_groups.mlag_ipv4_underlay_peer.name }}
+          remote_as: "{{ switch.bgp_as }}"
+          description: {{ switch.mlag_peer }}
+{%                         set configure_mlag_ibgp_peering = false %}
+{%                     endif %}        
+      neighbors:
+{%                     if configure_mlag_ibgp_peering %}
         {{ switch.mlag_peer_l3_ip | arista.avd.default(switch.mlag_peer_ip) }}:
           peer_group: {{ switch.bgp_peer_groups.mlag_ipv4_underlay_peer.name }}
-{%                         endif %}
 {%                     endif %}
 {%                     for bgp_peer in vrf.bgp_peers %}
 {%                         if inventory_hostname in bgp_peer.nodes | arista.avd.default([]) %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-vrfs.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-vrfs.j2
@@ -64,7 +64,7 @@
           remote_as: "{{ switch.bgp_as }}"
           description: {{ switch.mlag_peer }}
 {%                         set configure_mlag_ibgp_peering = false %}
-{%                     endif %}        
+{%                     endif %}
       neighbors:
 {%                     if configure_mlag_ibgp_peering %}
         {{ switch.mlag_peer_l3_ip | arista.avd.default(switch.mlag_peer_ip) }}:
@@ -108,7 +108,7 @@
 {%                                     break %}
 {%                                 endif %}
 {%                             endfor %}
-{%                         elif vrf.redistribute_static is arista.avd.defined(true)  %}
+{%                         elif vrf.redistribute_static is arista.avd.defined(true) %}
         - static
 {%                         endif %}
 {%                     endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-vrfs.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-vrfs.j2
@@ -56,7 +56,7 @@
                                                  tenant.enable_mlag_ibgp_peering_vrfs,
                                                  true) %}
 {%                     endif %}
-{%                     if configure_mlag_ibgp_peering and underlay_rfc5549 is arista.avd.defined(true) and underlay_ipv6 is arista.avd.defined(true) %}
+{%                     if configure_mlag_ibgp_peering and underlay_rfc5549 is arista.avd.defined(true) and overlay_mlag_rfc5549 is arista.avd.defined(true) %}
 {%                         set vrf_id_int = vrf.vrf_id | arista.avd.default(vrf.vrf_vni) | int %}
       neighbor_interfaces:
         Vlan{{ vrf.mlag_ibgp_peering_vlan | arista.avd.default(mlag_ibgp_peering_vrfs.base_vlan + (vrf_id_int - 1)) }}:

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vlan-interfaces.j2
@@ -142,7 +142,7 @@ vlan_interfaces:
     shutdown: false
     description: "MLAG_PEER_L3_iBGP: vrf {{ vrf.name }}"
     vrf: {{ vrf.name }}
-{%                     if underlay_rfc5549 is arista.avd.defined(true) and switch.underlay_ipv6 is arista.avd.defined(true) %}
+{%                     if underlay_rfc5549 is arista.avd.defined(true) and overlay_mlag_rfc5549 is arista.avd.defined(true) %}
     ipv6_enable: true
 {%                     else %}
     ip_address: {{ switch.mlag_l3_ip | arista.avd.default(switch.mlag_ip) }}/31

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vlan-interfaces.j2
@@ -142,11 +142,11 @@ vlan_interfaces:
     shutdown: false
     description: "MLAG_PEER_L3_iBGP: vrf {{ vrf.name }}"
     vrf: {{ vrf.name }}
-{%     if underlay_rfc5549 is arista.avd.defined(true) and switch.underlay_ipv6 is arista.avd.defined(true) %}
+{%                      if underlay_rfc5549 is arista.avd.defined(true) and switch.underlay_ipv6 is arista.avd.defined(true) %}
     ipv6_enable: true
-{%     else %}
+{%                      else %}
     ip_address: {{ switch.mlag_l3_ip | arista.avd.default(switch.mlag_ip) }}/31
-{%     endif %}
+{%                      endif %}
     mtu: {{ p2p_uplinks_mtu }}
 {%                 endif %}
 {%             endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vlan-interfaces.j2
@@ -142,11 +142,11 @@ vlan_interfaces:
     shutdown: false
     description: "MLAG_PEER_L3_iBGP: vrf {{ vrf.name }}"
     vrf: {{ vrf.name }}
-{%                      if underlay_rfc5549 is arista.avd.defined(true) and switch.underlay_ipv6 is arista.avd.defined(true) %}
+{%                     if underlay_rfc5549 is arista.avd.defined(true) and switch.underlay_ipv6 is arista.avd.defined(true) %}
     ipv6_enable: true
-{%                      else %}
+{%                     else %}
     ip_address: {{ switch.mlag_l3_ip | arista.avd.default(switch.mlag_ip) }}/31
-{%                      endif %}
+{%                     endif %}
     mtu: {{ p2p_uplinks_mtu }}
 {%                 endif %}
 {%             endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vlan-interfaces.j2
@@ -142,7 +142,11 @@ vlan_interfaces:
     shutdown: false
     description: "MLAG_PEER_L3_iBGP: vrf {{ vrf.name }}"
     vrf: {{ vrf.name }}
+{%     if underlay_rfc5549 is arista.avd.defined(true) and switch.underlay_ipv6 is arista.avd.defined(true) %}
+    ipv6_enable: true
+{%     else %}
     ip_address: {{ switch.mlag_l3_ip | arista.avd.default(switch.mlag_ip) }}/31
+{%     endif %}
     mtu: {{ p2p_uplinks_mtu }}
 {%                 endif %}
 {%             endif %}


### PR DESCRIPTION
## Change Summary

Enable RFC5549 for iBGP over peer-link in MLAG scenarios within VRFs.
Only when RFC5549 and ipv6_underlay are enabled.

## Related Issue(s)


## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
