### PR TITLE
Feat(eos_designs): Relax requirement of node-specific configuration

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/device.with.dots.in.hostname.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/device.with.dots.in.hostname.yml
@@ -1,9 +1,8 @@
 ---
 type: spine
 spine:
-  nodes:
-    device.with.dots.in.hostname:
-      id: 1
-      loopback_ipv4_pool: 1.2.3.4/24
-      bgp_as: 1234
+  defaults:
+    id: 1
+    loopback_ipv4_pool: 1.2.3.4/24
+    bgp_as: 1234
 mgmt_gateway: 192.168.0.1

--- a/ansible_collections/arista/avd/plugins/module_utils/eos_designs_facts.py
+++ b/ansible_collections/arista/avd/plugins/module_utils/eos_designs_facts.py
@@ -316,13 +316,13 @@ class EosDesignsFacts:
             combined : dict
                 Combined configuration after inheritance from all levels
         """
-        switch_data = {}
+        switch_data = {'node_group': {}}
+        node_config = {}
         hostname = self.hostname
         node_type_config = get(self._hostvars, f"{self.node_type_key}", required=True)
 
         if hostname in node_type_config.get('nodes', {}):
             node_config = node_type_config['nodes'][hostname]
-            switch_data['node_group'] = {}
         else:
             for node_group in node_type_config.get('node_groups', {}):
                 if hostname in node_type_config['node_groups'][node_group].get('nodes', {}):
@@ -330,9 +330,6 @@ class EosDesignsFacts:
                     switch_data['node_group'] = node_type_config['node_groups'][node_group]
                     switch_data['group'] = node_group
                     break
-
-        if not node_config:
-            raise AristaAvdMissingVariableError(f"{self.node_type_key}.(node_groups.)nodes.{hostname}")
 
         # Load defaults
         defaults_config = node_type_config.get('defaults', {})


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Relax requirement of node-specific configuration

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

Currently all nodes must be defined under `nodes`. Ex for a l3leaf:
```
l3leaf:
  nodes:
    MY-L3LEAF-123:
      id: 123
      mgmt_ip: 10.20.30.40/24
```
or
```
l3leaf:
  node_groups:
    MY_NODE_GROUP:
      nodes:
        MY-L3LEAF-123:
          id: 123
          mgmt_ip: 10.20.30.40/24
```

With this PR we relax this requirement, so all the node vars can be set on any level. Ex.
```
l3leaf:
  defaults:
    id: 123
    mgmt_ip: 10.20.30.40/24
```

This is useful when the inventory is using in-line jinja or if the inventory is created from external scripts/roles setting host_vars per device.
Ex:
```
l3leaf:
  defaults:
    id: {{ inventory_hostname | split('-') | last }}
    mgmt_ip: {{ lookup('my_ipam', inventory_hostname, 'mgmt_ip') }}
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Moved topology vars defined in hostvars to `defaults` for one host. Failed before this change, but is accepted with no changes to output.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
