### PR TITLE
Fix(eos_cli_config_gen): add vlan.vni var is defined

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vxlan-interface.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vxlan-interface.md
@@ -85,6 +85,7 @@ interface Management1
 | ---- | --- | ---------- | --------------- |
 | 110 | 10110 | - | 239.9.1.4 |
 | 111 | 10111 | 10.1.1.10<br/>10.1.1.11 | - |
+| 112 | - | - | 239.9.1.6 |
 
 #### VRF to VNI and Multicast Group Mappings
 
@@ -121,6 +122,7 @@ interface Vxlan1
    vxlan qos dscp propagation encapsulation
    vxlan qos map dscp to traffic-class decapsulation
    vxlan vlan 110 multicast group 239.9.1.4
+   vxlan vlan 112 multicast group 239.9.1.6
    vxlan vrf Tenant_A_OP_Zone multicast group 232.0.0.10
    vxlan encapsulation ipv4
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vxlan-interface.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vxlan-interface.cfg
@@ -30,6 +30,7 @@ interface Vxlan1
    vxlan qos dscp propagation encapsulation
    vxlan qos map dscp to traffic-class decapsulation
    vxlan vlan 110 multicast group 239.9.1.4
+   vxlan vlan 112 multicast group 239.9.1.6
    vxlan vrf Tenant_A_OP_Zone multicast group 232.0.0.10
    vxlan encapsulation ipv4
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vxlan-interface.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vxlan-interface.yml
@@ -25,6 +25,8 @@ vxlan_interface:
           flood_vteps:
             - 10.1.1.10
             - 10.1.1.11
+        112:
+          multicast_group: 239.9.1.6
       vrfs:
         Tenant_A_OP_Zone:
           vni: 10

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vxlan-interface.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vxlan-interface.j2
@@ -19,7 +19,9 @@ interface Vxlan1
    vxlan flood vtep learned data-plane
 {%     endif %}
 {%     for vlan in vxlan_interface.Vxlan1.vxlan.vlans | arista.avd.convert_dicts('id') | arista.avd.natural_sort('id') %}
+{%         if vlan.vni is arista.avd.defined %}
    vxlan vlan {{ vlan.id }} vni {{ vlan.vni }}
+{%         endif %}
 {%         if vlan.flood_vteps is arista.avd.defined %}
    vxlan vlan {{ vlan.id }} flood vtep {{ vlan.flood_vteps | join(' ') }}
 {%         endif %}


### PR DESCRIPTION
## Change Summary

Add vlan.vni protection "is defined" during vxlan-interface rendering. Covers corner case when some knob was added to Vxlan vlan level with structured_config and SVI/l2vlan was removed later.

## Related Issue(s)

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Usual "if ... is arista.avd.defined" for vlan.vni variable

## How to test
molecule converge -s

ansible-avd/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vxlan-interface.yml
contains vlan 112 which doesn't have vni key.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
