### PR TITLE
Fix(eos_designs): fix logic for underlay_multicast

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L2LEAF1A.cfg
@@ -1,0 +1,46 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname UNDERLAY-MULTICAST-L2LEAF1A
+!
+no enable password
+no aaa root
+!
+vrf instance MGMT
+!
+interface Port-Channel1
+   description DC1_LEAF1_Po6
+   no shutdown
+   switchport
+   switchport trunk allowed vlan none
+   switchport mode trunk
+!
+interface Ethernet1
+   description UNDERLAY-MULTICAST-L3LEAF1A_Ethernet6
+   no shutdown
+   channel-group 1 mode active
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.200.109/24
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.200.5
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF1A.cfg
@@ -8,9 +8,7 @@ service routing protocols model multi-agent
 !
 hostname UNDERLAY-MULTICAST-L3LEAF1A
 !
-spanning-tree mode mstp
 no spanning-tree vlan-id 4093-4094
-spanning-tree mst 0 priority 4096
 !
 no enable password
 no aaa root
@@ -34,6 +32,14 @@ interface Port-Channel3
    switchport trunk group LEAF_PEER_L3
    switchport trunk group MLAG
 !
+interface Port-Channel6
+   description UNDERLAY-MULTICAST-L2LEAF1A_Po1
+   no shutdown
+   switchport
+   switchport trunk allowed vlan none
+   switchport mode trunk
+   mlag 6
+!
 interface Ethernet1
    description P2P_LINK_TO_UNDERLAY-MULTICAST-SPINE1_Ethernet1
    no shutdown
@@ -41,6 +47,13 @@ interface Ethernet1
    no switchport
    ip address 172.31.255.1/31
    pim ipv4 sparse-mode
+!
+interface Ethernet2
+   description P2P_LINK_TO_UNDERLAY-MULTICAST-SPINE2_Ethernet1
+   no shutdown
+   mtu 9000
+   no switchport
+   ip address 172.31.255.3/31
 !
 interface Ethernet3
    description MLAG_PEER_UNDERLAY-MULTICAST-L3LEAF1B_Ethernet3
@@ -51,6 +64,11 @@ interface Ethernet4
    description MLAG_PEER_UNDERLAY-MULTICAST-L3LEAF1B_Ethernet4
    no shutdown
    channel-group 3 mode active
+!
+interface Ethernet6
+   description UNDERLAY-MULTICAST-L2LEAF1A_Ethernet1
+   no shutdown
+   channel-group 6 mode active
 !
 interface Loopback0
    description EVPN_Overlay_Peering
@@ -141,9 +159,15 @@ router bgp 65101
    neighbor 172.31.255.0 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.31.255.0 remote-as 65001
    neighbor 172.31.255.0 description UNDERLAY-MULTICAST-SPINE1_Ethernet1
+   neighbor 172.31.255.2 peer group IPv4-UNDERLAY-PEERS
+   neighbor 172.31.255.2 remote-as 65001
+   neighbor 172.31.255.2 description UNDERLAY-MULTICAST-SPINE2_Ethernet1
    neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS
    neighbor 192.168.255.1 remote-as 65001
    neighbor 192.168.255.1 description UNDERLAY-MULTICAST-SPINE1
+   neighbor 192.168.255.2 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.2 remote-as 65001
+   neighbor 192.168.255.2 description UNDERLAY-MULTICAST-SPINE2
    redistribute connected route-map RM-CONN-2-BGP
    !
    address-family evpn

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF1B.cfg
@@ -8,9 +8,7 @@ service routing protocols model multi-agent
 !
 hostname UNDERLAY-MULTICAST-L3LEAF1B
 !
-spanning-tree mode mstp
 no spanning-tree vlan-id 4093-4094
-spanning-tree mst 0 priority 4096
 !
 no enable password
 no aaa root
@@ -39,8 +37,15 @@ interface Ethernet1
    no shutdown
    mtu 9000
    no switchport
-   ip address 172.31.255.3/31
+   ip address 172.31.255.5/31
    pim ipv4 sparse-mode
+!
+interface Ethernet2
+   description P2P_LINK_TO_UNDERLAY-MULTICAST-SPINE2_Ethernet2
+   no shutdown
+   mtu 9000
+   no switchport
+   ip address 172.31.255.7/31
 !
 interface Ethernet3
    description MLAG_PEER_UNDERLAY-MULTICAST-L3LEAF1A_Ethernet3
@@ -138,12 +143,18 @@ router bgp 65101
    neighbor MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN in
    neighbor 10.255.251.0 peer group MLAG-IPv4-UNDERLAY-PEER
    neighbor 10.255.251.0 description UNDERLAY-MULTICAST-L3LEAF1A
-   neighbor 172.31.255.2 peer group IPv4-UNDERLAY-PEERS
-   neighbor 172.31.255.2 remote-as 65001
-   neighbor 172.31.255.2 description UNDERLAY-MULTICAST-SPINE1_Ethernet2
+   neighbor 172.31.255.4 peer group IPv4-UNDERLAY-PEERS
+   neighbor 172.31.255.4 remote-as 65001
+   neighbor 172.31.255.4 description UNDERLAY-MULTICAST-SPINE1_Ethernet2
+   neighbor 172.31.255.6 peer group IPv4-UNDERLAY-PEERS
+   neighbor 172.31.255.6 remote-as 65001
+   neighbor 172.31.255.6 description UNDERLAY-MULTICAST-SPINE2_Ethernet2
    neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS
    neighbor 192.168.255.1 remote-as 65001
    neighbor 192.168.255.1 description UNDERLAY-MULTICAST-SPINE1
+   neighbor 192.168.255.2 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.2 remote-as 65001
+   neighbor 192.168.255.2 description UNDERLAY-MULTICAST-SPINE2
    redistribute connected route-map RM-CONN-2-BGP
    !
    address-family evpn

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF2A.cfg
@@ -8,9 +8,7 @@ service routing protocols model multi-agent
 !
 hostname UNDERLAY-MULTICAST-L3LEAF2A
 !
-spanning-tree mode mstp
 no spanning-tree vlan-id 4094
-spanning-tree mst 0 priority 4096
 !
 no enable password
 no aaa root
@@ -35,8 +33,15 @@ interface Ethernet1
    no shutdown
    mtu 9000
    no switchport
-   ip address 172.31.255.5/31
+   ip address 172.31.255.9/31
    pim ipv4 sparse-mode
+!
+interface Ethernet2
+   description P2P_LINK_TO_UNDERLAY-MULTICAST-SPINE2_Ethernet3
+   no shutdown
+   mtu 9000
+   no switchport
+   ip address 172.31.255.11/31
 !
 interface Ethernet3
    description MLAG_PEER_UNDERLAY-MULTICAST-L3LEAF2B_Ethernet3
@@ -128,12 +133,18 @@ router bgp 65102
    neighbor MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN in
    neighbor 10.255.252.5 peer group MLAG-IPv4-UNDERLAY-PEER
    neighbor 10.255.252.5 description UNDERLAY-MULTICAST-L3LEAF2B
-   neighbor 172.31.255.4 peer group IPv4-UNDERLAY-PEERS
-   neighbor 172.31.255.4 remote-as 65001
-   neighbor 172.31.255.4 description UNDERLAY-MULTICAST-SPINE1_Ethernet3
+   neighbor 172.31.255.8 peer group IPv4-UNDERLAY-PEERS
+   neighbor 172.31.255.8 remote-as 65001
+   neighbor 172.31.255.8 description UNDERLAY-MULTICAST-SPINE1_Ethernet3
+   neighbor 172.31.255.10 peer group IPv4-UNDERLAY-PEERS
+   neighbor 172.31.255.10 remote-as 65001
+   neighbor 172.31.255.10 description UNDERLAY-MULTICAST-SPINE2_Ethernet3
    neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS
    neighbor 192.168.255.1 remote-as 65001
    neighbor 192.168.255.1 description UNDERLAY-MULTICAST-SPINE1
+   neighbor 192.168.255.2 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.2 remote-as 65001
+   neighbor 192.168.255.2 description UNDERLAY-MULTICAST-SPINE2
    redistribute connected route-map RM-CONN-2-BGP
    !
    address-family evpn

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF2B.cfg
@@ -8,9 +8,7 @@ service routing protocols model multi-agent
 !
 hostname UNDERLAY-MULTICAST-L3LEAF2B
 !
-spanning-tree mode mstp
 no spanning-tree vlan-id 4094
-spanning-tree mst 0 priority 4096
 !
 no enable password
 no aaa root
@@ -35,8 +33,15 @@ interface Ethernet1
    no shutdown
    mtu 9000
    no switchport
-   ip address 172.31.255.7/31
+   ip address 172.31.255.13/31
    pim ipv4 sparse-mode
+!
+interface Ethernet2
+   description P2P_LINK_TO_UNDERLAY-MULTICAST-SPINE2_Ethernet4
+   no shutdown
+   mtu 9000
+   no switchport
+   ip address 172.31.255.15/31
 !
 interface Ethernet3
    description MLAG_PEER_UNDERLAY-MULTICAST-L3LEAF2A_Ethernet3
@@ -128,12 +133,18 @@ router bgp 65102
    neighbor MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN in
    neighbor 10.255.252.4 peer group MLAG-IPv4-UNDERLAY-PEER
    neighbor 10.255.252.4 description UNDERLAY-MULTICAST-L3LEAF2A
-   neighbor 172.31.255.6 peer group IPv4-UNDERLAY-PEERS
-   neighbor 172.31.255.6 remote-as 65001
-   neighbor 172.31.255.6 description UNDERLAY-MULTICAST-SPINE1_Ethernet4
+   neighbor 172.31.255.12 peer group IPv4-UNDERLAY-PEERS
+   neighbor 172.31.255.12 remote-as 65001
+   neighbor 172.31.255.12 description UNDERLAY-MULTICAST-SPINE1_Ethernet4
+   neighbor 172.31.255.14 peer group IPv4-UNDERLAY-PEERS
+   neighbor 172.31.255.14 remote-as 65001
+   neighbor 172.31.255.14 description UNDERLAY-MULTICAST-SPINE2_Ethernet4
    neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS
    neighbor 192.168.255.1 remote-as 65001
    neighbor 192.168.255.1 description UNDERLAY-MULTICAST-SPINE1
+   neighbor 192.168.255.2 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.2 remote-as 65001
+   neighbor 192.168.255.2 description UNDERLAY-MULTICAST-SPINE2
    redistribute connected route-map RM-CONN-2-BGP
    !
    address-family evpn

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-SPINE2.cfg
@@ -6,7 +6,7 @@ transceiver qsfp default-mode 4x10G
 !
 service routing protocols model multi-agent
 !
-hostname UNDERLAY-MULTICAST-SPINE1
+hostname UNDERLAY-MULTICAST-SPINE2
 !
 spanning-tree mode none
 !
@@ -16,47 +16,43 @@ no aaa root
 vrf instance MGMT
 !
 interface Ethernet1
-   description P2P_LINK_TO_UNDERLAY-MULTICAST-L3LEAF1A_Ethernet1
+   description P2P_LINK_TO_UNDERLAY-MULTICAST-L3LEAF1A_Ethernet2
    no shutdown
    mtu 9000
    no switchport
-   ip address 172.31.255.0/31
-   pim ipv4 sparse-mode
+   ip address 172.31.255.2/31
 !
 interface Ethernet2
-   description P2P_LINK_TO_UNDERLAY-MULTICAST-L3LEAF1B_Ethernet1
+   description P2P_LINK_TO_UNDERLAY-MULTICAST-L3LEAF1B_Ethernet2
    no shutdown
    mtu 9000
    no switchport
-   ip address 172.31.255.4/31
-   pim ipv4 sparse-mode
+   ip address 172.31.255.6/31
 !
 interface Ethernet3
-   description P2P_LINK_TO_UNDERLAY-MULTICAST-L3LEAF2A_Ethernet1
+   description P2P_LINK_TO_UNDERLAY-MULTICAST-L3LEAF2A_Ethernet2
    no shutdown
    mtu 9000
    no switchport
-   ip address 172.31.255.8/31
-   pim ipv4 sparse-mode
+   ip address 172.31.255.10/31
 !
 interface Ethernet4
-   description P2P_LINK_TO_UNDERLAY-MULTICAST-L3LEAF2B_Ethernet1
+   description P2P_LINK_TO_UNDERLAY-MULTICAST-L3LEAF2B_Ethernet2
    no shutdown
    mtu 9000
    no switchport
-   ip address 172.31.255.12/31
-   pim ipv4 sparse-mode
+   ip address 172.31.255.14/31
 !
 interface Loopback0
    description EVPN_Overlay_Peering
    no shutdown
-   ip address 192.168.255.1/32
+   ip address 192.168.255.2/32
 !
 interface Management1
    description oob_management
    no shutdown
    vrf MGMT
-   ip address 192.168.200.101/24
+   ip address 192.168.200.102/24
 !
 ip routing
 no ip routing vrf MGMT
@@ -73,7 +69,7 @@ router bfd
    multihop interval 300 min-rx 300 multiplier 3
 !
 router bgp 65001
-   router-id 192.168.255.1
+   router-id 192.168.255.2
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
@@ -85,18 +81,18 @@ router bgp 65001
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
-   neighbor 172.31.255.1 peer group IPv4-UNDERLAY-PEERS
-   neighbor 172.31.255.1 remote-as 65101
-   neighbor 172.31.255.1 description UNDERLAY-MULTICAST-L3LEAF1A_Ethernet1
-   neighbor 172.31.255.5 peer group IPv4-UNDERLAY-PEERS
-   neighbor 172.31.255.5 remote-as 65101
-   neighbor 172.31.255.5 description UNDERLAY-MULTICAST-L3LEAF1B_Ethernet1
-   neighbor 172.31.255.9 peer group IPv4-UNDERLAY-PEERS
-   neighbor 172.31.255.9 remote-as 65102
-   neighbor 172.31.255.9 description UNDERLAY-MULTICAST-L3LEAF2A_Ethernet1
-   neighbor 172.31.255.13 peer group IPv4-UNDERLAY-PEERS
-   neighbor 172.31.255.13 remote-as 65102
-   neighbor 172.31.255.13 description UNDERLAY-MULTICAST-L3LEAF2B_Ethernet1
+   neighbor 172.31.255.3 peer group IPv4-UNDERLAY-PEERS
+   neighbor 172.31.255.3 remote-as 65101
+   neighbor 172.31.255.3 description UNDERLAY-MULTICAST-L3LEAF1A_Ethernet2
+   neighbor 172.31.255.7 peer group IPv4-UNDERLAY-PEERS
+   neighbor 172.31.255.7 remote-as 65101
+   neighbor 172.31.255.7 description UNDERLAY-MULTICAST-L3LEAF1B_Ethernet2
+   neighbor 172.31.255.11 peer group IPv4-UNDERLAY-PEERS
+   neighbor 172.31.255.11 remote-as 65102
+   neighbor 172.31.255.11 description UNDERLAY-MULTICAST-L3LEAF2A_Ethernet2
+   neighbor 172.31.255.15 peer group IPv4-UNDERLAY-PEERS
+   neighbor 172.31.255.15 remote-as 65102
+   neighbor 172.31.255.15 description UNDERLAY-MULTICAST-L3LEAF2B_Ethernet2
    neighbor 192.168.255.3 peer group EVPN-OVERLAY-PEERS
    neighbor 192.168.255.3 remote-as 65101
    neighbor 192.168.255.3 description UNDERLAY-MULTICAST-L3LEAF1A
@@ -117,10 +113,6 @@ router bgp 65001
    address-family ipv4
       no neighbor EVPN-OVERLAY-PEERS activate
       neighbor IPv4-UNDERLAY-PEERS activate
-!
-router multicast
-   ipv4
-      routing
 !
 management api http-commands
    protocol https

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L2LEAF1A.yml
@@ -1,0 +1,46 @@
+static_routes:
+- vrf: MGMT
+  destination_address_prefix: 0.0.0.0/0
+  gateway: 192.168.200.5
+service_routing_protocols_model: multi-agent
+ip_routing: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+vrfs:
+  MGMT:
+    ip_routing: false
+management_interfaces:
+  Management1:
+    description: oob_management
+    shutdown: false
+    vrf: MGMT
+    ip_address: 192.168.200.109/24
+    gateway: 192.168.200.5
+    type: oob
+management_api_http:
+  enable_vrfs:
+    MGMT: {}
+  enable_https: true
+ethernet_interfaces:
+  Ethernet1:
+    peer: UNDERLAY-MULTICAST-L3LEAF1A
+    peer_interface: Ethernet6
+    peer_type: l3leaf
+    description: UNDERLAY-MULTICAST-L3LEAF1A_Ethernet6
+    type: switched
+    shutdown: false
+    channel_group:
+      id: 1
+      mode: active
+port_channel_interfaces:
+  Port-Channel1:
+    description: DC1_LEAF1_Po6
+    type: switched
+    shutdown: false
+    vlans: none
+    mode: trunk
+ip_igmp_snooping:
+  globally_enabled: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF1A.yml
@@ -39,9 +39,17 @@ router_bgp:
       peer_group: IPv4-UNDERLAY-PEERS
       remote_as: '65001'
       description: UNDERLAY-MULTICAST-SPINE1_Ethernet1
+    172.31.255.2:
+      peer_group: IPv4-UNDERLAY-PEERS
+      remote_as: '65001'
+      description: UNDERLAY-MULTICAST-SPINE2_Ethernet1
     192.168.255.1:
       peer_group: EVPN-OVERLAY-PEERS
       description: UNDERLAY-MULTICAST-SPINE1
+      remote_as: '65001'
+    192.168.255.2:
+      peer_group: EVPN-OVERLAY-PEERS
+      description: UNDERLAY-MULTICAST-SPINE2
       remote_as: '65001'
   redistribute_routes:
     connected:
@@ -64,12 +72,6 @@ vlan_internal_order:
   range:
     beginning: 1006
     ending: 1199
-spanning_tree:
-  mode: mstp
-  mst_instances:
-    '0':
-      priority: 4096
-  no_spanning_tree_vlan: 4093-4094
 vrfs:
   MGMT:
     ip_routing: false
@@ -85,6 +87,8 @@ management_api_http:
   enable_vrfs:
     MGMT: {}
   enable_https: true
+spanning_tree:
+  no_spanning_tree_vlan: 4093-4094
 vlans:
   4093:
     tenant: system
@@ -121,6 +125,13 @@ port_channel_interfaces:
     trunk_groups:
     - LEAF_PEER_L3
     - MLAG
+  Port-Channel6:
+    description: UNDERLAY-MULTICAST-L2LEAF1A_Po1
+    type: switched
+    shutdown: false
+    vlans: none
+    mode: trunk
+    mlag: 6
 ethernet_interfaces:
   Ethernet3:
     peer: UNDERLAY-MULTICAST-L3LEAF1B
@@ -154,6 +165,25 @@ ethernet_interfaces:
     pim:
       ipv4:
         sparse_mode: true
+  Ethernet2:
+    peer: UNDERLAY-MULTICAST-SPINE2
+    peer_interface: Ethernet1
+    peer_type: spine
+    description: P2P_LINK_TO_UNDERLAY-MULTICAST-SPINE2_Ethernet1
+    mtu: 9000
+    type: routed
+    shutdown: false
+    ip_address: 172.31.255.3/31
+  Ethernet6:
+    peer: UNDERLAY-MULTICAST-L2LEAF1A
+    peer_interface: Ethernet1
+    peer_type: l2leaf
+    description: UNDERLAY-MULTICAST-L2LEAF1A_Ethernet1
+    type: switched
+    shutdown: false
+    channel_group:
+      id: 6
+      mode: active
 mlag_configuration:
   domain_id: DC1_LEAF1
   local_interface: Vlan4094

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF1B.yml
@@ -35,13 +35,21 @@ router_bgp:
     10.255.251.0:
       peer_group: MLAG-IPv4-UNDERLAY-PEER
       description: UNDERLAY-MULTICAST-L3LEAF1A
-    172.31.255.2:
+    172.31.255.4:
       peer_group: IPv4-UNDERLAY-PEERS
       remote_as: '65001'
       description: UNDERLAY-MULTICAST-SPINE1_Ethernet2
+    172.31.255.6:
+      peer_group: IPv4-UNDERLAY-PEERS
+      remote_as: '65001'
+      description: UNDERLAY-MULTICAST-SPINE2_Ethernet2
     192.168.255.1:
       peer_group: EVPN-OVERLAY-PEERS
       description: UNDERLAY-MULTICAST-SPINE1
+      remote_as: '65001'
+    192.168.255.2:
+      peer_group: EVPN-OVERLAY-PEERS
+      description: UNDERLAY-MULTICAST-SPINE2
       remote_as: '65001'
   redistribute_routes:
     connected:
@@ -64,12 +72,6 @@ vlan_internal_order:
   range:
     beginning: 1006
     ending: 1199
-spanning_tree:
-  mode: mstp
-  mst_instances:
-    '0':
-      priority: 4096
-  no_spanning_tree_vlan: 4093-4094
 vrfs:
   MGMT:
     ip_routing: false
@@ -85,6 +87,8 @@ management_api_http:
   enable_vrfs:
     MGMT: {}
   enable_https: true
+spanning_tree:
+  no_spanning_tree_vlan: 4093-4094
 vlans:
   4093:
     tenant: system
@@ -150,10 +154,19 @@ ethernet_interfaces:
     mtu: 9000
     type: routed
     shutdown: false
-    ip_address: 172.31.255.3/31
+    ip_address: 172.31.255.5/31
     pim:
       ipv4:
         sparse_mode: true
+  Ethernet2:
+    peer: UNDERLAY-MULTICAST-SPINE2
+    peer_interface: Ethernet2
+    peer_type: spine
+    description: P2P_LINK_TO_UNDERLAY-MULTICAST-SPINE2_Ethernet2
+    mtu: 9000
+    type: routed
+    shutdown: false
+    ip_address: 172.31.255.7/31
 mlag_configuration:
   domain_id: DC1_LEAF1
   local_interface: Vlan4094

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF2A.yml
@@ -35,13 +35,21 @@ router_bgp:
     10.255.252.5:
       peer_group: MLAG-IPv4-UNDERLAY-PEER
       description: UNDERLAY-MULTICAST-L3LEAF2B
-    172.31.255.4:
+    172.31.255.8:
       peer_group: IPv4-UNDERLAY-PEERS
       remote_as: '65001'
       description: UNDERLAY-MULTICAST-SPINE1_Ethernet3
+    172.31.255.10:
+      peer_group: IPv4-UNDERLAY-PEERS
+      remote_as: '65001'
+      description: UNDERLAY-MULTICAST-SPINE2_Ethernet3
     192.168.255.1:
       peer_group: EVPN-OVERLAY-PEERS
       description: UNDERLAY-MULTICAST-SPINE1
+      remote_as: '65001'
+    192.168.255.2:
+      peer_group: EVPN-OVERLAY-PEERS
+      description: UNDERLAY-MULTICAST-SPINE2
       remote_as: '65001'
   redistribute_routes:
     connected:
@@ -64,12 +72,6 @@ vlan_internal_order:
   range:
     beginning: 1006
     ending: 1199
-spanning_tree:
-  mode: mstp
-  mst_instances:
-    '0':
-      priority: 4096
-  no_spanning_tree_vlan: 4094
 vrfs:
   MGMT:
     ip_routing: false
@@ -85,6 +87,8 @@ management_api_http:
   enable_vrfs:
     MGMT: {}
   enable_https: true
+spanning_tree:
+  no_spanning_tree_vlan: 4094
 vlans:
   4094:
     tenant: system
@@ -140,10 +144,19 @@ ethernet_interfaces:
     mtu: 9000
     type: routed
     shutdown: false
-    ip_address: 172.31.255.5/31
+    ip_address: 172.31.255.9/31
     pim:
       ipv4:
         sparse_mode: true
+  Ethernet2:
+    peer: UNDERLAY-MULTICAST-SPINE2
+    peer_interface: Ethernet3
+    peer_type: spine
+    description: P2P_LINK_TO_UNDERLAY-MULTICAST-SPINE2_Ethernet3
+    mtu: 9000
+    type: routed
+    shutdown: false
+    ip_address: 172.31.255.11/31
 mlag_configuration:
   domain_id: DC1_LEAF2
   local_interface: Vlan4094

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF2B.yml
@@ -35,13 +35,21 @@ router_bgp:
     10.255.252.4:
       peer_group: MLAG-IPv4-UNDERLAY-PEER
       description: UNDERLAY-MULTICAST-L3LEAF2A
-    172.31.255.6:
+    172.31.255.12:
       peer_group: IPv4-UNDERLAY-PEERS
       remote_as: '65001'
       description: UNDERLAY-MULTICAST-SPINE1_Ethernet4
+    172.31.255.14:
+      peer_group: IPv4-UNDERLAY-PEERS
+      remote_as: '65001'
+      description: UNDERLAY-MULTICAST-SPINE2_Ethernet4
     192.168.255.1:
       peer_group: EVPN-OVERLAY-PEERS
       description: UNDERLAY-MULTICAST-SPINE1
+      remote_as: '65001'
+    192.168.255.2:
+      peer_group: EVPN-OVERLAY-PEERS
+      description: UNDERLAY-MULTICAST-SPINE2
       remote_as: '65001'
   redistribute_routes:
     connected:
@@ -64,12 +72,6 @@ vlan_internal_order:
   range:
     beginning: 1006
     ending: 1199
-spanning_tree:
-  mode: mstp
-  mst_instances:
-    '0':
-      priority: 4096
-  no_spanning_tree_vlan: 4094
 vrfs:
   MGMT:
     ip_routing: false
@@ -85,6 +87,8 @@ management_api_http:
   enable_vrfs:
     MGMT: {}
   enable_https: true
+spanning_tree:
+  no_spanning_tree_vlan: 4094
 vlans:
   4094:
     tenant: system
@@ -140,10 +144,19 @@ ethernet_interfaces:
     mtu: 9000
     type: routed
     shutdown: false
-    ip_address: 172.31.255.7/31
+    ip_address: 172.31.255.13/31
     pim:
       ipv4:
         sparse_mode: true
+  Ethernet2:
+    peer: UNDERLAY-MULTICAST-SPINE2
+    peer_interface: Ethernet4
+    peer_type: spine
+    description: P2P_LINK_TO_UNDERLAY-MULTICAST-SPINE2_Ethernet4
+    mtu: 9000
+    type: routed
+    shutdown: false
+    ip_address: 172.31.255.15/31
 mlag_configuration:
   domain_id: DC1_LEAF2
   local_interface: Vlan4094

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-SPINE2.yml
@@ -1,6 +1,6 @@
 router_bgp:
   as: '65001'
-  router_id: 192.168.255.1
+  router_id: 192.168.255.2
   bgp_defaults:
   - maximum-paths 4 ecmp 4
   peer_groups:
@@ -26,22 +26,22 @@ router_bgp:
     connected:
       route_map: RM-CONN-2-BGP
   neighbors:
-    172.31.255.1:
+    172.31.255.3:
       peer_group: IPv4-UNDERLAY-PEERS
       remote_as: '65101'
-      description: UNDERLAY-MULTICAST-L3LEAF1A_Ethernet1
-    172.31.255.5:
+      description: UNDERLAY-MULTICAST-L3LEAF1A_Ethernet2
+    172.31.255.7:
       peer_group: IPv4-UNDERLAY-PEERS
       remote_as: '65101'
-      description: UNDERLAY-MULTICAST-L3LEAF1B_Ethernet1
-    172.31.255.9:
+      description: UNDERLAY-MULTICAST-L3LEAF1B_Ethernet2
+    172.31.255.11:
       peer_group: IPv4-UNDERLAY-PEERS
       remote_as: '65102'
-      description: UNDERLAY-MULTICAST-L3LEAF2A_Ethernet1
-    172.31.255.13:
+      description: UNDERLAY-MULTICAST-L3LEAF2A_Ethernet2
+    172.31.255.15:
       peer_group: IPv4-UNDERLAY-PEERS
       remote_as: '65102'
-      description: UNDERLAY-MULTICAST-L3LEAF2B_Ethernet1
+      description: UNDERLAY-MULTICAST-L3LEAF2B_Ethernet2
     192.168.255.3:
       peer_group: EVPN-OVERLAY-PEERS
       description: UNDERLAY-MULTICAST-L3LEAF1A
@@ -68,9 +68,6 @@ static_routes:
   gateway: 192.168.200.5
 service_routing_protocols_model: multi-agent
 ip_routing: true
-router_multicast:
-  ipv4:
-    routing: true
 vlan_internal_order:
   allocation: ascending
   range:
@@ -86,7 +83,7 @@ management_interfaces:
     description: oob_management
     shutdown: false
     vrf: MGMT
-    ip_address: 192.168.200.101/24
+    ip_address: 192.168.200.102/24
     gateway: 192.168.200.5
     type: oob
 management_api_http:
@@ -96,57 +93,45 @@ management_api_http:
 ethernet_interfaces:
   Ethernet1:
     peer: UNDERLAY-MULTICAST-L3LEAF1A
-    peer_interface: Ethernet1
+    peer_interface: Ethernet2
     peer_type: l3leaf
-    description: P2P_LINK_TO_UNDERLAY-MULTICAST-L3LEAF1A_Ethernet1
+    description: P2P_LINK_TO_UNDERLAY-MULTICAST-L3LEAF1A_Ethernet2
     mtu: 9000
     type: routed
     shutdown: false
-    ip_address: 172.31.255.0/31
-    pim:
-      ipv4:
-        sparse_mode: true
+    ip_address: 172.31.255.2/31
   Ethernet2:
     peer: UNDERLAY-MULTICAST-L3LEAF1B
-    peer_interface: Ethernet1
+    peer_interface: Ethernet2
     peer_type: l3leaf
-    description: P2P_LINK_TO_UNDERLAY-MULTICAST-L3LEAF1B_Ethernet1
+    description: P2P_LINK_TO_UNDERLAY-MULTICAST-L3LEAF1B_Ethernet2
     mtu: 9000
     type: routed
     shutdown: false
-    ip_address: 172.31.255.4/31
-    pim:
-      ipv4:
-        sparse_mode: true
+    ip_address: 172.31.255.6/31
   Ethernet3:
     peer: UNDERLAY-MULTICAST-L3LEAF2A
-    peer_interface: Ethernet1
+    peer_interface: Ethernet2
     peer_type: l3leaf
-    description: P2P_LINK_TO_UNDERLAY-MULTICAST-L3LEAF2A_Ethernet1
+    description: P2P_LINK_TO_UNDERLAY-MULTICAST-L3LEAF2A_Ethernet2
     mtu: 9000
     type: routed
     shutdown: false
-    ip_address: 172.31.255.8/31
-    pim:
-      ipv4:
-        sparse_mode: true
+    ip_address: 172.31.255.10/31
   Ethernet4:
     peer: UNDERLAY-MULTICAST-L3LEAF2B
-    peer_interface: Ethernet1
+    peer_interface: Ethernet2
     peer_type: l3leaf
-    description: P2P_LINK_TO_UNDERLAY-MULTICAST-L3LEAF2B_Ethernet1
+    description: P2P_LINK_TO_UNDERLAY-MULTICAST-L3LEAF2B_Ethernet2
     mtu: 9000
     type: routed
     shutdown: false
-    ip_address: 172.31.255.12/31
-    pim:
-      ipv4:
-        sparse_mode: true
+    ip_address: 172.31.255.14/31
 loopback_interfaces:
   Loopback0:
     description: EVPN_Overlay_Peering
     shutdown: false
-    ip_address: 192.168.255.1/32
+    ip_address: 192.168.255.2/32
 prefix_lists:
   PL-LOOPBACKS-EVPN-OVERLAY:
     sequence_numbers:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/UNDERLAY_MULTICAST_L2LEAFS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/UNDERLAY_MULTICAST_L2LEAFS.yml
@@ -1,0 +1,21 @@
+# UNDERLAY_MULTICAST_TESTS
+
+type: l2leaf
+
+underlay_multicast: true
+
+l2leaf:
+  defaults:
+    platform: vEOS-LAB
+    uplink_interfaces: ['Ethernet1']
+    uplink_switches: ['UNDERLAY-MULTICAST-L3LEAF1A']
+  node_groups:
+    # Test scenario of child device with underlay_router: false (default for l2leaf).
+    # Expected results:
+    # - No multicast configuration
+    DC1_LEAF1:
+      nodes:
+        UNDERLAY-MULTICAST-L2LEAF1A:
+          id: 1
+          mgmt_ip: 192.168.200.109/24
+          uplink_switch_interfaces: [Ethernet6]

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/UNDERLAY_MULTICAST_L3LEAFS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/UNDERLAY_MULTICAST_L3LEAFS.yml
@@ -1,3 +1,6 @@
+# UNDERLAY_MULTICAST_TESTS
+
+# Test underlay multicast configuration on underlay router + mlag
 type: l3leaf
 
 underlay_multicast: true
@@ -8,27 +11,35 @@ l3leaf:
     loopback_ipv4_pool: 192.168.255.0/24
     loopback_ipv4_offset: 2
     vtep_loopback_ipv4_pool: 192.168.254.0/24
-    uplink_interfaces: ['Ethernet1']
-    uplink_switches: ['UNDERLAY-MULTICAST-SPINE1']
+    uplink_interfaces: [Ethernet1, Ethernet2]
+    uplink_switches: ['UNDERLAY-MULTICAST-SPINE1', 'UNDERLAY-MULTICAST-SPINE2']
     uplink_ipv4_pool: 172.31.255.0/24
     mlag_interfaces: [ Ethernet3, Ethernet4 ]
     virtual_router_mac_address: 00:dc:00:00:00:0a
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
     mlag_peer_ipv4_pool: 10.255.252.0/24
-    spanning_tree_mode: mstp
-    spanning_tree_priority: 4096
   node_groups:
+    # Test multicast configuration with mlag pair.
+    # Expected results:
+    # - router multicast enabled for ipv4
+    # - p2p links configured with "pim ipv4 sparse-mode"
+    # - VLAN 4093 configured with "pim ipv4 sparse-mode"
     DC1_LEAF1:
       bgp_as: 65101
       nodes:
         UNDERLAY-MULTICAST-L3LEAF1A:
           id: 1
           mgmt_ip: 192.168.200.105/24
-          uplink_switch_interfaces: [ Ethernet1]
+          uplink_switch_interfaces: [Ethernet1, Ethernet1]
         UNDERLAY-MULTICAST-L3LEAF1B:
           id: 2
           mgmt_ip: 192.168.200.106/24
-          uplink_switch_interfaces: [ Ethernet2]
+          uplink_switch_interfaces: [Ethernet2, Ethernet2]
+    # Test multicast configuration with mlag pair sharing same vlan for l3 peering (4094)
+    # Expected results:
+    # - router multicast enabled for ipv4
+    # - p2p links configured with "pim ipv4 sparse-mode"
+    # - VLAN 4094 configured with "pim ipv4 sparse-mode"
     DC1_LEAF2:
       bgp_as: 65102
       mlag_peer_l3_vlan: 4094
@@ -36,8 +47,8 @@ l3leaf:
         UNDERLAY-MULTICAST-L3LEAF2A:
           id: 3
           mgmt_ip: 192.168.200.107/24
-          uplink_switch_interfaces: [ Ethernet3]
+          uplink_switch_interfaces: [Ethernet3, Ethernet3]
         UNDERLAY-MULTICAST-L3LEAF2B:
           id: 4
           mgmt_ip: 192.168.200.108/24
-          uplink_switch_interfaces: [ Ethernet4]
+          uplink_switch_interfaces: [Ethernet4, Ethernet4]

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/UNDERLAY_MULTICAST_SPINES.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/UNDERLAY_MULTICAST_SPINES.yml
@@ -1,3 +1,8 @@
+# UNDERLAY_MULTICAST_TESTS
+
+# Test underlay_multicast and validate that multicast configuration on p2p links and router_multicast based on child configuration.
+underlay_multicast: true
+
 type: spine
 
 # Spine Switches
@@ -7,6 +12,16 @@ spine:
     bgp_as: 65001
     loopback_ipv4_pool: 192.168.255.0/24
   nodes:
+    # Test multicast configuration on parent device.
+    # Expected results:
+    # - router multicast enabled for ipv4
+    # - p2p links configured with "pim ipv4 sparse-mode"
     UNDERLAY-MULTICAST-SPINE1:
       id: 1
       mgmt_ip: 192.168.200.101/24
+    # Test scenario of parent device with "underlay_multicast: false" in host_vars.
+    # Expected results:
+    # - No multicast configuration
+    UNDERLAY-MULTICAST-SPINE2:
+      id: 2
+      mgmt_ip: 192.168.200.102/24

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/UNDERLAY_MULTICAST_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/UNDERLAY_MULTICAST_TESTS.yml
@@ -1,1 +1,3 @@
+# UNDERLAY_MULTICAST_TESTS
+
 mgmt_gateway: 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/UNDERLAY-MULTICAST-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/UNDERLAY-MULTICAST-SPINE2.yml
@@ -1,0 +1,8 @@
+# UNDERLAY_MULTICAST_TESTS
+
+# Test to disable Multicast on a parent device, where child nodes have underlay_multicast: true
+# Expected results:
+# - UNDERLAY-MULTICAST-SPINE2 will not generate any multicast configuration
+# - Child devices in group UNDERLAY_MULTICAST_L3LEAFS will not generate multicast configuration on p2p links towards UNDERLAY-MULTICAST-SPINE2
+
+underlay_multicast: false

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
@@ -44,12 +44,16 @@ all:
             UNDERLAY_MULTICAST_SPINES:
               hosts:
                 UNDERLAY-MULTICAST-SPINE1:
+                UNDERLAY-MULTICAST-SPINE2:
             UNDERLAY_MULTICAST_L3LEAFS:
               hosts:
                 UNDERLAY-MULTICAST-L3LEAF1A:
                 UNDERLAY-MULTICAST-L3LEAF1B:
                 UNDERLAY-MULTICAST-L3LEAF2A:
                 UNDERLAY-MULTICAST-L3LEAF2B:
+            UNDERLAY_MULTICAST_L2LEAFS:
+              hosts:
+                UNDERLAY-MULTICAST-L2LEAF1A:
         BGP_PEER_GROUPS_STRUCTURED_CONFIG:
           hosts:
             bgp-peer-groups-structured-config-1:

--- a/ansible_collections/arista/avd/plugins/module_utils/eos_designs_facts.py
+++ b/ansible_collections/arista/avd/plugins/module_utils/eos_designs_facts.py
@@ -1306,8 +1306,8 @@ class EosDesignsFacts:
                     uplink['ptp'] = self.uplink_ptp
                 if self.uplink_macsec is not None:
                     uplink['mac_security'] = self.uplink_macsec
-                if self.underlay_multicast is True:
-                    uplink['underlay_multicast'] = True
+                if self.underlay_multicast is True and uplink_switch_facts.underlay_multicast is True:
+                        uplink['underlay_multicast'] = True
                 if get(self._hostvars, "underlay_rfc5549") is True:
                     uplink['ipv6_enable'] = True
                 else:

--- a/ansible_collections/arista/avd/plugins/module_utils/eos_designs_facts.py
+++ b/ansible_collections/arista/avd/plugins/module_utils/eos_designs_facts.py
@@ -1307,7 +1307,7 @@ class EosDesignsFacts:
                 if self.uplink_macsec is not None:
                     uplink['mac_security'] = self.uplink_macsec
                 if self.underlay_multicast is True and uplink_switch_facts.underlay_multicast is True:
-                        uplink['underlay_multicast'] = True
+                    uplink['underlay_multicast'] = True
                 if get(self._hostvars, "underlay_rfc5549") is True:
                     uplink['ipv6_enable'] = True
                 else:

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/base/router-multicast.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/base/router-multicast.j2
@@ -1,4 +1,4 @@
-{% if switch.underlay_multicast is arista.avd.defined(true) %}
+{% if switch.underlay_multicast is arista.avd.defined(true) and switch.underlay_router is arista.avd.defined(true) %}
 router_multicast:
   ipv4:
     routing: true


### PR DESCRIPTION
## Change Summary

Fix logic for underlay_multicast:
- Don't configure multicast when the parent device is not `underlay_multicast: true`
  - applies to both parent device and child node p2p links towards the parent.
- Don't configure router_multicast when `underlay_router: false` i.e l2leafs

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

- fixed logic in python facts and router_multicast template, see commits: 
  - bdd452b75ae12c7ecd81f4cbbaa77101b335bd6a
  - 0c2546656c048b5af10a33507fd2a0b9339a4a10

## How to test
See new improved molecule test coverage

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
