### PR TITLE
Feat(eos_cli_config_gen): Support bgp missing-policy under router bgp vrf address-families

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-v4-evpn.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-v4-evpn.md
@@ -317,6 +317,8 @@ router bgp 65101
       redistribute static
       !
       address-family ipv4
+         bgp missing-policy direction in action permit
+         bgp missing-policy direction out action deny
          bgp additional-paths install
          bgp additional-paths receive
          bgp additional-paths send ecmp

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-v4-evpn.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-v4-evpn.cfg
@@ -109,6 +109,8 @@ router bgp 65101
       redistribute static
       !
       address-family ipv4
+         bgp missing-policy direction in action permit
+         bgp missing-policy direction out action deny
          bgp additional-paths install
          bgp additional-paths receive
          bgp additional-paths send ecmp

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-v4-evpn.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-v4-evpn.yml
@@ -154,6 +154,9 @@ router_bgp:
       address_families:
         ipv4:
           bgp:
+            missing_policy:
+              direction_in_action: permit
+              direction_out_action: deny
             additional_paths:
               - install
               - receive

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -3313,6 +3313,9 @@ router_bgp:
       address_families:
         < address_family >:
           bgp:
+            missing_policy:
+              direction_in_action: < deny | deny-in-out | permit >
+              direction_out_action: < deny | deny-in-out | permit >
             additional_paths:
               - < bgp_additional_paths_command >
               - < bgp_additional_paths_command >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -923,9 +923,17 @@ router bgp {{ router_bgp.as }}
 {%         for  address_family in vrf.address_families | arista.avd.convert_dicts('address_family') | arista.avd.natural_sort('address_family') %}
       !
       address-family {{ address_family.address_family }}
-{%             for additional_path in address_family.bgp.additional_paths | arista.avd.natural_sort %}
+{%             if address_family.bgp is arista.avd.defined %}
+{%                 if address_family.bgp.missing_policy.direction_in_action is arista.avd.defined %}
+         bgp missing-policy direction in action {{ address_family.bgp.missing_policy.direction_in_action }}
+{%                 endif %}
+{%                 if address_family.bgp.missing_policy.direction_out_action is arista.avd.defined %}
+         bgp missing-policy direction out action {{ address_family.bgp.missing_policy.direction_out_action }}
+{%                 endif %}
+{%                 for additional_path in address_family.bgp.additional_paths | arista.avd.natural_sort %}
          bgp additional-paths {{ additional_path }}
-{%             endfor %}
+{%                 endfor %}
+{%             endif %}
 {%             for peer_group in address_family.peer_groups | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
 {%                 if peer_group.activate is arista.avd.defined(true) %}
          neighbor {{ peer_group.name }} activate


### PR DESCRIPTION
## Change Summary

Support bgp missing-policy under router_bgp vrf address_families

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

```yaml
router_bgp:
  vrfs:
    < vrf >:
      address_families:
        < address_family >:
          bgp:
            missing_policy:
              direction_in_action: < deny | deny-in-out | permit >
              direction_out_action: < deny | deny-in-out | permit >
```

<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test

molecule converge -s eos_cli_config_gen -- --limit router-bgp-v4-evpn 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
