### PR TITLE
Bump(requirements): Relax ansible.netcommon requirements to ">=2.4.0,!=2.6.0"

### DIFF
--- a/ansible_collections/arista/avd/collections.yml
+++ b/ansible_collections/arista/avd/collections.yml
@@ -3,4 +3,4 @@ collections:
   - name: arista.cvp
   - name: arista.eos
   - name: ansible.netcommon
-    version: ">=2.4.0,<2.6.0"
+    version: ">=2.4.0"

--- a/ansible_collections/arista/avd/collections.yml
+++ b/ansible_collections/arista/avd/collections.yml
@@ -3,4 +3,4 @@ collections:
   - name: arista.cvp
   - name: arista.eos
   - name: ansible.netcommon
-    version: ">=2.4.0"
+    version: ">=2.4.0,!=2.6.0"

--- a/ansible_collections/arista/avd/galaxy.yml
+++ b/ansible_collections/arista/avd/galaxy.yml
@@ -39,7 +39,7 @@ tags: ['arista', 'network', 'networking', 'eos', 'avd', 'cloudvision', 'cvp']
 dependencies:
     "arista.cvp": ">=3.2.0"
     "arista.eos": ">=3.1.0"
-    "ansible.netcommon": ">=2.4.0"
+    "ansible.netcommon": ">=2.4.0,!=2.6.0"
 
 # The URL of the originating SCM repository
 repository: https://github.com/aristanetworks/ansible-avd

--- a/ansible_collections/arista/avd/galaxy.yml
+++ b/ansible_collections/arista/avd/galaxy.yml
@@ -39,7 +39,7 @@ tags: ['arista', 'network', 'networking', 'eos', 'avd', 'cloudvision', 'cvp']
 dependencies:
     "arista.cvp": ">=3.2.0"
     "arista.eos": ">=3.1.0"
-    "ansible.netcommon": ">=2.4.0,<2.6.0"
+    "ansible.netcommon": ">=2.4.0"
 
 # The URL of the originating SCM repository
 repository: https://github.com/aristanetworks/ansible-avd

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vtep-logic.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vtep-logic.j2
@@ -6,7 +6,7 @@
 {%         set network_services_data.rd_admin_subfield = switch.vtep_ip %}
 {%     elif tmp_admin_subfield == "bgp_as" %}
 {%         set network_services_data.rd_admin_subfield = switch.bgp_as %}
-{%     elif tmp_admin_subfield | ansible.netcommon.ipaddr %}
+{%     elif tmp_admin_subfield is string and tmp_admin_subfield | ansible.netcommon.ipaddr %}
 {%         set network_services_data.rd_admin_subfield = tmp_admin_subfield %}
 {%     elif tmp_admin_subfield is number and
             tmp_admin_subfield >= 0 and


### PR DESCRIPTION
## Change Summary

Relax ansible.netcommon requirements to allow versions 2.6.1 which fixes https://github.com/ansible-collections/ansible.netcommon/issues/375

## Related Issue(s)

No issue

## Component(s) name

## Proposed changes

* change requirements versions to allow all versions above 2.4.0 except 2.6.0
* fix one occurence of invalid input value to ansible.netcommon.ipaddr filter 

## How to test

molecule tests complete

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
