### PR TITLE
Doc(eos_designs): change adapters.mode to Optional

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_designs/doc/connected-endpoints-v4.0.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/connected-endpoints-v4.0.md
@@ -100,31 +100,31 @@ port_profiles:
         # Adapter speed - if not specified will be auto.
       - speed: < interface_speed | forced interface_speed | auto interface_speed >
 
-        # Local endpoint port(s) | required
+        # Local endpoint port(s) | Required
         endpoint_ports: [ < interface_name > ]
 
-        # List of port(s) connected to switches | required
+        # List of port(s) connected to switches | Required
         switch_ports: [ < switchport_interface > ]
 
-        # List of switch(es) | required
+        # List of switch(es) | Required
         switches: [ < device > ]
 
         # Port-profile name, to inherit configuration.
         profile: < port_profile_name >
 
-        # Administrative state | optional - default is true
+        # Administrative state | Optional - default is true
         # setting to false will set port to 'shutdown' in intended configuration
         enabled: < true | false >
 
-        # Interface mode | required
+        # Interface mode | Optional
         mode: < access | dot1q-tunnel | trunk >
 
-        # Native VLAN for a trunk port | optional
+        # Native VLAN for a trunk port | Optional
         # If setting both native_vlan and native_vlan_tag, native_vlan_tag takes precedence
         native_vlan: < native_vlan_number >
         native_vlan_tag: < boolean | default -> false >
 
-        # Interface vlans | required
+        # Interface vlans | Required
         vlans: < vlans as string >
 
         # Spanning Tree
@@ -210,7 +210,7 @@ port_profiles:
           # Port-Channel Description.
           description: < port_channel_description >
 
-          # Port-Channel administrative state | optional - default is true
+          # Port-Channel administrative state | Optional - default is true
           # setting to false will set port to 'shutdown' in intended configuration
           enabled: < true | false >
 

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/connected-endpoints.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/connected-endpoints.md
@@ -73,7 +73,7 @@ Both data models support variable inheritance from profiles defined under [`port
         # setting to false will set port to 'shutdown' in intended configuration
         enabled: < true | false >
 
-        # Interface mode | Required
+        # Interface mode | Optional
         mode: < access | dot1q-tunnel | trunk >
 
         # MTU | Optional


### PR DESCRIPTION
## Change Summary

cf issue

## Related Issue(s)

Fixes #1936 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

```diff
-        # Interface mode | required
+        # Interface mode | Optional
         mode: < access | dot1q-tunnel | trunk >
```

## How to test
No test - already the current behavior.

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
