### PR TITLE
CI: move j2lint check to pre-commit

### DIFF
--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -391,18 +391,3 @@ jobs:
         with:
           name: importer-logs
           path: ./importer_result.json
-
-  j2lint:
-    name: Validate j2 files
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-        timeout-minutes: 2
-      - name: Setup J2Lint
-        timeout-minutes: 2
-        run: |
-          pip install git+https://github.com/aristanetworks/j2lint.git
-      - name: Run J2lint
-        timeout-minutes: 2
-        run: |
-          j2lint $GITHUB_WORKSPACE

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,3 +45,8 @@ repos:
         language: python
         types: [file, yaml]
         args: [--strict, -c=.github/yamllintrc]
+
+  - repo: https://github.com/aristanetworks/j2lint.git
+    rev: "v0.1.0-alpha"
+    hooks:
+      - id: j2lint


### PR DESCRIPTION
## Change Summary

Move j2lint check to pre-commit leveraging the `v0.1.0-alpha` tag

## Related Issue(s)

Fixes #1869 aristanetworks/avd-internal#25

## Component(s) name

`ci`

## How to test

* Pipeline running j2ilnt as part of pre-commit
* locally running the new pre-commit hook

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
