### PR TITLE
Feat(eos_cli_config_gen): Enhance support for PTP monitoring

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ptp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ptp.md
@@ -51,8 +51,8 @@ interface Management1
 
 ### PTP Summary
 
-| Clock ID    | Source IP | Priority 1 | Priority 2 | TTL | Domain | Mode        | Forward Unicast |
-| ----------- | --------- | ---------- | ---------- | --- | ------ | ----------- | --------------- |
+| Clock ID | Source IP | Priority 1 | Priority 2 | TTL | Domain | Mode | Forward Unicast |
+| -------- | --------- | ---------- | ---------- | --- | ------ | ---- | --------------- |
 | 11:11:11:11:11:11 | 1.1.2.3 | 101 | 102 | 12 | 17 | boundary | True |
 
 ### PTP Device Configuration

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ptp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ptp.md
@@ -51,33 +51,36 @@ interface Management1
 
 ### PTP Summary
 
-| PTP setting | Value |
-| ----------- | ----- |
-| Clock-identity | 123.123.123.123 |
-| Source IP | 1.1.1.1 |
-| Priority1 | 1 |
-| Priority2 | 2 |
-| TTL | 200 |
-| Domain | 1 |
-| Msg General | DSCP 4 |
-| Msg Event | DSCP 8 |
+| Clock ID    | Source IP | Priority 1 | Priority 2 | TTL | Domain | Mode        | Forward Unicast |
+| ----------- | --------- | ---------- | ---------- | --- | ------ | ----------- | --------------- |
+| 11:11:11:11:11:11 | 1.1.2.3 | 101 | 102 | 12 | 17 | boundary | True |
 
 ### PTP Device Configuration
 
 ```eos
 !
-ptp clock-identity 123.123.123.123
-ptp source ip 1.1.1.1
-ptp priority1 1
-ptp priority2 2
-ptp ttl 200
-ptp domain 1
-ptp message-type general dscp 4 default
-ptp message-type event dscp 8 default
+ptp clock-identity 11:11:11:11:11:11
+ptp source ip 1.1.2.3
+ptp priority1 101
+ptp priority2 102
+ptp ttl 12
+ptp domain 17
+ptp message-type general dscp 36 default
+ptp message-type event dscp 46 default
 ptp mode boundary
 ptp forward-unicast
-ptp monitor threshold offset-from-master 1234
-ptp monitor threshold mean-path-delay 4321
+ptp monitor threshold offset-from-master 11
+ptp monitor threshold mean-path-delay 12
+ptp monitor threshold offset-from-master 13 nanoseconds drop
+ptp monitor threshold mean-path-delay 14 nanoseconds drop
+ptp monitor threshold missing-message announce 101 intervals
+ptp monitor threshold missing-message follow-up 102 intervals
+ptp monitor threshold missing-message sync 103 intervals
+ptp monitor sequence-id
+ptp monitor threshold missing-message announce 201 sequence-ids
+ptp monitor threshold missing-message delay-resp 202 sequence-ids
+ptp monitor threshold missing-message follow-up 203 sequence-ids
+ptp monitor threshold missing-message sync 204 sequence-ids
 ```
 
 # Authentication

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ptp.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ptp.cfg
@@ -4,18 +4,28 @@ transceiver qsfp default-mode 4x10G
 !
 hostname ptp
 !
-ptp clock-identity 123.123.123.123
-ptp source ip 1.1.1.1
-ptp priority1 1
-ptp priority2 2
-ptp ttl 200
-ptp domain 1
-ptp message-type general dscp 4 default
-ptp message-type event dscp 8 default
+ptp clock-identity 11:11:11:11:11:11
+ptp source ip 1.1.2.3
+ptp priority1 101
+ptp priority2 102
+ptp ttl 12
+ptp domain 17
+ptp message-type general dscp 36 default
+ptp message-type event dscp 46 default
 ptp mode boundary
 ptp forward-unicast
-ptp monitor threshold offset-from-master 1234
-ptp monitor threshold mean-path-delay 4321
+ptp monitor threshold offset-from-master 11
+ptp monitor threshold mean-path-delay 12
+ptp monitor threshold offset-from-master 13 nanoseconds drop
+ptp monitor threshold mean-path-delay 14 nanoseconds drop
+ptp monitor threshold missing-message announce 101 intervals
+ptp monitor threshold missing-message follow-up 102 intervals
+ptp monitor threshold missing-message sync 103 intervals
+ptp monitor sequence-id
+ptp monitor threshold missing-message announce 201 sequence-ids
+ptp monitor threshold missing-message delay-resp 202 sequence-ids
+ptp monitor threshold missing-message follow-up 203 sequence-ids
+ptp monitor threshold missing-message sync 204 sequence-ids
 !
 no enable password
 no aaa root

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ptp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ptp.yml
@@ -1,24 +1,41 @@
 ### ptp
 
 ptp:
-  clock_identity: 123.123.123.123
+  clock_identity: "11:11:11:11:11:11"
   source:
-    ip: 1.1.1.1
-  priority1: 1
-  priority2: 2
-  ttl: 200
-  domain: 1
+    ip: 1.1.2.3
+  priority1: 101
+  priority2: 102
+  ttl: 12
+  domain: 17
   message_type:
     general:
-      dscp: 4
+      dscp: 36
     event:
-      dscp: 8
-  monitor:
-    threshold:
-      offset_from_master: 1234
-      mean_path_delay: 4321
+      dscp: 46
   mode: boundary
   forward_unicast: true
+  monitor:
+    # enabled: true (default)
+    threshold:
+      offset_from_master: 11
+      mean_path_delay: 12
+      drop:
+        enabled: true
+        offset_from_master: 13
+        mean_path_delay: 14
+    missing_message:
+      intervals:
+        enabled: true
+        announce: 101
+        follow_up: 102
+        sync: 103
+      sequence_ids:
+        enabled: true
+        announce: 201
+        delay_resp: 202
+        follow_up: 203
+        sync: 204
 
 # port-channels
 port_channel_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ptp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ptp.yml
@@ -29,6 +29,7 @@ ptp:
         follow_up: 102
         sync: 103
       sequence_ids:
+        enabled: true
         announce: 201
         delay_resp: 202
         follow_up: 203

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ptp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ptp.yml
@@ -21,17 +21,14 @@ ptp:
       offset_from_master: 11
       mean_path_delay: 12
       drop:
-        enabled: true
         offset_from_master: 13
         mean_path_delay: 14
     missing_message:
       intervals:
-        enabled: true
         announce: 101
         follow_up: 102
         sync: 103
       sequence_ids:
-        enabled: true
         announce: 201
         delay_resp: 202
         follow_up: 203

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/ptp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/ptp.md
@@ -51,8 +51,8 @@ interface Management1
 
 ### PTP Summary
 
-| Clock ID    | Source IP | Priority 1 | Priority 2 | TTL | Domain | Mode        | Forward Unicast |
-| ----------- | --------- | ---------- | ---------- | --- | ------ | ----------- | --------------- |
+| Clock ID | Source IP | Priority 1 | Priority 2 | TTL | Domain | Mode | Forward Unicast |
+| -------- | --------- | ---------- | ---------- | --- | ------ | ---- | --------------- |
 | 123.123.123.123 | 1.1.1.1 | 1 | 2 | 200 | 1 | boundary | True |
 
 ### PTP Device Configuration

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/ptp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/ptp.md
@@ -51,16 +51,9 @@ interface Management1
 
 ### PTP Summary
 
-| PTP setting | Value |
-| ----------- | ----- |
-| Clock-identity | 123.123.123.123 |
-| Source IP | 1.1.1.1 |
-| Priority1 | 1 |
-| Priority2 | 2 |
-| TTL | 200 |
-| Domain | 1 |
-| Msg General | DSCP 4 |
-| Msg Event | DSCP 8 |
+| Clock ID    | Source IP | Priority 1 | Priority 2 | TTL | Domain | Mode        | Forward Unicast |
+| ----------- | --------- | ---------- | ---------- | --- | ------ | ----------- | --------------- |
+| 123.123.123.123 | 1.1.1.1 | 1 | 2 | 200 | 1 | boundary | True |
 
 ### PTP Device Configuration
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -2684,6 +2684,7 @@ ptp:
         follow_up: < 2-255 >
         sync: < 2-255 >
       sequence_ids:
+        enabled: < true | false -> default >
         announce: < 2-255 >
         delay_resp: < 2-255 >
         follow_up: < 2-255 >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -2671,7 +2671,7 @@ ptp:
     event:
       dscp: < dscp-value >
   monitor:
-    enabled: < false | true | default -> true >
+    enabled: < true | false | default -> true >
     threshold:
       offset_from_master: < 0-1000000000 >
       mean_path_delay: < 0-1000000000 >
@@ -2684,7 +2684,7 @@ ptp:
         follow_up: < 2-255 >
         sync: < 2-255 >
       sequence_ids:
-        enabled: < true | false -> default >
+        enabled: < true | false | default -> false >
         announce: < 2-255 >
         delay_resp: < 2-255 >
         follow_up: < 2-255 >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -2656,24 +2656,41 @@ patch_panel:
 
 ```yaml
 ptp:
-  mode: < mode >
+  mode: < boundary | transparent >
   forward_unicast: < true | false >
-  clock_identity: < clock-id >
+  clock_identity: < "clock-id in xx:xx:xx:xx:xx:xx format" >
   source:
-    ip: < source-ip>
-  priority1: < priority1 >
-  priority2: < priority2 >
-  ttl: < ttl >
-  domain: < integer >
+    ip: < source-ip >
+  priority1: < integer >
+  priority2: < integer >
+  ttl: < 1-254 >
+  domain: < 0-255 >
   message_type:
     general:
       dscp: < dscp-value >
     event:
-      dscp: < dscp-Value >
+      dscp: < dscp-value >
   monitor:
+    enabled: < false | true -> default >
     threshold:
-      offset_from_master: < offset >
-      mean_path_delay: < delay >
+      offset_from_master: < 0-1000000000 >
+      mean_path_delay: < 0-1000000000 >
+      drop:
+        enabled: < true | false -> default >
+        offset_from_master: < 0-1000000000 >
+        mean_path_delay: < 0-1000000000 >
+    missing_message:
+      intervals:
+        enabled: < true | false -> default >
+        announce: < 2-255 >
+        follow_up: < 2-255 >
+        sync: < 2-255 >
+      sequence_ids:
+        enabled: < true | false -> default >
+        announce: < 2-255 >
+        delay_resp: < 2-255 >
+        follow_up: < 2-255 >
+        sync: < 2-255 >
 ```
 
 ### Prompt

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -2661,8 +2661,8 @@ ptp:
   clock_identity: < "clock-id in xx:xx:xx:xx:xx:xx format" >
   source:
     ip: < source-ip >
-  priority1: < integer >
-  priority2: < integer >
+  priority1: < 0-255 >
+  priority2: < 0-255 >
   ttl: < 1-254 >
   domain: < 0-255 >
   message_type:
@@ -2671,12 +2671,12 @@ ptp:
     event:
       dscp: < dscp-value >
   monitor:
-    enabled: < false | true -> default >
+    enabled: < false | true | default -> true >
     threshold:
       offset_from_master: < 0-1000000000 >
       mean_path_delay: < 0-1000000000 >
       drop:
-        enabled: < true | false -> default >
+        # enabled: < true | false -> default >
         offset_from_master: < 0-1000000000 >
         mean_path_delay: < 0-1000000000 >
     missing_message:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -2676,17 +2676,14 @@ ptp:
       offset_from_master: < 0-1000000000 >
       mean_path_delay: < 0-1000000000 >
       drop:
-        # enabled: < true | false -> default >
         offset_from_master: < 0-1000000000 >
         mean_path_delay: < 0-1000000000 >
     missing_message:
       intervals:
-        enabled: < true | false -> default >
         announce: < 2-255 >
         follow_up: < 2-255 >
         sync: < 2-255 >
       sequence_ids:
-        enabled: < true | false -> default >
         announce: < 2-255 >
         delay_resp: < 2-255 >
         follow_up: < 2-255 >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ptp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ptp.j2
@@ -4,8 +4,8 @@
 
 ### PTP Summary
 
-| Clock ID    | Source IP | Priority 1 | Priority 2 | TTL | Domain | Mode        | Forward Unicast |
-| ----------- | --------- | ---------- | ---------- | --- | ------ | ----------- | --------------- |
+| Clock ID | Source IP | Priority 1 | Priority 2 | TTL | Domain | Mode | Forward Unicast |
+| -------- | --------- | ---------- | ---------- | --- | ------ | ---- | --------------- |
 {%     set clock_id = ptp.clock_identity | arista.avd.default('-') %}
 {%     set sip = ptp.source.ip | arista.avd.default('-') %}
 {%     set pri1 = ptp.priority1 | arista.avd.default('-') %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ptp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ptp.j2
@@ -4,40 +4,17 @@
 
 ### PTP Summary
 
-| PTP setting | Value |
-| ----------- | ----- |
-{%     if ptp.clock_identity is defined and ptp.clock_identity is not none %}
-| Clock-identity | {{ ptp.clock_identity }} |
-{%     endif %}
-{%     if ptp.source is defined and ptp.source is not none %}
-{%         if ptp.source.ip is defined and ptp.source.ip is not none %}
-| Source IP | {{ ptp.source.ip }} |
-{%         endif %}
-{%     endif %}
-{%     if ptp.priority1 is defined and ptp.priority1 is not none %}
-| Priority1 | {{ ptp.priority1 }} |
-{%     endif %}
-{%     if ptp.priority2 is defined and ptp.priority2 is not none %}
-| Priority2 | {{ ptp.priority2 }} |
-{%     endif %}
-{%     if ptp.ttl is defined and ptp.ttl is not none %}
-| TTL | {{ ptp.ttl }} |
-{%     endif %}
-{%     if ptp.domain is defined and ptp.domain is not none %}
-| Domain | {{ ptp.domain }} |
-{%     endif %}
-{%     if ptp.message_type is defined and ptp.message_type is not none %}
-{%         if ptp.message_type.general is defined and ptp.message_type.general is not none %}
-{%             if ptp.message_type.general.dscp is defined and ptp.message_type.general.dscp is not none %}
-| Msg General | DSCP {{ ptp.message_type.general.dscp }} |
-{%             endif %}
-{%         endif %}
-{%         if ptp.message_type.event is defined and ptp.message_type.event is not none %}
-{%             if ptp.message_type.event.dscp is defined and ptp.message_type.event.dscp is not none %}
-| Msg Event | DSCP {{ ptp.message_type.event.dscp }} |
-{%             endif %}
-{%         endif %}
-{%     endif %}
+| Clock ID    | Source IP | Priority 1 | Priority 2 | TTL | Domain | Mode        | Forward Unicast |
+| ----------- | --------- | ---------- | ---------- | --- | ------ | ----------- | --------------- |
+{%     set clock_id = ptp.clock_identity | arista.avd.default('-') %}
+{%     set sip = ptp.source.ip | arista.avd.default('-') %}
+{%     set pri1 = ptp.priority1 | arista.avd.default('-') %}
+{%     set pri2 = ptp.priority2 | arista.avd.default('-') %}
+{%     set ttl = ptp.ttl | arista.avd.default('-') %}
+{%     set domain = ptp.domain | arista.avd.default('-') %}
+{%     set mode = ptp.mode | arista.avd.default('-') %}
+{%     set forward_unicast = ptp.forward_unicast | arista.avd.default('-') %}
+| {{ clock_id }} | {{ sip }} | {{ pri1 }} | {{ pri2 }} | {{ ttl }} | {{ domain }} | {{ mode }} | {{ forward_unicast }} |
 
 ### PTP Device Configuration
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ptp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ptp.j2
@@ -31,10 +31,52 @@ ptp mode {{ ptp.mode }}
 {%     if ptp.forward_unicast is arista.avd.defined(true) %}
 ptp forward-unicast
 {%     endif %}
-{%     if ptp.monitor.threshold.offset_from_master is arista.avd.defined %}
-ptp monitor threshold offset-from-master {{ ptp.monitor.threshold.offset_from_master }}
+{%     if ptp.monitor.enabled is arista.avd.defined(false) %}
+no ptp monitor
 {%     endif %}
-{%     if ptp.monitor.threshold.mean_path_delay is arista.avd.defined %}
+{%     if ptp.monitor.enabled is not arista.avd.defined(false) %}
+{%         if ptp.monitor.threshold.offset_from_master is arista.avd.defined %}
+ptp monitor threshold offset-from-master {{ ptp.monitor.threshold.offset_from_master }}
+{%         endif %}
+{%         if ptp.monitor.threshold.mean_path_delay is arista.avd.defined %}
 ptp monitor threshold mean-path-delay {{ ptp.monitor.threshold.mean_path_delay }}
+{%         endif %}
+{%         if ptp.monitor.threshold.drop.enabled is arista.avd.defined(true) %}
+{%             if ptp.monitor.threshold.drop.offset_from_master is arista.avd.defined %}
+ptp monitor threshold offset-from-master {{ ptp.monitor.threshold.drop.offset_from_master }} nanoseconds drop
+{%             endif %}
+{%             if ptp.monitor.threshold.drop.mean_path_delay is arista.avd.defined %}
+ptp monitor threshold mean-path-delay {{ ptp.monitor.threshold.drop.mean_path_delay }} nanoseconds drop
+{%             endif %}
+{%         endif %}
+{%         if ptp.monitor.missing_message.intervals.enabled is arista.avd.defined(true) %}
+{%             if ptp.monitor.missing_message.intervals.announce is arista.avd.defined %}
+ptp monitor threshold missing-message announce {{ ptp.monitor.missing_message.intervals.announce }} intervals
+{%             endif %}
+{%             if ptp.monitor.missing_message.intervals.follow_up is arista.avd.defined %}
+ptp monitor threshold missing-message follow-up {{ ptp.monitor.missing_message.intervals.follow_up }} intervals
+{%             endif %}
+{%             if ptp.monitor.missing_message.intervals.sync is arista.avd.defined %}
+ptp monitor threshold missing-message sync {{ ptp.monitor.missing_message.intervals.sync }} intervals
+{%             endif %}
+{%         endif %}
+{%         if ptp.monitor.missing_message.sequence_ids.enabled is arista.avd.defined(false) %}
+no ptp monitor sequence-id
+{%         endif %}
+{%         if ptp.monitor.missing_message.sequence_ids.enabled is arista.avd.defined(true) %}
+ptp monitor sequence-id
+{%             if ptp.monitor.missing_message.sequence_ids.announce is arista.avd.defined %}
+ptp monitor threshold missing-message announce {{ ptp.monitor.missing_message.sequence_ids.announce }} sequence-ids
+{%             endif %}
+{%             if ptp.monitor.missing_message.sequence_ids.delay_resp is arista.avd.defined %}
+ptp monitor threshold missing-message delay-resp {{ ptp.monitor.missing_message.sequence_ids.delay_resp }} sequence-ids
+{%             endif %}
+{%             if ptp.monitor.missing_message.sequence_ids.follow_up is arista.avd.defined %}
+ptp monitor threshold missing-message follow-up {{ ptp.monitor.missing_message.sequence_ids.follow_up }} sequence-ids
+{%             endif %}
+{%             if ptp.monitor.missing_message.sequence_ids.sync is arista.avd.defined %}
+ptp monitor threshold missing-message sync {{ ptp.monitor.missing_message.sequence_ids.sync }} sequence-ids
+{%             endif %}
+{%         endif %}
 {%     endif %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ptp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ptp.j2
@@ -47,7 +47,7 @@ ptp monitor threshold offset-from-master {{ ptp.monitor.threshold.drop.offset_fr
 {%         if ptp.monitor.threshold.drop.mean_path_delay is arista.avd.defined %}
 ptp monitor threshold mean-path-delay {{ ptp.monitor.threshold.drop.mean_path_delay }} nanoseconds drop
 {%         endif %}
-{%         if ptp.monitor.missing_message.intervals.enabled is arista.avd.defined(true) %}
+{%         if ptp.monitor.missing_message.intervals is arista.avd.defined %}
 {%             if ptp.monitor.missing_message.intervals.announce is arista.avd.defined %}
 ptp monitor threshold missing-message announce {{ ptp.monitor.missing_message.intervals.announce }} intervals
 {%             endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ptp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ptp.j2
@@ -60,8 +60,7 @@ ptp monitor threshold missing-message sync {{ ptp.monitor.missing_message.interv
 {%         endif %}
 {%         if ptp.monitor.missing_message.sequence_ids.enabled is arista.avd.defined(false) %}
 no ptp monitor sequence-id
-{%         endif %}
-{%         if ptp.monitor.missing_message.sequence_ids.enabled is arista.avd.defined(true) %}
+{%         elif ptp.monitor.missing_message.sequence_ids.enabled is arista.avd.defined(true) %}
 ptp monitor sequence-id
 {%             if ptp.monitor.missing_message.sequence_ids.announce is arista.avd.defined %}
 ptp monitor threshold missing-message announce {{ ptp.monitor.missing_message.sequence_ids.announce }} sequence-ids

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ptp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ptp.j2
@@ -59,7 +59,7 @@ ptp monitor threshold missing-message sync {{ ptp.monitor.missing_message.interv
 {%         endif %}
 {%         if ptp.monitor.missing_message.sequence_ids.enabled is arista.avd.defined(false) %}
 no ptp monitor sequence-id
-{%         elif ptp.monitor.missing_message.sequence_ids.enabled is arista.avd.defined(true) %}
+{%         elif ptp.monitor.missing_message.sequence_ids is arista.avd.defined %}
 ptp monitor sequence-id
 {%             if ptp.monitor.missing_message.sequence_ids.announce is arista.avd.defined %}
 ptp monitor threshold missing-message announce {{ ptp.monitor.missing_message.sequence_ids.announce }} sequence-ids

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ptp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ptp.j2
@@ -33,8 +33,7 @@ ptp forward-unicast
 {%     endif %}
 {%     if ptp.monitor.enabled is arista.avd.defined(false) %}
 no ptp monitor
-{%     endif %}
-{%     if ptp.monitor.enabled is not arista.avd.defined(false) %}
+{%     elif ptp.monitor is arista.avd.defined %}
 {%         if ptp.monitor.threshold.offset_from_master is arista.avd.defined %}
 ptp monitor threshold offset-from-master {{ ptp.monitor.threshold.offset_from_master }}
 {%         endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ptp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ptp.j2
@@ -59,7 +59,7 @@ ptp monitor threshold missing-message sync {{ ptp.monitor.missing_message.interv
 {%         endif %}
 {%         if ptp.monitor.missing_message.sequence_ids.enabled is arista.avd.defined(false) %}
 no ptp monitor sequence-id
-{%         elif ptp.monitor.missing_message.sequence_ids is arista.avd.defined %}
+{%         elif ptp.monitor.missing_message.sequence_ids.enabled is arista.avd.defined(true) %}
 ptp monitor sequence-id
 {%             if ptp.monitor.missing_message.sequence_ids.announce is arista.avd.defined %}
 ptp monitor threshold missing-message announce {{ ptp.monitor.missing_message.sequence_ids.announce }} sequence-ids

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ptp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ptp.j2
@@ -41,13 +41,11 @@ ptp monitor threshold offset-from-master {{ ptp.monitor.threshold.offset_from_ma
 {%         if ptp.monitor.threshold.mean_path_delay is arista.avd.defined %}
 ptp monitor threshold mean-path-delay {{ ptp.monitor.threshold.mean_path_delay }}
 {%         endif %}
-{%         if ptp.monitor.threshold.drop.enabled is arista.avd.defined(true) %}
-{%             if ptp.monitor.threshold.drop.offset_from_master is arista.avd.defined %}
+{%         if ptp.monitor.threshold.drop.offset_from_master is arista.avd.defined %}
 ptp monitor threshold offset-from-master {{ ptp.monitor.threshold.drop.offset_from_master }} nanoseconds drop
-{%             endif %}
-{%             if ptp.monitor.threshold.drop.mean_path_delay is arista.avd.defined %}
+{%         endif %}
+{%         if ptp.monitor.threshold.drop.mean_path_delay is arista.avd.defined %}
 ptp monitor threshold mean-path-delay {{ ptp.monitor.threshold.drop.mean_path_delay }} nanoseconds drop
-{%             endif %}
 {%         endif %}
 {%         if ptp.monitor.missing_message.intervals.enabled is arista.avd.defined(true) %}
 {%             if ptp.monitor.missing_message.intervals.announce is arista.avd.defined %}


### PR DESCRIPTION
## Change Summary

Updated PTP config to reflect all necessary knobs needed to support PR #1916.

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Added support for PTP monitor thresholds for missing messages:

```yml
ptp:
  monitor:
    enabled: < true | false | default -> true >
    threshold:
      offset_from_master: < 0-1000000000 >
      mean_path_delay: < 0-1000000000 >
      drop:
        offset_from_master: < 0-1000000000 >
        mean_path_delay: < 0-1000000000 >
    missing_message:
      intervals:
        announce: < 2-255 >
        follow_up: < 2-255 >
        sync: < 2-255 >
      sequence_ids:
        enabled: < true | false | default -> false >
        announce: < 2-255 >
        delay_resp: < 2-255 >
        follow_up: < 2-255 >
        sync: < 2-255 >
```

## How to test

molecule converge --scenario-name eos_cli_config_gen --    

## Checklist

### User Checklist

- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
