### PR TITLE
Feat(eos_designs): Support for short_esi: auto in port profiles & use of new eos_cli_config_gen data model

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER1.md
@@ -298,6 +298,17 @@ interface Ethernet8
 | Port-Channel8.222 | - | l2dot1q | 222 | False | 222 | - | - | True | - | - | - |
 | Port-Channel8.333 | - | l2dot1q | 434 | False | 333 | - | - | True | - | - | - |
 
+#### EVPN Multihoming
+
+##### EVPN Multihoming Summary
+
+| Interface | Ethernet Segment Identifier | Multihoming Redundancy Mode | Route Target |
+| --------- | --------------------------- | --------------------------- | ------------ |
+| Port-Channel8 | 0000:0000:0303:0202:0101 | all-active | 03:03:02:02:01:01 |
+| Port-Channel8.111 | 0000:0000:0303:0202:0111 | all-active | 03:03:02:02:01:11 |
+| Port-Channel8.222 | 0000:0000:0303:0202:0222 | all-active | 03:03:02:02:02:22 |
+| Port-Channel8.333 | 0000:0000:0303:0202:0333 | all-active | 03:03:02:02:03:33 |
+
 ### Port-Channel Interfaces Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER2.md
@@ -294,6 +294,17 @@ interface Ethernet8
 | Port-Channel8.222 | - | l2dot1q | 222 | False | 222 | - | - | True | - | - | - |
 | Port-Channel8.333 | - | l2dot1q | 434 | False | 333 | - | - | True | - | - | - |
 
+#### EVPN Multihoming
+
+##### EVPN Multihoming Summary
+
+| Interface | Ethernet Segment Identifier | Multihoming Redundancy Mode | Route Target |
+| --------- | --------------------------- | --------------------------- | ------------ |
+| Port-Channel8 | 0000:0000:0303:0202:0101 | all-active | 03:03:02:02:01:01 |
+| Port-Channel8.111 | 0000:0000:0303:0202:0111 | all-active | 03:03:02:02:01:11 |
+| Port-Channel8.222 | 0000:0000:0303:0202:0222 | all-active | 03:03:02:02:02:22 |
+| Port-Channel8.333 | 0000:0000:0303:0202:0333 | all-active | 03:03:02:02:03:33 |
+
 ### Port-Channel Interfaces Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER1.yml
@@ -272,13 +272,15 @@ port_channel_interfaces:
     description: CPE_TENANT_A_SITE1_EVPN-A-A-PortChannel
     type: routed
     shutdown: false
-    esi: 0000:0000:0303:0202:0101
-    rt: 03:03:02:02:01:01
+    evpn_ethernet_segment:
+      identifier: 0000:0000:0303:0202:0101
+      route_target: 03:03:02:02:01:01
     lacp_id: 0303.0202.0101
   Port-Channel8.111:
     type: l2dot1q
-    esi: 0000:0000:0303:0202:0111
-    rt: 03:03:02:02:01:11
+    evpn_ethernet_segment:
+      identifier: 0000:0000:0303:0202:0111
+      route_target: 03:03:02:02:01:11
     vlan_id: 111
     encapsulation_vlan:
       client:
@@ -288,8 +290,9 @@ port_channel_interfaces:
         client: true
   Port-Channel8.222:
     type: l2dot1q
-    esi: 0000:0000:0303:0202:0222
-    rt: 03:03:02:02:02:22
+    evpn_ethernet_segment:
+      identifier: 0000:0000:0303:0202:0222
+      route_target: 03:03:02:02:02:22
     vlan_id: 222
     encapsulation_vlan:
       client:
@@ -299,8 +302,9 @@ port_channel_interfaces:
         client: true
   Port-Channel8.333:
     type: l2dot1q
-    esi: 0000:0000:0303:0202:0333
-    rt: 03:03:02:02:03:33
+    evpn_ethernet_segment:
+      identifier: 0000:0000:0303:0202:0333
+      route_target: 03:03:02:02:03:33
     vlan_id: 434
     encapsulation_vlan:
       client:

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER2.yml
@@ -301,13 +301,15 @@ port_channel_interfaces:
     description: CPE_TENANT_A_SITE1_EVPN-A-A-PortChannel
     type: routed
     shutdown: false
-    esi: 0000:0000:0303:0202:0101
-    rt: 03:03:02:02:01:01
+    evpn_ethernet_segment:
+      identifier: 0000:0000:0303:0202:0101
+      route_target: 03:03:02:02:01:01
     lacp_id: 0303.0202.0101
   Port-Channel8.111:
     type: l2dot1q
-    esi: 0000:0000:0303:0202:0111
-    rt: 03:03:02:02:01:11
+    evpn_ethernet_segment:
+      identifier: 0000:0000:0303:0202:0111
+      route_target: 03:03:02:02:01:11
     vlan_id: 111
     encapsulation_vlan:
       client:
@@ -317,8 +319,9 @@ port_channel_interfaces:
         client: true
   Port-Channel8.222:
     type: l2dot1q
-    esi: 0000:0000:0303:0202:0222
-    rt: 03:03:02:02:02:22
+    evpn_ethernet_segment:
+      identifier: 0000:0000:0303:0202:0222
+      route_target: 03:03:02:02:02:22
     vlan_id: 222
     encapsulation_vlan:
       client:
@@ -328,8 +331,9 @@ port_channel_interfaces:
         client: true
   Port-Channel8.333:
     type: l2dot1q
-    esi: 0000:0000:0303:0202:0333
-    rt: 03:03:02:02:03:33
+    evpn_ethernet_segment:
+      identifier: 0000:0000:0303:0202:0333
+      route_target: 03:03:02:02:03:33
     vlan_id: 434
     encapsulation_vlan:
       client:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2A.md
@@ -512,6 +512,17 @@ interface Ethernet21
 | Port-Channel14 | DC1_L2LEAF5_Po1 | switched | trunk | 110-112,120-121,130-131,160-161 | - | - | - | - | - | 0000:0000:71da:d362:2084 |
 | Port-Channel20 | FIREWALL01_PortChanne1 | switched | trunk | 110-111,210-211 | - | - | - | - | - | - |
 
+#### EVPN Multihoming
+
+##### EVPN Multihoming Summary
+
+| Interface | Ethernet Segment Identifier | Multihoming Redundancy Mode | Route Target |
+| --------- | --------------------------- | --------------------------- | ------------ |
+| Port-Channel7 | 0000:0000:0808:0707:0606 | all-active | 08:08:07:07:06:06 |
+| Port-Channel9 | 0000:0000:0606:0707:0808 | all-active | 06:06:07:07:08:08 |
+| Port-Channel13 | 0000:0000:a36b:7013:457b | all-active | a3:6b:70:13:45:7b |
+| Port-Channel14 | 0000:0000:71da:d362:2084 | all-active | 71:da:d3:62:20:84 |
+
 ### Port-Channel Interfaces Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2B.md
@@ -512,6 +512,17 @@ interface Ethernet21
 | Port-Channel14 | DC1_L2LEAF5_Po1 | switched | trunk | 110-112,120-121,130-131,160-161 | - | - | - | - | - | 0000:0000:71da:d362:2084 |
 | Port-Channel20 | FIREWALL01_PortChanne1 | switched | trunk | 110-111,210-211 | - | - | - | - | - | - |
 
+#### EVPN Multihoming
+
+##### EVPN Multihoming Summary
+
+| Interface | Ethernet Segment Identifier | Multihoming Redundancy Mode | Route Target |
+| --------- | --------------------------- | --------------------------- | ------------ |
+| Port-Channel7 | 0000:0000:0808:0707:0606 | all-active | 08:08:07:07:06:06 |
+| Port-Channel9 | 0000:0000:0606:0707:0808 | all-active | 06:06:07:07:08:08 |
+| Port-Channel13 | 0000:0000:a36b:7013:457b | all-active | a3:6b:70:13:45:7b |
+| Port-Channel14 | 0000:0000:71da:d362:2084 | all-active | 71:da:d3:62:20:84 |
+
 ### Port-Channel Interfaces Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/MH-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/MH-LEAF1A.md
@@ -291,6 +291,8 @@ vlan 310
 | --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
 | Ethernet10 | server01_ES1_Eth1 | *access | *310 | *- | *- | 10 |
 | Ethernet12 | server03_AUTO_ESI_Eth1 | *access | *310 | *- | *- | 12 |
+| Ethernet13 | server04_AUTO_ESI_Profile_Eth1 | *access | *310 | *- | *- | 13 |
+| Ethernet14 | server05_AUTO_ESI_Profile_Override_Eth1 | *access | *310 | *- | *- | 14 |
 
 *Inherited from Port-Channel Interface
 
@@ -332,6 +334,16 @@ interface Ethernet12
    description server03_AUTO_ESI_Eth1
    no shutdown
    channel-group 12 mode active
+!
+interface Ethernet13
+   description server04_AUTO_ESI_Profile_Eth1
+   no shutdown
+   channel-group 13 mode active
+!
+interface Ethernet14
+   description server05_AUTO_ESI_Profile_Override_Eth1
+   no shutdown
+   channel-group 14 mode active
 ```
 
 ## Port-Channel Interfaces
@@ -344,6 +356,8 @@ interface Ethernet12
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
 | Port-Channel10 | server01_ES1_PortChanne1 | switched | access | 310 | - | - | - | - | - | 0000:0000:0001:1010:1010 |
 | Port-Channel12 | server03_AUTO_ESI_Auto-ESI PortChannel | switched | access | 310 | - | - | - | - | - | 0000:0000:fc87:ae24:2cb3 |
+| Port-Channel13 | server04_AUTO_ESI_Profile_Auto-ESI PortChannel from profile | switched | access | 310 | - | - | - | - | - | 0000:0000:29cc:4043:0a29 |
+| Port-Channel14 | server05_AUTO_ESI_Profile_Override_Auto-ESI PortChannel from profile | switched | access | 310 | - | - | - | - | - | 0000:0000:010a:010a:010a |
 
 #### Flexible Encapsulation Interfaces
 
@@ -354,12 +368,29 @@ interface Ethernet12
 | Port-Channel11.103 | - | l2dot1q | 1103 | False | 2103 | - | - | True | - | - | - |
 | Port-Channel11.104 | - | l2dot1q | 1104 | False | 2104 | - | - | True | - | - | - |
 
+#### EVPN Multihoming
+
+##### EVPN Multihoming Summary
+
+| Interface | Ethernet Segment Identifier | Multihoming Redundancy Mode | Route Target |
+| --------- | --------------------------- | --------------------------- | ------------ |
+| Port-Channel10 | 0000:0000:0001:1010:1010 | all-active | 00:01:10:10:10:10 |
+| Port-Channel11.101 | 0000:0000:0000:0000:0101 | all-active | 00:00:00:00:01:01 |
+| Port-Channel11.102 | 0000:0000:0000:0000:0102 | all-active | 00:00:00:00:01:02 |
+| Port-Channel11.103 | 0000:0000:c2c9:c85a:ed92 | all-active | c2:c9:c8:5a:ed:92 |
+| Port-Channel11.104 | 0000:0000:5c8e:1f50:9fc4 | all-active | 5c:8e:1f:50:9f:c4 |
+| Port-Channel12 | 0000:0000:fc87:ae24:2cb3 | all-active | fc:87:ae:24:2c:b3 |
+| Port-Channel13 | 0000:0000:29cc:4043:0a29 | all-active | 29:cc:40:43:0a:29 |
+| Port-Channel14 | 0000:0000:010a:010a:010a | all-active | 01:0a:01:0a:01:0a |
+
 #### Link Tracking Groups
 
 | Interface | Group Name | Direction |
 | --------- | ---------- | --------- |
 | Port-Channel10 | LT_GROUP1 | downstream |
 | Port-Channel12 | LT_GROUP1 | downstream |
+| Port-Channel13 | LT_GROUP1 | downstream |
+| Port-Channel14 | LT_GROUP1 | downstream |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -422,6 +453,28 @@ interface Port-Channel12
       identifier 0000:0000:fc87:ae24:2cb3
       route-target import fc:87:ae:24:2c:b3
    lacp system-id fc87.ae24.2cb3
+   link tracking group LT_GROUP1 downstream
+!
+interface Port-Channel13
+   description server04_AUTO_ESI_Profile_Auto-ESI PortChannel from profile
+   no shutdown
+   switchport
+   switchport access vlan 310
+   evpn ethernet-segment
+      identifier 0000:0000:29cc:4043:0a29
+      route-target import 29:cc:40:43:0a:29
+   lacp system-id 29cc.4043.0a29
+   link tracking group LT_GROUP1 downstream
+!
+interface Port-Channel14
+   description server05_AUTO_ESI_Profile_Override_Auto-ESI PortChannel from profile
+   no shutdown
+   switchport
+   switchport access vlan 310
+   evpn ethernet-segment
+      identifier 0000:0000:010a:010a:010a
+      route-target import 01:0a:01:0a:01:0a
+   lacp system-id 010a.010a.010a
    link tracking group LT_GROUP1 downstream
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/MH-LEAF1B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/MH-LEAF1B.md
@@ -291,6 +291,8 @@ vlan 310
 | --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
 | Ethernet10 | server01_ES1_Eth2 | *access | *310 | *- | *- | 10 |
 | Ethernet12 | server03_AUTO_ESI_Eth2 | *access | *310 | *- | *- | 12 |
+| Ethernet13 | server04_AUTO_ESI_Profile_Eth2 | *access | *310 | *- | *- | 13 |
+| Ethernet14 | server05_AUTO_ESI_Profile_Override_Eth2 | *access | *310 | *- | *- | 14 |
 
 *Inherited from Port-Channel Interface
 
@@ -332,6 +334,16 @@ interface Ethernet12
    description server03_AUTO_ESI_Eth2
    no shutdown
    channel-group 12 mode active
+!
+interface Ethernet13
+   description server04_AUTO_ESI_Profile_Eth2
+   no shutdown
+   channel-group 13 mode active
+!
+interface Ethernet14
+   description server05_AUTO_ESI_Profile_Override_Eth2
+   no shutdown
+   channel-group 14 mode active
 ```
 
 ## Port-Channel Interfaces
@@ -344,6 +356,8 @@ interface Ethernet12
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
 | Port-Channel10 | server01_ES1_PortChanne1 | switched | access | 310 | - | - | - | - | - | 0000:0000:0001:1010:1010 |
 | Port-Channel12 | server03_AUTO_ESI_Auto-ESI PortChannel | switched | access | 310 | - | - | - | - | - | 0000:0000:fc87:ae24:2cb3 |
+| Port-Channel13 | server04_AUTO_ESI_Profile_Auto-ESI PortChannel from profile | switched | access | 310 | - | - | - | - | - | 0000:0000:29cc:4043:0a29 |
+| Port-Channel14 | server05_AUTO_ESI_Profile_Override_Auto-ESI PortChannel from profile | switched | access | 310 | - | - | - | - | - | 0000:0000:010a:010a:010a |
 
 #### Flexible Encapsulation Interfaces
 
@@ -354,12 +368,29 @@ interface Ethernet12
 | Port-Channel11.103 | - | l2dot1q | 1103 | False | 2103 | - | - | True | - | - | - |
 | Port-Channel11.104 | - | l2dot1q | 1104 | False | 2104 | - | - | True | - | - | - |
 
+#### EVPN Multihoming
+
+##### EVPN Multihoming Summary
+
+| Interface | Ethernet Segment Identifier | Multihoming Redundancy Mode | Route Target |
+| --------- | --------------------------- | --------------------------- | ------------ |
+| Port-Channel10 | 0000:0000:0001:1010:1010 | all-active | 00:01:10:10:10:10 |
+| Port-Channel11.101 | 0000:0000:0000:0000:0101 | all-active | 00:00:00:00:01:01 |
+| Port-Channel11.102 | 0000:0000:0000:0000:0102 | all-active | 00:00:00:00:01:02 |
+| Port-Channel11.103 | 0000:0000:c2c9:c85a:ed92 | all-active | c2:c9:c8:5a:ed:92 |
+| Port-Channel11.104 | 0000:0000:5c8e:1f50:9fc4 | all-active | 5c:8e:1f:50:9f:c4 |
+| Port-Channel12 | 0000:0000:fc87:ae24:2cb3 | all-active | fc:87:ae:24:2c:b3 |
+| Port-Channel13 | 0000:0000:29cc:4043:0a29 | all-active | 29:cc:40:43:0a:29 |
+| Port-Channel14 | 0000:0000:010a:010a:010a | all-active | 01:0a:01:0a:01:0a |
+
 #### Link Tracking Groups
 
 | Interface | Group Name | Direction |
 | --------- | ---------- | --------- |
 | Port-Channel10 | LT_GROUP1 | downstream |
 | Port-Channel12 | LT_GROUP1 | downstream |
+| Port-Channel13 | LT_GROUP1 | downstream |
+| Port-Channel14 | LT_GROUP1 | downstream |
 
 ### Port-Channel Interfaces Device Configuration
 
@@ -422,6 +453,28 @@ interface Port-Channel12
       identifier 0000:0000:fc87:ae24:2cb3
       route-target import fc:87:ae:24:2c:b3
    lacp system-id fc87.ae24.2cb3
+   link tracking group LT_GROUP1 downstream
+!
+interface Port-Channel13
+   description server04_AUTO_ESI_Profile_Auto-ESI PortChannel from profile
+   no shutdown
+   switchport
+   switchport access vlan 310
+   evpn ethernet-segment
+      identifier 0000:0000:29cc:4043:0a29
+      route-target import 29:cc:40:43:0a:29
+   lacp system-id 29cc.4043.0a29
+   link tracking group LT_GROUP1 downstream
+!
+interface Port-Channel14
+   description server05_AUTO_ESI_Profile_Override_Auto-ESI PortChannel from profile
+   no shutdown
+   switchport
+   switchport access vlan 310
+   evpn ethernet-segment
+      identifier 0000:0000:010a:010a:010a
+      route-target import 01:0a:01:0a:01:0a
+   lacp system-id 010a.010a.010a
    link tracking group LT_GROUP1 downstream
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/fabric/EOS_DESIGNS_UNIT_TESTS-topology.csv
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/fabric/EOS_DESIGNS_UNIT_TESTS-topology.csv
@@ -227,10 +227,14 @@ l3leaf,MH-LEAF1A,Ethernet1,spine,DC1-SPINE1,Ethernet10,True
 l3leaf,MH-LEAF1A,Ethernet10,server,server01_ES1,Eth1,True
 l3leaf,MH-LEAF1A,Ethernet11,router,ROUTER02_WITH_SUBIF,Eth1,True
 l3leaf,MH-LEAF1A,Ethernet12,server,server03_AUTO_ESI,Eth1,True
+l3leaf,MH-LEAF1A,Ethernet13,server,server04_AUTO_ESI_Profile,Eth1,True
+l3leaf,MH-LEAF1A,Ethernet14,server,server05_AUTO_ESI_Profile_Override,Eth1,True
 l3leaf,MH-LEAF1B,Ethernet1,spine,DC1-SPINE1,Ethernet11,True
 l3leaf,MH-LEAF1B,Ethernet10,server,server01_ES1,Eth2,True
 l3leaf,MH-LEAF1B,Ethernet11,router,ROUTER02_WITH_SUBIF,Eth2,True
 l3leaf,MH-LEAF1B,Ethernet12,server,server03_AUTO_ESI,Eth2,True
+l3leaf,MH-LEAF1B,Ethernet13,server,server04_AUTO_ESI_Profile,Eth2,True
+l3leaf,MH-LEAF1B,Ethernet14,server,server05_AUTO_ESI_Profile_Override,Eth2,True
 l3leaf,MH-LEAF2A,Ethernet1,spine,DC1-SPINE1,Ethernet12,True
 l3leaf,MH-LEAF2A,Ethernet2,l2leaf,MH-L2LEAF1A,Ethernet1,True
 l3leaf,MH-LEAF2A,Ethernet10,router,ROUTER01,Eth1,True

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MH-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MH-LEAF1A.cfg
@@ -100,6 +100,28 @@ interface Port-Channel12
    lacp system-id fc87.ae24.2cb3
    link tracking group LT_GROUP1 downstream
 !
+interface Port-Channel13
+   description server04_AUTO_ESI_Profile_Auto-ESI PortChannel from profile
+   no shutdown
+   switchport
+   switchport access vlan 310
+   evpn ethernet-segment
+      identifier 0000:0000:29cc:4043:0a29
+      route-target import 29:cc:40:43:0a:29
+   lacp system-id 29cc.4043.0a29
+   link tracking group LT_GROUP1 downstream
+!
+interface Port-Channel14
+   description server05_AUTO_ESI_Profile_Override_Auto-ESI PortChannel from profile
+   no shutdown
+   switchport
+   switchport access vlan 310
+   evpn ethernet-segment
+      identifier 0000:0000:010a:010a:010a
+      route-target import 01:0a:01:0a:01:0a
+   lacp system-id 010a.010a.010a
+   link tracking group LT_GROUP1 downstream
+!
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet10
    no shutdown
@@ -122,6 +144,16 @@ interface Ethernet12
    description server03_AUTO_ESI_Eth1
    no shutdown
    channel-group 12 mode active
+!
+interface Ethernet13
+   description server04_AUTO_ESI_Profile_Eth1
+   no shutdown
+   channel-group 13 mode active
+!
+interface Ethernet14
+   description server05_AUTO_ESI_Profile_Override_Eth1
+   no shutdown
+   channel-group 14 mode active
 !
 interface Loopback0
    description EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MH-LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MH-LEAF1B.cfg
@@ -100,6 +100,28 @@ interface Port-Channel12
    lacp system-id fc87.ae24.2cb3
    link tracking group LT_GROUP1 downstream
 !
+interface Port-Channel13
+   description server04_AUTO_ESI_Profile_Auto-ESI PortChannel from profile
+   no shutdown
+   switchport
+   switchport access vlan 310
+   evpn ethernet-segment
+      identifier 0000:0000:29cc:4043:0a29
+      route-target import 29:cc:40:43:0a:29
+   lacp system-id 29cc.4043.0a29
+   link tracking group LT_GROUP1 downstream
+!
+interface Port-Channel14
+   description server05_AUTO_ESI_Profile_Override_Auto-ESI PortChannel from profile
+   no shutdown
+   switchport
+   switchport access vlan 310
+   evpn ethernet-segment
+      identifier 0000:0000:010a:010a:010a
+      route-target import 01:0a:01:0a:01:0a
+   lacp system-id 010a.010a.010a
+   link tracking group LT_GROUP1 downstream
+!
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet11
    no shutdown
@@ -122,6 +144,16 @@ interface Ethernet12
    description server03_AUTO_ESI_Eth2
    no shutdown
    channel-group 12 mode active
+!
+interface Ethernet13
+   description server04_AUTO_ESI_Profile_Eth2
+   no shutdown
+   channel-group 13 mode active
+!
+interface Ethernet14
+   description server05_AUTO_ESI_Profile_Override_Eth2
+   no shutdown
+   channel-group 14 mode active
 !
 interface Loopback0
    description EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
@@ -535,8 +535,9 @@ port_channel_interfaces:
     shutdown: false
     vlans: 110-112,120-121,130-131,160-161
     mode: trunk
-    esi: 0000:0000:0808:0707:0606
-    rt: 08:08:07:07:06:06
+    evpn_ethernet_segment:
+      identifier: 0000:0000:0808:0707:0606
+      route_target: 08:08:07:07:06:06
     lacp_id: 0808.0707.0606
   Port-Channel9:
     description: DC1-L2LEAF3A_Po1
@@ -544,8 +545,9 @@ port_channel_interfaces:
     shutdown: false
     vlans: 110-112,120-121,130-131,160-161
     mode: trunk
-    esi: 0000:0000:0606:0707:0808
-    rt: 06:06:07:07:08:08
+    evpn_ethernet_segment:
+      identifier: 0000:0000:0606:0707:0808
+      route_target: 06:06:07:07:08:08
     lacp_id: 0606.0707.0808
   Port-Channel13:
     description: DC1-L2LEAF4A_Po1
@@ -553,8 +555,9 @@ port_channel_interfaces:
     shutdown: false
     vlans: 110-112,120-121,130-131,160-161
     mode: trunk
-    esi: 0000:0000:a36b:7013:457b
-    rt: a3:6b:70:13:45:7b
+    evpn_ethernet_segment:
+      identifier: 0000:0000:a36b:7013:457b
+      route_target: a3:6b:70:13:45:7b
     lacp_id: a36b.7013.457b
   Port-Channel14:
     description: DC1_L2LEAF5_Po1
@@ -562,8 +565,9 @@ port_channel_interfaces:
     shutdown: false
     vlans: 110-112,120-121,130-131,160-161
     mode: trunk
-    esi: 0000:0000:71da:d362:2084
-    rt: 71:da:d3:62:20:84
+    evpn_ethernet_segment:
+      identifier: 0000:0000:71da:d362:2084
+      route_target: 71:da:d3:62:20:84
     lacp_id: 71da.d362.2084
   Port-Channel20:
     description: FIREWALL01_PortChanne1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
@@ -535,8 +535,9 @@ port_channel_interfaces:
     shutdown: false
     vlans: 110-112,120-121,130-131,160-161
     mode: trunk
-    esi: 0000:0000:0808:0707:0606
-    rt: 08:08:07:07:06:06
+    evpn_ethernet_segment:
+      identifier: 0000:0000:0808:0707:0606
+      route_target: 08:08:07:07:06:06
     lacp_id: 0808.0707.0606
   Port-Channel9:
     description: DC1-L2LEAF3A_Po1
@@ -544,8 +545,9 @@ port_channel_interfaces:
     shutdown: false
     vlans: 110-112,120-121,130-131,160-161
     mode: trunk
-    esi: 0000:0000:0606:0707:0808
-    rt: 06:06:07:07:08:08
+    evpn_ethernet_segment:
+      identifier: 0000:0000:0606:0707:0808
+      route_target: 06:06:07:07:08:08
     lacp_id: 0606.0707.0808
   Port-Channel13:
     description: DC1-L2LEAF4A_Po1
@@ -553,8 +555,9 @@ port_channel_interfaces:
     shutdown: false
     vlans: 110-112,120-121,130-131,160-161
     mode: trunk
-    esi: 0000:0000:a36b:7013:457b
-    rt: a3:6b:70:13:45:7b
+    evpn_ethernet_segment:
+      identifier: 0000:0000:a36b:7013:457b
+      route_target: a3:6b:70:13:45:7b
     lacp_id: a36b.7013.457b
   Port-Channel14:
     description: DC1_L2LEAF5_Po1
@@ -562,8 +565,9 @@ port_channel_interfaces:
     shutdown: false
     vlans: 110-112,120-121,130-131,160-161
     mode: trunk
-    esi: 0000:0000:71da:d362:2084
-    rt: 71:da:d3:62:20:84
+    evpn_ethernet_segment:
+      identifier: 0000:0000:71da:d362:2084
+      route_target: 71:da:d3:62:20:84
     lacp_id: 71da.d362.2084
   Port-Channel20:
     description: FIREWALL01_PortChanne1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1A.yml
@@ -181,6 +181,30 @@ ethernet_interfaces:
     channel_group:
       id: 12
       mode: active
+  Ethernet13:
+    peer: server04_AUTO_ESI_Profile
+    peer_interface: Eth1
+    peer_type: server
+    description: server04_AUTO_ESI_Profile_Eth1
+    type: switched
+    shutdown: false
+    mode: access
+    vlans: 310
+    channel_group:
+      id: 13
+      mode: active
+  Ethernet14:
+    peer: server05_AUTO_ESI_Profile_Override
+    peer_interface: Eth1
+    peer_type: server
+    description: server05_AUTO_ESI_Profile_Override_Eth1
+    type: switched
+    shutdown: false
+    mode: access
+    vlans: 310
+    channel_group:
+      id: 14
+      mode: active
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
@@ -252,8 +276,9 @@ port_channel_interfaces:
     shutdown: false
   Port-Channel11.101:
     type: l2dot1q
-    esi: 0000:0000:0000:0000:0101
-    rt: 00:00:00:00:01:01
+    evpn_ethernet_segment:
+      identifier: 0000:0000:0000:0000:0101
+      route_target: 00:00:00:00:01:01
     vlan_id: 101
     encapsulation_vlan:
       client:
@@ -263,8 +288,9 @@ port_channel_interfaces:
         client: true
   Port-Channel11.102:
     type: l2dot1q
-    esi: 0000:0000:0000:0000:0102
-    rt: 00:00:00:00:01:02
+    evpn_ethernet_segment:
+      identifier: 0000:0000:0000:0000:0102
+      route_target: 00:00:00:00:01:02
     vlan_id: 1102
     encapsulation_vlan:
       client:
@@ -274,8 +300,9 @@ port_channel_interfaces:
         client: true
   Port-Channel11.103:
     type: l2dot1q
-    esi: 0000:0000:c2c9:c85a:ed92
-    rt: c2:c9:c8:5a:ed:92
+    evpn_ethernet_segment:
+      identifier: 0000:0000:c2c9:c85a:ed92
+      route_target: c2:c9:c8:5a:ed:92
     vlan_id: 1103
     encapsulation_vlan:
       client:
@@ -285,8 +312,9 @@ port_channel_interfaces:
         client: true
   Port-Channel11.104:
     type: l2dot1q
-    esi: 0000:0000:5c8e:1f50:9fc4
-    rt: 5c:8e:1f:50:9f:c4
+    evpn_ethernet_segment:
+      identifier: 0000:0000:5c8e:1f50:9fc4
+      route_target: 5c:8e:1f:50:9f:c4
     vlan_id: 1104
     encapsulation_vlan:
       client:
@@ -300,8 +328,9 @@ port_channel_interfaces:
     shutdown: false
     mode: access
     vlans: 310
-    esi: 0000:0000:0001:1010:1010
-    rt: 00:01:10:10:10:10
+    evpn_ethernet_segment:
+      identifier: 0000:0000:0001:1010:1010
+      route_target: 00:01:10:10:10:10
     lacp_id: 0001.1010.1010
     link_tracking_groups:
     - name: LT_GROUP1
@@ -312,9 +341,36 @@ port_channel_interfaces:
     shutdown: false
     mode: access
     vlans: 310
-    esi: 0000:0000:fc87:ae24:2cb3
-    rt: fc:87:ae:24:2c:b3
+    evpn_ethernet_segment:
+      identifier: 0000:0000:fc87:ae24:2cb3
+      route_target: fc:87:ae:24:2c:b3
     lacp_id: fc87.ae24.2cb3
+    link_tracking_groups:
+    - name: LT_GROUP1
+      direction: downstream
+  Port-Channel13:
+    description: server04_AUTO_ESI_Profile_Auto-ESI PortChannel from profile
+    type: switched
+    shutdown: false
+    mode: access
+    vlans: 310
+    evpn_ethernet_segment:
+      identifier: 0000:0000:29cc:4043:0a29
+      route_target: 29:cc:40:43:0a:29
+    lacp_id: 29cc.4043.0a29
+    link_tracking_groups:
+    - name: LT_GROUP1
+      direction: downstream
+  Port-Channel14:
+    description: server05_AUTO_ESI_Profile_Override_Auto-ESI PortChannel from profile
+    type: switched
+    shutdown: false
+    mode: access
+    vlans: 310
+    evpn_ethernet_segment:
+      identifier: 0000:0000:010a:010a:010a
+      route_target: 01:0a:01:0a:01:0a
+    lacp_id: 010a.010a.010a
     link_tracking_groups:
     - name: LT_GROUP1
       direction: downstream

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1B.yml
@@ -181,6 +181,30 @@ ethernet_interfaces:
     channel_group:
       id: 12
       mode: active
+  Ethernet13:
+    peer: server04_AUTO_ESI_Profile
+    peer_interface: Eth2
+    peer_type: server
+    description: server04_AUTO_ESI_Profile_Eth2
+    type: switched
+    shutdown: false
+    mode: access
+    vlans: 310
+    channel_group:
+      id: 13
+      mode: active
+  Ethernet14:
+    peer: server05_AUTO_ESI_Profile_Override
+    peer_interface: Eth2
+    peer_type: server
+    description: server05_AUTO_ESI_Profile_Override_Eth2
+    type: switched
+    shutdown: false
+    mode: access
+    vlans: 310
+    channel_group:
+      id: 14
+      mode: active
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
@@ -252,8 +276,9 @@ port_channel_interfaces:
     shutdown: false
   Port-Channel11.101:
     type: l2dot1q
-    esi: 0000:0000:0000:0000:0101
-    rt: 00:00:00:00:01:01
+    evpn_ethernet_segment:
+      identifier: 0000:0000:0000:0000:0101
+      route_target: 00:00:00:00:01:01
     vlan_id: 101
     encapsulation_vlan:
       client:
@@ -263,8 +288,9 @@ port_channel_interfaces:
         client: true
   Port-Channel11.102:
     type: l2dot1q
-    esi: 0000:0000:0000:0000:0102
-    rt: 00:00:00:00:01:02
+    evpn_ethernet_segment:
+      identifier: 0000:0000:0000:0000:0102
+      route_target: 00:00:00:00:01:02
     vlan_id: 1102
     encapsulation_vlan:
       client:
@@ -274,8 +300,9 @@ port_channel_interfaces:
         client: true
   Port-Channel11.103:
     type: l2dot1q
-    esi: 0000:0000:c2c9:c85a:ed92
-    rt: c2:c9:c8:5a:ed:92
+    evpn_ethernet_segment:
+      identifier: 0000:0000:c2c9:c85a:ed92
+      route_target: c2:c9:c8:5a:ed:92
     vlan_id: 1103
     encapsulation_vlan:
       client:
@@ -285,8 +312,9 @@ port_channel_interfaces:
         client: true
   Port-Channel11.104:
     type: l2dot1q
-    esi: 0000:0000:5c8e:1f50:9fc4
-    rt: 5c:8e:1f:50:9f:c4
+    evpn_ethernet_segment:
+      identifier: 0000:0000:5c8e:1f50:9fc4
+      route_target: 5c:8e:1f:50:9f:c4
     vlan_id: 1104
     encapsulation_vlan:
       client:
@@ -300,8 +328,9 @@ port_channel_interfaces:
     shutdown: false
     mode: access
     vlans: 310
-    esi: 0000:0000:0001:1010:1010
-    rt: 00:01:10:10:10:10
+    evpn_ethernet_segment:
+      identifier: 0000:0000:0001:1010:1010
+      route_target: 00:01:10:10:10:10
     lacp_id: 0001.1010.1010
     link_tracking_groups:
     - name: LT_GROUP1
@@ -312,9 +341,36 @@ port_channel_interfaces:
     shutdown: false
     mode: access
     vlans: 310
-    esi: 0000:0000:fc87:ae24:2cb3
-    rt: fc:87:ae:24:2c:b3
+    evpn_ethernet_segment:
+      identifier: 0000:0000:fc87:ae24:2cb3
+      route_target: fc:87:ae:24:2c:b3
     lacp_id: fc87.ae24.2cb3
+    link_tracking_groups:
+    - name: LT_GROUP1
+      direction: downstream
+  Port-Channel13:
+    description: server04_AUTO_ESI_Profile_Auto-ESI PortChannel from profile
+    type: switched
+    shutdown: false
+    mode: access
+    vlans: 310
+    evpn_ethernet_segment:
+      identifier: 0000:0000:29cc:4043:0a29
+      route_target: 29:cc:40:43:0a:29
+    lacp_id: 29cc.4043.0a29
+    link_tracking_groups:
+    - name: LT_GROUP1
+      direction: downstream
+  Port-Channel14:
+    description: server05_AUTO_ESI_Profile_Override_Auto-ESI PortChannel from profile
+    type: switched
+    shutdown: false
+    mode: access
+    vlans: 310
+    evpn_ethernet_segment:
+      identifier: 0000:0000:010a:010a:010a
+      route_target: 01:0a:01:0a:01:0a
+    lacp_id: 010a.010a.010a
     link_tracking_groups:
     - name: LT_GROUP1
       direction: downstream

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/MH_SERVERS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/MH_SERVERS.yml
@@ -6,6 +6,11 @@ port_profiles:
     link_tracking:
       enabled: true
 
+  Tenant_ESI_Auto:
+    parent_profile: Tenant_X
+    port_channel:
+      short_esi: auto
+
   Tenant_X_LT:
     mode: access
     vlans: "310"
@@ -48,6 +53,29 @@ servers:
           description: Auto-ESI PortChannel
           mode: active
           short_esi: auto
+
+  server04_AUTO_ESI_Profile:
+    rack: RackA
+    adapters:
+      - endpoint_ports: [ Eth1, Eth2 ]
+        switch_ports: [ Ethernet13, Ethernet13 ]
+        switches: [ MH-LEAF1A, MH-LEAF1B ]
+        profile: Tenant_ESI_Auto
+        port_channel:
+          description: Auto-ESI PortChannel from profile
+          mode: active
+
+  server05_AUTO_ESI_Profile_Override:
+    rack: RackA
+    adapters:
+      - endpoint_ports: [ Eth1, Eth2 ]
+        switch_ports: [ Ethernet14, Ethernet14 ]
+        switches: [ MH-LEAF1A, MH-LEAF1B ]
+        profile: Tenant_ESI_Auto
+        port_channel:
+          description: Auto-ESI PortChannel from profile
+          mode: active
+          short_esi: 010a:010a:010a
 
 routers:
   ROUTER01:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-LEAF2A.yml
@@ -479,8 +479,9 @@ port_channel_interfaces:
     shutdown: false
     vlans: 110-112,120-121,130-131,160-161
     mode: trunk
-    esi: 0000:0000:0808:0707:0606
-    rt: 08:08:07:07:06:06
+    evpn_ethernet_segment:
+      identifier: 0000:0000:0808:0707:0606
+      route_target: 08:08:07:07:06:06
     lacp_id: 0808.0707.0606
   Port-Channel9:
     description: DC1-L2LEAF3A_Po1
@@ -488,8 +489,9 @@ port_channel_interfaces:
     shutdown: false
     vlans: 110-112,120-121,130-131,160-161
     mode: trunk
-    esi: 0000:0000:0606:0707:0808
-    rt: 06:06:07:07:08:08
+    evpn_ethernet_segment:
+      identifier: 0000:0000:0606:0707:0808
+      route_target: 06:06:07:07:08:08
     lacp_id: 0606.0707.0808
   Port-Channel13:
     description: DC1-L2LEAF4A_Po1
@@ -497,8 +499,9 @@ port_channel_interfaces:
     shutdown: false
     vlans: 110-112,120-121,130-131,160-161
     mode: trunk
-    esi: 0000:0000:a36b:7013:457b
-    rt: a3:6b:70:13:45:7b
+    evpn_ethernet_segment:
+      identifier: 0000:0000:a36b:7013:457b
+      route_target: a3:6b:70:13:45:7b
     lacp_id: a36b.7013.457b
   Port-Channel14:
     description: DC1_L2LEAF5_Po1
@@ -506,8 +509,9 @@ port_channel_interfaces:
     shutdown: false
     vlans: 110-112,120-121,130-131,160-161
     mode: trunk
-    esi: 0000:0000:71da:d362:2084
-    rt: 71:da:d3:62:20:84
+    evpn_ethernet_segment:
+      identifier: 0000:0000:71da:d362:2084
+      route_target: 71:da:d3:62:20:84
     lacp_id: 71da.d362.2084
   Port-Channel20:
     description: FIREWALL01_PortChanne1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/DC1-LEAF2B.yml
@@ -479,8 +479,9 @@ port_channel_interfaces:
     shutdown: false
     vlans: 110-112,120-121,130-131,160-161
     mode: trunk
-    esi: 0000:0000:0808:0707:0606
-    rt: 08:08:07:07:06:06
+    evpn_ethernet_segment:
+      identifier: 0000:0000:0808:0707:0606
+      route_target: 08:08:07:07:06:06
     lacp_id: 0808.0707.0606
   Port-Channel9:
     description: DC1-L2LEAF3A_Po1
@@ -488,8 +489,9 @@ port_channel_interfaces:
     shutdown: false
     vlans: 110-112,120-121,130-131,160-161
     mode: trunk
-    esi: 0000:0000:0606:0707:0808
-    rt: 06:06:07:07:08:08
+    evpn_ethernet_segment:
+      identifier: 0000:0000:0606:0707:0808
+      route_target: 06:06:07:07:08:08
     lacp_id: 0606.0707.0808
   Port-Channel13:
     description: DC1-L2LEAF4A_Po1
@@ -497,8 +499,9 @@ port_channel_interfaces:
     shutdown: false
     vlans: 110-112,120-121,130-131,160-161
     mode: trunk
-    esi: 0000:0000:a36b:7013:457b
-    rt: a3:6b:70:13:45:7b
+    evpn_ethernet_segment:
+      identifier: 0000:0000:a36b:7013:457b
+      route_target: a3:6b:70:13:45:7b
     lacp_id: a36b.7013.457b
   Port-Channel14:
     description: DC1_L2LEAF5_Po1
@@ -506,8 +509,9 @@ port_channel_interfaces:
     shutdown: false
     vlans: 110-112,120-121,130-131,160-161
     mode: trunk
-    esi: 0000:0000:71da:d362:2084
-    rt: 71:da:d3:62:20:84
+    evpn_ethernet_segment:
+      identifier: 0000:0000:71da:d362:2084
+      route_target: 71:da:d3:62:20:84
     lacp_id: 71da.d362.2084
   Port-Channel20:
     description: FIREWALL01_PortChanne1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/MH-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/MH-LEAF1A.yml
@@ -252,8 +252,9 @@ port_channel_interfaces:
     shutdown: false
   Port-Channel11.101:
     type: l2dot1q
-    esi: 0000:0000:0000:0000:0101
-    rt: 00:00:00:00:01:01
+    evpn_ethernet_segment:
+      identifier: 0000:0000:0000:0000:0101
+      route_target: 00:00:00:00:01:01
     vlan_id: 101
     encapsulation_vlan:
       client:
@@ -263,8 +264,9 @@ port_channel_interfaces:
         client: true
   Port-Channel11.102:
     type: l2dot1q
-    esi: 0000:0000:0000:0000:0102
-    rt: 00:00:00:00:01:02
+    evpn_ethernet_segment:
+      identifier: 0000:0000:0000:0000:0102
+      route_target: 00:00:00:00:01:02
     vlan_id: 1102
     encapsulation_vlan:
       client:
@@ -274,8 +276,9 @@ port_channel_interfaces:
         client: true
   Port-Channel11.103:
     type: l2dot1q
-    esi: 0000:0000:c2c9:c85a:ed92
-    rt: c2:c9:c8:5a:ed:92
+    evpn_ethernet_segment:
+      identifier: 0000:0000:c2c9:c85a:ed92
+      route_target: c2:c9:c8:5a:ed:92
     vlan_id: 1103
     encapsulation_vlan:
       client:
@@ -285,8 +288,9 @@ port_channel_interfaces:
         client: true
   Port-Channel11.104:
     type: l2dot1q
-    esi: 0000:0000:5c8e:1f50:9fc4
-    rt: 5c:8e:1f:50:9f:c4
+    evpn_ethernet_segment:
+      identifier: 0000:0000:5c8e:1f50:9fc4
+      route_target: 5c:8e:1f:50:9f:c4
     vlan_id: 1104
     encapsulation_vlan:
       client:
@@ -300,8 +304,9 @@ port_channel_interfaces:
     shutdown: false
     mode: access
     vlans: 310
-    esi: 0000:0000:0001:1010:1010
-    rt: 00:01:10:10:10:10
+    evpn_ethernet_segment:
+      identifier: 0000:0000:0001:1010:1010
+      route_target: 00:01:10:10:10:10
     lacp_id: 0001.1010.1010
     link_tracking_groups:
     - name: LT_GROUP1
@@ -312,8 +317,9 @@ port_channel_interfaces:
     shutdown: false
     mode: access
     vlans: 310
-    esi: 0000:0000:fc87:ae24:2cb3
-    rt: fc:87:ae:24:2c:b3
+    evpn_ethernet_segment:
+      identifier: 0000:0000:fc87:ae24:2cb3
+      route_target: fc:87:ae:24:2c:b3
     lacp_id: fc87.ae24.2cb3
     link_tracking_groups:
     - name: LT_GROUP1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/MH-LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/intended/structured_configs/MH-LEAF1B.yml
@@ -252,8 +252,9 @@ port_channel_interfaces:
     shutdown: false
   Port-Channel11.101:
     type: l2dot1q
-    esi: 0000:0000:0000:0000:0101
-    rt: 00:00:00:00:01:01
+    evpn_ethernet_segment:
+      identifier: 0000:0000:0000:0000:0101
+      route_target: 00:00:00:00:01:01
     vlan_id: 101
     encapsulation_vlan:
       client:
@@ -263,8 +264,9 @@ port_channel_interfaces:
         client: true
   Port-Channel11.102:
     type: l2dot1q
-    esi: 0000:0000:0000:0000:0102
-    rt: 00:00:00:00:01:02
+    evpn_ethernet_segment:
+      identifier: 0000:0000:0000:0000:0102
+      route_target: 00:00:00:00:01:02
     vlan_id: 1102
     encapsulation_vlan:
       client:
@@ -274,8 +276,9 @@ port_channel_interfaces:
         client: true
   Port-Channel11.103:
     type: l2dot1q
-    esi: 0000:0000:c2c9:c85a:ed92
-    rt: c2:c9:c8:5a:ed:92
+    evpn_ethernet_segment:
+      identifier: 0000:0000:c2c9:c85a:ed92
+      route_target: c2:c9:c8:5a:ed:92
     vlan_id: 1103
     encapsulation_vlan:
       client:
@@ -285,8 +288,9 @@ port_channel_interfaces:
         client: true
   Port-Channel11.104:
     type: l2dot1q
-    esi: 0000:0000:5c8e:1f50:9fc4
-    rt: 5c:8e:1f:50:9f:c4
+    evpn_ethernet_segment:
+      identifier: 0000:0000:5c8e:1f50:9fc4
+      route_target: 5c:8e:1f:50:9f:c4
     vlan_id: 1104
     encapsulation_vlan:
       client:
@@ -300,8 +304,9 @@ port_channel_interfaces:
     shutdown: false
     mode: access
     vlans: 310
-    esi: 0000:0000:0001:1010:1010
-    rt: 00:01:10:10:10:10
+    evpn_ethernet_segment:
+      identifier: 0000:0000:0001:1010:1010
+      route_target: 00:01:10:10:10:10
     lacp_id: 0001.1010.1010
     link_tracking_groups:
     - name: LT_GROUP1
@@ -312,8 +317,9 @@ port_channel_interfaces:
     shutdown: false
     mode: access
     vlans: 310
-    esi: 0000:0000:fc87:ae24:2cb3
-    rt: fc:87:ae:24:2c:b3
+    evpn_ethernet_segment:
+      identifier: 0000:0000:fc87:ae24:2cb3
+      route_target: fc:87:ae:24:2c:b3
     lacp_id: fc87.ae24.2cb3
     link_tracking_groups:
     - name: LT_GROUP1

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -467,6 +467,15 @@ interface Ethernet21
 | Port-Channel12 | CUSTOM_server01_MTU_ADAPTOR_MLAG_PortChanne1 | switched | access | - | - | - | - | - | - | - |
 | Port-Channel20 | CUSTOM_FIREWALL01_PortChanne1 | switched | trunk | 110-111,210-211 | - | - | - | - | - | - |
 
+#### EVPN Multihoming
+
+##### EVPN Multihoming Summary
+
+| Interface | Ethernet Segment Identifier | Multihoming Redundancy Mode | Route Target |
+| --------- | --------------------------- | --------------------------- | ------------ |
+| Port-Channel7 | 0000:1234:0808:0707:0606 | all-active | 08:08:07:07:06:06 |
+| Port-Channel9 | 0000:1234:0606:0707:0808 | all-active | 06:06:07:07:08:08 |
+
 ### Port-Channel Interfaces Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -467,6 +467,15 @@ interface Ethernet21
 | Port-Channel12 | CUSTOM_server01_MTU_ADAPTOR_MLAG_PortChanne1 | switched | access | - | - | - | - | - | - | - |
 | Port-Channel20 | CUSTOM_FIREWALL01_PortChanne1 | switched | trunk | 110-111,210-211 | - | - | - | - | - | - |
 
+#### EVPN Multihoming
+
+##### EVPN Multihoming Summary
+
+| Interface | Ethernet Segment Identifier | Multihoming Redundancy Mode | Route Target |
+| --------- | --------------------------- | --------------------------- | ------------ |
+| Port-Channel7 | 0000:1234:0808:0707:0606 | all-active | 08:08:07:07:06:06 |
+| Port-Channel9 | 0000:1234:0606:0707:0808 | all-active | 06:06:07:07:08:08 |
+
 ### Port-Channel Interfaces Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -634,6 +634,14 @@ interface Ethernet44
 | Port-Channel19 | CUSTOM_server12_inherit_nested_profile_port_channel_lacp_fallback_NESTED_ALL_WITH_SECURITY_PORT_CHANNEL | switched | trunk | 1-4094 | - | - | 10 | static | 19 | - |
 | Port-Channel22 | CUSTOM_server15_port_channel_disabled_interfaces_ | switched | access | 110 | - | - | - | - | 22 | - |
 
+#### EVPN Multihoming
+
+##### EVPN Multihoming Summary
+
+| Interface | Ethernet Segment Identifier | Multihoming Redundancy Mode | Route Target |
+| --------- | --------------------------- | --------------------------- | ------------ |
+| Port-Channel10 | 0000:1234:0303:0202:0101 | all-active | 03:03:02:02:01:01 |
+
 ### Port-Channel Interfaces Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -634,6 +634,14 @@ interface Ethernet44
 | Port-Channel19 | CUSTOM_server12_inherit_nested_profile_port_channel_lacp_fallback_NESTED_ALL_WITH_SECURITY_PORT_CHANNEL | switched | trunk | 1-4094 | - | - | 10 | static | 19 | - |
 | Port-Channel22 | CUSTOM_server15_port_channel_disabled_interfaces_ | switched | access | 110 | - | - | - | - | 22 | - |
 
+#### EVPN Multihoming
+
+##### EVPN Multihoming Summary
+
+| Interface | Ethernet Segment Identifier | Multihoming Redundancy Mode | Route Target |
+| --------- | --------------------------- | --------------------------- | ------------ |
+| Port-Channel10 | 0000:1234:0303:0202:0101 | all-active | 03:03:02:02:01:01 |
+
 ### Port-Channel Interfaces Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -462,8 +462,9 @@ port_channel_interfaces:
     shutdown: false
     vlans: 110-111,120-124,130-131,160-162
     mode: trunk
-    esi: 0000:1234:0808:0707:0606
-    rt: 08:08:07:07:06:06
+    evpn_ethernet_segment:
+      identifier: 0000:1234:0808:0707:0606
+      route_target: 08:08:07:07:06:06
     lacp_id: 0808.0707.0606
   Port-Channel9:
     description: CUSTOM_DC1-L2LEAF3A_Po1
@@ -471,8 +472,9 @@ port_channel_interfaces:
     shutdown: false
     vlans: 110-111,120-124,130-131,160-162
     mode: trunk
-    esi: 0000:1234:0606:0707:0808
-    rt: 06:06:07:07:08:08
+    evpn_ethernet_segment:
+      identifier: 0000:1234:0606:0707:0808
+      route_target: 06:06:07:07:08:08
     lacp_id: 0606.0707.0808
   Port-Channel20:
     description: CUSTOM_FIREWALL01_PortChanne1

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -462,8 +462,9 @@ port_channel_interfaces:
     shutdown: false
     vlans: 110-111,120-124,130-131,160-162
     mode: trunk
-    esi: 0000:1234:0808:0707:0606
-    rt: 08:08:07:07:06:06
+    evpn_ethernet_segment:
+      identifier: 0000:1234:0808:0707:0606
+      route_target: 08:08:07:07:06:06
     lacp_id: 0808.0707.0606
   Port-Channel9:
     description: CUSTOM_DC1-L2LEAF3A_Po1
@@ -471,8 +472,9 @@ port_channel_interfaces:
     shutdown: false
     vlans: 110-111,120-124,130-131,160-162
     mode: trunk
-    esi: 0000:1234:0606:0707:0808
-    rt: 06:06:07:07:08:08
+    evpn_ethernet_segment:
+      identifier: 0000:1234:0606:0707:0808
+      route_target: 06:06:07:07:08:08
     lacp_id: 0606.0707.0808
   Port-Channel20:
     description: CUSTOM_FIREWALL01_PortChanne1

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -790,8 +790,9 @@ port_channel_interfaces:
     shutdown: false
     mode: trunk
     vlans: 110-111,210-211
-    esi: 0000:1234:0303:0202:0101
-    rt: 03:03:02:02:01:01
+    evpn_ethernet_segment:
+      identifier: 0000:1234:0303:0202:0101
+      route_target: 03:03:02:02:01:01
     lacp_id: 0303.0202.0101
   Port-Channel14:
     description: CUSTOM_server07_inherit_all_from_profile_port_channel_ALL_WITH_SECURITY_PORT_CHANNEL

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -790,8 +790,9 @@ port_channel_interfaces:
     shutdown: false
     mode: trunk
     vlans: 110-111,210-211
-    esi: 0000:1234:0303:0202:0101
-    rt: 03:03:02:02:01:01
+    evpn_ethernet_segment:
+      identifier: 0000:1234:0303:0202:0101
+      route_target: 03:03:02:02:01:01
     lacp_id: 0303.0202.0101
   Port-Channel14:
     description: CUSTOM_server07_inherit_all_from_profile_port_channel_ALL_WITH_SECURITY_PORT_CHANNEL

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -451,6 +451,15 @@ interface Ethernet21
 | Port-Channel12 | server01_MTU_ADAPTOR_MLAG_PortChanne1 | switched | access | - | - | - | - | - | - | - |
 | Port-Channel20 | FIREWALL01_PortChanne1 | switched | trunk | 110-111,210-211 | - | - | - | - | - | - |
 
+#### EVPN Multihoming
+
+##### EVPN Multihoming Summary
+
+| Interface | Ethernet Segment Identifier | Multihoming Redundancy Mode | Route Target |
+| --------- | --------------------------- | --------------------------- | ------------ |
+| Port-Channel7 | 0000:1234:0808:0707:0606 | all-active | 08:08:07:07:06:06 |
+| Port-Channel9 | 0000:1234:0606:0707:0808 | all-active | 06:06:07:07:08:08 |
+
 ### Port-Channel Interfaces Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -451,6 +451,15 @@ interface Ethernet21
 | Port-Channel12 | server01_MTU_ADAPTOR_MLAG_PortChanne1 | switched | access | - | - | - | - | - | - | - |
 | Port-Channel20 | FIREWALL01_PortChanne1 | switched | trunk | 110-111,210-211 | - | - | - | - | - | - |
 
+#### EVPN Multihoming
+
+##### EVPN Multihoming Summary
+
+| Interface | Ethernet Segment Identifier | Multihoming Redundancy Mode | Route Target |
+| --------- | --------------------------- | --------------------------- | ------------ |
+| Port-Channel7 | 0000:1234:0808:0707:0606 | all-active | 08:08:07:07:06:06 |
+| Port-Channel9 | 0000:1234:0606:0707:0808 | all-active | 06:06:07:07:08:08 |
+
 ### Port-Channel Interfaces Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -600,6 +600,14 @@ interface Ethernet44
 | Port-Channel18 | server11_inherit_profile_port_channel_lacp_fallback_ALL_WITH_SECURITY_PORT_CHANNEL | switched | trunk | 1-4094 | - | - | 10 | static | 18 | - |
 | Port-Channel19 | server12_inherit_nested_profile_port_channel_lacp_fallback_NESTED_ALL_WITH_SECURITY_PORT_CHANNEL | switched | trunk | 1-4094 | - | - | 10 | static | 19 | - |
 
+#### EVPN Multihoming
+
+##### EVPN Multihoming Summary
+
+| Interface | Ethernet Segment Identifier | Multihoming Redundancy Mode | Route Target |
+| --------- | --------------------------- | --------------------------- | ------------ |
+| Port-Channel10 | 0000:1234:0303:0202:0101 | all-active | 03:03:02:02:01:01 |
+
 ### Port-Channel Interfaces Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -600,6 +600,14 @@ interface Ethernet44
 | Port-Channel18 | server11_inherit_profile_port_channel_lacp_fallback_ALL_WITH_SECURITY_PORT_CHANNEL | switched | trunk | 1-4094 | - | - | 10 | static | 18 | - |
 | Port-Channel19 | server12_inherit_nested_profile_port_channel_lacp_fallback_NESTED_ALL_WITH_SECURITY_PORT_CHANNEL | switched | trunk | 1-4094 | - | - | 10 | static | 19 | - |
 
+#### EVPN Multihoming
+
+##### EVPN Multihoming Summary
+
+| Interface | Ethernet Segment Identifier | Multihoming Redundancy Mode | Route Target |
+| --------- | --------------------------- | --------------------------- | ------------ |
+| Port-Channel10 | 0000:1234:0303:0202:0101 | all-active | 03:03:02:02:01:01 |
+
 ### Port-Channel Interfaces Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -458,8 +458,9 @@ port_channel_interfaces:
     shutdown: false
     vlans: 110-111,120-121,130-131,160-161
     mode: trunk
-    esi: 0000:1234:0808:0707:0606
-    rt: 08:08:07:07:06:06
+    evpn_ethernet_segment:
+      identifier: 0000:1234:0808:0707:0606
+      route_target: 08:08:07:07:06:06
     lacp_id: 0808.0707.0606
   Port-Channel9:
     description: DC1-L2LEAF3A_Po1
@@ -467,8 +468,9 @@ port_channel_interfaces:
     shutdown: false
     vlans: 110-111,120-121,130-131,160-161
     mode: trunk
-    esi: 0000:1234:0606:0707:0808
-    rt: 06:06:07:07:08:08
+    evpn_ethernet_segment:
+      identifier: 0000:1234:0606:0707:0808
+      route_target: 06:06:07:07:08:08
     lacp_id: 0606.0707.0808
   Port-Channel20:
     description: FIREWALL01_PortChanne1

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -458,8 +458,9 @@ port_channel_interfaces:
     shutdown: false
     vlans: 110-111,120-121,130-131,160-161
     mode: trunk
-    esi: 0000:1234:0808:0707:0606
-    rt: 08:08:07:07:06:06
+    evpn_ethernet_segment:
+      identifier: 0000:1234:0808:0707:0606
+      route_target: 08:08:07:07:06:06
     lacp_id: 0808.0707.0606
   Port-Channel9:
     description: DC1-L2LEAF3A_Po1
@@ -467,8 +468,9 @@ port_channel_interfaces:
     shutdown: false
     vlans: 110-111,120-121,130-131,160-161
     mode: trunk
-    esi: 0000:1234:0606:0707:0808
-    rt: 06:06:07:07:08:08
+    evpn_ethernet_segment:
+      identifier: 0000:1234:0606:0707:0808
+      route_target: 06:06:07:07:08:08
     lacp_id: 0606.0707.0808
   Port-Channel20:
     description: FIREWALL01_PortChanne1

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -755,8 +755,9 @@ port_channel_interfaces:
     shutdown: false
     mode: trunk
     vlans: 110-111,210-211
-    esi: 0000:1234:0303:0202:0101
-    rt: 03:03:02:02:01:01
+    evpn_ethernet_segment:
+      identifier: 0000:1234:0303:0202:0101
+      route_target: 03:03:02:02:01:01
     lacp_id: 0303.0202.0101
   Port-Channel14:
     description: server07_inherit_all_from_profile_port_channel_ALL_WITH_SECURITY_PORT_CHANNEL

--- a/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -755,8 +755,9 @@ port_channel_interfaces:
     shutdown: false
     mode: trunk
     vlans: 110-111,210-211
-    esi: 0000:1234:0303:0202:0101
-    rt: 03:03:02:02:01:01
+    evpn_ethernet_segment:
+      identifier: 0000:1234:0303:0202:0101
+      route_target: 03:03:02:02:01:01
     lacp_id: 0303.0202.0101
   Port-Channel14:
     description: server07_inherit_all_from_profile_port_channel_ALL_WITH_SECURITY_PORT_CHANNEL

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/connected-endpoints.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/connected-endpoints.md
@@ -76,6 +76,9 @@ port_profiles:
     port_channel:
       description: < port_channel_description >
       mode: < "active" | "passive" | "on" >
+      # Allocates an automatic short_esi to all ports using this profile
+      # Please see the notes under "EVPN A/A ESI dual-attached endpoint scenario" before setting short_esi: auto.
+      short_esi: auto
       lacp_fallback:
         mode: < static > | Currently only static mode is supported
         timeout: < timeout in seconds > | Optional - default is 90 seconds

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/port-channel-interfaces.j2
@@ -76,20 +76,21 @@ port_channel_interfaces:
     mtu: {{ adapter_settings.mtu }}
 {%                         endif %}
 {%                         if adapter_settings.switches | unique | list | length > 1 %}
-{%                             if adapter.port_channel.short_esi is arista.avd.defined %}
-{%                                 if adapter.port_channel.short_esi | lower == 'auto' %}
+{%                             if adapter_settings.port_channel.short_esi is arista.avd.defined %}
+{%                                 if adapter_settings.port_channel.short_esi | lower == 'auto' %}
 {%                                     set esi_hash_switches = adapter_settings.switches[:2] | join %}
 {%                                     set esi_hash_switch_ports = adapter_settings.switch_ports[:2] | join %}
 {%                                     set esi_hash_endpoint_ports = adapter_settings.endpoint_ports[:2] | join %}
 {%                                     set esi_hash = (esi_hash_switches ~ esi_hash_switch_ports ~ esi_hash_endpoint_ports ~ channel_group_id) | hash('sha256') %}
 {%                                     set short_esi_hash = (esi_hash | regex_replace("([0-9a-f]{4})","\\1:"))[:14] %}
-{%                                     do adapter.update({ 'port_channel': { 'short_esi': short_esi_hash }}) %}
+{%                                     do adapter_settings.port_channel.update({ 'short_esi': short_esi_hash }) %}
 {%                                 endif %}
-{%                                 if adapter.port_channel.short_esi.split(':') | length == 3 %}
-    esi: {{ adapter.port_channel.short_esi | arista.avd.generate_esi(evpn_short_esi_prefix) }}
-    rt: {{ adapter.port_channel.short_esi | arista.avd.generate_route_target }}
+{%                                 if adapter_settings.port_channel.short_esi.split(':') | length == 3 %}
+    evpn_ethernet_segment:
+      identifier: {{ adapter_settings.port_channel.short_esi | arista.avd.generate_esi(evpn_short_esi_prefix) }}
+      route_target: {{ adapter_settings.port_channel.short_esi | arista.avd.generate_route_target }}
 {%                                     if adapter_settings.port_channel.mode == 'active' %}
-    lacp_id: {{ adapter.port_channel.short_esi | arista.avd.generate_lacp_id }}
+    lacp_id: {{ adapter_settings.port_channel.short_esi | arista.avd.generate_lacp_id }}
 {%                                     endif %}
 {%                                 endif %}
 {%                             elif switch.mlag is arista.avd.defined(true) %}
@@ -130,8 +131,9 @@ port_channel_interfaces:
 {%                                         do subinterface.update({ 'short_esi': short_esi_hash }) %}
 {%                                     endif %}
 {%                                     if subinterface.short_esi.split(':') | length == 3 %}
-    esi: {{ subinterface.short_esi | arista.avd.generate_esi(evpn_short_esi_prefix) }}
-    rt: {{ subinterface.short_esi | arista.avd.generate_route_target }}
+    evpn_ethernet_segment:
+      identifier: {{ subinterface.short_esi | arista.avd.generate_esi(evpn_short_esi_prefix) }}
+      route_target: {{ subinterface.short_esi | arista.avd.generate_route_target }}
 {%                                     endif %}
 {%                                 endif %}
     vlan_id: {{ subinterface.vlan_id | arista.avd.default(subinterface.number) }}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/underlay/interfaces/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/underlay/interfaces/port-channel-interfaces.j2
@@ -21,8 +21,9 @@ port_channel_interfaces:
 {%         if switch.mlag is arista.avd.defined(true) %}
     mlag: {{ link.channel_group_id }}
 {%         elif link.short_esi is arista.avd.defined %}
-    esi: {{ link.short_esi | arista.avd.generate_esi(evpn_short_esi_prefix) }}
-    rt: {{ link.short_esi | arista.avd.generate_route_target }}
+    evpn_ethernet_segment:
+      identifier: {{ link.short_esi | arista.avd.generate_esi(evpn_short_esi_prefix) }}
+      route_target: {{ link.short_esi | arista.avd.generate_route_target }}
     lacp_id: {{ link.short_esi | arista.avd.generate_lacp_id }}
 {%         endif %}
 {%         if link.link_tracking_groups is arista.avd.defined %}


### PR DESCRIPTION
## Change Summary

Allow use of short_esi: auto in port_profiles for connected_endpoints.
Make use of new eos_cli_config_gen evpn_ethernet_segment data model.

## Related Issue(s)

This is part of the fix for #1771 - a 2nd PR will be forthcoming for the remainder of this
This is a replacement for #1772 which I've closed.

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
This change builds on the existing short_esi functionality but references adapter_settings instead of adapter - allowing for short_esi to be inherited from a port_profile.

This change also switches both underlay and connected_endpoints port-channels to using the new `evpn_ethernet_segment` key in structured config.

Data model change:
```yaml
port_profiles:
  < port_profile_1 >:
    port_channel:
      short_esi: auto
```

## How to test
New test added in `eos_designs_unit_tests` to inherit from a port_profile that defines short_esi: auto.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
