### PR TITLE
Feat(eos_cli_config_gen): BGP VPN-IPv4/v6 SAFI route-map and match failure discard

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vpn-ipv4-vpn-ipv6.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vpn-ipv4-vpn-ipv6.md
@@ -136,6 +136,22 @@ interface Management1
 | ---------- | -------- |
 | MPLS-IBGP-PEERS | True |
 
+### Router BGP VPN-IPv6 Address Family
+
+- VPN import pruning is __enabled__
+
+#### VPN-IPv6 Neighbors
+
+| Neighbor | Activate |
+| -------- | -------- |
+| 2001:cafe:192:168::4 | True |
+
+#### VPN-IPv6 Peer Groups
+
+| Peer Group | Activate |
+| ---------- | -------- |
+| MPLS-IBGP-PEERS | True |
+
 ### Router BGP Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vpn-ipv4-vpn-ipv6.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vpn-ipv4-vpn-ipv6.md
@@ -126,15 +126,15 @@ interface Management1
 
 #### VPN-IPv4 Neighbors
 
-| Neighbor | Activate |
-| -------- | -------- |
-| 192.168.255.4 | True |
+| Neighbor | Activate | Route-map In | Route-map Out |
+| -------- | -------- | ------------ | ------------- |
+| 192.168.255.4 | True | RM-NEIGHBOR-PEER-IN4 | RM-NEIGHBOR-PEER-OUT4 |
 
 #### VPN-IPv4 Peer Groups
 
-| Peer Group | Activate |
-| ---------- | -------- |
-| MPLS-IBGP-PEERS | True |
+| Peer Group | Activate | Route-map In | Route-map Out |
+| ---------- | -------- | ------------ | ------------- |
+| MPLS-IBGP-PEERS | True | RM-IBGP-PEER-IN4 | RM-IBGP-PEER-OUT4 |
 
 ### Router BGP VPN-IPv6 Address Family
 
@@ -142,15 +142,15 @@ interface Management1
 
 #### VPN-IPv6 Neighbors
 
-| Neighbor | Activate |
-| -------- | -------- |
-| 2001:cafe:192:168::4 | True |
+| Neighbor | Activate | Route-map In | Route-map Out |
+| -------- | -------- | ------------ | ------------- |
+| 2001:cafe:192:168::4 | True | RM-NEIGHBOR-PEER-IN6 | RM-NEIGHBOR-PEER-OUT6 |
 
 #### VPN-IPv6 Peer Groups
 
-| Peer Group | Activate |
-| ---------- | -------- |
-| MPLS-IBGP-PEERS | True |
+| Peer Group | Activate | Route-map In | Route-map Out |
+| ---------- | -------- | ------------ | ------------- |
+| MPLS-IBGP-PEERS | True | RM-IBGP-PEER-IN6 | RM-IBGP-PEER-OUT6 |
 
 ### Router BGP Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vpn-ipv4-vpn-ipv6.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vpn-ipv4-vpn-ipv6.md
@@ -117,6 +117,24 @@ interface Management1
 | -------- | --------- | --- | -------- | -------------- | -------------- | ---------- | --- | --------------------- |
 | 192.168.255.1 | Inherited from peer group MPLS-IBGP-PEERS | default | - | Inherited from peer group MPLS-IBGP-PEERS | Inherited from peer group MPLS-IBGP-PEERS | - | - | - |
 | 192.168.255.2 | Inherited from peer group MPLS-IBGP-PEERS | default | - | Inherited from peer group MPLS-IBGP-PEERS | Inherited from peer group MPLS-IBGP-PEERS | - | - | - |
+| 192.168.255.4 | 65004 | default | - | all | - | - | - | - |
+| 2001:cafe:192:168::4 | 65004 | default | - | all | - | - | - | - |
+
+### Router BGP VPN-IPv4 Address Family
+
+- VPN import pruning is __enabled__
+
+#### VPN-IPv4 Neighbors
+
+| Neighbor | Activate |
+| -------- | -------- |
+| 192.168.255.4 | True |
+
+#### VPN-IPv4 Peer Groups
+
+| Peer Group | Activate |
+| ---------- | -------- |
+| MPLS-IBGP-PEERS | True |
 
 ### Router BGP Device Configuration
 
@@ -137,18 +155,32 @@ router bgp 65103
    neighbor MPLS-IBGP-PEERS maximum-routes 0
    neighbor 192.168.255.1 peer group MPLS-IBGP-PEERS
    neighbor 192.168.255.2 peer group MPLS-IBGP-PEERS
+   neighbor 192.168.255.4 remote-as 65004
+   neighbor 192.168.255.4 send-community
+   neighbor 2001:cafe:192:168::4 remote-as 65004
+   neighbor 2001:cafe:192:168::4 send-community
    !
    address-family vpn-ipv4
       domain identifier 3900000
       neighbor MPLS-IBGP-PEERS activate
+      neighbor MPLS-IBGP-PEERS route-map RM-IBGP-PEER-IN4 in
+      neighbor MPLS-IBGP-PEERS route-map RM-IBGP-PEER-OUT4 out
       neighbor 192.168.255.4 activate
+      neighbor 192.168.255.4 route-map RM-NEIGHBOR-PEER-IN4 in
+      neighbor 192.168.255.4 route-map RM-NEIGHBOR-PEER-OUT4 out
       neighbor default encapsulation mpls next-hop-self source-interface Loopback0
+      route import match-failure action discard
    !
    address-family vpn-ipv6
       domain identifier 3900000
       neighbor MPLS-IBGP-PEERS activate
-      neighbor 192.168.255.4 activate
+      neighbor MPLS-IBGP-PEERS route-map RM-IBGP-PEER-IN6 in
+      neighbor MPLS-IBGP-PEERS route-map RM-IBGP-PEER-OUT6 out
+      neighbor 2001:cafe:192:168::4 activate
+      neighbor 2001:cafe:192:168::4 route-map RM-NEIGHBOR-PEER-IN6 in
+      neighbor 2001:cafe:192:168::4 route-map RM-NEIGHBOR-PEER-OUT6 out
       neighbor default encapsulation mpls next-hop-self source-interface Loopback0
+      route import match-failure action discard
 ```
 
 # Multicast

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-vpn-ipv4-vpn-ipv6.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-vpn-ipv4-vpn-ipv6.cfg
@@ -27,17 +27,31 @@ router bgp 65103
    neighbor MPLS-IBGP-PEERS maximum-routes 0
    neighbor 192.168.255.1 peer group MPLS-IBGP-PEERS
    neighbor 192.168.255.2 peer group MPLS-IBGP-PEERS
+   neighbor 192.168.255.4 remote-as 65004
+   neighbor 192.168.255.4 send-community
+   neighbor 2001:cafe:192:168::4 remote-as 65004
+   neighbor 2001:cafe:192:168::4 send-community
    !
    address-family vpn-ipv4
       domain identifier 3900000
       neighbor MPLS-IBGP-PEERS activate
+      neighbor MPLS-IBGP-PEERS route-map RM-IBGP-PEER-IN4 in
+      neighbor MPLS-IBGP-PEERS route-map RM-IBGP-PEER-OUT4 out
       neighbor 192.168.255.4 activate
+      neighbor 192.168.255.4 route-map RM-NEIGHBOR-PEER-IN4 in
+      neighbor 192.168.255.4 route-map RM-NEIGHBOR-PEER-OUT4 out
       neighbor default encapsulation mpls next-hop-self source-interface Loopback0
+      route import match-failure action discard
    !
    address-family vpn-ipv6
       domain identifier 3900000
       neighbor MPLS-IBGP-PEERS activate
-      neighbor 192.168.255.4 activate
+      neighbor MPLS-IBGP-PEERS route-map RM-IBGP-PEER-IN6 in
+      neighbor MPLS-IBGP-PEERS route-map RM-IBGP-PEER-OUT6 out
+      neighbor 2001:cafe:192:168::4 activate
+      neighbor 2001:cafe:192:168::4 route-map RM-NEIGHBOR-PEER-IN6 in
+      neighbor 2001:cafe:192:168::4 route-map RM-NEIGHBOR-PEER-OUT6 out
       neighbor default encapsulation mpls next-hop-self source-interface Loopback0
+      route import match-failure action discard
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-vpn-ipv4-vpn-ipv6.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-vpn-ipv4-vpn-ipv6.yml
@@ -21,23 +21,41 @@ router_bgp:
       peer_group: MPLS-IBGP-PEERS
     192.168.255.2:
       peer_group: MPLS-IBGP-PEERS
+    192.168.255.4:
+      remote_as: 65004
+      send_community: all
+    2001:cafe:192:168::4:
+      remote_as: 65004
+      send_community: all
   address_family_vpn_ipv4:
     domain_identifier: 65000:0
+    route:
+      import_match_failure_action: discard
     peer_groups:
       MPLS-IBGP-PEERS:
         activate: true
+        route_map_in: RM-IBGP-PEER-IN4
+        route_map_out: RM-IBGP-PEER-OUT4
     neighbors:
       192.168.255.4:
         activate: true
+        route_map_in: RM-NEIGHBOR-PEER-IN4
+        route_map_out: RM-NEIGHBOR-PEER-OUT4
     neighbor_default_encapsulation_mpls_next_hop_self:
       source_interface: Loopback0
   address_family_vpn_ipv6:
     domain_identifier: 65000:0
+    route:
+      import_match_failure_action: discard
     peer_groups:
       MPLS-IBGP-PEERS:
         activate: true
+        route_map_in: RM-IBGP-PEER-IN6
+        route_map_out: RM-IBGP-PEER-OUT6
     neighbors:
-      192.168.255.4:
+      2001:cafe:192:168::4:
         activate: true
+        route_map_in: RM-NEIGHBOR-PEER-IN6
+        route_map_out: RM-NEIGHBOR-PEER-OUT6
     neighbor_default_encapsulation_mpls_next_hop_self:
       source_interface: Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/router-bgp-vpn-ipv4-vpn-ipv6.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/router-bgp-vpn-ipv4-vpn-ipv6.md
@@ -118,6 +118,20 @@ interface Management1
 | 192.168.255.1 | Inherited from peer group MPLS-IBGP-PEERS | default | - | Inherited from peer group MPLS-IBGP-PEERS | Inherited from peer group MPLS-IBGP-PEERS | - | - | - |
 | 192.168.255.2 | Inherited from peer group MPLS-IBGP-PEERS | default | - | Inherited from peer group MPLS-IBGP-PEERS | Inherited from peer group MPLS-IBGP-PEERS | - | - | - |
 
+### Router BGP VPN-IPv4 Address Family
+
+#### VPN-IPv4 Neighbors
+
+| Neighbor | Activate |
+| -------- | -------- |
+| 192.168.255.4 | True |
+
+#### VPN-IPv4 Peer Groups
+
+| Peer Group | Activate |
+| ---------- | -------- |
+| MPLS-IBGP-PEERS | True |
+
 ### Router BGP Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/router-bgp-vpn-ipv4-vpn-ipv6.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/router-bgp-vpn-ipv4-vpn-ipv6.md
@@ -122,29 +122,29 @@ interface Management1
 
 #### VPN-IPv4 Neighbors
 
-| Neighbor | Activate |
-| -------- | -------- |
-| 192.168.255.4 | True |
+| Neighbor | Activate | Route-map In | Route-map Out |
+| -------- | -------- | ------------ | ------------- |
+| 192.168.255.4 | True | - | - |
 
 #### VPN-IPv4 Peer Groups
 
-| Peer Group | Activate |
-| ---------- | -------- |
-| MPLS-IBGP-PEERS | True |
+| Peer Group | Activate | Route-map In | Route-map Out |
+| ---------- | -------- | ------------ | ------------- |
+| MPLS-IBGP-PEERS | True | - | - |
 
 ### Router BGP VPN-IPv6 Address Family
 
 #### VPN-IPv6 Neighbors
 
-| Neighbor | Activate |
-| -------- | -------- |
-| 192.168.255.4 | True |
+| Neighbor | Activate | Route-map In | Route-map Out |
+| -------- | -------- | ------------ | ------------- |
+| 192.168.255.4 | True | - | - |
 
 #### VPN-IPv6 Peer Groups
 
-| Peer Group | Activate |
-| ---------- | -------- |
-| MPLS-IBGP-PEERS | True |
+| Peer Group | Activate | Route-map In | Route-map Out |
+| ---------- | -------- | ------------ | ------------- |
+| MPLS-IBGP-PEERS | True | - | - |
 
 ### Router BGP Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/router-bgp-vpn-ipv4-vpn-ipv6.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/router-bgp-vpn-ipv4-vpn-ipv6.md
@@ -132,6 +132,20 @@ interface Management1
 | ---------- | -------- |
 | MPLS-IBGP-PEERS | True |
 
+### Router BGP VPN-IPv6 Address Family
+
+#### VPN-IPv6 Neighbors
+
+| Neighbor | Activate |
+| -------- | -------- |
+| 192.168.255.4 | True |
+
+#### VPN-IPv6 Peer Groups
+
+| Peer Group | Activate |
+| ---------- | -------- |
+| MPLS-IBGP-PEERS | True |
+
 ### Router BGP Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER2.md
@@ -613,17 +613,17 @@ router isis CORE
 
 #### VPN-IPv4 Peer Groups
 
-| Peer Group | Activate |
-| ---------- | -------- |
-| MPLS-OVERLAY-PEERS | True |
+| Peer Group | Activate | Route-map In | Route-map Out |
+| ---------- | -------- | ------------ | ------------- |
+| MPLS-OVERLAY-PEERS | True | - | - |
 
 ### Router BGP VPN-IPv6 Address Family
 
 #### VPN-IPv6 Peer Groups
 
-| Peer Group | Activate |
-| ---------- | -------- |
-| MPLS-OVERLAY-PEERS | True |
+| Peer Group | Activate | Route-map In | Route-map Out |
+| ---------- | -------- | ------------ | ------------- |
+| MPLS-OVERLAY-PEERS | True | - | - |
 
 ### Router BGP VLANs
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER2.md
@@ -609,6 +609,14 @@ router isis CORE
 | ------------------------------ | ------------------------------ |
 | mpls | Loopback0 |
 
+### Router BGP VPN-IPv4 Address Family
+
+#### VPN-IPv4 Peer Groups
+
+| Peer Group | Activate |
+| ---------- | -------- |
+| MPLS-OVERLAY-PEERS | True |
+
 ### Router BGP VLANs
 
 | VLAN | Route-Distinguisher | Both Route-Target | Import Route Target | Export Route-Target | Redistribute |

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER2.md
@@ -617,6 +617,14 @@ router isis CORE
 | ---------- | -------- |
 | MPLS-OVERLAY-PEERS | True |
 
+### Router BGP VPN-IPv6 Address Family
+
+#### VPN-IPv6 Peer Groups
+
+| Peer Group | Activate |
+| ---------- | -------- |
+| MPLS-OVERLAY-PEERS | True |
+
 ### Router BGP VLANs
 
 | VLAN | Route-Distinguisher | Both Route-Target | Import Route Target | Export Route-Target | Redistribute |

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-RR1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-RR1.md
@@ -401,19 +401,19 @@ router isis CORE
 
 #### VPN-IPv4 Peer Groups
 
-| Peer Group | Activate |
-| ---------- | -------- |
-| MPLS-OVERLAY-PEERS | True |
-| RR-OVERLAY-PEERS | True |
+| Peer Group | Activate | Route-map In | Route-map Out |
+| ---------- | -------- | ------------ | ------------- |
+| MPLS-OVERLAY-PEERS | True | - | - |
+| RR-OVERLAY-PEERS | True | - | - |
 
 ### Router BGP VPN-IPv6 Address Family
 
 #### VPN-IPv6 Peer Groups
 
-| Peer Group | Activate |
-| ---------- | -------- |
-| MPLS-OVERLAY-PEERS | True |
-| RR-OVERLAY-PEERS | True |
+| Peer Group | Activate | Route-map In | Route-map Out |
+| ---------- | -------- | ------------ | ------------- |
+| MPLS-OVERLAY-PEERS | True | - | - |
+| RR-OVERLAY-PEERS | True | - | - |
 
 ### Router BGP Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-RR1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-RR1.md
@@ -406,6 +406,15 @@ router isis CORE
 | MPLS-OVERLAY-PEERS | True |
 | RR-OVERLAY-PEERS | True |
 
+### Router BGP VPN-IPv6 Address Family
+
+#### VPN-IPv6 Peer Groups
+
+| Peer Group | Activate |
+| ---------- | -------- |
+| MPLS-OVERLAY-PEERS | True |
+| RR-OVERLAY-PEERS | True |
+
 ### Router BGP Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-RR1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-RR1.md
@@ -397,6 +397,15 @@ router isis CORE
 | ------------------------------ | ------------------------------ |
 | mpls | - |
 
+### Router BGP VPN-IPv4 Address Family
+
+#### VPN-IPv4 Peer Groups
+
+| Peer Group | Activate |
+| ---------- | -------- |
+| MPLS-OVERLAY-PEERS | True |
+| RR-OVERLAY-PEERS | True |
+
 ### Router BGP Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-LER1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-LER1.md
@@ -648,6 +648,14 @@ router isis CORE
 | ------------------------------ | ------------------------------ |
 | mpls | Loopback0 |
 
+### Router BGP VPN-IPv4 Address Family
+
+#### VPN-IPv4 Peer Groups
+
+| Peer Group | Activate |
+| ---------- | -------- |
+| MPLS-OVERLAY-PEERS | True |
+
 ### Router BGP VLANs
 
 | VLAN | Route-Distinguisher | Both Route-Target | Import Route Target | Export Route-Target | Redistribute |

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-LER1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-LER1.md
@@ -652,17 +652,17 @@ router isis CORE
 
 #### VPN-IPv4 Peer Groups
 
-| Peer Group | Activate |
-| ---------- | -------- |
-| MPLS-OVERLAY-PEERS | True |
+| Peer Group | Activate | Route-map In | Route-map Out |
+| ---------- | -------- | ------------ | ------------- |
+| MPLS-OVERLAY-PEERS | True | - | - |
 
 ### Router BGP VPN-IPv6 Address Family
 
 #### VPN-IPv6 Peer Groups
 
-| Peer Group | Activate |
-| ---------- | -------- |
-| MPLS-OVERLAY-PEERS | True |
+| Peer Group | Activate | Route-map In | Route-map Out |
+| ---------- | -------- | ------------ | ------------- |
+| MPLS-OVERLAY-PEERS | True | - | - |
 
 ### Router BGP VLANs
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-LER1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-LER1.md
@@ -656,6 +656,14 @@ router isis CORE
 | ---------- | -------- |
 | MPLS-OVERLAY-PEERS | True |
 
+### Router BGP VPN-IPv6 Address Family
+
+#### VPN-IPv6 Peer Groups
+
+| Peer Group | Activate |
+| ---------- | -------- |
+| MPLS-OVERLAY-PEERS | True |
+
 ### Router BGP VLANs
 
 | VLAN | Route-Distinguisher | Both Route-Target | Import Route Target | Export Route-Target | Redistribute |

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-RR1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-RR1.md
@@ -401,19 +401,19 @@ router isis CORE
 
 #### VPN-IPv4 Peer Groups
 
-| Peer Group | Activate |
-| ---------- | -------- |
-| MPLS-OVERLAY-PEERS | True |
-| RR-OVERLAY-PEERS | True |
+| Peer Group | Activate | Route-map In | Route-map Out |
+| ---------- | -------- | ------------ | ------------- |
+| MPLS-OVERLAY-PEERS | True | - | - |
+| RR-OVERLAY-PEERS | True | - | - |
 
 ### Router BGP VPN-IPv6 Address Family
 
 #### VPN-IPv6 Peer Groups
 
-| Peer Group | Activate |
-| ---------- | -------- |
-| MPLS-OVERLAY-PEERS | True |
-| RR-OVERLAY-PEERS | True |
+| Peer Group | Activate | Route-map In | Route-map Out |
+| ---------- | -------- | ------------ | ------------- |
+| MPLS-OVERLAY-PEERS | True | - | - |
+| RR-OVERLAY-PEERS | True | - | - |
 
 ### Router BGP Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-RR1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-RR1.md
@@ -406,6 +406,15 @@ router isis CORE
 | MPLS-OVERLAY-PEERS | True |
 | RR-OVERLAY-PEERS | True |
 
+### Router BGP VPN-IPv6 Address Family
+
+#### VPN-IPv6 Peer Groups
+
+| Peer Group | Activate |
+| ---------- | -------- |
+| MPLS-OVERLAY-PEERS | True |
+| RR-OVERLAY-PEERS | True |
+
 ### Router BGP Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-RR1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-RR1.md
@@ -397,6 +397,15 @@ router isis CORE
 | ------------------------------ | ------------------------------ |
 | mpls | - |
 
+### Router BGP VPN-IPv4 Address Family
+
+#### VPN-IPv4 Peer Groups
+
+| Peer Group | Activate |
+| ---------- | -------- |
+| MPLS-OVERLAY-PEERS | True |
+| RR-OVERLAY-PEERS | True |
+
 ### Router BGP Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -3178,21 +3178,33 @@ router_bgp:
     peer_groups:
       < peer_group_name >:
         activate: < true | false >
+        route_map_in: < route_map_name >
+        route_map_out: < route_map_name >
     neighbors:
       < neighbor_ip_address >:
         activate: < true | false >
+        route_map_in: < route_map_name >
+        route_map_out: < route_map_name >
     neighbor_default_encapsulation_mpls_next_hop_self:
       source_interface: < interface >
+    route:
+      import_match_failure_action: < 'discard' >
   address_family_vpn_ipv6:
     domain_identifier: < string >
     peer_groups:
       < peer_group_name >:
         activate: < true | false >
+        route_map_in: < route_map_name >
+        route_map_out: < route_map_name >
     neighbors:
       < neighbor_ip_address >:
         activate: < true | false >
+        route_map_in: < route_map_name >
+        route_map_out: < route_map_name >
     neighbor_default_encapsulation_mpls_next_hop_self:
       source_interface: < interface >
+    route:
+      import_match_failure_action: < 'discard' >
   vrfs:
     < vrf_name_1 >:
       rd: "< route distinguisher >"

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
@@ -507,20 +507,24 @@
 
 #### VPN-IPv4 Neighbors
 
-| Neighbor | Activate |
-| -------- | -------- |
+| Neighbor | Activate | Route-map In | Route-map Out |
+| -------- | -------- | ------------ | ------------- |
 {%             for neighbor in router_bgp.address_family_vpn_ipv4.neighbors | arista.avd.convert_dicts('ip_address') | arista.avd.natural_sort('ip_address') %}
-| {{ neighbor.ip_address }} | {{ neighbor.activate | arista.avd.default(false) }} |
+{%                 set route_map_in = neighbor.route_map_in | arista.avd.default("-") %}
+{%                 set route_map_out = neighbor.route_map_out | arista.avd.default("-") %}
+| {{ neighbor.ip_address }} | {{ neighbor.activate | arista.avd.default(false) }} | {{ route_map_in }} | {{ route_map_out }} |
 {%             endfor %}
 {%         endif %}
 {%         if router_bgp.address_family_vpn_ipv4.peer_groups is arista.avd.defined %}
 
 #### VPN-IPv4 Peer Groups
 
-| Peer Group | Activate |
-| ---------- | -------- |
+| Peer Group | Activate | Route-map In | Route-map Out |
+| ---------- | -------- | ------------ | ------------- |
 {%             for peer_group in router_bgp.address_family_vpn_ipv4.peer_groups | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
-| {{ peer_group.name }} | {{ peer_group.activate | arista.avd.default(false) }} |
+{%                 set route_map_in = peer_group.route_map_in | arista.avd.default("-") %}
+{%                 set route_map_out = peer_group.route_map_out | arista.avd.default("-") %}
+| {{ peer_group.name }} | {{ peer_group.activate | arista.avd.default(false) }} | {{ route_map_in }} | {{ route_map_out }} |
 {%             endfor %}
 {%         endif %}
 {%     endif %}
@@ -535,20 +539,24 @@
 
 #### VPN-IPv6 Neighbors
 
-| Neighbor | Activate |
-| -------- | -------- |
+| Neighbor | Activate | Route-map In | Route-map Out |
+| -------- | -------- | ------------ | ------------- |
 {%             for neighbor in router_bgp.address_family_vpn_ipv6.neighbors | arista.avd.convert_dicts('ip_address') | arista.avd.natural_sort('ip_address') %}
-| {{ neighbor.ip_address }} | {{ neighbor.activate | arista.avd.default(false) }} |
+{%                 set route_map_in = neighbor.route_map_in | arista.avd.default("-") %}
+{%                 set route_map_out = neighbor.route_map_out | arista.avd.default("-") %}
+| {{ neighbor.ip_address }} | {{ neighbor.activate | arista.avd.default(false) }} | {{ route_map_in }} | {{ route_map_out }} |
 {%             endfor %}
 {%         endif %}
 {%         if router_bgp.address_family_vpn_ipv6.peer_groups is arista.avd.defined %}
 
 #### VPN-IPv6 Peer Groups
 
-| Peer Group | Activate |
-| ---------- | -------- |
+| Peer Group | Activate | Route-map In | Route-map Out |
+| ---------- | -------- | ------------ | ------------- |
 {%             for peer_group in router_bgp.address_family_vpn_ipv6.peer_groups | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
-| {{ peer_group.name }} | {{ peer_group.activate | arista.avd.default(false) }} |
+{%                 set route_map_in = peer_group.route_map_in | arista.avd.default("-") %}
+{%                 set route_map_out = peer_group.route_map_out | arista.avd.default("-") %}
+| {{ peer_group.name }} | {{ peer_group.activate | arista.avd.default(false) }} | {{ route_map_in }} | {{ route_map_out }} |
 {%             endfor %}
 {%         endif %}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
@@ -496,6 +496,62 @@
 | L3 Gateway Inter-domain | True |
 {%         endif %}
 {%     endif %}
+{%     if router_bgp.address_family_vpn_ipv4 is arista.avd.defined %}
+
+### Router BGP VPN-IPv4 Address Family
+{%         if router_bgp.address_family_vpn_ipv4.route.import_match_failure_action is arista.avd.defined('discard') %}
+
+- VPN import pruning is __enabled__
+{%         endif %}
+{%         if router_bgp.address_family_vpn_ipv4.neighbors is arista.avd.defined %}
+
+#### VPN-IPv4 Neighbors
+
+| Neighbor | Activate |
+| -------- | -------- |
+{%             for neighbor in router_bgp.address_family_vpn_ipv4.neighbors | arista.avd.convert_dicts('ip_address') | arista.avd.natural_sort('ip_address') %}
+| {{ neighbor.ip_address }} | {{ neighbor.activate | arista.avd.default(false) }} |
+{%             endfor %}
+{%         endif %}
+{%         if router_bgp.address_family_vpn_ipv4.peer_groups is arista.avd.defined %}
+
+#### VPN-IPv4 Peer Groups
+
+| Peer Group | Activate |
+| ---------- | -------- |
+{%             for peer_group in router_bgp.address_family_vpn_ipv4.peer_groups | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+| {{ peer_group.name }} | {{ peer_group.activate | arista.avd.default(false) }} |
+{%             endfor %}
+{%         endif %}
+{%     endif %}
+{%     if router_bgp.address_family_vpn_ipv6 is arista.avd.defined %}
+
+### Router BGP VPN-IPv6 Address Family
+{%         if router_bgp.address_family_vpn_ipv6.route.import_match_failure_action is arista.avd.defined('discard') %}
+
+- VPN import pruning is __enabled__
+{%         endif %}
+{%         if router_bgp.address_family_vpn_ipv6.neighbors is arista.avd.defined %}
+
+#### VPN-IPv6 Neighbors
+
+| Neighbor | Activate |
+| -------- | -------- |
+{%             for neighbor in router_bgp.address_family_vpn_ipv6.neighbors | arista.avd.convert_dicts('ip_address') | arista.avd.natural_sort('ip_address') %}
+| {{ neighbor.ip_address }} | {{ neighbor.activate | arista.avd.default(false) }} |
+{%             endfor %}
+{%         endif %}
+{%         if router_bgp.address_family_vpn_ipv6.peer_groups is arista.avd.defined %}
+
+#### VPN-IPv6 Peer Groups
+
+| Peer Group | Activate |
+| ---------- | -------- |
+{%             for peer_group in router_bgp.address_family_vpn_ipv6.peer_groups | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+| {{ peer_group.name }} | {{ peer_group.activate | arista.avd.default(false) }} |
+{%             endfor %}
+{%         endif %}
+{%     endif %}
 {%     if router_bgp.vlan_aware_bundles is arista.avd.defined %}
 
 ### Router BGP VLAN Aware Bundles

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -676,6 +676,12 @@ router bgp {{ router_bgp.as }}
 {%             elif peer_group.activate is arista.avd.defined(false) %}
       no neighbor {{ peer_group.name }} activate
 {%             endif %}
+{%             if peer_group.route_map_in is arista.avd.defined %}
+      neighbor {{ peer_group.name }} route-map {{ peer_group.route_map_in }} in
+{%             endif %}
+{%             if peer_group.route_map_out is arista.avd.defined %}
+      neighbor {{ peer_group.name }} route-map {{ peer_group.route_map_out }} out
+{%             endif %}
 {%         endfor %}
 {%         for neighbor in router_bgp.address_family_vpn_ipv4.neighbors | arista.avd.convert_dicts('ip_address') | arista.avd.natural_sort('ip_address') %}
 {%             if neighbor.activate is arista.avd.defined(true) %}
@@ -683,9 +689,18 @@ router bgp {{ router_bgp.as }}
 {%             elif neighbor.activate is arista.avd.defined(false) %}
       no neighbor {{ neighbor.ip_address }} activate
 {%             endif %}
+{%             if neighbor.route_map_in is arista.avd.defined %}
+      neighbor {{ neighbor.ip_address }} route-map {{ neighbor.route_map_in }} in
+{%             endif %}
+{%             if neighbor.route_map_out is arista.avd.defined %}
+      neighbor {{ neighbor.ip_address }} route-map {{ neighbor.route_map_out }} out
+{%             endif %}
 {%         endfor %}
 {%         if router_bgp.address_family_vpn_ipv4.neighbor_default_encapsulation_mpls_next_hop_self.source_interface is arista.avd.defined %}
       neighbor default encapsulation mpls next-hop-self source-interface {{ router_bgp.address_family_vpn_ipv4.neighbor_default_encapsulation_mpls_next_hop_self.source_interface }}
+{%         endif %}
+{%         if router_bgp.address_family_vpn_ipv4.route.import_match_failure_action is arista.avd.defined('discard') %}
+      route import match-failure action discard
 {%         endif %}
 {%     endif %}
 {# address family vpn-ipv6 activation #}
@@ -701,6 +716,12 @@ router bgp {{ router_bgp.as }}
 {%             elif peer_group.activate is arista.avd.defined(false) %}
       no neighbor {{ peer_group.name }} activate
 {%             endif %}
+{%             if peer_group.route_map_in is arista.avd.defined %}
+      neighbor {{ peer_group.name }} route-map {{ peer_group.route_map_in }} in
+{%             endif %}
+{%             if peer_group.route_map_out is arista.avd.defined %}
+      neighbor {{ peer_group.name }} route-map {{ peer_group.route_map_out }} out
+{%             endif %}
 {%         endfor %}
 {%         for neighbor in router_bgp.address_family_vpn_ipv6.neighbors | arista.avd.convert_dicts('ip_address') | arista.avd.natural_sort('ip_address') %}
 {%             if neighbor.activate is arista.avd.defined(true) %}
@@ -708,9 +729,18 @@ router bgp {{ router_bgp.as }}
 {%             elif neighbor.activate is arista.avd.defined(false) %}
       no neighbor {{ neighbor.ip_address }} activate
 {%             endif %}
+{%             if neighbor.route_map_in is arista.avd.defined %}
+      neighbor {{ neighbor.ip_address }} route-map {{ neighbor.route_map_in }} in
+{%             endif %}
+{%             if neighbor.route_map_out is arista.avd.defined %}
+      neighbor {{ neighbor.ip_address }} route-map {{ neighbor.route_map_out }} out
+{%             endif %}
 {%         endfor %}
 {%         if router_bgp.address_family_vpn_ipv6.neighbor_default_encapsulation_mpls_next_hop_self.source_interface is arista.avd.defined %}
       neighbor default encapsulation mpls next-hop-self source-interface {{ router_bgp.address_family_vpn_ipv6.neighbor_default_encapsulation_mpls_next_hop_self.source_interface }}
+{%         endif %}
+{%         if router_bgp.address_family_vpn_ipv6.route.import_match_failure_action is arista.avd.defined('discard') %}
+      route import match-failure action discard
 {%         endif %}
 {%     endif %}
 {# L3VPNs - (vxlan) VRFs #}


### PR DESCRIPTION
## Change Summary

Render route-map and route import match failure for VPN-IPv4 and VPN-IPv6 SAFIs

## Related Issue(s)

Fixes #1845 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Updated data model

```yaml
  address_family_vpn_ipv4:
    domain_identifier: 65000:0
    route:
      import_match_failure_action: discard
    peer_groups:
      MPLS-IBGP-PEERS:
        route_map_in: RM-IBGP-PEER-IN4
        route_map_out: RM-IBGP-PEER-OUT4

  address_family_vpn_ipv6:
    route:
      import_match_failure_action: discard
    peer_groups:
      MPLS-IBGP-PEERS:
        activate: true
        route_map_in: RM-IBGP-PEER-IN6
        route_map_out: RM-IBGP-PEER-OUT6
    neighbors:
      2001:cafe:192:168::4:
        route_map_in: RM-NEIGHBOR-PEER-IN6
        route_map_out: RM-NEIGHBOR-PEER-OUT6
```

For vpn-ipv6, updated molecule test to cater IPv6 peer address as well.

## How to test
```make refresh-facts```

Updated markdown documentation for ```eos_designs-mpls-isis-sr-ldp```

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- [x] No breaking changes

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
