### PR TITLE
Feat(eos_designs): Support all keys with svi_profiles

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SVI_PROFILE_NODE_1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SVI_PROFILE_NODE_1.cfg
@@ -4,6 +4,7 @@ vlan internal order ascending range 1006 1199
 !
 ip igmp snooping vlan 210
 ip igmp snooping vlan 211
+ip igmp snooping vlan 212
 !
 transceiver qsfp default-mode 4x10G
 !
@@ -206,8 +207,6 @@ interface Vxlan1
    vxlan vlan 210 vni 10210
    vxlan vlan 211 vni 10211
    vxlan vlan 212 vni 10212
-   vxlan vlan 311 vni 10311
-   vxlan vlan 312 vni 10312
    vxlan vlan 410 vni 10410
    vxlan vlan 411 vni 10411
    vxlan vlan 412 vni 10412
@@ -229,6 +228,7 @@ ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
 ip route vrf MGMT 0.0.0.0/0 10.0.0.1
 ip route vrf svi_profile_tests_vrf 10.4.10.0/24 Vlan410 name VARP
 ip route vrf svi_profile_tests_vrf 10.4.11.0/24 Vlan411 name VARP
+ip route vrf svi_profile_tests_vrf 10.4.12.0/24 Vlan412 name VARP
 !
 route-map RM-CONN-2-BGP permit 10
    match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
@@ -295,16 +295,6 @@ router bgp 65001
       route-target both 10212:10212
       redistribute learned
    !
-   vlan 311
-      rd 192.168.255.1:10311
-      route-target both 10311:10311
-      redistribute learned
-   !
-   vlan 312
-      rd 192.168.255.1:10312
-      route-target both 10312:10312
-      redistribute learned
-   !
    vlan 410
       rd 192.168.255.1:10410
       route-target both 10410:10410
@@ -354,6 +344,8 @@ router ospf 1 vrf svi_profile_tests_vrf
    router-id 192.168.255.1
    passive-interface default
    no passive-interface Vlan510
+   no passive-interface Vlan511
+   no passive-interface Vlan512
    max-lsa 15000
    redistribute bgp
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SVI_PROFILE_NODE_1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SVI_PROFILE_NODE_1.cfg
@@ -1,0 +1,367 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+ip igmp snooping vlan 210
+ip igmp snooping vlan 211
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname SVI_PROFILE_NODE_1
+!
+no enable password
+no aaa root
+!
+vlan 110
+   name svi_profile_tests_110_description
+!
+vlan 111
+   name svi_profile_tests_111_description
+!
+vlan 112
+   name svi_profile_tests_112_description
+!
+vlan 113
+   name svi_profile_tests_113_description
+!
+vlan 114
+   name svi_profile_tests_114_description
+!
+vlan 115
+   name svi_profile_tests_115_description
+!
+vlan 210
+   name igmp_snooping_enabled_210
+!
+vlan 211
+   name igmp_snooping_enabled_211
+!
+vlan 212
+   name igmp_snooping_enabled_212
+!
+vlan 310
+   name vxlan_disabled_310
+!
+vlan 311
+   name vxlan_disabled_311
+!
+vlan 312
+   name vxlan_disabled_312
+!
+vlan 410
+   name static_routes_410
+!
+vlan 411
+   name static_routes_411
+!
+vlan 412
+   name static_routes_412
+!
+vlan 510
+   name ospf_enabled_510
+!
+vlan 511
+   name ospf_enabled_511
+!
+vlan 512
+   name ospf_enabled_512
+!
+vrf instance MGMT
+!
+vrf instance svi_profile_tests_vrf
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 192.168.255.1/32
+!
+interface Loopback1
+   description VTEP_VXLAN_Tunnel_Source
+   no shutdown
+   ip address 192.168.254.1/32
+!
+interface Vlan110
+   description set from structured_config on svi.nodes[inventory_hostname].structured_config
+   no shutdown
+   vrf svi_profile_tests_vrf
+   ip address virtual 10.1.10.1/24
+!
+interface Vlan111
+   description set from structured_config on svi_profile.nodes[inventory_hostname].structured_config
+   no shutdown
+   vrf svi_profile_tests_vrf
+   ip address virtual 10.1.11.1/24
+!
+interface Vlan112
+   description set from structured_config on svi_parent_profile.nodes[inventory_hostname].structured_config
+   no shutdown
+   vrf svi_profile_tests_vrf
+   ip address virtual 10.1.12.1/24
+!
+interface Vlan113
+   description set from svi.structured_config
+   no shutdown
+   vrf svi_profile_tests_vrf
+   ip address virtual 10.1.13.1/24
+!
+interface Vlan114
+   description set from structured_config on svi_profile.structured_config
+   no shutdown
+   vrf svi_profile_tests_vrf
+   ip address virtual 10.1.14.1/24
+!
+interface Vlan115
+   description set from structured_config on svi_parent_profile.structured_config
+   no shutdown
+   vrf svi_profile_tests_vrf
+   ip address virtual 10.1.15.1/24
+!
+interface Vlan210
+   description igmp_snooping_enabled_210
+   no shutdown
+   vrf svi_profile_tests_vrf
+   ip address virtual 10.2.10.1/24
+!
+interface Vlan211
+   description igmp_snooping_enabled_211
+   no shutdown
+   vrf svi_profile_tests_vrf
+   ip address virtual 10.2.11.1/24
+!
+interface Vlan212
+   description igmp_snooping_enabled_212
+   no shutdown
+   vrf svi_profile_tests_vrf
+   ip address virtual 10.2.12.1/24
+!
+interface Vlan310
+   description vxlan_disabled_310
+   no shutdown
+   vrf svi_profile_tests_vrf
+   ip address virtual 10.3.10.1/24
+!
+interface Vlan311
+   description vxlan_disabled_311
+   no shutdown
+   vrf svi_profile_tests_vrf
+   ip address virtual 10.3.11.1/24
+!
+interface Vlan312
+   description vxlan_disabled_312
+   no shutdown
+   vrf svi_profile_tests_vrf
+   ip address virtual 10.3.12.1/24
+!
+interface Vlan410
+   description static_routes_410
+   no shutdown
+   vrf svi_profile_tests_vrf
+   ip virtual-router address 10.4.10.1/24
+!
+interface Vlan411
+   description static_routes_411
+   no shutdown
+   vrf svi_profile_tests_vrf
+   ip virtual-router address 10.4.11.1/24
+!
+interface Vlan412
+   description static_routes_412
+   no shutdown
+   vrf svi_profile_tests_vrf
+   ip virtual-router address 10.4.12.1/24
+!
+interface Vlan510
+   description ospf_enabled_510
+   no shutdown
+   vrf svi_profile_tests_vrf
+   ip ospf area 0
+   ip address virtual 10.5.10.1/24
+!
+interface Vlan511
+   description ospf_enabled_511
+   no shutdown
+   vrf svi_profile_tests_vrf
+   ip ospf area 0
+   ip address virtual 10.5.11.1/24
+!
+interface Vlan512
+   description ospf_enabled_512
+   no shutdown
+   vrf svi_profile_tests_vrf
+   ip ospf area 0
+   ip address virtual 10.5.12.1/24
+!
+interface Vxlan1
+   description SVI_PROFILE_NODE_1_VTEP
+   vxlan source-interface Loopback1
+   vxlan udp-port 4789
+   vxlan vlan 110 vni 10110
+   vxlan vlan 111 vni 10111
+   vxlan vlan 112 vni 10112
+   vxlan vlan 113 vni 10113
+   vxlan vlan 114 vni 10114
+   vxlan vlan 115 vni 10115
+   vxlan vlan 210 vni 10210
+   vxlan vlan 211 vni 10211
+   vxlan vlan 212 vni 10212
+   vxlan vlan 311 vni 10311
+   vxlan vlan 312 vni 10312
+   vxlan vlan 410 vni 10410
+   vxlan vlan 411 vni 10411
+   vxlan vlan 412 vni 10412
+   vxlan vlan 510 vni 10510
+   vxlan vlan 511 vni 10511
+   vxlan vlan 512 vni 10512
+   vxlan vrf svi_profile_tests_vrf vni 1
+!
+ip virtual-router mac-address 00:1c:73:00:dc:01
+!
+ip routing
+no ip routing vrf MGMT
+ip routing vrf svi_profile_tests_vrf
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+   seq 20 permit 192.168.254.0/24 eq 32
+!
+ip route vrf MGMT 0.0.0.0/0 10.0.0.1
+ip route vrf svi_profile_tests_vrf 10.4.10.0/24 Vlan410 name VARP
+ip route vrf svi_profile_tests_vrf 10.4.11.0/24 Vlan411 name VARP
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 65001
+   router-id 192.168.255.1
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   vlan 110
+      rd 192.168.255.1:10110
+      route-target both 10110:10110
+      redistribute learned
+   !
+   vlan 111
+      rd 192.168.255.1:10111
+      route-target both 10111:10111
+      redistribute learned
+   !
+   vlan 112
+      rd 192.168.255.1:10112
+      route-target both 10112:10112
+      redistribute learned
+   !
+   vlan 113
+      rd 192.168.255.1:10113
+      route-target both 10113:10113
+      redistribute learned
+   !
+   vlan 114
+      rd 192.168.255.1:10114
+      route-target both 10114:10114
+      redistribute learned
+   !
+   vlan 115
+      rd 192.168.255.1:10115
+      route-target both 10115:10115
+      redistribute learned
+   !
+   vlan 210
+      rd 192.168.255.1:10210
+      route-target both 10210:10210
+      redistribute learned
+   !
+   vlan 211
+      rd 192.168.255.1:10211
+      route-target both 10211:10211
+      redistribute learned
+   !
+   vlan 212
+      rd 192.168.255.1:10212
+      route-target both 10212:10212
+      redistribute learned
+   !
+   vlan 311
+      rd 192.168.255.1:10311
+      route-target both 10311:10311
+      redistribute learned
+   !
+   vlan 312
+      rd 192.168.255.1:10312
+      route-target both 10312:10312
+      redistribute learned
+   !
+   vlan 410
+      rd 192.168.255.1:10410
+      route-target both 10410:10410
+      redistribute learned
+   !
+   vlan 411
+      rd 192.168.255.1:10411
+      route-target both 10411:10411
+      redistribute learned
+   !
+   vlan 412
+      rd 192.168.255.1:10412
+      route-target both 10412:10412
+      redistribute learned
+   !
+   vlan 510
+      rd 192.168.255.1:10510
+      route-target both 10510:10510
+      redistribute learned
+   !
+   vlan 511
+      rd 192.168.255.1:10511
+      route-target both 10511:10511
+      redistribute learned
+   !
+   vlan 512
+      rd 192.168.255.1:10512
+      route-target both 10512:10512
+      redistribute learned
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor IPv4-UNDERLAY-PEERS activate
+   !
+   vrf svi_profile_tests_vrf
+      rd 192.168.255.1:1
+      route-target import evpn 1:1
+      route-target export evpn 1:1
+      router-id 192.168.255.1
+      redistribute connected
+      redistribute ospf
+!
+router ospf 1 vrf svi_profile_tests_vrf
+   router-id 192.168.255.1
+   passive-interface default
+   no passive-interface Vlan510
+   max-lsa 15000
+   redistribute bgp
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SVI_PROFILE_NODE_2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SVI_PROFILE_NODE_2.cfg
@@ -4,6 +4,7 @@ vlan internal order ascending range 1006 1199
 !
 ip igmp snooping vlan 210
 ip igmp snooping vlan 211
+ip igmp snooping vlan 212
 !
 transceiver qsfp default-mode 4x10G
 !
@@ -206,8 +207,6 @@ interface Vxlan1
    vxlan vlan 210 vni 10210
    vxlan vlan 211 vni 10211
    vxlan vlan 212 vni 10212
-   vxlan vlan 311 vni 10311
-   vxlan vlan 312 vni 10312
    vxlan vlan 410 vni 10410
    vxlan vlan 411 vni 10411
    vxlan vlan 412 vni 10412
@@ -229,6 +228,7 @@ ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
 ip route vrf MGMT 0.0.0.0/0 10.0.0.1
 ip route vrf svi_profile_tests_vrf 10.4.10.0/24 Vlan410 name VARP
 ip route vrf svi_profile_tests_vrf 10.4.11.0/24 Vlan411 name VARP
+ip route vrf svi_profile_tests_vrf 10.4.12.0/24 Vlan412 name VARP
 !
 route-map RM-CONN-2-BGP permit 10
    match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
@@ -254,7 +254,7 @@ router bgp 65002
       rd 192.168.255.1:1
       route-target both 1:1
       redistribute learned
-      vlan 110-115,210-212,311-312,410-412,510-512
+      vlan 110-115,210-212,410-412,510-512
    !
    address-family evpn
       neighbor EVPN-OVERLAY-PEERS activate
@@ -275,6 +275,8 @@ router ospf 1 vrf svi_profile_tests_vrf
    router-id 192.168.255.1
    passive-interface default
    no passive-interface Vlan510
+   no passive-interface Vlan511
+   no passive-interface Vlan512
    max-lsa 15000
    redistribute bgp
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SVI_PROFILE_NODE_2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SVI_PROFILE_NODE_2.cfg
@@ -1,0 +1,288 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+ip igmp snooping vlan 210
+ip igmp snooping vlan 211
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname SVI_PROFILE_NODE_2
+!
+no enable password
+no aaa root
+!
+vlan 110
+   name svi_profile_tests_110_description
+!
+vlan 111
+   name svi_profile_tests_111_description
+!
+vlan 112
+   name svi_profile_tests_112_description
+!
+vlan 113
+   name svi_profile_tests_113_description
+!
+vlan 114
+   name svi_profile_tests_114_description
+!
+vlan 115
+   name svi_profile_tests_115_description
+!
+vlan 210
+   name igmp_snooping_enabled_210
+!
+vlan 211
+   name igmp_snooping_enabled_211
+!
+vlan 212
+   name igmp_snooping_enabled_212
+!
+vlan 310
+   name vxlan_disabled_310
+!
+vlan 311
+   name vxlan_disabled_311
+!
+vlan 312
+   name vxlan_disabled_312
+!
+vlan 410
+   name static_routes_410
+!
+vlan 411
+   name static_routes_411
+!
+vlan 412
+   name static_routes_412
+!
+vlan 510
+   name ospf_enabled_510
+!
+vlan 511
+   name ospf_enabled_511
+!
+vlan 512
+   name ospf_enabled_512
+!
+vrf instance MGMT
+!
+vrf instance svi_profile_tests_vrf
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 192.168.255.1/32
+!
+interface Loopback1
+   description VTEP_VXLAN_Tunnel_Source
+   no shutdown
+   ip address 192.168.254.1/32
+!
+interface Vlan110
+   description set from structured_config on svi.nodes[inventory_hostname].structured_config
+   no shutdown
+   vrf svi_profile_tests_vrf
+   ip address virtual 10.1.10.1/24
+!
+interface Vlan111
+   description set from structured_config on svi_profile.nodes[inventory_hostname].structured_config
+   no shutdown
+   vrf svi_profile_tests_vrf
+   ip address virtual 10.1.11.1/24
+!
+interface Vlan112
+   description set from structured_config on svi_parent_profile.nodes[inventory_hostname].structured_config
+   no shutdown
+   vrf svi_profile_tests_vrf
+   ip address virtual 10.1.12.1/24
+!
+interface Vlan113
+   description set from svi.structured_config
+   no shutdown
+   vrf svi_profile_tests_vrf
+   ip address virtual 10.1.13.1/24
+!
+interface Vlan114
+   description set from structured_config on svi_profile.structured_config
+   no shutdown
+   vrf svi_profile_tests_vrf
+   ip address virtual 10.1.14.1/24
+!
+interface Vlan115
+   description set from structured_config on svi_parent_profile.structured_config
+   no shutdown
+   vrf svi_profile_tests_vrf
+   ip address virtual 10.1.15.1/24
+!
+interface Vlan210
+   description igmp_snooping_enabled_210
+   no shutdown
+   vrf svi_profile_tests_vrf
+   ip address virtual 10.2.10.1/24
+!
+interface Vlan211
+   description igmp_snooping_enabled_211
+   no shutdown
+   vrf svi_profile_tests_vrf
+   ip address virtual 10.2.11.1/24
+!
+interface Vlan212
+   description igmp_snooping_enabled_212
+   no shutdown
+   vrf svi_profile_tests_vrf
+   ip address virtual 10.2.12.1/24
+!
+interface Vlan310
+   description vxlan_disabled_310
+   no shutdown
+   vrf svi_profile_tests_vrf
+   ip address virtual 10.3.10.1/24
+!
+interface Vlan311
+   description vxlan_disabled_311
+   no shutdown
+   vrf svi_profile_tests_vrf
+   ip address virtual 10.3.11.1/24
+!
+interface Vlan312
+   description vxlan_disabled_312
+   no shutdown
+   vrf svi_profile_tests_vrf
+   ip address virtual 10.3.12.1/24
+!
+interface Vlan410
+   description static_routes_410
+   no shutdown
+   vrf svi_profile_tests_vrf
+   ip virtual-router address 10.4.10.1/24
+!
+interface Vlan411
+   description static_routes_411
+   no shutdown
+   vrf svi_profile_tests_vrf
+   ip virtual-router address 10.4.11.1/24
+!
+interface Vlan412
+   description static_routes_412
+   no shutdown
+   vrf svi_profile_tests_vrf
+   ip virtual-router address 10.4.12.1/24
+!
+interface Vlan510
+   description ospf_enabled_510
+   no shutdown
+   vrf svi_profile_tests_vrf
+   ip ospf area 0
+   ip address virtual 10.5.10.1/24
+!
+interface Vlan511
+   description ospf_enabled_511
+   no shutdown
+   vrf svi_profile_tests_vrf
+   ip ospf area 0
+   ip address virtual 10.5.11.1/24
+!
+interface Vlan512
+   description ospf_enabled_512
+   no shutdown
+   vrf svi_profile_tests_vrf
+   ip ospf area 0
+   ip address virtual 10.5.12.1/24
+!
+interface Vxlan1
+   description SVI_PROFILE_NODE_2_VTEP
+   vxlan source-interface Loopback1
+   vxlan udp-port 4789
+   vxlan vlan 110 vni 10110
+   vxlan vlan 111 vni 10111
+   vxlan vlan 112 vni 10112
+   vxlan vlan 113 vni 10113
+   vxlan vlan 114 vni 10114
+   vxlan vlan 115 vni 10115
+   vxlan vlan 210 vni 10210
+   vxlan vlan 211 vni 10211
+   vxlan vlan 212 vni 10212
+   vxlan vlan 311 vni 10311
+   vxlan vlan 312 vni 10312
+   vxlan vlan 410 vni 10410
+   vxlan vlan 411 vni 10411
+   vxlan vlan 412 vni 10412
+   vxlan vlan 510 vni 10510
+   vxlan vlan 511 vni 10511
+   vxlan vlan 512 vni 10512
+   vxlan vrf svi_profile_tests_vrf vni 1
+!
+ip virtual-router mac-address 00:1c:73:00:dc:01
+!
+ip routing
+no ip routing vrf MGMT
+ip routing vrf svi_profile_tests_vrf
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+   seq 20 permit 192.168.254.0/24 eq 32
+!
+ip route vrf MGMT 0.0.0.0/0 10.0.0.1
+ip route vrf svi_profile_tests_vrf 10.4.10.0/24 Vlan410 name VARP
+ip route vrf svi_profile_tests_vrf 10.4.11.0/24 Vlan411 name VARP
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 65002
+   router-id 192.168.255.1
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   vlan-aware-bundle svi_profile_tests_vrf
+      rd 192.168.255.1:1
+      route-target both 1:1
+      redistribute learned
+      vlan 110-115,210-212,311-312,410-412,510-512
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor IPv4-UNDERLAY-PEERS activate
+   !
+   vrf svi_profile_tests_vrf
+      rd 192.168.255.1:1
+      route-target import evpn 1:1
+      route-target export evpn 1:1
+      router-id 192.168.255.1
+      redistribute connected
+      redistribute ospf
+!
+router ospf 1 vrf svi_profile_tests_vrf
+   router-id 192.168.255.1
+   passive-interface default
+   no passive-interface Vlan510
+   max-lsa 15000
+   redistribute bgp
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SVI_PROFILE_NODE_1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SVI_PROFILE_NODE_1.yml
@@ -115,22 +115,6 @@ router_bgp:
         - 10212:10212
       redistribute_routes:
       - learned
-    311:
-      tenant: svi_profile_tests
-      rd: 192.168.255.1:10311
-      route_targets:
-        both:
-        - 10311:10311
-      redistribute_routes:
-      - learned
-    312:
-      tenant: svi_profile_tests
-      rd: 192.168.255.1:10312
-      route_targets:
-        both:
-        - 10312:10312
-      redistribute_routes:
-      - learned
     410:
       tenant: svi_profile_tests
       rd: 192.168.255.1:10410
@@ -191,6 +175,10 @@ static_routes:
   vrf: svi_profile_tests_vrf
   name: VARP
   interface: Vlan411
+- destination_address_prefix: 10.4.12.0/24
+  vrf: svi_profile_tests_vrf
+  name: VARP
+  interface: Vlan412
 service_routing_protocols_model: multi-agent
 ip_routing: true
 vlan_internal_order:
@@ -297,6 +285,8 @@ ip_igmp_snooping:
     210:
       enabled: true
     211:
+      enabled: true
+    212:
       enabled: true
 ip_virtual_router_mac_address: 00:1c:73:00:dc:01
 vlan_interfaces:
@@ -437,6 +427,8 @@ router_ospf:
       router_id: 192.168.255.1
       no_passive_interfaces:
       - Vlan510
+      - Vlan511
+      - Vlan512
       max_lsa: 15000
       redistribute:
         bgp:
@@ -466,10 +458,6 @@ vxlan_interface:
           vni: 10211
         212:
           vni: 10212
-        311:
-          vni: 10311
-        312:
-          vni: 10312
         410:
           vni: 10410
         411:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SVI_PROFILE_NODE_1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SVI_PROFILE_NODE_1.yml
@@ -1,0 +1,487 @@
+router_bgp:
+  as: '65001'
+  router_id: 192.168.255.1
+  bgp_defaults:
+  - maximum-paths 4 ecmp 4
+  peer_groups:
+    IPv4-UNDERLAY-PEERS:
+      type: ipv4
+      maximum_routes: 12000
+      send_community: all
+    EVPN-OVERLAY-PEERS:
+      type: evpn
+      update_source: Loopback0
+      bfd: true
+      ebgp_multihop: '3'
+      send_community: all
+      maximum_routes: 0
+  address_family_ipv4:
+    peer_groups:
+      IPv4-UNDERLAY-PEERS:
+        activate: true
+      EVPN-OVERLAY-PEERS:
+        activate: false
+  redistribute_routes:
+    connected:
+      route_map: RM-CONN-2-BGP
+  address_family_evpn:
+    peer_groups:
+      EVPN-OVERLAY-PEERS:
+        activate: true
+  vrfs:
+    svi_profile_tests_vrf:
+      router_id: 192.168.255.1
+      rd: 192.168.255.1:1
+      route_targets:
+        import:
+          evpn:
+          - '1:1'
+        export:
+          evpn:
+          - '1:1'
+      redistribute_routes:
+      - connected
+      - ospf
+  vlans:
+    110:
+      tenant: svi_profile_tests
+      rd: 192.168.255.1:10110
+      route_targets:
+        both:
+        - 10110:10110
+      redistribute_routes:
+      - learned
+    111:
+      tenant: svi_profile_tests
+      rd: 192.168.255.1:10111
+      route_targets:
+        both:
+        - 10111:10111
+      redistribute_routes:
+      - learned
+    112:
+      tenant: svi_profile_tests
+      rd: 192.168.255.1:10112
+      route_targets:
+        both:
+        - 10112:10112
+      redistribute_routes:
+      - learned
+    113:
+      tenant: svi_profile_tests
+      rd: 192.168.255.1:10113
+      route_targets:
+        both:
+        - 10113:10113
+      redistribute_routes:
+      - learned
+    114:
+      tenant: svi_profile_tests
+      rd: 192.168.255.1:10114
+      route_targets:
+        both:
+        - 10114:10114
+      redistribute_routes:
+      - learned
+    115:
+      tenant: svi_profile_tests
+      rd: 192.168.255.1:10115
+      route_targets:
+        both:
+        - 10115:10115
+      redistribute_routes:
+      - learned
+    210:
+      tenant: svi_profile_tests
+      rd: 192.168.255.1:10210
+      route_targets:
+        both:
+        - 10210:10210
+      redistribute_routes:
+      - learned
+    211:
+      tenant: svi_profile_tests
+      rd: 192.168.255.1:10211
+      route_targets:
+        both:
+        - 10211:10211
+      redistribute_routes:
+      - learned
+    212:
+      tenant: svi_profile_tests
+      rd: 192.168.255.1:10212
+      route_targets:
+        both:
+        - 10212:10212
+      redistribute_routes:
+      - learned
+    311:
+      tenant: svi_profile_tests
+      rd: 192.168.255.1:10311
+      route_targets:
+        both:
+        - 10311:10311
+      redistribute_routes:
+      - learned
+    312:
+      tenant: svi_profile_tests
+      rd: 192.168.255.1:10312
+      route_targets:
+        both:
+        - 10312:10312
+      redistribute_routes:
+      - learned
+    410:
+      tenant: svi_profile_tests
+      rd: 192.168.255.1:10410
+      route_targets:
+        both:
+        - 10410:10410
+      redistribute_routes:
+      - learned
+    411:
+      tenant: svi_profile_tests
+      rd: 192.168.255.1:10411
+      route_targets:
+        both:
+        - 10411:10411
+      redistribute_routes:
+      - learned
+    412:
+      tenant: svi_profile_tests
+      rd: 192.168.255.1:10412
+      route_targets:
+        both:
+        - 10412:10412
+      redistribute_routes:
+      - learned
+    510:
+      tenant: svi_profile_tests
+      rd: 192.168.255.1:10510
+      route_targets:
+        both:
+        - 10510:10510
+      redistribute_routes:
+      - learned
+    511:
+      tenant: svi_profile_tests
+      rd: 192.168.255.1:10511
+      route_targets:
+        both:
+        - 10511:10511
+      redistribute_routes:
+      - learned
+    512:
+      tenant: svi_profile_tests
+      rd: 192.168.255.1:10512
+      route_targets:
+        both:
+        - 10512:10512
+      redistribute_routes:
+      - learned
+static_routes:
+- vrf: MGMT
+  destination_address_prefix: 0.0.0.0/0
+  gateway: 10.0.0.1
+- destination_address_prefix: 10.4.10.0/24
+  vrf: svi_profile_tests_vrf
+  name: VARP
+  interface: Vlan410
+- destination_address_prefix: 10.4.11.0/24
+  vrf: svi_profile_tests_vrf
+  name: VARP
+  interface: Vlan411
+service_routing_protocols_model: multi-agent
+ip_routing: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+vrfs:
+  MGMT:
+    ip_routing: false
+  svi_profile_tests_vrf:
+    tenant: svi_profile_tests
+    ip_routing: true
+management_api_http:
+  enable_vrfs:
+    MGMT: {}
+  enable_https: true
+loopback_interfaces:
+  Loopback0:
+    description: EVPN_Overlay_Peering
+    shutdown: false
+    ip_address: 192.168.255.1/32
+  Loopback1:
+    description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
+    ip_address: 192.168.254.1/32
+prefix_lists:
+  PL-LOOPBACKS-EVPN-OVERLAY:
+    sequence_numbers:
+      10:
+        action: permit 192.168.255.0/24 eq 32
+      20:
+        action: permit 192.168.254.0/24 eq 32
+route_maps:
+  RM-CONN-2-BGP:
+    sequence_numbers:
+      10:
+        type: permit
+        match:
+        - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+router_bfd:
+  multihop:
+    interval: 300
+    min_rx: 300
+    multiplier: 3
+vlans:
+  110:
+    tenant: svi_profile_tests
+    name: svi_profile_tests_110_description
+  111:
+    tenant: svi_profile_tests
+    name: svi_profile_tests_111_description
+  112:
+    tenant: svi_profile_tests
+    name: svi_profile_tests_112_description
+  113:
+    tenant: svi_profile_tests
+    name: svi_profile_tests_113_description
+  114:
+    tenant: svi_profile_tests
+    name: svi_profile_tests_114_description
+  115:
+    tenant: svi_profile_tests
+    name: svi_profile_tests_115_description
+  210:
+    tenant: svi_profile_tests
+    name: igmp_snooping_enabled_210
+  211:
+    tenant: svi_profile_tests
+    name: igmp_snooping_enabled_211
+  212:
+    tenant: svi_profile_tests
+    name: igmp_snooping_enabled_212
+  310:
+    tenant: svi_profile_tests
+    name: vxlan_disabled_310
+  311:
+    tenant: svi_profile_tests
+    name: vxlan_disabled_311
+  312:
+    tenant: svi_profile_tests
+    name: vxlan_disabled_312
+  410:
+    tenant: svi_profile_tests
+    name: static_routes_410
+  411:
+    tenant: svi_profile_tests
+    name: static_routes_411
+  412:
+    tenant: svi_profile_tests
+    name: static_routes_412
+  510:
+    tenant: svi_profile_tests
+    name: ospf_enabled_510
+  511:
+    tenant: svi_profile_tests
+    name: ospf_enabled_511
+  512:
+    tenant: svi_profile_tests
+    name: ospf_enabled_512
+ip_igmp_snooping:
+  globally_enabled: true
+  vlans:
+    210:
+      enabled: true
+    211:
+      enabled: true
+ip_virtual_router_mac_address: 00:1c:73:00:dc:01
+vlan_interfaces:
+  Vlan110:
+    tenant: svi_profile_tests
+    description: set from structured_config on svi.nodes[inventory_hostname].structured_config
+    shutdown: false
+    vrf: svi_profile_tests_vrf
+    ip_address_virtual: 10.1.10.1/24
+    struct_cfg:
+      description: set from structured_config on svi.nodes[inventory_hostname].structured_config
+  Vlan111:
+    tenant: svi_profile_tests
+    description: set from structured_config on svi_profile.nodes[inventory_hostname].structured_config
+    shutdown: false
+    vrf: svi_profile_tests_vrf
+    ip_address_virtual: 10.1.11.1/24
+    struct_cfg:
+      description: set from structured_config on svi_profile.nodes[inventory_hostname].structured_config
+  Vlan112:
+    tenant: svi_profile_tests
+    description: set from structured_config on svi_parent_profile.nodes[inventory_hostname].structured_config
+    shutdown: false
+    vrf: svi_profile_tests_vrf
+    ip_address_virtual: 10.1.12.1/24
+    struct_cfg:
+      description: set from structured_config on svi_parent_profile.nodes[inventory_hostname].structured_config
+  Vlan113:
+    tenant: svi_profile_tests
+    description: set from svi.structured_config
+    shutdown: false
+    vrf: svi_profile_tests_vrf
+    ip_address_virtual: 10.1.13.1/24
+    struct_cfg:
+      description: set from svi.structured_config
+  Vlan114:
+    tenant: svi_profile_tests
+    description: set from structured_config on svi_profile.structured_config
+    shutdown: false
+    vrf: svi_profile_tests_vrf
+    ip_address_virtual: 10.1.14.1/24
+    struct_cfg:
+      description: set from structured_config on svi_profile.structured_config
+  Vlan115:
+    tenant: svi_profile_tests
+    description: set from structured_config on svi_parent_profile.structured_config
+    shutdown: false
+    vrf: svi_profile_tests_vrf
+    ip_address_virtual: 10.1.15.1/24
+    struct_cfg:
+      description: set from structured_config on svi_parent_profile.structured_config
+  Vlan210:
+    tenant: svi_profile_tests
+    description: igmp_snooping_enabled_210
+    shutdown: false
+    vrf: svi_profile_tests_vrf
+    ip_address_virtual: 10.2.10.1/24
+  Vlan211:
+    tenant: svi_profile_tests
+    description: igmp_snooping_enabled_211
+    shutdown: false
+    vrf: svi_profile_tests_vrf
+    ip_address_virtual: 10.2.11.1/24
+  Vlan212:
+    tenant: svi_profile_tests
+    description: igmp_snooping_enabled_212
+    shutdown: false
+    vrf: svi_profile_tests_vrf
+    ip_address_virtual: 10.2.12.1/24
+  Vlan310:
+    tenant: svi_profile_tests
+    description: vxlan_disabled_310
+    shutdown: false
+    vrf: svi_profile_tests_vrf
+    ip_address_virtual: 10.3.10.1/24
+  Vlan311:
+    tenant: svi_profile_tests
+    description: vxlan_disabled_311
+    shutdown: false
+    vrf: svi_profile_tests_vrf
+    ip_address_virtual: 10.3.11.1/24
+  Vlan312:
+    tenant: svi_profile_tests
+    description: vxlan_disabled_312
+    shutdown: false
+    vrf: svi_profile_tests_vrf
+    ip_address_virtual: 10.3.12.1/24
+  Vlan410:
+    tenant: svi_profile_tests
+    description: static_routes_410
+    shutdown: false
+    vrf: svi_profile_tests_vrf
+    ip_virtual_router_addresses:
+    - 10.4.10.1/24
+  Vlan411:
+    tenant: svi_profile_tests
+    description: static_routes_411
+    shutdown: false
+    vrf: svi_profile_tests_vrf
+    ip_virtual_router_addresses:
+    - 10.4.11.1/24
+  Vlan412:
+    tenant: svi_profile_tests
+    description: static_routes_412
+    shutdown: false
+    vrf: svi_profile_tests_vrf
+    ip_virtual_router_addresses:
+    - 10.4.12.1/24
+  Vlan510:
+    tenant: svi_profile_tests
+    description: ospf_enabled_510
+    shutdown: false
+    vrf: svi_profile_tests_vrf
+    ip_address_virtual: 10.5.10.1/24
+    ospf_area: 0
+    ospf_network_point_to_point: false
+  Vlan511:
+    tenant: svi_profile_tests
+    description: ospf_enabled_511
+    shutdown: false
+    vrf: svi_profile_tests_vrf
+    ip_address_virtual: 10.5.11.1/24
+    ospf_area: 0
+    ospf_network_point_to_point: false
+  Vlan512:
+    tenant: svi_profile_tests
+    description: ospf_enabled_512
+    shutdown: false
+    vrf: svi_profile_tests_vrf
+    ip_address_virtual: 10.5.12.1/24
+    ospf_area: 0
+    ospf_network_point_to_point: false
+router_ospf:
+  process_ids:
+    1:
+      vrf: svi_profile_tests_vrf
+      passive_interface_default: true
+      router_id: 192.168.255.1
+      no_passive_interfaces:
+      - Vlan510
+      max_lsa: 15000
+      redistribute:
+        bgp:
+          enabled: true
+vxlan_interface:
+  Vxlan1:
+    description: SVI_PROFILE_NODE_1_VTEP
+    vxlan:
+      source_interface: Loopback1
+      udp_port: 4789
+      vlans:
+        110:
+          vni: 10110
+        111:
+          vni: 10111
+        112:
+          vni: 10112
+        113:
+          vni: 10113
+        114:
+          vni: 10114
+        115:
+          vni: 10115
+        210:
+          vni: 10210
+        211:
+          vni: 10211
+        212:
+          vni: 10212
+        311:
+          vni: 10311
+        312:
+          vni: 10312
+        410:
+          vni: 10410
+        411:
+          vni: 10411
+        412:
+          vni: 10412
+        510:
+          vni: 10510
+        511:
+          vni: 10511
+        512:
+          vni: 10512
+      vrfs:
+        svi_profile_tests_vrf:
+          vni: 1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SVI_PROFILE_NODE_2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SVI_PROFILE_NODE_2.yml
@@ -50,7 +50,7 @@ router_bgp:
         - '1:1'
       redistribute_routes:
       - learned
-      vlan: 110-115,210-212,311-312,410-412,510-512
+      vlan: 110-115,210-212,410-412,510-512
 static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0
@@ -63,6 +63,10 @@ static_routes:
   vrf: svi_profile_tests_vrf
   name: VARP
   interface: Vlan411
+- destination_address_prefix: 10.4.12.0/24
+  vrf: svi_profile_tests_vrf
+  name: VARP
+  interface: Vlan412
 service_routing_protocols_model: multi-agent
 ip_routing: true
 vlan_internal_order:
@@ -169,6 +173,8 @@ ip_igmp_snooping:
     210:
       enabled: true
     211:
+      enabled: true
+    212:
       enabled: true
 ip_virtual_router_mac_address: 00:1c:73:00:dc:01
 vlan_interfaces:
@@ -309,6 +315,8 @@ router_ospf:
       router_id: 192.168.255.1
       no_passive_interfaces:
       - Vlan510
+      - Vlan511
+      - Vlan512
       max_lsa: 15000
       redistribute:
         bgp:
@@ -338,10 +346,6 @@ vxlan_interface:
           vni: 10211
         212:
           vni: 10212
-        311:
-          vni: 10311
-        312:
-          vni: 10312
         410:
           vni: 10410
         411:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SVI_PROFILE_NODE_2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SVI_PROFILE_NODE_2.yml
@@ -1,0 +1,359 @@
+router_bgp:
+  as: '65002'
+  router_id: 192.168.255.1
+  bgp_defaults:
+  - maximum-paths 4 ecmp 4
+  peer_groups:
+    IPv4-UNDERLAY-PEERS:
+      type: ipv4
+      maximum_routes: 12000
+      send_community: all
+    EVPN-OVERLAY-PEERS:
+      type: evpn
+      update_source: Loopback0
+      bfd: true
+      ebgp_multihop: '3'
+      send_community: all
+      maximum_routes: 0
+  address_family_ipv4:
+    peer_groups:
+      IPv4-UNDERLAY-PEERS:
+        activate: true
+      EVPN-OVERLAY-PEERS:
+        activate: false
+  redistribute_routes:
+    connected:
+      route_map: RM-CONN-2-BGP
+  address_family_evpn:
+    peer_groups:
+      EVPN-OVERLAY-PEERS:
+        activate: true
+  vrfs:
+    svi_profile_tests_vrf:
+      router_id: 192.168.255.1
+      rd: 192.168.255.1:1
+      route_targets:
+        import:
+          evpn:
+          - '1:1'
+        export:
+          evpn:
+          - '1:1'
+      redistribute_routes:
+      - connected
+      - ospf
+  vlan_aware_bundles:
+    svi_profile_tests_vrf:
+      rd: 192.168.255.1:1
+      route_targets:
+        both:
+        - '1:1'
+      redistribute_routes:
+      - learned
+      vlan: 110-115,210-212,311-312,410-412,510-512
+static_routes:
+- vrf: MGMT
+  destination_address_prefix: 0.0.0.0/0
+  gateway: 10.0.0.1
+- destination_address_prefix: 10.4.10.0/24
+  vrf: svi_profile_tests_vrf
+  name: VARP
+  interface: Vlan410
+- destination_address_prefix: 10.4.11.0/24
+  vrf: svi_profile_tests_vrf
+  name: VARP
+  interface: Vlan411
+service_routing_protocols_model: multi-agent
+ip_routing: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+vrfs:
+  MGMT:
+    ip_routing: false
+  svi_profile_tests_vrf:
+    tenant: svi_profile_tests
+    ip_routing: true
+management_api_http:
+  enable_vrfs:
+    MGMT: {}
+  enable_https: true
+loopback_interfaces:
+  Loopback0:
+    description: EVPN_Overlay_Peering
+    shutdown: false
+    ip_address: 192.168.255.1/32
+  Loopback1:
+    description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
+    ip_address: 192.168.254.1/32
+prefix_lists:
+  PL-LOOPBACKS-EVPN-OVERLAY:
+    sequence_numbers:
+      10:
+        action: permit 192.168.255.0/24 eq 32
+      20:
+        action: permit 192.168.254.0/24 eq 32
+route_maps:
+  RM-CONN-2-BGP:
+    sequence_numbers:
+      10:
+        type: permit
+        match:
+        - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+router_bfd:
+  multihop:
+    interval: 300
+    min_rx: 300
+    multiplier: 3
+vlans:
+  110:
+    tenant: svi_profile_tests
+    name: svi_profile_tests_110_description
+  111:
+    tenant: svi_profile_tests
+    name: svi_profile_tests_111_description
+  112:
+    tenant: svi_profile_tests
+    name: svi_profile_tests_112_description
+  113:
+    tenant: svi_profile_tests
+    name: svi_profile_tests_113_description
+  114:
+    tenant: svi_profile_tests
+    name: svi_profile_tests_114_description
+  115:
+    tenant: svi_profile_tests
+    name: svi_profile_tests_115_description
+  210:
+    tenant: svi_profile_tests
+    name: igmp_snooping_enabled_210
+  211:
+    tenant: svi_profile_tests
+    name: igmp_snooping_enabled_211
+  212:
+    tenant: svi_profile_tests
+    name: igmp_snooping_enabled_212
+  310:
+    tenant: svi_profile_tests
+    name: vxlan_disabled_310
+  311:
+    tenant: svi_profile_tests
+    name: vxlan_disabled_311
+  312:
+    tenant: svi_profile_tests
+    name: vxlan_disabled_312
+  410:
+    tenant: svi_profile_tests
+    name: static_routes_410
+  411:
+    tenant: svi_profile_tests
+    name: static_routes_411
+  412:
+    tenant: svi_profile_tests
+    name: static_routes_412
+  510:
+    tenant: svi_profile_tests
+    name: ospf_enabled_510
+  511:
+    tenant: svi_profile_tests
+    name: ospf_enabled_511
+  512:
+    tenant: svi_profile_tests
+    name: ospf_enabled_512
+ip_igmp_snooping:
+  globally_enabled: true
+  vlans:
+    210:
+      enabled: true
+    211:
+      enabled: true
+ip_virtual_router_mac_address: 00:1c:73:00:dc:01
+vlan_interfaces:
+  Vlan110:
+    tenant: svi_profile_tests
+    description: set from structured_config on svi.nodes[inventory_hostname].structured_config
+    shutdown: false
+    vrf: svi_profile_tests_vrf
+    ip_address_virtual: 10.1.10.1/24
+    struct_cfg:
+      description: set from structured_config on svi.nodes[inventory_hostname].structured_config
+  Vlan111:
+    tenant: svi_profile_tests
+    description: set from structured_config on svi_profile.nodes[inventory_hostname].structured_config
+    shutdown: false
+    vrf: svi_profile_tests_vrf
+    ip_address_virtual: 10.1.11.1/24
+    struct_cfg:
+      description: set from structured_config on svi_profile.nodes[inventory_hostname].structured_config
+  Vlan112:
+    tenant: svi_profile_tests
+    description: set from structured_config on svi_parent_profile.nodes[inventory_hostname].structured_config
+    shutdown: false
+    vrf: svi_profile_tests_vrf
+    ip_address_virtual: 10.1.12.1/24
+    struct_cfg:
+      description: set from structured_config on svi_parent_profile.nodes[inventory_hostname].structured_config
+  Vlan113:
+    tenant: svi_profile_tests
+    description: set from svi.structured_config
+    shutdown: false
+    vrf: svi_profile_tests_vrf
+    ip_address_virtual: 10.1.13.1/24
+    struct_cfg:
+      description: set from svi.structured_config
+  Vlan114:
+    tenant: svi_profile_tests
+    description: set from structured_config on svi_profile.structured_config
+    shutdown: false
+    vrf: svi_profile_tests_vrf
+    ip_address_virtual: 10.1.14.1/24
+    struct_cfg:
+      description: set from structured_config on svi_profile.structured_config
+  Vlan115:
+    tenant: svi_profile_tests
+    description: set from structured_config on svi_parent_profile.structured_config
+    shutdown: false
+    vrf: svi_profile_tests_vrf
+    ip_address_virtual: 10.1.15.1/24
+    struct_cfg:
+      description: set from structured_config on svi_parent_profile.structured_config
+  Vlan210:
+    tenant: svi_profile_tests
+    description: igmp_snooping_enabled_210
+    shutdown: false
+    vrf: svi_profile_tests_vrf
+    ip_address_virtual: 10.2.10.1/24
+  Vlan211:
+    tenant: svi_profile_tests
+    description: igmp_snooping_enabled_211
+    shutdown: false
+    vrf: svi_profile_tests_vrf
+    ip_address_virtual: 10.2.11.1/24
+  Vlan212:
+    tenant: svi_profile_tests
+    description: igmp_snooping_enabled_212
+    shutdown: false
+    vrf: svi_profile_tests_vrf
+    ip_address_virtual: 10.2.12.1/24
+  Vlan310:
+    tenant: svi_profile_tests
+    description: vxlan_disabled_310
+    shutdown: false
+    vrf: svi_profile_tests_vrf
+    ip_address_virtual: 10.3.10.1/24
+  Vlan311:
+    tenant: svi_profile_tests
+    description: vxlan_disabled_311
+    shutdown: false
+    vrf: svi_profile_tests_vrf
+    ip_address_virtual: 10.3.11.1/24
+  Vlan312:
+    tenant: svi_profile_tests
+    description: vxlan_disabled_312
+    shutdown: false
+    vrf: svi_profile_tests_vrf
+    ip_address_virtual: 10.3.12.1/24
+  Vlan410:
+    tenant: svi_profile_tests
+    description: static_routes_410
+    shutdown: false
+    vrf: svi_profile_tests_vrf
+    ip_virtual_router_addresses:
+    - 10.4.10.1/24
+  Vlan411:
+    tenant: svi_profile_tests
+    description: static_routes_411
+    shutdown: false
+    vrf: svi_profile_tests_vrf
+    ip_virtual_router_addresses:
+    - 10.4.11.1/24
+  Vlan412:
+    tenant: svi_profile_tests
+    description: static_routes_412
+    shutdown: false
+    vrf: svi_profile_tests_vrf
+    ip_virtual_router_addresses:
+    - 10.4.12.1/24
+  Vlan510:
+    tenant: svi_profile_tests
+    description: ospf_enabled_510
+    shutdown: false
+    vrf: svi_profile_tests_vrf
+    ip_address_virtual: 10.5.10.1/24
+    ospf_area: 0
+    ospf_network_point_to_point: false
+  Vlan511:
+    tenant: svi_profile_tests
+    description: ospf_enabled_511
+    shutdown: false
+    vrf: svi_profile_tests_vrf
+    ip_address_virtual: 10.5.11.1/24
+    ospf_area: 0
+    ospf_network_point_to_point: false
+  Vlan512:
+    tenant: svi_profile_tests
+    description: ospf_enabled_512
+    shutdown: false
+    vrf: svi_profile_tests_vrf
+    ip_address_virtual: 10.5.12.1/24
+    ospf_area: 0
+    ospf_network_point_to_point: false
+router_ospf:
+  process_ids:
+    1:
+      vrf: svi_profile_tests_vrf
+      passive_interface_default: true
+      router_id: 192.168.255.1
+      no_passive_interfaces:
+      - Vlan510
+      max_lsa: 15000
+      redistribute:
+        bgp:
+          enabled: true
+vxlan_interface:
+  Vxlan1:
+    description: SVI_PROFILE_NODE_2_VTEP
+    vxlan:
+      source_interface: Loopback1
+      udp_port: 4789
+      vlans:
+        110:
+          vni: 10110
+        111:
+          vni: 10111
+        112:
+          vni: 10112
+        113:
+          vni: 10113
+        114:
+          vni: 10114
+        115:
+          vni: 10115
+        210:
+          vni: 10210
+        211:
+          vni: 10211
+        212:
+          vni: 10212
+        311:
+          vni: 10311
+        312:
+          vni: 10312
+        410:
+          vni: 10410
+        411:
+          vni: 10411
+        412:
+          vni: 10412
+        510:
+          vni: 10510
+        511:
+          vni: 10511
+        512:
+          vni: 10512
+      vrfs:
+        svi_profile_tests_vrf:
+          vni: 1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/SVI_PROFILE_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/SVI_PROFILE_TESTS.yml
@@ -119,9 +119,9 @@ svi_profiles:
   vxlan_child_profile_3:
     parent_profile: vxlan_parent_profile_2
 
-#### ---- Test enheritance of svi.ip_virtual_router_addresses ----- ###
+#### ---- Test inheritance of svi.ip_virtual_router_addresses ----- ###
 # Tests logic for network services: static-routes and vlan-interfaces
-# Prescendence order:
+# Precedence order:
 # 1. svi.ip_virtual_router_addresses
 # 2. svi_profile.ip_virtual_router_addresses
 # 3. svi_parent_profile.ip_virtual_router_addresses

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/SVI_PROFILE_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/SVI_PROFILE_TESTS.yml
@@ -21,7 +21,7 @@ l3leaf:
       bgp_as: 65002
 
 
-#### ---- Test enheritance of svi structured_configuration ----- ###
+#### ---- Test inheritance of svi structured_configuration ----- ###
 # Test logic for network services: vlan-interfaces
 # Structured config is not be merged recursively, but will be taken directly from the most specific level
 # Prescendence order:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/SVI_PROFILE_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/SVI_PROFILE_TESTS.yml
@@ -333,7 +333,7 @@ tenants:
             profile: static_routes_child_profile_3
 
 
-#### ---- Test enheritance of svi ospf.enabled ----- ###
+#### ---- Test inheritance of svi ospf.enabled ----- ###
 # Tests logic for network services: ospf and vlan-interfaces.
 
           # # ospf_enabled_set on svi to true, child_profile and parent_profile set to false

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/SVI_PROFILE_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/SVI_PROFILE_TESTS.yml
@@ -143,11 +143,9 @@ svi_profiles:
   static_routes_child_profile_3:
     parent_profile: static_routes_parent_profile_2
 
-#### ---- Test enheritance of svi ospf.enabled ----- ###
-
-#### ---- Test enheritance of svi.ospf.enabled ----- ###
+#### ---- Test inheritance of svi.ospf.enabled ----- ###
 # Tests logic for network services: static-routes and vlan-interfaces
-# Prescendence order:
+# Precedence order:
 # 1. svi.ospf.enabled
 # 2. svi_profile.ospf.enabled
 # 3. svi_parent_profile.ospf.enabled

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/SVI_PROFILE_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/SVI_PROFILE_TESTS.yml
@@ -184,8 +184,8 @@ tenants:
           max_lsa: 15000
         svis:
 
-#### ---- Test enheritance of svi structured_configuration ----- ###
-# Test logic for network services: vlan-interfaces
+#### ---- Test inheritance of svi structured_configuration ----- ###
+# Tests logic for network services: vlan-interfaces
 
           # Set nodes[inventory_hostname].structured_config on all levels
           # Expected results:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/SVI_PROFILE_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/SVI_PROFILE_TESTS.yml
@@ -95,9 +95,9 @@ svi_profiles:
   igmp_child_profile_3:
     parent_profile: igmp_parent_profile_2
 
-#### ---- Test enheritance of svi.vxlan ----- ###
+#### ---- Test inheritance of svi.vxlan ----- ###
 # Tests logic for network services: router-bgp-vlan-aware-bundles, router-bgp-vlans and vxlan-interface.
-# Prescendence order:
+# Precedence order:
 # 1. svi.vxlan
 # 2. svi_profile.vxlan
 # 3. svi_parent_profile.vxlan

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/SVI_PROFILE_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/SVI_PROFILE_TESTS.yml
@@ -253,7 +253,7 @@ tenants:
             ip_address_virtual: 10.1.15.1/24
             profile: struct_config_child_profile_4
 
-#### ---- Test enheritance of svi igmp_snooping_enabled ----- ###
+#### ---- Test inheritance of svi igmp_snooping_enabled ----- ###
 # Tests logic for network services: ip igmp snooping
 # Expected result for all tests is that igmp snooping is enabled for all VLANs
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/SVI_PROFILE_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/SVI_PROFILE_TESTS.yml
@@ -23,7 +23,7 @@ l3leaf:
 
 #### ---- Test inheritance of svi structured_configuration ----- ###
 # Test logic for network services: vlan-interfaces
-# Structured config is not be merged recursively, but will be taken directly from the most specific level
+# Structured config is not being merged recursively, but will be taken directly from the most specific level
 # Prescendence order:
 # 1. svi.nodes[inventory_hostname].structured_config
 # 2. svi_profile.nodes[inventory_hostname].structured_config

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/SVI_PROFILE_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/SVI_PROFILE_TESTS.yml
@@ -307,7 +307,7 @@ tenants:
             ip_address_virtual: 10.3.12.1/24
             profile: vxlan_child_profile_3
 
-#### ---- Test enheritance of svi ip_virtual_router_addresses ----- ###
+#### ---- Test inheritance of svi ip_virtual_router_addresses ----- ###
 # Tests logic for network services: static-routes and vlan-interfaces.
 
           # ip_virtual_router_addresses set on svi, child_profile and parent_profile

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/SVI_PROFILE_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/SVI_PROFILE_TESTS.yml
@@ -72,9 +72,9 @@ svi_profiles:
     parent_profile: struct_config_parent_profile_2
 
 
-#### ---- Test enheritance of svi igmp_snooping_enabled ----- ###
+#### ---- Test inheritance of svi igmp_snooping_enabled ----- ###
 # Tests logic for network services: ip igmp snooping
-# Prescendence order:
+# Precedence order:
 # 1. svi.igmp_snooping_enabled
 # 2. svi_profile.igmp_snooping_enabled
 # 3. svi_parent_profile.igmp_snooping_enabled

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/SVI_PROFILE_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/SVI_PROFILE_TESTS.yml
@@ -1,0 +1,363 @@
+---
+# This test case is not for testing every single feature, but more to test the inheritance between
+# svi profiles, parent profiles and svis.
+
+type: l3leaf
+mgmt_gateway: 10.0.0.1
+
+l3leaf:
+  defaults:
+    loopback_ipv4_pool: 192.168.255.0/24
+    vtep_loopback_ipv4_pool: 192.168.254.0/24
+    virtual_router_mac_address: 00:1c:73:00:DC:01
+  nodes:
+    #
+    SVI_PROFILE_NODE_1:
+      id: 1
+      bgp_as: 65001
+    # test with evpn_vlan_aware_bundles: true
+    SVI_PROFILE_NODE_2:
+      id: 1
+      bgp_as: 65002
+
+
+#### ---- Test enheritance of svi structured_configuration ----- ###
+# Test logic for network services: vlan-interfaces
+# Structured config is not be merged recursively, but will be taken directly from the most specific level
+# Prescendence order:
+# 1. svi.nodes[inventory_hostname].structured_config
+# 2. svi_profile.nodes[inventory_hostname].structured_config
+# 3. svi_parent_profile.nodes[inventory_hostname].structured_config
+# 4. svi.structured_config
+# 5. svi_profile.structured_config
+# 6. svi_parent_profile.structured_config
+
+svi_profiles:
+  struct_config_parent_profile_1:
+    structured_config:
+      description: "set from structured_config on svi_parent_profile.structured_config"
+    nodes:
+      SVI_PROFILE_NODE_1:
+        structured_config:
+          description: "set from structured_config on svi_parent_profile.nodes[inventory_hostname].structured_config"
+      SVI_PROFILE_NODE_2:
+        structured_config:
+          description: "set from structured_config on svi_parent_profile.nodes[inventory_hostname].structured_config"
+
+  struct_config_child_profile_1:
+    structured_config:
+      description: "set from structured_config on svi_profile.structured_config"
+    nodes:
+      SVI_PROFILE_NODE_1:
+        structured_config:
+          description: "set from structured_config on svi_profile.nodes[inventory_hostname].structured_config"
+      SVI_PROFILE_NODE_2:
+        structured_config:
+          description: "set from structured_config on svi_profile.nodes[inventory_hostname].structured_config"
+    parent_profile: struct_config_parent_profile_1
+
+  struct_config_child_profile_2:
+    parent_profile: struct_config_parent_profile_1
+
+  struct_config_parent_profile_2:
+    structured_config:
+      description: "set from structured_config on svi_parent_profile.structured_config"
+
+  struct_config_child_profile_3:
+    structured_config:
+      description: "set from structured_config on svi_profile.structured_config"
+    parent_profile: struct_config_parent_profile_2
+
+  struct_config_child_profile_4:
+    parent_profile: struct_config_parent_profile_2
+
+
+#### ---- Test enheritance of svi igmp_snooping_enabled ----- ###
+# Tests logic for network services: ip igmp snooping
+# Prescendence order:
+# 1. svi.igmp_snooping_enabled
+# 2. svi_profile.igmp_snooping_enabled
+# 3. svi_parent_profile.igmp_snooping_enabled
+
+  igmp_parent_profile_1:
+    igmp_snooping_enabled: false
+
+  igmp_parent_profile_2:
+    igmp_snooping_enabled: true
+
+  igmp_child_profile_1:
+    igmp_snooping_enabled: false
+
+  igmp_child_profile_2:
+    igmp_snooping_enabled: true
+    parent_profile: igmp_parent_profile_1
+
+  igmp_child_profile_3:
+    parent_profile: igmp_parent_profile_2
+
+#### ---- Test enheritance of svi.vxlan ----- ###
+# Tests logic for network services: router-bgp-vlan-aware-bundles, router-bgp-vlans and vxlan-interface.
+# Prescendence order:
+# 1. svi.vxlan
+# 2. svi_profile.vxlan
+# 3. svi_parent_profile.vxlan
+
+  vxlan_parent_profile_1:
+    vxlan: true
+
+  vxlan_parent_profile_2:
+    vxlan: false
+
+  vxlan_child_profile_1:
+    vxlan: true
+    parent_profile: vxlan_parent_profile_1
+
+  vxlan_child_profile_2:
+    vxlan: false
+    parent_profile: vxlan_parent_profile_1
+
+  vxlan_child_profile_3:
+    parent_profile: vxlan_parent_profile_2
+
+#### ---- Test enheritance of svi.ip_virtual_router_addresses ----- ###
+# Tests logic for network services: static-routes and vlan-interfaces
+# Prescendence order:
+# 1. svi.ip_virtual_router_addresses
+# 2. svi_profile.ip_virtual_router_addresses
+# 3. svi_parent_profile.ip_virtual_router_addresses
+
+  static_routes_parent_profile_1:
+    ip_virtual_router_addresses: [1.1.1.1/24]
+
+  static_routes_parent_profile_2:
+    ip_virtual_router_addresses: [10.4.12.1/24]
+
+  static_routes_child_profile_1:
+    ip_virtual_router_addresses: [1.1.1.1/24]
+    parent_profile: static_routes_parent_profile_1
+
+  static_routes_child_profile_2:
+    ip_virtual_router_addresses: [10.4.11.1/24]
+    parent_profile: static_routes_parent_profile_1
+
+  static_routes_child_profile_3:
+    parent_profile: static_routes_parent_profile_2
+
+#### ---- Test enheritance of svi ospf.enabled ----- ###
+
+#### ---- Test enheritance of svi.ospf.enabled ----- ###
+# Tests logic for network services: static-routes and vlan-interfaces
+# Prescendence order:
+# 1. svi.ospf.enabled
+# 2. svi_profile.ospf.enabled
+# 3. svi_parent_profile.ospf.enabled
+
+  ospf_enabled_parent_profile_1:
+    ospf:
+      enabled: false
+
+  ospf_enabled_parent_profile_2:
+    ospf:
+      enabled: true
+
+  ospf_enabled_child_profile_1:
+    ospf:
+      enabled: false
+    parent_profile: ospf_enabled_parent_profile_1
+
+  ospf_enabled_child_profile_2:
+    ospf:
+      enabled: true
+    parent_profile: ospf_enabled_parent_profile_1
+
+  ospf_enabled_child_profile_3:
+    parent_profile: ospf_enabled_parent_profile_2
+
+### --- Network Services Generic base config--- ###
+
+tenants:
+  svi_profile_tests:
+    mac_vrf_vni_base: 10000
+    vrfs:
+      svi_profile_tests_vrf:
+        vrf_id: 1
+        ospf:
+          enabled: true
+          max_lsa: 15000
+        svis:
+
+#### ---- Test enheritance of svi structured_configuration ----- ###
+# Test logic for network services: vlan-interfaces
+
+          # Set nodes[inventory_hostname].structured_config on all levels
+          # Expected results:
+          # - description: "set from structured_config on svi.nodes[inventory_hostname].structured_config"
+          110:
+            name: svi_profile_tests_110_description
+            enabled: true
+            ip_address_virtual: 10.1.10.1/24
+            structured_config:
+              description: set from svi.structured_config
+            nodes:
+              SVI_PROFILE_NODE_1:
+                structured_config:
+                  description: set from structured_config on svi.nodes[inventory_hostname].structured_config
+              SVI_PROFILE_NODE_2:
+                structured_config:
+                  description: set from structured_config on svi.nodes[inventory_hostname].structured_config
+            profile: struct_config_child_profile_1
+
+          # Set nodes[inventory_hostname].structured_config on child_profile and parent_profile
+          # Expected results:
+          # - description: "set from structured_config on svi_profile.nodes[inventory_hostname].structured_config"
+          111:
+            name: svi_profile_tests_111_description
+            enabled: true
+            ip_address_virtual: 10.1.11.1/24
+            structured_config:
+              description: set from svi.structured_config
+            profile: struct_config_child_profile_1
+
+          # Set nodes[inventory_hostname].structured_config on parent_profile
+          # Expected results:
+          # - descripton: "set from structured_config on svi_parent_profile.nodes[inventory_hostname].structured_config"
+          112:
+            name: svi_profile_tests_112_description
+            enabled: true
+            ip_address_virtual: 10.1.12.1/24
+            structured_config:
+              description: set from svi.structured_config
+            profile: struct_config_child_profile_2
+
+          # Expected results:
+          # - description: "set from structured_config on svi.structured_config"
+          113:
+            name: svi_profile_tests_113_description
+            enabled: true
+            ip_address_virtual: 10.1.13.1/24
+            structured_config:
+              description: set from svi.structured_config
+            profile: struct_config_child_profile_3
+
+          # Expected results:
+          # - description: set from structured_config on svi_profile.structured_config
+          114:
+            name: svi_profile_tests_114_description
+            enabled: true
+            ip_address_virtual: 10.1.14.1/24
+            profile: struct_config_child_profile_3
+
+          # Expected results:
+          # - description: set from structured_config on svi_parent_profile.structured_config
+          115:
+            name: svi_profile_tests_115_description
+            enabled: true
+            ip_address_virtual: 10.1.15.1/24
+            profile: struct_config_child_profile_4
+
+#### ---- Test enheritance of svi igmp_snooping_enabled ----- ###
+# Tests logic for network services: ip igmp snooping
+# Expected result for all tests is that igmp snooping is enabled for all VLANs
+
+          # igmp_snooping_enabled set on svi to true, child_profile and parent_profile set to false
+          210:
+            name: igmp_snooping_enabled_210
+            enabled: true
+            ip_address_virtual: 10.2.10.1/24
+            igmp_snooping_enabled: true
+            profile: igmp_child_profile_1
+
+          # igmp_snooping_enabled set on child_profile to true and parent_profile set to false
+          211:
+            name: igmp_snooping_enabled_211
+            enabled: true
+            ip_address_virtual: 10.2.11.1/24
+            profile: igmp_child_profile_2
+
+          # igmp_snooping_enabled set on parent_profile to true
+          212:
+            name: igmp_snooping_enabled_212
+            enabled: true
+            ip_address_virtual: 10.2.12.1/24
+            profile: igmp_child_profile_3
+
+#### ---- Test enheritance of svi ip_virtual_router_addresses ----- ###
+# Tests logic for network services: static-routes.
+# Expected result for all tests is vxlan disabled for all VLANs
+
+          # vxlan set on svi to false, child_profile and parent_profile set to true
+          310:
+            name: vxlan_disabled_310
+            enabled: true
+            ip_address_virtual: 10.3.10.1/24
+            vxlan: false
+            profile: vxlan_child_profile_1
+
+          # vxlan set on child_profile to false and parent_profile set to true
+          311:
+            name: vxlan_disabled_311
+            enabled: true
+            ip_address_virtual: 10.3.11.1/24
+            profile: vxlan_child_profile_2
+
+          # vxlan set on parent_profile to false
+          312:
+            name: vxlan_disabled_312
+            enabled: true
+            ip_address_virtual: 10.3.12.1/24
+            profile: vxlan_child_profile_3
+
+#### ---- Test enheritance of svi ip_virtual_router_addresses ----- ###
+# Tests logic for network services: static-routes and vlan-interfaces.
+
+          # ip_virtual_router_addresses set on svi, child_profile and parent_profile
+          # expected result: svi.ip_virtual_router_addresses should win
+          410:
+            name: static_routes_410
+            enabled: true
+            ip_virtual_router_addresses: [10.4.10.1/24]
+            profile: static_routes_child_profile_1
+
+          # ip_virtual_router_addresses set on child_profile and parent_profile
+          # expected result: child_profile.ip_virtual_router_addresses should win
+          411:
+            name: static_routes_411
+            enabled: true
+            profile: static_routes_child_profile_2
+
+          # ip_virtual_router_addresses set on child_profile and parent_profile
+          # expected result: parent_profile.ip_virtual_router_addresses should win
+          412:
+            name: static_routes_412
+            enabled: true
+            profile: static_routes_child_profile_3
+
+
+#### ---- Test enheritance of svi ospf.enabled ----- ###
+# Tests logic for network services: ospf and vlan-interfaces.
+
+          # # ospf_enabled_set on svi to true, child_profile and parent_profile set to false
+          # # expected result: osfp enabled on svi
+          510:
+            name: ospf_enabled_510
+            enabled: true
+            ip_address_virtual: 10.5.10.1/24
+            ospf:
+              enabled: true
+            profile: ospf_enabled_child_profile_1
+
+          # ospf_enabled set on child_profile to true and parent_profile set to false
+          # expected result: osfp enabled on svi
+          511:
+            name: ospf_enabled_511
+            enabled: true
+            ip_address_virtual: 10.5.11.1/24
+            profile: ospf_enabled_child_profile_2
+
+          # ospf_enabled on parent_profile set to true
+          # expected result: osfp enabled on svi
+          512:
+            name: ospf_enabled_512
+            enabled: true
+            ip_address_virtual: 10.5.12.1/24
+            profile: ospf_enabled_child_profile_3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/SVI_PROFILE_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/SVI_PROFILE_TESTS.yml
@@ -336,8 +336,8 @@ tenants:
 #### ---- Test inheritance of svi ospf.enabled ----- ###
 # Tests logic for network services: ospf and vlan-interfaces.
 
-          # # ospf_enabled_set on svi to true, child_profile and parent_profile set to false
-          # # expected result: osfp enabled on svi
+          # ospf_enabled_set on svi to true, child_profile and parent_profile set to false
+          # expected result: osfp enabled on svi
           510:
             name: ospf_enabled_510
             enabled: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/SVI_PROFILE_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/SVI_PROFILE_TESTS.yml
@@ -24,7 +24,7 @@ l3leaf:
 #### ---- Test inheritance of svi structured_configuration ----- ###
 # Test logic for network services: vlan-interfaces
 # Structured config is not being merged recursively, but will be taken directly from the most specific level
-# Prescendence order:
+# Precedence order:
 # 1. svi.nodes[inventory_hostname].structured_config
 # 2. svi_profile.nodes[inventory_hostname].structured_config
 # 3. svi_parent_profile.nodes[inventory_hostname].structured_config

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/SVI_PROFILE_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/SVI_PROFILE_TESTS.yml
@@ -281,7 +281,7 @@ tenants:
             ip_address_virtual: 10.2.12.1/24
             profile: igmp_child_profile_3
 
-#### ---- Test enheritance of svi ip_virtual_router_addresses ----- ###
+#### ---- Test inheritance of svi ip_virtual_router_addresses ----- ###
 # Tests logic for network services: static-routes.
 # Expected result for all tests is vxlan disabled for all VLANs
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/SVI_PROFILE_NODE_2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/SVI_PROFILE_NODE_2.yml
@@ -1,0 +1,1 @@
+evpn_vlan_aware_bundles: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
@@ -38,7 +38,6 @@ all:
               hosts:
                 UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1A:
                 UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1B:
-
         UNDERLAY_MULTICAST_TESTS:
           children:
             UNDERLAY_MULTICAST_SPINES:
@@ -63,6 +62,11 @@ all:
             EVPN-MULTICAST-L3LEAF1A:
             EVPN-MULTICAST-L3LEAF1B:
             EVPN-MULTICAST-L3LEAF2A:
+        SVI_PROFILE_TESTS:
+          hosts:
+            SVI_PROFILE_NODE_1:
+            SVI_PROFILE_NODE_2:
+
         AVD_LAB:
           children:
             DC1_FABRIC:

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
@@ -607,7 +607,7 @@ mac_address_table:
 ```yaml
 # Optional profiles to share common settings for SVIs
 # Keys are the same used under SVIs. Keys defined under SVIs take precedence.
-# Note, structured configuration is not merged recursively and will be taken directly from the most specific level in the following order:
+# Note: structured configuration is not merged recursively and will be taken directly from the most specific level in the following order:
 # 1. svi.nodes[inventory_hostname].structured_config
 # 2. svi_profile.nodes[inventory_hostname].structured_config
 # 3. svi_parent_profile.nodes[inventory_hostname].structured_config

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
@@ -607,7 +607,7 @@ mac_address_table:
 ```yaml
 # Optional profiles to share common settings for SVIs
 # Keys are the same used under SVIs. Keys defined under SVIs take precedence.
-# Note, structured configuration is not merged recursilvy and will be taken directly from the most specific level in the following order:
+# Note, structured configuration is not merged recursively and will be taken directly from the most specific level in the following order:
 # 1. svi.nodes[inventory_hostname].structured_config
 # 2. svi_profile.nodes[inventory_hostname].structured_config
 # 3. svi_parent_profile.nodes[inventory_hostname].structured_config

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
@@ -9,7 +9,7 @@
 
 ## Variables and Options
 
-### Tenants Keys
+### Global Network Services Parameters
 
 ```yaml
 # Define network services keys, to define grouping of network services.
@@ -70,28 +70,11 @@ internal_vlan_order:
 # Use to change the EOS default of 300
 mac_address_table:
   aging_time: < time_in_seconds >
+```
 
-# Optional profiles to apply on SVI interfaces
-# Each profile can support all or some of the following keys according to your own needs.
-# Keys are the same used under SVI.
-# Svi_profiles can refer to another svi_profiles to inherit settings in up to two levels (svi->profile->parent_profile).
-svi_profiles:
-  < profile_name >:
-    parent_profile: < svi_profile_name >
-    mtu: < mtu >
-    enabled: < true | false >
-    ip_virtual_router_addresses:
-      - < IPv4_address/Mask | IPv4_address >
-    ip_address_virtual: < IPv4_address/Mask >
-    ipv6_address_virtual: < IPv6_address/Mask >
-    ip_address_virtual_secondaries:
-      - < IPv4_address/Mask >
-    igmp_snooping_enabled: < true | false | default true (eos) >
-    ip_helpers:
-      < IPv4 dhcp server IP >:
-        source_interface: < interface-name >
-        source_vrf: < VRF to originate DHCP relay packets to DHCP server >
+### Tenant Network Service Definitions
 
+```yaml
 # Dictionary of network services: L3 VRFs and L2 VLANS.
 # The network service key from network_services_keys
 < network_services_keys.key_1 >:
@@ -617,6 +600,25 @@ svi_profiles:
       < 1-4096 >:
         name: < description >
         tags: [ < tag_1 >, < tag_2 > ]
+```
+
+### SVI Profiles
+
+```yaml
+# Optional profiles to share common settings for SVIs
+# Keys are the same used under SVIs. Keys defined under SVIs take precedence.
+# Note, structured configuration is not merged recursilvy and will be taken directly from the most specific level in the following order:
+# 1. svi.nodes[inventory_hostname].structured_config
+# 2. svi_profile.nodes[inventory_hostname].structured_config
+# 3. svi_parent_profile.nodes[inventory_hostname].structured_config
+# 4. svi.structured_config
+# 5. svi_profile.structured_config
+# 6. svi_parent_profile.structured_config
+svi_profiles:
+  < profile_name >:
+    # Parent Profile | Optional
+    # svi_profiles can refer to another svi_profile to inherit settings in up to two levels (adapter->svi_profile->svi_parent_profile).
+    parent_profile: < svi_profile_name >
 ```
 
 ## Examples

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/ip-igmp-snooping.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/ip-igmp-snooping.j2
@@ -10,23 +10,9 @@ ip_igmp_snooping:
 {%         for vrf in tenant.vrfs %}
 {# Tenant VLANs w/SVIs #}
 {%             for svi in vrf.svis %}
-{# Detect if a svi_profile exists #}
-{# If exists, create a shortpath to access profile data #}
-{%                 if svi.profile is arista.avd.defined %}
-{%                     set svi_profile = svi_profiles | arista.avd.default([]) |
-                                                                      arista.avd.convert_dicts('profile') |
-                                                                      selectattr('profile', 'arista.avd.defined', svi.profile) |
-                                                                      first %}
-{%                 endif %}
-{%                 if svi_profile.parent_profile is arista.avd.defined %}
-{%                     set parent_profile = svi_profile.parent_profile | arista.avd.default({}) %}
-{%                 endif %}
-{%                 set svi_igmp_snooping_enabled = svi.igmp_snooping_enabled | arista.avd.default(
-                                                   svi_profile.igmp_snooping_enabled,
-                                                   parent_profile.igmp_snooping_enabled) %}
-{%                 if svi_igmp_snooping_enabled is arista.avd.defined %}
+{%                 if svi.igmp_snooping_enabled is arista.avd.defined %}
     {{ svi.id | int }}:
-      enabled: {{ svi_igmp_snooping_enabled }}
+      enabled: {{ svi.igmp_snooping_enabled }}
 {%                 endif %}
 {%             endfor %}
 {%         endfor %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/logic.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/logic.j2
@@ -38,6 +38,7 @@
 {%                     for svi in vrf.svis | arista.avd.convert_dicts('id') | arista.avd.natural_sort('id') %}
 {%                         if svi.id | int in whitelist.vlans %}
 {%                             if "all" in match_tags or svi.tags | arista.avd.default(['all']) is arista.avd.contains(match_tags) %}
+{%                                 set tmp_svi = {} %}
 {%                                 if svi.profile is arista.avd.defined %}
 {%                                     set svi_profile = svi_profiles | arista.avd.default({}) |
                                                                         arista.avd.convert_dicts('profile') |
@@ -48,11 +49,11 @@
                                                                                    arista.avd.convert_dicts('profile') |
                                                                                    selectattr('profile', 'arista.avd.defined', svi_profile.parent_profile) |
                                                                                    first %}
+{%                                         set tmp_svi = svi_parent_profile %}
 {%                                     endif %}
+{%                                     set tmp_svi = tmp_svi | ansible.builtin.combine(svi_profile, recursive=true, list_merge='replace') %}
 {%                                 endif %}
-{%                                 set tmp_svi = {} | ansible.builtin.combine(svi_parent_profile | arista.avd.default({}),
-                                                       svi_profile | arista.avd.default({}),
-                                                       svi, recursive=true, list_merge='replace') %}
+{%                                 set tmp_svi = tmp_svi | ansible.builtin.combine(svi, recursive=true, list_merge='replace') %}
 {#                                 Structured config should not be merged recursively, but will be taken directly from the most specific level #}
 {%                                 do tmp_svi.update({"structured_config": svi.nodes[inventory_hostname].structured_config | arista.avd.default(
                                                                            svi_profile.nodes[inventory_hostname].structured_config,

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/logic.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/logic.j2
@@ -38,7 +38,29 @@
 {%                     for svi in vrf.svis | arista.avd.convert_dicts('id') | arista.avd.natural_sort('id') %}
 {%                         if svi.id | int in whitelist.vlans %}
 {%                             if "all" in match_tags or svi.tags | arista.avd.default(['all']) is arista.avd.contains(match_tags) %}
-{%                                 do tmp_svis.append(svi) %}
+{%                                 if svi.profile is arista.avd.defined %}
+{%                                     set svi_profile = svi_profiles | arista.avd.default({}) |
+                                                                        arista.avd.convert_dicts('profile') |
+                                                                        selectattr('profile', 'arista.avd.defined', svi.profile) |
+                                                                        first %}
+{%                                     if svi_profile.parent_profile is arista.avd.defined %}
+{%                                         set svi_parent_profile = svi_profiles | arista.avd.default({}) |
+                                                                                   arista.avd.convert_dicts('profile') |
+                                                                                   selectattr('profile', 'arista.avd.defined', svi_profile.parent_profile) |
+                                                                                   first %}
+{%                                     endif %}
+{%                                 endif %}
+{%                                 set tmp_svi = {} | ansible.builtin.combine(svi_parent_profile | arista.avd.default({}),
+                                                       svi_profile | arista.avd.default({}),
+                                                       svi, recursive=true, list_merge='replace') %}
+{#                                 Structured config should not be merged recursively, but will be taken directly from the most specific level #}
+{%                                 do tmp_svi.update({"structured_config": svi.nodes[inventory_hostname].structured_config | arista.avd.default(
+                                                                           svi_profile.nodes[inventory_hostname].structured_config,
+                                                                           svi_parent_profile.nodes[inventory_hostname].structured_config,
+                                                                           svi.structured_config,
+                                                                           svi_profile.structured_config,
+                                                                           svi_parent_profile.structured_config)}) %}
+{%                                 do tmp_svis.append(tmp_svi) %}
 {%                             endif %}
 {%                         endif %}
 {%                     endfor %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/static-routes.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/static-routes.j2
@@ -28,20 +28,10 @@ ipv6_static_routes:
 {%             endfor %}
 {%         endif %}
 {%         for svi in vrf.svis %}
-{# Detect if a svi_profile exists #}
-{# If exists, create a shortpath to access profile data #}
-{%             if svi.profile is arista.avd.defined %}
-{%                 set svi_profile = svi_profiles | arista.avd.default([]) |
-                                                                      arista.avd.convert_dicts('profile') |
-                                                                      selectattr('profile', 'arista.avd.defined', svi.profile) |
-                                                                      first %}
-{%             endif %}
-{%             set svi_varpv6 = svi.ipv6_virtual_router_addresses | arista.avd.default(
-                              svi_profile.ipv6_virtual_router_addresses) %}
-{%             if svi_varpv6 is arista.avd.defined %}
+{%             if svi.ipv6_virtual_router_addresses is arista.avd.defined %}
 {# Detect if VARP addresses with prefixes exist and loop through the ip_address/prefix #}
 {# If the VARP address with prefix doesn't exist then it will loop through empty_list [], so config is not generated in this scenario #}
-{%                 for dest_addr_prefix in svi_varpv6 | ansible.netcommon.ipaddr(0) | ansible.netcommon.ipaddr('net') %}
+{%                 for dest_addr_prefix in svi.ipv6_virtual_router_addresses | ansible.netcommon.ipaddr(0) | ansible.netcommon.ipaddr('net') %}
   - destination_address_prefix: {{ dest_addr_prefix }}
     vrf: {{ vrf.name }}
     name: "VARPv6"
@@ -81,20 +71,10 @@ static_routes:
 {%             endfor %}
 {%         endif %}
 {%         for svi in vrf.svis %}
-{# Detect if a svi_profile exists #}
-{# If exists, create a shortpath to access profile data #}
-{%             if svi.profile is arista.avd.defined %}
-{%                 set svi_profile = svi_profiles | arista.avd.default([]) |
-                                                                      arista.avd.convert_dicts('profile') |
-                                                                      selectattr('profile', 'arista.avd.defined', svi.profile) |
-                                                                      first %}
-{%             endif %}
-{%             set svi_varp = svi.ip_virtual_router_addresses | arista.avd.default(
-                              svi_profile.ip_virtual_router_addresses) %}
-{%             if svi_varp is arista.avd.defined %}
+{%             if svi.ip_virtual_router_addresses  is arista.avd.defined %}
 {# Detect if VARP addresses with prefixes exist and loop through the ip_address/prefix #}
 {# If the VARP address with prefix doesn't exist then it will loop through empty_list [], so config is not generated in this scenario #}
-{%                 for dest_addr_prefix in svi_varp | ansible.netcommon.ipaddr(0) | ansible.netcommon.ipaddr('net') %}
+{%                 for dest_addr_prefix in svi.ip_virtual_router_addresses | ansible.netcommon.ipaddr(0) | ansible.netcommon.ipaddr('net') %}
   - destination_address_prefix: {{ dest_addr_prefix }}
     vrf: {{ vrf.name }}
     name: "VARP"

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vlan-interfaces.j2
@@ -3,43 +3,19 @@ vlan_interfaces:
 {% for tenant in network_services_data.tenants %}
 {%     for vrf in tenant.vrfs %}
 {%         for svi in vrf.svis %}
-{# Detect if a svi_profile exists #}
-{# If exists, create a shortpath to access profile data #}
-{%             if svi.profile is arista.avd.defined %}
-{%                 set svi_profile = svi_profiles | arista.avd.default([]) |
-                                                                      arista.avd.convert_dicts('profile') |
-                                                                      selectattr('profile', 'arista.avd.defined', svi.profile) |
-                                                                      first %}
-{%             endif %}
-{%             if svi_profile.parent_profile is arista.avd.defined %}
-{%                 set parent_profile = svi_profiles | arista.avd.default([]) |
-                                                                      arista.avd.convert_dicts('profile') |
-                                                                      selectattr('profile', 'arista.avd.defined', svi_profile.parent_profile) |
-                                                                      first %}
-{%             endif %}
-{%             set svi_settings = {} | ansible.builtin.combine(parent_profile | arista.avd.default({}),
-                                               svi_profile | arista.avd.default({}),
-                                               svi, recursive=true, list_merge='replace') %}
-{#             Structured config should not be merged recursively, but will be taken directly from the most specific level #}
-{%             set svi_structured_config = svi.nodes[inventory_hostname].structured_config | arista.avd.default(
-                                           svi_profile.nodes[inventory_hostname].structured_config,
-                                           parent_profile.nodes[inventory_hostname].structured_config,
-                                           svi.structured_config,
-                                           svi_profile.structured_config,
-                                           parent_profile.structured_config) %}
-{%             set svi_raw_eos_cli = svi_settings.nodes[inventory_hostname].raw_eos_cli | arista.avd.default(
-                                     svi_settings.raw_eos_cli) %}
-{%             set svi_ip_helpers = svi_settings.ip_helpers | arista.avd.default(
+{%             set svi_raw_eos_cli = svi.nodes[inventory_hostname].raw_eos_cli | arista.avd.default(
+                                     svi.raw_eos_cli) %}
+{%             set svi_ip_helpers = svi.ip_helpers | arista.avd.default(
                                     vrf.ip_helpers) | arista.avd.convert_dicts('ip_helper') %}
-{%             set svi_description = svi_settings.description | arista.avd.default(
-                                     svi_settings.name) %}
+{%             set svi_description = svi.description | arista.avd.default(
+                                     svi.name) %}
   Vlan{{ svi.id | int }}:
     tenant: {{ tenant.name }}
-    tags: {{ svi_settings.tags | arista.avd.default }}
+    tags: {{ svi.tags | arista.avd.default }}
 {%             if svi_description is arista.avd.defined %}
     description: {{ svi_description }}
 {%             endif %}
-{%             if svi_settings.enabled is arista.avd.defined(true) %}
+{%             if svi.enabled is arista.avd.defined(true) %}
     shutdown: false
 {%             else %}
     shutdown: true
@@ -47,48 +23,48 @@ vlan_interfaces:
 {%             if vrf.name != 'default' %}
     vrf: {{ vrf.name }}
 {%             else %}
-{%                 set svi_subnet = svi_settings.nodes[inventory_hostname].ip_address | arista.avd.default(svi_settings.ip_address_virtual) | ansible.netcommon.ipaddr('subnet') %}
+{%                 set svi_subnet = svi.nodes[inventory_hostname].ip_address | arista.avd.default(svi.ip_address_virtual) | ansible.netcommon.ipaddr('subnet') %}
 {%                 if svi_subnet is arista.avd.defined and svi_subnet %}
 {%                     do default_vrf.svi_subnets.append(svi_subnet) %}
 {%                 endif %}
 {%             endif %}
 {# IP address configuration #}
-{%             if svi_settings.nodes[inventory_hostname].ip_address is arista.avd.defined %}
-    ip_address: {{ svi_settings.nodes[inventory_hostname].ip_address }}
+{%             if svi.nodes[inventory_hostname].ip_address is arista.avd.defined %}
+    ip_address: {{ svi.nodes[inventory_hostname].ip_address }}
 {%             endif %}
 {# IPv6 address configuration #}
-{%             if svi_settings.nodes[inventory_hostname].ipv6_address is arista.avd.defined %}
+{%             if svi.nodes[inventory_hostname].ipv6_address is arista.avd.defined %}
 {%                 do network_services_data.ipv6vrfs.update({vrf.name: True}) %}
-    ipv6_address: {{ svi_settings.nodes[inventory_hostname].ipv6_address }}
+    ipv6_address: {{ svi.nodes[inventory_hostname].ipv6_address }}
 {%             endif %}
 {# Virtual Router IP Address #}
-{%             if svi_settings.ip_virtual_router_addresses is arista.avd.defined %}
-    ip_virtual_router_addresses: {{ svi_settings.ip_virtual_router_addresses }}
+{%             if svi.ip_virtual_router_addresses is arista.avd.defined %}
+    ip_virtual_router_addresses: {{ svi.ip_virtual_router_addresses }}
 {%             endif %}
 {# Virtual Router IPv6 Address #}
-{%             if svi_settings.ipv6_virtual_router_addresses is arista.avd.defined %}
-    ipv6_virtual_router_addresses: {{ svi_settings.ipv6_virtual_router_addresses }}
+{%             if svi.ipv6_virtual_router_addresses is arista.avd.defined %}
+    ipv6_virtual_router_addresses: {{ svi.ipv6_virtual_router_addresses }}
 {%             endif %}
 {# Virtual IP address #}
-{%             if svi_settings.ip_address_virtual is arista.avd.defined %}
-    ip_address_virtual: {{ svi_settings.ip_address_virtual }}
+{%             if svi.ip_address_virtual is arista.avd.defined %}
+    ip_address_virtual: {{ svi.ip_address_virtual }}
 {%             endif %}
 {# Virtual IPv6 address #}
-{%             if svi_settings.ipv6_address_virtual is arista.avd.defined %}
+{%             if svi.ipv6_address_virtual is arista.avd.defined %}
 {%                 do network_services_data.ipv6vrfs.update({vrf.name: True}) %}
-    ipv6_address_virtual: {{ svi_settings.ipv6_address_virtual }}
+    ipv6_address_virtual: {{ svi.ipv6_address_virtual }}
 {%             endif %}
 {# Virtual Secondary IP address #}
-{%             if svi_settings.ip_address_virtual_secondaries is arista.avd.defined %}
-    ip_address_virtual_secondaries: {{ svi_settings.ip_address_virtual_secondaries }}
+{%             if svi.ip_address_virtual_secondaries is arista.avd.defined %}
+    ip_address_virtual_secondaries: {{ svi.ip_address_virtual_secondaries }}
 {%             endif %}
 {# Virtual Secondary IPv6 address #}
-{%             if svi_settings.ipv6_address_virtual_secondaries is arista.avd.defined %}
-    ipv6_address_virtual_secondaries: {{ svi_settings.ipv6_address_virtual_secondaries }}
+{%             if svi.ipv6_address_virtual_secondaries is arista.avd.defined %}
+    ipv6_address_virtual_secondaries: {{ svi.ipv6_address_virtual_secondaries }}
 {%             endif %}
 {# MTU definition #}
-{%             if svi_settings.mtu is arista.avd.defined %}
-    mtu: {{ svi_settings.mtu }}
+{%             if svi.mtu is arista.avd.defined %}
+    mtu: {{ svi.mtu }}
 {%             endif %}
 {# IP helper configuration #}
 {%             if svi_ip_helpers is arista.avd.defined %}
@@ -99,19 +75,19 @@ vlan_interfaces:
         vrf: {{ helper_ip.source_vrf | arista.avd.default }}
 {%                 endfor %}
 {%             endif %}
-{%             if svi_settings.ospf.enabled is arista.avd.defined(true) and vrf.ospf.enabled is arista.avd.defined(true) %}
-    ospf_area: {{ svi_settings.ospf.area | arista.avd.default(0) }}
-    ospf_network_point_to_point: {{ svi_settings.ospf.point_to_point | arista.avd.default(false) }}
-{%                 if svi_settings.ospf.cost is arista.avd.defined %}
-    ospf_cost: {{ svi_settings.ospf.cost }}
+{%             if svi.ospf.enabled is arista.avd.defined(true) and vrf.ospf.enabled is arista.avd.defined(true) %}
+    ospf_area: {{ svi.ospf.area | arista.avd.default(0) }}
+    ospf_network_point_to_point: {{ svi.ospf.point_to_point | arista.avd.default(false) }}
+{%                 if svi.ospf.cost is arista.avd.defined %}
+    ospf_cost: {{ svi.ospf.cost }}
 {%                 endif %}
-{%                 if svi_settings.ospf.authentication is arista.avd.defined("simple") and svi_settings.ospf.simple_auth_key is arista.avd.defined %}
+{%                 if svi.ospf.authentication is arista.avd.defined("simple") and svi.ospf.simple_auth_key is arista.avd.defined %}
     ospf_authentication: "simple"
-    ospf_authentication_key: {{ svi_settings.ospf.simple_auth_key }}
-{%                 elif svi_settings.ospf.authentication is arista.avd.defined("message-digest") and svi_settings.ospf.message_digest_keys is arista.avd.defined %}
+    ospf_authentication_key: {{ svi.ospf.simple_auth_key }}
+{%                 elif svi.ospf.authentication is arista.avd.defined("message-digest") and svi.ospf.message_digest_keys is arista.avd.defined %}
     ospf_authentication: "message-digest"
     ospf_message_digest_keys:
-{%                     for key in svi_settings.ospf.message_digest_keys | arista.avd.natural_sort %}
+{%                     for key in svi.ospf.message_digest_keys | arista.avd.natural_sort %}
 {%                         if key.id is arista.avd.defined and key.key is arista.avd.defined %}
       {{ key.id }}:
         hash_algorithm: {{ key.hash_algorithm | arista.avd.default("sha512") }}
@@ -124,8 +100,8 @@ vlan_interfaces:
     eos_cli: |
       {{ svi_raw_eos_cli | indent(6,false) }}
 {%             endif %}
-{%             if svi_structured_config is arista.avd.defined %}
-    struct_cfg: {{ svi_structured_config }}
+{%             if svi.structured_config is arista.avd.defined %}
+    struct_cfg: {{ svi.structured_config }}
 {%             endif %}
 {%         endfor %}
 {# VLAN interface for iBGP peering in overlay VRFs #}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vlan-interfaces.j2
@@ -5,16 +5,11 @@ vlan_interfaces:
 {%         for svi in vrf.svis %}
 {%             set svi_raw_eos_cli = svi.nodes[inventory_hostname].raw_eos_cli | arista.avd.default(
                                      svi.raw_eos_cli) %}
-{%             set svi_ip_helpers = svi.ip_helpers | arista.avd.default(
-                                    vrf.ip_helpers) | arista.avd.convert_dicts('ip_helper') %}
-{%             set svi_description = svi.description | arista.avd.default(
-                                     svi.name) %}
+{%             set svi_ip_helpers = svi.ip_helpers | arista.avd.default(vrf.ip_helpers) %}
   Vlan{{ svi.id | int }}:
     tenant: {{ tenant.name }}
     tags: {{ svi.tags | arista.avd.default }}
-{%             if svi_description is arista.avd.defined %}
-    description: {{ svi_description }}
-{%             endif %}
+    description: {{ svi.description | arista.avd.default(svi.name) }}
 {%             if svi.enabled is arista.avd.defined(true) %}
     shutdown: false
 {%             else %}
@@ -69,7 +64,7 @@ vlan_interfaces:
 {# IP helper configuration #}
 {%             if svi_ip_helpers is arista.avd.defined %}
     ip_helpers:
-{%                 for helper_ip in svi_ip_helpers %}
+{%                 for helper_ip in svi_ip_helpers | arista.avd.convert_dicts('ip_helper') %}
       {{ helper_ip.ip_helper }}:
         source_interface: {{ helper_ip.source_interface | arista.avd.default }}
         vrf: {{ helper_ip.source_vrf | arista.avd.default }}


### PR DESCRIPTION
## Change Summary

- Refactor logic for svi_profile and svi_profile.parent_profile to be processed in logic.j2 template
   - This change makes all keys able to be used with svi_profiles.
   - Kept existing behavior of key merging strategies, so change is non-breaking.
- Fix issue in igmp template where svi_profile.parent_profile was not being processed.
- Improvement of test coverage in `eos_designs_unit_tests`.

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

No data model changes.

## How to test

See Molecule results

`molecule converge --scenario-name eos_designs_unit_tests -- --limit SVI_PROFILE_TESTS`

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
