### PR TITLE
Feat(eos_cli_config_gen): add support for logging event congestion-drops

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -303,6 +303,7 @@ interface Ethernet5
 interface Ethernet6
    description SRV-POD02_Eth1
    logging event link-status
+   logging event congestion-drops
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
    switchport
@@ -379,6 +380,7 @@ interface Ethernet12
 interface Ethernet13
    description interface_in_mode_access_with_voice
    no logging event link-status
+   no logging event congestion-drops
    switchport trunk native vlan 100
    switchport phone vlan 70
    switchport phone trunk untagged

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
@@ -91,6 +91,7 @@ interface Ethernet5
 interface Ethernet6
    description SRV-POD02_Eth1
    logging event link-status
+   logging event congestion-drops
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
    switchport
@@ -167,6 +168,7 @@ interface Ethernet12
 interface Ethernet13
    description interface_in_mode_access_with_voice
    no logging event link-status
+   no logging event congestion-drops
    switchport trunk native vlan 100
    switchport phone vlan 70
    switchport phone trunk untagged

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
@@ -131,6 +131,7 @@ ethernet_interfaces:
     logging:
       event:
         link_status: true
+        congestion_drops: true
     peer: SRV-POD02
     peer_interface: Eth1
     peer_type: server
@@ -234,6 +235,7 @@ ethernet_interfaces:
     logging:
       event:
         link_status: false
+        congestion_drops: false
     description: interface_in_mode_access_with_voice
     type: switched
     native_vlan: 100

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/ethernet-interfaces.md
@@ -279,6 +279,7 @@ interface Ethernet5
 interface Ethernet6
    description SRV-POD02_Eth1
    logging event link-status
+   logging event congestion-drops
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
    switchport
@@ -355,6 +356,7 @@ interface Ethernet12
 interface Ethernet13
    description interface_in_mode_access_with_voice
    no logging event link-status
+   no logging event congestion-drops
    switchport trunk native vlan 100
    switchport phone vlan 70
    switchport phone trunk untagged

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/ethernet-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/ethernet-interfaces.cfg
@@ -87,6 +87,7 @@ interface Ethernet5
 interface Ethernet6
    description SRV-POD02_Eth1
    logging event link-status
+   logging event congestion-drops
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
    switchport
@@ -163,6 +164,7 @@ interface Ethernet12
 interface Ethernet13
    description interface_in_mode_access_with_voice
    no logging event link-status
+   no logging event congestion-drops
    switchport trunk native vlan 100
    switchport phone vlan 70
    switchport phone trunk untagged

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/ethernet-interfaces.yml
@@ -127,6 +127,7 @@ ethernet_interfaces:
     logging:
       event:
         link_status: true
+        congestion_drops: true
     peer: SRV-POD02
     peer_interface: Eth1
     peer_type: server
@@ -230,6 +231,7 @@ ethernet_interfaces:
     logging:
       event:
         link_status: false
+        congestion_drops: false
     description: interface_in_mode_access_with_voice
     type: switched
     native_vlan: 100

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1032,7 +1032,7 @@ ethernet_interfaces:
     logging:
       event:
         link_status: < true | false >
-        congestion_drops: < true | false >  # not supported on vEOS-lab
+        congestion_drops: < true | false >
     lldp:
       transmit: < true | false >
       receive: < true | false >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1032,6 +1032,7 @@ ethernet_interfaces:
     logging:
       event:
         link_status: < true | false >
+        congestion_drops: < true | false >  # not supported on vEOS-lab
     lldp:
       transmit: < true | false >
       receive: < true | false >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
@@ -932,7 +932,7 @@ ethernet_interfaces:
     logging:
       event:
         link_status: < true | false >
-        congestion_drops: < true | false >  # not supported on vEOS-lab
+        congestion_drops: < true | false >
     lldp:
       transmit: < true | false >
       receive: < true | false >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
@@ -932,6 +932,7 @@ ethernet_interfaces:
     logging:
       event:
         link_status: < true | false >
+        congestion_drops: < true | false >  # not supported on vEOS-lab
     lldp:
       transmit: < true | false >
       receive: < true | false >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -32,15 +32,17 @@ interface {{ ethernet_interface.name }}
    mtu {{ ethernet_interface.mtu }}
 {%         endif %}
 {%     endif %}
-{%     if ethernet_interface.logging.event.link_status is arista.avd.defined(true) %}
+{%     if ethernet_interface.logging.event is arista.avd.defined %}
+{%         if ethernet_interface.logging.event.link_status is arista.avd.defined(true) %}
    logging event link-status
-{%     elif ethernet_interface.logging.event.link_status is arista.avd.defined(false) %}
+{%         elif ethernet_interface.logging.event.link_status is arista.avd.defined(false) %}
    no logging event link-status
-{%     endif %}
-{%     if ethernet_interface.logging.event.congestion_drops is arista.avd.defined(true) %}
+{%         endif %}
+{%         if ethernet_interface.logging.event.congestion_drops is arista.avd.defined(true) %}
    logging event congestion-drops
-{%     elif ethernet_interface.logging.event.congestion_drops is arista.avd.defined(false) %}
+{%         elif ethernet_interface.logging.event.congestion_drops is arista.avd.defined(false) %}
    no logging event congestion-drops
+{%         endif %}
 {%     endif %}
 {%     if print_ethernet is arista.avd.defined(true) %}
 {%         if ethernet_interface.flowcontrol.received is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -37,6 +37,11 @@ interface {{ ethernet_interface.name }}
 {%     elif ethernet_interface.logging.event.link_status is arista.avd.defined(false) %}
    no logging event link-status
 {%     endif %}
+{%     if ethernet_interface.logging.event.congestion_drops is arista.avd.defined(true) %}
+   logging event congestion-drops
+{%     elif ethernet_interface.logging.event.congestion_drops is arista.avd.defined(false) %}
+   no logging event congestion-drops
+{%     endif %}
 {%     if print_ethernet is arista.avd.defined(true) %}
 {%         if ethernet_interface.flowcontrol.received is arista.avd.defined %}
    flowcontrol receive {{ ethernet_interface.flowcontrol.received }}


### PR DESCRIPTION
## Change Summary

Add the support for logging event congestion-drops for ethernet interfaces

Does not implement it for port-channels as it looks not supported

## Related Issue(s)

Fixes #1929 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

added the following to eos_cli_config_gen/templates/eos/ethernet-interfaces.j2 

```
{%     if ethernet_interface.logging.event.congestion_drops is arista.avd.defined(true) %}
   logging event congestion-drops
{%     elif ethernet_interface.logging.event.congestion_drops is arista.avd.defined(false) %}
   no logging event congestion-drops
{%     endif %}
```

## How to test
molecule tests for eos_cli_config_gen

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
