### PR TITLE
Fix(eos_designs): correct error if missing node

### DIFF
--- a/ansible_collections/arista/avd/plugins/module_utils/eos_designs_facts.py
+++ b/ansible_collections/arista/avd/plugins/module_utils/eos_designs_facts.py
@@ -319,6 +319,7 @@ class EosDesignsFacts:
         switch_data = {}
         hostname = self.hostname
         node_type_config = get(self._hostvars, f"{self.node_type_key}", required=True)
+        node_config = None
 
         if hostname in node_type_config.get('nodes', {}):
             node_config = node_type_config['nodes'][hostname]


### PR DESCRIPTION
## Change Summary

Provide the correct error message.

## Related Issue(s)

Fixes #1877

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
define var in outer scope 

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X] My code has been rebased from devel before I start
- [ X] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
