### PR TITLE
Fix(eos_validate_state): Follow alphabetical order on generated reports

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_validate_state/templates/generate_state_report_results.j2
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/templates/generate_state_report_results.j2
@@ -95,9 +95,9 @@ eos_validate_state_report:
 {%             endif %}
 {%         endfor %}
 {%     endif %}
-{# NTP Status Results #}
 {% endfor %}
 {% for node in groups[fabric_name] | arista.avd.natural_sort %}
+{# NTP Status Results #}
 {%     if copy_hostvars[node].ntp_status_results is arista.avd.defined and copy_hostvars[node].ntp_status_results.skipped is not arista.avd.defined %}
 {%         set test_id.value = test_id.value + 1 %}
 - id: {{ test_id.value }}

--- a/ansible_collections/arista/avd/roles/eos_validate_state/templates/generate_state_report_results.j2
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/templates/generate_state_report_results.j2
@@ -96,6 +96,8 @@ eos_validate_state_report:
 {%         endfor %}
 {%     endif %}
 {# NTP Status Results #}
+{% endfor %}
+{% for node in groups[fabric_name] | arista.avd.natural_sort %}
 {%     if copy_hostvars[node].ntp_status_results is arista.avd.defined and copy_hostvars[node].ntp_status_results.skipped is not arista.avd.defined %}
 {%         set test_id.value = test_id.value + 1 %}
 - id: {{ test_id.value }}


### PR DESCRIPTION
Fixes #1866

## Change Summary

Added end of loop and start where needed

## Related Issue(s)

Fixes #1866 

## Component(s) name

`arista.avd.eos_validate_state`

## Proposed changes
Keep the loops beginning and end where needed

## How to test
Run against an inventory.
Previous output:
```
65,POD1_LEAF01A,Hardware,Transceivers manufacturers,Port 37,PASS,
66,POD1_LEAF01A,Hardware,Transceivers manufacturers,Port 32,PASS,
67,POD1_LEAF01A,NTP,Synchronised with NTP server,NTP,PASS,
68,POD1_LEAF01B,Hardware,Transceivers manufacturers,Port 30,PASS,
69,POD1_LEAF01B,Hardware,Transceivers manufacturers,Port 28,PASS,
(...)
116,POD1_LEAF01B,Hardware,Transceivers manufacturers,Port 32,PASS,
117,POD1_LEAF01B,NTP,Synchronised with NTP server,NTP,PASS,
118,POD1_LEAF01A,Interface State,Ethernet Interface & Line Protocol == "up",Ethernet3 - MLAG_PEER_POD1_LEAF01B_Ethernet3,FAIL,Interface shutdown: False - interface status: adminDown - line protocol status: down
```

New output:
```
64,POD1_LEAF01A,Hardware,Transceivers manufacturers,Port 33,PASS,
65,POD1_LEAF01A,Hardware,Transceivers manufacturers,Port 37,PASS,
66,POD1_LEAF01A,Hardware,Transceivers manufacturers,Port 32,PASS,
67,POD1_LEAF01B,Hardware,Transceivers manufacturers,Port 30,PASS,
68,POD1_LEAF01B,Hardware,Transceivers manufacturers,Port 28,PASS,
69,POD1_LEAF01B,Hardware,Transceivers manufacturers,Port 29,PASS,
(...)
115,POD1_LEAF01B,Hardware,Transceivers manufacturers,Port 32,PASS,
116,POD1_LEAF01A,NTP,Synchronised with NTP server,NTP,PASS,
117,POD1_LEAF01B,NTP,Synchronised with NTP server,NTP,PASS,
```

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
