### PR TITLE
Test(eos_designs): Remove invalid variables from molecule scenarios

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/mgmt_interface_default.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/mgmt_interface_default.md
@@ -45,7 +45,7 @@
 
 | Management Interface | description | Type | VRF | IP Address | Gateway |
 | -------------------- | ----------- | ---- | --- | ---------- | ------- |
-| Management1 | oob_management | oob | MGMT | 1.1.1.2 | 192.168.200.5 |
+| Management1 | oob_management | oob | MGMT | 1.1.1.2 | 1.1.1.1 |
 
 #### IPv6
 
@@ -390,13 +390,13 @@ no ip routing vrf MGMT
 
 | VRF | Destination Prefix | Next Hop IP             | Exit interface      | Administrative Distance       | Tag               | Route Name                    | Metric         |
 | --- | ------------------ | ----------------------- | ------------------- | ----------------------------- | ----------------- | ----------------------------- | -------------- |
-| MGMT | 0.0.0.0/0 | 192.168.200.5 | - | 1 | - | - | - |
+| MGMT | 0.0.0.0/0 | 1.1.1.1 | - | 1 | - | - | - |
 
 ### Static Routes Device Configuration
 
 ```eos
 !
-ip route vrf MGMT 0.0.0.0/0 192.168.200.5
+ip route vrf MGMT 0.0.0.0/0 1.1.1.1
 ```
 
 # Multicast

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/mgmt_interface_fabric.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/mgmt_interface_fabric.md
@@ -45,7 +45,7 @@
 
 | Management Interface | description | Type | VRF | IP Address | Gateway |
 | -------------------- | ----------- | ---- | --- | ---------- | ------- |
-| MY_INTERFACE_FABRIC | oob_management | oob | MGMT | 1.1.1.2 | 192.168.200.5 |
+| MY_INTERFACE_FABRIC | oob_management | oob | MGMT | 1.1.1.2 | 1.1.1.1 |
 
 #### IPv6
 
@@ -377,13 +377,13 @@ no ip routing vrf MGMT
 
 | VRF | Destination Prefix | Next Hop IP             | Exit interface      | Administrative Distance       | Tag               | Route Name                    | Metric         |
 | --- | ------------------ | ----------------------- | ------------------- | ----------------------------- | ----------------- | ----------------------------- | -------------- |
-| MGMT | 0.0.0.0/0 | 192.168.200.5 | - | 1 | - | - | - |
+| MGMT | 0.0.0.0/0 | 1.1.1.1 | - | 1 | - | - | - |
 
 ### Static Routes Device Configuration
 
 ```eos
 !
-ip route vrf MGMT 0.0.0.0/0 192.168.200.5
+ip route vrf MGMT 0.0.0.0/0 1.1.1.1
 ```
 
 # Multicast

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/mgmt_interface_host.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/mgmt_interface_host.md
@@ -50,7 +50,7 @@
 
 | Management Interface | description | Type | VRF | IP Address | Gateway |
 | -------------------- | ----------- | ---- | --- | ---------- | ------- |
-| MY_INTERFACE_HOST | oob_management | oob | MGMT | 1.1.1.2 | 192.168.200.5 |
+| MY_INTERFACE_HOST | oob_management | oob | MGMT | 1.1.1.2 | 1.1.1.1 |
 
 #### IPv6
 
@@ -394,13 +394,13 @@ no ip routing vrf MGMT
 
 | VRF | Destination Prefix | Next Hop IP             | Exit interface      | Administrative Distance       | Tag               | Route Name                    | Metric         |
 | --- | ------------------ | ----------------------- | ------------------- | ----------------------------- | ----------------- | ----------------------------- | -------------- |
-| MGMT | 0.0.0.0/0 | 192.168.200.5 | - | 1 | - | - | - |
+| MGMT | 0.0.0.0/0 | 1.1.1.1 | - | 1 | - | - | - |
 
 ### Static Routes Device Configuration
 
 ```eos
 !
-ip route vrf MGMT 0.0.0.0/0 192.168.200.5
+ip route vrf MGMT 0.0.0.0/0 1.1.1.1
 ```
 
 # Multicast

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/mgmt_interface_platform.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/documentation/devices/mgmt_interface_platform.md
@@ -50,7 +50,7 @@
 
 | Management Interface | description | Type | VRF | IP Address | Gateway |
 | -------------------- | ----------- | ---- | --- | ---------- | ------- |
-| Management0 | oob_management | oob | MGMT | 1.1.1.2 | 192.168.200.5 |
+| Management0 | oob_management | oob | MGMT | 1.1.1.2 | 1.1.1.1 |
 
 #### IPv6
 
@@ -394,13 +394,13 @@ no ip routing vrf MGMT
 
 | VRF | Destination Prefix | Next Hop IP             | Exit interface      | Administrative Distance       | Tag               | Route Name                    | Metric         |
 | --- | ------------------ | ----------------------- | ------------------- | ----------------------------- | ----------------- | ----------------------------- | -------------- |
-| MGMT | 0.0.0.0/0 | 192.168.200.5 | - | 1 | - | - | - |
+| MGMT | 0.0.0.0/0 | 1.1.1.1 | - | 1 | - | - | - |
 
 ### Static Routes Device Configuration
 
 ```eos
 !
-ip route vrf MGMT 0.0.0.0/0 192.168.200.5
+ip route vrf MGMT 0.0.0.0/0 1.1.1.1
 ```
 
 # Multicast

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_default.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_default.cfg
@@ -127,7 +127,7 @@ interface Management1
 ip routing
 no ip routing vrf MGMT
 !
-ip route vrf MGMT 0.0.0.0/0 192.168.200.5
+ip route vrf MGMT 0.0.0.0/0 1.1.1.1
 !
 management api http-commands
    protocol https

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_fabric.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_fabric.cfg
@@ -123,7 +123,7 @@ interface MY_INTERFACE_FABRIC
 ip routing
 no ip routing vrf MGMT
 !
-ip route vrf MGMT 0.0.0.0/0 192.168.200.5
+ip route vrf MGMT 0.0.0.0/0 1.1.1.1
 !
 management api http-commands
    protocol https

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_host.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_host.cfg
@@ -128,7 +128,7 @@ hardware tcam
 ip routing
 no ip routing vrf MGMT
 !
-ip route vrf MGMT 0.0.0.0/0 192.168.200.5
+ip route vrf MGMT 0.0.0.0/0 1.1.1.1
 !
 management api http-commands
    protocol https

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_platform.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_platform.cfg
@@ -128,7 +128,7 @@ hardware tcam
 ip routing
 no ip routing vrf MGMT
 !
-ip route vrf MGMT 0.0.0.0/0 192.168.200.5
+ip route vrf MGMT 0.0.0.0/0 1.1.1.1
 !
 management api http-commands
    protocol https

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_default.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_default.yml
@@ -1,7 +1,7 @@
 static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  gateway: 1.1.1.1
 service_routing_protocols_model: multi-agent
 ip_routing: true
 daemon_terminattr:
@@ -72,7 +72,7 @@ management_interfaces:
     shutdown: false
     vrf: MGMT
     ip_address: 1.1.1.2
-    gateway: 192.168.200.5
+    gateway: 1.1.1.1
     type: oob
 management_api_http:
   enable_vrfs:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_fabric.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_fabric.yml
@@ -1,7 +1,7 @@
 static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  gateway: 1.1.1.1
 service_routing_protocols_model: multi-agent
 ip_routing: true
 daemon_terminattr:
@@ -48,7 +48,7 @@ management_interfaces:
     shutdown: false
     vrf: MGMT
     ip_address: 1.1.1.2
-    gateway: 192.168.200.5
+    gateway: 1.1.1.1
     type: oob
 management_api_http:
   enable_vrfs:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_host.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_host.yml
@@ -1,7 +1,7 @@
 static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  gateway: 1.1.1.1
 service_routing_protocols_model: multi-agent
 ip_routing: true
 daemon_terminattr:
@@ -48,7 +48,7 @@ management_interfaces:
     shutdown: false
     vrf: MGMT
     ip_address: 1.1.1.2
-    gateway: 192.168.200.5
+    gateway: 1.1.1.1
     type: oob
 tcam_profile:
   system: vxlan-routing

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_platform.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_platform.yml
@@ -1,7 +1,7 @@
 static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  gateway: 1.1.1.1
 service_routing_protocols_model: multi-agent
 ip_routing: true
 daemon_terminattr:
@@ -48,7 +48,7 @@ management_interfaces:
     shutdown: false
     vrf: MGMT
     ip_address: 1.1.1.2
-    gateway: 192.168.200.5
+    gateway: 1.1.1.1
     type: oob
 tcam_profile:
   system: vxlan-routing

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CORE_UNIT_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CORE_UNIT_TESTS.yml
@@ -40,7 +40,6 @@ core_router:
     loopback_ipv6_pool: "2000:1234:ffff:ffff::/64"
     node_sid_base: 200
     isis_system_id_prefix: "0000.0001"
-    core_interface_speed: "forced 100gfull"
   nodes:
     core-1-isis-sr-ldp:
       id: 1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/mgmt_interface_default.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/mgmt_interface_default.yml
@@ -1,10 +1,10 @@
 # Minimum config to only test the specific feature.
+mgmt_interface_vrf: MGMT
+mgmt_gateway: 1.1.1.1
 l2leaf:
   defaults:
   nodes:
     mgmt_interface_default:
-      mgmt_interface_vrf: MGMT
-      mgmt_gateway: 1.1.1.1
       mgmt_ip: 1.1.1.2
       id: 102
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/mgmt_interface_fabric.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/mgmt_interface_fabric.yml
@@ -1,10 +1,10 @@
 # Minimum config to only test the specific feature.
 mgmt_interface: MY_INTERFACE_FABRIC
+mgmt_interface_vrf: MGMT
+mgmt_gateway: 1.1.1.1
 l2leaf:
   defaults:
   nodes:
     mgmt_interface_fabric:
-      mgmt_interface_vrf: MGMT
-      mgmt_gateway: 1.1.1.1
       mgmt_ip: 1.1.1.2
       id: 103

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/mgmt_interface_host.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/mgmt_interface_host.yml
@@ -1,11 +1,11 @@
 # Minimum config to only test the specific feature.
+mgmt_interface_vrf: MGMT
+mgmt_gateway: 1.1.1.1
 l2leaf:
   defaults:
   nodes:
     mgmt_interface_host:
       platform: 7500R2
       mgmt_interface: MY_INTERFACE_HOST
-      mgmt_interface_vrf: MGMT
-      mgmt_gateway: 1.1.1.1
       mgmt_ip: 1.1.1.2
       id: 104

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/mgmt_interface_platform.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/mgmt_interface_platform.yml
@@ -1,10 +1,10 @@
 # Minimum config to only test the specific feature.
+mgmt_interface_vrf: MGMT
+mgmt_gateway: 1.1.1.1
 l2leaf:
   defaults:
   nodes:
     mgmt_interface_platform:
       platform: 7500R2
-      mgmt_interface_vrf: MGMT
-      mgmt_gateway: 1.1.1.1
       mgmt_ip: 1.1.1.2
       id: 105

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/inventory/host_vars/mgmt_interface_default.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/inventory/host_vars/mgmt_interface_default.yml
@@ -3,7 +3,5 @@ l2leaf:
   defaults:
   nodes:
     - name: mgmt_interface_default
-      mgmt_interface_vrf: MGMT
-      mgmt_gateway: 1.1.1.1
       mgmt_ip: 1.1.1.2
       id: 102

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/inventory/host_vars/mgmt_interface_fabric.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/inventory/host_vars/mgmt_interface_fabric.yml
@@ -4,7 +4,5 @@ l2leaf:
   defaults:
   nodes:
     - name: mgmt_interface_fabric
-      mgmt_interface_vrf: MGMT
-      mgmt_gateway: 1.1.1.1
       mgmt_ip: 1.1.1.2
       id: 103

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/inventory/host_vars/mgmt_interface_host.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/inventory/host_vars/mgmt_interface_host.yml
@@ -5,7 +5,5 @@ l2leaf:
     - name: mgmt_interface_host
       platform: 7500R2
       mgmt_interface: MY_INTERFACE_HOST
-      mgmt_interface_vrf: MGMT
-      mgmt_gateway: 1.1.1.1
       mgmt_ip: 1.1.1.2
       id: 104

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/inventory/host_vars/mgmt_interface_platform.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/inventory/host_vars/mgmt_interface_platform.yml
@@ -4,7 +4,5 @@ l2leaf:
   nodes:
     - name: mgmt_interface_platform
       platform: 7500R2
-      mgmt_interface_vrf: MGMT
-      mgmt_gateway: 1.1.1.1
       mgmt_ip: 1.1.1.2
       id: 105


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Remove invalid variables from molecule scenarios

During development of schemas I found a few molecule scenarios using non-existing variables. These are not used or tested further, so it will have no impact to remove them.

In one of the scenarios the mgmt_gateway was inherited from a group setting, leaving a mismatched gateway with the mgmt_ip. I have fixed as well, so that change will affect the molecule config.

`arista.avd.eos_designs`

## Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
