### PR TITLE
Feat(eos_designs,eos_cli_config_gen): support 'switchport trunk native vlan tag' config

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -112,6 +112,8 @@ interface Management1
 | Ethernet43 |  DOT1X Testing - timeout values | access | - | - | - | - |
 | Ethernet44 |  DOT1X Testing - reauthorization_request_limit | access | - | - | - | - |
 | Ethernet45 |  DOT1X Testing - all features | access | - | - | - | - |
+| Ethernet46 |  native-vlan-tag-precedence | trunk | - | tag | - | - |
+| Ethernet47 |  native-vlan-warning | trunk | - | tag | - | - |
 
 *Inherited from Port-Channel Interface
 
@@ -616,6 +618,17 @@ interface Ethernet45
    dot1x timeout reauth-period server
    dot1x timeout idle-host 10 seconds
    dot1x reauthorization request limit 2
+!
+interface Ethernet46
+   description native-vlan-tag-precedence
+   switchport trunk native vlan tag
+   switchport mode trunk
+   switchport
+!
+interface Ethernet47
+   description native-vlan-warning
+   switchport mode trunk
+   switchport
 ```
 
 # Routing

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -113,7 +113,6 @@ interface Management1
 | Ethernet44 |  DOT1X Testing - reauthorization_request_limit | access | - | - | - | - |
 | Ethernet45 |  DOT1X Testing - all features | access | - | - | - | - |
 | Ethernet46 |  native-vlan-tag-precedence | trunk | - | tag | - | - |
-| Ethernet47 |  native-vlan-warning | trunk | - | tag | - | - |
 
 *Inherited from Port-Channel Interface
 
@@ -622,11 +621,6 @@ interface Ethernet45
 interface Ethernet46
    description native-vlan-tag-precedence
    switchport trunk native vlan tag
-   switchport mode trunk
-   switchport
-!
-interface Ethernet47
-   description native-vlan-warning
    switchport mode trunk
    switchport
 ```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
@@ -225,6 +225,7 @@ interface Ethernet50
 | Port-Channel108 | bpdu false | switched | access | - | - | - | - | - | - | - |
 | Port-Channel109 | Molecule ACLs | switched | access | 110 | - | - | - | - | - | - |
 | Port-Channel112 | LACP fallback individual | switched | trunk | 112 | - | - | 5 | individual | - | - |
+| Port-Channel115 | native-vlan-tag-precedence | switched | trunk | - | tag | - | - | - | - | - |
 
 #### Encapsulation Dot1q Interfaces
 
@@ -590,6 +591,12 @@ interface Port-Channel114
    ip address 172.31.128.10/31
    no mpls ip
    no mpls ldp interface
+!
+interface Port-Channel115
+   description native-vlan-tag-precedence
+   switchport
+   switchport trunk native vlan tag
+   switchport mode trunk
 ```
 
 # Routing

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
@@ -407,6 +407,17 @@ interface Ethernet45
    dot1x timeout idle-host 10 seconds
    dot1x reauthorization request limit 2
 !
+interface Ethernet46
+   description native-vlan-tag-precedence
+   switchport trunk native vlan tag
+   switchport mode trunk
+   switchport
+!
+interface Ethernet47
+   description native-vlan-warning
+   switchport mode trunk
+   switchport
+!
 interface Management1
    description oob_management
    vrf MGMT

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
@@ -413,11 +413,6 @@ interface Ethernet46
    switchport mode trunk
    switchport
 !
-interface Ethernet47
-   description native-vlan-warning
-   switchport mode trunk
-   switchport
-!
 interface Management1
    description oob_management
    vrf MGMT

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
@@ -293,6 +293,12 @@ interface Port-Channel114
    no mpls ip
    no mpls ldp interface
 !
+interface Port-Channel115
+   description native-vlan-tag-precedence
+   switchport
+   switchport trunk native vlan tag
+   switchport mode trunk
+!
 interface Ethernet3
    description MLAG_PEER_DC1-LEAF1B_Ethernet3
    channel-group 3 mode active

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
@@ -537,8 +537,3 @@ ethernet_interfaces:
     native_vlan_tag: true
     native_vlan: 100
     mode: trunk
-
-  Ethernet47:
-    description: native-vlan-warning
-    native_vlan: tag
-    mode: trunk

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
@@ -531,3 +531,14 @@ ethernet_interfaces:
         reauth_timeout_ignore: true
         tx_period: 10
       reauthorization_request_limit: 2
+
+  Ethernet46:
+    description: native-vlan-tag-precedence
+    native_vlan_tag: true
+    native_vlan: 100
+    mode: trunk
+
+  Ethernet47:
+    description: native-vlan-warning
+    native_vlan: tag
+    mode: trunk

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
@@ -339,6 +339,12 @@ port_channel_interfaces:
       ldp:
         interface: false
 
+  Port-Channel115:
+    description: native-vlan-tag-precedence
+    native_vlan_tag: true
+    native_vlan: 100
+    mode: trunk
+
 # Children interfaces
 ethernet_interfaces:
   Ethernet5:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1068,7 +1068,9 @@ ethernet_interfaces:
     mtu: < mtu >
     l2_mtu: < l2-mtu - if defined this profile should only be used for platforms supporting the "l2 mtu" CLI >
     vlans: "< list of vlans as string >"
-    native_vlan: < native_vlan_number | tag >
+    # if setting both, native_vlan_tag takes precedence
+    native_vlan: < native_vlan_number >
+    native_vlan_tag: < boolean | default -> false >
     mode: < access | dot1q-tunnel | trunk | "trunk phone" >
     phone:
       trunk: < tagged | untagged >
@@ -1293,7 +1295,9 @@ port_channel_interfaces:
         client: < true | false >
     vlan_id: < 1-4094 >
     mode: < access | dot1q-tunnel | trunk | "trunk phone" >
-    native_vlan: < native_vlan_number | tag >
+    # if setting both, native_vlan_tag takes precedence
+    native_vlan: < native_vlan_number >
+    native_vlan_tag: < boolean | default -> false >
     snmp_trap_link_change: < true | false >
     link_tracking_groups:
       - name: < group_name >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1068,7 +1068,7 @@ ethernet_interfaces:
     mtu: < mtu >
     l2_mtu: < l2-mtu - if defined this profile should only be used for platforms supporting the "l2 mtu" CLI >
     vlans: "< list of vlans as string >"
-    native_vlan: <native vlan number>
+    native_vlan: < native_vlan_number | tag >
     mode: < access | dot1q-tunnel | trunk | "trunk phone" >
     phone:
       trunk: < tagged | untagged >
@@ -1293,7 +1293,7 @@ port_channel_interfaces:
         client: < true | false >
     vlan_id: < 1-4094 >
     mode: < access | dot1q-tunnel | trunk | "trunk phone" >
-    native_vlan: < native vlan number >
+    native_vlan: < native_vlan_number | tag >
     snmp_trap_link_change: < true | false >
     link_tracking_groups:
       - name: < group_name >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1068,7 +1068,7 @@ ethernet_interfaces:
     mtu: < mtu >
     l2_mtu: < l2-mtu - if defined this profile should only be used for platforms supporting the "l2 mtu" CLI >
     vlans: "< list of vlans as string >"
-    # if setting both, native_vlan_tag takes precedence
+    # If setting both native_vlan and native_vlan_tag, native_vlan_tag takes precedence
     native_vlan: < native_vlan_number >
     native_vlan_tag: < boolean | default -> false >
     mode: < access | dot1q-tunnel | trunk | "trunk phone" >
@@ -1295,7 +1295,7 @@ port_channel_interfaces:
         client: < true | false >
     vlan_id: < 1-4094 >
     mode: < access | dot1q-tunnel | trunk | "trunk phone" >
-    # if setting both, native_vlan_tag takes precedence
+    # If setting both native_vlan and native_vlan_tag, native_vlan_tag takes precedence
     native_vlan: < native_vlan_number >
     native_vlan_tag: < boolean | default -> false >
     snmp_trap_link_change: < true | false >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
@@ -976,7 +976,7 @@ ethernet_interfaces:
     mtu: < mtu >
     l2_mtu: < l2-mtu - if defined this profile should only be used for platforms supporting the "l2 mtu" CLI >
     vlans: "< list of vlans as string >"
-    native_vlan: <native vlan number>
+    native_vlan: < native_vlan_number | tag >
     mode: < access | dot1q-tunnel | trunk | "trunk phone" >
     phone:
       trunk: < tagged | untagged >
@@ -1169,7 +1169,7 @@ port_channel_interfaces:
         client: < true | false >
     vlan_id: < 1-4094 >
     mode: < access | dot1q-tunnel | trunk | "trunk phone" >
-    native_vlan: < native vlan number >
+    native_vlan: < native_vlan_number | tag >
     link_tracking_groups:
       - name: < group_name >
         direction: < upstream | downstream >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
@@ -976,7 +976,9 @@ ethernet_interfaces:
     mtu: < mtu >
     l2_mtu: < l2-mtu - if defined this profile should only be used for platforms supporting the "l2 mtu" CLI >
     vlans: "< list of vlans as string >"
-    native_vlan: < native_vlan_number | tag >
+    # if setting both, native_vlan_tag takes precedence
+    native_vlan: < native_vlan_number >
+    native_vlan_tag: < boolean | default -> false >
     mode: < access | dot1q-tunnel | trunk | "trunk phone" >
     phone:
       trunk: < tagged | untagged >
@@ -1169,7 +1171,9 @@ port_channel_interfaces:
         client: < true | false >
     vlan_id: < 1-4094 >
     mode: < access | dot1q-tunnel | trunk | "trunk phone" >
-    native_vlan: < native_vlan_number | tag >
+    # if setting both, native_vlan_tag takes precedence
+    native_vlan: < native_vlan_number >
+    native_vlan_tag: < boolean | default -> false >
     link_tracking_groups:
       - name: < group_name >
         direction: < upstream | downstream >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
@@ -976,7 +976,7 @@ ethernet_interfaces:
     mtu: < mtu >
     l2_mtu: < l2-mtu - if defined this profile should only be used for platforms supporting the "l2 mtu" CLI >
     vlans: "< list of vlans as string >"
-    # if setting both, native_vlan_tag takes precedence
+    # If setting both native_vlan and native_vlan_tag, native_vlan_tag takes precedence
     native_vlan: < native_vlan_number >
     native_vlan_tag: < boolean | default -> false >
     mode: < access | dot1q-tunnel | trunk | "trunk phone" >
@@ -1171,7 +1171,7 @@ port_channel_interfaces:
         client: < true | false >
     vlan_id: < 1-4094 >
     mode: < access | dot1q-tunnel | trunk | "trunk phone" >
-    # if setting both, native_vlan_tag takes precedence
+    # If setting both native_vlan and native_vlan_tag, native_vlan_tag takes precedence
     native_vlan: < native_vlan_number >
     native_vlan_tag: < boolean | default -> false >
     link_tracking_groups:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ethernet-interfaces.j2
@@ -19,7 +19,11 @@
 {%                 set description = ethernet_interface.description | arista.avd.default("-") %}
 {%                 set mode = port_channel_interface.mode | arista.avd.default("access") %}
 {%                 set vlans = port_channel_interface.vlans | arista.avd.default('-') %}
-{%                 set native_vlan = port_channel_interface.native_vlan | arista.avd.default('-') %}
+{%                 if  port_channel_interface.native_vlan_tag is arista.avd.defined(true) %}
+{%                     set native_vlan = "tag" %}
+{%                 else %}
+{%                     set native_vlan = port_channel_interface.native_vlan | arista.avd.default('-') %}
+{%                 endif %}
 {%                 set channel_group = ethernet_interface.channel_group.id %}
 {%                 if port_channel_interface.trunk_groups is arista.avd.defined %}
 {%                     set l2 = namespace() %}
@@ -37,7 +41,11 @@
 {%             set description = ethernet_interface.description | arista.avd.default("-") %}
 {%             set mode = ethernet_interface.mode | arista.avd.default("access") %}
 {%             set vlans = ethernet_interface.vlans | arista.avd.default('-') %}
-{%             set native_vlan = ethernet_interface.native_vlan | arista.avd.default('-') %}
+{%             if  ethernet_interface.native_vlan_tag is arista.avd.defined(true) %}
+{%                 set native_vlan = "tag" %}
+{%             else %}
+{%                 set native_vlan = ethernet_interface.native_vlan | arista.avd.default('-') %}
+{%             endif %}
 {%             if ethernet_interface.trunk_groups is defined %}
 {%                 set l2 = namespace() %}
 {%                 set l2.trunk_groups = [] %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/port-channel-interfaces.j2
@@ -14,7 +14,11 @@
 {%             set type = port_channel_interface.type | arista.avd.default("switched") %}
 {%             set mode = port_channel_interface.mode | arista.avd.default("access") %}
 {%             set vlans = port_channel_interface.vlans | arista.avd.default("-") %}
-{%             set native_vlan = port_channel_interface.native_vlan | arista.avd.default("-") %}
+{%             if  port_channel_interface.native_vlan_tag is arista.avd.defined(true) %}
+{%                 set native_vlan = "tag" %}
+{%             else %}
+{%                 set native_vlan = port_channel_interface.native_vlan | arista.avd.default("-") %}
+{%             endif %}
 {%             if port_channel_interface.trunk_groups is defined %}
 {%                 set l2 = namespace() %}
 {%                 set l2.trunk_groups = [] %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -74,10 +74,16 @@ interface {{ ethernet_interface.name }}
 {%             endif %}
 {%         endif %}
 {%         if ethernet_interface.mode is arista.avd.defined('trunk') %}
-{%             if ethernet_interface.native_vlan is arista.avd.defined %}
+{%             if ethernet_interface.native_vlan_tag is arista.avd.defined(true) %}
+   switchport trunk native vlan tag
+{# next is a way of checking the type is int only if the value is defined #}
+{# not doing the two checks would lead to false warnings when the value is undefined #}
+{%             elif ethernet_interface.native_vlan is arista.avd.defined and
+                    ethernet_interface.native_vlan is arista.avd.defined(fail_action='warning', var_type='int', var_name='native_vlan') %}
    switchport trunk native vlan {{ ethernet_interface.native_vlan }}
 {%             endif %}
 {%         endif %}
+{# TODO - understand what trunk phone is  and if it can have tag for native_vlan #}
 {%         if ethernet_interface.mode is arista.avd.defined("trunk phone") and ethernet_interface.native_vlan %}
    switchport trunk native vlan {{ ethernet_interface.native_vlan }}
 {%         endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -73,7 +73,7 @@ interface {{ ethernet_interface.name }}
    switchport access vlan {{ ethernet_interface.vlans }}
 {%             endif %}
 {%         endif %}
-{%         if ethernet_interface.mode is arista.avd.defined('trunk') or ethernet_interface.mode is arista.avd.defined('trunk phone') %}
+{%         if ethernet_interface.mode is arista.avd.defined and ethernet_interface.mode in ['trunk', 'trunk phone'] %}
 {%             if ethernet_interface.native_vlan_tag is arista.avd.defined(true) %}
    switchport trunk native vlan tag
 {%             elif ethernet_interface.native_vlan is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -73,19 +73,12 @@ interface {{ ethernet_interface.name }}
    switchport access vlan {{ ethernet_interface.vlans }}
 {%             endif %}
 {%         endif %}
-{%         if ethernet_interface.mode is arista.avd.defined('trunk') %}
+{%         if ethernet_interface.mode is arista.avd.defined('trunk') or ethernet_interface.mode is arista.avd.defined('trunk phone') %}
 {%             if ethernet_interface.native_vlan_tag is arista.avd.defined(true) %}
    switchport trunk native vlan tag
-{# next is a way of checking the type is int only if the value is defined #}
-{# not doing the two checks would lead to false warnings when the value is undefined #}
-{%             elif ethernet_interface.native_vlan is arista.avd.defined and
-                    ethernet_interface.native_vlan is arista.avd.defined(fail_action='warning', var_type='int', var_name='native_vlan') %}
+{%             elif ethernet_interface.native_vlan is arista.avd.defined %}
    switchport trunk native vlan {{ ethernet_interface.native_vlan }}
 {%             endif %}
-{%         endif %}
-{# TODO - understand what trunk phone is  and if it can have tag for native_vlan #}
-{%         if ethernet_interface.mode is arista.avd.defined("trunk phone") and ethernet_interface.native_vlan %}
-   switchport trunk native vlan {{ ethernet_interface.native_vlan }}
 {%         endif %}
 {%         if ethernet_interface.phone.vlan is arista.avd.defined %}
    switchport phone vlan {{ ethernet_interface.phone.vlan }}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
@@ -57,7 +57,7 @@ interface {{ port_channel_interface.name }}
 {%     if port_channel_interface.vlans is arista.avd.defined and port_channel_interface.mode is arista.avd.defined("trunk") %}
    switchport trunk allowed vlan {{ port_channel_interface.vlans }}
 {%     endif %}
-{%     if port_channel_interface.mode is arista.avd.defined('trunk') or port_channel_interface.mode is arista.avd.defined('trunk phone') %}
+{%     if port_channel_interface.mode is arista.avd.defined and port_channel_interface.mode in ['trunk', 'trunk phone'] %}
 {%         if port_channel_interface.native_vlan_tag is arista.avd.defined(true) %}
    switchport trunk native vlan tag
 {%         elif port_channel_interface.native_vlan is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
@@ -57,9 +57,17 @@ interface {{ port_channel_interface.name }}
 {%     if port_channel_interface.vlans is arista.avd.defined and port_channel_interface.mode is arista.avd.defined("trunk") %}
    switchport trunk allowed vlan {{ port_channel_interface.vlans }}
 {%     endif %}
-{%     if port_channel_interface.native_vlan is arista.avd.defined and port_channel_interface.mode is arista.avd.defined("trunk") %}
+{%     if port_channel_interface.mode is arista.avd.defined('trunk') %}
+{%         if port_channel_interface.native_vlan_tag is arista.avd.defined(true) %}
+   switchport trunk native vlan tag
+{# next is a way of checking the type is int only if the value is defined #}
+{# not doing the two checks would lead to false warnings when the value is undefined #}
+{%         elif port_channel_interface.native_vlan is arista.avd.defined and
+               port_channel_interface.native_vlan is arista.avd.defined(fail_action='warning', var_type='int', var_name='native_vlan') %}
    switchport trunk native vlan {{ port_channel_interface.native_vlan }}
+{%         endif %}
 {%     endif %}
+{# TODO - understand what trunk phone is  and if it can have tag for native_vlan #}
 {%     if port_channel_interface.mode is arista.avd.defined("trunk phone") and port_channel_interface.native_vlan %}
    switchport trunk native vlan {{ port_channel_interface.native_vlan }}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
@@ -57,19 +57,12 @@ interface {{ port_channel_interface.name }}
 {%     if port_channel_interface.vlans is arista.avd.defined and port_channel_interface.mode is arista.avd.defined("trunk") %}
    switchport trunk allowed vlan {{ port_channel_interface.vlans }}
 {%     endif %}
-{%     if port_channel_interface.mode is arista.avd.defined('trunk') %}
+{%     if port_channel_interface.mode is arista.avd.defined('trunk') or port_channel_interface.mode is arista.avd.defined('trunk phone') %}
 {%         if port_channel_interface.native_vlan_tag is arista.avd.defined(true) %}
    switchport trunk native vlan tag
-{# next is a way of checking the type is int only if the value is defined #}
-{# not doing the two checks would lead to false warnings when the value is undefined #}
-{%         elif port_channel_interface.native_vlan is arista.avd.defined and
-               port_channel_interface.native_vlan is arista.avd.defined(fail_action='warning', var_type='int', var_name='native_vlan') %}
+{%         elif port_channel_interface.native_vlan is arista.avd.defined %}
    switchport trunk native vlan {{ port_channel_interface.native_vlan }}
 {%         endif %}
-{%     endif %}
-{# TODO - understand what trunk phone is  and if it can have tag for native_vlan #}
-{%     if port_channel_interface.mode is arista.avd.defined("trunk phone") and port_channel_interface.native_vlan %}
-   switchport trunk native vlan {{ port_channel_interface.native_vlan }}
 {%     endif %}
 {%     if port_channel_interface.phone.vlan is arista.avd.defined %}
    switchport phone vlan {{ port_channel_interface.phone.vlan }}

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/connected-endpoints-v4.0.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/connected-endpoints-v4.0.md
@@ -50,7 +50,9 @@ port_profiles:
     mode: < access | dot1q-tunnel | trunk >
     mtu: < mtu >
     l2_mtu: < l2_mtu - if defined this profile should only be used for platforms supporting the "l2 mtu" CLI >
-    native_vlan: < native_vlan_number | tag >
+    # if setting both, native_vlan_tag takes precedence
+    native_vlan: < native_vlan_number >
+    native_vlan_tag: < boolean | default -> false >
     vlans: < vlans as string >
     spanning_tree_portfast: < edge | network >
     spanning_tree_bpdufilter: < "enabled" | true | "disabled" >
@@ -118,7 +120,9 @@ port_profiles:
         mode: < access | dot1q-tunnel | trunk >
 
         # Native VLAN for a trunk port | optional
-        native_vlan: < native_vlan_number | tag >
+        # if setting both, native_vlan_tag takes precedence
+        native_vlan: < native_vlan_number >
+        native_vlan_tag: < boolean | default -> false >
 
         # Interface vlans | required
         vlans: < vlans as string >

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/connected-endpoints-v4.0.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/connected-endpoints-v4.0.md
@@ -50,7 +50,7 @@ port_profiles:
     mode: < access | dot1q-tunnel | trunk >
     mtu: < mtu >
     l2_mtu: < l2_mtu - if defined this profile should only be used for platforms supporting the "l2 mtu" CLI >
-    native_vlan: <native vlan number>
+    native_vlan: < native_vlan_number | tag >
     vlans: < vlans as string >
     spanning_tree_portfast: < edge | network >
     spanning_tree_bpdufilter: < "enabled" | true | "disabled" >
@@ -118,7 +118,7 @@ port_profiles:
         mode: < access | dot1q-tunnel | trunk >
 
         # Native VLAN for a trunk port | optional
-        native_vlan: <native vlan number>
+        native_vlan: < native_vlan_number | tag >
 
         # Interface vlans | required
         vlans: < vlans as string >

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/connected-endpoints-v4.0.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/connected-endpoints-v4.0.md
@@ -50,7 +50,7 @@ port_profiles:
     mode: < access | dot1q-tunnel | trunk >
     mtu: < mtu >
     l2_mtu: < l2_mtu - if defined this profile should only be used for platforms supporting the "l2 mtu" CLI >
-    # if setting both, native_vlan_tag takes precedence
+    # If setting both native_vlan and native_vlan_tag, native_vlan_tag takes precedence
     native_vlan: < native_vlan_number >
     native_vlan_tag: < boolean | default -> false >
     vlans: < vlans as string >
@@ -120,7 +120,7 @@ port_profiles:
         mode: < access | dot1q-tunnel | trunk >
 
         # Native VLAN for a trunk port | optional
-        # if setting both, native_vlan_tag takes precedence
+        # If setting both native_vlan and native_vlan_tag, native_vlan_tag takes precedence
         native_vlan: < native_vlan_number >
         native_vlan_tag: < boolean | default -> false >
 

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/connected-endpoints.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/connected-endpoints.md
@@ -50,7 +50,9 @@ port_profiles:
     mode: < access | dot1q-tunnel | trunk >
     mtu: < mtu >
     l2_mtu: < l2_mtu - if defined this profile should only be used for platforms supporting the "l2 mtu" CLI >
-    native_vlan: < native_vlan_number | tag >
+    # if setting both, native_vlan_tag takes precedence
+    native_vlan: < native_vlan_number >
+    native_vlan_tag: < boolean | default -> false >
     vlans: < vlans as string >
     spanning_tree_portfast: < edge | network >
     spanning_tree_bpdufilter: < "enabled" | true | "disabled" >
@@ -121,7 +123,9 @@ port_profiles:
         mode: < access | dot1q-tunnel | trunk >
 
         # Native VLAN for a trunk port | optional
-        native_vlan: < native_vlan_number | tag >
+        # if setting both, native_vlan_tag takes precedence
+        native_vlan: < native_vlan_number >
+        native_vlan_tag: < boolean | default -> false >
 
         # Interface vlans | required
         vlans: < vlans as string >

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/connected-endpoints.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/connected-endpoints.md
@@ -50,7 +50,7 @@ port_profiles:
     mode: < access | dot1q-tunnel | trunk >
     mtu: < mtu >
     l2_mtu: < l2_mtu - if defined this profile should only be used for platforms supporting the "l2 mtu" CLI >
-    native_vlan: <native vlan number>
+    native_vlan: < native_vlan_number | tag >
     vlans: < vlans as string >
     spanning_tree_portfast: < edge | network >
     spanning_tree_bpdufilter: < "enabled" | true | "disabled" >
@@ -121,7 +121,7 @@ port_profiles:
         mode: < access | dot1q-tunnel | trunk >
 
         # Native VLAN for a trunk port | optional
-        native_vlan: <native vlan number>
+        native_vlan: < native_vlan_number | tag >
 
         # Interface vlans | required
         vlans: < vlans as string >

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/connected-endpoints.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/connected-endpoints.md
@@ -50,7 +50,7 @@ port_profiles:
     mode: < access | dot1q-tunnel | trunk >
     mtu: < mtu >
     l2_mtu: < l2_mtu - if defined this profile should only be used for platforms supporting the "l2 mtu" CLI >
-    # if setting both, native_vlan_tag takes precedence
+    # If setting both native_vlan and native_vlan_tag, native_vlan_tag takes precedence
     native_vlan: < native_vlan_number >
     native_vlan_tag: < boolean | default -> false >
     vlans: < vlans as string >
@@ -123,7 +123,7 @@ port_profiles:
         mode: < access | dot1q-tunnel | trunk >
 
         # Native VLAN for a trunk port | optional
-        # if setting both, native_vlan_tag takes precedence
+        # If setting both native_vlan and native_vlan_tag, native_vlan_tag takes precedence
         native_vlan: < native_vlan_number >
         native_vlan_tag: < boolean | default -> false >
 

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/ethernet-interfaces.j2
@@ -59,9 +59,9 @@ ethernet_interfaces:
     mode: {{ adapter_settings.mode | arista.avd.default }}
     vlans: {{ adapter_settings.vlans | arista.avd.default }}
 {%                     if adapter_settings.native_vlan_tag is arista.avd.defined %}
-    native_vlan_tag: adapter_settings.native_vlan_tag
+    native_vlan_tag: {{ adapter_settings.native_vlan_tag }}
 {%                     endif %}
-{%                     if adapter_settings.native_vlan is arista.avd.defined(fail_action='warning', var_type='int') %}
+{%                     if adapter_settings.native_vlan is arista.avd.defined %}
     native_vlan: {{ adapter_settings.native_vlan }}
 {%                     endif %}
 {%                     if adapter_settings.spanning_tree_portfast is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/ethernet-interfaces.j2
@@ -58,7 +58,10 @@ ethernet_interfaces:
 {%                     endif %}
     mode: {{ adapter_settings.mode | arista.avd.default }}
     vlans: {{ adapter_settings.vlans | arista.avd.default }}
-{%                     if adapter_settings.native_vlan is arista.avd.defined %}
+{%                     if adapter_settings.native_vlan_tag is arista.avd.defined %}
+    native_vlan_tag: adapter_settings.native_vlan_tag
+{%                     endif %}
+{%                     if adapter_settings.native_vlan is arista.avd.defined(fail_action='warning', var_type='int') %}
     native_vlan: {{ adapter_settings.native_vlan }}
 {%                     endif %}
 {%                     if adapter_settings.spanning_tree_portfast is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/port-channel-interfaces.j2
@@ -50,9 +50,9 @@ port_channel_interfaces:
 {%                             endif %}
     vlans: {{ adapter_settings.vlans | arista.avd.default }}
 {%                             if adapter_settings.native_vlan_tag is arista.avd.defined %}
-    native_vlan_tag: adapter_settings.native_vlan_tag
+    native_vlan_tag: {{ adapter_settings.native_vlan_tag }}
 {%                             endif %}
-{%                             if adapter_settings.native_vlan is arista.avd.defined(fail_action='warning', var_type='int') %}
+{%                             if adapter_settings.native_vlan is arista.avd.defined %}
     native_vlan: {{ adapter_settings.native_vlan }}
 {%                             endif %}
 {%                             if adapter_settings.spanning_tree_portfast is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/port-channel-interfaces.j2
@@ -49,7 +49,10 @@ port_channel_interfaces:
     l2_mtu: {{ adapter_settings.l2_mtu }}
 {%                             endif %}
     vlans: {{ adapter_settings.vlans | arista.avd.default }}
-{%                             if adapter_settings.native_vlan is arista.avd.defined %}
+{%                             if adapter_settings.native_vlan_tag is arista.avd.defined %}
+    native_vlan_tag: adapter_settings.native_vlan_tag
+{%                             endif %}
+{%                             if adapter_settings.native_vlan is arista.avd.defined(fail_action='warning', var_type='int') %}
     native_vlan: {{ adapter_settings.native_vlan }}
 {%                             endif %}
 {%                             if adapter_settings.spanning_tree_portfast is arista.avd.defined %}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->

## Related Issue(s)

Fixes #1870

## Component(s) name

`arista.avd.eos_designs`
`arista.avd.eos_cli_config_gen`

## Proposed changes

For every occurence:
```diff
-    native_vlan: <native vlan number>
+    native_vlan: < native_vlan_number | tag >
```


## How to test

Nothing to test

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
