### PR TITLE
CI: fix j2lint typo delimeter -> delimiter

### DIFF
--- a/ansible_collections/arista/avd/docs/_build/rst.j2
+++ b/ansible_collections/arista/avd/docs/_build/rst.j2
@@ -1,4 +1,4 @@
-{# j2lint: disable=jinja-statements-delimeter j2lint: disable=single-statement-per-line #}
+{# j2lint: disable=jinja-statements-delimiter j2lint: disable=single-statement-per-line #}
 .. _@{ module }@:
 
 {% set title = module %}

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/templates/interface-descriptions/underlay/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/templates/interface-descriptions/underlay/ethernet-interfaces.j2
@@ -1,4 +1,4 @@
-{# j2lint: disable=jinja-statements-delimeter #}
+{# j2lint: disable=jinja-statements-delimiter #}
 {%- if link.type is arista.avd.defined('underlay_p2p') -%}
 {%-     if switch.struct_cfg.tags is arista.avd.defined() -%}
 CUSTOM_P2P_LINK_TO_{{ link.peer | upper }}_{{ link.peer_interface }} {{ switch.struct_cfg.tags | arista.avd.default() }}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/interface_descriptions/underlay/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/interface_descriptions/underlay/ethernet-interfaces.j2
@@ -1,4 +1,4 @@
-{# j2lint: disable=jinja-statements-delimeter #}
+{# j2lint: disable=jinja-statements-delimiter #}
 {%- if link.type is arista.avd.defined('underlay_p2p') -%}
 P2P_LINK_TO_{{ link.peer | upper }}_{{ link.peer_interface }}
 {%- elif link.type is arista.avd.defined('underlay_l2') -%}

--- a/ansible_collections/arista/avd/roles/eos_snapshot/templates/fabric_json_output.j2
+++ b/ansible_collections/arista/avd/roles/eos_snapshot/templates/fabric_json_output.j2
@@ -1,4 +1,4 @@
-{# j2lint: disable=jinja-statements-delimeter #}
+{# j2lint: disable=jinja-statements-delimiter #}
 {
     "devices": {
 {% for node in groups[fabric_name] | arista.avd.natural_sort %}


### PR DESCRIPTION
## Change Summary

Fix typo in j2lint rule `jinja-statements-delimeter` vs `jinja-statements-delimiter` 

Update rule in templates that contain: `{# j2lint: disable=jinja-statements-delimiter #}`

Requires aristanetworks/j2lint#39 to be merged

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
