### PR TITLE
Feat(eos_cli_config_gen): add PIM sparse-mode interfaces in doc

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -17,6 +17,7 @@
 - [MPLS](#mpls)
   - [MPLS Interfaces](#mpls-interfaces)
 - [Multicast](#multicast)
+  - [PIM Sparse Mode](#pim-sparse-mode)
 - [Filters](#filters)
 - [802.1X Port Security](#8021x-port-security)
   - [802.1X Summary](#8021x-summary)
@@ -657,6 +658,14 @@ interface Ethernet45
 | Ethernet10 | False | False | - |
 
 # Multicast
+
+## PIM Sparse Mode
+
+### PIM Sparse Mode enabled interfaces
+
+| Interface Name | VRF Name | IP Version | DR Priority | Local Interface |
+| -------------- | -------- | ---------- | ----------- | --------------- |
+| Ethernet5 | - | IPv4 | 200 | - |
 
 # Filters
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
@@ -18,6 +18,7 @@
 - [MPLS](#mpls)
   - [MPLS Interfaces](#mpls-interfaces)
 - [Multicast](#multicast)
+  - [PIM Sparse Mode](#pim-sparse-mode)
 - [Filters](#filters)
 - [ACL](#acl)
 - [Quality Of Service](#quality-of-service)
@@ -631,6 +632,14 @@ interface Port-Channel114
 | Port-Channel114 | False | False | - |
 
 # Multicast
+
+## PIM Sparse Mode
+
+### PIM Sparse Mode enabled interfaces
+
+| Interface Name | VRF Name | IP Version | DR Priority | Local Interface |
+| -------------- | -------- | ---------- | ----------- | --------------- |
+| Port-Channel99 | - | IPv4 | 200 | - |
 
 # Filters
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-pim-sparse-mode.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-pim-sparse-mode.md
@@ -12,7 +12,7 @@
   - [IP Routing](#ip-routing)
   - [IPv6 Routing](#ipv6-routing)
 - [Multicast](#multicast)
-  - [Router PIM Sparse Mode](#router-pim-sparse-mode)
+  - [PIM Sparse Mode](#pim-sparse-mode)
 - [Filters](#filters)
 - [ACL](#acl)
 - [Quality Of Service](#quality-of-service)
@@ -85,30 +85,32 @@ interface Management1
 
 # Multicast
 
-## Router PIM Sparse Mode
+## PIM Sparse Mode
 
-### IP Sparse Mode Information
+### Router PIM Sparse Mode
 
-#### IP Rendezvous Information
+#### IP Sparse Mode Information
+
+##### IP Rendezvous Information
 
 | Rendezvous Point Address | Group Address |
 | ------------------------ | ------------- |
 | 10.238.1.161 | 239.12.12.12/32, 239.12.12.13/32, 239.12.12.14/32, 239.12.12.16/32, 239.12.12.20/32, 239.12.12.21/32 |
 
-#### IP Anycast Information
+##### IP Anycast Information
 
 | IP Anycast Address | Other Rendezvous Point Address | Register Count |
 | ------------------ | ------------------------------ | -------------- |
 | 10.38.1.161 | 10.50.64.16 | 15 |
 
-#### IP Sparse Mode VRFs
+##### IP Sparse Mode VRFs
 
 | VRF Name | Rendezvous Point Address | Group Address |
 | -------- | ------------------------ | ------------- |
 | MCAST_VRF1 | 10.238.2.161 | 239.12.22.12/32, 239.12.22.13/32, 239.12.22.14/32 |
 | MCAST_VRF2_ALL_GROUPS | 10.238.3.161 | - |
 
-### Router Multicast Device Configuration
+#### Router Multicast Device Configuration
 
 ```eos
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
@@ -15,6 +15,7 @@
 - [BFD](#bfd)
   - [BFD Interfaces](#bfd-interfaces)
 - [Multicast](#multicast)
+  - [PIM Sparse Mode](#pim-sparse-mode)
 - [Filters](#filters)
 - [ACL](#acl)
 - [Quality Of Service](#quality-of-service)
@@ -395,6 +396,15 @@ interface Vlan4094
 | Vlan85 | 500 | 500 | 5 | True |
 
 # Multicast
+
+## PIM Sparse Mode
+
+### PIM Sparse Mode enabled interfaces
+
+| Interface Name | VRF Name | IP Version | DR Priority | Local Interface |
+| -------------- | -------- | ---------- | ----------- | --------------- |
+| Vlan89 | - | IPv4 | - | Loopback0 |
+| Vlan4094 | - | IPv4 | 200 | - |
 
 # Filters
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/ethernet-interfaces.md
@@ -17,6 +17,7 @@
 - [MPLS](#mpls)
   - [MPLS Interfaces](#mpls-interfaces)
 - [Multicast](#multicast)
+  - [PIM Sparse Mode](#pim-sparse-mode)
 - [Filters](#filters)
 - [ACL](#acl)
 - [Quality Of Service](#quality-of-service)
@@ -530,6 +531,14 @@ interface Ethernet28
 | Ethernet10 | False | False | - |
 
 # Multicast
+
+## PIM Sparse Mode
+
+### PIM Sparse Mode enabled interfaces
+
+| Interface Name | VRF Name | IP Version | DR Priority | Local Interface |
+| -------------- | -------- | ---------- | ----------- | --------------- |
+| Ethernet5 | - | IPv4 | - | - |
 
 # Filters
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/router-pim-sparse-mode.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/router-pim-sparse-mode.md
@@ -12,7 +12,7 @@
   - [IP Routing](#ip-routing)
   - [IPv6 Routing](#ipv6-routing)
 - [Multicast](#multicast)
-  - [Router PIM Sparse Mode](#router-pim-sparse-mode)
+  - [PIM Sparse Mode](#pim-sparse-mode)
 - [Filters](#filters)
 - [ACL](#acl)
 - [Quality Of Service](#quality-of-service)
@@ -85,30 +85,32 @@ interface Management1
 
 # Multicast
 
-## Router PIM Sparse Mode
+## PIM Sparse Mode
 
-### IP Sparse Mode Information
+### Router PIM Sparse Mode
 
-#### IP Rendezvous Information
+#### IP Sparse Mode Information
+
+##### IP Rendezvous Information
 
 | Rendezvous Point Address | Group Address |
 | ------------------------ | ------------- |
 | 10.238.1.161 | 239.12.12.12/32, 239.12.12.13/32, 239.12.12.14/32, 239.12.12.16/32, 239.12.12.20/32, 239.12.12.21/32 |
 
-#### IP Anycast Information
+##### IP Anycast Information
 
 | IP Anycast Address | Other Rendezvous Point Address | Register Count |
 | ------------------ | ------------------------------ | -------------- |
 | 10.38.1.161 | 10.50.64.16 | 15 |
 
-#### IP Sparse Mode VRFs
+##### IP Sparse Mode VRFs
 
 | VRF Name | Rendezvous Point Address | Group Address |
 | -------- | ------------------------ | ------------- |
 | MCAST_VRF1 | 10.238.2.161 | 239.12.22.12/32, 239.12.22.13/32, 239.12.22.14/32 |
 | MCAST_VRF2_ALL_GROUPS | 10.238.3.161 | - |
 
-### Router Multicast Device Configuration
+#### Router Multicast Device Configuration
 
 ```eos
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/vlan-interfaces.md
@@ -15,6 +15,7 @@
 - [BFD](#bfd)
   - [BFD Interfaces](#bfd-interfaces)
 - [Multicast](#multicast)
+  - [PIM Sparse Mode](#pim-sparse-mode)
 - [Filters](#filters)
 - [ACL](#acl)
 - [Quality Of Service](#quality-of-service)
@@ -331,6 +332,15 @@ interface Vlan4094
 | Vlan85 | 500 | 500 | 5 | - |
 
 # Multicast
+
+## PIM Sparse Mode
+
+### PIM Sparse Mode enabled interfaces
+
+| Interface Name | VRF Name | IP Version | DR Priority | Local Interface |
+| -------------- | -------- | ---------- | ----------- | --------------- |
+| Vlan89 | - | IPv4 | - | Loopback0 |
+| Vlan4094 | - | IPv4 | - | - |
 
 # Filters
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/pim-sparse-mode-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/pim-sparse-mode-interfaces.j2
@@ -1,0 +1,15 @@
+{# Building list of PIM interfaces - Only IPv4 supported today #}
+{% if pim_interfaces | length > 0 %}
+
+### PIM Sparse Mode enabled interfaces
+
+| Interface Name | VRF Name | IP Version | DR Priority | Local Interface |
+| -------------- | -------- | ---------- | ----------- | --------------- |
+{%     for interface in pim_interfaces %}
+{%         set vrf = interface.vrf | arista.avd.default('-') %}
+{%         set ip_version = "IPv4" %}
+{%         set dr_priority = interface.pim.ipv4.dr_priority | arista.avd.default('-') %}
+{%         set local_interface = interface.pim.ipv4.local_interface | arista.avd.default('-') %}
+| {{ interface.name }} | {{ vrf }} | {{ ip_version }} | {{ dr_priority }} | {{ local_interface }} |
+{%     endfor %}
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/pim-sparse-mode.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/pim-sparse-mode.j2
@@ -20,6 +20,6 @@
 ## PIM Sparse Mode
 {## Router pim sparse-mode #}
 {%     include 'documentation/router-pim-sparse-mode.j2' %}
-{## PIM Spare Mode Interfaces #}
+{## PIM Sparse Mode Interfaces #}
 {%     include 'documentation/pim-sparse-mode-interfaces.j2' %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/pim-sparse-mode.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/pim-sparse-mode.j2
@@ -1,0 +1,25 @@
+{# Interfaces #}
+{% set pim_interfaces = [] %}
+{% for ethernet_interface in ethernet_interfaces | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%     if ethernet_interface.pim.ipv4.sparse_mode is arista.avd.defined(true) %}
+{%         do pim_interfaces.append(ethernet_interface) %}
+{%     endif %}
+{% endfor %}
+{% for port_channel_interface in port_channel_interfaces | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%     if port_channel_interface.pim.ipv4.sparse_mode is arista.avd.defined(true) %}
+{%         do pim_interfaces.append(port_channel_interface) %}
+{%     endif %}
+{% endfor %}
+{% for vlan_interface in vlan_interfaces | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%     if vlan_interface.pim.ipv4.sparse_mode is arista.avd.defined(true) %}
+{%         do pim_interfaces.append(vlan_interface) %}
+{%     endif %}
+{% endfor %}
+{% if router_pim_sparse_mode is arista.avd.defined or pim_interfaces | length > 0 %}
+
+## PIM Sparse Mode
+{## Router pim sparse-mode #}
+{%     include 'documentation/router-pim-sparse-mode.j2' %}
+{## PIM Spare Mode Interfaces #}
+{%     include 'documentation/pim-sparse-mode-interfaces.j2' %}
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-pim-sparse-mode.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-pim-sparse-mode.j2
@@ -1,13 +1,13 @@
 {# IP PIM Sparse Mode Summary #}
 {% if router_pim_sparse_mode is arista.avd.defined %}
 
-## Router PIM Sparse Mode
+### Router PIM Sparse Mode
 
-### IP Sparse Mode Information
+#### IP Sparse Mode Information
 {%     if router_pim_sparse_mode.ipv4 is arista.avd.defined %}
 {%         if router_pim_sparse_mode.ipv4.rp_addresses is arista.avd.defined %}
 
-#### IP Rendezvous Information
+##### IP Rendezvous Information
 
 | Rendezvous Point Address | Group Address |
 | ------------------------ | ------------- |
@@ -18,7 +18,7 @@
 {%         endif %}
 {%         if router_pim_sparse_mode.ipv4.anycast_rps is arista.avd.defined %}
 
-#### IP Anycast Information
+##### IP Anycast Information
 
 | IP Anycast Address | Other Rendezvous Point Address | Register Count |
 | ------------------ | ------------------------------ | -------------- |
@@ -32,7 +32,7 @@
 {%     endif %}
 {%     if router_pim_sparse_mode.vrfs is arista.avd.defined %}
 
-#### IP Sparse Mode VRFs
+##### IP Sparse Mode VRFs
 
 | VRF Name | Rendezvous Point Address | Group Address |
 | -------- | ------------------------ | ------------- |
@@ -46,7 +46,7 @@
 {%         endfor %}
 {%     endif %}
 
-### Router Multicast Device Configuration
+#### Router Multicast Device Configuration
 
 ```eos
 {%     include 'eos/router-pim-sparse-mode.j2' %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-device-documentation.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-device-documentation.j2
@@ -181,7 +181,7 @@
 {## Router Multicast #}
 {% include 'documentation/router-multicast.j2' %}
 {## Router PIM Sparse Mode #}
-{% include 'documentation/router-pim-sparse-mode.j2' %}
+{% include 'documentation/pim-sparse-mode.j2' %}
 {## Router IGMP #}
 {% include 'documentation/router-igmp.j2' %}
 


### PR DESCRIPTION
## Change Summary

Add a section for PIM Spare-Mode enabled interfaces in generated device documentation

## Related Issue(s)

Fixes #1562 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Following the BFD/BFD interfaces pattern, this PR adds a section to generate the PIM spare-mode (IPv4 only for now as this is all we support) enabled interfaces. The current PR for now hardcode "IPv4", once support for v6 is added the field can be updated.

## How to test

molecule tests / output updated

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
