### PR TITLE
CI: Remove validation of single commit title

### DIFF
--- a/.github/workflows/pull-request-triage.yml
+++ b/.github/workflows/pull-request-triage.yml
@@ -100,4 +100,6 @@ jobs:
           # will suggest using that commit message instead of the PR title for the
           # merge commit, and it's easy to commit this by mistake. Enable this option
           # to also validate the commit message for one commit PRs.
-          validateSingleCommit: true
+          # Update 13-Jul-2022 CH: GitHub now offers a toggle for this behavior.
+          # We have set that to always use the PR title, so this check is no longer needed.
+          validateSingleCommit: false


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
CI: Remove validation of single commit title

Github now offers a toggle to always use the PR title as squash-merge message. We have set this toggle on github, so we no longer need to run this check in the pipeline.
