### PR TITLE
Feat(eos_cli_config_gen): Add support for OSPF BFD sessions for adjacencies in any state

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
@@ -188,15 +188,15 @@ interface Vlan24
 
 ### Router OSPF Summary
 
-| Process ID | Router ID | Default Passive Interface | No Passive Interface | BFD | Max LSA | Default Information Originate | Log Adjacency Changes Detail | Auto Cost Reference Bandwidth | Maximum Paths | MPLS LDP Sync Default | Distribute List In |
-| ---------- | --------- | ------------------------- | -------------------- | --- | ------- | ----------------------------- | ---------------------------- | ----------------------------- | ------------- | --------------------- | ------------------ |
-| 100 | 192.168.255.3 | enabled | Ethernet1 <br> Ethernet2 <br> Vlan4093 <br> | enabled | 12000 | disabled | disabled | 100 | 10 | True | route-map RM-OSPF-DIST-IN |
-| 101 | 1.0.1.1 | enabled | Ethernet2.101 <br> | disabled | default | disabled | enabled | - | - | - | - |
-| 200 | 192.168.254.1 | disabled |- | disabled | 5 | Always | enabled | - | - | - | - |
-| 300 | - | disabled |- | disabled | default | disabled | disabled | - | - | - | - |
-| 400 | - | disabled |- | disabled | default | disabled | disabled | - | - | - | - |
-| 500 | - | disabled |- | disabled | default | disabled | disabled | - | - | - | - |
-| 600 | - | disabled |- | disabled | default | disabled | disabled | - | - | - | - |
+| Process ID | Router ID | Default Passive Interface | No Passive Interface | BFD | BFD Any | Max LSA | Default Information Originate | Log Adjacency Changes Detail | Auto Cost Reference Bandwidth | Maximum Paths | MPLS LDP Sync Default | Distribute List In |
+| ---------- | --------- | ------------------------- | -------------------- | --- | ------- | ------- |----------------------------- | ---------------------------- | ----------------------------- | ------------- | --------------------- | ------------------ |
+| 100 | 192.168.255.3 | enabled | Ethernet1 <br> Ethernet2 <br> Vlan4093 <br> | enabled | enabled | 12000 | disabled | disabled | 100 | 10 | True | route-map RM-OSPF-DIST-IN |
+| 101 | 1.0.1.1 | enabled | Ethernet2.101 <br> | disabled | disabled | default | disabled | enabled | - | - | - | - |
+| 200 | 192.168.254.1 | disabled |- | disabled | disabled | 5 | Always | enabled | - | - | - | - |
+| 300 | - | disabled |- | disabled | disabled | default | disabled | disabled | - | - | - | - |
+| 400 | - | disabled |- | disabled | disabled | default | disabled | disabled | - | - | - | - |
+| 500 | - | disabled |- | disabled | disabled | default | disabled | disabled | - | - | - | - |
+| 600 | - | disabled |- | disabled | disabled | default | disabled | disabled | - | - | - | - |
 
 ### Router OSPF Distance
 
@@ -280,6 +280,7 @@ router ospf 100
    network 198.51.100.0/24 area 0.0.0.1
    network 203.0.113.0/24 area 0.0.0.2
    bfd default
+   bfd adjacency state any
    distribute-list route-map RM-OSPF-DIST-IN in
    max-lsa 12000
    default-information originate

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
@@ -188,15 +188,15 @@ interface Vlan24
 
 ### Router OSPF Summary
 
-| Process ID | Router ID | Default Passive Interface | No Passive Interface | BFD | BFD Any | Max LSA | Default Information Originate | Log Adjacency Changes Detail | Auto Cost Reference Bandwidth | Maximum Paths | MPLS LDP Sync Default | Distribute List In |
-| ---------- | --------- | ------------------------- | -------------------- | --- | ------- | ------- |----------------------------- | ---------------------------- | ----------------------------- | ------------- | --------------------- | ------------------ |
-| 100 | 192.168.255.3 | enabled | Ethernet1 <br> Ethernet2 <br> Vlan4093 <br> | enabled | enabled | 12000 | disabled | disabled | 100 | 10 | True | route-map RM-OSPF-DIST-IN |
-| 101 | 1.0.1.1 | enabled | Ethernet2.101 <br> | disabled | disabled | default | disabled | enabled | - | - | - | - |
-| 200 | 192.168.254.1 | disabled |- | disabled | disabled | 5 | Always | enabled | - | - | - | - |
-| 300 | - | disabled |- | disabled | disabled | default | disabled | disabled | - | - | - | - |
-| 400 | - | disabled |- | disabled | disabled | default | disabled | disabled | - | - | - | - |
-| 500 | - | disabled |- | disabled | disabled | default | disabled | disabled | - | - | - | - |
-| 600 | - | disabled |- | disabled | disabled | default | disabled | disabled | - | - | - | - |
+| Process ID | Router ID | Default Passive Interface | No Passive Interface | BFD | Max LSA | Default Information Originate | Log Adjacency Changes Detail | Auto Cost Reference Bandwidth | Maximum Paths | MPLS LDP Sync Default | Distribute List In |
+| ---------- | --------- | ------------------------- | -------------------- | --- | ------- | ----------------------------- | ---------------------------- | ----------------------------- | ------------- | --------------------- | ------------------ |
+| 100 | 192.168.255.3 | enabled | Ethernet1 <br> Ethernet2 <br> Vlan4093 <br> | enabled<br>(any state) | 12000 | disabled | disabled | 100 | 10 | True | route-map RM-OSPF-DIST-IN |
+| 101 | 1.0.1.1 | enabled | Ethernet2.101 <br> | disabled | default | disabled | enabled | - | - | - | - |
+| 200 | 192.168.254.1 | disabled |- | disabled | 5 | Always | enabled | - | - | - | - |
+| 300 | - | disabled |- | disabled | default | disabled | disabled | - | - | - | - |
+| 400 | - | disabled |- | disabled | default | disabled | disabled | - | - | - | - |
+| 500 | - | disabled |- | disabled | default | disabled | disabled | - | - | - | - |
+| 600 | - | disabled |- | disabled | default | disabled | disabled | - | - | - | - |
 
 ### Router OSPF Distance
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-ospf.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-ospf.cfg
@@ -50,6 +50,7 @@ router ospf 100
    network 198.51.100.0/24 area 0.0.0.1
    network 203.0.113.0/24 area 0.0.0.2
    bfd default
+   bfd adjacency state any
    distribute-list route-map RM-OSPF-DIST-IN in
    max-lsa 12000
    default-information originate

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-ospf.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-ospf.yml
@@ -15,7 +15,6 @@ router_ospf:
           area: 0.0.0.2
       bfd_enable: true
       bfd_adjacency_state_any: true
-
       max_lsa: 12000
       default_information_originate:
       redistribute:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-ospf.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-ospf.yml
@@ -14,6 +14,8 @@ router_ospf:
         203.0.113.0/24:
           area: 0.0.0.2
       bfd_enable: true
+      bfd_adjacency_state_any: true
+
       max_lsa: 12000
       default_information_originate:
       redistribute:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -3349,6 +3349,7 @@ router_ospf:
         < IPv4 subnet / netmask >:
           area: < area >
       bfd_enable: < true | false >
+      bfd_adjacency_state_any: < true | false >
       no_passive_interfaces:
         - < interface_1 >
         - < interface_2 >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-ospf.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-ospf.j2
@@ -4,8 +4,8 @@
 
 ### Router OSPF Summary
 
-| Process ID | Router ID | Default Passive Interface | No Passive Interface | BFD | Max LSA | Default Information Originate | Log Adjacency Changes Detail | Auto Cost Reference Bandwidth | Maximum Paths | MPLS LDP Sync Default | Distribute List In |
-| ---------- | --------- | ------------------------- | -------------------- | --- | ------- | ----------------------------- | ---------------------------- | ----------------------------- | ------------- | --------------------- | ------------------ |
+| Process ID | Router ID | Default Passive Interface | No Passive Interface | BFD | BFD Any | Max LSA | Default Information Originate | Log Adjacency Changes Detail | Auto Cost Reference Bandwidth | Maximum Paths | MPLS LDP Sync Default | Distribute List In |
+| ---------- | --------- | ------------------------- | -------------------- | --- | ------- | ------- |----------------------------- | ---------------------------- | ----------------------------- | ------------- | --------------------- | ------------------ |
 {%     for process_id in router_ospf.process_ids | arista.avd.convert_dicts('id') | arista.avd.natural_sort('id') %}
 {%         set router_id = process_id.router_id | arista.avd.default ('-') %}
 {%         if process_id.passive_interface_default is arista.avd.defined(true) %}
@@ -26,6 +26,11 @@
 {%             set bfd_enable = 'enabled' %}
 {%         else %}
 {%             set bfd_enable = 'disabled' %}
+{%         endif %}
+{%         if process_id.bfd_adjacency_state_any is arista.avd.defined(true) %}
+{%             set bfd_any = 'enabled' %}
+{%         else %}
+{%             set bfd_any = 'disabled' %}
 {%         endif %}
 {%         set max_lsa = process_id.max_lsa | arista.avd.default('default') %}
 {%         if process_id.default_information_originate is arista.avd.defined %}
@@ -50,7 +55,7 @@
 {%         else %}
 {%             set distribute_list_in = '-' %}
 {%         endif %}
-| {{ process_id.id }} | {{ router_id }} | {{ passive_interface_default }} |{{ no_passive_interfaces.list }} | {{ bfd_enable }} | {{ max_lsa }} | {{ default_information_originate }} | {{ log_adjacency_changes_detail }} | {{ auto_cost_reference_bandwidth }} | {{ maximum_paths }} | {{ mpls_ldp_sync_default }} | {{ distribute_list_in }} |
+| {{ process_id.id }} | {{ router_id }} | {{ passive_interface_default }} |{{ no_passive_interfaces.list }} | {{ bfd_enable }} | {{ bfd_any }} | {{ max_lsa }} | {{ default_information_originate }} | {{ log_adjacency_changes_detail }} | {{ auto_cost_reference_bandwidth }} | {{ maximum_paths }} | {{ mpls_ldp_sync_default }} | {{ distribute_list_in }} |
 {%     endfor %}
 {# OSPF Distance #}
 {%     set ospf_distance_process_ids = [] %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-ospf.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-ospf.j2
@@ -25,7 +25,7 @@
 {%         if process_id.bfd_enable is arista.avd.defined(true) %}
 {%             set bfd_enable = 'enabled' %}
 {%             if process_id.bfd_adjacency_state_any is arista.avd.defined(true) %}
-{%                  set bfd_enable = bfd_enable ~ '<br>(any state)' %}
+{%                 set bfd_enable = bfd_enable ~ '<br>(any state)' %}
 {%             endif %}
 {%         else %}
 {%             set bfd_enable = 'disabled' %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-ospf.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-ospf.j2
@@ -4,8 +4,8 @@
 
 ### Router OSPF Summary
 
-| Process ID | Router ID | Default Passive Interface | No Passive Interface | BFD | BFD Any | Max LSA | Default Information Originate | Log Adjacency Changes Detail | Auto Cost Reference Bandwidth | Maximum Paths | MPLS LDP Sync Default | Distribute List In |
-| ---------- | --------- | ------------------------- | -------------------- | --- | ------- | ------- |----------------------------- | ---------------------------- | ----------------------------- | ------------- | --------------------- | ------------------ |
+| Process ID | Router ID | Default Passive Interface | No Passive Interface | BFD | Max LSA | Default Information Originate | Log Adjacency Changes Detail | Auto Cost Reference Bandwidth | Maximum Paths | MPLS LDP Sync Default | Distribute List In |
+| ---------- | --------- | ------------------------- | -------------------- | --- | ------- | ----------------------------- | ---------------------------- | ----------------------------- | ------------- | --------------------- | ------------------ |
 {%     for process_id in router_ospf.process_ids | arista.avd.convert_dicts('id') | arista.avd.natural_sort('id') %}
 {%         set router_id = process_id.router_id | arista.avd.default ('-') %}
 {%         if process_id.passive_interface_default is arista.avd.defined(true) %}
@@ -24,13 +24,11 @@
 {%         endif %}
 {%         if process_id.bfd_enable is arista.avd.defined(true) %}
 {%             set bfd_enable = 'enabled' %}
+{%             if process_id.bfd_adjacency_state_any is arista.avd.defined(true) %}
+{%                  set bfd_enable = bfd_enable ~ '<br>(any state)' %}
+{%             endif %}
 {%         else %}
 {%             set bfd_enable = 'disabled' %}
-{%         endif %}
-{%         if process_id.bfd_adjacency_state_any is arista.avd.defined(true) %}
-{%             set bfd_any = 'enabled' %}
-{%         else %}
-{%             set bfd_any = 'disabled' %}
 {%         endif %}
 {%         set max_lsa = process_id.max_lsa | arista.avd.default('default') %}
 {%         if process_id.default_information_originate is arista.avd.defined %}
@@ -55,7 +53,7 @@
 {%         else %}
 {%             set distribute_list_in = '-' %}
 {%         endif %}
-| {{ process_id.id }} | {{ router_id }} | {{ passive_interface_default }} |{{ no_passive_interfaces.list }} | {{ bfd_enable }} | {{ bfd_any }} | {{ max_lsa }} | {{ default_information_originate }} | {{ log_adjacency_changes_detail }} | {{ auto_cost_reference_bandwidth }} | {{ maximum_paths }} | {{ mpls_ldp_sync_default }} | {{ distribute_list_in }} |
+| {{ process_id.id }} | {{ router_id }} | {{ passive_interface_default }} |{{ no_passive_interfaces.list }} | {{ bfd_enable }} | {{ max_lsa }} | {{ default_information_originate }} | {{ log_adjacency_changes_detail }} | {{ auto_cost_reference_bandwidth }} | {{ maximum_paths }} | {{ mpls_ldp_sync_default }} | {{ distribute_list_in }} |
 {%     endfor %}
 {# OSPF Distance #}
 {%     set ospf_distance_process_ids = [] %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-ospf.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-ospf.j2
@@ -37,7 +37,7 @@ router ospf {{ process_id.id }}
 {%     if process_id.bfd_enable is arista.avd.defined(true) %}
    bfd default
 {%     endif %}
-{%     if process_id.bfd_adjacency_state_any is arista.avd.defined and process_id.bfd_adjacency_state_any %}
+{%     if process_id.bfd_adjacency_state_any is arista.avd.defined(true) %}
    bfd adjacency state any
 {%     endif %}
 {%     for area in process_id.areas | arista.avd.convert_dicts('id') | arista.avd.natural_sort('id') %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-ospf.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-ospf.j2
@@ -34,11 +34,11 @@ router ospf {{ process_id.id }}
 {%     for network_prefix in process_id.network_prefixes | arista.avd.convert_dicts('ipv4_prefix') | arista.avd.natural_sort('ipv4_prefix') %}
    network {{ network_prefix.ipv4_prefix }} area {{ network_prefix.area }}
 {%     endfor %}
-{%     if process_id.bfd_enable is arista.avd.defined and process_id.bfd_enable %}
+{%     if process_id.bfd_enable is arista.avd.defined(true) %}
    bfd default
-{%         if process_id.bfd_adjacency_state_any is arista.avd.defined and process_id.bfd_adjacency_state_any %}
+{%     endif %}
+{%     if process_id.bfd_adjacency_state_any is arista.avd.defined and process_id.bfd_adjacency_state_any %}
    bfd adjacency state any
-{%         endif %}
 {%     endif %}
 {%     for area in process_id.areas | arista.avd.convert_dicts('id') | arista.avd.natural_sort('id') %}
 {# OSPF stub area configuration #}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-ospf.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-ospf.j2
@@ -36,6 +36,9 @@ router ospf {{ process_id.id }}
 {%     endfor %}
 {%     if process_id.bfd_enable is arista.avd.defined and process_id.bfd_enable %}
    bfd default
+{%         if process_id.bfd_adjacency_state_any is arista.avd.defined and process_id.bfd_adjacency_state_any %}
+   bfd adjacency state any
+{%         endif %}
 {%     endif %}
 {%     for area in process_id.areas | arista.avd.convert_dicts('id') | arista.avd.natural_sort('id') %}
 {# OSPF stub area configuration #}


### PR DESCRIPTION
…encies in any state #1825

## Change Summary

This change adds support for rendering the `bfd adjacency state any` command

## Related Issue(s)

Fixes #1825

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Add support for new key and update the documentation.

Model change:
add the key:
```bfd_adjacency_state_any: true```

## How to test
Tested via molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been rebased from devel before I start
- [X] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [X] My change requires a change to the documentation and documentation have been updated accordingly.
- [X] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
