### PR TITLE
Fix(eos_designs, eos_cli_config_gen): Fix the AVD version print in virtual environments

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/tasks/main.yml
@@ -4,7 +4,7 @@
   set_fact:
     avd_collection_version: version
   vars:
-    versions: "{{ lookup('pipe', 'ansible-galaxy collection list --format yaml ' ~ ansible_collection_name) | from_yaml }}"
+    versions: "{{ lookup('pipe', 'ansible-galaxy collection list -p ' ~ collection_path ~ ' --format yaml ' ~ ansible_collection_name) | from_yaml }}"
     collection_path: "{{ (role_path | split('/'))[0:-4] | join('/') }}"
     version: "{{ versions[collection_path][ansible_collection_name].version | default('Unknown') }}"
     git_tag: "{{ lookup('pipe', 'git -C ' ~ collection_path ~ ' describe --tags --always 2>/dev/null', errors='ignore') }}"

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v1/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v1/main.yml
@@ -6,7 +6,7 @@
   set_fact:
     avd_collection_version: version
   vars:
-    versions: "{{ lookup('pipe', 'ansible-galaxy collection list --format yaml ' ~ ansible_collection_name) | from_yaml }}"
+    versions: "{{ lookup('pipe', 'ansible-galaxy collection list -p ' ~ collection_path ~ ' --format yaml ' ~ ansible_collection_name) | from_yaml }}"
     collection_path: "{{ (role_path | split('/'))[0:-4] | join('/') }}"
     version: "{{ versions[collection_path][ansible_collection_name].version | default('Unknown') }}"
     git_tag: "{{ lookup('pipe', 'git -C ' ~ collection_path ~ ' describe --tags --always 2>/dev/null', errors='ignore') }}"

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v3/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v3/main.yml
@@ -4,7 +4,7 @@
   set_fact:
     avd_collection_version: version
   vars:
-    versions: "{{ lookup('pipe', 'ansible-galaxy collection list --format yaml ' ~ ansible_collection_name) | from_yaml }}"
+    versions: "{{ lookup('pipe', 'ansible-galaxy collection list -p ' ~ collection_path ~ ' --format yaml ' ~ ansible_collection_name) | from_yaml }}"
     collection_path: "{{ (role_path | split('/'))[0:-4] | join('/') }}"
     version: "{{ versions[collection_path][ansible_collection_name].version | default('Unknown') }}"
     git_tag: "{{ lookup('pipe', 'git -C ' ~ collection_path ~ ' describe --tags --always 2>/dev/null', errors='ignore') }}"

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_eapi/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_eapi/tasks/main.yml
@@ -4,7 +4,7 @@
   set_fact:
     avd_collection_version: version
   vars:
-    versions: "{{ lookup('pipe', 'ansible-galaxy collection list --format yaml ' ~ ansible_collection_name) | from_yaml }}"
+    versions: "{{ lookup('pipe', 'ansible-galaxy collection list -p ' ~ collection_path ~ ' --format yaml ' ~ ansible_collection_name) | from_yaml }}"
     collection_path: "{{ (role_path | split('/'))[0:-4] | join('/') }}"
     version: "{{ versions[collection_path][ansible_collection_name].version | default('Unknown') }}"
     git_tag: "{{ lookup('pipe', 'git -C ' ~ collection_path ~ ' describe --tags --always 2>/dev/null', errors='ignore') }}"

--- a/ansible_collections/arista/avd/roles/eos_designs/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/tasks/main.yml
@@ -4,7 +4,7 @@
   ansible.builtin.set_fact:
     avd_collection_version: version
   vars:
-    versions: "{{ lookup('pipe', 'ansible-galaxy collection list --format yaml ' ~ ansible_collection_name) | from_yaml }}"
+    versions: "{{ lookup('pipe', 'ansible-galaxy collection list -p ' ~ collection_path ~ ' --format yaml ' ~ ansible_collection_name) | from_yaml }}"
     collection_path: "{{ (role_path | split('/'))[0:-4] | join('/') }}"
     version: "{{ versions[collection_path][ansible_collection_name].version | default('Unknown') }}"
     git_tag: "{{ lookup('pipe', 'git -C ' ~ collection_path ~ ' describe --tags --always 2>/dev/null', errors='ignore') }}"

--- a/ansible_collections/arista/avd/roles/eos_snapshot/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_snapshot/tasks/main.yml
@@ -5,7 +5,7 @@
   set_fact:
     avd_collection_version: version
   vars:
-    versions: "{{ lookup('pipe', 'ansible-galaxy collection list --format yaml ' ~ ansible_collection_name) | from_yaml }}"
+    versions: "{{ lookup('pipe', 'ansible-galaxy collection list -p ' ~ collection_path ~ ' --format yaml ' ~ ansible_collection_name) | from_yaml }}"
     collection_path: "{{ (role_path | split('/'))[0:-4] | join('/') }}"
     version: "{{ versions[collection_path][ansible_collection_name].version | default('Unknown') }}"
     git_tag: "{{ lookup('pipe', 'git -C ' ~ collection_path ~ ' describe --tags --always 2>/dev/null', errors='ignore') }}"

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/main.yml
@@ -4,7 +4,7 @@
   set_fact:
     avd_collection_version: version
   vars:
-    versions: "{{ lookup('pipe', 'ansible-galaxy collection list --format yaml ' ~ ansible_collection_name) | from_yaml }}"
+    versions: "{{ lookup('pipe', 'ansible-galaxy collection list -p ' ~ collection_path ~ ' --format yaml ' ~ ansible_collection_name) | from_yaml }}"
     collection_path: "{{ (role_path | split('/'))[0:-4] | join('/') }}"
     version: "{{ versions[collection_path][ansible_collection_name].version | default('Unknown') }}"
     git_tag: "{{ lookup('pipe', 'git -C ' ~ collection_path ~ ' describe --tags --always 2>/dev/null', errors='ignore') }}"


### PR DESCRIPTION
## Change Summary

```ansible-galaxy collection list``` fails sometimes if the ansible collections path is not loaded properly. Even after the collections path is set properly in ansible.cfg, it still fails in few virtual environments. So providing the collections path is safer, ```ansible-galaxy collection list -p < collections_path >```

<!-- Enter short PR description -->

## Related Issue(s)

Fixes #1874 

## Component(s) name

## Proposed changes

ansible-galaxy collection list -p COLLECTIONS_PATH
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test

Tested locally on a virtual environment, to see if the correct collection version is printed or not.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

- [x] Test this fix in a virtual environment and verify if the correct AVD version is printed

<!-- Add your own checklist using MD syntax and by replacing N/A -->

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
