### PR TITLE
Fix(eos_cli_config_gen): print the vlans in alphabetical order for `router bgp`

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-evpn.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-evpn.md
@@ -176,6 +176,10 @@ interface Management1
 
 | VLAN | Route-Distinguisher | Both Route-Target | Import Route Target | Export Route-Target | Redistribute |
 | ---- | ------------------- | ----------------- | ------------------- | ------------------- | ------------ |
+| 66 | 145.245.21.0:66 | 145.245.21.0:66 | - | - | no learned |
+| 67 | 145.245.21.0:67 | 145.245.21.0:67 | - | - | no learned |
+| 600 | 145.245.21.0:600 | 145.245.21.0:600 | - | - | no learned |
+| 666 | 145.245.21.0:666 | 145.245.21.0:666 | - | - | no learned |
 | 2488 | 145.245.21.0:1 | 145.245.21.0:1 | - | - | no learned |
 
 ### Router BGP VRFs
@@ -222,6 +226,26 @@ router bgp 65101
    vlan 2488
       rd 145.245.21.0:1
       route-target both 145.245.21.0:1
+      no redistribute learned
+   !
+   vlan 600
+      rd 145.245.21.0:600
+      route-target both 145.245.21.0:600
+      no redistribute learned
+   !
+   vlan 66
+      rd 145.245.21.0:66
+      route-target both 145.245.21.0:66
+      no redistribute learned
+   !
+   vlan 666
+      rd 145.245.21.0:666
+      route-target both 145.245.21.0:666
+      no redistribute learned
+   !
+   vlan 67
+      rd 145.245.21.0:67
+      route-target both 145.245.21.0:67
       no redistribute learned
    !
    vlan-aware-bundle B-ELAN-201

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-evpn.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-evpn.cfg
@@ -47,6 +47,26 @@ router bgp 65101
       route-target both 145.245.21.0:1
       no redistribute learned
    !
+   vlan 600
+      rd 145.245.21.0:600
+      route-target both 145.245.21.0:600
+      no redistribute learned
+   !
+   vlan 66
+      rd 145.245.21.0:66
+      route-target both 145.245.21.0:66
+      no redistribute learned
+   !
+   vlan 666
+      rd 145.245.21.0:666
+      route-target both 145.245.21.0:666
+      no redistribute learned
+   !
+   vlan 67
+      rd 145.245.21.0:67
+      route-target both 145.245.21.0:67
+      no redistribute learned
+   !
    vlan-aware-bundle B-ELAN-201
       rd 192.168.255.3:20201
       route-target both 20201:20201

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-evpn.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-evpn.yml
@@ -120,6 +120,34 @@ router_bgp:
           - 145.245.21.0:1
       no_redistribute_routes:
         - learned
+    66:
+      rd: 145.245.21.0:66
+      route_targets:
+        both:
+          - 145.245.21.0:66
+      no_redistribute_routes:
+        - learned
+    600:
+      rd: 145.245.21.0:600
+      route_targets:
+        both:
+          - 145.245.21.0:600
+      no_redistribute_routes:
+        - learned
+    666:
+      rd: 145.245.21.0:666
+      route_targets:
+        both:
+          - 145.245.21.0:666
+      no_redistribute_routes:
+        - learned
+    67:
+      rd: 145.245.21.0:67
+      route_targets:
+        both:
+          - 145.245.21.0:67
+      no_redistribute_routes:
+        - learned
   vrfs:
 ## Tenant_A ##
     TENANT_A_PROJECT01:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/router-bgp-evpn.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/router-bgp-evpn.md
@@ -169,6 +169,10 @@ interface Management1
 
 | VLAN | Route-Distinguisher | Both Route-Target | Import Route Target | Export Route-Target | Redistribute |
 | ---- | ------------------- | ----------------- | ------------------- | ------------------- | ------------ |
+| 66 | 145.245.21.0:66 | 145.245.21.0:66 | - | - | no learned |
+| 67 | 145.245.21.0:67 | 145.245.21.0:67 | - | - | no learned |
+| 600 | 145.245.21.0:600 | 145.245.21.0:600 | - | - | no learned |
+| 666 | 145.245.21.0:666 | 145.245.21.0:666 | - | - | no learned |
 | 2488 | 145.245.21.0:1 | 145.245.21.0:1 | - | - | no learned |
 
 ### Router BGP VRFs
@@ -215,6 +219,26 @@ router bgp 65101
    vlan 2488
       rd 145.245.21.0:1
       route-target both 145.245.21.0:1
+      no redistribute learned
+   !
+   vlan 600
+      rd 145.245.21.0:600
+      route-target both 145.245.21.0:600
+      no redistribute learned
+   !
+   vlan 66
+      rd 145.245.21.0:66
+      route-target both 145.245.21.0:66
+      no redistribute learned
+   !
+   vlan 666
+      rd 145.245.21.0:666
+      route-target both 145.245.21.0:666
+      no redistribute learned
+   !
+   vlan 67
+      rd 145.245.21.0:67
+      route-target both 145.245.21.0:67
       no redistribute learned
    !
    vlan-aware-bundle B-ELAN-201

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/router-bgp-evpn.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/router-bgp-evpn.cfg
@@ -47,6 +47,26 @@ router bgp 65101
       route-target both 145.245.21.0:1
       no redistribute learned
    !
+   vlan 600
+      rd 145.245.21.0:600
+      route-target both 145.245.21.0:600
+      no redistribute learned
+   !
+   vlan 66
+      rd 145.245.21.0:66
+      route-target both 145.245.21.0:66
+      no redistribute learned
+   !
+   vlan 666
+      rd 145.245.21.0:666
+      route-target both 145.245.21.0:666
+      no redistribute learned
+   !
+   vlan 67
+      rd 145.245.21.0:67
+      route-target both 145.245.21.0:67
+      no redistribute learned
+   !
    vlan-aware-bundle B-ELAN-201
       rd 192.168.255.3:20201
       route-target both 20201:20201

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/router-bgp-evpn.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/router-bgp-evpn.yml
@@ -119,6 +119,34 @@ router_bgp:
           - 145.245.21.0:1
       no_redistribute_routes:
         - learned
+    - id: 66
+      rd: 145.245.21.0:66
+      route_targets:
+        both:
+          - 145.245.21.0:66
+      no_redistribute_routes:
+        - learned
+    - id: 600
+      rd: 145.245.21.0:600
+      route_targets:
+        both:
+          - 145.245.21.0:600
+      no_redistribute_routes:
+        - learned
+    - id: 666
+      rd: 145.245.21.0:666
+      route_targets:
+        both:
+          - 145.245.21.0:666
+      no_redistribute_routes:
+        - learned
+    - id: 67
+      rd: 145.245.21.0:67
+      route_targets:
+        both:
+          - 145.245.21.0:67
+      no_redistribute_routes:
+        - learned
   vrfs:
 ## Tenant_A ##
     - name: TENANT_A_PROJECT01

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -309,40 +309,47 @@ router bgp {{ router_bgp.as }}
 {%         endif %}
 {%     endfor %}
 {# L2VPNs - (vxlan) vlan based #}
-{%     for vlan in router_bgp.vlans | arista.avd.convert_dicts('id') | arista.avd.natural_sort('id') %}
+{%     if router_bgp.vlans is arista.avd.defined %}
+{# Force the ids to be string to follow the same ordering as on EOS #}
+{%         set bgp_vlans = router_bgp.vlans | arista.avd.convert_dicts('id') %}
+{%         for bgp_vlan in bgp_vlans %}
+{%             do bgp_vlan.update({"id": bgp_vlan['id'] | string}) %}
+{%         endfor %}
+{%         for vlan in bgp_vlans | sort(attribute="id") %}
    !
    vlan {{ vlan.id }}
-{%         if vlan.rd is arista.avd.defined %}
+{%             if vlan.rd is arista.avd.defined %}
       rd {{ vlan.rd }}
-{%         endif %}
-{%         if vlan.rd_evpn_domain.domain is arista.avd.defined and vlan.rd_evpn_domain.rd is arista.avd.defined %}
+{%             endif %}
+{%             if vlan.rd_evpn_domain.domain is arista.avd.defined and vlan.rd_evpn_domain.rd is arista.avd.defined %}
       rd evpn domain {{ vlan.rd_evpn_domain.domain }} {{ vlan.rd_evpn_domain.rd }}
-{%         endif %}
-{%         for route_target in vlan.route_targets.both | arista.avd.natural_sort %}
+{%             endif %}
+{%             for route_target in vlan.route_targets.both | arista.avd.natural_sort %}
       route-target both {{ route_target }}
-{%         endfor %}
-{%         for route_target in vlan.route_targets.import | arista.avd.natural_sort %}
+{%             endfor %}
+{%             for route_target in vlan.route_targets.import | arista.avd.natural_sort %}
       route-target import {{ route_target }}
-{%         endfor %}
-{%         for route_target in vlan.route_targets.export | arista.avd.natural_sort %}
+{%             endfor %}
+{%             for route_target in vlan.route_targets.export | arista.avd.natural_sort %}
       route-target export {{ route_target }}
-{%         endfor %}
-{%         for route_target in vlan.route_targets.import_evpn_domains | arista.avd.natural_sort %}
+{%             endfor %}
+{%             for route_target in vlan.route_targets.import_evpn_domains | arista.avd.natural_sort %}
       route-target import evpn domain {{ route_target.domain }} {{ route_target.route_target }}
-{%         endfor %}
-{%         for route_target in vlan.route_targets.export_evpn_domains | arista.avd.natural_sort %}
+{%             endfor %}
+{%             for route_target in vlan.route_targets.export_evpn_domains | arista.avd.natural_sort %}
       route-target export evpn domain {{ route_target.domain }} {{ route_target.route_target }}
-{%         endfor %}
-{%         for route_target in vlan.route_targets.import_export_evpn_domains | arista.avd.natural_sort %}
+{%             endfor %}
+{%             for route_target in vlan.route_targets.import_export_evpn_domains | arista.avd.natural_sort %}
       route-target import export evpn domain {{ route_target.domain }} {{ route_target.route_target }}
-{%         endfor %}
-{%         for redistribute_route in vlan.redistribute_routes | arista.avd.natural_sort %}
+{%             endfor %}
+{%             for redistribute_route in vlan.redistribute_routes | arista.avd.natural_sort %}
       redistribute {{ redistribute_route }}
-{%         endfor %}
-{%         for no_redistribute_route in vlan.no_redistribute_routes | arista.avd.natural_sort %}
+{%             endfor %}
+{%             for no_redistribute_route in vlan.no_redistribute_routes | arista.avd.natural_sort %}
       no redistribute {{ no_redistribute_route }}
+{%             endfor %}
 {%         endfor %}
-{%     endfor %}
+{%     endif %}
 {# vxlan vlan aware bundles #}
 {%     for vlan_aware_bundle in router_bgp.vlan_aware_bundles | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
    !


### PR DESCRIPTION
## Change Summary

* EOS prints the vlans in alphabetical order under `router bgp` and this
  commit allows to mimick this behavior
* The commit does not change the order of the VLAN in the documentation
  where it is clearer to have the VLAN in numerical order
* This implies a different output between the documenation table and the
  generated yaml file

## Related Issue(s)


Fixes #1605

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

As described in the issue, change the template for eos config generation to follow the same logic as EOS. This implies converting explicitely all the `vlan.id` to strings

## How to test

molecule

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
