### PR TITLE
Feat(eos_designs): Support for structured_config on bgp_peer_groups

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/bgp-peer-groups-structured-config-1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/bgp-peer-groups-structured-config-1.md
@@ -1,0 +1,585 @@
+# bgp-peer-groups-structured-config-1
+# Table of Contents
+
+- [Management](#management)
+  - [Management API HTTP](#management-api-http)
+- [Authentication](#authentication)
+- [Monitoring](#monitoring)
+- [MLAG](#mlag)
+  - [MLAG Summary](#mlag-summary)
+  - [MLAG Device Configuration](#mlag-device-configuration)
+- [Spanning Tree](#spanning-tree)
+  - [Spanning Tree Summary](#spanning-tree-summary)
+  - [Spanning Tree Device Configuration](#spanning-tree-device-configuration)
+- [Internal VLAN Allocation Policy](#internal-vlan-allocation-policy)
+  - [Internal VLAN Allocation Policy Summary](#internal-vlan-allocation-policy-summary)
+  - [Internal VLAN Allocation Policy Configuration](#internal-vlan-allocation-policy-configuration)
+- [VLANs](#vlans)
+  - [VLANs Summary](#vlans-summary)
+  - [VLANs Device Configuration](#vlans-device-configuration)
+- [Interfaces](#interfaces)
+  - [Ethernet Interfaces](#ethernet-interfaces)
+  - [Port-Channel Interfaces](#port-channel-interfaces)
+  - [Loopback Interfaces](#loopback-interfaces)
+  - [VLAN Interfaces](#vlan-interfaces)
+  - [VXLAN Interface](#vxlan-interface)
+- [Routing](#routing)
+  - [Service Routing Protocols Model](#service-routing-protocols-model)
+  - [Virtual Router MAC Address](#virtual-router-mac-address)
+  - [IP Routing](#ip-routing)
+  - [IPv6 Routing](#ipv6-routing)
+  - [Static Routes](#static-routes)
+  - [Router BGP](#router-bgp)
+- [BFD](#bfd)
+  - [Router BFD](#router-bfd)
+- [Multicast](#multicast)
+  - [IP IGMP Snooping](#ip-igmp-snooping)
+- [Filters](#filters)
+  - [Prefix-lists](#prefix-lists)
+  - [Route-maps](#route-maps)
+  - [IP Extended Community Lists](#ip-extended-community-lists)
+- [ACL](#acl)
+- [VRF Instances](#vrf-instances)
+  - [VRF Instances Summary](#vrf-instances-summary)
+  - [VRF Instances Device Configuration](#vrf-instances-device-configuration)
+- [Quality Of Service](#quality-of-service)
+
+# Management
+
+## Management API HTTP
+
+### Management API HTTP Summary
+
+| HTTP | HTTPS | Default Services |
+| ---- | ----- | ---------------- |
+| False | True | - |
+
+### Management API VRF Access
+
+| VRF Name | IPv4 ACL | IPv6 ACL |
+| -------- | -------- | -------- |
+| MGMT | - | - |
+
+### Management API HTTP Configuration
+
+```eos
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+```
+
+# Authentication
+
+# Monitoring
+
+# MLAG
+
+## MLAG Summary
+
+| Domain-id | Local-interface | Peer-address | Peer-link |
+| --------- | --------------- | ------------ | --------- |
+| mlag | Vlan4094 | 192.168.253.205 | Port-Channel3 |
+
+Dual primary detection is disabled.
+
+## MLAG Device Configuration
+
+```eos
+!
+mlag configuration
+   domain-id mlag
+   local-interface Vlan4094
+   peer-address 192.168.253.205
+   peer-link Port-Channel3
+   reload-delay mlag 300
+   reload-delay non-mlag 330
+```
+
+# Spanning Tree
+
+## Spanning Tree Summary
+
+STP mode: **mstp**
+
+### Global Spanning-Tree Settings
+
+- Spanning Tree disabled for VLANs: **4094**
+
+## Spanning Tree Device Configuration
+
+```eos
+!
+no spanning-tree vlan-id 4094
+```
+
+# Internal VLAN Allocation Policy
+
+## Internal VLAN Allocation Policy Summary
+
+| Policy Allocation | Range Beginning | Range Ending |
+| ------------------| --------------- | ------------ |
+| ascending | 1006 | 1199 |
+
+## Internal VLAN Allocation Policy Configuration
+
+```eos
+!
+vlan internal order ascending range 1006 1199
+```
+
+# VLANs
+
+## VLANs Summary
+
+| VLAN ID | Name | Trunk Groups |
+| ------- | ---- | ------------ |
+| 4094 | MLAG_PEER | MLAG |
+
+## VLANs Device Configuration
+
+```eos
+!
+vlan 4094
+   name MLAG_PEER
+   trunk group MLAG
+```
+
+# Interfaces
+
+## Ethernet Interfaces
+
+### Ethernet Interfaces Summary
+
+#### L2
+
+| Interface | Description | Mode | VLANs | Native VLAN | Trunk Group | Channel-Group |
+| --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
+| Ethernet3 | MLAG_PEER_bgp-peer-groups-structured-config-2_Ethernet3 | *trunk | *2-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 3 |
+
+*Inherited from Port-Channel Interface
+
+### Ethernet Interfaces Device Configuration
+
+```eos
+!
+interface Ethernet3
+   description MLAG_PEER_bgp-peer-groups-structured-config-2_Ethernet3
+   no shutdown
+   channel-group 3 mode active
+```
+
+## Port-Channel Interfaces
+
+### Port-Channel Interfaces Summary
+
+#### L2
+
+| Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
+| --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
+| Port-Channel3 | MLAG_PEER_bgp-peer-groups-structured-config-2_Po3 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
+
+### Port-Channel Interfaces Device Configuration
+
+```eos
+!
+interface Port-Channel3
+   description MLAG_PEER_bgp-peer-groups-structured-config-2_Po3
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 2-4094
+   switchport mode trunk
+   switchport trunk group LEAF_PEER_L3
+   switchport trunk group MLAG
+```
+
+## Loopback Interfaces
+
+### Loopback Interfaces Summary
+
+#### IPv4
+
+| Interface | Description | VRF | IP Address |
+| --------- | ----------- | --- | ---------- |
+| Loopback0 | EVPN_Overlay_Peering | default | 192.168.255.111/32 |
+| Loopback1 | VTEP_VXLAN_Tunnel_Source | default | 192.168.254.111/32 |
+
+#### IPv6
+
+| Interface | Description | VRF | IPv6 Address |
+| --------- | ----------- | --- | ------------ |
+| Loopback0 | EVPN_Overlay_Peering | default | - |
+| Loopback1 | VTEP_VXLAN_Tunnel_Source | default | - |
+
+
+### Loopback Interfaces Device Configuration
+
+```eos
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 192.168.255.111/32
+!
+interface Loopback1
+   description VTEP_VXLAN_Tunnel_Source
+   no shutdown
+   ip address 192.168.254.111/32
+```
+
+## VLAN Interfaces
+
+### VLAN Interfaces Summary
+
+| Interface | Description | VRF |  MTU | Shutdown |
+| --------- | ----------- | --- | ---- | -------- |
+| Vlan4094 | MLAG_PEER | default | 9000 | false |
+
+#### IPv4
+
+| Interface | VRF | IP Address | IP Address Virtual | IP Router Virtual Address | VRRP | ACL In | ACL Out |
+| --------- | --- | ---------- | ------------------ | ------------------------- | ---- | ------ | ------- |
+| Vlan4094 |  default  |  192.168.253.204/31  |  -  |  -  |  -  |  -  |  -  |
+
+### VLAN Interfaces Device Configuration
+
+```eos
+!
+interface Vlan4094
+   description MLAG_PEER
+   no shutdown
+   mtu 9000
+   no autostate
+   ip address 192.168.253.204/31
+```
+
+## VXLAN Interface
+
+### VXLAN Interface Summary
+
+| Setting | Value |
+| ------- | ----- |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
+| EVPN MLAG Shared Router MAC | mlag-system-id |
+
+### VXLAN Interface Device Configuration
+
+```eos
+!
+interface Vxlan1
+   description bgp-peer-groups-structured-config-1_VTEP
+   vxlan source-interface Loopback1
+   vxlan virtual-router encapsulation mac-address mlag-system-id
+   vxlan udp-port 4789
+```
+
+# Routing
+## Service Routing Protocols Model
+
+Multi agent routing protocol model enabled
+
+```eos
+!
+service routing protocols model multi-agent
+```
+
+## Virtual Router MAC Address
+
+### Virtual Router MAC Address Summary
+
+#### Virtual Router MAC Address: 00:dc:00:00:00:0a
+
+### Virtual Router MAC Address Configuration
+
+```eos
+!
+ip virtual-router mac-address 00:dc:00:00:00:0a
+```
+
+## IP Routing
+
+### IP Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | true |
+| MGMT | false |
+
+### IP Routing Device Configuration
+
+```eos
+!
+ip routing
+no ip routing vrf MGMT
+```
+## IPv6 Routing
+
+### IPv6 Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | false |
+| MGMT | false |
+
+## Static Routes
+
+### Static Routes Summary
+
+| VRF | Destination Prefix | Next Hop IP             | Exit interface      | Administrative Distance       | Tag               | Route Name                    | Metric         |
+| --- | ------------------ | ----------------------- | ------------------- | ----------------------------- | ----------------- | ----------------------------- | -------------- |
+| MGMT | 0.0.0.0/0 | 192.168.0.1 | - | 1 | - | - | - |
+
+### Static Routes Device Configuration
+
+```eos
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.0.1
+```
+
+## Router BGP
+
+### Router BGP Summary
+
+| BGP AS | Router ID |
+| ------ | --------- |
+| 65001|  192.168.255.111 |
+
+| BGP Tuning |
+| ---------- |
+| maximum-paths 4 ecmp 4 |
+
+### Router BGP Peer Groups
+
+#### EVPN-OVERLAY-PEERS
+
+| Settings | Value |
+| -------- | ----- |
+| Address Family | mpls |
+| Remote AS | 65001 |
+| Source | Loopback0 |
+| BFD | True |
+| Send community | all |
+| Maximum routes | 0 (no limit) |
+
+#### IPv4-UNDERLAY-PEERS
+
+| Settings | Value |
+| -------- | ----- |
+| Address Family | ipv4 |
+| Send community | all |
+| Maximum routes | 12000 |
+
+#### MLAG-IPv4-UNDERLAY-PEER
+
+| Settings | Value |
+| -------- | ----- |
+| Address Family | ipv4 |
+| Remote AS | 65001 |
+| Next-hop self | True |
+| Send community | all |
+| Maximum routes | 12000 |
+
+### BGP Neighbors
+
+| Neighbor | Remote AS | VRF | Shutdown | Send-community | Maximum-routes | Allowas-in | BFD | RIB Pre-Policy Retain |
+| -------- | --------- | --- | -------- | -------------- | -------------- | ---------- | --- | --------------------- |
+| 192.168.253.205 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | default | - | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | - | - | - |
+| 192.168.255.112 | Inherited from peer group EVPN-OVERLAY-PEERS | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - |
+
+### Router BGP EVPN Address Family
+
+#### EVPN Peer Groups
+
+| Peer Group | Activate |
+| ---------- | -------- |
+| EVPN-OVERLAY-PEERS | True |
+
+#### EVPN Neighbor Default Encapsulation
+
+| Neighbor Default Encapsulation | Next-hop-self Source Interface |
+| ------------------------------ | ------------------------------ |
+| mpls | Loopback0 |
+
+### Router BGP Device Configuration
+
+```eos
+!
+router bgp 65001
+   router-id 192.168.255.111
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS remote-as 65001
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS description Description for evpn_overlay_peers via structured_config
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS description Description for ipv4_underlay_peers via structured_config
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   neighbor MLAG-IPv4-UNDERLAY-PEER peer group
+   neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65001
+   neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
+   neighbor MLAG-IPv4-UNDERLAY-PEER description Description for mlag_ipv4_underlay_peer via structured_config
+   neighbor MLAG-IPv4-UNDERLAY-PEER send-community
+   neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000
+   neighbor MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN in
+   neighbor 192.168.253.205 peer group MLAG-IPv4-UNDERLAY-PEER
+   neighbor 192.168.253.205 description bgp-peer-groups-structured-config-2
+   neighbor 192.168.255.112 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.112 description bgp-peer-groups-structured-config-2
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   address-family evpn
+      neighbor default encapsulation mpls next-hop-self source-interface Loopback0
+      neighbor EVPN-OVERLAY-PEERS route-map RM-EVPN-SOO-IN in
+      neighbor EVPN-OVERLAY-PEERS route-map RM-EVPN-SOO-OUT out
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor IPv4-UNDERLAY-PEERS activate
+      neighbor MLAG-IPv4-UNDERLAY-PEER activate
+```
+
+# BFD
+
+## Router BFD
+
+### Router BFD Multihop Summary
+
+| Interval | Minimum RX | Multiplier |
+| -------- | ---------- | ---------- |
+| 300 | 300 | 3 |
+
+### Router BFD Device Configuration
+
+```eos
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+```
+
+# Multicast
+
+## IP IGMP Snooping
+
+### IP IGMP Snooping Summary
+
+| IGMP Snooping | Fast Leave | Interface Restart Query | Proxy | Restart Query Interval | Robustness Variable |
+| ------------- | ---------- | ----------------------- | ----- | ---------------------- | ------------------- |
+| Enabled | - | - | - | - | - |
+
+### IP IGMP Snooping Device Configuration
+
+```eos
+```
+
+# Filters
+
+## Prefix-lists
+
+### Prefix-lists Summary
+
+#### PL-LOOPBACKS-EVPN-OVERLAY
+
+| Sequence | Action |
+| -------- | ------ |
+| 10 | permit 192.168.255.0/24 eq 32 |
+| 20 | permit 192.168.254.0/24 eq 32 |
+
+### Prefix-lists Device Configuration
+
+```eos
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+   seq 20 permit 192.168.254.0/24 eq 32
+```
+
+## Route-maps
+
+### Route-maps Summary
+
+#### RM-CONN-2-BGP
+
+| Sequence | Type | Match and/or Set |
+| -------- | ---- | ---------------- |
+| 10 | permit | match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY |
+
+#### RM-EVPN-SOO-IN
+
+| Sequence | Type | Match and/or Set |
+| -------- | ---- | ---------------- |
+| 10 | deny | match extcommunity ECL-EVPN-SOO |
+
+#### RM-EVPN-SOO-OUT
+
+| Sequence | Type | Match and/or Set |
+| -------- | ---- | ---------------- |
+| 10 | permit | set extcommunity soo 192.168.254.111:1 additive |
+
+#### RM-MLAG-PEER-IN
+
+| Sequence | Type | Match and/or Set |
+| -------- | ---- | ---------------- |
+| 10 | permit | set origin incomplete |
+
+### Route-maps Device Configuration
+
+```eos
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+route-map RM-EVPN-SOO-IN deny 10
+   match extcommunity ECL-EVPN-SOO
+!
+route-map RM-EVPN-SOO-IN permit 20
+!
+route-map RM-EVPN-SOO-OUT permit 10
+   set extcommunity soo 192.168.254.111:1 additive
+!
+route-map RM-MLAG-PEER-IN permit 10
+   description Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing
+   set origin incomplete
+```
+
+## IP Extended Community Lists
+
+### IP Extended Community Lists Summary
+
+| List Name | Type | Extended Communities |
+| --------- | ---- | -------------------- |
+| ECL-EVPN-SOO | permit | soo 192.168.254.111:1 |
+
+### IP Extended Community Lists configuration
+
+```eos
+!
+ip extcommunity-list ECL-EVPN-SOO permit soo 192.168.254.111:1
+```
+
+# ACL
+
+# VRF Instances
+
+## VRF Instances Summary
+
+| VRF Name | IP Routing |
+| -------- | ---------- |
+| MGMT | disabled |
+
+## VRF Instances Device Configuration
+
+```eos
+!
+vrf instance MGMT
+```
+
+# Quality Of Service

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/bgp-peer-groups-structured-config-2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/bgp-peer-groups-structured-config-2.md
@@ -1,0 +1,609 @@
+# bgp-peer-groups-structured-config-2
+# Table of Contents
+
+- [Management](#management)
+  - [Management API HTTP](#management-api-http)
+- [Authentication](#authentication)
+- [Monitoring](#monitoring)
+- [MLAG](#mlag)
+  - [MLAG Summary](#mlag-summary)
+  - [MLAG Device Configuration](#mlag-device-configuration)
+- [Spanning Tree](#spanning-tree)
+  - [Spanning Tree Summary](#spanning-tree-summary)
+  - [Spanning Tree Device Configuration](#spanning-tree-device-configuration)
+- [Internal VLAN Allocation Policy](#internal-vlan-allocation-policy)
+  - [Internal VLAN Allocation Policy Summary](#internal-vlan-allocation-policy-summary)
+  - [Internal VLAN Allocation Policy Configuration](#internal-vlan-allocation-policy-configuration)
+- [VLANs](#vlans)
+  - [VLANs Summary](#vlans-summary)
+  - [VLANs Device Configuration](#vlans-device-configuration)
+- [Interfaces](#interfaces)
+  - [Ethernet Interfaces](#ethernet-interfaces)
+  - [Port-Channel Interfaces](#port-channel-interfaces)
+  - [Loopback Interfaces](#loopback-interfaces)
+  - [VLAN Interfaces](#vlan-interfaces)
+  - [VXLAN Interface](#vxlan-interface)
+- [Routing](#routing)
+  - [Service Routing Protocols Model](#service-routing-protocols-model)
+  - [Virtual Router MAC Address](#virtual-router-mac-address)
+  - [IP Routing](#ip-routing)
+  - [IPv6 Routing](#ipv6-routing)
+  - [Static Routes](#static-routes)
+  - [Router BGP](#router-bgp)
+- [BFD](#bfd)
+  - [Router BFD](#router-bfd)
+- [Multicast](#multicast)
+  - [IP IGMP Snooping](#ip-igmp-snooping)
+- [Filters](#filters)
+  - [Prefix-lists](#prefix-lists)
+  - [Route-maps](#route-maps)
+  - [IP Extended Community Lists](#ip-extended-community-lists)
+- [ACL](#acl)
+- [VRF Instances](#vrf-instances)
+  - [VRF Instances Summary](#vrf-instances-summary)
+  - [VRF Instances Device Configuration](#vrf-instances-device-configuration)
+- [Quality Of Service](#quality-of-service)
+
+# Management
+
+## Management API HTTP
+
+### Management API HTTP Summary
+
+| HTTP | HTTPS | Default Services |
+| ---- | ----- | ---------------- |
+| False | True | - |
+
+### Management API VRF Access
+
+| VRF Name | IPv4 ACL | IPv6 ACL |
+| -------- | -------- | -------- |
+| MGMT | - | - |
+
+### Management API HTTP Configuration
+
+```eos
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+```
+
+# Authentication
+
+# Monitoring
+
+# MLAG
+
+## MLAG Summary
+
+| Domain-id | Local-interface | Peer-address | Peer-link |
+| --------- | --------------- | ------------ | --------- |
+| mlag | Vlan4094 | 192.168.253.204 | Port-Channel3 |
+
+Dual primary detection is disabled.
+
+## MLAG Device Configuration
+
+```eos
+!
+mlag configuration
+   domain-id mlag
+   local-interface Vlan4094
+   peer-address 192.168.253.204
+   peer-link Port-Channel3
+   reload-delay mlag 300
+   reload-delay non-mlag 330
+```
+
+# Spanning Tree
+
+## Spanning Tree Summary
+
+STP mode: **mstp**
+
+### Global Spanning-Tree Settings
+
+- Spanning Tree disabled for VLANs: **4094**
+
+## Spanning Tree Device Configuration
+
+```eos
+!
+no spanning-tree vlan-id 4094
+```
+
+# Internal VLAN Allocation Policy
+
+## Internal VLAN Allocation Policy Summary
+
+| Policy Allocation | Range Beginning | Range Ending |
+| ------------------| --------------- | ------------ |
+| ascending | 1006 | 1199 |
+
+## Internal VLAN Allocation Policy Configuration
+
+```eos
+!
+vlan internal order ascending range 1006 1199
+```
+
+# VLANs
+
+## VLANs Summary
+
+| VLAN ID | Name | Trunk Groups |
+| ------- | ---- | ------------ |
+| 4094 | MLAG_PEER | MLAG |
+
+## VLANs Device Configuration
+
+```eos
+!
+vlan 4094
+   name MLAG_PEER
+   trunk group MLAG
+```
+
+# Interfaces
+
+## Ethernet Interfaces
+
+### Ethernet Interfaces Summary
+
+#### L2
+
+| Interface | Description | Mode | VLANs | Native VLAN | Trunk Group | Channel-Group |
+| --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
+| Ethernet3 | MLAG_PEER_bgp-peer-groups-structured-config-1_Ethernet3 | *trunk | *2-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 3 |
+
+*Inherited from Port-Channel Interface
+
+### Ethernet Interfaces Device Configuration
+
+```eos
+!
+interface Ethernet3
+   description MLAG_PEER_bgp-peer-groups-structured-config-1_Ethernet3
+   no shutdown
+   channel-group 3 mode active
+```
+
+## Port-Channel Interfaces
+
+### Port-Channel Interfaces Summary
+
+#### L2
+
+| Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
+| --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
+| Port-Channel3 | MLAG_PEER_bgp-peer-groups-structured-config-1_Po3 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
+
+### Port-Channel Interfaces Device Configuration
+
+```eos
+!
+interface Port-Channel3
+   description MLAG_PEER_bgp-peer-groups-structured-config-1_Po3
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 2-4094
+   switchport mode trunk
+   switchport trunk group LEAF_PEER_L3
+   switchport trunk group MLAG
+```
+
+## Loopback Interfaces
+
+### Loopback Interfaces Summary
+
+#### IPv4
+
+| Interface | Description | VRF | IP Address |
+| --------- | ----------- | --- | ---------- |
+| Loopback0 | EVPN_Overlay_Peering | default | 192.168.255.112/32 |
+| Loopback1 | VTEP_VXLAN_Tunnel_Source | default | 192.168.254.111/32 |
+
+#### IPv6
+
+| Interface | Description | VRF | IPv6 Address |
+| --------- | ----------- | --- | ------------ |
+| Loopback0 | EVPN_Overlay_Peering | default | - |
+| Loopback1 | VTEP_VXLAN_Tunnel_Source | default | - |
+
+
+### Loopback Interfaces Device Configuration
+
+```eos
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 192.168.255.112/32
+!
+interface Loopback1
+   description VTEP_VXLAN_Tunnel_Source
+   no shutdown
+   ip address 192.168.254.111/32
+```
+
+## VLAN Interfaces
+
+### VLAN Interfaces Summary
+
+| Interface | Description | VRF |  MTU | Shutdown |
+| --------- | ----------- | --- | ---- | -------- |
+| Vlan4094 | MLAG_PEER | default | 9000 | false |
+
+#### IPv4
+
+| Interface | VRF | IP Address | IP Address Virtual | IP Router Virtual Address | VRRP | ACL In | ACL Out |
+| --------- | --- | ---------- | ------------------ | ------------------------- | ---- | ------ | ------- |
+| Vlan4094 |  default  |  192.168.253.205/31  |  -  |  -  |  -  |  -  |  -  |
+
+### VLAN Interfaces Device Configuration
+
+```eos
+!
+interface Vlan4094
+   description MLAG_PEER
+   no shutdown
+   mtu 9000
+   no autostate
+   ip address 192.168.253.205/31
+```
+
+## VXLAN Interface
+
+### VXLAN Interface Summary
+
+| Setting | Value |
+| ------- | ----- |
+| Source Interface | Loopback1 |
+| UDP port | 4789 |
+| EVPN MLAG Shared Router MAC | mlag-system-id |
+
+### VXLAN Interface Device Configuration
+
+```eos
+!
+interface Vxlan1
+   description bgp-peer-groups-structured-config-2_VTEP
+   vxlan source-interface Loopback1
+   vxlan virtual-router encapsulation mac-address mlag-system-id
+   vxlan udp-port 4789
+```
+
+# Routing
+## Service Routing Protocols Model
+
+Multi agent routing protocol model enabled
+
+```eos
+!
+service routing protocols model multi-agent
+```
+
+## Virtual Router MAC Address
+
+### Virtual Router MAC Address Summary
+
+#### Virtual Router MAC Address: 00:dc:00:00:00:0a
+
+### Virtual Router MAC Address Configuration
+
+```eos
+!
+ip virtual-router mac-address 00:dc:00:00:00:0a
+```
+
+## IP Routing
+
+### IP Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | true |
+| MGMT | false |
+
+### IP Routing Device Configuration
+
+```eos
+!
+ip routing
+no ip routing vrf MGMT
+```
+## IPv6 Routing
+
+### IPv6 Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | false |
+| MGMT | false |
+
+## Static Routes
+
+### Static Routes Summary
+
+| VRF | Destination Prefix | Next Hop IP             | Exit interface      | Administrative Distance       | Tag               | Route Name                    | Metric         |
+| --- | ------------------ | ----------------------- | ------------------- | ----------------------------- | ----------------- | ----------------------------- | -------------- |
+| MGMT | 0.0.0.0/0 | 192.168.0.1 | - | 1 | - | - | - |
+
+### Static Routes Device Configuration
+
+```eos
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.0.1
+```
+
+## Router BGP
+
+### Router BGP Summary
+
+| BGP AS | Router ID |
+| ------ | --------- |
+| 65001|  192.168.255.112 |
+
+| BGP AS | Cluster ID |
+| ------ | --------- |
+| 65001|  192.168.255.112 |
+
+| BGP Tuning |
+| ---------- |
+| maximum-paths 4 ecmp 4 |
+
+### Router BGP Peer Groups
+
+#### IPv4-UNDERLAY-PEERS
+
+| Settings | Value |
+| -------- | ----- |
+| Address Family | ipv4 |
+| Send community | all |
+| Maximum routes | 12000 |
+
+#### MLAG-IPv4-UNDERLAY-PEER
+
+| Settings | Value |
+| -------- | ----- |
+| Address Family | ipv4 |
+| Remote AS | 65001 |
+| Next-hop self | True |
+| Send community | all |
+| Maximum routes | 12000 |
+
+#### MPLS-OVERLAY-PEERS
+
+| Settings | Value |
+| -------- | ----- |
+| Address Family | mpls |
+| Remote AS | 65001 |
+| Route Reflector Client | Yes |
+| Source | Loopback0 |
+| BFD | True |
+| Send community | all |
+| Maximum routes | 0 (no limit) |
+
+#### RR-OVERLAY-PEERS
+
+| Settings | Value |
+| -------- | ----- |
+| Address Family | mpls |
+| Remote AS | 65001 |
+| Source | Loopback0 |
+| BFD | True |
+
+### BGP Neighbors
+
+| Neighbor | Remote AS | VRF | Shutdown | Send-community | Maximum-routes | Allowas-in | BFD | RIB Pre-Policy Retain |
+| -------- | --------- | --- | -------- | -------------- | -------------- | ---------- | --- | --------------------- |
+| 192.168.253.204 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | default | - | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | - | - | - |
+| 192.168.255.111 | Inherited from peer group RR-OVERLAY-PEERS | default | - | - | - | - | Inherited from peer group RR-OVERLAY-PEERS | - |
+
+### Router BGP EVPN Address Family
+
+#### EVPN Peer Groups
+
+| Peer Group | Activate |
+| ---------- | -------- |
+| MPLS-OVERLAY-PEERS | True |
+| RR-OVERLAY-PEERS | True |
+
+#### EVPN Neighbor Default Encapsulation
+
+| Neighbor Default Encapsulation | Next-hop-self Source Interface |
+| ------------------------------ | ------------------------------ |
+| mpls | - |
+
+### Router BGP Device Configuration
+
+```eos
+!
+router bgp 65001
+   router-id 192.168.255.112
+   bgp cluster-id 192.168.255.112
+   maximum-paths 4 ecmp 4
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS description Description for ipv4_underlay_peers via structured_config
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   neighbor MLAG-IPv4-UNDERLAY-PEER peer group
+   neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65001
+   neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
+   neighbor MLAG-IPv4-UNDERLAY-PEER description Description for mlag_ipv4_underlay_peer via structured_config
+   neighbor MLAG-IPv4-UNDERLAY-PEER send-community
+   neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000
+   neighbor MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN in
+   neighbor MPLS-OVERLAY-PEERS peer group
+   neighbor MPLS-OVERLAY-PEERS remote-as 65001
+   neighbor MPLS-OVERLAY-PEERS update-source Loopback0
+   neighbor MPLS-OVERLAY-PEERS description Description for mpls_overlay_peers via structured_config
+   neighbor MPLS-OVERLAY-PEERS route-reflector-client
+   neighbor MPLS-OVERLAY-PEERS bfd
+   neighbor MPLS-OVERLAY-PEERS send-community
+   neighbor MPLS-OVERLAY-PEERS maximum-routes 0
+   neighbor RR-OVERLAY-PEERS peer group
+   neighbor RR-OVERLAY-PEERS remote-as 65001
+   neighbor RR-OVERLAY-PEERS update-source Loopback0
+   neighbor RR-OVERLAY-PEERS description Description for rr_overlay_peers via structured_config
+   neighbor RR-OVERLAY-PEERS bfd
+   neighbor 192.168.253.204 peer group MLAG-IPv4-UNDERLAY-PEER
+   neighbor 192.168.253.204 description bgp-peer-groups-structured-config-1
+   neighbor 192.168.255.111 peer group RR-OVERLAY-PEERS
+   neighbor 192.168.255.111 description bgp-peer-groups-structured-config-1
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   address-family evpn
+      neighbor default encapsulation mpls
+      neighbor MPLS-OVERLAY-PEERS route-map RM-EVPN-SOO-IN in
+      neighbor MPLS-OVERLAY-PEERS route-map RM-EVPN-SOO-OUT out
+      neighbor MPLS-OVERLAY-PEERS activate
+      neighbor RR-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      neighbor IPv4-UNDERLAY-PEERS activate
+      neighbor MLAG-IPv4-UNDERLAY-PEER activate
+      no neighbor MPLS-OVERLAY-PEERS activate
+      no neighbor RR-OVERLAY-PEERS activate
+```
+
+# BFD
+
+## Router BFD
+
+### Router BFD Multihop Summary
+
+| Interval | Minimum RX | Multiplier |
+| -------- | ---------- | ---------- |
+| 300 | 300 | 3 |
+
+### Router BFD Device Configuration
+
+```eos
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+```
+
+# Multicast
+
+## IP IGMP Snooping
+
+### IP IGMP Snooping Summary
+
+| IGMP Snooping | Fast Leave | Interface Restart Query | Proxy | Restart Query Interval | Robustness Variable |
+| ------------- | ---------- | ----------------------- | ----- | ---------------------- | ------------------- |
+| Enabled | - | - | - | - | - |
+
+### IP IGMP Snooping Device Configuration
+
+```eos
+```
+
+# Filters
+
+## Prefix-lists
+
+### Prefix-lists Summary
+
+#### PL-LOOPBACKS-EVPN-OVERLAY
+
+| Sequence | Action |
+| -------- | ------ |
+| 10 | permit 192.168.255.0/24 eq 32 |
+| 20 | permit 192.168.254.0/24 eq 32 |
+
+### Prefix-lists Device Configuration
+
+```eos
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+   seq 20 permit 192.168.254.0/24 eq 32
+```
+
+## Route-maps
+
+### Route-maps Summary
+
+#### RM-CONN-2-BGP
+
+| Sequence | Type | Match and/or Set |
+| -------- | ---- | ---------------- |
+| 10 | permit | match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY |
+
+#### RM-EVPN-SOO-IN
+
+| Sequence | Type | Match and/or Set |
+| -------- | ---- | ---------------- |
+| 10 | deny | match extcommunity ECL-EVPN-SOO |
+
+#### RM-EVPN-SOO-OUT
+
+| Sequence | Type | Match and/or Set |
+| -------- | ---- | ---------------- |
+| 10 | permit | set extcommunity soo 192.168.254.111:1 additive |
+
+#### RM-MLAG-PEER-IN
+
+| Sequence | Type | Match and/or Set |
+| -------- | ---- | ---------------- |
+| 10 | permit | set origin incomplete |
+
+### Route-maps Device Configuration
+
+```eos
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+route-map RM-EVPN-SOO-IN deny 10
+   match extcommunity ECL-EVPN-SOO
+!
+route-map RM-EVPN-SOO-IN permit 20
+!
+route-map RM-EVPN-SOO-OUT permit 10
+   set extcommunity soo 192.168.254.111:1 additive
+!
+route-map RM-MLAG-PEER-IN permit 10
+   description Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing
+   set origin incomplete
+```
+
+## IP Extended Community Lists
+
+### IP Extended Community Lists Summary
+
+| List Name | Type | Extended Communities |
+| --------- | ---- | -------------------- |
+| ECL-EVPN-SOO | permit | soo 192.168.254.111:1 |
+
+### IP Extended Community Lists configuration
+
+```eos
+!
+ip extcommunity-list ECL-EVPN-SOO permit soo 192.168.254.111:1
+```
+
+# ACL
+
+# VRF Instances
+
+## VRF Instances Summary
+
+| VRF Name | IP Routing |
+| -------- | ---------- |
+| MGMT | disabled |
+
+## VRF Instances Device Configuration
+
+```eos
+!
+vrf instance MGMT
+```
+
+# Quality Of Service

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-peer-groups-structured-config-1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-peer-groups-structured-config-1.cfg
@@ -1,0 +1,143 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname bgp-peer-groups-structured-config-1
+!
+no spanning-tree vlan-id 4094
+!
+no enable password
+no aaa root
+!
+vlan 4094
+   name MLAG_PEER
+   trunk group MLAG
+!
+vrf instance MGMT
+!
+interface Port-Channel3
+   description MLAG_PEER_bgp-peer-groups-structured-config-2_Po3
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 2-4094
+   switchport mode trunk
+   switchport trunk group LEAF_PEER_L3
+   switchport trunk group MLAG
+!
+interface Ethernet3
+   description MLAG_PEER_bgp-peer-groups-structured-config-2_Ethernet3
+   no shutdown
+   channel-group 3 mode active
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 192.168.255.111/32
+!
+interface Loopback1
+   description VTEP_VXLAN_Tunnel_Source
+   no shutdown
+   ip address 192.168.254.111/32
+!
+interface Vlan4094
+   description MLAG_PEER
+   no shutdown
+   mtu 9000
+   no autostate
+   ip address 192.168.253.204/31
+!
+interface Vxlan1
+   description bgp-peer-groups-structured-config-1_VTEP
+   vxlan source-interface Loopback1
+   vxlan virtual-router encapsulation mac-address mlag-system-id
+   vxlan udp-port 4789
+!
+ip virtual-router mac-address 00:dc:00:00:00:0a
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip extcommunity-list ECL-EVPN-SOO permit soo 192.168.254.111:1
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+   seq 20 permit 192.168.254.0/24 eq 32
+!
+mlag configuration
+   domain-id mlag
+   local-interface Vlan4094
+   peer-address 192.168.253.205
+   peer-link Port-Channel3
+   reload-delay mlag 300
+   reload-delay non-mlag 330
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.0.1
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+route-map RM-EVPN-SOO-IN deny 10
+   match extcommunity ECL-EVPN-SOO
+!
+route-map RM-EVPN-SOO-IN permit 20
+!
+route-map RM-EVPN-SOO-OUT permit 10
+   set extcommunity soo 192.168.254.111:1 additive
+!
+route-map RM-MLAG-PEER-IN permit 10
+   description Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing
+   set origin incomplete
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 65001
+   router-id 192.168.255.111
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS remote-as 65001
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS description Description for evpn_overlay_peers via structured_config
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS description Description for ipv4_underlay_peers via structured_config
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   neighbor MLAG-IPv4-UNDERLAY-PEER peer group
+   neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65001
+   neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
+   neighbor MLAG-IPv4-UNDERLAY-PEER description Description for mlag_ipv4_underlay_peer via structured_config
+   neighbor MLAG-IPv4-UNDERLAY-PEER send-community
+   neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000
+   neighbor MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN in
+   neighbor 192.168.253.205 peer group MLAG-IPv4-UNDERLAY-PEER
+   neighbor 192.168.253.205 description bgp-peer-groups-structured-config-2
+   neighbor 192.168.255.112 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.112 description bgp-peer-groups-structured-config-2
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   address-family evpn
+      neighbor default encapsulation mpls next-hop-self source-interface Loopback0
+      neighbor EVPN-OVERLAY-PEERS route-map RM-EVPN-SOO-IN in
+      neighbor EVPN-OVERLAY-PEERS route-map RM-EVPN-SOO-OUT out
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor IPv4-UNDERLAY-PEERS activate
+      neighbor MLAG-IPv4-UNDERLAY-PEER activate
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-peer-groups-structured-config-2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-peer-groups-structured-config-2.cfg
@@ -1,0 +1,152 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname bgp-peer-groups-structured-config-2
+!
+no spanning-tree vlan-id 4094
+!
+no enable password
+no aaa root
+!
+vlan 4094
+   name MLAG_PEER
+   trunk group MLAG
+!
+vrf instance MGMT
+!
+interface Port-Channel3
+   description MLAG_PEER_bgp-peer-groups-structured-config-1_Po3
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 2-4094
+   switchport mode trunk
+   switchport trunk group LEAF_PEER_L3
+   switchport trunk group MLAG
+!
+interface Ethernet3
+   description MLAG_PEER_bgp-peer-groups-structured-config-1_Ethernet3
+   no shutdown
+   channel-group 3 mode active
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 192.168.255.112/32
+!
+interface Loopback1
+   description VTEP_VXLAN_Tunnel_Source
+   no shutdown
+   ip address 192.168.254.111/32
+!
+interface Vlan4094
+   description MLAG_PEER
+   no shutdown
+   mtu 9000
+   no autostate
+   ip address 192.168.253.205/31
+!
+interface Vxlan1
+   description bgp-peer-groups-structured-config-2_VTEP
+   vxlan source-interface Loopback1
+   vxlan virtual-router encapsulation mac-address mlag-system-id
+   vxlan udp-port 4789
+!
+ip virtual-router mac-address 00:dc:00:00:00:0a
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip extcommunity-list ECL-EVPN-SOO permit soo 192.168.254.111:1
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+   seq 20 permit 192.168.254.0/24 eq 32
+!
+mlag configuration
+   domain-id mlag
+   local-interface Vlan4094
+   peer-address 192.168.253.204
+   peer-link Port-Channel3
+   reload-delay mlag 300
+   reload-delay non-mlag 330
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.0.1
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+route-map RM-EVPN-SOO-IN deny 10
+   match extcommunity ECL-EVPN-SOO
+!
+route-map RM-EVPN-SOO-IN permit 20
+!
+route-map RM-EVPN-SOO-OUT permit 10
+   set extcommunity soo 192.168.254.111:1 additive
+!
+route-map RM-MLAG-PEER-IN permit 10
+   description Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing
+   set origin incomplete
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 65001
+   router-id 192.168.255.112
+   bgp cluster-id 192.168.255.112
+   maximum-paths 4 ecmp 4
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS description Description for ipv4_underlay_peers via structured_config
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   neighbor MLAG-IPv4-UNDERLAY-PEER peer group
+   neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65001
+   neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
+   neighbor MLAG-IPv4-UNDERLAY-PEER description Description for mlag_ipv4_underlay_peer via structured_config
+   neighbor MLAG-IPv4-UNDERLAY-PEER send-community
+   neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000
+   neighbor MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN in
+   neighbor MPLS-OVERLAY-PEERS peer group
+   neighbor MPLS-OVERLAY-PEERS remote-as 65001
+   neighbor MPLS-OVERLAY-PEERS update-source Loopback0
+   neighbor MPLS-OVERLAY-PEERS description Description for mpls_overlay_peers via structured_config
+   neighbor MPLS-OVERLAY-PEERS route-reflector-client
+   neighbor MPLS-OVERLAY-PEERS bfd
+   neighbor MPLS-OVERLAY-PEERS send-community
+   neighbor MPLS-OVERLAY-PEERS maximum-routes 0
+   neighbor RR-OVERLAY-PEERS peer group
+   neighbor RR-OVERLAY-PEERS remote-as 65001
+   neighbor RR-OVERLAY-PEERS update-source Loopback0
+   neighbor RR-OVERLAY-PEERS description Description for rr_overlay_peers via structured_config
+   neighbor RR-OVERLAY-PEERS bfd
+   neighbor 192.168.253.204 peer group MLAG-IPv4-UNDERLAY-PEER
+   neighbor 192.168.253.204 description bgp-peer-groups-structured-config-1
+   neighbor 192.168.255.111 peer group MPLS-OVERLAY-PEERS
+   neighbor 192.168.255.111 description bgp-peer-groups-structured-config-1
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   address-family evpn
+      neighbor default encapsulation mpls
+      neighbor MPLS-OVERLAY-PEERS route-map RM-EVPN-SOO-IN in
+      neighbor MPLS-OVERLAY-PEERS route-map RM-EVPN-SOO-OUT out
+      neighbor MPLS-OVERLAY-PEERS activate
+      neighbor RR-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      neighbor IPv4-UNDERLAY-PEERS activate
+      neighbor MLAG-IPv4-UNDERLAY-PEER activate
+      no neighbor MPLS-OVERLAY-PEERS activate
+      no neighbor RR-OVERLAY-PEERS activate
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-structured-config-1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-structured-config-1.yml
@@ -1,0 +1,184 @@
+router_bgp:
+  as: '65001'
+  router_id: 192.168.255.111
+  bgp_defaults:
+  - maximum-paths 4 ecmp 4
+  peer_groups:
+    MLAG-IPv4-UNDERLAY-PEER:
+      type: ipv4
+      remote_as: '65001'
+      next_hop_self: true
+      description: Description for mlag_ipv4_underlay_peer via structured_config
+      maximum_routes: 12000
+      send_community: all
+      route_map_in: RM-MLAG-PEER-IN
+      struct_cfg:
+        description: Description for mlag_ipv4_underlay_peer via structured_config
+    IPv4-UNDERLAY-PEERS:
+      type: ipv4
+      maximum_routes: 12000
+      send_community: all
+      struct_cfg:
+        description: Description for ipv4_underlay_peers via structured_config
+      description: Description for ipv4_underlay_peers via structured_config
+    EVPN-OVERLAY-PEERS:
+      type: mpls
+      update_source: Loopback0
+      remote_as: '65001'
+      bfd: true
+      send_community: all
+      maximum_routes: 0
+      struct_cfg:
+        description: Description for evpn_overlay_peers via structured_config
+      description: Description for evpn_overlay_peers via structured_config
+  address_family_ipv4:
+    peer_groups:
+      MLAG-IPv4-UNDERLAY-PEER:
+        activate: true
+      IPv4-UNDERLAY-PEERS:
+        activate: true
+      EVPN-OVERLAY-PEERS:
+        activate: false
+  neighbors:
+    192.168.253.205:
+      peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: bgp-peer-groups-structured-config-2
+    192.168.255.112:
+      peer_group: EVPN-OVERLAY-PEERS
+      description: bgp-peer-groups-structured-config-2
+  redistribute_routes:
+    connected:
+      route_map: RM-CONN-2-BGP
+  address_family_evpn:
+    neighbor_default:
+      encapsulation: mpls
+      next_hop_self_source_interface: Loopback0
+    peer_groups:
+      EVPN-OVERLAY-PEERS:
+        activate: true
+        route_map_in: RM-EVPN-SOO-IN
+        route_map_out: RM-EVPN-SOO-OUT
+static_routes:
+- vrf: MGMT
+  destination_address_prefix: 0.0.0.0/0
+  gateway: 192.168.0.1
+service_routing_protocols_model: multi-agent
+ip_routing: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+vrfs:
+  MGMT:
+    ip_routing: false
+management_api_http:
+  enable_vrfs:
+    MGMT: {}
+  enable_https: true
+spanning_tree:
+  no_spanning_tree_vlan: 4094
+vlans:
+  4094:
+    tenant: system
+    name: MLAG_PEER
+    trunk_groups:
+    - MLAG
+vlan_interfaces:
+  Vlan4094:
+    description: MLAG_PEER
+    shutdown: false
+    ip_address: 192.168.253.204/31
+    no_autostate: true
+    mtu: 9000
+port_channel_interfaces:
+  Port-Channel3:
+    description: MLAG_PEER_bgp-peer-groups-structured-config-2_Po3
+    type: switched
+    shutdown: false
+    vlans: 2-4094
+    mode: trunk
+    trunk_groups:
+    - LEAF_PEER_L3
+    - MLAG
+ethernet_interfaces:
+  Ethernet3:
+    peer: bgp-peer-groups-structured-config-2
+    peer_interface: Ethernet3
+    peer_type: mlag_peer
+    description: MLAG_PEER_bgp-peer-groups-structured-config-2_Ethernet3
+    type: switched
+    shutdown: false
+    channel_group:
+      id: 3
+      mode: active
+mlag_configuration:
+  domain_id: mlag
+  local_interface: Vlan4094
+  peer_address: 192.168.253.205
+  peer_link: Port-Channel3
+  reload_delay_mlag: 300
+  reload_delay_non_mlag: 330
+route_maps:
+  RM-MLAG-PEER-IN:
+    sequence_numbers:
+      10:
+        type: permit
+        set:
+        - origin incomplete
+        description: Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing
+  RM-CONN-2-BGP:
+    sequence_numbers:
+      10:
+        type: permit
+        match:
+        - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+  RM-EVPN-SOO-IN:
+    sequence_numbers:
+      10:
+        type: deny
+        match:
+        - extcommunity ECL-EVPN-SOO
+      20:
+        type: permit
+  RM-EVPN-SOO-OUT:
+    sequence_numbers:
+      10:
+        type: permit
+        set:
+        - extcommunity soo 192.168.254.111:1 additive
+loopback_interfaces:
+  Loopback0:
+    description: EVPN_Overlay_Peering
+    shutdown: false
+    ip_address: 192.168.255.111/32
+  Loopback1:
+    description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
+    ip_address: 192.168.254.111/32
+prefix_lists:
+  PL-LOOPBACKS-EVPN-OVERLAY:
+    sequence_numbers:
+      10:
+        action: permit 192.168.255.0/24 eq 32
+      20:
+        action: permit 192.168.254.0/24 eq 32
+router_bfd:
+  multihop:
+    interval: 300
+    min_rx: 300
+    multiplier: 3
+ip_extcommunity_lists:
+  ECL-EVPN-SOO:
+  - type: permit
+    extcommunities: soo 192.168.254.111:1
+ip_igmp_snooping:
+  globally_enabled: true
+ip_virtual_router_mac_address: 00:dc:00:00:00:0a
+vxlan_interface:
+  Vxlan1:
+    description: bgp-peer-groups-structured-config-1_VTEP
+    vxlan:
+      source_interface: Loopback1
+      virtual_router_encapsulation_mac_address: mlag-system-id
+      udp_port: 4789

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-structured-config-2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-structured-config-2.yml
@@ -1,0 +1,197 @@
+router_bgp:
+  as: '65001'
+  router_id: 192.168.255.112
+  bgp_defaults:
+  - maximum-paths 4 ecmp 4
+  peer_groups:
+    MLAG-IPv4-UNDERLAY-PEER:
+      type: ipv4
+      remote_as: '65001'
+      next_hop_self: true
+      description: Description for mlag_ipv4_underlay_peer via structured_config
+      maximum_routes: 12000
+      send_community: all
+      route_map_in: RM-MLAG-PEER-IN
+      struct_cfg:
+        description: Description for mlag_ipv4_underlay_peer via structured_config
+    IPv4-UNDERLAY-PEERS:
+      type: ipv4
+      maximum_routes: 12000
+      send_community: all
+      struct_cfg:
+        description: Description for ipv4_underlay_peers via structured_config
+      description: Description for ipv4_underlay_peers via structured_config
+    MPLS-OVERLAY-PEERS:
+      type: mpls
+      update_source: Loopback0
+      remote_as: '65001'
+      bfd: true
+      send_community: all
+      maximum_routes: 0
+      route_reflector_client: true
+      struct_cfg:
+        description: Description for mpls_overlay_peers via structured_config
+      description: Description for mpls_overlay_peers via structured_config
+    RR-OVERLAY-PEERS:
+      type: mpls
+      update_source: Loopback0
+      remote_as: '65001'
+      bfd: true
+      struct_cfg:
+        description: Description for rr_overlay_peers via structured_config
+      description: Description for rr_overlay_peers via structured_config
+  address_family_ipv4:
+    peer_groups:
+      MLAG-IPv4-UNDERLAY-PEER:
+        activate: true
+      IPv4-UNDERLAY-PEERS:
+        activate: true
+      MPLS-OVERLAY-PEERS:
+        activate: false
+      RR-OVERLAY-PEERS:
+        activate: false
+  neighbors:
+    192.168.253.204:
+      peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: bgp-peer-groups-structured-config-1
+    192.168.255.111:
+      peer_group: MPLS-OVERLAY-PEERS
+      description: bgp-peer-groups-structured-config-1
+  redistribute_routes:
+    connected:
+      route_map: RM-CONN-2-BGP
+  bgp_cluster_id: 192.168.255.112
+  address_family_evpn:
+    neighbor_default:
+      encapsulation: mpls
+    peer_groups:
+      MPLS-OVERLAY-PEERS:
+        activate: true
+        route_map_in: RM-EVPN-SOO-IN
+        route_map_out: RM-EVPN-SOO-OUT
+      RR-OVERLAY-PEERS:
+        activate: true
+static_routes:
+- vrf: MGMT
+  destination_address_prefix: 0.0.0.0/0
+  gateway: 192.168.0.1
+service_routing_protocols_model: multi-agent
+ip_routing: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+vrfs:
+  MGMT:
+    ip_routing: false
+management_api_http:
+  enable_vrfs:
+    MGMT: {}
+  enable_https: true
+spanning_tree:
+  no_spanning_tree_vlan: 4094
+vlans:
+  4094:
+    tenant: system
+    name: MLAG_PEER
+    trunk_groups:
+    - MLAG
+vlan_interfaces:
+  Vlan4094:
+    description: MLAG_PEER
+    shutdown: false
+    ip_address: 192.168.253.205/31
+    no_autostate: true
+    mtu: 9000
+port_channel_interfaces:
+  Port-Channel3:
+    description: MLAG_PEER_bgp-peer-groups-structured-config-1_Po3
+    type: switched
+    shutdown: false
+    vlans: 2-4094
+    mode: trunk
+    trunk_groups:
+    - LEAF_PEER_L3
+    - MLAG
+ethernet_interfaces:
+  Ethernet3:
+    peer: bgp-peer-groups-structured-config-1
+    peer_interface: Ethernet3
+    peer_type: mlag_peer
+    description: MLAG_PEER_bgp-peer-groups-structured-config-1_Ethernet3
+    type: switched
+    shutdown: false
+    channel_group:
+      id: 3
+      mode: active
+mlag_configuration:
+  domain_id: mlag
+  local_interface: Vlan4094
+  peer_address: 192.168.253.204
+  peer_link: Port-Channel3
+  reload_delay_mlag: 300
+  reload_delay_non_mlag: 330
+route_maps:
+  RM-MLAG-PEER-IN:
+    sequence_numbers:
+      10:
+        type: permit
+        set:
+        - origin incomplete
+        description: Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing
+  RM-CONN-2-BGP:
+    sequence_numbers:
+      10:
+        type: permit
+        match:
+        - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+  RM-EVPN-SOO-IN:
+    sequence_numbers:
+      10:
+        type: deny
+        match:
+        - extcommunity ECL-EVPN-SOO
+      20:
+        type: permit
+  RM-EVPN-SOO-OUT:
+    sequence_numbers:
+      10:
+        type: permit
+        set:
+        - extcommunity soo 192.168.254.111:1 additive
+loopback_interfaces:
+  Loopback0:
+    description: EVPN_Overlay_Peering
+    shutdown: false
+    ip_address: 192.168.255.112/32
+  Loopback1:
+    description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
+    ip_address: 192.168.254.111/32
+prefix_lists:
+  PL-LOOPBACKS-EVPN-OVERLAY:
+    sequence_numbers:
+      10:
+        action: permit 192.168.255.0/24 eq 32
+      20:
+        action: permit 192.168.254.0/24 eq 32
+router_bfd:
+  multihop:
+    interval: 300
+    min_rx: 300
+    multiplier: 3
+ip_extcommunity_lists:
+  ECL-EVPN-SOO:
+  - type: permit
+    extcommunities: soo 192.168.254.111:1
+ip_igmp_snooping:
+  globally_enabled: true
+ip_virtual_router_mac_address: 00:dc:00:00:00:0a
+vxlan_interface:
+  Vxlan1:
+    description: bgp-peer-groups-structured-config-2_VTEP
+    vxlan:
+      source_interface: Loopback1
+      virtual_router_encapsulation_mac_address: mlag-system-id
+      udp_port: 4789

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/BGP_PEER_GROUPS_STRUCTURED_CONFIG.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/BGP_PEER_GROUPS_STRUCTURED_CONFIG.yml
@@ -1,0 +1,69 @@
+# Minimum config to only test the specific feature.
+# This is in no way a "good" or working config.
+# Everything is tweaked to trigger config generation of all the different peer-groups
+
+bgp_peer_groups:
+  ipv4_underlay_peers:
+    # Custom structured config added under router_bgp.peer_groups.<name> for eos_cli_config_gen
+    structured_config:
+      description: Description for ipv4_underlay_peers via structured_config
+  mlag_ipv4_underlay_peer:
+    # Custom structured config added under router_bgp.peer_groups.<name> for eos_cli_config_gen
+    structured_config:
+      description: Description for mlag_ipv4_underlay_peer via structured_config
+  evpn_overlay_peers:
+    # Custom structured config added under router_bgp.peer_groups.<name> for eos_cli_config_gen
+    structured_config:
+      description: Description for evpn_overlay_peers via structured_config
+  evpn_overlay_core:
+    # Custom structured config added under router_bgp.peer_groups.<name> for eos_cli_config_gen
+    structured_config:
+      description: Description for evpn_overlay_core via structured_config
+  mpls_overlay_peers:
+    # Custom structured config added under router_bgp.peer_groups.<name> for eos_cli_config_gen
+    structured_config:
+      description: Description for mpls_overlay_peers via structured_config
+  rr_overlay_peers:
+    # Custom structured config added under router_bgp.peer_groups.<name> for eos_cli_config_gen
+    structured_config:
+      description: Description for rr_overlay_peers via structured_config
+
+type: l3leaf
+mgmt_gateway: 192.168.0.1
+overlay_routing_protocol: ibgp
+bgp_as: 65001
+
+l3leaf:
+  defaults:
+    loopback_ipv4_pool: 192.168.255.0/24
+    loopback_ipv4_offset: 8
+    vtep_loopback_ipv4_pool: 192.168.254.0/24
+    virtual_router_mac_address: 00:dc:00:00:00:0a
+    mlag_peer_l3_vlan: 4094
+    mlag_peer_ipv4_pool: 192.168.253.0/24
+    mlag_interfaces: [ Ethernet3 ]
+  node_groups:
+    mlag:
+      nodes:
+        bgp-peer-groups-structured-config-1:
+          id: 103
+          bgp_as: 103
+          evpn_route_servers: [ bgp-peer-groups-structured-config-2 ]
+          mpls_route_reflectors: [ bgp-peer-groups-structured-config-2 ]
+          mpls_overlay_role: client
+          evpn_gateway:
+            evpn_l3:
+              enabled: true
+        bgp-peer-groups-structured-config-2:
+          id: 104
+          bgp_as: 104
+          evpn_role: server
+          mpls_overlay_role: server
+
+# MPLS Beta code is hardcoded to look for this dictionary.
+rr:
+  node_groups:
+    dummy:
+      nodes:
+        bgp-peer-groups-structured-config-1:
+        bgp-peer-groups-structured-config-2:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
@@ -50,6 +50,10 @@ all:
                 UNDERLAY-MULTICAST-L3LEAF1B:
                 UNDERLAY-MULTICAST-L3LEAF2A:
                 UNDERLAY-MULTICAST-L3LEAF2B:
+        BGP_PEER_GROUPS_STRUCTURED_CONFIG:
+          hosts:
+            bgp-peer-groups-structured-config-1:
+            bgp-peer-groups-structured-config-2:
         AVD_LAB:
           children:
             DC1_FABRIC:

--- a/ansible_collections/arista/avd/plugins/module_utils/eos_designs_facts.py
+++ b/ansible_collections/arista/avd/plugins/module_utils/eos_designs_facts.py
@@ -767,6 +767,10 @@ class EosDesignsFacts:
                         get(self._hostvars, "bgp_peer_groups.ipv4_underlay_peers.password"),
                         get(self._hostvars, "bgp_peer_groups.IPv4_UNDERLAY_PEERS.password")
                     ),
+                    "structured_config": default(
+                        get(self._hostvars, "bgp_peer_groups.ipv4_underlay_peers.structured_config"),
+                        get(self._hostvars, "bgp_peer_groups.IPv4_UNDERLAY_PEERS.structured_config")
+                    ),
                 },
                 "mlag_ipv4_underlay_peer": {
                     "name": default(
@@ -777,6 +781,10 @@ class EosDesignsFacts:
                     "password": default(
                         get(self._hostvars, "bgp_peer_groups.mlag_ipv4_underlay_peer.password"),
                         get(self._hostvars, "bgp_peer_groups.MLAG_IPv4_UNDERLAY_PEER.password")
+                    ),
+                    "structured_config": default(
+                        get(self._hostvars, "bgp_peer_groups.mlag_ipv4_underlay_peer.structured_config"),
+                        get(self._hostvars, "bgp_peer_groups.MLAG_IPv4_UNDERLAY_PEER.structured_config")
                     ),
                 },
                 "evpn_overlay_peers": {
@@ -789,18 +797,25 @@ class EosDesignsFacts:
                         get(self._hostvars, "bgp_peer_groups.evpn_overlay_peers.password"),
                         get(self._hostvars, "bgp_peer_groups.EVPN_OVERLAY_PEERS.password")
                     ),
+                    "structured_config": default(
+                        get(self._hostvars, "bgp_peer_groups.evpn_overlay_peers.structured_config"),
+                        get(self._hostvars, "bgp_peer_groups.EVPN_OVERLAY_PEERS.structured_config")
+                    ),
                 },
                 "evpn_overlay_core": {
                     "name": get(self._hostvars, "bgp_peer_groups.evpn_overlay_core.name", default="EVPN-OVERLAY-CORE"),
-                    "password": get(self._hostvars, "bgp_peer_groups.evpn_overlay_core.password")
+                    "password": get(self._hostvars, "bgp_peer_groups.evpn_overlay_core.password"),
+                    "structured_config": get(self._hostvars, "bgp_peer_groups.evpn_overlay_core.structured_config"),
                 },
                 "mpls_overlay_peers": {
                     "name": get(self._hostvars, "bgp_peer_groups.mpls_overlay_peers.name", default="MPLS-OVERLAY-PEERS"),
-                    "password": get(self._hostvars, "bgp_peer_groups.mpls_overlay_peers.password")
+                    "password": get(self._hostvars, "bgp_peer_groups.mpls_overlay_peers.password"),
+                    "structured_config": get(self._hostvars, "bgp_peer_groups.mpls_overlay_peers.structured_config"),
                 },
                 "rr_overlay_peers": {
                     "name": get(self._hostvars, "bgp_peer_groups.rr_overlay_peers.name", default="RR-OVERLAY-PEERS"),
-                    "password": get(self._hostvars, "bgp_peer_groups.rr_overlay_peers.password")
+                    "password": get(self._hostvars, "bgp_peer_groups.rr_overlay_peers.password"),
+                    "structured_config": get(self._hostvars, "bgp_peer_groups.rr_overlay_peers.structured_config"),
                 },
             }
         return None

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-variables-mpls-BETA.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-variables-mpls-BETA.md
@@ -57,9 +57,13 @@ bgp_peer_groups:
   mpls_overlay_peers:
     name: < name of peer group | default -> MPLS-OVERLAY-PEERS >
     password: "< encrypted password >"
+    # Custom structured config added under router_bgp.peer_groups.<name> for eos_cli_config_gen
+    structured_config: < dictionary >
   rr_overlay_peers:
     name: < name of peer group | default -> RR-OVERLAY-PEERS >
     password: "< encrypted password >"
+    # Custom structured config added under router_bgp.peer_groups.<name> for eos_cli_config_gen
+    structured_config: < dictionary >
 ```
 
 ## Unsupported Fabric Variables

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-variables.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-variables.md
@@ -114,21 +114,29 @@ evpn_ebgp_gateway_multihop: < ebgp_multihop | default -> 15 >
 # Leverage an Arista EOS switch to generate the encrypted password using the correct peer group name.
 # Note that the name of the peer groups use '-' instead of '_' in EOS configuration.
 bgp_peer_groups:
-   # Old mixed case key "IPv4_UNDERLAY_PEERS" is supported for backward-compatibility
+  # Old mixed case key "IPv4_UNDERLAY_PEERS" is supported for backward-compatibility
   ipv4_underlay_peers:
     name: < name of peer group | default -> IPv4-UNDERLAY-PEERS >
     password: "< encrypted password >"
-   # Old mixed case key "MLAG_IPv4_UNDERLAY_PEER" is supported for backward-compatibility
+    # Custom structured config added under router_bgp.peer_groups.<name> for eos_cli_config_gen
+    structured_config: < dictionary >
+  # Old mixed case key "MLAG_IPv4_UNDERLAY_PEER" is supported for backward-compatibility
   mlag_ipv4_underlay_peer:
     name: < name of peer group | default -> MLAG-IPv4-UNDERLAY-PEER >
     password: "< encrypted password >"
-   # Old upper case key "EVPN_OVERLAY_PEERS" is supported for backward-compatibility
+    # Custom structured config added under router_bgp.peer_groups.<name> for eos_cli_config_gen
+    structured_config: < dictionary >
+  # Old upper case key "EVPN_OVERLAY_PEERS" is supported for backward-compatibility
   evpn_overlay_peers:
     name: < name of peer group | default -> EVPN-OVERLAY-PEERS >
     password: "< encrypted password >"
+    # Custom structured config added under router_bgp.peer_groups.<name> for eos_cli_config_gen
+    structured_config: < dictionary >
   evpn_overlay_core:
     name: < name of peer group | default -> EVPN-OVERLAY-CORE >
     password: "< encrypted password >"
+    # Custom structured config added under router_bgp.peer_groups.<name> for eos_cli_config_gen
+    structured_config: < dictionary >
 
 # Enable vlan aware bundles for EVPN MAC-VRF | Required.
 # Old variable name vxlan_vlan_aware_bundles, supported for backward-compatibility.

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/custom_structured_configuration/logic-router-bgp-peer-groups-struct-cfg.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/custom_structured_configuration/logic-router-bgp-peer-groups-struct-cfg.j2
@@ -1,0 +1,12 @@
+{% for peer_group in router_bgp.peer_groups | arista.avd.natural_sort %}
+{%     if router_bgp.peer_groups[peer_group].struct_cfg is arista.avd.defined %}
+{%         set tmp_custom_structured_configuration = {
+               "router_bgp" : {
+                   "peer_groups": {
+                       peer_group: router_bgp.peer_groups[peer_group].struct_cfg
+                   }
+               }
+           } %}
+{%         do custom_structured_configuration_data.append(tmp_custom_structured_configuration) %}
+{%     endif %}
+{% endfor %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/custom_structured_configuration/main.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/custom_structured_configuration/main.j2
@@ -14,6 +14,8 @@
 
 {% include 'custom_structured_configuration/logic-vlan-interfaces-struct-cfg.j2' %}
 
+{% include 'custom_structured_configuration/logic-router-bgp-peer-groups-struct-cfg.j2' %}
+
 {% include 'custom_structured_configuration/logic-router-bgp-vrfs-struct-cfg.j2' %}
 
 {# custom_structured_configuration is also the one rendering the output, so it should come last #}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/mlag/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/mlag/router-bgp.j2
@@ -15,6 +15,7 @@ router_bgp:
 {%     if switch.mlag_ibgp_origin_incomplete == true %}
       route_map_in: RM-MLAG-PEER-IN
 {%     endif %}
+      struct_cfg: {{ switch.bgp_peer_groups.mlag_ipv4_underlay_peer.structured_config | arista.avd.default }}
 {%     if switch.underlay_ipv6 is arista.avd.defined(true) %}
   address_family_ipv6:
     peer_groups:

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/ebgp/peer-groups.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/ebgp/peer-groups.j2
@@ -12,6 +12,7 @@
 {% if switch.evpn_role == "server" %}
       next_hop_unchanged: true
 {% endif %}
+      struct_cfg: {{ switch.bgp_peer_groups.evpn_overlay_peers.structured_config | arista.avd.default }}
 {% if switch.evpn_gateway_vxlan_l2 is arista.avd.defined(true) or switch.evpn_gateway_vxlan_l3 is arista.avd.defined(true) %}
     {{ switch.bgp_peer_groups.evpn_overlay_core.name }}:
       type: evpn
@@ -23,4 +24,5 @@
 {%     endif %}
       send_community: all
       maximum_routes: 0
+      struct_cfg: {{ switch.bgp_peer_groups.evpn_overlay_core.structured_config | arista.avd.default }}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/ibgp/address-family-evpn.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/ibgp/address-family-evpn.j2
@@ -7,14 +7,14 @@
 {%     endif %}
 {% endif %}
     peer_groups:
-      {{ overlay_data.overlay_peer_group_name }}:
+      {{ overlay_data.overlay_peer_group.name }}:
         activate: true
 {% if switch.vtep_ip is arista.avd.defined %}
         route_map_in: RM-EVPN-SOO-IN
         route_map_out: RM-EVPN-SOO-OUT
 {% endif %}
 {% if switch.mpls_overlay_role == "server" and overlay_data.mpls_rr_peers is arista.avd.defined %}
-      {{ overlay_data.rr_peers_peer_group_name }}:
+      {{ overlay_data.rr_peers_peer_group.name }}:
         activate: true
 {% endif %}
 {% if switch.vtep_ip is arista.avd.defined and evpn_hostflap_detection is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/ibgp/address-family-ipv4.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/ibgp/address-family-ipv4.j2
@@ -1,8 +1,8 @@
   address_family_ipv4:
     peer_groups:
-      {{ overlay_data.overlay_peer_group_name }}:
+      {{ overlay_data.overlay_peer_group.name }}:
         activate: false
 {% if switch.mpls_overlay_role == "server" and overlay_data.mpls_rr_peers is arista.avd.defined %}
-      {{ overlay_data.rr_peers_peer_group_name }}:
+      {{ overlay_data.rr_peers_peer_group.name }}:
         activate: false
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/ibgp/address-family-rtc.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/ibgp/address-family-rtc.j2
@@ -1,6 +1,6 @@
   address_family_rtc:
     peer_groups:
-      {{ overlay_data.overlay_peer_group_name }}:
+      {{ overlay_data.overlay_peer_group.name }}:
         activate: true
 {% if switch.evpn_role == "server" or switch.mpls_overlay_role == "server" %}
         default_route_target:

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/ibgp/address-family-vpn-ipv4.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/ibgp/address-family-vpn-ipv4.j2
@@ -5,10 +5,10 @@
       source_interface: Loopback0
 {%     endif %}
     peer_groups:
-      {{ overlay_data.overlay_peer_group_name }}:
+      {{ overlay_data.overlay_peer_group.name }}:
         activate: true
 {%     if switch.mpls_overlay_role == "server" and overlay_data.mpls_rr_peers is arista.avd.defined %}
-      {{ overlay_data.rr_peers_peer_group_name }}:
+      {{ overlay_data.rr_peers_peer_group.name }}:
         activate: true
 {%     endif %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/ibgp/address-family-vpn-ipv6.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/ibgp/address-family-vpn-ipv6.j2
@@ -5,10 +5,10 @@
       source_interface: Loopback0
 {%     endif %}
     peer_groups:
-      {{ overlay_data.overlay_peer_group_name }}:
+      {{ overlay_data.overlay_peer_group.name }}:
         activate: true
 {%     if switch.mpls_overlay_role == "server" and overlay_data.mpls_rr_peers is arista.avd.defined %}
-      {{ overlay_data.rr_peers_peer_group_name }}:
+      {{ overlay_data.rr_peers_peer_group.name }}:
         activate: true
 {%     endif %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/ibgp/neighbors.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/ibgp/neighbors.j2
@@ -2,37 +2,37 @@
 {% if switch.mpls_overlay_role in ["server", "client"] %}
 {%     for mpls_route_reflector in overlay_data.mpls_route_reflectors | arista.avd.natural_sort %}
     {{ overlay_data.mpls_route_reflectors[mpls_route_reflector].ip_address }}:
-      peer_group: {{ overlay_data.overlay_peer_group_name }}
+      peer_group: {{ overlay_data.overlay_peer_group.name }}
       description: {{ mpls_route_reflector }}
 {%     endfor %}
 {%     for mpls_route_client in overlay_data.mpls_route_clients | arista.avd.natural_sort %}
     {{ overlay_data.mpls_route_clients[mpls_route_client].ip_address }}:
-      peer_group: {{ overlay_data.overlay_peer_group_name }}
+      peer_group: {{ overlay_data.overlay_peer_group.name }}
       description: {{ mpls_route_client }}
 {%     endfor %}
 {%     if overlay_data.mpls_mesh_pes is arista.avd.defined %}
 {%         for mpls_mesh_pe in overlay_data.mpls_mesh_pes | arista.avd.natural_sort %}
     {{ overlay_data.mpls_mesh_pes[mpls_mesh_pe].ip_address }}:
-      peer_group: {{ overlay_data.overlay_peer_group_name }}
+      peer_group: {{ overlay_data.overlay_peer_group.name }}
       description: {{ mpls_mesh_pe }}
 {%         endfor %}
 {%     endif %}
 {%     if switch.mpls_overlay_role == "server" and overlay_data.mpls_rr_peers is arista.avd.defined %}
 {%         for mpls_rr_peer in overlay_data.mpls_rr_peers | arista.avd.natural_sort %}
     {{ overlay_data.mpls_rr_peers[mpls_rr_peer].ip_address }}:
-      peer_group: {{ overlay_data.rr_peers_peer_group_name }}
+      peer_group: {{ overlay_data.rr_peers_peer_group.name }}
       description: {{ mpls_rr_peer }}
 {%         endfor %}
 {%     endif %}
 {% else %}
 {%     for evpn_route_server in overlay_data.evpn_route_servers | arista.avd.natural_sort %}
     {{ overlay_data.evpn_route_servers[evpn_route_server].ip_address }}:
-      peer_group: {{ overlay_data.overlay_peer_group_name }}
+      peer_group: {{ overlay_data.overlay_peer_group.name }}
       description: {{ evpn_route_server }}
 {%     endfor %}
 {%     for evpn_route_client in overlay_data.evpn_route_clients | arista.avd.natural_sort %}
     {{ overlay_data.evpn_route_clients[evpn_route_client].ip_address }}:
-      peer_group: {{ overlay_data.overlay_peer_group_name }}
+      peer_group: {{ overlay_data.overlay_peer_group.name }}
       description: {{ evpn_route_client }}
 {%     endfor %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/ibgp/peer-groups.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/ibgp/peer-groups.j2
@@ -1,5 +1,5 @@
   peer_groups:
-    {{ overlay_data.overlay_peer_group_name }}:
+    {{ overlay_data.overlay_peer_group.name }}:
 {% if switch.mpls_overlay_role in ["server", "client"] %}
       type: mpls
 {% else %}
@@ -8,29 +8,25 @@
       update_source: Loopback0
       remote_as: "{{ switch.bgp_as }}"
       bfd: true
-{% if switch.mpls_overlay_role in ["server", "client"] %}
-{%     if switch.bgp_peer_groups.mpls_overlay_peers.password is arista.avd.defined %}
-      password: "{{ switch.bgp_peer_groups.mpls_overlay_peers.password }}"
-{%     endif %}
-{% else %}
-{%     if switch.bgp_peer_groups.evpn_overlay_peers.password is arista.avd.defined %}
-      password: "{{ switch.bgp_peer_groups.evpn_overlay_peers.password }}"
-{%     endif %}
+{% if overlay_data.overlay_peer_group.password is arista.avd.defined %}
+      password: "{{ overlay_data.overlay_peer_group.password }}"
 {% endif %}
       send_community: all
       maximum_routes: 0
 {% if switch.evpn_role == "server" or switch.mpls_overlay_role == "server" %}
       route_reflector_client: true
 {% endif %}
+      struct_cfg: {{ overlay_data.overlay_peer_group.structured_config | arista.avd.default }}
 {% if switch.mpls_overlay_role == "server" and overlay_data.mpls_rr_peers is arista.avd.defined %}
-    {{ overlay_data.rr_peers_peer_group_name }}:
+    {{ overlay_data.rr_peers_peer_group.name }}:
       type: mpls
       update_source: Loopback0
       remote_as: "{{ bgp_as }}"
       bfd: true
-{%     if switch.bgp_peer_groups.rr_overlay_peers.password is arista.avd.defined() %}
-      password: "{{ switch.bgp_peer_groups.rr_overlay_peers.password }}"
+{%     if overlay_data.rr_peers_peer_group.password is arista.avd.defined %}
+      password: "{{ overlay_data.rr_peers_peer_group.password }}"
       send_community: all
       maximum_routes: 0
 {%     endif %}
+      struct_cfg: {{ overlay_data.rr_peers_peer_group.structured_config | arista.avd.default }}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/main.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/main.j2
@@ -3,12 +3,12 @@
 {%     set overlay_data = namespace() %}
 {# Set peer group names for overlay peering #}
 {%     if switch.mpls_ler is arista.avd.defined(true) or switch.mpls_overlay_role == "server" %}
-{%         set overlay_data.overlay_peer_group_name = switch.bgp_peer_groups.mpls_overlay_peers.name %}
+{%         set overlay_data.overlay_peer_group = switch.bgp_peer_groups.mpls_overlay_peers %}
 {%     else %}
-{%         set overlay_data.overlay_peer_group_name = switch.bgp_peer_groups.evpn_overlay_peers.name %}
+{%         set overlay_data.overlay_peer_group = switch.bgp_peer_groups.evpn_overlay_peers %}
 {%     endif %}
 {%     if switch.mpls_overlay_role == "server" %}
-{%         set overlay_data.rr_peers_peer_group_name = switch.bgp_peer_groups.rr_overlay_peers.name %}
+{%         set overlay_data.rr_peers_peer_group = switch.bgp_peer_groups.rr_overlay_peers %}
 {%     endif %}
 {%     if switch.mpls_overlay_role in ["client", "server"] %}
 {%         include 'overlay/logic-mpls-route-servers.j2' %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/underlay/ebgp/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/underlay/ebgp/router-bgp.j2
@@ -9,6 +9,7 @@ router_bgp:
 {% endif %}
       maximum_routes: 12000
       send_community: all
+      struct_cfg: {{ switch.bgp_peer_groups.ipv4_underlay_peers.structured_config | arista.avd.default }}
   address_family_ipv4:
     peer_groups:
       {{ switch.bgp_peer_groups.ipv4_underlay_peers.name }}:


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Support for `structured_config` on `bgp_peer_groups`

## Related Issue(s)

Fixes #1885 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

```yaml
bgp_peer_groups:
  ipv4_underlay_peers:
    # Custom structured config added under router_bgp.peer_groups.<name> for eos_cli_config_gen
    structured_config: < dictionary >
  mlag_ipv4_underlay_peer:
    # Custom structured config added under router_bgp.peer_groups.<name> for eos_cli_config_gen
    structured_config: < dictionary >
  evpn_overlay_peers:
    # Custom structured config added under router_bgp.peer_groups.<name> for eos_cli_config_gen
    structured_config: < dictionary >
  evpn_overlay_core:
    # Custom structured config added under router_bgp.peer_groups.<name> for eos_cli_config_gen
    structured_config: < dictionary >
  mpls_overlay_peers:
    # Custom structured config added under router_bgp.peer_groups.<name> for eos_cli_config_gen
    structured_config: < dictionary >
  rr_overlay_peers:
    # Custom structured config added under router_bgp.peer_groups.<name> for eos_cli_config_gen
    structured_config: < dictionary >
```

Part of this required to modify/simplify a bit of the internal logic for ibgp overlay.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Molecule unit test case added.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
