### PR TITLE
Feat(eos_designs): Add none as a valid value for underlay and underlay protocol

### DIFF
--- a/ansible_collections/arista/avd/plugins/module_utils/eos_designs_facts.py
+++ b/ansible_collections/arista/avd/plugins/module_utils/eos_designs_facts.py
@@ -574,7 +574,7 @@ class EosDesignsFacts:
     @cached_property
     def overlay_routing_protocol(self):
         overlay_routing_protocol = str(get(self._hostvars, "overlay_routing_protocol", default=self.default_overlay_routing_protocol)).lower()
-        if overlay_routing_protocol not in ['ebgp', 'ibgp']:
+        if overlay_routing_protocol not in ['ebgp', 'ibgp', 'none']:
             overlay_routing_protocol = self.default_overlay_routing_protocol
         return overlay_routing_protocol
 

--- a/ansible_collections/arista/avd/plugins/module_utils/eos_designs_facts.py
+++ b/ansible_collections/arista/avd/plugins/module_utils/eos_designs_facts.py
@@ -574,7 +574,7 @@ class EosDesignsFacts:
     @cached_property
     def overlay_routing_protocol(self):
         overlay_routing_protocol = str(get(self._hostvars, "overlay_routing_protocol", default=self.default_overlay_routing_protocol)).lower()
-        if overlay_routing_protocol not in ['ebgp', 'ibgp', 'none']:
+        if overlay_routing_protocol not in ['ebgp', 'ibgp']:
             overlay_routing_protocol = self.default_overlay_routing_protocol
         return overlay_routing_protocol
 

--- a/ansible_collections/arista/avd/plugins/module_utils/eos_designs_facts.py
+++ b/ansible_collections/arista/avd/plugins/module_utils/eos_designs_facts.py
@@ -567,14 +567,14 @@ class EosDesignsFacts:
     @cached_property
     def underlay_routing_protocol(self):
         underlay_routing_protocol = str(get(self._hostvars, "underlay_routing_protocol", default=self.default_underlay_routing_protocol)).lower()
-        if underlay_routing_protocol not in ['ebgp', 'isis', 'isis-ldp', 'isis-sr', 'isis-sr-ldp', 'ospf', 'ospf-ldp']:
+        if underlay_routing_protocol not in ['ebgp', 'isis', 'isis-ldp', 'isis-sr', 'isis-sr-ldp', 'ospf', 'ospf-ldp', 'none']:
             underlay_routing_protocol = self.default_underlay_routing_protocol
         return underlay_routing_protocol
 
     @cached_property
     def overlay_routing_protocol(self):
         overlay_routing_protocol = str(get(self._hostvars, "overlay_routing_protocol", default=self.default_overlay_routing_protocol)).lower()
-        if overlay_routing_protocol not in ['ebgp', 'ibgp']:
+        if overlay_routing_protocol not in ['ebgp', 'ibgp', 'none']:
             overlay_routing_protocol = self.default_overlay_routing_protocol
         return overlay_routing_protocol
 

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-variables.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-variables.md
@@ -9,16 +9,17 @@
   - ISIS-LDP*.
   - ISIS-SR-LDP*.
   - OSPF-LDP*.
-  - none (for use with l2ls)**.
+  - none**.
 - The following overlay routing protocols are supported:
   - EBGP (default for l3ls-evpn)
   - IBGP (only with OSPF or ISIS variants in underlay)
+  - none**
 - Only summary network addresses need to be defined. IP addresses are then assigned to each node, based on its unique device id.
   - To view IP address allocation and consumption, a summary is provided in the auto-generated fabric documentation in Markdown and CSV format.
 
 *Only supported with core_interfaces data model.
 
-** For use with design type l2ls
+** For use with design type "l2ls" or other designs where there is no requirement for a routing protocol for underlay and/or overlay on l3 devices.
 
 ## Flagging a Device as Not Deployed
 

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-variables.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-variables.md
@@ -9,6 +9,7 @@
   - ISIS-LDP*.
   - ISIS-SR-LDP*.
   - OSPF-LDP*.
+  - none (for use with l2ls)**.
 - The following overlay routing protocols are supported:
   - EBGP (default for l3ls-evpn)
   - IBGP (only with OSPF or ISIS variants in underlay)
@@ -16,6 +17,7 @@
   - To view IP address allocation and consumption, a summary is provided in the auto-generated fabric documentation in Markdown and CSV format.
 
 *Only supported with core_interfaces data model.
+** For use with design type l2ls
 
 ## Flagging a Device as Not Deployed
 
@@ -41,8 +43,8 @@ Note: The variables should be applied to all devices in the fabric.
 shutdown_interfaces_towards_undeployed_peers: < true | false | default -> false >
 
 # Underlay routing protocol | Required.
-underlay_routing_protocol: < EBGP | OSPF | ISIS | ISIS-SR | ISIS-LDP | ISIS-SR-LDP | OSPF-LDP | default for l3ls-evpn -> EBGP >
-overlay_routing_protocol: < EBGP | IBGP | default for l3ls-evpn -> EBGP >
+underlay_routing_protocol: < EBGP | OSPF | ISIS | ISIS-SR | ISIS-LDP | ISIS-SR-LDP | OSPF-LDP | none | default for l3ls-evpn -> EBGP >
+overlay_routing_protocol: < EBGP | IBGP | none | default for l3ls-evpn -> EBGP >
 
 # Point to Point Underlay with RFC 5549(eBGP), i.e. IPv6 Unnumbered.
 # Requires "underlay_routing_protocol: EBGP"

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-variables.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-variables.md
@@ -17,6 +17,7 @@
   - To view IP address allocation and consumption, a summary is provided in the auto-generated fabric documentation in Markdown and CSV format.
 
 *Only supported with core_interfaces data model.
+
 ** For use with design type l2ls
 
 ## Flagging a Device as Not Deployed


### PR DESCRIPTION
## Change Summary

Add `none` as a valid value for underlay and underlay protocol to support Design Type: L2LS.

## Related Issue(s)

Fixes #[29](https://github.com/aristanetworks/avd-internal/issues/29)

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Update eos_design_facts.py by adding none to the list of valid values for both underlay and overlay protocols.
```python
    @cached_property
    def underlay_routing_protocol(self):
        underlay_routing_protocol = str(get(self._hostvars, "underlay_routing_protocol", default=self.default_underlay_routing_protocol)).lower()
        if underlay_routing_protocol not in ['ebgp', 'isis', 'isis-ldp', 'isis-sr', 'isis-sr-ldp', 'ospf', 'ospf-ldp', 'none']:
            underlay_routing_protocol = self.default_underlay_routing_protocol
        return underlay_routing_protocol

    @cached_property
    def overlay_routing_protocol(self):
        overlay_routing_protocol = str(get(self._hostvars, "overlay_routing_protocol", default=self.default_overlay_routing_protocol)).lower()
        if overlay_routing_protocol not in ['ebgp', 'ibgp', 'none']:
            overlay_routing_protocol = self.default_overlay_routing_protocol
        return overlay_routing_protocol
```

## How to test
molecule converge -s eos_design_unit_tests
no errors

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
