### PR TITLE
Fix(eos_designs): remove the need for mgmt_gateway

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/no_mgmt_interface.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/no_mgmt_interface.cfg
@@ -1,0 +1,26 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname no_mgmt_interface
+!
+no enable password
+no aaa root
+!
+vrf instance MGMT
+!
+ip routing
+no ip routing vrf MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/no_mgmt_interface.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/no_mgmt_interface.yml
@@ -1,0 +1,16 @@
+service_routing_protocols_model: multi-agent
+ip_routing: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+vrfs:
+  MGMT:
+    ip_routing: false
+management_api_http:
+  enable_vrfs:
+    MGMT: {}
+  enable_https: true
+ip_igmp_snooping:
+  globally_enabled: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/no_mgmt_interface.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/no_mgmt_interface.yml
@@ -1,0 +1,7 @@
+# Minimum config to only test the specific feature.
+type: l2leaf
+l2leaf:
+  defaults:
+  nodes:
+    no_mgmt_interface:
+      id: 105

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
@@ -243,3 +243,7 @@ all:
               children:
                 MH_LEAFS_TESTS:
                 MH_L2LEAFS_TESTS:
+
+        ISOLATED_HOSTS:
+          hosts:
+            no_mgmt_interface:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/inventory/host_vars/no_mgmt_interface.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/inventory/host_vars/no_mgmt_interface.yml
@@ -1,0 +1,7 @@
+# Minimum config to only test the specific feature.
+type: l2leaf
+l2leaf:
+  defaults:
+  nodes:
+    no_mgmt_interface:
+      id: 105

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/inventory/hosts.yml
@@ -130,3 +130,7 @@ all:
               children:
                 MH_LEAFS_TESTS:
                 MH_L2LEAFS_TESTS:
+
+      ISOLATED_HOSTS:
+        hosts:
+          no_mgmt_interface:

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/management-settings-v4.0.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/management-settings-v4.0.md
@@ -53,7 +53,7 @@ terminattr_smashexcludes: "< smash excludes | default -> ale,flexCounter,hardwar
 terminattr_ingestexclude: "< ingest excludes | default -> /Sysdb/cell/1/agent,/Sysdb/cell/2/agent >"
 terminattr_disable_aaa: "< boolean | default -> false >"
 
-# Management interface configuration | Required
+# Management interface configuration | Optional
 mgmt_vrf_routing: < boolean | default -> false >
 mgmt_interface: < mgmt_interface | default -> Management1 >
 mgmt_interface_vrf: < vrf_name | default -> MGMT >

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/management-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/management-settings.md
@@ -53,7 +53,7 @@ terminattr_smashexcludes: "< smash excludes | default -> ale,flexCounter,hardwar
 terminattr_ingestexclude: "< ingest excludes | default -> /Sysdb/cell/1/agent,/Sysdb/cell/2/agent >"
 terminattr_disable_aaa: "< boolean | default -> false >"
 
-# Management interface configuration | Required
+# Management interface configuration | Optional
 mgmt_vrf_routing: < boolean | default -> false >
 mgmt_interface: < mgmt_interface | default -> Management1 >
 mgmt_interface_vrf: < vrf_name | default -> MGMT >

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/base/static-routes.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/base/static-routes.j2
@@ -1,12 +1,14 @@
 static_routes:
-{% if mgmt_destination_networks is arista.avd.defined and mgmt_destination_networks | length > 0 %}
-{%     for mgmt_destination_network in mgmt_destination_networks %}
+{% if mgmt_gateway is arista.avd.defined %}
+{%     if mgmt_destination_networks is arista.avd.defined and mgmt_destination_networks | length > 0 %}
+{%         for mgmt_destination_network in mgmt_destination_networks %}
   - vrf: {{ mgmt_interface_vrf }}
     destination_address_prefix: {{ mgmt_destination_network }}
     gateway: {{ mgmt_gateway }}
-{%     endfor %}
-{% else %}
+{%         endfor %}
+{%     else %}
   - vrf: {{ mgmt_interface_vrf }}
     destination_address_prefix: 0.0.0.0/0
     gateway: {{ mgmt_gateway }}
+{%     endif %}
 {% endif %}


### PR DESCRIPTION
## Change Summary

This PR relax the need for a `mgmt_gateway`. Currently the behavior is that `eos_designs` will still try to install a static default route to the `mgmt_gateway` even if it is not defined.

Note: however the default behavior is still to configure a default `MGMT` vrf so this PR may need some more adjustments.

## Related Issue(s)

Fixes #1886 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

in the `eos_designs/template/base/static-routes.j2`, attempt to install a default mgmt route only if `mgmt_gateway` is defined.

## How to test

molecule with a new device `no_mgmt_interface`

## Checklist

### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
