### PR TITLE
Feat(eos_cli_config_gen): Add sflow interface disable default command

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/sflow.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/sflow.md
@@ -70,6 +70,8 @@ sFlow Sample Rate: 1000
 
 sFlow is enabled.
 
+sFlow is disabled in all interfaces per default.
+
 sFlow hardware acceleration is enabled.
 
 sFlow hardware accelerated Sample Rate: 1024
@@ -98,6 +100,7 @@ sflow destination 10.6.75.61
 sflow destination 10.6.75.62 123
 sflow source-interface Management0
 sflow run
+sflow interface disable default
 sflow hardware acceleration
 sflow hardware acceleration sample 1024
 sflow hardware acceleration module Linecard1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/sflow.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/sflow.md
@@ -70,7 +70,7 @@ sFlow Sample Rate: 1000
 
 sFlow is enabled.
 
-sFlow is disabled in all interfaces per default.
+sFlow is disabled on all interfaces by default.
 
 sFlow hardware acceleration is enabled.
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/sflow.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/sflow.cfg
@@ -16,6 +16,7 @@ sflow destination 10.6.75.61
 sflow destination 10.6.75.62 123
 sflow source-interface Management0
 sflow run
+sflow interface disable default
 sflow hardware acceleration
 sflow hardware acceleration sample 1024
 sflow hardware acceleration module Linecard1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/sflow.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/sflow.yml
@@ -24,6 +24,9 @@ sflow:
   sample: 1000
   dangerous: true
   run: true
+  interface:
+    disable:
+      default: true
   hardware_acceleration:
     enabled: true
     sample: 1024

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -2388,6 +2388,9 @@ sflow:
       port: < port_number >
     < sflow_destination_ip_2 >:
   source_interface: < source_interface >
+  interface:
+    disable:
+      default: < true | false >
   run: < true | false >
   hardware_acceleration:
     enabled: < true | false >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/sflow.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/sflow.j2
@@ -43,7 +43,7 @@ sFlow is disabled.
 {%     endif %}
 {%     if sflow.interface.disable.default is arista.avd.defined(true) %}
 
-sFlow is disabled in all interfaces per default.
+sFlow is disabled on all interfaces per default.
 {%     endif %}
 {%     if sflow.hardware_acceleration.enabled is arista.avd.defined(true) %}
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/sflow.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/sflow.j2
@@ -41,6 +41,10 @@ sFlow is enabled.
 
 sFlow is disabled.
 {%     endif %}
+{%     if sflow.interface.disable.default is arista.avd.defined(true) %}
+
+sFlow is disabled in all interfaces per default.
+{%     endif %}
 {%     if sflow.hardware_acceleration.enabled is arista.avd.defined(true) %}
 
 sFlow hardware acceleration is enabled.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/sflow.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/sflow.j2
@@ -43,7 +43,7 @@ sFlow is disabled.
 {%     endif %}
 {%     if sflow.interface.disable.default is arista.avd.defined(true) %}
 
-sFlow is disabled on all interfaces per default.
+sFlow is disabled on all interfaces by default.
 {%     endif %}
 {%     if sflow.hardware_acceleration.enabled is arista.avd.defined(true) %}
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/sflow.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/sflow.j2
@@ -34,6 +34,9 @@ sflow source-interface {{ sflow.source_interface }}
 {%     if sflow.run is arista.avd.defined(true) %}
 sflow run
 {%     endif %}
+{%     if sflow.interface.disable.default is arista.avd.defined(true) %}
+sflow interface disable default
+{%     endif %}
 {%     if sflow.hardware_acceleration.enabled is arista.avd.defined(true) %}
 sflow hardware acceleration
 {%     endif %}


### PR DESCRIPTION
Fixes #1820

## Change Summary

Adding a new variable in sflow data model to support the command. 

```
sflow:
  interface:
    disable:
      default: < true | false >
```

## Related Issue(s)

Fixes #1820 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Add a new variable and the corresponding command and documentation.

## How to test
molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
