### PR TITLE
CI: add flake8 support matching ansible-test sanity

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
           - --max-line-length=160
           - --config=/dev/null
           - --
-        # Match the paths from ansible-test sanity command running in pipelien
+        # Match the paths from ansible-test sanity command running in pipeline
         types: [python]
         files: ansible_collections/arista/avd/(plugins|test|doc)
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,11 +14,6 @@ repos:
       - id: check-merge-conflict
         exclude: ansible_collections/arista/avd/molecule
 
-  # - repo: https://github.com/pre-commit/pre-commit-hooks
-  #   rev: v2.3.0
-  #   hooks:
-  #   - id: flake8
-
   # - repo: https://github.com/pre-commit/mirrors-autopep8
   #   rev: 'v1.5.6'  # Use the sha / tag you want to point at
   #   hooks:
@@ -36,9 +31,7 @@ repos:
           - --max-line-length=160
           - --config=/dev/null
           - --
-        # Match the paths from ansible-test sanity command running in pipeline
         types: [python]
-        files: ansible_collections/arista/avd/(plugins|test|doc)
 
   - repo: https://github.com/pycqa/pylint
     rev: 'pylint-2.6.0'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,22 @@ repos:
   #   hooks:
   #   -   id: autopep8
 
+  - repo: https://github.com/pycqa/flake8
+    rev: 4.0.1  # Note ansible-test uses pycodestyle 2.8.0 which is part of this tagged release of flake8
+    hooks:
+      - id: flake8
+        name: Check for PEP8 error on Python files
+        # ignoring errors and selecting line length as per
+        # https://github.com/ansible/ansible/blob/devel/test/lib/ansible_test/_util/controller/sanity/pep8/current-ignore.txt
+        args:
+          - --ignore=E402,W503,W504,E741
+          - --max-line-length=160
+          - --config=/dev/null
+          - --
+        # Match the paths from ansible-test sanity command running in pipelien
+        types: [python]
+        files: ansible_collections/arista/avd/(plugins|test|doc)
+
   - repo: https://github.com/pycqa/pylint
     rev: 'pylint-2.6.0'
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,6 @@ repos:
           - --ignore=E402,W503,W504,E741
           - --max-line-length=160
           - --config=/dev/null
-          - --
         types: [python]
 
   - repo: https://github.com/pycqa/pylint

--- a/ansible_collections/arista/avd/docs/_build/ansible2rst.py
+++ b/ansible_collections/arista/avd/docs/_build/ansible2rst.py
@@ -20,12 +20,9 @@ __metaclass__ = type
 
 import os
 import re
-import sys
 import datetime
 import cgi
 import yaml
-import logging
-from distutils.version import LooseVersion
 from jinja2 import Environment, FileSystemLoader
 from ansible.module_utils.six import print_
 from ansible.module_utils.common._collections_compat import MutableMapping, MutableSet, MutableSequence
@@ -34,14 +31,11 @@ from ansible.parsing.plugin_docs import read_docstring
 from ansible.parsing.yaml.loader import AnsibleLoader
 from ansible.plugins.loader import fragment_loader
 from ansible.module_utils._text import to_bytes
-from ansible.errors import AnsibleError, AnsibleParserError
+from ansible.errors import AnsibleError
 
 try:
     from html import escape as html_escape
 except ImportError:
-    # Python-3.2 or later
-    import cgi
-
     def html_escape(text, quote=True):
         return cgi.escape(text, quote)
 
@@ -77,7 +71,7 @@ def too_old(added):
         added_tokens = str(added).split(".")
         readded = added_tokens[0] + "." + added_tokens[1]
         added_float = float(readded)
-    except ValueError as e:
+    except ValueError:
         return False
     return added_float < TO_OLD_TO_BE_NOTABLE
 

--- a/ansible_collections/arista/avd/tests/unit/filters/test_add_md_toc.py
+++ b/ansible_collections/arista/avd/tests/unit/filters/test_add_md_toc.py
@@ -48,8 +48,7 @@ class TestAddMdTocFilter():
         if(MD_INPUT is not None):
             with open(MD_INPUT, "r") as input_file:
                 with pytest.raises(ValueError):
-                    resp = add_md_toc(input_file.read(),
-                                      toc_levels=INVALID_TOC_LEVEL)
+                    add_md_toc(input_file.read(), toc_levels=INVALID_TOC_LEVEL)
 
     def test_add_md_toc_invalid(self):
         md_input_toc_invalid = open(MD_INPUT_INVALID, "r")

--- a/ansible_collections/arista/avd/tests/unit/filters/test_convert_dicts.py
+++ b/ansible_collections/arista/avd/tests/unit/filters/test_convert_dicts.py
@@ -2,7 +2,6 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from ansible_collections.arista.avd.plugins.filter.convert_dicts import convert_dicts, FilterModule
-import pytest
 
 nested_list_of_dict = {'TEST1': [{'type': 'permit', 'extcommunities': '65000:65000'},
                                  {'type': 'deny', 'extcommunities': '65002:65002'}],

--- a/ansible_collections/arista/avd/tests/unit/filters/test_esi_management.py
+++ b/ansible_collections/arista/avd/tests/unit/filters/test_esi_management.py
@@ -2,11 +2,6 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from ansible_collections.arista.avd.plugins.filter.esi_management import FilterModule
-import logging
-import pytest
-import ansible
-import sys
-from jinja2.runtime import Undefined
 from ansible_collections.arista.avd.tests.unit.filters.filter_utils import convert_esi_short_to_route_target_format
 
 ESI_SHORT = "0303:0202:0101"

--- a/ansible_collections/arista/avd/tests/unit/filters/test_list_compress.py
+++ b/ansible_collections/arista/avd/tests/unit/filters/test_list_compress.py
@@ -14,14 +14,14 @@ f = FilterModule()
 
 class TestListCompressFilter():
     @pytest.mark.parametrize("LIST_TO_COMPRESS_INVALID", LIST_TO_COMPRESS_INVALID_VALUES)
-    def test_list_compress(self, LIST_TO_COMPRESS_INVALID):
+    def test_list_compress_invalid(self, LIST_TO_COMPRESS_INVALID):
         with pytest.raises(AnsibleFilterError) as exc_info:
             list_compress(LIST_TO_COMPRESS_INVALID)
         assert str(
             exc_info.value) == f"value must be of type list, got {type(LIST_TO_COMPRESS_INVALID)}"
 
     @pytest.mark.parametrize("LIST_TO_COMPRESS_VALID", LIST_TO_COMPRESS_VALID_VALUES)
-    def test_list_compress(self, LIST_TO_COMPRESS_VALID):
+    def test_list_compress_valid(self, LIST_TO_COMPRESS_VALID):
         resp = list_compress(LIST_TO_COMPRESS_VALID)
         assert resp in EXPECTED_RESULT_VALID_VALUES
 

--- a/ansible_collections/arista/avd/tests/unit/filters/test_range_expand.py
+++ b/ansible_collections/arista/avd/tests/unit/filters/test_range_expand.py
@@ -4,7 +4,7 @@ __metaclass__ = type
 from ansible_collections.arista.avd.plugins.filter.range_expand import FilterModule, AnsibleFilterError, range_expand
 import pytest
 
-RANGE_TO_EXPAND_INVALID_VALUES = ["1_3", {"key": "value"}, 33]
+RANGE_TO_EXPAND_INVALID_VALUES = [True, {"key": "value"}, 33]
 RANGE_TO_EXPAND_VALID_VALUES = [
     "Ethernet1",
     "Ethernet1-2",

--- a/ansible_collections/arista/avd/tests/unit/filters/test_range_expand.py
+++ b/ansible_collections/arista/avd/tests/unit/filters/test_range_expand.py
@@ -42,14 +42,14 @@ f = FilterModule()
 
 class TestListCompressFilter():
     @pytest.mark.parametrize("RANGE_TO_EXPAND_INVALID", RANGE_TO_EXPAND_INVALID_VALUES)
-    def test_range_expand(self, RANGE_TO_EXPAND_INVALID):
+    def test_range_expand_invalid(self, RANGE_TO_EXPAND_INVALID):
         with pytest.raises(AnsibleFilterError) as exc_info:
             range_expand(RANGE_TO_EXPAND_INVALID)
         assert str(
             exc_info.value) == f"value must be of type list or str, got {type(RANGE_TO_EXPAND_INVALID)}"
 
     @pytest.mark.parametrize("RANGE_TO_EXPAND_VALID", RANGE_TO_EXPAND_VALID_VALUES)
-    def test_range_expand(self, RANGE_TO_EXPAND_VALID):
+    def test_range_expand_valid(self, RANGE_TO_EXPAND_VALID):
         resp = range_expand(RANGE_TO_EXPAND_VALID)
         assert resp in EXPECTED_RESULT_VALID_VALUES
 

--- a/ansible_collections/arista/avd/tests/unit/filters/test_range_expand.py
+++ b/ansible_collections/arista/avd/tests/unit/filters/test_range_expand.py
@@ -4,7 +4,7 @@ __metaclass__ = type
 from ansible_collections.arista.avd.plugins.filter.range_expand import FilterModule, AnsibleFilterError, range_expand
 import pytest
 
-RANGE_TO_EXPAND_INVALID_VALUES = ["1-3", {"key": "value"}, 33]
+RANGE_TO_EXPAND_INVALID_VALUES = ["1_3", {"key": "value"}, 33]
 RANGE_TO_EXPAND_VALID_VALUES = [
     "Ethernet1",
     "Ethernet1-2",

--- a/ansible_collections/arista/avd/tests/unit/module_utils/test_strip_empties.py
+++ b/ansible_collections/arista/avd/tests/unit/module_utils/test_strip_empties.py
@@ -3,7 +3,6 @@ __metaclass__ = type
 
 from ansible_collections.arista.avd.plugins.module_utils.strip_empties import strip_null_from_data
 import pytest
-import logging
 
 STRIP_EMPTIES_LIST = {
     "None": ["string1", "string2", "string3", None],

--- a/ansible_collections/arista/avd/tests/unit/module_utils/test_utils.py
+++ b/ansible_collections/arista/avd/tests/unit/module_utils/test_utils.py
@@ -4,7 +4,6 @@ __metaclass__ = type
 from ansible_collections.arista.avd.plugins.module_utils.utils import get, AristaAvdError
 from contextlib import contextmanager
 import pytest
-import logging
 import re
 
 

--- a/ansible_collections/arista/avd/tests/unit/modules/test_configlet_build_config.py
+++ b/ansible_collections/arista/avd/tests/unit/modules/test_configlet_build_config.py
@@ -3,7 +3,6 @@ __metaclass__ = type
 
 from ansible_collections.arista.avd.plugins.modules.configlet_build_config import get_configlet
 import os
-import logging
 import pytest
 
 CONFIGLETS_DIR = os.path.dirname(os.path.realpath(

--- a/ansible_collections/arista/avd/tests/unit/modules/test_inventory_to_container.py
+++ b/ansible_collections/arista/avd/tests/unit/modules/test_inventory_to_container.py
@@ -164,7 +164,6 @@ class TestInventoryToContainer:
         assert output is None
 
     def test_get_device_option_value_empty_data(self, inventory):
-        data = inventory['all']['children']['CVP']['hosts']
         output = get_device_option_value(
             device_data_dict=None,
             option_name='cv_server')
@@ -189,7 +188,7 @@ class TestInventoryToContainer:
             inventory, search_container=SEARCH_CONTAINER, devices=devices)
         assert output == ["TEST_DEVICE"] + GET_DEVICES
 
-    def test_get_devices_preexisting_devices(self, inventory):
+    def test_get_devices_preexisting_devices_with_device_filter(self, inventory):
         output = get_devices(
             inventory, search_container=SEARCH_CONTAINER, devices=[], device_filter=[GET_DEVICE_FILTER])
         assert [GET_DEVICE_FILTER in item for item in output]


### PR DESCRIPTION
## Change Summary

Add Flake8 to pre-commit hook to run pycodestyle like in ansible-test sanity and be able to catch PEP8 errors locally before pushing to the repo

## Component(s) name

`pre-commit`

## Proposed changes

* Add flake8 hooks in pre-commit, passing the same options as the ones used in ansible-test sanity so that pycodestyle runs exactly the same (max line length 160, list of ignore code ..).
* Limit the files to the one listed in ansible-test sanity
* fixed a couple of python issues that flake8 found (unused imports, ...).

## How to test

Make a PEP8 error, e.g. over indent a line in a python file and run `pre-commit run` locally to see the error.

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
