### PR TITLE
Feat(eos_designs): Support different ipv4 pool for mlag ibgp peerings

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3A.md
@@ -998,7 +998,7 @@ interface Loopback100
 | Vlan311 |  Tenant_C_OP_Zone  |  -  |  10.3.11.1/24  |  -  |  -  |  -  |  -  |
 | Vlan350 |  Tenant_C_WAN_Zone  |  -  |  10.3.50.1/24  |  -  |  -  |  -  |  -  |
 | Vlan3008 |  Tenant_A_OP_Zone  |  10.255.251.6/31  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3010 |  Tenant_A_WEB_Zone  |  10.255.251.6/31  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3010 |  Tenant_A_WEB_Zone  |  172.31.11.6/31  |  -  |  -  |  -  |  -  |  -  |
 | Vlan3011 |  Tenant_A_APP_Zone  |  10.255.251.6/31  |  -  |  -  |  -  |  -  |  -  |
 | Vlan3012 |  Tenant_A_DB_Zone  |  10.255.251.6/31  |  -  |  -  |  -  |  -  |  -  |
 | Vlan3013 |  Tenant_A_WAN_Zone  |  10.255.251.6/31  |  -  |  -  |  -  |  -  |  -  |
@@ -1137,7 +1137,7 @@ interface Vlan3010
    no shutdown
    mtu 1500
    vrf Tenant_A_WEB_Zone
-   ip address 10.255.251.6/31
+   ip address 172.31.11.6/31
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
@@ -1432,7 +1432,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | 10.255.251.7 | Inherited from peer group MLAG-PEERS | Tenant_A_DB_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
 | 10.255.251.7 | Inherited from peer group MLAG-PEERS | Tenant_A_OP_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
 | 10.255.251.7 | Inherited from peer group MLAG-PEERS | Tenant_A_WAN_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
-| 10.255.251.7 | Inherited from peer group MLAG-PEERS | Tenant_A_WEB_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
+| 172.31.11.8 | Inherited from peer group MLAG-PEERS | Tenant_A_WEB_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
 | 10.255.251.7 | Inherited from peer group MLAG-PEERS | Tenant_B_OP_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
 | 10.255.251.7 | Inherited from peer group MLAG-PEERS | Tenant_B_WAN_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
 | 10.255.251.7 | Inherited from peer group MLAG-PEERS | Tenant_C_OP_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
@@ -1652,7 +1652,7 @@ router bgp 65103
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.12
-      neighbor 10.255.251.7 peer group MLAG-PEERS
+      neighbor 172.31.11.8 peer group MLAG-PEERS
       redistribute connected
    !
    vrf Tenant_B_OP_Zone

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3A.md
@@ -1432,7 +1432,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | 10.255.251.7 | Inherited from peer group MLAG-PEERS | Tenant_A_DB_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
 | 10.255.251.7 | Inherited from peer group MLAG-PEERS | Tenant_A_OP_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
 | 10.255.251.7 | Inherited from peer group MLAG-PEERS | Tenant_A_WAN_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
-| 172.31.11.8 | Inherited from peer group MLAG-PEERS | Tenant_A_WEB_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
+| 172.31.11.7 | Inherited from peer group MLAG-PEERS | Tenant_A_WEB_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
 | 10.255.251.7 | Inherited from peer group MLAG-PEERS | Tenant_B_OP_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
 | 10.255.251.7 | Inherited from peer group MLAG-PEERS | Tenant_B_WAN_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
 | 10.255.251.7 | Inherited from peer group MLAG-PEERS | Tenant_C_OP_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
@@ -1652,7 +1652,7 @@ router bgp 65103
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.12
-      neighbor 172.31.11.8 peer group MLAG-PEERS
+      neighbor 172.31.11.7 peer group MLAG-PEERS
       redistribute connected
    !
    vrf Tenant_B_OP_Zone

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3B.md
@@ -968,7 +968,7 @@ interface Loopback100
 | Vlan311 |  Tenant_C_OP_Zone  |  -  |  10.3.11.1/24  |  -  |  -  |  -  |  -  |
 | Vlan350 |  Tenant_C_WAN_Zone  |  -  |  10.3.50.1/24  |  -  |  -  |  -  |  -  |
 | Vlan3008 |  Tenant_A_OP_Zone  |  10.255.251.7/31  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3010 |  Tenant_A_WEB_Zone  |  10.255.251.7/31  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3010 |  Tenant_A_WEB_Zone  |  172.31.11.6/31  |  -  |  -  |  -  |  -  |  -  |
 | Vlan3011 |  Tenant_A_APP_Zone  |  10.255.251.7/31  |  -  |  -  |  -  |  -  |  -  |
 | Vlan3012 |  Tenant_A_DB_Zone  |  10.255.251.7/31  |  -  |  -  |  -  |  -  |  -  |
 | Vlan3013 |  Tenant_A_WAN_Zone  |  10.255.251.7/31  |  -  |  -  |  -  |  -  |  -  |
@@ -1107,7 +1107,7 @@ interface Vlan3010
    no shutdown
    mtu 1500
    vrf Tenant_A_WEB_Zone
-   ip address 10.255.251.7/31
+   ip address 172.31.11.6/31
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
@@ -1402,7 +1402,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | 10.255.251.6 | Inherited from peer group MLAG-PEERS | Tenant_A_DB_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
 | 10.255.251.6 | Inherited from peer group MLAG-PEERS | Tenant_A_OP_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
 | 10.255.251.6 | Inherited from peer group MLAG-PEERS | Tenant_A_WAN_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
-| 10.255.251.6 | Inherited from peer group MLAG-PEERS | Tenant_A_WEB_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
+| 172.31.11.8 | Inherited from peer group MLAG-PEERS | Tenant_A_WEB_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
 | 10.255.251.6 | Inherited from peer group MLAG-PEERS | Tenant_B_OP_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
 | 10.255.251.6 | Inherited from peer group MLAG-PEERS | Tenant_B_WAN_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
 | 10.255.251.6 | Inherited from peer group MLAG-PEERS | Tenant_C_OP_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
@@ -1622,7 +1622,7 @@ router bgp 65103
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.13
-      neighbor 10.255.251.6 peer group MLAG-PEERS
+      neighbor 172.31.11.8 peer group MLAG-PEERS
       redistribute connected
    !
    vrf Tenant_B_OP_Zone

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-SVC3B.md
@@ -968,7 +968,7 @@ interface Loopback100
 | Vlan311 |  Tenant_C_OP_Zone  |  -  |  10.3.11.1/24  |  -  |  -  |  -  |  -  |
 | Vlan350 |  Tenant_C_WAN_Zone  |  -  |  10.3.50.1/24  |  -  |  -  |  -  |  -  |
 | Vlan3008 |  Tenant_A_OP_Zone  |  10.255.251.7/31  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3010 |  Tenant_A_WEB_Zone  |  172.31.11.6/31  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3010 |  Tenant_A_WEB_Zone  |  172.31.11.7/31  |  -  |  -  |  -  |  -  |  -  |
 | Vlan3011 |  Tenant_A_APP_Zone  |  10.255.251.7/31  |  -  |  -  |  -  |  -  |  -  |
 | Vlan3012 |  Tenant_A_DB_Zone  |  10.255.251.7/31  |  -  |  -  |  -  |  -  |  -  |
 | Vlan3013 |  Tenant_A_WAN_Zone  |  10.255.251.7/31  |  -  |  -  |  -  |  -  |  -  |
@@ -1107,7 +1107,7 @@ interface Vlan3010
    no shutdown
    mtu 1500
    vrf Tenant_A_WEB_Zone
-   ip address 172.31.11.6/31
+   ip address 172.31.11.7/31
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
@@ -1402,7 +1402,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | 10.255.251.6 | Inherited from peer group MLAG-PEERS | Tenant_A_DB_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
 | 10.255.251.6 | Inherited from peer group MLAG-PEERS | Tenant_A_OP_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
 | 10.255.251.6 | Inherited from peer group MLAG-PEERS | Tenant_A_WAN_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
-| 172.31.11.8 | Inherited from peer group MLAG-PEERS | Tenant_A_WEB_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
+| 172.31.11.6 | Inherited from peer group MLAG-PEERS | Tenant_A_WEB_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
 | 10.255.251.6 | Inherited from peer group MLAG-PEERS | Tenant_B_OP_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
 | 10.255.251.6 | Inherited from peer group MLAG-PEERS | Tenant_B_WAN_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
 | 10.255.251.6 | Inherited from peer group MLAG-PEERS | Tenant_C_OP_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
@@ -1622,7 +1622,7 @@ router bgp 65103
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.13
-      neighbor 172.31.11.8 peer group MLAG-PEERS
+      neighbor 172.31.11.6 peer group MLAG-PEERS
       redistribute connected
    !
    vrf Tenant_B_OP_Zone

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1_UNDEPLOYED_LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1_UNDEPLOYED_LEAF1A.md
@@ -1070,7 +1070,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | 10.255.251.25 | Inherited from peer group MLAG-PEERS | Tenant_A_DB_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
 | 10.255.251.25 | Inherited from peer group MLAG-PEERS | Tenant_A_OP_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
 | 10.255.251.25 | Inherited from peer group MLAG-PEERS | Tenant_A_WAN_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
-| 172.31.11.26 | Inherited from peer group MLAG-PEERS | Tenant_A_WEB_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
+| 172.31.11.25 | Inherited from peer group MLAG-PEERS | Tenant_A_WEB_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
 | 10.255.251.25 | Inherited from peer group MLAG-PEERS | Tenant_B_OP_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
 | 10.255.251.25 | Inherited from peer group MLAG-PEERS | Tenant_B_WAN_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
 | 10.255.251.25 | Inherited from peer group MLAG-PEERS | Tenant_C_OP_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
@@ -1290,7 +1290,7 @@ router bgp 65110
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.21
-      neighbor 172.31.11.26 peer group MLAG-PEERS
+      neighbor 172.31.11.25 peer group MLAG-PEERS
       redistribute connected
    !
    vrf Tenant_B_OP_Zone

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1_UNDEPLOYED_LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1_UNDEPLOYED_LEAF1A.md
@@ -636,7 +636,7 @@ interface Loopback100
 | Vlan311 |  Tenant_C_OP_Zone  |  -  |  10.3.11.1/24  |  -  |  -  |  -  |  -  |
 | Vlan350 |  Tenant_C_WAN_Zone  |  -  |  10.3.50.1/24  |  -  |  -  |  -  |  -  |
 | Vlan3008 |  Tenant_A_OP_Zone  |  10.255.251.24/31  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3010 |  Tenant_A_WEB_Zone  |  10.255.251.24/31  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3010 |  Tenant_A_WEB_Zone  |  172.31.11.24/31  |  -  |  -  |  -  |  -  |  -  |
 | Vlan3011 |  Tenant_A_APP_Zone  |  10.255.251.24/31  |  -  |  -  |  -  |  -  |  -  |
 | Vlan3012 |  Tenant_A_DB_Zone  |  10.255.251.24/31  |  -  |  -  |  -  |  -  |  -  |
 | Vlan3013 |  Tenant_A_WAN_Zone  |  10.255.251.24/31  |  -  |  -  |  -  |  -  |  -  |
@@ -775,7 +775,7 @@ interface Vlan3010
    no shutdown
    mtu 1500
    vrf Tenant_A_WEB_Zone
-   ip address 10.255.251.24/31
+   ip address 172.31.11.24/31
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
@@ -1070,7 +1070,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | 10.255.251.25 | Inherited from peer group MLAG-PEERS | Tenant_A_DB_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
 | 10.255.251.25 | Inherited from peer group MLAG-PEERS | Tenant_A_OP_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
 | 10.255.251.25 | Inherited from peer group MLAG-PEERS | Tenant_A_WAN_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
-| 10.255.251.25 | Inherited from peer group MLAG-PEERS | Tenant_A_WEB_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
+| 172.31.11.26 | Inherited from peer group MLAG-PEERS | Tenant_A_WEB_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
 | 10.255.251.25 | Inherited from peer group MLAG-PEERS | Tenant_B_OP_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
 | 10.255.251.25 | Inherited from peer group MLAG-PEERS | Tenant_B_WAN_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
 | 10.255.251.25 | Inherited from peer group MLAG-PEERS | Tenant_C_OP_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
@@ -1290,7 +1290,7 @@ router bgp 65110
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.21
-      neighbor 10.255.251.25 peer group MLAG-PEERS
+      neighbor 172.31.11.26 peer group MLAG-PEERS
       redistribute connected
    !
    vrf Tenant_B_OP_Zone

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1_UNDEPLOYED_LEAF1B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1_UNDEPLOYED_LEAF1B.md
@@ -636,7 +636,7 @@ interface Loopback100
 | Vlan311 |  Tenant_C_OP_Zone  |  -  |  10.3.11.1/24  |  -  |  -  |  -  |  -  |
 | Vlan350 |  Tenant_C_WAN_Zone  |  -  |  10.3.50.1/24  |  -  |  -  |  -  |  -  |
 | Vlan3008 |  Tenant_A_OP_Zone  |  10.255.251.25/31  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3010 |  Tenant_A_WEB_Zone  |  10.255.251.25/31  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3010 |  Tenant_A_WEB_Zone  |  172.31.11.24/31  |  -  |  -  |  -  |  -  |  -  |
 | Vlan3011 |  Tenant_A_APP_Zone  |  10.255.251.25/31  |  -  |  -  |  -  |  -  |  -  |
 | Vlan3012 |  Tenant_A_DB_Zone  |  10.255.251.25/31  |  -  |  -  |  -  |  -  |  -  |
 | Vlan3013 |  Tenant_A_WAN_Zone  |  10.255.251.25/31  |  -  |  -  |  -  |  -  |  -  |
@@ -775,7 +775,7 @@ interface Vlan3010
    no shutdown
    mtu 1500
    vrf Tenant_A_WEB_Zone
-   ip address 10.255.251.25/31
+   ip address 172.31.11.24/31
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
@@ -1070,7 +1070,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | 10.255.251.24 | Inherited from peer group MLAG-PEERS | Tenant_A_DB_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
 | 10.255.251.24 | Inherited from peer group MLAG-PEERS | Tenant_A_OP_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
 | 10.255.251.24 | Inherited from peer group MLAG-PEERS | Tenant_A_WAN_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
-| 10.255.251.24 | Inherited from peer group MLAG-PEERS | Tenant_A_WEB_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
+| 172.31.11.26 | Inherited from peer group MLAG-PEERS | Tenant_A_WEB_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
 | 10.255.251.24 | Inherited from peer group MLAG-PEERS | Tenant_B_OP_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
 | 10.255.251.24 | Inherited from peer group MLAG-PEERS | Tenant_B_WAN_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
 | 10.255.251.24 | Inherited from peer group MLAG-PEERS | Tenant_C_OP_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
@@ -1290,7 +1290,7 @@ router bgp 65111
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.22
-      neighbor 10.255.251.24 peer group MLAG-PEERS
+      neighbor 172.31.11.26 peer group MLAG-PEERS
       redistribute connected
    !
    vrf Tenant_B_OP_Zone

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1_UNDEPLOYED_LEAF1B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1_UNDEPLOYED_LEAF1B.md
@@ -636,7 +636,7 @@ interface Loopback100
 | Vlan311 |  Tenant_C_OP_Zone  |  -  |  10.3.11.1/24  |  -  |  -  |  -  |  -  |
 | Vlan350 |  Tenant_C_WAN_Zone  |  -  |  10.3.50.1/24  |  -  |  -  |  -  |  -  |
 | Vlan3008 |  Tenant_A_OP_Zone  |  10.255.251.25/31  |  -  |  -  |  -  |  -  |  -  |
-| Vlan3010 |  Tenant_A_WEB_Zone  |  172.31.11.24/31  |  -  |  -  |  -  |  -  |  -  |
+| Vlan3010 |  Tenant_A_WEB_Zone  |  172.31.11.25/31  |  -  |  -  |  -  |  -  |  -  |
 | Vlan3011 |  Tenant_A_APP_Zone  |  10.255.251.25/31  |  -  |  -  |  -  |  -  |  -  |
 | Vlan3012 |  Tenant_A_DB_Zone  |  10.255.251.25/31  |  -  |  -  |  -  |  -  |  -  |
 | Vlan3013 |  Tenant_A_WAN_Zone  |  10.255.251.25/31  |  -  |  -  |  -  |  -  |  -  |
@@ -775,7 +775,7 @@ interface Vlan3010
    no shutdown
    mtu 1500
    vrf Tenant_A_WEB_Zone
-   ip address 172.31.11.24/31
+   ip address 172.31.11.25/31
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
@@ -1070,7 +1070,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | 10.255.251.24 | Inherited from peer group MLAG-PEERS | Tenant_A_DB_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
 | 10.255.251.24 | Inherited from peer group MLAG-PEERS | Tenant_A_OP_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
 | 10.255.251.24 | Inherited from peer group MLAG-PEERS | Tenant_A_WAN_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
-| 172.31.11.26 | Inherited from peer group MLAG-PEERS | Tenant_A_WEB_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
+| 172.31.11.24 | Inherited from peer group MLAG-PEERS | Tenant_A_WEB_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
 | 10.255.251.24 | Inherited from peer group MLAG-PEERS | Tenant_B_OP_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
 | 10.255.251.24 | Inherited from peer group MLAG-PEERS | Tenant_B_WAN_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
 | 10.255.251.24 | Inherited from peer group MLAG-PEERS | Tenant_C_OP_Zone | - | Inherited from peer group MLAG-PEERS | Inherited from peer group MLAG-PEERS | - | - | - |
@@ -1290,7 +1290,7 @@ router bgp 65111
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.22
-      neighbor 172.31.11.26 peer group MLAG-PEERS
+      neighbor 172.31.11.24 peer group MLAG-PEERS
       redistribute connected
    !
    vrf Tenant_B_OP_Zone

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3A.cfg
@@ -652,7 +652,7 @@ interface Vlan3010
    no shutdown
    mtu 1500
    vrf Tenant_A_WEB_Zone
-   ip address 10.255.251.6/31
+   ip address 172.31.11.6/31
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
@@ -961,7 +961,7 @@ router bgp 65103
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.12
-      neighbor 10.255.251.7 peer group MLAG-PEERS
+      neighbor 172.31.11.8 peer group MLAG-PEERS
       redistribute connected
    !
    vrf Tenant_B_OP_Zone

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3A.cfg
@@ -961,7 +961,7 @@ router bgp 65103
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.12
-      neighbor 172.31.11.8 peer group MLAG-PEERS
+      neighbor 172.31.11.7 peer group MLAG-PEERS
       redistribute connected
    !
    vrf Tenant_B_OP_Zone

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3B.cfg
@@ -627,7 +627,7 @@ interface Vlan3010
    no shutdown
    mtu 1500
    vrf Tenant_A_WEB_Zone
-   ip address 172.31.11.6/31
+   ip address 172.31.11.7/31
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
@@ -935,7 +935,7 @@ router bgp 65103
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.13
-      neighbor 172.31.11.8 peer group MLAG-PEERS
+      neighbor 172.31.11.6 peer group MLAG-PEERS
       redistribute connected
    !
    vrf Tenant_B_OP_Zone

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3B.cfg
@@ -627,7 +627,7 @@ interface Vlan3010
    no shutdown
    mtu 1500
    vrf Tenant_A_WEB_Zone
-   ip address 10.255.251.7/31
+   ip address 172.31.11.6/31
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
@@ -935,7 +935,7 @@ router bgp 65103
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.13
-      neighbor 10.255.251.6 peer group MLAG-PEERS
+      neighbor 172.31.11.8 peer group MLAG-PEERS
       redistribute connected
    !
    vrf Tenant_B_OP_Zone

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1_UNDEPLOYED_LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1_UNDEPLOYED_LEAF1A.cfg
@@ -661,7 +661,7 @@ router bgp 65110
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.21
-      neighbor 172.31.11.26 peer group MLAG-PEERS
+      neighbor 172.31.11.25 peer group MLAG-PEERS
       redistribute connected
    !
    vrf Tenant_B_OP_Zone

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1_UNDEPLOYED_LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1_UNDEPLOYED_LEAF1A.cfg
@@ -362,7 +362,7 @@ interface Vlan3010
    no shutdown
    mtu 1500
    vrf Tenant_A_WEB_Zone
-   ip address 10.255.251.24/31
+   ip address 172.31.11.24/31
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
@@ -661,7 +661,7 @@ router bgp 65110
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.21
-      neighbor 10.255.251.25 peer group MLAG-PEERS
+      neighbor 172.31.11.26 peer group MLAG-PEERS
       redistribute connected
    !
    vrf Tenant_B_OP_Zone

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1_UNDEPLOYED_LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1_UNDEPLOYED_LEAF1B.cfg
@@ -362,7 +362,7 @@ interface Vlan3010
    no shutdown
    mtu 1500
    vrf Tenant_A_WEB_Zone
-   ip address 172.31.11.24/31
+   ip address 172.31.11.25/31
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
@@ -661,7 +661,7 @@ router bgp 65111
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.22
-      neighbor 172.31.11.26 peer group MLAG-PEERS
+      neighbor 172.31.11.24 peer group MLAG-PEERS
       redistribute connected
    !
    vrf Tenant_B_OP_Zone

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1_UNDEPLOYED_LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1_UNDEPLOYED_LEAF1B.cfg
@@ -362,7 +362,7 @@ interface Vlan3010
    no shutdown
    mtu 1500
    vrf Tenant_A_WEB_Zone
-   ip address 10.255.251.25/31
+   ip address 172.31.11.24/31
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
@@ -661,7 +661,7 @@ router bgp 65111
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.22
-      neighbor 10.255.251.24 peer group MLAG-PEERS
+      neighbor 172.31.11.26 peer group MLAG-PEERS
       redistribute connected
    !
    vrf Tenant_B_OP_Zone

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
@@ -158,7 +158,7 @@ router_bgp:
           evpn:
           - '11:11'
       neighbors:
-        10.255.251.7:
+        172.31.11.8:
           peer_group: MLAG-PEERS
       redistribute_routes:
       - connected
@@ -669,7 +669,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone'
     vrf: Tenant_A_WEB_Zone
-    ip_address: 10.255.251.6/31
+    ip_address: 172.31.11.6/31
     mtu: 1500
   Vlan210:
     tenant: Tenant_B

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
@@ -158,7 +158,7 @@ router_bgp:
           evpn:
           - '11:11'
       neighbors:
-        172.31.11.8:
+        172.31.11.7:
           peer_group: MLAG-PEERS
       redistribute_routes:
       - connected

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
@@ -158,7 +158,7 @@ router_bgp:
           evpn:
           - '11:11'
       neighbors:
-        10.255.251.6:
+        172.31.11.8:
           peer_group: MLAG-PEERS
       redistribute_routes:
       - connected
@@ -669,7 +669,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone'
     vrf: Tenant_A_WEB_Zone
-    ip_address: 10.255.251.7/31
+    ip_address: 172.31.11.6/31
     mtu: 1500
   Vlan210:
     tenant: Tenant_B

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
@@ -158,7 +158,7 @@ router_bgp:
           evpn:
           - '11:11'
       neighbors:
-        172.31.11.8:
+        172.31.11.6:
           peer_group: MLAG-PEERS
       redistribute_routes:
       - connected
@@ -669,7 +669,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone'
     vrf: Tenant_A_WEB_Zone
-    ip_address: 172.31.11.6/31
+    ip_address: 172.31.11.7/31
     mtu: 1500
   Vlan210:
     tenant: Tenant_B

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1A.yml
@@ -158,7 +158,7 @@ router_bgp:
           evpn:
           - '11:11'
       neighbors:
-        10.255.251.25:
+        172.31.11.26:
           peer_group: MLAG-PEERS
       redistribute_routes:
       - connected
@@ -685,7 +685,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone'
     vrf: Tenant_A_WEB_Zone
-    ip_address: 10.255.251.24/31
+    ip_address: 172.31.11.24/31
     mtu: 1500
   Vlan210:
     tenant: Tenant_B

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1A.yml
@@ -158,7 +158,7 @@ router_bgp:
           evpn:
           - '11:11'
       neighbors:
-        172.31.11.26:
+        172.31.11.25:
           peer_group: MLAG-PEERS
       redistribute_routes:
       - connected

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1B.yml
@@ -158,7 +158,7 @@ router_bgp:
           evpn:
           - '11:11'
       neighbors:
-        10.255.251.24:
+        172.31.11.26:
           peer_group: MLAG-PEERS
       redistribute_routes:
       - connected
@@ -685,7 +685,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone'
     vrf: Tenant_A_WEB_Zone
-    ip_address: 10.255.251.25/31
+    ip_address: 172.31.11.24/31
     mtu: 1500
   Vlan210:
     tenant: Tenant_B

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1B.yml
@@ -158,7 +158,7 @@ router_bgp:
           evpn:
           - '11:11'
       neighbors:
-        172.31.11.26:
+        172.31.11.24:
           peer_group: MLAG-PEERS
       redistribute_routes:
       - connected
@@ -685,7 +685,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone'
     vrf: Tenant_A_WEB_Zone
-    ip_address: 172.31.11.24/31
+    ip_address: 172.31.11.25/31
     mtu: 1500
   Vlan210:
     tenant: Tenant_B

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_A.yml
@@ -35,6 +35,7 @@ Tenant_A:
           enabled: True
     Tenant_A_WEB_Zone:
       vrf_vni: 11
+      mlag_ibgp_peering_ipv4_pool: 172.31.11.0/24
       svis:
         120:
           name: Tenant_A_WEB_Zone_1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SVC3A.yml
@@ -158,7 +158,7 @@ router_bgp:
           evpn:
           - '11:11'
       neighbors:
-        10.255.251.7:
+        172.31.11.8:
           peer_group: MLAG-PEERS
       redistribute_routes:
       - connected
@@ -669,7 +669,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone'
     vrf: Tenant_A_WEB_Zone
-    ip_address: 10.255.251.6/31
+    ip_address: 172.31.11.6/31
     mtu: 1500
   Vlan210:
     tenant: Tenant_B

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SVC3A.yml
@@ -158,7 +158,7 @@ router_bgp:
           evpn:
           - '11:11'
       neighbors:
-        172.31.11.8:
+        172.31.11.7:
           peer_group: MLAG-PEERS
       redistribute_routes:
       - connected

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SVC3B.yml
@@ -158,7 +158,7 @@ router_bgp:
           evpn:
           - '11:11'
       neighbors:
-        10.255.251.6:
+        172.31.11.8:
           peer_group: MLAG-PEERS
       redistribute_routes:
       - connected
@@ -669,7 +669,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone'
     vrf: Tenant_A_WEB_Zone
-    ip_address: 10.255.251.7/31
+    ip_address: 172.31.11.6/31
     mtu: 1500
   Vlan210:
     tenant: Tenant_B

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-SVC3B.yml
@@ -158,7 +158,7 @@ router_bgp:
           evpn:
           - '11:11'
       neighbors:
-        172.31.11.8:
+        172.31.11.6:
           peer_group: MLAG-PEERS
       redistribute_routes:
       - connected
@@ -669,7 +669,7 @@ vlan_interfaces:
     shutdown: false
     description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone'
     vrf: Tenant_A_WEB_Zone
-    ip_address: 172.31.11.6/31
+    ip_address: 172.31.11.7/31
     mtu: 1500
   Vlan210:
     tenant: Tenant_B

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/inventory/group_vars/DC1_TENANTS_NETWORKS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/inventory/group_vars/DC1_TENANTS_NETWORKS.yml
@@ -76,6 +76,7 @@ tenants:
             enabled: True
       - name: Tenant_A_WEB_Zone
         vrf_vni: 11
+        mlag_ibgp_peering_ipv4_pool: 172.31.11.0/24
         svis:
           - id: 120
             name: Tenant_A_WEB_Zone_1

--- a/ansible_collections/arista/avd/plugins/module_utils/eos_designs_facts.py
+++ b/ansible_collections/arista/avd/plugins/module_utils/eos_designs_facts.py
@@ -1432,7 +1432,7 @@ class EosDesignsFacts:
                        required=True,
                        org_key=f"avd_switch_facts.({self.mlag_peer}).switch.id",
                        separator="..")
-    
+
     @cached_property
     def mlag_switch_ids(self):
         '''

--- a/ansible_collections/arista/avd/plugins/module_utils/eos_designs_facts.py
+++ b/ansible_collections/arista/avd/plugins/module_utils/eos_designs_facts.py
@@ -1432,6 +1432,16 @@ class EosDesignsFacts:
                        required=True,
                        org_key=f"avd_switch_facts.({self.mlag_peer}).switch.id",
                        separator="..")
+    
+    @cached_property
+    def mlag_switch_ids(self):
+        '''
+        Returns the switch id's of both primary and secondary switches for a given node group
+        '''
+        if self.mlag_role == 'primary':
+            return {"primary": self.id, "secondary": self._mlag_peer_id}
+        elif self.mlag_role == 'secondary':
+            return {"primary": self._mlag_peer_id, "secondary": self.id}
 
     @cached_property
     def vtep_ip(self):

--- a/ansible_collections/arista/avd/roles/eos_designs/defaults/main/default-templates.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/defaults/main/default-templates.yml
@@ -34,6 +34,8 @@ default_templates:
       mlag_ip_secondary: 'ip_addressing/mlag-ip-secondary.j2'
       mlag_l3_ip_primary: 'ip_addressing/mlag-l3-ip-primary.j2'
       mlag_l3_ip_secondary: 'ip_addressing/mlag-l3-ip-secondary.j2'
+      mlag_ibgp_peering_ip_primary: 'ip_addressing/mlag-ibgp-peering-ip-primary.j2'
+      mlag_ibgp_peering_ip_secondary: 'ip_addressing/mlag-ibgp-peering-ip-secondary.j2'
       p2p_uplinks_ip: 'ip_addressing/p2p-uplinks-ip.j2'
       p2p_uplinks_peer_ip: 'ip_addressing/p2p-uplinks-peer-ip.j2'
       vtep_ip_mlag: 'ip_addressing/vtep-ip-mlag.j2'

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/network-services-v4.0.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/network-services-v4.0.md
@@ -144,6 +144,12 @@ svi_profiles:
         # "vrf_id" is preferred over "vrf_vni" for MLAG IBGP peering vlan, see "mlag_ibgp_peering_vrfs.base_vlan" for details
         vrf_id: < 1-1024 >
 
+        # MLAG IBGP Peering IPv4 Pool | Optional
+        # The subnet used for iBGP peering in the VRF.
+        # Each MLAG pair will be assigned a subnet based on the ID of the primary MLAG switch
+        # If not set, "mlag_peer_l3_ipv4_pool" or "mlag_peer_ipv4_pool" will be used
+        mlag_ibgp_peering_ipv4_pool: < IPv4_address/Mask >
+
         # IP Helper for DHCP relay
         ip_helpers:
           - ip_helper: < IPv4 dhcp server IP >

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
@@ -171,6 +171,12 @@ svi_profiles:
         # "vrf_id" is preferred over "vrf_vni" for MLAG IBGP peering vlan, see "mlag_ibgp_peering_vrfs.base_vlan" for details
         vrf_id: < 1-1024 >
 
+        # MLAG IBGP Peering IPv4 Pool | Optional
+        # The subnet used for iBGP peering in the VRF.
+        # Each MLAG pair will be assigned a subnet based on the ID of the primary MLAG switch
+        # If not set, "mlag_peer_l3_ipv4_pool" or "mlag_peer_ipv4_pool" will be used
+        mlag_ibgp_peering_ipv4_pool: < IPv4_address/Mask >
+
         # IP Helper for DHCP relay
         ip_helpers:
           < IPv4 dhcp server IP >:

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/ip_addressing/mlag-ibgp-peering-ip-primary.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/ip_addressing/mlag-ibgp-peering-ip-primary.j2
@@ -1,0 +1,1 @@
+{% set mlag_ibgp_peering_ip.ip = vrf.mlag_ibgp_peering_ipv4_pool | ansible.netcommon.ipaddr('subnet') | ansible.netcommon.ipmath((switch.mlag_switch_ids.primary - 1) * 2) %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/ip_addressing/mlag-ibgp-peering-ip-primary.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/ip_addressing/mlag-ibgp-peering-ip-primary.j2
@@ -1,1 +1,1 @@
-{% set mlag_ibgp_peering_ip.ip = vrf.mlag_ibgp_peering_ipv4_pool | ansible.netcommon.ipaddr('subnet') | ansible.netcommon.ipmath((switch.mlag_switch_ids.primary - 1) * 2) %}
+{{ vrf.mlag_ibgp_peering_ipv4_pool | ansible.netcommon.ipaddr('subnet') | ansible.netcommon.ipmath((switch.mlag_switch_ids.primary - 1) * 2) }}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/ip_addressing/mlag-ibgp-peering-ip-secondary.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/ip_addressing/mlag-ibgp-peering-ip-secondary.j2
@@ -1,1 +1,1 @@
-{% set mlag_ibgp_peering_ip.ip = vrf.mlag_ibgp_peering_ipv4_pool | ansible.netcommon.ipaddr('subnet') | ansible.netcommon.ipmath(((switch.mlag_switch_ids.primary - 1) * 2) + 1) %}
+{{ vrf.mlag_ibgp_peering_ipv4_pool | ansible.netcommon.ipaddr('subnet') | ansible.netcommon.ipmath(((switch.mlag_switch_ids.primary - 1) * 2) + 1) }}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/ip_addressing/mlag-ibgp-peering-ip-secondary.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/ip_addressing/mlag-ibgp-peering-ip-secondary.j2
@@ -1,1 +1,1 @@
-{% set mlag_ibgp_peering_ip.peer_ip = vrf.mlag_ibgp_peering_ipv4_pool | ansible.netcommon.ipaddr('subnet') | ansible.netcommon.ipmath((switch.mlag_switch_ids.secondary - 1) * 2) %}
+{% set mlag_ibgp_peering_ip.ip = vrf.mlag_ibgp_peering_ipv4_pool | ansible.netcommon.ipaddr('subnet') | ansible.netcommon.ipmath(((switch.mlag_switch_ids.primary - 1) * 2) + 1) %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/ip_addressing/mlag-ibgp-peering-ip-secondary.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/ip_addressing/mlag-ibgp-peering-ip-secondary.j2
@@ -1,0 +1,1 @@
+{% set mlag_ibgp_peering_ip.peer_ip = vrf.mlag_ibgp_peering_ipv4_pool | ansible.netcommon.ipaddr('subnet') | ansible.netcommon.ipmath((switch.mlag_switch_ids.secondary - 1) * 2) %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-vrfs.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-vrfs.j2
@@ -69,9 +69,13 @@
 {%                     if configure_mlag_ibgp_peering %}
 {%                         if vrf.mlag_ibgp_peering_ipv4_pool is arista.avd.defined %}
 {%                             set mlag_ibgp_peering_ip = namespace() %}
-{%                             include switch.ip_addressing.mlag_ibgp_peering_ip_secondary %}
+{%                             if switch.mlag_role == 'primary' %}
+{%                                 include switch.ip_addressing.mlag_ibgp_peering_ip_secondary %}
+{%                             else %}
+{%                                 include switch.ip_addressing.mlag_ibgp_peering_ip_primary %}
+{%                             endif %}
 {%                         endif %}
-        {{ mlag_ibgp_peering_ip.peer_ip | arista.avd.default(switch.mlag_peer_l3_ip, switch.mlag_peer_ip) }}:
+        {{ mlag_ibgp_peering_ip.ip | arista.avd.default(switch.mlag_peer_l3_ip, switch.mlag_peer_ip) }}:
           peer_group: {{ switch.bgp_peer_groups.mlag_ipv4_underlay_peer.name }}
 {%                     endif %}
 {%                     for bgp_peer in vrf.bgp_peers %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-vrfs.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-vrfs.j2
@@ -68,14 +68,14 @@
       neighbors:
 {%                     if configure_mlag_ibgp_peering %}
 {%                         if vrf.mlag_ibgp_peering_ipv4_pool is arista.avd.defined %}
-{%                             set mlag_ibgp_peering_ip = namespace() %}
 {%                             if switch.mlag_role == 'primary' %}
-{%                                 include switch.ip_addressing.mlag_ibgp_peering_ip_secondary %}
+        "{% include switch.ip_addressing.mlag_ibgp_peering_ip_secondary %}":
 {%                             else %}
-{%                                 include switch.ip_addressing.mlag_ibgp_peering_ip_primary %}
+        "{% include switch.ip_addressing.mlag_ibgp_peering_ip_primary %}":
 {%                             endif %}
+{%                         else %}
+        {{ switch.mlag_peer_l3_ip | arista.avd.default(switch.mlag_peer_ip) }}:
 {%                         endif %}
-        {{ mlag_ibgp_peering_ip.ip | arista.avd.default(switch.mlag_peer_l3_ip, switch.mlag_peer_ip) }}:
           peer_group: {{ switch.bgp_peer_groups.mlag_ipv4_underlay_peer.name }}
 {%                     endif %}
 {%                     for bgp_peer in vrf.bgp_peers %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-vrfs.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-vrfs.j2
@@ -67,7 +67,11 @@
 {%                     endif %}
       neighbors:
 {%                     if configure_mlag_ibgp_peering %}
-        {{ switch.mlag_peer_l3_ip | arista.avd.default(switch.mlag_peer_ip) }}:
+{%                         if vrf.mlag_ibgp_peering_ipv4_pool is arista.avd.defined %}
+{%                             set mlag_ibgp_peering_ip = namespace() %}
+{%                             include switch.ip_addressing.mlag_ibgp_peering_ip_secondary %}
+{%                         endif %}
+        {{ mlag_ibgp_peering_ip.peer_ip | arista.avd.default(switch.mlag_peer_l3_ip, switch.mlag_peer_ip) }}:
           peer_group: {{ switch.bgp_peer_groups.mlag_ipv4_underlay_peer.name }}
 {%                     endif %}
 {%                     for bgp_peer in vrf.bgp_peers %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vlan-interfaces.j2
@@ -138,7 +138,11 @@ vlan_interfaces:
 {%                 if vrf.name != 'default' %}
 {%                     if vrf.mlag_ibgp_peering_ipv4_pool is arista.avd.defined %}
 {%                         set mlag_ibgp_peering_ip = namespace() %}
-{%                         include switch.ip_addressing.mlag_ibgp_peering_ip_primary %}
+{%                         if switch.mlag_role == 'primary' %}
+{%                             include switch.ip_addressing.mlag_ibgp_peering_ip_primary %}
+{%                         else %}
+{%                             include switch.ip_addressing.mlag_ibgp_peering_ip_secondary %}
+{%                         endif %}
 {%                     endif %}
   Vlan{{ vrf.mlag_ibgp_peering_vlan | arista.avd.default(mlag_ibgp_peering_vrfs.base_vlan + (vrf_id_int - 1)) }}:
     tenant: {{ tenant.name }}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vlan-interfaces.j2
@@ -136,14 +136,6 @@ vlan_interfaces:
 {%             if configure_mlag_ibgp_peering %}
 {%                 set vrf_id_int = vrf.vrf_id | arista.avd.default(vrf.vrf_vni) | int %}
 {%                 if vrf.name != 'default' %}
-{%                     if vrf.mlag_ibgp_peering_ipv4_pool is arista.avd.defined %}
-{%                         set mlag_ibgp_peering_ip = namespace() %}
-{%                         if switch.mlag_role == 'primary' %}
-{%                             include switch.ip_addressing.mlag_ibgp_peering_ip_primary %}
-{%                         else %}
-{%                             include switch.ip_addressing.mlag_ibgp_peering_ip_secondary %}
-{%                         endif %}
-{%                     endif %}
   Vlan{{ vrf.mlag_ibgp_peering_vlan | arista.avd.default(mlag_ibgp_peering_vrfs.base_vlan + (vrf_id_int - 1)) }}:
     tenant: {{ tenant.name }}
     type: underlay_peering
@@ -152,8 +144,14 @@ vlan_interfaces:
     vrf: {{ vrf.name }}
 {%                     if underlay_rfc5549 is arista.avd.defined(true) and overlay_mlag_rfc5549 is arista.avd.defined(true) %}
     ipv6_enable: true
+{%                     elif vrf.mlag_ibgp_peering_ipv4_pool is arista.avd.defined %}
+{%                         if switch.mlag_role == 'primary' %}
+    ip_address: "{% include switch.ip_addressing.mlag_ibgp_peering_ip_primary %}/31"
+{%                         else %}
+    ip_address: "{% include switch.ip_addressing.mlag_ibgp_peering_ip_secondary %}/31"
+{%                         endif %}
 {%                     else %}
-    ip_address: {{ mlag_ibgp_peering_ip.ip | arista.avd.default(switch.mlag_l3_ip, switch.mlag_ip) }}/31
+    ip_address: {{ switch.mlag_l3_ip | arista.avd.default(switch.mlag_ip) }}/31
 {%                     endif %}
     mtu: {{ p2p_uplinks_mtu }}
 {%                 endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vlan-interfaces.j2
@@ -136,6 +136,10 @@ vlan_interfaces:
 {%             if configure_mlag_ibgp_peering %}
 {%                 set vrf_id_int = vrf.vrf_id | arista.avd.default(vrf.vrf_vni) | int %}
 {%                 if vrf.name != 'default' %}
+{%                     if vrf.mlag_ibgp_peering_ipv4_pool is arista.avd.defined %}
+{%                         set mlag_ibgp_peering_ip = namespace() %}
+{%                         include switch.ip_addressing.mlag_ibgp_peering_ip_primary %}
+{%                     endif %}
   Vlan{{ vrf.mlag_ibgp_peering_vlan | arista.avd.default(mlag_ibgp_peering_vrfs.base_vlan + (vrf_id_int - 1)) }}:
     tenant: {{ tenant.name }}
     type: underlay_peering
@@ -145,7 +149,7 @@ vlan_interfaces:
 {%                     if underlay_rfc5549 is arista.avd.defined(true) and overlay_mlag_rfc5549 is arista.avd.defined(true) %}
     ipv6_enable: true
 {%                     else %}
-    ip_address: {{ switch.mlag_l3_ip | arista.avd.default(switch.mlag_ip) }}/31
+    ip_address: {{ mlag_ibgp_peering_ip.ip | arista.avd.default(switch.mlag_l3_ip, switch.mlag_ip) }}/31
 {%                     endif %}
     mtu: {{ p2p_uplinks_mtu }}
 {%                 endif %}


### PR DESCRIPTION
## Change Summary

Support to add user defined ip for mlag ibgp peering.

## Related Issue(s)

Fixes #1797 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

Add knob (mlag_ibgp_peering_ipv4_pool) which works on both new and old data-models:

1) Old
```yaml
tenants:
  <tenant1>:
    vrfs:
      <vrf1>:
        mlag_ibgp_peering_ipv4_pool: < IPv4address/Mask | default -> mlag_l3_ip -> mlag_ip >
```

2) New
```yaml
tenants:
  - name: < tenant1 >
    vrfs:
      - name: <vrf1>
        mlag_ibgp_peering_ipv4_pool: < IPv4address/Mask | default -> mlag_l3_ip -> mlag_ip >
```
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test

molecule converge -s eos_designs_unit_tests
molecule converge -s eos_designs_unit_testsv4.0

Optional: make refresh-facts

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

- [x] eos_designs_unit_tests and eos_designs_unit_testsv4.0 artifacts should be same

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
