### PR TITLE
Feat(eos_designs): Support automatic BGP peer groups without nodes

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL2A.cfg
@@ -184,6 +184,10 @@ router bgp 65106
    neighbor Tenant_C_BGP_PEER_GROUP maximum-routes 1000
    neighbor Tenant_C_BGP_PEER_GROUP route-map TEST_IN in
    neighbor Tenant_C_BGP_PEER_GROUP route-map TEST_OUT out
+   neighbor Tenant_C_BGP_PEER_GROUP2 peer group
+   neighbor Tenant_C_BGP_PEER_GROUP2 remote-as 667
+   neighbor Tenant_C_BGP_PEER_GROUP2 update-source lo0
+   neighbor Tenant_C_BGP_PEER_GROUP2 description Tenant C peer group2
    neighbor UNDERLAY-PEERS peer group
    neighbor UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
    neighbor UNDERLAY-PEERS send-community
@@ -270,10 +274,13 @@ router bgp 65106
       router-id 192.168.255.16
       neighbor 2.2.2.2 peer group Tenant_C_BGP_PEER_GROUP
       neighbor 2.2.2.2 description test_bgp_peer_group_with_out_nodes
+      neighbor 2.2.2.3 peer group Tenant_C_BGP_PEER_GROUP2
+      neighbor 2.2.2.3 description test_bgp_peer_group_with_out_nodes_2nd_time
       redistribute connected
       !
       address-family ipv4
          neighbor 2.2.2.2 activate
+         neighbor 2.2.2.3 activate
 !
 management api http-commands
    protocol https

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL2A.cfg
@@ -273,9 +273,9 @@ router bgp 65106
       route-target export evpn 31:31
       router-id 192.168.255.16
       neighbor 2.2.2.2 peer group Tenant_C_BGP_PEER_GROUP
-      neighbor 2.2.2.2 description test_bgp_peer_group_with_out_nodes
+      neighbor 2.2.2.2 description test_bgp_peer_group_without_nodes
       neighbor 2.2.2.3 peer group Tenant_C_BGP_PEER_GROUP2
-      neighbor 2.2.2.3 description test_bgp_peer_group_with_out_nodes_2nd_time
+      neighbor 2.2.2.3 description test_bgp_peer_group_without_nodes_2nd_time
       redistribute connected
       !
       address-family ipv4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL2A.cfg
@@ -172,6 +172,18 @@ router bgp 65106
    neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
    neighbor EVPN-OVERLAY-PEERS send-community
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor Tenant_C_BGP_PEER_GROUP peer group
+   neighbor Tenant_C_BGP_PEER_GROUP remote-as 666
+   neighbor Tenant_C_BGP_PEER_GROUP local-as 777 no-prepend replace-as
+   neighbor Tenant_C_BGP_PEER_GROUP next-hop-self
+   neighbor Tenant_C_BGP_PEER_GROUP update-source lo0
+   neighbor Tenant_C_BGP_PEER_GROUP description Tenant C peer group
+   neighbor Tenant_C_BGP_PEER_GROUP ebgp-multihop 3
+   neighbor Tenant_C_BGP_PEER_GROUP default-originate always
+   neighbor Tenant_C_BGP_PEER_GROUP send-community
+   neighbor Tenant_C_BGP_PEER_GROUP maximum-routes 1000
+   neighbor Tenant_C_BGP_PEER_GROUP route-map TEST_IN in
+   neighbor Tenant_C_BGP_PEER_GROUP route-map TEST_OUT out
    neighbor UNDERLAY-PEERS peer group
    neighbor UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
    neighbor UNDERLAY-PEERS send-community
@@ -256,7 +268,12 @@ router bgp 65106
       route-target import evpn 31:31
       route-target export evpn 31:31
       router-id 192.168.255.16
+      neighbor 2.2.2.2 peer group Tenant_C_BGP_PEER_GROUP
+      neighbor 2.2.2.2 description test_bgp_peer_group_with_out_nodes
       redistribute connected
+      !
+      address-family ipv4
+         neighbor 2.2.2.2 activate
 !
 management api http-commands
    protocol https

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL2B.cfg
@@ -170,30 +170,18 @@ router bgp 65107
    neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==
    neighbor EVPN-OVERLAY-PEERS send-community
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0
-   neighbor Tenant_C_BGP_PEER_GROUP peer group
-   neighbor Tenant_C_BGP_PEER_GROUP remote-as 666
-   neighbor Tenant_C_BGP_PEER_GROUP local-as 777 no-prepend replace-as
-   neighbor Tenant_C_BGP_PEER_GROUP next-hop-self
-   neighbor Tenant_C_BGP_PEER_GROUP update-source lo0
-   neighbor Tenant_C_BGP_PEER_GROUP description Tenant C peer group
-   neighbor Tenant_C_BGP_PEER_GROUP ebgp-multihop 3
-   neighbor Tenant_C_BGP_PEER_GROUP default-originate always
-   neighbor Tenant_C_BGP_PEER_GROUP send-community
-   neighbor Tenant_C_BGP_PEER_GROUP maximum-routes 1000
-   neighbor Tenant_C_BGP_PEER_GROUP route-map TEST_IN in
-   neighbor Tenant_C_BGP_PEER_GROUP route-map TEST_OUT out
-   neighbor Tenant_C_VRF_WAN_Zone_BGP_PEER_GROUP peer group
-   neighbor Tenant_C_VRF_WAN_Zone_BGP_PEER_GROUP remote-as 666
-   neighbor Tenant_C_VRF_WAN_Zone_BGP_PEER_GROUP local-as 777 no-prepend replace-as
-   neighbor Tenant_C_VRF_WAN_Zone_BGP_PEER_GROUP next-hop-self
-   neighbor Tenant_C_VRF_WAN_Zone_BGP_PEER_GROUP update-source lo0
-   neighbor Tenant_C_VRF_WAN_Zone_BGP_PEER_GROUP description Tenant C VRF WAN Zone peer group
-   neighbor Tenant_C_VRF_WAN_Zone_BGP_PEER_GROUP ebgp-multihop 3
-   neighbor Tenant_C_VRF_WAN_Zone_BGP_PEER_GROUP default-originate always
-   neighbor Tenant_C_VRF_WAN_Zone_BGP_PEER_GROUP send-community
-   neighbor Tenant_C_VRF_WAN_Zone_BGP_PEER_GROUP maximum-routes 1000
-   neighbor Tenant_C_VRF_WAN_Zone_BGP_PEER_GROUP route-map TEST_IN in
-   neighbor Tenant_C_VRF_WAN_Zone_BGP_PEER_GROUP route-map TEST_OUT out
+   neighbor Tenant_C_WAN_Zone_BGP_PEER_GROUP peer group
+   neighbor Tenant_C_WAN_Zone_BGP_PEER_GROUP remote-as 666
+   neighbor Tenant_C_WAN_Zone_BGP_PEER_GROUP local-as 777 no-prepend replace-as
+   neighbor Tenant_C_WAN_Zone_BGP_PEER_GROUP next-hop-self
+   neighbor Tenant_C_WAN_Zone_BGP_PEER_GROUP update-source lo0
+   neighbor Tenant_C_WAN_Zone_BGP_PEER_GROUP description Tenant C VRF WAN Zone peer group
+   neighbor Tenant_C_WAN_Zone_BGP_PEER_GROUP ebgp-multihop 3
+   neighbor Tenant_C_WAN_Zone_BGP_PEER_GROUP default-originate always
+   neighbor Tenant_C_WAN_Zone_BGP_PEER_GROUP send-community
+   neighbor Tenant_C_WAN_Zone_BGP_PEER_GROUP maximum-routes 1000
+   neighbor Tenant_C_WAN_Zone_BGP_PEER_GROUP route-map TEST_IN in
+   neighbor Tenant_C_WAN_Zone_BGP_PEER_GROUP route-map TEST_OUT out
    neighbor UNDERLAY-PEERS peer group
    neighbor UNDERLAY-PEERS password 7 AQQvKeimxJu+uGQ/yYvv9w==
    neighbor UNDERLAY-PEERS send-community

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL2A.yml
@@ -142,10 +142,10 @@ router_bgp:
       neighbors:
         2.2.2.2:
           peer_group: Tenant_C_BGP_PEER_GROUP
-          description: test_bgp_peer_group_with_out_nodes
+          description: test_bgp_peer_group_without_nodes
         2.2.2.3:
           peer_group: Tenant_C_BGP_PEER_GROUP2
-          description: test_bgp_peer_group_with_out_nodes_2nd_time
+          description: test_bgp_peer_group_without_nodes_2nd_time
       redistribute_routes:
       - connected
       address_families:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL2A.yml
@@ -19,6 +19,22 @@ router_bgp:
       password: q+VNViP5i4rVjW1cxFv2wA==
       send_community: all
       maximum_routes: 0
+    Tenant_C_BGP_PEER_GROUP:
+      remote_as: 666
+      description: Tenant C peer group
+      send_community: all
+      next_hop_self: true
+      maximum_routes: 1000
+      default_originate:
+        enabled: true
+        always: true
+      update_source: lo0
+      bfd: false
+      ebgp_multihop: 3
+      set_ipv4_next_hop: 1.1.1.1
+      route_map_out: TEST_OUT
+      route_map_in: TEST_IN
+      local_as: 777
   address_family_ipv4:
     peer_groups:
       UNDERLAY-PEERS:
@@ -119,8 +135,17 @@ router_bgp:
         export:
           evpn:
           - '31:31'
+      neighbors:
+        2.2.2.2:
+          peer_group: Tenant_C_BGP_PEER_GROUP
+          description: test_bgp_peer_group_with_out_nodes
       redistribute_routes:
       - connected
+      address_families:
+        ipv4:
+          neighbors:
+            2.2.2.2:
+              activate: true
   vlan_aware_bundles:
     Tenant_A_WAN_Zone:
       rd: 192.168.255.16:14

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL2A.yml
@@ -35,6 +35,10 @@ router_bgp:
       route_map_out: TEST_OUT
       route_map_in: TEST_IN
       local_as: 777
+    Tenant_C_BGP_PEER_GROUP2:
+      remote_as: 667
+      description: Tenant C peer group2
+      update_source: lo0
   address_family_ipv4:
     peer_groups:
       UNDERLAY-PEERS:
@@ -139,12 +143,17 @@ router_bgp:
         2.2.2.2:
           peer_group: Tenant_C_BGP_PEER_GROUP
           description: test_bgp_peer_group_with_out_nodes
+        2.2.2.3:
+          peer_group: Tenant_C_BGP_PEER_GROUP2
+          description: test_bgp_peer_group_with_out_nodes_2nd_time
       redistribute_routes:
       - connected
       address_families:
         ipv4:
           neighbors:
             2.2.2.2:
+              activate: true
+            2.2.2.3:
               activate: true
   vlan_aware_bundles:
     Tenant_A_WAN_Zone:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL2B.yml
@@ -19,25 +19,7 @@ router_bgp:
       password: q+VNViP5i4rVjW1cxFv2wA==
       send_community: all
       maximum_routes: 0
-    Tenant_C_BGP_PEER_GROUP:
-      remote_as: 666
-      description: Tenant C peer group
-      send_community: all
-      next_hop_self: true
-      maximum_routes: 1000
-      default_originate:
-        enabled: true
-        always: true
-      nodes:
-      - DC1-BL2B
-      update_source: lo0
-      bfd: false
-      ebgp_multihop: 3
-      set_ipv4_next_hop: 1.1.1.1
-      route_map_out: TEST_OUT
-      route_map_in: TEST_IN
-      local_as: 777
-    Tenant_C_VRF_WAN_Zone_BGP_PEER_GROUP:
+    Tenant_C_WAN_Zone_BGP_PEER_GROUP:
       remote_as: 666
       description: Tenant C VRF WAN Zone peer group
       send_community: all
@@ -46,8 +28,6 @@ router_bgp:
       default_originate:
         enabled: true
         always: true
-      nodes:
-      - DC1-BL2B
       update_source: lo0
       bfd: false
       ebgp_multihop: 3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_C.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_C.yml
@@ -79,8 +79,8 @@ Tenant_C:
         2.2.2.2:
           peer_group: Tenant_C_BGP_PEER_GROUP
           nodes: [ DC1-BL2A ]
-          description: test_bgp_peer_group_with_out_nodes
+          description: test_bgp_peer_group_without_nodes
         2.2.2.3:
           peer_group: Tenant_C_BGP_PEER_GROUP2
           nodes: [DC1-BL2A]
-          description: test_bgp_peer_group_with_out_nodes_2nd_time
+          description: test_bgp_peer_group_without_nodes_2nd_time

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_C.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_C.yml
@@ -10,7 +10,6 @@ Tenant_C:
       default_originate:
         enabled: true
         always: true
-      nodes: [ DC1-BL2B ]
       update_source: lo0
       bfd: false
       ebgp_multihop: 3
@@ -43,7 +42,7 @@ Tenant_C:
           enabled: True
           ip_address_virtual: 10.3.50.1/24
       bgp_peer_groups:
-        - name: Tenant_C_VRF_WAN_Zone_BGP_PEER_GROUP
+        - name: Tenant_C_WAN_Zone_BGP_PEER_GROUP
           remote_as: 666
           description: "Tenant C VRF WAN Zone peer group"
           send_community: all
@@ -73,3 +72,7 @@ Tenant_C:
           peer_group: Tenant_C_WAN_Zone_BGP_PEER_GROUP
           nodes: [ DC1-BL2B ]
           description: test_ipv6
+        2.2.2.2:
+          peer_group: Tenant_C_BGP_PEER_GROUP
+          nodes: [ DC1-BL2A ]
+          description: test_bgp_peer_group_with_out_nodes

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_C.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_C.yml
@@ -17,6 +17,10 @@ Tenant_C:
       route_map_out: TEST_OUT
       route_map_in: TEST_IN
       local_as: 777
+    - name: Tenant_C_BGP_PEER_GROUP2
+      remote_as: 667
+      description: "Tenant C peer group2"
+      update_source: lo0
   vrfs:
     Tenant_C_OP_Zone:
       vrf_vni: 30
@@ -76,3 +80,7 @@ Tenant_C:
           peer_group: Tenant_C_BGP_PEER_GROUP
           nodes: [ DC1-BL2A ]
           description: test_bgp_peer_group_with_out_nodes
+        2.2.2.3:
+          peer_group: Tenant_C_BGP_PEER_GROUP2
+          nodes: [DC1-BL2A]
+          description: test_bgp_peer_group_with_out_nodes_2nd_time

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
@@ -135,7 +135,8 @@ svi_profiles:
           enabled: < true | false >
           always: < true | false >
         # Nodes is required to restrict configuration of BGP peer groups to certain nodes in the network.
-        nodes: [ < node_1 >, < node_2> ]
+        # If not set the peer-group is created on the device which has a bgp_peer mapped to corresponding peer_group.
+        nodes: [ < node_1 >, < node_2 > ]
         update_source: < interface >
         bfd: < true | false >
         ebgp_multihop: < 1-255 >
@@ -433,7 +434,7 @@ svi_profiles:
             update_source: < interface >
             ebgp_multihop: < 1-255 >
             # Nodes is required to restrict configuration of BGP neighbors to certain nodes in the network.
-            nodes: [ < node_1 >, < node_2> ]
+            nodes: [ < node_1 >, < node_2 > ]
             # Next hop settings can be either ipv4 or ipv6 for one neighbor, this will be applied by a uniquely generated route-map per neighbor.
             # Next hop takes precedence over route_map_out.
             set_ipv4_next_hop: < IPv4_address >
@@ -461,7 +462,7 @@ svi_profiles:
               enabled: < true | false >
               always: < true | false >
             # Nodes is required to restrict configuration of BGP peer groups to certain nodes in the network.
-            nodes: [ < node_1 >, < node_2> ]
+            nodes: [ < node_1 >, < node_2 > ]
             update_source: < interface >
             bfd: < true | false >
             ebgp_multihop: < 1-255 >

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
@@ -462,6 +462,7 @@ svi_profiles:
               enabled: < true | false >
               always: < true | false >
             # Nodes is required to restrict configuration of BGP peer groups to certain nodes in the network.
+            # If not set the peer-group is created on the device which has a bgp_peer mapped to corresponding peer_group.
             nodes: [ < node_1 >, < node_2 > ]
             update_source: < interface >
             bfd: < true | false >

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/logic.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/logic.j2
@@ -25,16 +25,9 @@
 {%                 set tmp_bgp_peer_groups = [] %}
 {%                 set tmp_mapped_peer_groups = [] %}
 {%                 for vrf in tenant.vrfs | arista.avd.convert_dicts | arista.avd.natural_sort('name') %}
-{%                     set tmp_mapped_vrf_peer_groups = [] %}
 {%                     do vrf.update({'bgp_peers': vrf.bgp_peers | arista.avd.convert_dicts('ip_address') | arista.avd.natural_sort('ip_address')}) %}
-{%                     for bgp_peer in vrf.bgp_peers %}
-{%                         if (bgp_peer.peer_group is arista.avd.defined) and (inventory_hostname in bgp_peer.nodes | arista.avd.default([])) and (bgp_peer.peer_group not in tmp_mapped_vrf_peer_groups) %}
-{%                             do tmp_mapped_vrf_peer_groups.append(bgp_peer.peer_group) %}
-{%                             if bgp_peer.peer_group not in tmp_mapped_peer_groups %}
-{%                                 do tmp_mapped_peer_groups.append(bgp_peer.peer_group) %}
-{%                             endif %}
-{%                         endif %}
-{%                     endfor %}
+{%                     set tmp_mapped_vrf_peer_groups = vrf.bgp_peers | selectattr("peer_group", "arista.avd.defined") | selectattr("nodes", "arista.avd.contains", inventory_hostname) | map(attribute="peer_group") %}
+{%                     do tmp_mapped_peer_groups.extend(tmp_mapped_vrf_peer_groups) %}
 {#                     svis & bgp_peers #}
 {%                     for bgp_peer_group in vrf.bgp_peer_groups | arista.avd.natural_sort('name') %}
 {%                         if (inventory_hostname in bgp_peer_group.nodes | arista.avd.default([])) or (bgp_peer_group.name in tmp_mapped_vrf_peer_groups) %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/logic.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/logic.j2
@@ -22,10 +22,25 @@
 {%             if switch.filter_tenants is arista.avd.contains([tenant.name, "all"]) %}
 {#                 vrfs #}
 {%                 set tmp_vrfs = [] %}
+{%                 set tmp_bgp_peer_groups = [] %}
+{%                 set tmp_mapped_peer_groups = [] %}
 {%                 for vrf in tenant.vrfs | arista.avd.convert_dicts | arista.avd.natural_sort('name') %}
+{%                     set tmp_mapped_vrf_peer_groups = [] %}
 {%                     do vrf.update({'bgp_peers': vrf.bgp_peers | arista.avd.convert_dicts('ip_address') | arista.avd.natural_sort('ip_address')}) %}
+{%                     for bgp_peer in vrf.bgp_peers %}
+{%                         if (bgp_peer.peer_group is arista.avd.defined) and (inventory_hostname in bgp_peer.nodes | arista.avd.default([])) and (bgp_peer.peer_group not in tmp_mapped_vrf_peer_groups) %}
+{%                             do tmp_mapped_vrf_peer_groups.append(bgp_peer.peer_group) %}
+{%                             if bgp_peer.peer_group not in tmp_mapped_peer_groups %}
+{%                                 do tmp_mapped_peer_groups.append(bgp_peer.peer_group) %}
+{%                             endif %}
+{%                         endif %}
+{%                     endfor %}
 {#                     svis & bgp_peers #}
-{%                     do vrf.update({'bgp_peer_groups': vrf.bgp_peer_groups | arista.avd.natural_sort('name')}) %}
+{%                     for bgp_peer_group in vrf.bgp_peer_groups | arista.avd.natural_sort('name') %}
+{%                         if (inventory_hostname in bgp_peer_group.nodes | arista.avd.default([])) or (bgp_peer_group.name in tmp_mapped_vrf_peer_groups) %}
+{%                             do tmp_bgp_peer_groups.append(bgp_peer_group) %}
+{%                         endif %}
+{%                     endfor %}
 {%                     set tmp_svis = [] %}
 {%                     for svi in vrf.svis | arista.avd.convert_dicts('id') | arista.avd.natural_sort('id') %}
 {%                         if svi.id | int in whitelist.vlans %}
@@ -72,12 +87,10 @@
 {%                         endif %}
 {%                     endfor %}
 {%                 endfor %}
-{#                 bgp_peers at tenant level #}
-{%                 set tmp_bgp_peer_groups = [] %}
+{#                 bgp_peer_groups at tenant level #}
 {%                 for bgp_peer_group in tenant.bgp_peer_groups | arista.avd.natural_sort('name') %}
-{%                     if inventory_hostname in bgp_peer_group.nodes | arista.avd.default([]) %}
+{%                     if (inventory_hostname in bgp_peer_group.nodes | arista.avd.default([])) or (bgp_peer_group.name in tmp_mapped_peer_groups) %}
 {%                         do tmp_bgp_peer_groups.append(bgp_peer_group) %}
-{%                         break %}
 {%                     endif %}
 {%                 endfor %}
 {%                 do tenant.update({'vrfs': tmp_vrfs, 'l2vlans': tmp_l2vlans, 'point_to_point_services': tmp_point_to_point_services, 'bgp_peer_groups': tmp_bgp_peer_groups}) %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-peer-groups.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-peer-groups.j2
@@ -3,9 +3,7 @@
 {%     for tenant in network_services_data.tenants %}
 {# All peer_groups defined on a host #}
 {%         for bgp_peer_group in tenant.bgp_peer_groups | arista.avd.natural_sort('name') %}
-{%             if bgp_peer_group.nodes is arista.avd.defined %}
-{%                 do bgp_peer_group.pop("nodes") %}
-{%             endif %}
+{%             do bgp_peer_group.pop("nodes", none) %}
     {{ bgp_peer_group.name }}:
 {%             do bgp_peer_group.pop("name") %}
       {{ bgp_peer_group }}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-peer-groups.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-peer-groups.j2
@@ -1,19 +1,14 @@
 {% if switch.network_services_l3 is arista.avd.defined(true) %}
   peer_groups:
 {%     for tenant in network_services_data.tenants %}
-{# add peer_groups defined at tenant level #}
-{%         for bgp_peer_group in tenant.bgp_peer_groups if inventory_hostname in bgp_peer_group.nodes | arista.avd.default([]) %}
+{# All peer_groups defined on a host #}
+{%         for bgp_peer_group in tenant.bgp_peer_groups | arista.avd.natural_sort('name') %}
+{%             if bgp_peer_group.nodes is arista.avd.defined %}
+{%                 do bgp_peer_group.pop("nodes") %}
+{%             endif %}
     {{ bgp_peer_group.name }}:
-{%                 do bgp_peer_group.pop("name") %}
+{%             do bgp_peer_group.pop("name") %}
       {{ bgp_peer_group }}
-{%         endfor %}
-{# add peer_groups defined at vrf level for all tenants #}
-{%         for vrf in tenant.vrfs %}
-{%             for bgp_peer_group in vrf.bgp_peer_groups if inventory_hostname in bgp_peer_group.nodes | arista.avd.default([]) %}
-    {{ bgp_peer_group.name }}:
-{%                 do bgp_peer_group.pop("name") %}
-      {{ bgp_peer_group }}
-{%             endfor %}
 {%         endfor %}
 {%     endfor %}
 {% endif %}


### PR DESCRIPTION
## Change Summary

This is to set the default nodes of bgp_peer_groups, when the **nodes** is not set on a bgp_peer_groups.<bgp_peer_group> (tenant or vrf level), the bgp_peer_group is not created.

The default behavior is as below:
Add the bgp_peer_group(s) to a device based on the device's bgp_peers. When the bgp_peer's peer_group is set, the bgp_peer_group config is automatically added to the device unless **nodes** is defined on bgp_peer_groups, which takes precedence.

## Related Issue(s)

Fixes #874 #1663 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

Same as old, just changed the default behavior.
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test

molecule converge -s eos_designs_unit_tests.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
