### PR TITLE
Refactor(eos_designs)!: MPLS Peer Logic

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/inventory/group_vars/MPLS_CORE.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/inventory/group_vars/MPLS_CORE.yml
@@ -132,6 +132,7 @@ rr:
     node_sid_base: 100
     isis_system_id_prefix: '0000.0002'
     overlay_address_families: [ evpn, vpn-ipv4, vpn-ipv6 ]
+    mpls_route_reflectors: [ SITE1-RR1, SITE2-RR1 ]
     bgp_defaults:
       - 'no bgp default ipv4-unicast'
       - 'distance bgp 20 200 200'

--- a/ansible_collections/arista/avd/plugins/action/eos_designs_facts.py
+++ b/ansible_collections/arista/avd/plugins/action/eos_designs_facts.py
@@ -58,9 +58,17 @@ class ActionModule(ActionBase):
 
             for host in fabric_hosts:
                 host_evpn_route_servers = avd_switch_facts[host]['switch'].get('evpn_route_servers', [])
-
                 for peer in host_evpn_route_servers:
                     avd_overlay_peers.setdefault(peer, []).append(host)
+
+                host_mpls_route_reflectors = avd_switch_facts[host]['switch'].get('mpls_route_reflectors', [])
+                for peer in host_mpls_route_reflectors:
+                    avd_overlay_peers.setdefault(peer, []).append(host)
+
+                # Make sure a device with mpls_overlay_role:server is in the avd_overlay_peers dict.
+                # This is used for automatic peering between mpls route reflectors.
+                if avd_switch_facts[host]['switch'].get('mpls_overlay_role') == "server":
+                    avd_overlay_peers.setdefault(host, [])
 
                 host_topology_peers = avd_switch_facts[host]['switch'].get('uplink_peers', [])
 

--- a/ansible_collections/arista/avd/plugins/action/eos_designs_facts.py
+++ b/ansible_collections/arista/avd/plugins/action/eos_designs_facts.py
@@ -65,11 +65,6 @@ class ActionModule(ActionBase):
                 for peer in host_mpls_route_reflectors:
                     avd_overlay_peers.setdefault(peer, []).append(host)
 
-                # Make sure a device with mpls_overlay_role:server is in the avd_overlay_peers dict.
-                # This is used for automatic peering between mpls route reflectors.
-                if avd_switch_facts[host]['switch'].get('mpls_overlay_role') == "server":
-                    avd_overlay_peers.setdefault(host, [])
-
                 host_topology_peers = avd_switch_facts[host]['switch'].get('uplink_peers', [])
 
                 for peer in host_topology_peers:

--- a/ansible_collections/arista/avd/plugins/module_utils/eos_designs_facts.py
+++ b/ansible_collections/arista/avd/plugins/module_utils/eos_designs_facts.py
@@ -1391,3 +1391,9 @@ class EosDesignsFacts:
                     "combination with 'underlay_ipv6: True' and 'underlay_rfc5549: True'"
                 )
         return overlay_routing_protocol_address_family
+
+    @cached_property
+    def overlay_routing_protocol_peering_address(self):
+        if self.overlay_routing_protocol_address_family == "ipv6":
+            return self.ipv6_router_id
+        return self.router_id

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/ibgp/neighbors.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/ibgp/neighbors.j2
@@ -1,9 +1,9 @@
   neighbors:
 {% if switch.mpls_overlay_role in ["server", "client"] %}
-{%     for mpls_route_server in overlay_data.mpls_route_servers | arista.avd.natural_sort %}
-    {{ overlay_data.mpls_route_servers[mpls_route_server].ip_address }}:
+{%     for mpls_route_reflector in overlay_data.mpls_route_reflectors | arista.avd.natural_sort %}
+    {{ overlay_data.mpls_route_reflectors[mpls_route_reflector].ip_address }}:
       peer_group: {{ overlay_data.overlay_peer_group_name }}
-      description: {{ mpls_route_server }}
+      description: {{ mpls_route_reflector }}
 {%     endfor %}
 {%     for mpls_route_client in overlay_data.mpls_route_clients | arista.avd.natural_sort %}
     {{ overlay_data.mpls_route_clients[mpls_route_client].ip_address }}:

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/logic-evpn-route-clients.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/logic-evpn-route-clients.j2
@@ -13,11 +13,7 @@
 {# Found a matching client. Gathering information for this client #}
 {%                 set client = namespace() %}
 {%                 set client.bgp_as = peer_facts.switch.bgp_as %}
-{%                 if switch.overlay_routing_protocol_address_family is arista.avd.defined("ipv6") %}
-{%                     set client.ip_address = peer_facts.switch.ipv6_router_id %}
-{%                 else %}
-{%                     set client.ip_address = peer_facts.switch.router_id %}
-{%                 endif %}
+{%                 set client.ip_address = peer_facts.switch.overlay_routing_protocol_peering_address %}
 {%                 do overlay_data.evpn_route_clients.update({ peer: client }) %}
 {%             endif %}
 {%         endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/logic-evpn-route-servers.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/logic-evpn-route-servers.j2
@@ -9,11 +9,7 @@
 {# Found a matching server. Gathering information for this server #}
 {%             set server = namespace() %}
 {%             set server.bgp_as = peer_facts.switch.bgp_as %}
-{%             if switch.overlay_routing_protocol_address_family is arista.avd.defined("ipv6") %}
-{%                 set server.ip_address = peer_facts.switch.ipv6_router_id %}
-{%             else %}
-{%                 set server.ip_address = peer_facts.switch.router_id %}
-{%             endif %}
+{%             set server.ip_address = peer_facts.switch.overlay_routing_protocol_peering_address %}
 {%             do overlay_data.evpn_route_servers.update({ route_server: server }) %}
 {%         endif %}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/logic-mpls-route-clients.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/logic-mpls-route-clients.j2
@@ -1,32 +1,52 @@
 {% if switch.mpls_overlay_role == "server" %}
 {%     set overlay_data.mpls_route_clients = {} %}
 {%     set overlay_data.mpls_rr_peers = {} %}
-{# Look for switches pointing to us as evpn_route_server #}
-{%     for fabric_switch in groups[fabric_name] if fabric_switch not in overlay_data.mpls_route_servers | arista.avd.natural_sort %}
-{%         if avd_switch_facts[fabric_switch].switch is arista.avd.defined(fail_action='warning',var_name='avd_switch_facts[' ~ fabric_switch ~ '].switch') %}
-{%             set fabric_switch_vars = avd_switch_facts[fabric_switch] %}
-{%             set fabric_switch_mpls_overlay_role = fabric_switch_vars.switch.mpls_overlay_role | arista.avd.default('none') %}
-{%             set fabric_switch_mpls_route_servers = fabric_switch_vars.switch.mpls_route_reflectors | arista.avd.default([]) %}
-{%             if inventory_hostname in fabric_switch_mpls_route_servers and fabric_switch_mpls_overlay_role in ['client', 'server'] %}
+
+{%     set overlay_peers = avd_overlay_peers[inventory_hostname] | arista.avd.default([]) %}
+
+{# Parse switches pointing to us as mpls_route_reflector #}
+{%     for peer in overlay_peers %}
+{%         set peer_facts = avd_switch_facts[peer] %}
+{%         if peer_facts.switch is arista.avd.defined(fail_action='warning',var_name='avd_switch_facts[' ~ peer ~ '].switch') %}
+{%             if inventory_hostname in peer_facts.switch.mpls_route_reflectors | arista.avd.default([]) and
+                  peer_facts.switch.mpls_overlay_role in ['client', 'server'] and
+                  peer not in overlay_data.evpn_route_reflectors | arista.avd.default([]) %}
 {# Found a matching client. Gathering information for this client #}
 {%                 set client = namespace() %}
-{%                 set client.bgp_as = fabric_switch_vars.switch.bgp_as %}
-{%                 set client.ip_address = fabric_switch_vars.switch.router_id %}
-{%                 do overlay_data.mpls_route_clients.update({ fabric_switch: client }) %}
+{%                 set client.bgp_as = peer_facts.switch.bgp_as %}
+{%                 if switch.overlay_routing_protocol_address_family is arista.avd.defined("ipv6") %}
+{%                     set client.ip_address = peer_facts.switch.ipv6_router_id %}
+{%                 else %}
+{%                     set client.ip_address = peer_facts.switch.router_id %}
+{%                 endif %}
+{%                 do overlay_data.mpls_route_clients.update({ peer: client }) %}
 {%             endif %}
 {%         endif %}
 {%     endfor %}
-{%     for node_group in rr.node_groups %}
-{%         if inventory_hostname in rr.node_groups[node_group].nodes and rr.node_groups[node_group].nodes | length > 1 %}
-{%             for node in rr.node_groups[node_group].nodes %}
-{%                 if node != inventory_hostname %}
-{%                     set rr_peer_vars = avd_switch_facts[node] %}
-{%                     set rr_peer = namespace() %}
-{%                     set rr_peer.bgp_as = bgp_as %}
-{%                     set rr_peer.ip_address = rr_peer_vars.switch.router_id %}
-{%                     do overlay_data.mpls_rr_peers.update({ node: rr_peer }) %}
+
+{# All MPLS servers peer to each other by default #}
+{# To avoid parsing all devices in the fabric, looking for route-reflectors, we parse avd_overlay_peers keys  #}
+{# That list contains all devices pointed to in "evpn_route_servers", "mpls_route_reflectors" AND all devices #}
+{# with "mpls_overlay_role: server", so we have to check for mpls_overlay_role: server                        #}
+{%     for peer in avd_overlay_peers %}
+{%         if peer == inventory_hostname %}
+{%             continue %}
+{%         endif %}
+{%         set peer_facts = avd_switch_facts[peer] %}
+{%         if peer_facts.switch is arista.avd.defined(fail_action='warning',var_name='avd_switch_facts[' ~ peer ~ '].switch') %}
+{%             if peer_facts.switch.mpls_overlay_role is arista.avd.defined('server') and
+                  peer not in overlay_data.mpls_route_reflectors and
+                  peer not in overlay_data.mpls_route_clients %}
+{# Found a matching peer. Gathering information for this rr_peer #}
+{%                 set rr_peer = namespace() %}
+{%                 set rr_peer.bgp_as = peer_facts.switch.bgp_as %}
+{%                 if switch.overlay_routing_protocol_address_family is arista.avd.defined("ipv6") %}
+{%                     set rr_peer.ip_address = peer_facts.switch.ipv6_router_id %}
+{%                 else %}
+{%                     set rr_peer.ip_address = peer_facts.switch.router_id %}
 {%                 endif %}
-{%             endfor %}
+{%                 do overlay_data.mpls_rr_peers.update({ peer: rr_peer }) %}
+{%             endif %}
 {%         endif %}
 {%     endfor %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/logic-mpls-route-clients.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/logic-mpls-route-clients.j2
@@ -13,11 +13,7 @@
 {# Found a matching client. Gathering information for this client #}
 {%                 set client = namespace() %}
 {%                 set client.bgp_as = peer_facts.switch.bgp_as %}
-{%                 if switch.overlay_routing_protocol_address_family is arista.avd.defined("ipv6") %}
-{%                     set client.ip_address = peer_facts.switch.ipv6_router_id %}
-{%                 else %}
-{%                     set client.ip_address = peer_facts.switch.router_id %}
-{%                 endif %}
+{%                 set client.ip_address = peer_facts.switch.overlay_routing_protocol_peering_address %}
 {%                 if peer_facts.switch.mpls_overlay_role == "client" %}
 {%                     do overlay_data.mpls_route_clients.update({ peer: client }) %}
 {%                 elif peer_facts.switch.mpls_overlay_role == "server" %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/logic-mpls-route-clients.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/logic-mpls-route-clients.j2
@@ -1,16 +1,15 @@
 {% if switch.mpls_overlay_role == "server" %}
 {%     set overlay_data.mpls_route_clients = {} %}
-{%     set overlay_data.mpls_rr_peers = {} %}
 
-{%     set overlay_peers = avd_overlay_peers[inventory_hostname] | arista.avd.default([]) %}
+{%     set avd_overlay_peers = avd_overlay_peers[inventory_hostname] | arista.avd.default([]) %}
 
 {# Parse switches pointing to us as mpls_route_reflector #}
-{%     for peer in overlay_peers %}
+{%     for peer in avd_overlay_peers %}
 {%         set peer_facts = avd_switch_facts[peer] %}
 {%         if peer_facts.switch is arista.avd.defined(fail_action='warning',var_name='avd_switch_facts[' ~ peer ~ '].switch') %}
 {%             if inventory_hostname in peer_facts.switch.mpls_route_reflectors | arista.avd.default([]) and
                   peer_facts.switch.mpls_overlay_role in ['client', 'server'] and
-                  peer not in overlay_data.evpn_route_reflectors | arista.avd.default([]) %}
+                  peer not in switch.mpls_route_reflectors | arista.avd.default([]) %}
 {# Found a matching client. Gathering information for this client #}
 {%                 set client = namespace() %}
 {%                 set client.bgp_as = peer_facts.switch.bgp_as %}
@@ -19,33 +18,11 @@
 {%                 else %}
 {%                     set client.ip_address = peer_facts.switch.router_id %}
 {%                 endif %}
-{%                 do overlay_data.mpls_route_clients.update({ peer: client }) %}
-{%             endif %}
-{%         endif %}
-{%     endfor %}
-
-{# All MPLS servers peer to each other by default #}
-{# To avoid parsing all devices in the fabric, looking for route-reflectors, we parse avd_overlay_peers keys  #}
-{# That list contains all devices pointed to in "evpn_route_servers", "mpls_route_reflectors" AND all devices #}
-{# with "mpls_overlay_role: server", so we have to check for mpls_overlay_role: server                        #}
-{%     for peer in avd_overlay_peers %}
-{%         if peer == inventory_hostname %}
-{%             continue %}
-{%         endif %}
-{%         set peer_facts = avd_switch_facts[peer] %}
-{%         if peer_facts.switch is arista.avd.defined(fail_action='warning',var_name='avd_switch_facts[' ~ peer ~ '].switch') %}
-{%             if peer_facts.switch.mpls_overlay_role is arista.avd.defined('server') and
-                  peer not in overlay_data.mpls_route_reflectors and
-                  peer not in overlay_data.mpls_route_clients %}
-{# Found a matching peer. Gathering information for this rr_peer #}
-{%                 set rr_peer = namespace() %}
-{%                 set rr_peer.bgp_as = peer_facts.switch.bgp_as %}
-{%                 if switch.overlay_routing_protocol_address_family is arista.avd.defined("ipv6") %}
-{%                     set rr_peer.ip_address = peer_facts.switch.ipv6_router_id %}
-{%                 else %}
-{%                     set rr_peer.ip_address = peer_facts.switch.router_id %}
+{%                 if peer_facts.switch.mpls_overlay_role == "client" %}
+{%                     do overlay_data.mpls_route_clients.update({ peer: client }) %}
+{%                 elif peer_facts.switch.mpls_overlay_role == "server" %}
+{%                     do overlay_data.mpls_rr_peers.update({ peer: client }) %}
 {%                 endif %}
-{%                 do overlay_data.mpls_rr_peers.update({ peer: rr_peer }) %}
 {%             endif %}
 {%         endif %}
 {%     endfor %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/logic-mpls-route-servers.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/logic-mpls-route-servers.j2
@@ -12,11 +12,7 @@
 {# Found a matching server. Gathering information for this server #}
 {%             set server = namespace() %}
 {%             set server.bgp_as = peer_facts.switch.bgp_as %}
-{%             if switch.overlay_routing_protocol_address_family is arista.avd.defined("ipv6") %}
-{%                 set server.ip_address = peer_facts.switch.ipv6_router_id %}
-{%             else %}
-{%                 set server.ip_address = peer_facts.switch.router_id %}
-{%             endif %}
+{%             set server.ip_address = peer_facts.switch.overlay_routing_protocol_peering_address %}
 {%             if switch.mpls_overlay_role == "client" %}
 {%                 do overlay_data.mpls_route_reflectors.update({ route_reflector: server }) %}
 {%             elif switch.mpls_overlay_role == "server" %}
@@ -29,15 +25,11 @@
 {%     set overlay_data.mpls_mesh_pes = {} %}
 {%     for fabric_switch in groups[fabric_name] if fabric_switch not in overlay_data.mpls_route_reflectors %}
 {%         if fabric_switch != inventory_hostname %}
-{%             set overlay_pe_vars = avd_switch_facts[fabric_switch] %}
-{%             if overlay_pe_vars.switch.mpls_overlay_role is arista.avd.defined('client') %}
+{%             set peer_facts = avd_switch_facts[fabric_switch] %}
+{%             if peer_facts.switch.mpls_overlay_role is arista.avd.defined('client') %}
 {%                 set peer_pe = namespace() %}
-{%                 set peer_pe.bgp_as = overlay_pe_vars.switch.bgp_as %}
-{%                 if switch.overlay_routing_protocol_address_family is arista.avd.defined("ipv6") %}
-{%                     set peer_pe.ip_address = overlay_pe_vars.switch.ipv6_router_id %}
-{%                 else %}
-{%                     set peer_pe.ip_address = overlay_pe_vars.switch.router_id %}
-{%                 endif %}
+{%                 set peer_pe.bgp_as = peer_facts.switch.bgp_as %}
+{%                 set peer_pe.ip_address = peer_facts.switch.overlay_routing_protocol_peering_address %}
 {%                 do overlay_data.mpls_mesh_pes.update({ fabric_switch: peer_pe }) %}
 {%             endif %}
 {%         endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/logic-mpls-route-servers.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/logic-mpls-route-servers.j2
@@ -1,20 +1,25 @@
-{% set overlay_data.mpls_route_servers = {} %}
-{# Expand data for evpn_route_servers #}
-{% for route_server in switch.mpls_route_reflectors | arista.avd.natural_sort %}
-{%     if avd_switch_facts[route_server].switch is arista.avd.defined(fail_action='warning',var_name='avd_switch_facts[' ~ route_server ~ '].switch') %}
-{%         set route_server_vars = avd_switch_facts[route_server] %}
-{%         if route_server_vars.switch.mpls_overlay_role is arista.avd.defined('server') %}
+{% set overlay_data.mpls_route_reflectors = {} %}
+
+{# Expand data for mpls_route_reflectors #}
+{% for route_reflector in switch.mpls_route_reflectors | arista.avd.natural_sort %}
+{%     set peer_facts = avd_switch_facts[route_reflector] %}
+{%     if peer_facts.switch is arista.avd.defined(fail_action='warning',var_name='avd_switch_facts[' ~ route_reflector ~ '].switch') %}
+{%         if peer_facts.switch.mpls_overlay_role is arista.avd.defined('server') %}
 {# Found a matching server. Gathering information for this server #}
 {%             set server = namespace() %}
-{%             set server.bgp_as = route_server_vars.switch.bgp_as %}
-{%             set server.ip_address = route_server_vars.switch.router_id %}
-{%             do overlay_data.mpls_route_servers.update({ route_server: server }) %}
+{%             set server.bgp_as = peer_facts.switch.bgp_as %}
+{%             if switch.overlay_routing_protocol_address_family is arista.avd.defined("ipv6") %}
+{%                 set server.ip_address = peer_facts.switch.ipv6_router_id %}
+{%             else %}
+{%                 set server.ip_address = peer_facts.switch.router_id %}
+{%             endif %}
+{%             do overlay_data.mpls_route_reflectors.update({ route_reflector: server }) %}
 {%         endif %}
 {%     endif %}
 {% endfor %}
 {% if bgp_mesh_pes is arista.avd.defined(true) %}
 {%     set overlay_data.mpls_mesh_pes = {} %}
-{%     for fabric_switch in groups[fabric_name] if fabric_switch not in overlay_data.mpls_route_servers | arista.avd.natural_sort %}
+{%     for fabric_switch in groups[fabric_name] if fabric_switch not in overlay_data.mpls_route_reflectors %}
 {%         if fabric_switch != inventory_hostname %}
 {%             set overlay_pe_vars = avd_switch_facts[fabric_switch] %}
 {%             if overlay_pe_vars.switch.mpls_overlay_role is arista.avd.defined('client') %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/logic-mpls-route-servers.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/overlay/logic-mpls-route-servers.j2
@@ -1,7 +1,11 @@
 {% set overlay_data.mpls_route_reflectors = {} %}
+{% set overlay_data.mpls_rr_peers = {} %}
 
 {# Expand data for mpls_route_reflectors #}
 {% for route_reflector in switch.mpls_route_reflectors | arista.avd.natural_sort %}
+{%     if route_reflector == inventory_hostname %}
+{%         continue %}
+{%     endif %}
 {%     set peer_facts = avd_switch_facts[route_reflector] %}
 {%     if peer_facts.switch is arista.avd.defined(fail_action='warning',var_name='avd_switch_facts[' ~ route_reflector ~ '].switch') %}
 {%         if peer_facts.switch.mpls_overlay_role is arista.avd.defined('server') %}
@@ -13,7 +17,11 @@
 {%             else %}
 {%                 set server.ip_address = peer_facts.switch.router_id %}
 {%             endif %}
-{%             do overlay_data.mpls_route_reflectors.update({ route_reflector: server }) %}
+{%             if switch.mpls_overlay_role == "client" %}
+{%                 do overlay_data.mpls_route_reflectors.update({ route_reflector: server }) %}
+{%             elif switch.mpls_overlay_role == "server" %}
+{%                 do overlay_data.mpls_rr_peers.update({ route_reflector: server }) %}
+{%             endif %}
 {%         endif %}
 {%     endif %}
 {% endfor %}
@@ -25,7 +33,11 @@
 {%             if overlay_pe_vars.switch.mpls_overlay_role is arista.avd.defined('client') %}
 {%                 set peer_pe = namespace() %}
 {%                 set peer_pe.bgp_as = overlay_pe_vars.switch.bgp_as %}
-{%                 set peer_pe.ip_address = overlay_pe_vars.switch.router_id %}
+{%                 if switch.overlay_routing_protocol_address_family is arista.avd.defined("ipv6") %}
+{%                     set peer_pe.ip_address = overlay_pe_vars.switch.ipv6_router_id %}
+{%                 else %}
+{%                     set peer_pe.ip_address = overlay_pe_vars.switch.router_id %}
+{%                 endif %}
 {%                 do overlay_data.mpls_mesh_pes.update({ fabric_switch: peer_pe }) %}
 {%             endif %}
 {%         endif %}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Breaking change for MPLS Beta feature!

Refactor(eos_designs): MPLS Peer Logic

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->
- Remove default rr<->rr peerings. Instead we will leverage `mpls_route_reflectors` on the `route_reflectors` themselves - similar to what we do with EVPN. This change allows for more flexible RR designs, including hierarchical RRs.
- Align MPLS client/server logic with evpn templates.
- Update `avd_overlay_peers` to also cover mpls route_reflectors
- Leverage `avd_overlay_peers` fact instead of accessing group vars directly (hardcoded `rr`)

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- Tested with existing molecule scenarios.
- Added the now required `mpls_route_reflectors` to the RRs, to avoid changes.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
