### PR TITLE
Feat(eos_snapshot): Support for commands containing / character

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_snapshot/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_snapshot/tasks/main.yml
@@ -39,7 +39,7 @@
 - name: save collected commands in text files
   template:
     src: device_text_command.j2
-    dest: "{{ snapshots_backup_dir }}/{{ inventory_hostname }}/{{ item.item | replace('/', '_') }}.txt"
+    dest: "{{ snapshots_backup_dir }}/{{ inventory_hostname }}/{{ item.item | replace('/', '_')}}.txt"
     mode: 0664
   loop: "{{ cli_output.results }}"
   when: "'text' in output_format"

--- a/ansible_collections/arista/avd/roles/eos_snapshot/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_snapshot/tasks/main.yml
@@ -39,7 +39,7 @@
 - name: save collected commands in text files
   template:
     src: device_text_command.j2
-    dest: "{{ snapshots_backup_dir }}/{{ inventory_hostname }}/{{ item.item | replace(\"/\", \"_\") }}.txt"
+    dest: "{{ snapshots_backup_dir }}/{{ inventory_hostname }}/{{ item.item  | replace(\"/\", \"_\") }}.txt"
     mode: 0664
   loop: "{{ cli_output.results }}"
   when: "'text' in output_format"

--- a/ansible_collections/arista/avd/roles/eos_snapshot/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_snapshot/tasks/main.yml
@@ -39,7 +39,7 @@
 - name: save collected commands in text files
   template:
     src: device_text_command.j2
-    dest: "{{ snapshots_backup_dir }}/{{ inventory_hostname }}/{{ item.item | replace(\"/\", \"_\") }}.txt"
+    dest: "{{ snapshots_backup_dir }}/{{ inventory_hostname }}/{{ item.item | replace('/', '_') }}.txt"
     mode: 0664
   loop: "{{ cli_output.results }}"
   when: "'text' in output_format"

--- a/ansible_collections/arista/avd/roles/eos_snapshot/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_snapshot/tasks/main.yml
@@ -39,7 +39,7 @@
 - name: save collected commands in text files
   template:
     src: device_text_command.j2
-    dest: "{{ snapshots_backup_dir }}/{{ inventory_hostname }}/{{ item.item  | replace(\"/\", \"_\") }}.txt"
+    dest: "{{ snapshots_backup_dir }}/{{ inventory_hostname }}/{{ item.item | replace(\"/\", \"_\") }}.txt"
     mode: 0664
   loop: "{{ cli_output.results }}"
   when: "'text' in output_format"

--- a/ansible_collections/arista/avd/roles/eos_snapshot/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_snapshot/tasks/main.yml
@@ -39,7 +39,7 @@
 - name: save collected commands in text files
   template:
     src: device_text_command.j2
-    dest: "{{ snapshots_backup_dir }}/{{ inventory_hostname }}/{{ item.item | replace('/', '_')}}.txt"
+    dest: "{{ snapshots_backup_dir }}/{{ inventory_hostname }}/{{ item.item | replace('/', '_') }}.txt"
     mode: 0664
   loop: "{{ cli_output.results }}"
   when: "'text' in output_format"

--- a/ansible_collections/arista/avd/roles/eos_snapshot/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_snapshot/tasks/main.yml
@@ -39,7 +39,7 @@
 - name: save collected commands in text files
   template:
     src: device_text_command.j2
-    dest: "{{ snapshots_backup_dir }}/{{ inventory_hostname }}/{{ item.item }}.txt"
+    dest: "{{ snapshots_backup_dir }}/{{ inventory_hostname }}/{{ item.item | replace(\"/\", \"_\") }}.txt"
     mode: 0664
   loop: "{{ cli_output.results }}"
   when: "'text' in output_format"

--- a/ansible_collections/arista/avd/roles/eos_snapshot/tasks/markdown.yml
+++ b/ansible_collections/arista/avd/roles/eos_snapshot/tasks/markdown.yml
@@ -7,7 +7,7 @@
 - name: save collected commands in md files
   template:
     src: md_report.j2
-    dest: "{{ snapshots_backup_dir }}/{{ inventory_hostname }}/md_fragments/{{ item.item }}.md"
+    dest: "{{ snapshots_backup_dir }}/{{ inventory_hostname }}/md_fragments/{{ item.item | replace(\"/\", \"_\") }}.md"
     mode: 0664
   loop: "{{ cli_output.results }}"
 

--- a/ansible_collections/arista/avd/roles/eos_snapshot/tasks/markdown.yml
+++ b/ansible_collections/arista/avd/roles/eos_snapshot/tasks/markdown.yml
@@ -7,7 +7,7 @@
 - name: save collected commands in md files
   template:
     src: md_report.j2
-    dest: "{{ snapshots_backup_dir }}/{{ inventory_hostname }}/md_fragments/{{ item.item | replace(\"/\", \"_\") }}.md"
+    dest: "{{ snapshots_backup_dir }}/{{ inventory_hostname }}/md_fragments/{{ item.item | replace('/', '_') }}.md"
     mode: 0664
   loop: "{{ cli_output.results }}"
 


### PR DESCRIPTION
## Change Summary

Using commands containing / such as certain bash commands will cause the output file logic to break. This PR replaces any / in output file names with _.

## Component(s) name

`arista.avd.eos_snapshot`

## Proposed changes

Uses replace filter in 2 tasks to change / to _.

## How to test
Tested on my lab setup. Works as expected.

### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
