### PR TITLE
Fix(eos_cli_config_gen): VRF BGP neighbor allowas_in.enabled renders invalid config

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vrf-lite.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vrf-lite.md
@@ -167,8 +167,8 @@ ip route vrf BLUE-C1 193.1.2.0/24 Null0
 | 10.1.1.0 | Inherited from peer group OBS_WAN | BLUE-C1 | - | - | - | - | - | - |
 | 10.255.1.1 | Inherited from peer group WELCOME_ROUTERS | BLUE-C1 | - | - | - | - | - | - |
 | 101.0.3.1 | Inherited from peer group SEDI | BLUE-C1 | - | - | - | - | - | - |
-| 101.0.3.2 | Inherited from peer group SEDI | BLUE-C1 | True | - | - | - | - | - |
-| 101.0.3.3 | - | BLUE-C1 | Inherited from peer group SEDI-shut | - | - | - | - | - |
+| 101.0.3.2 | Inherited from peer group SEDI | BLUE-C1 | True | - | - | Allowed, allowed 3 (default) times | - | - |
+| 101.0.3.3 | - | BLUE-C1 | Inherited from peer group SEDI-shut | - | - | Allowed, allowed 5 times | - | - |
 | 10.1.1.0 | Inherited from peer group OBS_WAN | RED-C1 | - | - | - | - | - | - |
 | 10.1.1.0 | Inherited from peer group OBS_WAN | YELLOW-C1 | - | - | - | - | - | - |
 
@@ -222,8 +222,10 @@ router bgp 65001
       neighbor 101.0.3.1 peer group SEDI
       neighbor 101.0.3.1 weight 100
       neighbor 101.0.3.2 peer group SEDI
+      neighbor 101.0.3.2 allowas-in
       neighbor 101.0.3.2 shutdown
       neighbor 101.0.3.3 peer group SEDI-shut
+      neighbor 101.0.3.3 allowas-in 5
       aggregate-address 0.0.0.0/0 as-set summary-only attribute-map RM-BGP-AGG-APPLY-SET
       aggregate-address 193.1.0.0/16 as-set summary-only attribute-map RM-BGP-AGG-APPLY-SET
       redistribute static

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-vrf-lite.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-vrf-lite.cfg
@@ -71,8 +71,10 @@ router bgp 65001
       neighbor 101.0.3.1 peer group SEDI
       neighbor 101.0.3.1 weight 100
       neighbor 101.0.3.2 peer group SEDI
+      neighbor 101.0.3.2 allowas-in
       neighbor 101.0.3.2 shutdown
       neighbor 101.0.3.3 peer group SEDI-shut
+      neighbor 101.0.3.3 allowas-in 5
       aggregate-address 0.0.0.0/0 as-set summary-only attribute-map RM-BGP-AGG-APPLY-SET
       aggregate-address 193.1.0.0/16 as-set summary-only attribute-map RM-BGP-AGG-APPLY-SET
       redistribute static

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-vrf-lite.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-vrf-lite.yml
@@ -85,8 +85,13 @@ router_bgp:
         101.0.3.2:
           peer_group: SEDI
           shutdown: true
+          allowas_in:
+            enabled: true
         101.0.3.3:
           peer_group: SEDI-shut
+          allowas_in:
+            enabled: true
+            times: 5
       redistribute_routes:
         - static
       aggregate_addresses:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -822,7 +822,6 @@ router bgp {{ router_bgp.as }}
       no neighbor {{ neighbo.ip_address }} bfd
 {%             endif %}
 {%             if neighbor.allowas_in.enabled is arista.avd.defined(true) %}
-{{ neighbor.ip_address }}
 {%                 set allowas_in_cli = "neighbor " ~ neighbor.ip_address ~ " allowas-in" %}
 {%                 if neighbor.allowas_in.times is arista.avd.defined %}
 {%                     set allowas_in_cli = allowas_in_cli ~ " " ~ neighbor.allowas_in.times %}


### PR DESCRIPTION
## Change Summary

Invalid config caused by extra {{ neighbor.ip_address }} in template. Removed the line and added molecule test for this scenario.

## Related Issue(s)

Fixes #1890

## Component(s) name

`arista.avd.eos_cli_config_gen`

### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
