### PR TITLE
Test(eos_cli_config_gen): Add artifacts for router_bgp vrfs address_families peer_groups

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-v4-evpn.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-v4-evpn.md
@@ -317,6 +317,8 @@ router bgp 65101
       redistribute static
       !
       address-family ipv4
+         neighbor TEST_PEER_GRP activate
+         neighbor TEST_PEER_GRP next-hop address-family ipv6 originate
          neighbor 10.2.3.4 activate
          neighbor 10.2.3.4 route-map RM-10.2.3.4-SET-NEXT-HOP-OUT out
          neighbor 10.2.3.5 activate

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-v4-evpn.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-v4-evpn.cfg
@@ -109,6 +109,8 @@ router bgp 65101
       redistribute static
       !
       address-family ipv4
+         neighbor TEST_PEER_GRP activate
+         neighbor TEST_PEER_GRP next-hop address-family ipv6 originate
          neighbor 10.2.3.4 activate
          neighbor 10.2.3.4 route-map RM-10.2.3.4-SET-NEXT-HOP-OUT out
          neighbor 10.2.3.5 activate

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-v4-evpn.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-v4-evpn.yml
@@ -164,6 +164,11 @@ router_bgp:
             10.0.0.0/8:
             100.64.0.0/10:
               route_map: RM-10.2.3.4
+          peer_groups:
+            TEST_PEER_GRP:
+              activate: true
+              next_hop:
+                address_family_ipv6_originate: true
       redistribute_routes:
         - connected
         - static

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/router-bgp-v4-evpn.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/router-bgp-v4-evpn.md
@@ -312,6 +312,8 @@ router bgp 65101
       redistribute static
       !
       address-family ipv4
+         neighbor TEST_PEER_GRP activate
+         neighbor TEST_PEER_GRP next-hop address-family ipv6 originate
          neighbor 10.2.3.4 activate
          neighbor 10.2.3.4 route-map RM-10.2.3.4-SET-NEXT-HOP-OUT out
          neighbor 10.2.3.5 activate

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/router-bgp-v4-evpn.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/router-bgp-v4-evpn.cfg
@@ -106,6 +106,8 @@ router bgp 65101
       redistribute static
       !
       address-family ipv4
+         neighbor TEST_PEER_GRP activate
+         neighbor TEST_PEER_GRP next-hop address-family ipv6 originate
          neighbor 10.2.3.4 activate
          neighbor 10.2.3.4 route-map RM-10.2.3.4-SET-NEXT-HOP-OUT out
          neighbor 10.2.3.5 activate

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/router-bgp-v4-evpn.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/router-bgp-v4-evpn.yml
@@ -155,6 +155,11 @@ router_bgp:
             - prefix: 10.0.0.0/8
             - prefix: 100.64.0.0/10
               route_map: RM-10.2.3.4
+          peer_groups:
+            - name: TEST_PEER_GRP
+              activate: true
+              next_hop:
+                address_family_ipv6_originate: true
       redistribute_routes:
         - source_protocol: connected
         - source_protocol: static

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -3295,6 +3295,11 @@ router_bgp:
               activate: < true | false >
               route_map_out: < route_map_name >
               route_map_in: < route_map_name >
+          peer_groups:
+            < peer_group >:
+              activate: < true | false >
+              next_hop:
+                address_family_ipv6_originate: < true | false >
           networks:
             < prefix_address >:
               route_map: < route_map_name >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
@@ -2915,6 +2915,11 @@ router_bgp:
               activate: < true | false >
               route_map_out: < route_map_name >
               route_map_in: < route_map_name >
+          peer_groups:
+            - name: < peer_group >
+              activate: < true | false >
+              next_hop:
+                address_family_ipv6_originate: < true | false >
           networks:
             - prefix: < prefix_address >
               route_map: < route_map_name >


### PR DESCRIPTION
## Change Summary

Add the missing artifacts and the documentation for the ```router_bgp.vrfs.<vrf>.address_families.<address_family>.peer_groups```. Added to both eos_cli_config_gen and v4.0 as well.
<!-- Enter short PR description -->

## Related Issue(s)

Fixes #1852 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test

molecule converge -s eos_cli_config_gen -- --limit router-bgp-v4-evpn
molecule converge -s eos_cli_config_gen_v4.0 -- --limit router-bgp-v4-evpn
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
