### PR TITLE
Doc(eos_cli_config_gen): Improve documentation for router_general

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -2804,6 +2804,10 @@ ip_routing_ipv6_interfaces: < true | false >
 
 ```yaml
 router_general:
+  router_id:
+    ipv4: < IPv4_address >
+    ipv6: < IPv6_address >
+  nexthop_fast_failover: < true | false | default -> false >
   vrfs:
     < destination-vrf >:
       leak_routes:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
@@ -2490,6 +2490,10 @@ ip_routing_ipv6_interfaces: < true | false >
 
 ```yaml
 router_general:
+  router_id:
+    ipv4: < IPv4_address >
+    ipv6: < IPv6_address >
+  nexthop_fast_failover: < true | false | default -> false >
   vrfs:
     - name: < destination-vrf >
       leak_routes:


### PR DESCRIPTION
## Change Summary

The following knobs have been implemented by PR #1495 but not documented in README

This PR fixes this

## Related Issue(s)

Fixes #1828 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Adding

```yaml
router_general:
  router_id:
    ipv4: < IPv4_address >
    ipv6: < IPv6_address >
  nexthop_fast_failover: < true | false | default -> false >
```

in README.md and README_v4.0.md

## How to test

Tests are already in place, only doc was missing

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
