### PR TITLE
Feat(eos_cli_config_gen): Support bfd vtep evpn commands

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vxlan-interface.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vxlan-interface.md
@@ -74,10 +74,10 @@ interface Management1
 | VXLAN flood-lists learning from data-plane | Enabled |
 | Qos dscp propagation encapsulation | Enabled |
 | Qos map dscp to traffic-class decapsulation | Enabled |
-| Transmission rate set for remote VTEPs EVPN BFD configuration | 300ms |
-| Expected minimum incoming rate set for remote VTEPs EVPN BFD configuration | 300ms |
-| Multiplier set for remote VTEPs EVPN BFD configuration | 3 |
-| Prefix-list reference for remote VTEPs EVPN BFD configuration | PL-TEST |
+| Remote VTEPs EVPN BFD transmission rate | 300ms |
+| Remote VTEPs EVPN BFD expected minimum incoming rate (min-rx) | 300ms |
+| Remote VTEPs EVPN BFD multiplier | 3 |
+| Remote VTEPs EVPN BFD prefix-list | PL-TEST |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vxlan-interface.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vxlan-interface.md
@@ -74,6 +74,10 @@ interface Management1
 | VXLAN flood-lists learning from data-plane | Enabled |
 | Qos dscp propagation encapsulation | Enabled |
 | Qos map dscp to traffic-class decapsulation | Enabled |
+| Transmission rate set for remote VTEPs EVPN BFD configuration | 300ms |
+| Expected minimum incoming rate set for remote VTEPs EVPN BFD configuration | 300ms |
+| Multiplier set for remote VTEPs EVPN BFD configuration | 3 |
+| Prefix-list reference for remote VTEPs EVPN BFD configuration | PL-TEST |
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings
 
@@ -111,6 +115,8 @@ interface Vxlan1
    vxlan vrf Tenant_A_OP_Zone vni 10
    vxlan vrf Tenant_A_WEB_Zone vni 11
    vxlan mlag source-interface Loopback1
+   bfd vtep evpn interval 300 min-rx 300 multiplier 3
+   bfd vtep evpn prefix-list PL-TEST
    vxlan flood vtep 10.1.0.10 10.1.0.11
    vxlan qos dscp propagation encapsulation
    vxlan qos map dscp to traffic-class decapsulation

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vxlan-interface.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vxlan-interface.cfg
@@ -24,6 +24,8 @@ interface Vxlan1
    vxlan vrf Tenant_A_OP_Zone vni 10
    vxlan vrf Tenant_A_WEB_Zone vni 11
    vxlan mlag source-interface Loopback1
+   bfd vtep evpn interval 300 min-rx 300 multiplier 3
+   bfd vtep evpn prefix-list PL-TEST
    vxlan flood vtep 10.1.0.10 10.1.0.11
    vxlan qos dscp propagation encapsulation
    vxlan qos map dscp to traffic-class decapsulation

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vxlan-interface.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vxlan-interface.yml
@@ -11,6 +11,11 @@ vxlan_interface:
       qos:
         dscp_propagation_encapsulation: true
         map_dscp_to_traffic_class_decapsulation: true
+      bfd_vtep_evpn:
+        interval: 300
+        min_rx: 300
+        multiplier: 3
+        prefix_list: PL-TEST
       vlans:
         110:
           vni: 10110

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1593,7 +1593,7 @@ vxlan_interface:
         interval: < integer >
         min_rx: < integer >
         multiplier: < 3-50 >
-        prefix_list: < prefix-list >
+        prefix_list: < prefix_list >
       qos:
         # !!!Warning, only few hardware types with software version >= 4.26.0 support the below knobs to configure Vxlan DSCP mapping.
         # For the Traffic Class to be derived based on the outer DSCP field of the incoming VxLan packet, the core ports must be in "DSCP Trust" mode.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1589,6 +1589,11 @@ vxlan_interface:
       mlag_source_interface: < source_interface_name >
       udp_port: < udp_port >
       virtual_router_encapsulation_mac_address: < mlag-system-id | ethernet_address (H.H.H) >
+      bfd_vtep_evpn:
+        interval: < integer >
+        min_rx: < integer >
+        multiplier: < 3-50 >
+        prefix_list: < prefix-list >
       qos:
         # !!!Warning, only few hardware types with software version >= 4.26.0 support the below knobs to configure Vxlan DSCP mapping.
         # For the Traffic Class to be derived based on the outer DSCP field of the incoming VxLan packet, the core ports must be in "DSCP Trust" mode.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vxlan-interface.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vxlan-interface.j2
@@ -34,16 +34,16 @@
 {%     endif %}
 {%     if vxlan_interface.Vxlan1.vxlan.bfd_vtep_evpn is arista.avd.defined %}
 {%         if vxlan_interface.Vxlan1.vxlan.bfd_vtep_evpn.interval is arista.avd.defined %}
-| Transmission rate set for remote VTEPs EVPN BFD configuration | {{ vxlan_interface.Vxlan1.vxlan.bfd_vtep_evpn.interval }}ms |
+| Remote VTEPs EVPN BFD transmission rate | {{ vxlan_interface.Vxlan1.vxlan.bfd_vtep_evpn.interval }}ms |
 {%         endif %}
 {%         if vxlan_interface.Vxlan1.vxlan.bfd_vtep_evpn.min_rx is arista.avd.defined %}
-| Expected minimum incoming rate set for remote VTEPs EVPN BFD configuration | {{ vxlan_interface.Vxlan1.vxlan.bfd_vtep_evpn.min_rx }}ms |
+| Remote VTEPs EVPN BFD expected minimum incoming rate (min-rx) | {{ vxlan_interface.Vxlan1.vxlan.bfd_vtep_evpn.min_rx }}ms |
 {%         endif %}
 {%         if vxlan_interface.Vxlan1.vxlan.bfd_vtep_evpn.multiplier is arista.avd.defined %}
-| Multiplier set for remote VTEPs EVPN BFD configuration | {{ vxlan_interface.Vxlan1.vxlan.bfd_vtep_evpn.multiplier }} |
+| Remote VTEPs EVPN BFD multiplier | {{ vxlan_interface.Vxlan1.vxlan.bfd_vtep_evpn.multiplier }} |
 {%         endif %}
 {%         if vxlan_interface.Vxlan1.vxlan.bfd_vtep_evpn.prefix_list is arista.avd.defined %}
-| Prefix-list reference for remote VTEPs EVPN BFD configuration | {{ vxlan_interface.Vxlan1.vxlan.bfd_vtep_evpn.prefix_list }} |
+| Remote VTEPs EVPN BFD prefix-list | {{ vxlan_interface.Vxlan1.vxlan.bfd_vtep_evpn.prefix_list }} |
 {%         endif %}
 {%     endif %}
 {%     if vxlan_interface.Vxlan1.vxlan.vlans is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vxlan-interface.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vxlan-interface.j2
@@ -32,6 +32,20 @@
 {%     elif vxlan_interface.Vxlan1.vxlan.qos.map_dscp_to_traffic_class_decapsulation is arista.avd.defined(false) %}
 | Qos map dscp to traffic-class decapsulation | Disabled |
 {%     endif %}
+{%     if vxlan_interface.Vxlan1.vxlan.bfd_vtep_evpn is arista.avd.defined %}
+{%         if vxlan_interface.Vxlan1.vxlan.bfd_vtep_evpn.interval is arista.avd.defined %}
+| Transmission rate set for remote VTEPs EVPN BFD configuration | {{ vxlan_interface.Vxlan1.vxlan.bfd_vtep_evpn.interval }}ms |
+{%         endif %}
+{%         if vxlan_interface.Vxlan1.vxlan.bfd_vtep_evpn.min_rx is arista.avd.defined %}
+| Expected minimum incoming rate set for remote VTEPs EVPN BFD configuration | {{ vxlan_interface.Vxlan1.vxlan.bfd_vtep_evpn.min_rx }}ms |
+{%         endif %}
+{%         if vxlan_interface.Vxlan1.vxlan.bfd_vtep_evpn.multiplier is arista.avd.defined %}
+| Multiplier set for remote VTEPs EVPN BFD configuration | {{ vxlan_interface.Vxlan1.vxlan.bfd_vtep_evpn.multiplier }} |
+{%         endif %}
+{%         if vxlan_interface.Vxlan1.vxlan.bfd_vtep_evpn.prefix_list is arista.avd.defined %}
+| Prefix-list reference for remote VTEPs EVPN BFD configuration | {{ vxlan_interface.Vxlan1.vxlan.bfd_vtep_evpn.prefix_list }} |
+{%         endif %}
+{%     endif %}
 {%     if vxlan_interface.Vxlan1.vxlan.vlans is arista.avd.defined %}
 
 #### VLAN to VNI, Flood List and Multicast Group Mappings

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vxlan-interface.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vxlan-interface.j2
@@ -32,6 +32,16 @@ interface Vxlan1
 {%     if vxlan_interface.Vxlan1.vxlan.mlag_source_interface is arista.avd.defined %}
    vxlan mlag source-interface {{ vxlan_interface.Vxlan1.vxlan.mlag_source_interface }}
 {%     endif %}
+{%     if vxlan_interface.Vxlan1.vxlan.bfd_vtep_evpn is arista.avd.defined %}
+{%         if vxlan_interface.Vxlan1.vxlan.bfd_vtep_evpn.interval is arista.avd.defined 
+               and vxlan_interface.Vxlan1.vxlan.bfd_vtep_evpn.min_rx is arista.avd.defined 
+               and vxlan_interface.Vxlan1.vxlan.bfd_vtep_evpn.multiplier is arista.avd.defined %}
+   bfd vtep evpn interval {{ vxlan_interface.Vxlan1.vxlan.bfd_vtep_evpn.interval }} min-rx {{ vxlan_interface.Vxlan1.vxlan.bfd_vtep_evpn.min_rx }} multiplier {{ vxlan_interface.Vxlan1.vxlan.bfd_vtep_evpn.multiplier }}
+{%         endif %}
+{%         if vxlan_interface.Vxlan1.vxlan.bfd_vtep_evpn.prefix_list is arista.avd.defined %}
+   bfd vtep evpn prefix-list {{ vxlan_interface.Vxlan1.vxlan.bfd_vtep_evpn.prefix_list }}
+{%         endif %}
+{%     endif %}
 {%     if vxlan_interface.Vxlan1.vxlan.flood_vteps is arista.avd.defined %}
    vxlan flood vtep {{ vxlan_interface.Vxlan1.vxlan.flood_vteps | join(' ') }}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vxlan-interface.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vxlan-interface.j2
@@ -33,8 +33,8 @@ interface Vxlan1
    vxlan mlag source-interface {{ vxlan_interface.Vxlan1.vxlan.mlag_source_interface }}
 {%     endif %}
 {%     if vxlan_interface.Vxlan1.vxlan.bfd_vtep_evpn is arista.avd.defined %}
-{%         if vxlan_interface.Vxlan1.vxlan.bfd_vtep_evpn.interval is arista.avd.defined 
-               and vxlan_interface.Vxlan1.vxlan.bfd_vtep_evpn.min_rx is arista.avd.defined 
+{%         if vxlan_interface.Vxlan1.vxlan.bfd_vtep_evpn.interval is arista.avd.defined
+               and vxlan_interface.Vxlan1.vxlan.bfd_vtep_evpn.min_rx is arista.avd.defined
                and vxlan_interface.Vxlan1.vxlan.bfd_vtep_evpn.multiplier is arista.avd.defined %}
    bfd vtep evpn interval {{ vxlan_interface.Vxlan1.vxlan.bfd_vtep_evpn.interval }} min-rx {{ vxlan_interface.Vxlan1.vxlan.bfd_vtep_evpn.min_rx }} multiplier {{ vxlan_interface.Vxlan1.vxlan.bfd_vtep_evpn.multiplier }}
 {%         endif %}


### PR DESCRIPTION
## Change Summary

Support bfd vtep evpn commands.
<!-- Enter short PR description -->

## Related Issue(s)

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

```yaml
vxlan_interface:
  Vxlan1:
    vxlan:
      bfd_vtep_evpn:
        interval: < integer >
        min_rx: < integer >
        multiplier: < 3-50 >
        prefix_list: < prefix-list >
```

<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test

molecule converge -s eos_cli_config_gen -- --limit vxlan-interface

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
