### PR TITLE
Feat(eos_cli_config_gen): Support bgp additional-paths in router_bgp vrf address-families

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-v4-evpn.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-v4-evpn.md
@@ -317,6 +317,9 @@ router bgp 65101
       redistribute static
       !
       address-family ipv4
+         bgp additional-paths install
+         bgp additional-paths receive
+         bgp additional-paths send ecmp
          neighbor TEST_PEER_GRP activate
          neighbor TEST_PEER_GRP next-hop address-family ipv6 originate
          neighbor 10.2.3.4 activate

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-v4-evpn.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-v4-evpn.cfg
@@ -109,6 +109,9 @@ router bgp 65101
       redistribute static
       !
       address-family ipv4
+         bgp additional-paths install
+         bgp additional-paths receive
+         bgp additional-paths send ecmp
          neighbor TEST_PEER_GRP activate
          neighbor TEST_PEER_GRP next-hop address-family ipv6 originate
          neighbor 10.2.3.4 activate

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-v4-evpn.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-v4-evpn.yml
@@ -153,6 +153,11 @@ router_bgp:
           route_map_out: RM-10.2.3.4-SET-NEXT-HOP-OUT
       address_families:
         ipv4:
+          bgp:
+            additional_paths:
+              - install
+              - receive
+              - send ecmp
           neighbors:
             10.2.3.4:
               activate: true

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -3303,6 +3303,10 @@ router_bgp:
           advertise_only: < true | false >
       address_families:
         < address_family >:
+          bgp:
+            additional_paths:
+              - < bgp_additional_paths_command >
+              - < bgp_additional_paths_command >
           neighbors:
             < neighbor_ip_address >:
               activate: < true | false >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -924,6 +924,9 @@ router bgp {{ router_bgp.as }}
 {%         for  address_family in vrf.address_families | arista.avd.convert_dicts('address_family') | arista.avd.natural_sort('address_family') %}
       !
       address-family {{ address_family.address_family }}
+{%             for additional_path in address_family.bgp.additional_paths | arista.avd.natural_sort %}
+         bgp additional-paths {{ additional_path }}
+{%             endfor %}
 {%             for peer_group in address_family.peer_groups | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
 {%                 if peer_group.activate is arista.avd.defined(true) %}
          neighbor {{ peer_group.name }} activate


### PR DESCRIPTION
## Change Summary

Support bgp additional-paths in router_bgp vrf address-families. This will support adding a list of commands.

<!-- Enter short PR description -->

## Related Issue(s)

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

```yaml
router_bgp:
  vrfs:
    <vrf>:
      address_families:
        <address_family>:
          bgp:
            additional_paths:
              - < bgp_additional_paths_command >
              - < bgp_additional_paths_command >
```

<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test

molecule converge -s eos_cli_config_gen -- --limit router-bgp-v4-evpn
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
