### PR TITLE
Feat(eos_designs): Support structured config under network services svis and l2vlans for bgp commands

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
@@ -865,7 +865,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 | VLAN | Route-Distinguisher | Both Route-Target | Import Route Target | Export Route-Target | Redistribute |
 | ---- | ------------------- | ----------------- | ------------------- | ------------------- | ------------ |
 | 110 | 172.16.110.5:99110 | 99110:99110<br>remote 99110:99110 | - | - | learned |
-| 111 | 172.16.110.5:50111 | 50111:50111<br>remote 50111:50111 | - | - | learned |
+| 111 | 172.16.110.5:50111 | 50111:50111<br>remote 50111:50111 | - | - | learned<br>router-mac system |
 | 112 | 172.16.110.5:20112 | 20112:20112<br>remote 20112:20112 | - | - | learned |
 | 2500 | 172.16.110.5:2500 | 2500:2500<br>remote 2500:2500 | - | - | learned |
 | 2600 | 172.16.110.5:32600 | 32600:32600<br>remote 32600:32600 | - | - | learned |
@@ -965,6 +965,12 @@ router bgp 65112.100
       route-target both 50111:50111
       route-target import export evpn domain remote 50111:50111
       redistribute learned
+      redistribute router-mac system
+      !
+      comment
+      comment created from raw_eos_cli under router bgp vlan 113
+      EOF
+
    !
    vlan 112
       rd 172.16.110.5:20112

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
@@ -868,7 +868,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 | 111 | 172.16.110.5:50111 | 50111:50111<br>remote 50111:50111 | - | - | learned<br>router-mac system |
 | 112 | 172.16.110.5:20112 | 20112:20112<br>remote 20112:20112 | - | - | learned<br>router-mac system |
 | 2500 | 172.16.110.5:2500 | 2500:2500<br>remote 2500:2500 | - | - | learned |
-| 2600 | 172.16.110.5:32600 | 32600:32600<br>remote 32600:32600 | - | - | learned |
+| 2600 | 172.16.110.5:32600 | 32600:32600<br>remote 32600:32600 | - | - | learned<br>router-mac system |
 
 ### Router BGP VRFs
 
@@ -961,7 +961,7 @@ router bgp 65112.100
       redistribute router-mac system
       !
       comment
-      comment created from raw_eos_cli under router bgp vlan from svi profile
+      comment created from raw_eos_cli under router bgp svis inherited from svi profile
       EOF
 
    !
@@ -974,7 +974,7 @@ router bgp 65112.100
       redistribute router-mac system
       !
       comment
-      comment created from raw_eos_cli under router bgp vlan 111 from svi
+      comment created from raw_eos_cli under router bgp svi 111
       EOF
 
    !
@@ -987,7 +987,7 @@ router bgp 65112.100
       redistribute router-mac system
       !
       comment
-      comment created from raw_eos_cli under router bgp vlan from svi parent profile
+      comment created from raw_eos_cli under router bgp svis inherited from svi parent profile
       EOF
 
    !
@@ -1004,6 +1004,12 @@ router bgp 65112.100
       route-target both 32600:32600
       route-target import export evpn domain remote 32600:32600
       redistribute learned
+      redistribute router-mac system
+      !
+      comment
+      comment created from raw_eos_cli under router bgp l2vlan 2600
+      EOF
+
    !
    address-family evpn
       neighbor EVPN-OVERLAY-CORE activate

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD1-LEAF2B.md
@@ -864,9 +864,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 
 | VLAN | Route-Distinguisher | Both Route-Target | Import Route Target | Export Route-Target | Redistribute |
 | ---- | ------------------- | ----------------- | ------------------- | ------------------- | ------------ |
-| 110 | 172.16.110.5:99110 | 99110:99110<br>remote 99110:99110 | - | - | learned |
+| 110 | 172.16.110.5:99110 | 99110:99110<br>remote 99110:99110 | - | - | learned<br>router-mac system |
 | 111 | 172.16.110.5:50111 | 50111:50111<br>remote 50111:50111 | - | - | learned<br>router-mac system |
-| 112 | 172.16.110.5:20112 | 20112:20112<br>remote 20112:20112 | - | - | learned |
+| 112 | 172.16.110.5:20112 | 20112:20112<br>remote 20112:20112 | - | - | learned<br>router-mac system |
 | 2500 | 172.16.110.5:2500 | 2500:2500<br>remote 2500:2500 | - | - | learned |
 | 2600 | 172.16.110.5:32600 | 32600:32600<br>remote 32600:32600 | - | - | learned |
 
@@ -958,6 +958,12 @@ router bgp 65112.100
       route-target both 99110:99110
       route-target import export evpn domain remote 99110:99110
       redistribute learned
+      redistribute router-mac system
+      !
+      comment
+      comment created from raw_eos_cli under router bgp vlan from svi profile
+      EOF
+
    !
    vlan 111
       rd 172.16.110.5:50111
@@ -968,7 +974,7 @@ router bgp 65112.100
       redistribute router-mac system
       !
       comment
-      comment created from raw_eos_cli under router bgp vlan 113
+      comment created from raw_eos_cli under router bgp vlan 111 from svi
       EOF
 
    !
@@ -978,6 +984,12 @@ router bgp 65112.100
       route-target both 20112:20112
       route-target import export evpn domain remote 20112:20112
       redistribute learned
+      redistribute router-mac system
+      !
+      comment
+      comment created from raw_eos_cli under router bgp vlan from svi parent profile
+      EOF
+
    !
    vlan 2500
       rd 172.16.110.5:2500

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-LEAF1A.md
@@ -590,9 +590,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 
 | VLAN | Route-Distinguisher | Both Route-Target | Import Route Target | Export Route-Target | Redistribute |
 | ---- | ------------------- | ----------------- | ------------------- | ------------------- | ------------ |
-| 110 | 172.16.120.3:99110 | 99110:99110 | - | - | learned |
+| 110 | 172.16.120.3:99110 | 99110:99110 | - | - | learned<br>router-mac system |
 | 111 | 172.16.120.3:50111 | 50111:50111 | - | - | learned<br>router-mac system |
-| 112 | 172.16.120.3:20112 | 20112:20112 | - | - | learned |
+| 112 | 172.16.120.3:20112 | 20112:20112 | - | - | learned<br>router-mac system |
 | 2500 | 172.16.120.3:2500 | 2500:2500 | - | - | learned |
 | 2600 | 172.16.120.3:32600 | 32600:32600 | - | - | learned |
 
@@ -651,6 +651,12 @@ router bgp 65121
       rd 172.16.120.3:99110
       route-target both 99110:99110
       redistribute learned
+      redistribute router-mac system
+      !
+      comment
+      comment created from raw_eos_cli under router bgp vlan from svi profile
+      EOF
+
    !
    vlan 111
       rd 172.16.120.3:50111
@@ -659,7 +665,7 @@ router bgp 65121
       redistribute router-mac system
       !
       comment
-      comment created from raw_eos_cli under router bgp vlan 113
+      comment created from raw_eos_cli under router bgp vlan 111 from svi
       EOF
 
    !
@@ -667,6 +673,12 @@ router bgp 65121
       rd 172.16.120.3:20112
       route-target both 20112:20112
       redistribute learned
+      redistribute router-mac system
+      !
+      comment
+      comment created from raw_eos_cli under router bgp vlan from svi parent profile
+      EOF
+
    !
    vlan 2500
       rd 172.16.120.3:2500

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-LEAF1A.md
@@ -594,7 +594,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 | 111 | 172.16.120.3:50111 | 50111:50111 | - | - | learned<br>router-mac system |
 | 112 | 172.16.120.3:20112 | 20112:20112 | - | - | learned<br>router-mac system |
 | 2500 | 172.16.120.3:2500 | 2500:2500 | - | - | learned |
-| 2600 | 172.16.120.3:32600 | 32600:32600 | - | - | learned |
+| 2600 | 172.16.120.3:32600 | 32600:32600 | - | - | learned<br>router-mac system |
 
 ### Router BGP VRFs
 
@@ -654,7 +654,7 @@ router bgp 65121
       redistribute router-mac system
       !
       comment
-      comment created from raw_eos_cli under router bgp vlan from svi profile
+      comment created from raw_eos_cli under router bgp svis inherited from svi profile
       EOF
 
    !
@@ -665,7 +665,7 @@ router bgp 65121
       redistribute router-mac system
       !
       comment
-      comment created from raw_eos_cli under router bgp vlan 111 from svi
+      comment created from raw_eos_cli under router bgp svi 111
       EOF
 
    !
@@ -676,7 +676,7 @@ router bgp 65121
       redistribute router-mac system
       !
       comment
-      comment created from raw_eos_cli under router bgp vlan from svi parent profile
+      comment created from raw_eos_cli under router bgp svis inherited from svi parent profile
       EOF
 
    !
@@ -689,6 +689,12 @@ router bgp 65121
       rd 172.16.120.3:32600
       route-target both 32600:32600
       redistribute learned
+      redistribute router-mac system
+      !
+      comment
+      comment created from raw_eos_cli under router bgp l2vlan 2600
+      EOF
+
    !
    address-family evpn
       neighbor EVPN-OVERLAY-PEERS activate

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1-POD2-LEAF1A.md
@@ -591,7 +591,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 | VLAN | Route-Distinguisher | Both Route-Target | Import Route Target | Export Route-Target | Redistribute |
 | ---- | ------------------- | ----------------- | ------------------- | ------------------- | ------------ |
 | 110 | 172.16.120.3:99110 | 99110:99110 | - | - | learned |
-| 111 | 172.16.120.3:50111 | 50111:50111 | - | - | learned |
+| 111 | 172.16.120.3:50111 | 50111:50111 | - | - | learned<br>router-mac system |
 | 112 | 172.16.120.3:20112 | 20112:20112 | - | - | learned |
 | 2500 | 172.16.120.3:2500 | 2500:2500 | - | - | learned |
 | 2600 | 172.16.120.3:32600 | 32600:32600 | - | - | learned |
@@ -656,6 +656,12 @@ router bgp 65121
       rd 172.16.120.3:50111
       route-target both 50111:50111
       redistribute learned
+      redistribute router-mac system
+      !
+      comment
+      comment created from raw_eos_cli under router bgp vlan 113
+      EOF
+
    !
    vlan 112
       rd 172.16.120.3:20112

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1.POD1.LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1.POD1.LEAF2A.md
@@ -840,9 +840,9 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 
 | VLAN | Route-Distinguisher | Both Route-Target | Import Route Target | Export Route-Target | Redistribute |
 | ---- | ------------------- | ----------------- | ------------------- | ------------------- | ------------ |
-| 110 | 172.16.110.4:99110 | 99110:99110 | - | - | learned |
+| 110 | 172.16.110.4:99110 | 99110:99110 | - | - | learned<br>router-mac system |
 | 111 | 172.16.110.4:50111 | 50111:50111 | - | - | learned<br>router-mac system |
-| 112 | 172.16.110.4:20112 | 20112:20112 | - | - | learned |
+| 112 | 172.16.110.4:20112 | 20112:20112 | - | - | learned<br>router-mac system |
 | 2500 | 172.16.110.4:2500 | 2500:2500 | - | - | learned |
 | 2600 | 172.16.110.4:32600 | 32600:32600 | - | - | learned |
 
@@ -930,6 +930,12 @@ router bgp 65112.100
       rd 172.16.110.4:99110
       route-target both 99110:99110
       redistribute learned
+      redistribute router-mac system
+      !
+      comment
+      comment created from raw_eos_cli under router bgp vlan from svi profile
+      EOF
+
    !
    vlan 111
       rd 172.16.110.4:50111
@@ -938,7 +944,7 @@ router bgp 65112.100
       redistribute router-mac system
       !
       comment
-      comment created from raw_eos_cli under router bgp vlan 113
+      comment created from raw_eos_cli under router bgp vlan 111 from svi
       EOF
 
    !
@@ -946,6 +952,12 @@ router bgp 65112.100
       rd 172.16.110.4:20112
       route-target both 20112:20112
       redistribute learned
+      redistribute router-mac system
+      !
+      comment
+      comment created from raw_eos_cli under router bgp vlan from svi parent profile
+      EOF
+
    !
    vlan 2500
       rd 172.16.110.4:2500

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1.POD1.LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1.POD1.LEAF2A.md
@@ -841,7 +841,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 | VLAN | Route-Distinguisher | Both Route-Target | Import Route Target | Export Route-Target | Redistribute |
 | ---- | ------------------- | ----------------- | ------------------- | ------------------- | ------------ |
 | 110 | 172.16.110.4:99110 | 99110:99110 | - | - | learned |
-| 111 | 172.16.110.4:50111 | 50111:50111 | - | - | learned |
+| 111 | 172.16.110.4:50111 | 50111:50111 | - | - | learned<br>router-mac system |
 | 112 | 172.16.110.4:20112 | 20112:20112 | - | - | learned |
 | 2500 | 172.16.110.4:2500 | 2500:2500 | - | - | learned |
 | 2600 | 172.16.110.4:32600 | 32600:32600 | - | - | learned |
@@ -935,6 +935,12 @@ router bgp 65112.100
       rd 172.16.110.4:50111
       route-target both 50111:50111
       redistribute learned
+      redistribute router-mac system
+      !
+      comment
+      comment created from raw_eos_cli under router bgp vlan 113
+      EOF
+
    !
    vlan 112
       rd 172.16.110.4:20112

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1.POD1.LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC1.POD1.LEAF2A.md
@@ -844,7 +844,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.1.254
 | 111 | 172.16.110.4:50111 | 50111:50111 | - | - | learned<br>router-mac system |
 | 112 | 172.16.110.4:20112 | 20112:20112 | - | - | learned<br>router-mac system |
 | 2500 | 172.16.110.4:2500 | 2500:2500 | - | - | learned |
-| 2600 | 172.16.110.4:32600 | 32600:32600 | - | - | learned |
+| 2600 | 172.16.110.4:32600 | 32600:32600 | - | - | learned<br>router-mac system |
 
 ### Router BGP VRFs
 
@@ -933,7 +933,7 @@ router bgp 65112.100
       redistribute router-mac system
       !
       comment
-      comment created from raw_eos_cli under router bgp vlan from svi profile
+      comment created from raw_eos_cli under router bgp svis inherited from svi profile
       EOF
 
    !
@@ -944,7 +944,7 @@ router bgp 65112.100
       redistribute router-mac system
       !
       comment
-      comment created from raw_eos_cli under router bgp vlan 111 from svi
+      comment created from raw_eos_cli under router bgp svi 111
       EOF
 
    !
@@ -955,7 +955,7 @@ router bgp 65112.100
       redistribute router-mac system
       !
       comment
-      comment created from raw_eos_cli under router bgp vlan from svi parent profile
+      comment created from raw_eos_cli under router bgp svis inherited from svi parent profile
       EOF
 
    !
@@ -968,6 +968,12 @@ router bgp 65112.100
       rd 172.16.110.4:32600
       route-target both 32600:32600
       redistribute learned
+      redistribute router-mac system
+      !
+      comment
+      comment created from raw_eos_cli under router bgp l2vlan 2600
+      EOF
+
    !
    address-family evpn
       neighbor EVPN-OVERLAY-CORE activate

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2B.cfg
@@ -472,7 +472,7 @@ router bgp 65112.100
       redistribute router-mac system
       !
       comment
-      comment created from raw_eos_cli under router bgp vlan from svi profile
+      comment created from raw_eos_cli under router bgp svis inherited from svi profile
       EOF
 
    !
@@ -485,7 +485,7 @@ router bgp 65112.100
       redistribute router-mac system
       !
       comment
-      comment created from raw_eos_cli under router bgp vlan 111 from svi
+      comment created from raw_eos_cli under router bgp svi 111
       EOF
 
    !
@@ -498,7 +498,7 @@ router bgp 65112.100
       redistribute router-mac system
       !
       comment
-      comment created from raw_eos_cli under router bgp vlan from svi parent profile
+      comment created from raw_eos_cli under router bgp svis inherited from svi parent profile
       EOF
 
    !
@@ -515,6 +515,12 @@ router bgp 65112.100
       route-target both 32600:32600
       route-target import export evpn domain remote 32600:32600
       redistribute learned
+      redistribute router-mac system
+      !
+      comment
+      comment created from raw_eos_cli under router bgp l2vlan 2600
+      EOF
+
    !
    address-family evpn
       neighbor EVPN-OVERLAY-CORE activate

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2B.cfg
@@ -476,6 +476,12 @@ router bgp 65112.100
       route-target both 50111:50111
       route-target import export evpn domain remote 50111:50111
       redistribute learned
+      redistribute router-mac system
+      !
+      comment
+      comment created from raw_eos_cli under router bgp vlan 113
+      EOF
+
    !
    vlan 112
       rd 172.16.110.5:20112

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2B.cfg
@@ -469,6 +469,12 @@ router bgp 65112.100
       route-target both 99110:99110
       route-target import export evpn domain remote 99110:99110
       redistribute learned
+      redistribute router-mac system
+      !
+      comment
+      comment created from raw_eos_cli under router bgp vlan from svi profile
+      EOF
+
    !
    vlan 111
       rd 172.16.110.5:50111
@@ -479,7 +485,7 @@ router bgp 65112.100
       redistribute router-mac system
       !
       comment
-      comment created from raw_eos_cli under router bgp vlan 113
+      comment created from raw_eos_cli under router bgp vlan 111 from svi
       EOF
 
    !
@@ -489,6 +495,12 @@ router bgp 65112.100
       route-target both 20112:20112
       route-target import export evpn domain remote 20112:20112
       redistribute learned
+      redistribute router-mac system
+      !
+      comment
+      comment created from raw_eos_cli under router bgp vlan from svi parent profile
+      EOF
+
    !
    vlan 2500
       rd 172.16.110.5:2500

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD2-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD2-LEAF1A.cfg
@@ -246,7 +246,7 @@ router bgp 65121
       redistribute router-mac system
       !
       comment
-      comment created from raw_eos_cli under router bgp vlan from svi profile
+      comment created from raw_eos_cli under router bgp svis inherited from svi profile
       EOF
 
    !
@@ -257,7 +257,7 @@ router bgp 65121
       redistribute router-mac system
       !
       comment
-      comment created from raw_eos_cli under router bgp vlan 111 from svi
+      comment created from raw_eos_cli under router bgp svi 111
       EOF
 
    !
@@ -268,7 +268,7 @@ router bgp 65121
       redistribute router-mac system
       !
       comment
-      comment created from raw_eos_cli under router bgp vlan from svi parent profile
+      comment created from raw_eos_cli under router bgp svis inherited from svi parent profile
       EOF
 
    !
@@ -281,6 +281,12 @@ router bgp 65121
       rd 172.16.120.3:32600
       route-target both 32600:32600
       redistribute learned
+      redistribute router-mac system
+      !
+      comment
+      comment created from raw_eos_cli under router bgp l2vlan 2600
+      EOF
+
    !
    address-family evpn
       neighbor EVPN-OVERLAY-PEERS activate

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD2-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD2-LEAF1A.cfg
@@ -243,6 +243,12 @@ router bgp 65121
       rd 172.16.120.3:99110
       route-target both 99110:99110
       redistribute learned
+      redistribute router-mac system
+      !
+      comment
+      comment created from raw_eos_cli under router bgp vlan from svi profile
+      EOF
+
    !
    vlan 111
       rd 172.16.120.3:50111
@@ -251,7 +257,7 @@ router bgp 65121
       redistribute router-mac system
       !
       comment
-      comment created from raw_eos_cli under router bgp vlan 113
+      comment created from raw_eos_cli under router bgp vlan 111 from svi
       EOF
 
    !
@@ -259,6 +265,12 @@ router bgp 65121
       rd 172.16.120.3:20112
       route-target both 20112:20112
       redistribute learned
+      redistribute router-mac system
+      !
+      comment
+      comment created from raw_eos_cli under router bgp vlan from svi parent profile
+      EOF
+
    !
    vlan 2500
       rd 172.16.120.3:2500

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD2-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD2-LEAF1A.cfg
@@ -248,6 +248,12 @@ router bgp 65121
       rd 172.16.120.3:50111
       route-target both 50111:50111
       redistribute learned
+      redistribute router-mac system
+      !
+      comment
+      comment created from raw_eos_cli under router bgp vlan 113
+      EOF
+
    !
    vlan 112
       rd 172.16.120.3:20112

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1.POD1.LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1.POD1.LEAF2A.cfg
@@ -461,6 +461,12 @@ router bgp 65112.100
       rd 172.16.110.4:99110
       route-target both 99110:99110
       redistribute learned
+      redistribute router-mac system
+      !
+      comment
+      comment created from raw_eos_cli under router bgp vlan from svi profile
+      EOF
+
    !
    vlan 111
       rd 172.16.110.4:50111
@@ -469,7 +475,7 @@ router bgp 65112.100
       redistribute router-mac system
       !
       comment
-      comment created from raw_eos_cli under router bgp vlan 113
+      comment created from raw_eos_cli under router bgp vlan 111 from svi
       EOF
 
    !
@@ -477,6 +483,12 @@ router bgp 65112.100
       rd 172.16.110.4:20112
       route-target both 20112:20112
       redistribute learned
+      redistribute router-mac system
+      !
+      comment
+      comment created from raw_eos_cli under router bgp vlan from svi parent profile
+      EOF
+
    !
    vlan 2500
       rd 172.16.110.4:2500

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1.POD1.LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1.POD1.LEAF2A.cfg
@@ -464,7 +464,7 @@ router bgp 65112.100
       redistribute router-mac system
       !
       comment
-      comment created from raw_eos_cli under router bgp vlan from svi profile
+      comment created from raw_eos_cli under router bgp svis inherited from svi profile
       EOF
 
    !
@@ -475,7 +475,7 @@ router bgp 65112.100
       redistribute router-mac system
       !
       comment
-      comment created from raw_eos_cli under router bgp vlan 111 from svi
+      comment created from raw_eos_cli under router bgp svi 111
       EOF
 
    !
@@ -486,7 +486,7 @@ router bgp 65112.100
       redistribute router-mac system
       !
       comment
-      comment created from raw_eos_cli under router bgp vlan from svi parent profile
+      comment created from raw_eos_cli under router bgp svis inherited from svi parent profile
       EOF
 
    !
@@ -499,6 +499,12 @@ router bgp 65112.100
       rd 172.16.110.4:32600
       route-target both 32600:32600
       redistribute learned
+      redistribute router-mac system
+      !
+      comment
+      comment created from raw_eos_cli under router bgp l2vlan 2600
+      EOF
+
    !
    address-family evpn
       neighbor EVPN-OVERLAY-CORE activate

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1.POD1.LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1.POD1.LEAF2A.cfg
@@ -466,6 +466,12 @@ router bgp 65112.100
       rd 172.16.110.4:50111
       route-target both 50111:50111
       redistribute learned
+      redistribute router-mac system
+      !
+      comment
+      comment created from raw_eos_cli under router bgp vlan 113
+      EOF
+
    !
    vlan 112
       rd 172.16.110.4:20112

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
@@ -189,7 +189,7 @@ router_bgp:
       - router-mac system
       eos_cli: 'comment
 
-        comment created from raw_eos_cli under router bgp vlan from svi profile
+        comment created from raw_eos_cli under router bgp svis inherited from svi profile
 
         EOF
 
@@ -214,7 +214,7 @@ router_bgp:
       - router-mac system
       eos_cli: 'comment
 
-        comment created from raw_eos_cli under router bgp vlan 111 from svi
+        comment created from raw_eos_cli under router bgp svi 111
 
         EOF
 
@@ -239,7 +239,7 @@ router_bgp:
       - router-mac system
       eos_cli: 'comment
 
-        comment created from raw_eos_cli under router bgp vlan from svi parent profile
+        comment created from raw_eos_cli under router bgp svis inherited from svi parent profile
 
         EOF
 
@@ -275,6 +275,17 @@ router_bgp:
           route_target: 32600:32600
       redistribute_routes:
       - learned
+      - router-mac system
+      eos_cli: 'comment
+
+        comment created from raw_eos_cli under router bgp l2vlan 2600
+
+        EOF
+
+        '
+      struct_cfg:
+        redistribute_routes:
+        - router-mac system
 static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
@@ -186,6 +186,17 @@ router_bgp:
           route_target: 99110:99110
       redistribute_routes:
       - learned
+      - router-mac system
+      eos_cli: 'comment
+
+        comment created from raw_eos_cli under router bgp vlan from svi profile
+
+        EOF
+
+        '
+      struct_cfg:
+        redistribute_routes:
+        - router-mac system
     111:
       tenant: Tenant_A
       rd: 172.16.110.5:50111
@@ -203,7 +214,7 @@ router_bgp:
       - router-mac system
       eos_cli: 'comment
 
-        comment created from raw_eos_cli under router bgp vlan 113
+        comment created from raw_eos_cli under router bgp vlan 111 from svi
 
         EOF
 
@@ -225,6 +236,17 @@ router_bgp:
           route_target: 20112:20112
       redistribute_routes:
       - learned
+      - router-mac system
+      eos_cli: 'comment
+
+        comment created from raw_eos_cli under router bgp vlan from svi parent profile
+
+        EOF
+
+        '
+      struct_cfg:
+        redistribute_routes:
+        - router-mac system
     2500:
       tenant: Tenant_A
       rd: 172.16.110.5:2500

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
@@ -200,6 +200,17 @@ router_bgp:
           route_target: 50111:50111
       redistribute_routes:
       - learned
+      - router-mac system
+      eos_cli: 'comment
+
+        comment created from raw_eos_cli under router bgp vlan 113
+
+        EOF
+
+        '
+      struct_cfg:
+        redistribute_routes:
+        - router-mac system
     112:
       tenant: Tenant_A
       rd: 172.16.110.5:20112

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-LEAF1A.yml
@@ -132,7 +132,7 @@ router_bgp:
       - router-mac system
       eos_cli: 'comment
 
-        comment created from raw_eos_cli under router bgp vlan from svi profile
+        comment created from raw_eos_cli under router bgp svis inherited from svi profile
 
         EOF
 
@@ -151,7 +151,7 @@ router_bgp:
       - router-mac system
       eos_cli: 'comment
 
-        comment created from raw_eos_cli under router bgp vlan 111 from svi
+        comment created from raw_eos_cli under router bgp svi 111
 
         EOF
 
@@ -170,7 +170,7 @@ router_bgp:
       - router-mac system
       eos_cli: 'comment
 
-        comment created from raw_eos_cli under router bgp vlan from svi parent profile
+        comment created from raw_eos_cli under router bgp svis inherited from svi parent profile
 
         EOF
 
@@ -194,6 +194,17 @@ router_bgp:
         - 32600:32600
       redistribute_routes:
       - learned
+      - router-mac system
+      eos_cli: 'comment
+
+        comment created from raw_eos_cli under router bgp l2vlan 2600
+
+        EOF
+
+        '
+      struct_cfg:
+        redistribute_routes:
+        - router-mac system
 static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-LEAF1A.yml
@@ -129,6 +129,17 @@ router_bgp:
         - 99110:99110
       redistribute_routes:
       - learned
+      - router-mac system
+      eos_cli: 'comment
+
+        comment created from raw_eos_cli under router bgp vlan from svi profile
+
+        EOF
+
+        '
+      struct_cfg:
+        redistribute_routes:
+        - router-mac system
     111:
       tenant: Tenant_A
       rd: 172.16.120.3:50111
@@ -140,7 +151,7 @@ router_bgp:
       - router-mac system
       eos_cli: 'comment
 
-        comment created from raw_eos_cli under router bgp vlan 113
+        comment created from raw_eos_cli under router bgp vlan 111 from svi
 
         EOF
 
@@ -156,6 +167,17 @@ router_bgp:
         - 20112:20112
       redistribute_routes:
       - learned
+      - router-mac system
+      eos_cli: 'comment
+
+        comment created from raw_eos_cli under router bgp vlan from svi parent profile
+
+        EOF
+
+        '
+      struct_cfg:
+        redistribute_routes:
+        - router-mac system
     2500:
       tenant: Tenant_A
       rd: 172.16.120.3:2500

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-LEAF1A.yml
@@ -137,6 +137,17 @@ router_bgp:
         - 50111:50111
       redistribute_routes:
       - learned
+      - router-mac system
+      eos_cli: 'comment
+
+        comment created from raw_eos_cli under router bgp vlan 113
+
+        EOF
+
+        '
+      struct_cfg:
+        redistribute_routes:
+        - router-mac system
     112:
       tenant: Tenant_A
       rd: 172.16.120.3:20112

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1.POD1.LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1.POD1.LEAF2A.yml
@@ -178,6 +178,17 @@ router_bgp:
         - 99110:99110
       redistribute_routes:
       - learned
+      - router-mac system
+      eos_cli: 'comment
+
+        comment created from raw_eos_cli under router bgp vlan from svi profile
+
+        EOF
+
+        '
+      struct_cfg:
+        redistribute_routes:
+        - router-mac system
     111:
       tenant: Tenant_A
       rd: 172.16.110.4:50111
@@ -189,7 +200,7 @@ router_bgp:
       - router-mac system
       eos_cli: 'comment
 
-        comment created from raw_eos_cli under router bgp vlan 113
+        comment created from raw_eos_cli under router bgp vlan 111 from svi
 
         EOF
 
@@ -205,6 +216,17 @@ router_bgp:
         - 20112:20112
       redistribute_routes:
       - learned
+      - router-mac system
+      eos_cli: 'comment
+
+        comment created from raw_eos_cli under router bgp vlan from svi parent profile
+
+        EOF
+
+        '
+      struct_cfg:
+        redistribute_routes:
+        - router-mac system
     2500:
       tenant: Tenant_A
       rd: 172.16.110.4:2500

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1.POD1.LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1.POD1.LEAF2A.yml
@@ -186,6 +186,17 @@ router_bgp:
         - 50111:50111
       redistribute_routes:
       - learned
+      - router-mac system
+      eos_cli: 'comment
+
+        comment created from raw_eos_cli under router bgp vlan 113
+
+        EOF
+
+        '
+      struct_cfg:
+        redistribute_routes:
+        - router-mac system
     112:
       tenant: Tenant_A
       rd: 172.16.110.4:20112

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1.POD1.LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1.POD1.LEAF2A.yml
@@ -181,7 +181,7 @@ router_bgp:
       - router-mac system
       eos_cli: 'comment
 
-        comment created from raw_eos_cli under router bgp vlan from svi profile
+        comment created from raw_eos_cli under router bgp svis inherited from svi profile
 
         EOF
 
@@ -200,7 +200,7 @@ router_bgp:
       - router-mac system
       eos_cli: 'comment
 
-        comment created from raw_eos_cli under router bgp vlan 111 from svi
+        comment created from raw_eos_cli under router bgp svi 111
 
         EOF
 
@@ -219,7 +219,7 @@ router_bgp:
       - router-mac system
       eos_cli: 'comment
 
-        comment created from raw_eos_cli under router bgp vlan from svi parent profile
+        comment created from raw_eos_cli under router bgp svis inherited from svi parent profile
 
         EOF
 
@@ -243,6 +243,17 @@ router_bgp:
         - 32600:32600
       redistribute_routes:
       - learned
+      - router-mac system
+      eos_cli: 'comment
+
+        comment created from raw_eos_cli under router bgp l2vlan 2600
+
+        EOF
+
+        '
+      struct_cfg:
+        redistribute_routes:
+        - router-mac system
 static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/TENANTS_NETWORKS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/TENANTS_NETWORKS.yml
@@ -28,6 +28,15 @@ tenants:
             name: Tenant_A_OP_Zone_2
             tags: [opzone]
             ip_address_virtual: 10.1.11.1/24
+            bgp:
+              structured_config:
+                # Will be merged with 'redistribute routes learned'
+                redistribute_routes:
+                  - router-mac system
+              raw_eos_cli: |
+                comment
+                comment created from raw_eos_cli under router bgp vlan 113
+                EOF
           "112":
             name: Tenant_A_OP_Zone_3
             tags: [opzone]

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/TENANTS_NETWORKS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/TENANTS_NETWORKS.yml
@@ -1,4 +1,25 @@
 ---
+svi_profiles:
+  PARENT_PROFILE_STRUCT_CFG:
+    bgp:
+      structured_config:
+        redistribute_routes:
+          - router-mac system
+      raw_eos_cli: |
+        comment
+        comment created from raw_eos_cli under router bgp vlan from svi parent profile
+        EOF
+  TEST_PARENT_PROFILE_STRUCT_CFG:
+    parent_profile: PARENT_PROFILE_STRUCT_CFG
+  TEST_PROFILE_STRUCT_CFG:
+    bgp:
+      structured_config:
+        redistribute_routes:
+          - router-mac system
+      raw_eos_cli: |
+        comment
+        comment created from raw_eos_cli under router bgp vlan from svi profile
+        EOF
 # DC Tenants
 # Documentation of Tenant specific information - Vlans/VRFs
 tenants:
@@ -17,6 +38,7 @@ tenants:
             enabled: true
             rt_override: 99110 # RT would have been 20000 + 110.
             ip_address_virtual: 10.1.10.1/24
+            profile: TEST_PROFILE_STRUCT_CFG
             structured_config:
               description: set from structured_config on svi (was Tenant_A_OP_Zone_1)
             nodes:
@@ -35,13 +57,14 @@ tenants:
                   - router-mac system
               raw_eos_cli: |
                 comment
-                comment created from raw_eos_cli under router bgp vlan 113
+                comment created from raw_eos_cli under router bgp vlan 111 from svi
                 EOF
           "112":
             name: Tenant_A_OP_Zone_3
             tags: [opzone]
             enabled: true
             ip_address_virtual: 10.1.12.1/24
+            profile: TEST_PARENT_PROFILE_STRUCT_CFG
             nodes:
               DC1-POD1-LEAF1A:
                 raw_eos_cli: |

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/TENANTS_NETWORKS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/inventory/group_vars/TENANTS_NETWORKS.yml
@@ -7,7 +7,7 @@ svi_profiles:
           - router-mac system
       raw_eos_cli: |
         comment
-        comment created from raw_eos_cli under router bgp vlan from svi parent profile
+        comment created from raw_eos_cli under router bgp svis inherited from svi parent profile
         EOF
   TEST_PARENT_PROFILE_STRUCT_CFG:
     parent_profile: PARENT_PROFILE_STRUCT_CFG
@@ -18,7 +18,7 @@ svi_profiles:
           - router-mac system
       raw_eos_cli: |
         comment
-        comment created from raw_eos_cli under router bgp vlan from svi profile
+        comment created from raw_eos_cli under router bgp svis inherited from svi profile
         EOF
 # DC Tenants
 # Documentation of Tenant specific information - Vlans/VRFs
@@ -57,7 +57,7 @@ tenants:
                   - router-mac system
               raw_eos_cli: |
                 comment
-                comment created from raw_eos_cli under router bgp vlan 111 from svi
+                comment created from raw_eos_cli under router bgp svi 111
                 EOF
           "112":
             name: Tenant_A_OP_Zone_3
@@ -150,6 +150,14 @@ tenants:
         rt_override: 32600
         name: web-l2-vlan-2
         tags: [web]
+        bgp:
+          structured_config:
+            redistribute_routes:
+              - router-mac system
+          raw_eos_cli: |
+            comment
+            comment created from raw_eos_cli under router bgp l2vlan 2600
+            EOF
       2601:
         name: l2vlan_with_no_vxlan
         tags: [web]

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -362,6 +362,10 @@ router bgp {{ router_bgp.as }}
 {%             for no_redistribute_route in vlan.no_redistribute_routes | arista.avd.natural_sort %}
       no redistribute {{ no_redistribute_route }}
 {%             endfor %}
+{%             if vlan.eos_cli is arista.avd.defined %}
+      !
+      {{ vlan.eos_cli | indent(6, false) }}
+{%             endif %}
 {%         endfor %}
 {%     endif %}
 {# vxlan vlan aware bundles #}

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/network-services-v4.0.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/network-services-v4.0.md
@@ -470,6 +470,13 @@ svi_profiles:
         # Activate or deactivate IGMP snooping | Optional, default is true
         igmp_snooping_enabled: < true | false >
 
+        # Structured configuration and eos cli commands rendered on router_bgp.vlans
+        # This configuration will not be applied to vlan aware bundles
+        bgp:
+          raw_eos_cli: |
+            < multiline eos cli >
+          structured_config: < dictionary >
+
   - name: < tenant_b >
     mac_vrf_vni_base: < 10000-16770000 >
     vrfs:

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/network-services-v4.0.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/network-services-v4.0.md
@@ -297,6 +297,13 @@ svi_profiles:
                   hash_algorithm: < md5 | sha1 | sha256 | sha384 | sha512, Default -> sha512 >
                   key: < key password >
 
+            # Structured configuration and eos cli commands rendered on router_bgp.vlans
+            # This configuration will not be applied to vlan aware bundles
+            bgp:
+              raw_eos_cli: |
+                < multiline eos cli >
+              structured_config: < dictionary >
+
             # EOS CLI rendered directly on the VLAN interface in the final EOS configuration
             raw_eos_cli: |
               < multiline eos cli >

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
@@ -361,6 +361,13 @@ mac_address_table:
                   hash_algorithm: < md5 | sha1 | sha256 | sha384 | sha512, Default -> sha512 >
                   key: < key password >
 
+            # Structured configuration and eos cli commands rendered on router_bgp.vlans
+            # This configuration will not be applied to vlan aware bundles
+            bgp:
+              raw_eos_cli: |
+                < multiline eos cli >
+              structured_config: < dictionary >
+
             # EOS CLI rendered directly on the VLAN interface in the final EOS configuration
             raw_eos_cli: |
               < multiline eos cli >

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
@@ -594,6 +594,13 @@ mac_address_table:
           source_address: < ipv4_address -> default ip address of Loopback0 >
           version: < 1, 2, 3 -> default 2 (EOS) >
 
+        # Structured configuration and eos cli commands rendered on router_bgp.vlans
+        # This configuration will not be applied to vlan aware bundles
+        bgp:
+          raw_eos_cli: |
+            < multiline eos cli >
+          structured_config: < dictionary >
+
   < tenant_b >:
     mac_vrf_vni_base: < 10000-16770000 >
     vrfs:

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/custom_structured_configuration/logic-router-bgp-vlans-struct-cfg.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/custom_structured_configuration/logic-router-bgp-vlans-struct-cfg.j2
@@ -1,0 +1,12 @@
+{% for vlan in router_bgp.vlans | arista.avd.natural_sort %}
+{%     if router_bgp.vlans[vlan].struct_cfg is arista.avd.defined %}
+{%         set tmp_custom_structured_configuration = {
+               "router_bgp" : {
+                   "vlans": {
+                       vlan: router_bgp.vlans[vlan].struct_cfg
+                   }
+               }
+           } %}
+{%         do custom_structured_configuration_data.append(tmp_custom_structured_configuration) %}
+{%     endif %}
+{% endfor %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/custom_structured_configuration/logic-router-bgp-vlans-struct-cfg.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/custom_structured_configuration/logic-router-bgp-vlans-struct-cfg.j2
@@ -1,12 +1,15 @@
+{% set tmp_custom_structured_configuration = {} %}
 {% for vlan in router_bgp.vlans | arista.avd.natural_sort %}
 {%     if router_bgp.vlans[vlan].struct_cfg is arista.avd.defined %}
-{%         set tmp_custom_structured_configuration = {
-               "router_bgp" : {
-                   "vlans": {
-                       vlan: router_bgp.vlans[vlan].struct_cfg
-                   }
-               }
-           } %}
-{%         do custom_structured_configuration_data.append(tmp_custom_structured_configuration) %}
+{%         do tmp_custom_structured_configuration.update({
+                vlan: router_bgp.vlans[vlan].struct_cfg
+            }) %}
 {%     endif %}
 {% endfor %}
+{% if tmp_custom_structured_configuration %}
+{%     do custom_structured_configuration_data.append({
+            "router_bgp" : {
+                "vlans": tmp_custom_structured_configuration
+            }
+        }) %}
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/custom_structured_configuration/main.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/custom_structured_configuration/main.j2
@@ -18,5 +18,7 @@
 
 {% include 'custom_structured_configuration/logic-router-bgp-vrfs-struct-cfg.j2' %}
 
+{% include 'custom_structured_configuration/logic-router-bgp-vlans-struct-cfg.j2' %}
+
 {# custom_structured_configuration is also the one rendering the output, so it should come last #}
 {% include 'custom_structured_configuration/custom-structured-configuration.j2' %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/logic.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/logic.j2
@@ -44,6 +44,8 @@
                                                                         selectattr('name', 'arista.avd.defined', inventory_hostname) |
                                                                         map(attribute='structured_config') |
                                                                         first %}
+{%                                 set bgp_svi_struct_cfg = svi.bgp.structured_config | arista.avd.default %}
+{%                                 set bgp_svi_raw_eos_cli = svi.bgp.raw_eos_cli | arista.avd.default %}
 {%                                 if svi.profile is arista.avd.defined %}
 {%                                     set svi_profile = svi_profiles | arista.avd.default({}) |
                                                                         arista.avd.convert_dicts('profile') |
@@ -54,6 +56,12 @@
                                                                                         selectattr('name', 'arista.avd.defined', inventory_hostname) |
                                                                                         map(attribute='structured_config') |
                                                                                         first %}
+{%                                     endif %}
+{%                                     if bgp_svi_struct_cfg is not arista.avd.defined and svi_profile.bgp.structured_config is arista.avd.defined %}
+{%                                         set bgp_svi_struct_cfg = svi_profile.bgp.structured_config %}
+{%                                     endif %}
+{%                                     if bgp_svi_raw_eos_cli is not arista.avd.defined and svi_profile.bgp.raw_eos_cli is arista.avd.defined %}
+{%                                         set bgp_svi_raw_eos_cli = svi_profile.bgp.raw_eos_cli %}
 {%                                     endif %}
 {%                                     if svi_profile.parent_profile is arista.avd.defined %}
 {%                                         set svi_parent_profile = svi_profiles | arista.avd.default({}) |
@@ -66,6 +74,12 @@
                                                                                                    map(attribute='structured_config') |
                                                                                                    first %}
 {%                                         endif %}
+{%                                         if bgp_svi_struct_cfg is not arista.avd.defined and svi_parent_profile.bgp.structured_config is arista.avd.defined %}
+{%                                             set bgp_svi_struct_cfg = svi_parent_profile.bgp.structured_config %}
+{%                                         endif %}
+{%                                         if bgp_svi_raw_eos_cli is not arista.avd.defined and svi_parent_profile.bgp.raw_eos_cli is arista.avd.defined %}
+{%                                             set bgp_svi_raw_eos_cli = svi_parent_profile.bgp.raw_eos_cli %}
+{%                                         endif %}
 {%                                         set tmp_svi = svi_parent_profile %}
 {%                                     endif %}
 {%                                     set tmp_svi = tmp_svi | ansible.builtin.combine(svi_profile, recursive=true, list_merge='replace') %}
@@ -77,6 +91,11 @@
                                                                            svi.structured_config,
                                                                            svi_profile.structured_config,
                                                                            svi_parent_profile.structured_config)}) %}
+{%                                 do tmp_svi.update({"bgp":
+                                                            {"structured_config": bgp_svi_struct_cfg,
+                                                             "raw_eos_cli": bgp_svi_raw_eos_cli
+                                                             }
+                                                     }) %}
 {%                                 do tmp_svis.append(tmp_svi) %}
 {%                             endif %}
 {%                         endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/logic.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/logic.j2
@@ -45,7 +45,6 @@
                                                                         map(attribute='structured_config') |
                                                                         first %}
 {%                                 set bgp_svi_struct_cfg = svi.bgp.structured_config | arista.avd.default %}
-{%                                 set bgp_svi_raw_eos_cli = svi.bgp.raw_eos_cli | arista.avd.default %}
 {%                                 if svi.profile is arista.avd.defined %}
 {%                                     set svi_profile = svi_profiles | arista.avd.default({}) |
                                                                         arista.avd.convert_dicts('profile') |
@@ -59,9 +58,6 @@
 {%                                     endif %}
 {%                                     if bgp_svi_struct_cfg is not arista.avd.defined and svi_profile.bgp.structured_config is arista.avd.defined %}
 {%                                         set bgp_svi_struct_cfg = svi_profile.bgp.structured_config %}
-{%                                     endif %}
-{%                                     if bgp_svi_raw_eos_cli is not arista.avd.defined and svi_profile.bgp.raw_eos_cli is arista.avd.defined %}
-{%                                         set bgp_svi_raw_eos_cli = svi_profile.bgp.raw_eos_cli %}
 {%                                     endif %}
 {%                                     if svi_profile.parent_profile is arista.avd.defined %}
 {%                                         set svi_parent_profile = svi_profiles | arista.avd.default({}) |
@@ -77,9 +73,6 @@
 {%                                         if bgp_svi_struct_cfg is not arista.avd.defined and svi_parent_profile.bgp.structured_config is arista.avd.defined %}
 {%                                             set bgp_svi_struct_cfg = svi_parent_profile.bgp.structured_config %}
 {%                                         endif %}
-{%                                         if bgp_svi_raw_eos_cli is not arista.avd.defined and svi_parent_profile.bgp.raw_eos_cli is arista.avd.defined %}
-{%                                             set bgp_svi_raw_eos_cli = svi_parent_profile.bgp.raw_eos_cli %}
-{%                                         endif %}
 {%                                         set tmp_svi = svi_parent_profile %}
 {%                                     endif %}
 {%                                     set tmp_svi = tmp_svi | ansible.builtin.combine(svi_profile, recursive=true, list_merge='replace') %}
@@ -91,11 +84,7 @@
                                                                            svi.structured_config,
                                                                            svi_profile.structured_config,
                                                                            svi_parent_profile.structured_config)}) %}
-{%                                 do tmp_svi.update({"bgp":
-                                                            {"structured_config": bgp_svi_struct_cfg,
-                                                             "raw_eos_cli": bgp_svi_raw_eos_cli
-                                                             }
-                                                     }) %}
+{%                                 do tmp_svi.setdefault("bgp", {}).update({"structured_config": bgp_svi_struct_cfg}) %}
 {%                                 do tmp_svis.append(tmp_svi) %}
 {%                             endif %}
 {%                         endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-vlans.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-vlans.j2
@@ -36,6 +36,13 @@
 {%                 if svi_evpn_l2_multicast_enabled is arista.avd.defined(true) %}
         - igmp
 {%                 endif %}
+{%                 if svi.bgp.raw_eos_cli is arista.avd.defined %}
+      eos_cli: |
+        {{ svi.bgp.raw_eos_cli | indent(8,false) }}
+{%                 endif %}
+{%                 if svi.bgp.structured_config is arista.avd.defined %}
+      struct_cfg: {{ svi.bgp.structured_config }}
+{%                 endif %}
 {%             endfor %}
 {%         endfor %}
 {%         for l2vlan in tenant.l2vlans %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-vlans.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-vlans.j2
@@ -76,6 +76,13 @@
 {%             if l2vlan_evpn_l2_multicast_enabled is arista.avd.defined(true) %}
         - igmp
 {%             endif %}
+{%             if l2vlan.bgp.raw_eos_cli is arista.avd.defined %}
+      eos_cli: |
+        {{ l2vlan.bgp.raw_eos_cli | indent(8,false) }}
+{%             endif %}
+{%             if l2vlan.bgp.structured_config is arista.avd.defined %}
+      struct_cfg: {{ l2vlan.bgp.structured_config }}
+{%             endif %}
 {%         endfor %}
 {%     endfor %}
 {% endif %}


### PR DESCRIPTION
## Change Summary

Support eos_designs structured config for network services **svis**, equivalent under router_bgp.vlans. The structured config is added only for router_bgp.vlans, in the network services, under svis. Also, added the raw_eos_cli at the same level under network services svis. that adds the cli commands under router_bgp.vlans

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

```yaml
tenants:
  <tenant>:
    vrfs:
      <vrf>:
        svis:
          <svi>:
            # Structured configuration and eos cli commands rendered on router_bgp.vlans
            # This configuration will not be applied to vlan aware bundles
            bgp:
              raw_eos_cli: |
                < multiline eos cli >
              structured_config: < dictionary >
        l2vlans:
          < vlan_id >:
            bgp:
              raw_eos_cli: |
                < multiline eos cli >
              structured_config: < dictionary >
```

<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test

`molecule converge -s eos_designs-twodc-5stage-clos`

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
