### PR TITLE
Feat(eos_designs): Support raw_eos_cli key on core_interfaces

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER1.md
@@ -249,7 +249,7 @@ interface Ethernet2
    isis network point-to-point
    isis authentication mode md5
    isis authentication key 7 asdadjiwtelogkkdng
-   link-debounce time 1000
+   link-debounce time 1500
 
 !
 interface Ethernet3

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER1.md
@@ -228,6 +228,8 @@ interface Ethernet1
    isis network point-to-point
    isis authentication mode md5
    isis authentication key 7 asdadjiwtelogkkdng
+   link-debounce time 1000
+
 !
 interface Ethernet2
    description P2P_LINK_TO_SITE1-LER2_Ethernet2
@@ -247,6 +249,8 @@ interface Ethernet2
    isis network point-to-point
    isis authentication mode md5
    isis authentication key 7 asdadjiwtelogkkdng
+   link-debounce time 1000
+
 !
 interface Ethernet3
    no shutdown

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER2.md
@@ -227,6 +227,8 @@ interface Ethernet1
    isis network point-to-point
    isis authentication mode md5
    isis authentication key 7 asdadjiwtelogkkdng
+   link-debounce time 1000
+
 !
 interface Ethernet2
    description P2P_LINK_TO_SITE1-LER1_Ethernet2
@@ -246,6 +248,8 @@ interface Ethernet2
    isis network point-to-point
    isis authentication mode md5
    isis authentication key 7 asdadjiwtelogkkdng
+   link-debounce time 1000
+
 !
 interface Ethernet3
    no shutdown

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER2.md
@@ -248,7 +248,7 @@ interface Ethernet2
    isis network point-to-point
    isis authentication mode md5
    isis authentication key 7 asdadjiwtelogkkdng
-   link-debounce time 1000
+   link-debounce time 1500
 
 !
 interface Ethernet3

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LSR1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LSR1.md
@@ -179,6 +179,8 @@ interface Ethernet1
    isis network point-to-point
    isis authentication mode md5
    isis authentication key 7 asdadjiwtelogkkdng
+   link-debounce time 1000
+
 !
 interface Ethernet3
    description P2P_LINK_TO_SITE2-LSR1_Ethernet3
@@ -198,6 +200,8 @@ interface Ethernet3
    isis network point-to-point
    isis authentication mode md5
    isis authentication key 7 asdadjiwtelogkkdng
+   link-debounce time 1000
+
 !
 interface Ethernet4
    description P2P_LINK_TO_SITE1-RR1_Ethernet4
@@ -217,6 +221,8 @@ interface Ethernet4
    isis network point-to-point
    isis authentication mode md5
    isis authentication key 7 asdadjiwtelogkkdng
+   link-debounce time 1000
+
 ```
 
 ## Loopback Interfaces

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LSR2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LSR2.md
@@ -176,6 +176,8 @@ interface Ethernet1
    isis network point-to-point
    isis authentication mode md5
    isis authentication key 7 asdadjiwtelogkkdng
+   link-debounce time 1000
+
 !
 interface Ethernet3
    description P2P_LINK_TO_SITE2-LSR2_Ethernet3
@@ -195,6 +197,8 @@ interface Ethernet3
    isis network point-to-point
    isis authentication mode md5
    isis authentication key 7 asdadjiwtelogkkdng
+   link-debounce time 1000
+
 ```
 
 ## Loopback Interfaces

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-RR1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-RR1.md
@@ -176,6 +176,8 @@ interface Ethernet4
    isis network point-to-point
    isis authentication mode md5
    isis authentication key 7 asdadjiwtelogkkdng
+   link-debounce time 1000
+
 ```
 
 ## Loopback Interfaces

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-LER1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-LER1.md
@@ -371,7 +371,7 @@ interface Port-Channel11
    no isis hello padding
    isis authentication mode md5
    isis authentication key 7 asdadjiwtelogkkdng
-   link-debounce time 1000
+   link-debounce time 1600
 
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-LER1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-LER1.md
@@ -235,6 +235,8 @@ interface Ethernet1
    isis network point-to-point
    isis authentication mode md5
    isis authentication key 7 asdadjiwtelogkkdng
+   link-debounce time 1000
+
 !
 interface Ethernet4
    no shutdown
@@ -369,6 +371,8 @@ interface Port-Channel11
    no isis hello padding
    isis authentication mode md5
    isis authentication key 7 asdadjiwtelogkkdng
+   link-debounce time 1000
+
 ```
 
 ## Loopback Interfaces

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-LSR1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-LSR1.md
@@ -179,6 +179,8 @@ interface Ethernet1
    isis network point-to-point
    isis authentication mode md5
    isis authentication key 7 asdadjiwtelogkkdng
+   link-debounce time 1000
+
 !
 interface Ethernet3
    description P2P_LINK_TO_SITE1-LSR1_Ethernet3
@@ -198,6 +200,8 @@ interface Ethernet3
    isis network point-to-point
    isis authentication mode md5
    isis authentication key 7 asdadjiwtelogkkdng
+   link-debounce time 1000
+
 !
 interface Ethernet4
    description P2P_LINK_TO_SITE2-RR1_Ethernet4
@@ -217,6 +221,8 @@ interface Ethernet4
    isis network point-to-point
    isis authentication mode md5
    isis authentication key 7 asdadjiwtelogkkdng
+   link-debounce time 1000
+
 ```
 
 ## Loopback Interfaces

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-LSR2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-LSR2.md
@@ -239,7 +239,7 @@ interface Port-Channel12
    no isis hello padding
    isis authentication mode md5
    isis authentication key 7 asdadjiwtelogkkdng
-   link-debounce time 1000
+   link-debounce time 1600
 
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-LSR2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-LSR2.md
@@ -183,6 +183,8 @@ interface Ethernet3
    isis network point-to-point
    isis authentication mode md5
    isis authentication key 7 asdadjiwtelogkkdng
+   link-debounce time 1000
+
 !
 interface Ethernet12
    description P2P_LINK_TO_SITE2-LER1_Port-Channel11
@@ -237,6 +239,8 @@ interface Port-Channel12
    no isis hello padding
    isis authentication mode md5
    isis authentication key 7 asdadjiwtelogkkdng
+   link-debounce time 1000
+
 ```
 
 ## Loopback Interfaces

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-RR1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-RR1.md
@@ -176,6 +176,8 @@ interface Ethernet4
    isis network point-to-point
    isis authentication mode md5
    isis authentication key 7 asdadjiwtelogkkdng
+   link-debounce time 1000
+
 ```
 
 ## Loopback Interfaces

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-LER1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-LER1.cfg
@@ -132,7 +132,7 @@ interface Ethernet2
    isis network point-to-point
    isis authentication mode md5
    isis authentication key 7 asdadjiwtelogkkdng
-   link-debounce time 1000
+   link-debounce time 1500
 
 !
 interface Ethernet3

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-LER1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-LER1.cfg
@@ -111,6 +111,8 @@ interface Ethernet1
    isis network point-to-point
    isis authentication mode md5
    isis authentication key 7 asdadjiwtelogkkdng
+   link-debounce time 1000
+
 !
 interface Ethernet2
    description P2P_LINK_TO_SITE1-LER2_Ethernet2
@@ -130,6 +132,8 @@ interface Ethernet2
    isis network point-to-point
    isis authentication mode md5
    isis authentication key 7 asdadjiwtelogkkdng
+   link-debounce time 1000
+
 !
 interface Ethernet3
    no shutdown

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-LER2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-LER2.cfg
@@ -113,6 +113,8 @@ interface Ethernet1
    isis network point-to-point
    isis authentication mode md5
    isis authentication key 7 asdadjiwtelogkkdng
+   link-debounce time 1000
+
 !
 interface Ethernet2
    description P2P_LINK_TO_SITE1-LER1_Ethernet2
@@ -132,6 +134,8 @@ interface Ethernet2
    isis network point-to-point
    isis authentication mode md5
    isis authentication key 7 asdadjiwtelogkkdng
+   link-debounce time 1000
+
 !
 interface Ethernet3
    no shutdown

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-LER2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-LER2.cfg
@@ -134,7 +134,7 @@ interface Ethernet2
    isis network point-to-point
    isis authentication mode md5
    isis authentication key 7 asdadjiwtelogkkdng
-   link-debounce time 1000
+   link-debounce time 1500
 
 !
 interface Ethernet3

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-LSR1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-LSR1.cfg
@@ -33,6 +33,8 @@ interface Ethernet1
    isis network point-to-point
    isis authentication mode md5
    isis authentication key 7 asdadjiwtelogkkdng
+   link-debounce time 1000
+
 !
 interface Ethernet3
    description P2P_LINK_TO_SITE2-LSR1_Ethernet3
@@ -52,6 +54,8 @@ interface Ethernet3
    isis network point-to-point
    isis authentication mode md5
    isis authentication key 7 asdadjiwtelogkkdng
+   link-debounce time 1000
+
 !
 interface Ethernet4
    description P2P_LINK_TO_SITE1-RR1_Ethernet4
@@ -71,6 +75,8 @@ interface Ethernet4
    isis network point-to-point
    isis authentication mode md5
    isis authentication key 7 asdadjiwtelogkkdng
+   link-debounce time 1000
+
 !
 interface Loopback0
    description LSR_Router_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-LSR2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-LSR2.cfg
@@ -33,6 +33,8 @@ interface Ethernet1
    isis network point-to-point
    isis authentication mode md5
    isis authentication key 7 asdadjiwtelogkkdng
+   link-debounce time 1000
+
 !
 interface Ethernet3
    description P2P_LINK_TO_SITE2-LSR2_Ethernet3
@@ -52,6 +54,8 @@ interface Ethernet3
    isis network point-to-point
    isis authentication mode md5
    isis authentication key 7 asdadjiwtelogkkdng
+   link-debounce time 1000
+
 !
 interface Loopback0
    description LSR_Router_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-RR1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-RR1.cfg
@@ -33,6 +33,8 @@ interface Ethernet4
    isis network point-to-point
    isis authentication mode md5
    isis authentication key 7 asdadjiwtelogkkdng
+   link-debounce time 1000
+
 !
 interface Loopback0
    description MPLS_Overlay_peering

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE2-LER1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE2-LER1.cfg
@@ -75,6 +75,8 @@ interface Port-Channel11
    no isis hello padding
    isis authentication mode md5
    isis authentication key 7 asdadjiwtelogkkdng
+   link-debounce time 1000
+
 !
 interface Ethernet1
    description P2P_LINK_TO_SITE2-LSR1_Ethernet1
@@ -94,6 +96,8 @@ interface Ethernet1
    isis network point-to-point
    isis authentication mode md5
    isis authentication key 7 asdadjiwtelogkkdng
+   link-debounce time 1000
+
 !
 interface Ethernet4
    no shutdown

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE2-LER1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE2-LER1.cfg
@@ -75,7 +75,7 @@ interface Port-Channel11
    no isis hello padding
    isis authentication mode md5
    isis authentication key 7 asdadjiwtelogkkdng
-   link-debounce time 1000
+   link-debounce time 1600
 
 !
 interface Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE2-LSR1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE2-LSR1.cfg
@@ -33,6 +33,8 @@ interface Ethernet1
    isis network point-to-point
    isis authentication mode md5
    isis authentication key 7 asdadjiwtelogkkdng
+   link-debounce time 1000
+
 !
 interface Ethernet3
    description P2P_LINK_TO_SITE1-LSR1_Ethernet3
@@ -52,6 +54,8 @@ interface Ethernet3
    isis network point-to-point
    isis authentication mode md5
    isis authentication key 7 asdadjiwtelogkkdng
+   link-debounce time 1000
+
 !
 interface Ethernet4
    description P2P_LINK_TO_SITE2-RR1_Ethernet4
@@ -71,6 +75,8 @@ interface Ethernet4
    isis network point-to-point
    isis authentication mode md5
    isis authentication key 7 asdadjiwtelogkkdng
+   link-debounce time 1000
+
 !
 interface Loopback0
    description LSR_Router_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE2-LSR2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE2-LSR2.cfg
@@ -32,6 +32,8 @@ interface Port-Channel12
    no isis hello padding
    isis authentication mode md5
    isis authentication key 7 asdadjiwtelogkkdng
+   link-debounce time 1000
+
 !
 interface Ethernet3
    description P2P_LINK_TO_SITE1-LSR2_Ethernet3
@@ -51,6 +53,8 @@ interface Ethernet3
    isis network point-to-point
    isis authentication mode md5
    isis authentication key 7 asdadjiwtelogkkdng
+   link-debounce time 1000
+
 !
 interface Ethernet12
    description P2P_LINK_TO_SITE2-LER1_Port-Channel11

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE2-LSR2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE2-LSR2.cfg
@@ -32,7 +32,7 @@ interface Port-Channel12
    no isis hello padding
    isis authentication mode md5
    isis authentication key 7 asdadjiwtelogkkdng
-   link-debounce time 1000
+   link-debounce time 1600
 
 !
 interface Ethernet3

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE2-RR1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE2-RR1.cfg
@@ -33,6 +33,8 @@ interface Ethernet4
    isis network point-to-point
    isis authentication mode md5
    isis authentication key 7 asdadjiwtelogkkdng
+   link-debounce time 1000
+
 !
 interface Loopback0
    description MPLS_Overlay_peering

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER1.yml
@@ -206,6 +206,9 @@ ethernet_interfaces:
       ldp:
         interface: true
         igp_sync: true
+    eos_cli: 'link-debounce time 1000
+
+      '
   Ethernet2:
     peer: SITE1-LER2
     peer_interface: Ethernet2
@@ -229,6 +232,9 @@ ethernet_interfaces:
       ldp:
         interface: true
         igp_sync: true
+    eos_cli: 'link-debounce time 1000
+
+      '
   Ethernet8:
     peer: CPE_TENANT_A_SITE1
     peer_interface: Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER1.yml
@@ -232,7 +232,7 @@ ethernet_interfaces:
       ldp:
         interface: true
         igp_sync: true
-    eos_cli: 'link-debounce time 1000
+    eos_cli: 'link-debounce time 1500
 
       '
   Ethernet8:

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER2.yml
@@ -264,7 +264,7 @@ ethernet_interfaces:
       ldp:
         interface: true
         igp_sync: true
-    eos_cli: 'link-debounce time 1000
+    eos_cli: 'link-debounce time 1500
 
       '
   Ethernet8:

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER2.yml
@@ -238,6 +238,9 @@ ethernet_interfaces:
       ldp:
         interface: true
         igp_sync: true
+    eos_cli: 'link-debounce time 1000
+
+      '
   Ethernet2:
     peer: SITE1-LER1
     peer_interface: Ethernet2
@@ -261,6 +264,9 @@ ethernet_interfaces:
       ldp:
         interface: true
         igp_sync: true
+    eos_cli: 'link-debounce time 1000
+
+      '
   Ethernet8:
     peer: CPE_TENANT_A_SITE1
     peer_interface: Ethernet2

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LSR1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LSR1.yml
@@ -96,6 +96,9 @@ ethernet_interfaces:
       ldp:
         interface: true
         igp_sync: true
+    eos_cli: 'link-debounce time 1000
+
+      '
   Ethernet3:
     peer: SITE2-LSR1
     peer_interface: Ethernet3
@@ -119,6 +122,9 @@ ethernet_interfaces:
       ldp:
         interface: true
         igp_sync: true
+    eos_cli: 'link-debounce time 1000
+
+      '
   Ethernet4:
     peer: SITE1-RR1
     peer_interface: Ethernet4
@@ -142,3 +148,6 @@ ethernet_interfaces:
       ldp:
         interface: true
         igp_sync: true
+    eos_cli: 'link-debounce time 1000
+
+      '

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LSR2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LSR2.yml
@@ -96,6 +96,9 @@ ethernet_interfaces:
       ldp:
         interface: true
         igp_sync: true
+    eos_cli: 'link-debounce time 1000
+
+      '
   Ethernet3:
     peer: SITE2-LSR2
     peer_interface: Ethernet3
@@ -119,3 +122,6 @@ ethernet_interfaces:
       ldp:
         interface: true
         igp_sync: true
+    eos_cli: 'link-debounce time 1000
+
+      '

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-RR1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-RR1.yml
@@ -164,6 +164,9 @@ ethernet_interfaces:
       ldp:
         interface: true
         igp_sync: true
+    eos_cli: 'link-debounce time 1000
+
+      '
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-LER1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-LER1.yml
@@ -335,7 +335,7 @@ port_channel_interfaces:
     isis_circuit_type: level-2
     isis_authentication_mode: md5
     isis_authentication_key: asdadjiwtelogkkdng
-    eos_cli: 'link-debounce time 1000
+    eos_cli: 'link-debounce time 1600
 
       '
     mpls:

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-LER1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-LER1.yml
@@ -253,6 +253,9 @@ ethernet_interfaces:
       ldp:
         interface: true
         igp_sync: true
+    eos_cli: 'link-debounce time 1000
+
+      '
   Ethernet11:
     type: routed
     description: P2P_LINK_TO_SITE2-LSR2_Port-Channel12
@@ -332,6 +335,9 @@ port_channel_interfaces:
     isis_circuit_type: level-2
     isis_authentication_mode: md5
     isis_authentication_key: asdadjiwtelogkkdng
+    eos_cli: 'link-debounce time 1000
+
+      '
     mpls:
       ip: true
       ldp:

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-LSR1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-LSR1.yml
@@ -96,6 +96,9 @@ ethernet_interfaces:
       ldp:
         interface: true
         igp_sync: true
+    eos_cli: 'link-debounce time 1000
+
+      '
   Ethernet3:
     peer: SITE1-LSR1
     peer_interface: Ethernet3
@@ -119,6 +122,9 @@ ethernet_interfaces:
       ldp:
         interface: true
         igp_sync: true
+    eos_cli: 'link-debounce time 1000
+
+      '
   Ethernet4:
     peer: SITE2-RR1
     peer_interface: Ethernet4
@@ -142,3 +148,6 @@ ethernet_interfaces:
       ldp:
         interface: true
         igp_sync: true
+    eos_cli: 'link-debounce time 1000
+
+      '

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-LSR2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-LSR2.yml
@@ -132,7 +132,7 @@ port_channel_interfaces:
     isis_circuit_type: level-2
     isis_authentication_mode: md5
     isis_authentication_key: asdadjiwtelogkkdng
-    eos_cli: 'link-debounce time 1000
+    eos_cli: 'link-debounce time 1600
 
       '
     mpls:

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-LSR2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-LSR2.yml
@@ -96,6 +96,9 @@ ethernet_interfaces:
       ldp:
         interface: true
         igp_sync: true
+    eos_cli: 'link-debounce time 1000
+
+      '
   Ethernet12:
     type: routed
     description: P2P_LINK_TO_SITE2-LER1_Port-Channel11
@@ -129,6 +132,9 @@ port_channel_interfaces:
     isis_circuit_type: level-2
     isis_authentication_mode: md5
     isis_authentication_key: asdadjiwtelogkkdng
+    eos_cli: 'link-debounce time 1000
+
+      '
     mpls:
       ip: true
       ldp:

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-RR1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-RR1.yml
@@ -164,6 +164,9 @@ ethernet_interfaces:
       ldp:
         interface: true
         igp_sync: true
+    eos_cli: 'link-debounce time 1000
+
+      '
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/inventory/group_vars/MPLS_CORE.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/inventory/group_vars/MPLS_CORE.yml
@@ -168,6 +168,8 @@ core_interfaces:
       ipv6_enable: true
       isis_authentication_mode: md5
       isis_authentication_key: asdadjiwtelogkkdng
+      raw_eos_cli: |
+        link-debounce time 1000
   p2p_links:
 
     - nodes: [ SITE1-LER1, SITE1-LSR1 ]

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/inventory/group_vars/MPLS_CORE.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/inventory/group_vars/MPLS_CORE.yml
@@ -193,6 +193,8 @@ core_interfaces:
       isis_metric: 500
       interfaces: [ Ethernet2, Ethernet2 ]
       profile: default_bb_profile
+      raw_eos_cli: |
+        link-debounce time 1500
 
     - nodes: [ SITE1-LSR1, SITE1-RR1 ]
       id: 4
@@ -227,3 +229,5 @@ core_interfaces:
           SITE2-LSR2: [ Ethernet12, Ethernet13 ]
           SITE2-LER1: [ Ethernet11, Ethernet11 ]
       profile: default_bb_profile
+      raw_eos_cli: |
+        link-debounce time 1600

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/core-interfaces-BETA.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/core-interfaces-BETA.md
@@ -79,6 +79,10 @@ core_interfaces:
       # Profile defined under p2p_profiles | Optional
       profile: < p2p_profile_name >
 
+      # EOS CLI rendered directly on the point-to-point interface in the final EOS configuration
+      raw_eos_cli: |
+        < multiline eos cli >
+
       # Port-channel parameters
       port_channel:
         mode: active

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/core_interfaces/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/core_interfaces/ethernet-interfaces.j2
@@ -58,6 +58,10 @@ ethernet_interfaces:
         igp_sync: true
 {%             endif %}
 {%         endif %}
+{%         if p2p_interface.raw_eos_cli is arista.avd.defined %}
+    eos_cli: |
+      {{ p2p_interface.raw_eos_cli | indent(6,false) }}
+{%         endif %}
 {%     endfor %}
 {%     for p2p_interface_key in core_interfaces_data.p2p_port_channels | arista.avd.natural_sort %}
 {%         set p2p_interface = core_interfaces_data.p2p_port_channels[p2p_interface_key] %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/core_interfaces/logic.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/core_interfaces/logic.j2
@@ -96,6 +96,7 @@
 {%         set p2p_interface.shutdown = "false" %}
 {%         set p2p_interface.description = "P2P_LINK_TO_" ~ p2p_interface.peer ~ "_" ~ p2p_interface.peer_interface %}
 {%         set p2p_interface.mpls_ip = p2p_link.mpls_ip | arista.avd.default(link_info.p2p_profile.mpls_ip, true) %}
+{%         set p2p_interface.raw_eos_cli = p2p_link.raw_eos_cli | arista.avd.default(link_info.p2p_profile.raw_eos_cli) %}
 {%         if p2p_link.port_channel is not arista.avd.defined %}
 {%             do core_interfaces_data.p2p_interfaces.update({ node_interface: p2p_interface }) %}
 {%         else %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/core_interfaces/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/core_interfaces/port-channel-interfaces.j2
@@ -49,6 +49,10 @@ port_channel_interfaces:
     isis_authentication_key: {{ p2p_interface.isis_authentication_key }}
 {%             endif %}
 {%         endif %}
+{%         if p2p_interface.raw_eos_cli is arista.avd.defined %}
+    eos_cli: |
+      {{ p2p_interface.raw_eos_cli | indent(6,false) }}
+{%         endif %}
 {%         if switch.mpls_lsr is arista.avd.defined(true) or p2p_interface.mpls_ip is arista.avd.defined(true) %}
     mpls:
       ip: true


### PR DESCRIPTION
## Change Summary

Implement raw_eos_cli key on core_interfaces/profiles.

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

```yaml
core_interfaces:
  p2p_links:
    - id: < integer - starting from 1 >
      ...
      # EOS CLI rendered directly on the point-to-point interface in the final EOS configuration
      raw_eos_cli: |
        < multiline eos cli >
```

## How to test

Tested with molecule example.

### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
