### PR TITLE
Fix(eos_designs): Wrong passive interfaces rendered under OSPF process

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2A.md
@@ -38,6 +38,7 @@
   - [IPv6 Routing](#ipv6-routing)
   - [Static Routes](#static-routes)
   - [IPv6 Static Routes](#ipv6-static-routes)
+  - [Router OSPF](#router-ospf)
   - [Router BGP](#router-bgp)
 - [BFD](#bfd)
   - [Router BFD](#router-bfd)
@@ -400,6 +401,8 @@ vlan 452
 | Ethernet2 | P2P_LINK_TO_DC1-SPINE2_Ethernet2 | routed | - | 172.31.255.19/31 | default | 1500 | false | - | - |
 | Ethernet3 | P2P_LINK_TO_DC1-SPINE3_Ethernet2 | routed | - | 172.31.255.21/31 | default | 1500 | false | - | - |
 | Ethernet4 | P2P_LINK_TO_DC1-SPINE4_Ethernet2 | routed | - | 172.31.255.23/31 | default | 1500 | false | - | - |
+| Ethernet22 | - | routed | - | 10.0.0.1/30 | Tenant_OSPF | - | false | - | - |
+| Ethernet23 | - | routed | - | 10.0.0.13/30 | Tenant_OSPF | - | false | - | - |
 
 ### Ethernet Interfaces Device Configuration
 
@@ -493,6 +496,22 @@ interface Ethernet21
    switchport access vlan 110
    switchport mode access
    switchport
+!
+interface Ethernet22
+   no shutdown
+   no switchport
+   vrf Tenant_OSPF
+   ip address 10.0.0.1/30
+   ip ospf network point-to-point
+   ip ospf area 0
+!
+interface Ethernet23
+   no shutdown
+   no switchport
+   vrf Tenant_OSPF
+   ip address 10.0.0.13/30
+   ip ospf network point-to-point
+   ip ospf area 0
 ```
 
 ## Port-Channel Interfaces
@@ -889,6 +908,7 @@ interface Vlan452
 | Tenant_C_OP_Zone | 30 | - |
 | Tenant_D_OP_Zone | 40 | - |
 | Tenant_D_WAN_Zone | 41 | - |
+| Tenant_OSPF | 30 | - |
 
 ### VXLAN Interface Device Configuration
 
@@ -927,6 +947,7 @@ interface Vxlan1
    vxlan vrf Tenant_C_OP_Zone vni 30
    vxlan vrf Tenant_D_OP_Zone vni 40
    vxlan vrf Tenant_D_WAN_Zone vni 41
+   vxlan vrf Tenant_OSPF vni 30
 ```
 
 # Routing
@@ -968,6 +989,7 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 | Tenant_C_OP_Zone | true |
 | Tenant_D_OP_Zone | true |
 | Tenant_D_WAN_Zone | true |
+| Tenant_OSPF | true |
 
 ### IP Routing Device Configuration
 
@@ -983,6 +1005,7 @@ ip routing vrf Tenant_B_OP_Zone
 ip routing vrf Tenant_C_OP_Zone
 ip routing vrf Tenant_D_OP_Zone
 ip routing vrf Tenant_D_WAN_Zone
+ip routing vrf Tenant_OSPF
 ```
 ## IPv6 Routing
 
@@ -1000,6 +1023,7 @@ ip routing vrf Tenant_D_WAN_Zone
 | Tenant_C_OP_Zone | false |
 | Tenant_D_OP_Zone | true |
 | Tenant_D_WAN_Zone | true |
+| Tenant_OSPF | false |
 
 ## Static Routes
 
@@ -1035,6 +1059,39 @@ ip route vrf Tenant_D_OP_Zone 10.3.11.0/24 Vlan411 name VARP
 !
 ipv6 route vrf Tenant_D_OP_Zone ::/0 2001:db8:311::4 name IPv6-test-2
 ipv6 route vrf Tenant_D_OP_Zone 2001:db8:311::/64 Vlan411 name VARPv6
+```
+
+## Router OSPF
+
+### Router OSPF Summary
+
+| Process ID | Router ID | Default Passive Interface | No Passive Interface | BFD | Max LSA | Default Information Originate | Log Adjacency Changes Detail | Auto Cost Reference Bandwidth | Maximum Paths | MPLS LDP Sync Default | Distribute List In |
+| ---------- | --------- | ------------------------- | -------------------- | --- | ------- | ----------------------------- | ---------------------------- | ----------------------------- | ------------- | --------------------- | ------------------ |
+| 30 | 192.168.255.10 | enabled | Ethernet22 <br> Ethernet23 <br> | disabled | default | disabled | disabled | - | - | - | - |
+
+### Router OSPF Router Redistribution
+
+| Process ID | Source Protocol | Route Map |
+| ---------- | --------------- | --------- |
+| 30 | bgp | - |
+
+### OSPF Interfaces
+
+| Interface | Area | Cost | Point To Point |
+| -------- | -------- | -------- | -------- |
+| Ethernet22 | 0 | - | True |
+| Ethernet23 | 0 | - | True |
+
+### Router OSPF Device Configuration
+
+```eos
+!
+router ospf 30 vrf Tenant_OSPF
+   router-id 192.168.255.10
+   passive-interface default
+   no passive-interface Ethernet22
+   no passive-interface Ethernet23
+   redistribute bgp
 ```
 
 ## Router BGP
@@ -1126,6 +1183,7 @@ ipv6 route vrf Tenant_D_OP_Zone 2001:db8:311::/64 Vlan411 name VARPv6
 | Tenant_C_OP_Zone | 65001:30 | connected |
 | Tenant_D_OP_Zone | 65001:40 | connected<br>static |
 | Tenant_D_WAN_Zone | 65001:41 | connected |
+| Tenant_OSPF | 65001:30 | connected<br>ospf |
 
 ### Router BGP Device Configuration
 
@@ -1297,6 +1355,14 @@ router bgp 65102
       route-target export evpn 100000:41
       router-id 192.168.255.10
       redistribute connected
+   !
+   vrf Tenant_OSPF
+      rd 65001:30
+      route-target import evpn 100000:30
+      route-target export evpn 100000:30
+      router-id 192.168.255.10
+      redistribute connected
+      redistribute ospf
 ```
 
 # BFD
@@ -1397,6 +1463,7 @@ route-map RM-CONN-2-BGP permit 10
 | Tenant_C_OP_Zone | enabled |
 | Tenant_D_OP_Zone | enabled |
 | Tenant_D_WAN_Zone | enabled |
+| Tenant_OSPF | enabled |
 
 ## VRF Instances Device Configuration
 
@@ -1420,6 +1487,8 @@ vrf instance Tenant_C_OP_Zone
 vrf instance Tenant_D_OP_Zone
 !
 vrf instance Tenant_D_WAN_Zone
+!
+vrf instance Tenant_OSPF
 ```
 
 # Virtual Source NAT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/DC1-LEAF2B.md
@@ -38,6 +38,7 @@
   - [IPv6 Routing](#ipv6-routing)
   - [Static Routes](#static-routes)
   - [IPv6 Static Routes](#ipv6-static-routes)
+  - [Router OSPF](#router-ospf)
   - [Router BGP](#router-bgp)
 - [BFD](#bfd)
   - [Router BFD](#router-bfd)
@@ -400,6 +401,7 @@ vlan 452
 | Ethernet2 | P2P_LINK_TO_DC1-SPINE2_Ethernet3 | routed | - | 172.31.255.35/31 | default | 1500 | false | - | - |
 | Ethernet3 | P2P_LINK_TO_DC1-SPINE3_Ethernet3 | routed | - | 172.31.255.37/31 | default | 1500 | false | - | - |
 | Ethernet4 | P2P_LINK_TO_DC1-SPINE4_Ethernet3 | routed | - | 172.31.255.39/31 | default | 1500 | false | - | - |
+| Ethernet24 | - | routed | - | 10.0.0.5/30 | Tenant_OSPF | - | false | - | - |
 
 ### Ethernet Interfaces Device Configuration
 
@@ -493,6 +495,14 @@ interface Ethernet21
    switchport access vlan 110
    switchport mode access
    switchport
+!
+interface Ethernet24
+   no shutdown
+   no switchport
+   vrf Tenant_OSPF
+   ip address 10.0.0.5/30
+   ip ospf network point-to-point
+   ip ospf area 0
 ```
 
 ## Port-Channel Interfaces
@@ -889,6 +899,7 @@ interface Vlan452
 | Tenant_C_OP_Zone | 30 | - |
 | Tenant_D_OP_Zone | 40 | - |
 | Tenant_D_WAN_Zone | 41 | - |
+| Tenant_OSPF | 30 | - |
 
 ### VXLAN Interface Device Configuration
 
@@ -927,6 +938,7 @@ interface Vxlan1
    vxlan vrf Tenant_C_OP_Zone vni 30
    vxlan vrf Tenant_D_OP_Zone vni 40
    vxlan vrf Tenant_D_WAN_Zone vni 41
+   vxlan vrf Tenant_OSPF vni 30
 ```
 
 # Routing
@@ -968,6 +980,7 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 | Tenant_C_OP_Zone | true |
 | Tenant_D_OP_Zone | true |
 | Tenant_D_WAN_Zone | true |
+| Tenant_OSPF | true |
 
 ### IP Routing Device Configuration
 
@@ -983,6 +996,7 @@ ip routing vrf Tenant_B_OP_Zone
 ip routing vrf Tenant_C_OP_Zone
 ip routing vrf Tenant_D_OP_Zone
 ip routing vrf Tenant_D_WAN_Zone
+ip routing vrf Tenant_OSPF
 ```
 ## IPv6 Routing
 
@@ -1000,6 +1014,7 @@ ip routing vrf Tenant_D_WAN_Zone
 | Tenant_C_OP_Zone | false |
 | Tenant_D_OP_Zone | true |
 | Tenant_D_WAN_Zone | true |
+| Tenant_OSPF | false |
 
 ## Static Routes
 
@@ -1035,6 +1050,37 @@ ip route vrf Tenant_D_OP_Zone 10.3.11.0/24 Vlan411 name VARP
 !
 ipv6 route vrf Tenant_D_OP_Zone ::/0 2001:db8:311::4 name IPv6-test-2
 ipv6 route vrf Tenant_D_OP_Zone 2001:db8:311::/64 Vlan411 name VARPv6
+```
+
+## Router OSPF
+
+### Router OSPF Summary
+
+| Process ID | Router ID | Default Passive Interface | No Passive Interface | BFD | Max LSA | Default Information Originate | Log Adjacency Changes Detail | Auto Cost Reference Bandwidth | Maximum Paths | MPLS LDP Sync Default | Distribute List In |
+| ---------- | --------- | ------------------------- | -------------------- | --- | ------- | ----------------------------- | ---------------------------- | ----------------------------- | ------------- | --------------------- | ------------------ |
+| 30 | 192.168.255.11 | enabled | Ethernet24 <br> | disabled | default | disabled | disabled | - | - | - | - |
+
+### Router OSPF Router Redistribution
+
+| Process ID | Source Protocol | Route Map |
+| ---------- | --------------- | --------- |
+| 30 | bgp | - |
+
+### OSPF Interfaces
+
+| Interface | Area | Cost | Point To Point |
+| -------- | -------- | -------- | -------- |
+| Ethernet24 | 0 | - | True |
+
+### Router OSPF Device Configuration
+
+```eos
+!
+router ospf 30 vrf Tenant_OSPF
+   router-id 192.168.255.11
+   passive-interface default
+   no passive-interface Ethernet24
+   redistribute bgp
 ```
 
 ## Router BGP
@@ -1126,6 +1172,7 @@ ipv6 route vrf Tenant_D_OP_Zone 2001:db8:311::/64 Vlan411 name VARPv6
 | Tenant_C_OP_Zone | 65001:30 | connected |
 | Tenant_D_OP_Zone | 65001:40 | connected<br>static |
 | Tenant_D_WAN_Zone | 65001:41 | connected |
+| Tenant_OSPF | 65001:30 | connected<br>ospf |
 
 ### Router BGP Device Configuration
 
@@ -1297,6 +1344,14 @@ router bgp 65102
       route-target export evpn 100000:41
       router-id 192.168.255.11
       redistribute connected
+   !
+   vrf Tenant_OSPF
+      rd 65001:30
+      route-target import evpn 100000:30
+      route-target export evpn 100000:30
+      router-id 192.168.255.11
+      redistribute connected
+      redistribute ospf
 ```
 
 # BFD
@@ -1397,6 +1452,7 @@ route-map RM-CONN-2-BGP permit 10
 | Tenant_C_OP_Zone | enabled |
 | Tenant_D_OP_Zone | enabled |
 | Tenant_D_WAN_Zone | enabled |
+| Tenant_OSPF | enabled |
 
 ## VRF Instances Device Configuration
 
@@ -1420,6 +1476,8 @@ vrf instance Tenant_C_OP_Zone
 vrf instance Tenant_D_OP_Zone
 !
 vrf instance Tenant_D_WAN_Zone
+!
+vrf instance Tenant_OSPF
 ```
 
 # Virtual Source NAT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/fabric/EOS_DESIGNS_UNIT_TESTS-topology.csv
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/fabric/EOS_DESIGNS_UNIT_TESTS-topology.csv
@@ -84,6 +84,8 @@ l3leaf,DC1-LEAF2A,Ethernet14,l2leaf,DC1-L2LEAF5A,Ethernet1,True
 l3leaf,DC1-LEAF2A,Ethernet15,l2leaf,DC1-L2LEAF5B,Ethernet1,True
 l3leaf,DC1-LEAF2A,Ethernet20,firewall,FIREWALL01,E0,True
 l3leaf,DC1-LEAF2A,Ethernet21,router,ROUTER01,Eth0,True
+l3leaf,DC1-LEAF2A,Ethernet22,l3_interface,,,True
+l3leaf,DC1-LEAF2A,Ethernet23,l3_interface,,,True
 l3leaf,DC1-LEAF2B,Ethernet1,spine,DC1-SPINE1,Ethernet3,True
 l3leaf,DC1-LEAF2B,Ethernet2,spine,DC1-SPINE2,Ethernet3,True
 l3leaf,DC1-LEAF2B,Ethernet3,spine,DC1-SPINE3,Ethernet3,True
@@ -99,6 +101,7 @@ l3leaf,DC1-LEAF2B,Ethernet14,l2leaf,DC1-L2LEAF5A,Ethernet2,True
 l3leaf,DC1-LEAF2B,Ethernet15,l2leaf,DC1-L2LEAF5B,Ethernet2,True
 l3leaf,DC1-LEAF2B,Ethernet20,firewall,FIREWALL01,E1,True
 l3leaf,DC1-LEAF2B,Ethernet21,router,ROUTER01,Eth1,True
+l3leaf,DC1-LEAF2B,Ethernet24,l3_interface,,,True
 spine,DC1-SPINE1,Ethernet1,l3leaf,DC1-LEAF1A,Ethernet1,True
 spine,DC1-SPINE1,Ethernet2,l3leaf,DC1-LEAF2A,Ethernet1,True
 spine,DC1-SPINE1,Ethernet3,l3leaf,DC1-LEAF2B,Ethernet1,True

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
@@ -124,6 +124,8 @@ vrf instance Tenant_D_OP_Zone
 !
 vrf instance Tenant_D_WAN_Zone
 !
+vrf instance Tenant_OSPF
+!
 interface Port-Channel7
    description DC1_L2LEAF1_Po1
    no shutdown
@@ -289,6 +291,22 @@ interface Ethernet21
    switchport access vlan 110
    switchport mode access
    switchport
+!
+interface Ethernet22
+   no shutdown
+   no switchport
+   vrf Tenant_OSPF
+   ip address 10.0.0.1/30
+   ip ospf network point-to-point
+   ip ospf area 0
+!
+interface Ethernet23
+   no shutdown
+   no switchport
+   vrf Tenant_OSPF
+   ip address 10.0.0.13/30
+   ip ospf network point-to-point
+   ip ospf area 0
 !
 interface Loopback0
    description EVPN_Overlay_Peering
@@ -474,6 +492,7 @@ interface Vxlan1
    vxlan vrf Tenant_C_OP_Zone vni 30
    vxlan vrf Tenant_D_OP_Zone vni 40
    vxlan vrf Tenant_D_WAN_Zone vni 41
+   vxlan vrf Tenant_OSPF vni 30
 !
 hardware tcam
    system profile vxlan-routing
@@ -492,6 +511,7 @@ ip routing vrf Tenant_B_OP_Zone
 ip routing vrf Tenant_C_OP_Zone
 ip routing vrf Tenant_D_OP_Zone
 ip routing vrf Tenant_D_WAN_Zone
+ip routing vrf Tenant_OSPF
 ipv6 unicast-routing vrf Tenant_D_OP_Zone
 ipv6 unicast-routing vrf Tenant_D_WAN_Zone
 !
@@ -678,6 +698,21 @@ router bgp 65102
       route-target export evpn 100000:41
       router-id 192.168.255.10
       redistribute connected
+   !
+   vrf Tenant_OSPF
+      rd 65001:30
+      route-target import evpn 100000:30
+      route-target export evpn 100000:30
+      router-id 192.168.255.10
+      redistribute connected
+      redistribute ospf
+!
+router ospf 30 vrf Tenant_OSPF
+   router-id 192.168.255.10
+   passive-interface default
+   no passive-interface Ethernet22
+   no passive-interface Ethernet23
+   redistribute bgp
 !
 management api http-commands
    protocol https

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
@@ -124,6 +124,8 @@ vrf instance Tenant_D_OP_Zone
 !
 vrf instance Tenant_D_WAN_Zone
 !
+vrf instance Tenant_OSPF
+!
 interface Port-Channel7
    description DC1_L2LEAF1_Po1
    no shutdown
@@ -289,6 +291,14 @@ interface Ethernet21
    switchport access vlan 110
    switchport mode access
    switchport
+!
+interface Ethernet24
+   no shutdown
+   no switchport
+   vrf Tenant_OSPF
+   ip address 10.0.0.5/30
+   ip ospf network point-to-point
+   ip ospf area 0
 !
 interface Loopback0
    description EVPN_Overlay_Peering
@@ -474,6 +484,7 @@ interface Vxlan1
    vxlan vrf Tenant_C_OP_Zone vni 30
    vxlan vrf Tenant_D_OP_Zone vni 40
    vxlan vrf Tenant_D_WAN_Zone vni 41
+   vxlan vrf Tenant_OSPF vni 30
 !
 hardware tcam
    system profile vxlan-routing
@@ -492,6 +503,7 @@ ip routing vrf Tenant_B_OP_Zone
 ip routing vrf Tenant_C_OP_Zone
 ip routing vrf Tenant_D_OP_Zone
 ip routing vrf Tenant_D_WAN_Zone
+ip routing vrf Tenant_OSPF
 ipv6 unicast-routing vrf Tenant_D_OP_Zone
 ipv6 unicast-routing vrf Tenant_D_WAN_Zone
 !
@@ -678,6 +690,20 @@ router bgp 65102
       route-target export evpn 100000:41
       router-id 192.168.255.11
       redistribute connected
+   !
+   vrf Tenant_OSPF
+      rd 65001:30
+      route-target import evpn 100000:30
+      route-target export evpn 100000:30
+      router-id 192.168.255.11
+      redistribute connected
+      redistribute ospf
+!
+router ospf 30 vrf Tenant_OSPF
+   router-id 192.168.255.11
+   passive-interface default
+   no passive-interface Ethernet24
+   redistribute bgp
 !
 management api http-commands
    protocol https

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
@@ -119,6 +119,19 @@ router_bgp:
           - '100000:11'
       redistribute_routes:
       - connected
+    Tenant_OSPF:
+      router_id: 192.168.255.10
+      rd: '65001:30'
+      route_targets:
+        import:
+          evpn:
+          - '100000:30'
+        export:
+          evpn:
+          - '100000:30'
+      redistribute_routes:
+      - connected
+      - ospf
     Tenant_B_OP_Zone:
       router_id: 192.168.255.10
       rd: '65001:20'
@@ -331,6 +344,9 @@ vrfs:
   Tenant_A_WEB_Zone:
     tenant: Tenant_A
     ip_routing: true
+  Tenant_OSPF:
+    tenant: Tenant_A
+    ip_routing: true
   Tenant_B_OP_Zone:
     tenant: Tenant_B
     ip_routing: true
@@ -465,6 +481,22 @@ ethernet_interfaces:
     channel_group:
       id: 14
       mode: active
+  Ethernet22:
+    type: routed
+    peer_type: l3_interface
+    vrf: Tenant_OSPF
+    ip_address: 10.0.0.1/30
+    shutdown: false
+    ospf_area: 0
+    ospf_network_point_to_point: true
+  Ethernet23:
+    type: routed
+    peer_type: l3_interface
+    vrf: Tenant_OSPF
+    ip_address: 10.0.0.13/30
+    shutdown: false
+    ospf_area: 0
+    ospf_network_point_to_point: true
   Ethernet20:
     peer: FIREWALL01
     peer_interface: E0
@@ -897,6 +929,18 @@ ipv6_static_routes:
   vrf: Tenant_D_OP_Zone
   name: VARPv6
   interface: Vlan411
+router_ospf:
+  process_ids:
+    30:
+      vrf: Tenant_OSPF
+      passive_interface_default: true
+      router_id: 192.168.255.10
+      no_passive_interfaces:
+      - Ethernet22
+      - Ethernet23
+      redistribute:
+        bgp:
+          enabled: true
 vxlan_interface:
   Vxlan1:
     description: DC1-LEAF2A_VTEP
@@ -955,6 +999,8 @@ vxlan_interface:
           vni: 10
         Tenant_A_WEB_Zone:
           vni: 11
+        Tenant_OSPF:
+          vni: 30
         Tenant_B_OP_Zone:
           vni: 20
         Tenant_C_OP_Zone:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
@@ -119,6 +119,19 @@ router_bgp:
           - '100000:11'
       redistribute_routes:
       - connected
+    Tenant_OSPF:
+      router_id: 192.168.255.11
+      rd: '65001:30'
+      route_targets:
+        import:
+          evpn:
+          - '100000:30'
+        export:
+          evpn:
+          - '100000:30'
+      redistribute_routes:
+      - connected
+      - ospf
     Tenant_B_OP_Zone:
       router_id: 192.168.255.11
       rd: '65001:20'
@@ -331,6 +344,9 @@ vrfs:
   Tenant_A_WEB_Zone:
     tenant: Tenant_A
     ip_routing: true
+  Tenant_OSPF:
+    tenant: Tenant_A
+    ip_routing: true
   Tenant_B_OP_Zone:
     tenant: Tenant_B
     ip_routing: true
@@ -465,6 +481,14 @@ ethernet_interfaces:
     channel_group:
       id: 14
       mode: active
+  Ethernet24:
+    type: routed
+    peer_type: l3_interface
+    vrf: Tenant_OSPF
+    ip_address: 10.0.0.5/30
+    shutdown: false
+    ospf_area: 0
+    ospf_network_point_to_point: true
   Ethernet20:
     peer: FIREWALL01
     peer_interface: E1
@@ -897,6 +921,17 @@ ipv6_static_routes:
   vrf: Tenant_D_OP_Zone
   name: VARPv6
   interface: Vlan411
+router_ospf:
+  process_ids:
+    30:
+      vrf: Tenant_OSPF
+      passive_interface_default: true
+      router_id: 192.168.255.11
+      no_passive_interfaces:
+      - Ethernet24
+      redistribute:
+        bgp:
+          enabled: true
 vxlan_interface:
   Vxlan1:
     description: DC1-LEAF2B_VTEP
@@ -955,6 +990,8 @@ vxlan_interface:
           vni: 10
         Tenant_A_WEB_Zone:
           vni: 11
+        Tenant_OSPF:
+          vni: 30
         Tenant_B_OP_Zone:
           vni: 20
         Tenant_C_OP_Zone:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_A.yml
@@ -213,17 +213,17 @@ Tenant_A:
         enabled: true
       l3_interfaces:
         - interfaces:
-          - Ethernet22
-          - Ethernet24
-          - Ethernet23
+            - Ethernet22
+            - Ethernet24
+            - Ethernet23
           ip_addresses:
-          - 10.0.0.1/30
-          - 10.0.0.5/30
-          - 10.0.0.13/30
+            - 10.0.0.1/30
+            - 10.0.0.5/30
+            - 10.0.0.13/30
           nodes:
-          - DC1-LEAF2A
-          - DC1-LEAF2B
-          - DC1-LEAF2A
+            - DC1-LEAF2A
+            - DC1-LEAF2B
+            - DC1-LEAF2A
           ospf:
             enabled: true
             point_to_point: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_A.yml
@@ -207,6 +207,27 @@ Tenant_A:
           mtu: 9000
           enabled: True
           description: "test"
+    Tenant_OSPF:
+      vrf_id: 30
+      ospf:
+        enabled: true
+      l3_interfaces:
+        - interfaces:
+          - Ethernet22
+          - Ethernet24
+          - Ethernet23
+          ip_addresses:
+          - 10.0.0.1/30
+          - 10.0.0.5/30
+          - 10.0.0.13/30
+          nodes:
+          - DC1-LEAF2A
+          - DC1-LEAF2B
+          - DC1-LEAF2A
+          ospf:
+            enabled: true
+            point_to_point: true
+            area: 0
   l2vlans:
     # L2 vlan as string
     '160':

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-ospf.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-ospf.j2
@@ -18,7 +18,7 @@ router_ospf:
 {%                 set ospf_router_id = vrf.ospf.router_id | arista.avd.default(switch.router_id) %}
 {%                 for l3_interface in vrf.l3_interfaces | arista.avd.natural_sort %}
 {%                     if inventory_hostname in l3_interface.nodes | arista.avd.default([inventory_hostname]) and l3_interface.interfaces is arista.avd.defined and l3_interface.ospf.enabled is arista.avd.defined(true) %}
-{%                         for node in l3_interface.nodes | arista.avd.natural_sort %}
+{%                         for node in l3_interface.nodes %}
 {%                             if node == inventory_hostname %}
 {%                                 do vrf_ospf_interfaces.append(l3_interface.interfaces[loop.index0]) %}
 {%                             endif %}


### PR DESCRIPTION
## Change Summary

Removes an arista.avd.natural_sort for handling ospf passive interfaces which was causing incorrect config to be rendered. Added molecule example to test for incorrect behavior and verified fix.

## Related Issue(s)

Fixes #1892

## Component(s) name

`arista.avd.eos_designs`

## How to test

Tested with molecule

### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
