### PR TITLE
Feat(eos_designs): Auto BGP ASN

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF1A.cfg
@@ -1,0 +1,87 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname AUTO_BGP_ASN_LEAF1A
+!
+spanning-tree mode mstp
+spanning-tree mst 0 priority 4096
+!
+no enable password
+no aaa root
+!
+vrf instance MGMT
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 192.168.255.3/32
+!
+interface Loopback1
+   description VTEP_VXLAN_Tunnel_Source
+   no shutdown
+   ip address 192.168.254.3/32
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.202.105/24
+!
+interface Vxlan1
+   description AUTO_BGP_ASN_LEAF1A_VTEP
+   vxlan source-interface Loopback1
+   vxlan udp-port 4789
+!
+ip virtual-router mac-address 00:dc:00:00:00:0a
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+   seq 20 permit 192.168.254.0/24 eq 32
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.202.1
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 65101
+   router-id 192.168.255.3
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor IPv4-UNDERLAY-PEERS activate
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF1B.cfg
@@ -1,0 +1,87 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname AUTO_BGP_ASN_LEAF1B
+!
+spanning-tree mode mstp
+spanning-tree mst 0 priority 4096
+!
+no enable password
+no aaa root
+!
+vrf instance MGMT
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 192.168.255.4/32
+!
+interface Loopback1
+   description VTEP_VXLAN_Tunnel_Source
+   no shutdown
+   ip address 192.168.254.4/32
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.202.106/24
+!
+interface Vxlan1
+   description AUTO_BGP_ASN_LEAF1B_VTEP
+   vxlan source-interface Loopback1
+   vxlan udp-port 4789
+!
+ip virtual-router mac-address 00:dc:00:00:00:0a
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+   seq 20 permit 192.168.254.0/24 eq 32
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.202.1
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 65102
+   router-id 192.168.255.4
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor IPv4-UNDERLAY-PEERS activate
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF2.cfg
@@ -1,0 +1,87 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname AUTO_BGP_ASN_LEAF2
+!
+spanning-tree mode mstp
+spanning-tree mst 0 priority 4096
+!
+no enable password
+no aaa root
+!
+vrf instance MGMT
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 192.168.255.5/32
+!
+interface Loopback1
+   description VTEP_VXLAN_Tunnel_Source
+   no shutdown
+   ip address 192.168.254.5/32
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.202.107/24
+!
+interface Vxlan1
+   description AUTO_BGP_ASN_LEAF2_VTEP
+   vxlan source-interface Loopback1
+   vxlan udp-port 4789
+!
+ip virtual-router mac-address 00:dc:00:00:00:0a
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+   seq 20 permit 192.168.254.0/24 eq 32
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.202.1
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 65103
+   router-id 192.168.255.5
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor IPv4-UNDERLAY-PEERS activate
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF3A.cfg
@@ -1,0 +1,151 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname AUTO_BGP_ASN_LEAF3A
+!
+spanning-tree mode mstp
+no spanning-tree vlan-id 4093-4094
+spanning-tree mst 0 priority 4096
+!
+no enable password
+no aaa root
+!
+vlan 4093
+   name LEAF_PEER_L3
+   trunk group LEAF_PEER_L3
+!
+vlan 4094
+   name MLAG_PEER
+   trunk group MLAG
+!
+vrf instance MGMT
+!
+interface Port-Channel3
+   description MLAG_PEER_AUTO_BGP_ASN_LEAF3B_Po3
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 2-4094
+   switchport mode trunk
+   switchport trunk group LEAF_PEER_L3
+   switchport trunk group MLAG
+!
+interface Ethernet3
+   description MLAG_PEER_AUTO_BGP_ASN_LEAF3B_Ethernet3
+   no shutdown
+   channel-group 3 mode active
+!
+interface Ethernet4
+   description MLAG_PEER_AUTO_BGP_ASN_LEAF3B_Ethernet4
+   no shutdown
+   channel-group 3 mode active
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 192.168.255.7/32
+!
+interface Loopback1
+   description VTEP_VXLAN_Tunnel_Source
+   no shutdown
+   ip address 192.168.254.7/32
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.202.109/24
+!
+interface Vlan4093
+   description MLAG_PEER_L3_PEERING
+   no shutdown
+   mtu 9000
+   ip address 10.255.251.8/31
+!
+interface Vlan4094
+   description MLAG_PEER
+   no shutdown
+   mtu 9000
+   no autostate
+   ip address 10.255.252.8/31
+!
+interface Vxlan1
+   description AUTO_BGP_ASN_LEAF3A_VTEP
+   vxlan source-interface Loopback1
+   vxlan virtual-router encapsulation mac-address mlag-system-id
+   vxlan udp-port 4789
+!
+ip virtual-router mac-address 00:dc:00:00:00:0a
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+   seq 20 permit 192.168.254.0/24 eq 32
+!
+mlag configuration
+   domain-id AUTO_BGP_ASN_LEAF3_MLAG
+   local-interface Vlan4094
+   peer-address 10.255.252.9
+   peer-link Port-Channel3
+   reload-delay mlag 300
+   reload-delay non-mlag 330
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.202.1
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+route-map RM-MLAG-PEER-IN permit 10
+   description Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing
+   set origin incomplete
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 65105
+   router-id 192.168.255.7
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   neighbor MLAG-IPv4-UNDERLAY-PEER peer group
+   neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65105
+   neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
+   neighbor MLAG-IPv4-UNDERLAY-PEER description AUTO_BGP_ASN_LEAF3B
+   neighbor MLAG-IPv4-UNDERLAY-PEER send-community
+   neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000
+   neighbor MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN in
+   neighbor 10.255.251.9 peer group MLAG-IPv4-UNDERLAY-PEER
+   neighbor 10.255.251.9 description AUTO_BGP_ASN_LEAF3B
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor IPv4-UNDERLAY-PEERS activate
+      neighbor MLAG-IPv4-UNDERLAY-PEER activate
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF3B.cfg
@@ -1,0 +1,151 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname AUTO_BGP_ASN_LEAF3B
+!
+spanning-tree mode mstp
+no spanning-tree vlan-id 4093-4094
+spanning-tree mst 0 priority 4096
+!
+no enable password
+no aaa root
+!
+vlan 4093
+   name LEAF_PEER_L3
+   trunk group LEAF_PEER_L3
+!
+vlan 4094
+   name MLAG_PEER
+   trunk group MLAG
+!
+vrf instance MGMT
+!
+interface Port-Channel3
+   description MLAG_PEER_AUTO_BGP_ASN_LEAF3A_Po3
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 2-4094
+   switchport mode trunk
+   switchport trunk group LEAF_PEER_L3
+   switchport trunk group MLAG
+!
+interface Ethernet3
+   description MLAG_PEER_AUTO_BGP_ASN_LEAF3A_Ethernet3
+   no shutdown
+   channel-group 3 mode active
+!
+interface Ethernet4
+   description MLAG_PEER_AUTO_BGP_ASN_LEAF3A_Ethernet4
+   no shutdown
+   channel-group 3 mode active
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 192.168.255.8/32
+!
+interface Loopback1
+   description VTEP_VXLAN_Tunnel_Source
+   no shutdown
+   ip address 192.168.254.7/32
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.202.110/24
+!
+interface Vlan4093
+   description MLAG_PEER_L3_PEERING
+   no shutdown
+   mtu 9000
+   ip address 10.255.251.9/31
+!
+interface Vlan4094
+   description MLAG_PEER
+   no shutdown
+   mtu 9000
+   no autostate
+   ip address 10.255.252.9/31
+!
+interface Vxlan1
+   description AUTO_BGP_ASN_LEAF3B_VTEP
+   vxlan source-interface Loopback1
+   vxlan virtual-router encapsulation mac-address mlag-system-id
+   vxlan udp-port 4789
+!
+ip virtual-router mac-address 00:dc:00:00:00:0a
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+   seq 20 permit 192.168.254.0/24 eq 32
+!
+mlag configuration
+   domain-id AUTO_BGP_ASN_LEAF3_MLAG
+   local-interface Vlan4094
+   peer-address 10.255.252.8
+   peer-link Port-Channel3
+   reload-delay mlag 300
+   reload-delay non-mlag 330
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.202.1
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+route-map RM-MLAG-PEER-IN permit 10
+   description Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing
+   set origin incomplete
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 65105
+   router-id 192.168.255.8
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   neighbor MLAG-IPv4-UNDERLAY-PEER peer group
+   neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65105
+   neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
+   neighbor MLAG-IPv4-UNDERLAY-PEER description AUTO_BGP_ASN_LEAF3A
+   neighbor MLAG-IPv4-UNDERLAY-PEER send-community
+   neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000
+   neighbor MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN in
+   neighbor 10.255.251.8 peer group MLAG-IPv4-UNDERLAY-PEER
+   neighbor 10.255.251.8 description AUTO_BGP_ASN_LEAF3A
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor IPv4-UNDERLAY-PEERS activate
+      neighbor MLAG-IPv4-UNDERLAY-PEER activate
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF4A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF4A.cfg
@@ -1,0 +1,151 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname AUTO_BGP_ASN_LEAF4A
+!
+spanning-tree mode mstp
+no spanning-tree vlan-id 4093-4094
+spanning-tree mst 0 priority 4096
+!
+no enable password
+no aaa root
+!
+vlan 4093
+   name LEAF_PEER_L3
+   trunk group LEAF_PEER_L3
+!
+vlan 4094
+   name MLAG_PEER
+   trunk group MLAG
+!
+vrf instance MGMT
+!
+interface Port-Channel3
+   description MLAG_PEER_AUTO_BGP_ASN_LEAF4B_Po3
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 2-4094
+   switchport mode trunk
+   switchport trunk group LEAF_PEER_L3
+   switchport trunk group MLAG
+!
+interface Ethernet3
+   description MLAG_PEER_AUTO_BGP_ASN_LEAF4B_Ethernet3
+   no shutdown
+   channel-group 3 mode active
+!
+interface Ethernet4
+   description MLAG_PEER_AUTO_BGP_ASN_LEAF4B_Ethernet4
+   no shutdown
+   channel-group 3 mode active
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 192.168.255.9/32
+!
+interface Loopback1
+   description VTEP_VXLAN_Tunnel_Source
+   no shutdown
+   ip address 192.168.254.9/32
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.202.111/24
+!
+interface Vlan4093
+   description MLAG_PEER_L3_PEERING
+   no shutdown
+   mtu 9000
+   ip address 10.255.251.12/31
+!
+interface Vlan4094
+   description MLAG_PEER
+   no shutdown
+   mtu 9000
+   no autostate
+   ip address 10.255.252.12/31
+!
+interface Vxlan1
+   description AUTO_BGP_ASN_LEAF4A_VTEP
+   vxlan source-interface Loopback1
+   vxlan virtual-router encapsulation mac-address mlag-system-id
+   vxlan udp-port 4789
+!
+ip virtual-router mac-address 00:dc:00:00:00:0a
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+   seq 20 permit 192.168.254.0/24 eq 32
+!
+mlag configuration
+   domain-id AUTO_BGP_ASN_LEAF4_MLAG_OVERRIDE
+   local-interface Vlan4094
+   peer-address 10.255.252.13
+   peer-link Port-Channel3
+   reload-delay mlag 300
+   reload-delay non-mlag 330
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.202.1
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+route-map RM-MLAG-PEER-IN permit 10
+   description Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing
+   set origin incomplete
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 65222
+   router-id 192.168.255.9
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   neighbor MLAG-IPv4-UNDERLAY-PEER peer group
+   neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65222
+   neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
+   neighbor MLAG-IPv4-UNDERLAY-PEER description AUTO_BGP_ASN_LEAF4B
+   neighbor MLAG-IPv4-UNDERLAY-PEER send-community
+   neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000
+   neighbor MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN in
+   neighbor 10.255.251.13 peer group MLAG-IPv4-UNDERLAY-PEER
+   neighbor 10.255.251.13 description AUTO_BGP_ASN_LEAF4B
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor IPv4-UNDERLAY-PEERS activate
+      neighbor MLAG-IPv4-UNDERLAY-PEER activate
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF4B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF4B.cfg
@@ -1,0 +1,151 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname AUTO_BGP_ASN_LEAF4B
+!
+spanning-tree mode mstp
+no spanning-tree vlan-id 4093-4094
+spanning-tree mst 0 priority 4096
+!
+no enable password
+no aaa root
+!
+vlan 4093
+   name LEAF_PEER_L3
+   trunk group LEAF_PEER_L3
+!
+vlan 4094
+   name MLAG_PEER
+   trunk group MLAG
+!
+vrf instance MGMT
+!
+interface Port-Channel3
+   description MLAG_PEER_AUTO_BGP_ASN_LEAF4A_Po3
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 2-4094
+   switchport mode trunk
+   switchport trunk group LEAF_PEER_L3
+   switchport trunk group MLAG
+!
+interface Ethernet3
+   description MLAG_PEER_AUTO_BGP_ASN_LEAF4A_Ethernet3
+   no shutdown
+   channel-group 3 mode active
+!
+interface Ethernet4
+   description MLAG_PEER_AUTO_BGP_ASN_LEAF4A_Ethernet4
+   no shutdown
+   channel-group 3 mode active
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 192.168.255.10/32
+!
+interface Loopback1
+   description VTEP_VXLAN_Tunnel_Source
+   no shutdown
+   ip address 192.168.254.9/32
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.202.112/24
+!
+interface Vlan4093
+   description MLAG_PEER_L3_PEERING
+   no shutdown
+   mtu 9000
+   ip address 10.255.251.13/31
+!
+interface Vlan4094
+   description MLAG_PEER
+   no shutdown
+   mtu 9000
+   no autostate
+   ip address 10.255.252.13/31
+!
+interface Vxlan1
+   description AUTO_BGP_ASN_LEAF4B_VTEP
+   vxlan source-interface Loopback1
+   vxlan virtual-router encapsulation mac-address mlag-system-id
+   vxlan udp-port 4789
+!
+ip virtual-router mac-address 00:dc:00:00:00:0a
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+   seq 20 permit 192.168.254.0/24 eq 32
+!
+mlag configuration
+   domain-id AUTO_BGP_ASN_LEAF4_MLAG_OVERRIDE
+   local-interface Vlan4094
+   peer-address 10.255.252.12
+   peer-link Port-Channel3
+   reload-delay mlag 300
+   reload-delay non-mlag 330
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.202.1
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+route-map RM-MLAG-PEER-IN permit 10
+   description Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing
+   set origin incomplete
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 65222
+   router-id 192.168.255.10
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   neighbor MLAG-IPv4-UNDERLAY-PEER peer group
+   neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65222
+   neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
+   neighbor MLAG-IPv4-UNDERLAY-PEER description AUTO_BGP_ASN_LEAF4A
+   neighbor MLAG-IPv4-UNDERLAY-PEER send-community
+   neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000
+   neighbor MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN in
+   neighbor 10.255.251.12 peer group MLAG-IPv4-UNDERLAY-PEER
+   neighbor 10.255.251.12 description AUTO_BGP_ASN_LEAF4A
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor IPv4-UNDERLAY-PEERS activate
+      neighbor MLAG-IPv4-UNDERLAY-PEER activate
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF5A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF5A.cfg
@@ -1,0 +1,87 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname AUTO_BGP_ASN_LEAF5A
+!
+spanning-tree mode mstp
+spanning-tree mst 0 priority 4096
+!
+no enable password
+no aaa root
+!
+vrf instance MGMT
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 192.168.255.11/32
+!
+interface Loopback1
+   description VTEP_VXLAN_Tunnel_Source
+   no shutdown
+   ip address 192.168.254.11/32
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.202.113/24
+!
+interface Vxlan1
+   description AUTO_BGP_ASN_LEAF5A_VTEP
+   vxlan source-interface Loopback1
+   vxlan udp-port 4789
+!
+ip virtual-router mac-address 00:dc:00:00:00:0a
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+   seq 20 permit 192.168.254.0/24 eq 32
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.202.1
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 65333
+   router-id 192.168.255.11
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor IPv4-UNDERLAY-PEERS activate
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_UNGROUPED_LEAF6.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_UNGROUPED_LEAF6.cfg
@@ -1,0 +1,87 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname AUTO_BGP_UNGROUPED_LEAF6
+!
+spanning-tree mode mstp
+spanning-tree mst 0 priority 4096
+!
+no enable password
+no aaa root
+!
+vrf instance MGMT
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 192.168.255.12/32
+!
+interface Loopback1
+   description VTEP_VXLAN_Tunnel_Source
+   no shutdown
+   ip address 192.168.254.12/32
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.202.114/24
+!
+interface Vxlan1
+   description AUTO_BGP_UNGROUPED_LEAF6_VTEP
+   vxlan source-interface Loopback1
+   vxlan udp-port 4789
+!
+ip virtual-router mac-address 00:dc:00:00:00:0a
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+   seq 20 permit 192.168.254.0/24 eq 32
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.202.1
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 65110
+   router-id 192.168.255.12
+   no bgp default ipv4-unicast
+   distance bgp 20 200 200
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor IPv4-UNDERLAY-PEERS activate
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF1A.yml
@@ -1,0 +1,100 @@
+router_bgp:
+  as: '65101'
+  router_id: 192.168.255.3
+  bgp_defaults:
+  - no bgp default ipv4-unicast
+  - distance bgp 20 200 200
+  - maximum-paths 4 ecmp 4
+  peer_groups:
+    IPv4-UNDERLAY-PEERS:
+      type: ipv4
+      maximum_routes: 12000
+      send_community: all
+    EVPN-OVERLAY-PEERS:
+      type: evpn
+      update_source: Loopback0
+      bfd: true
+      ebgp_multihop: '3'
+      send_community: all
+      maximum_routes: 0
+  address_family_ipv4:
+    peer_groups:
+      IPv4-UNDERLAY-PEERS:
+        activate: true
+      EVPN-OVERLAY-PEERS:
+        activate: false
+  redistribute_routes:
+    connected:
+      route_map: RM-CONN-2-BGP
+  address_family_evpn:
+    peer_groups:
+      EVPN-OVERLAY-PEERS:
+        activate: true
+static_routes:
+- vrf: MGMT
+  destination_address_prefix: 0.0.0.0/0
+  gateway: 192.168.202.1
+service_routing_protocols_model: multi-agent
+ip_routing: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+spanning_tree:
+  mode: mstp
+  mst_instances:
+    '0':
+      priority: 4096
+vrfs:
+  MGMT:
+    ip_routing: false
+management_interfaces:
+  Management1:
+    description: oob_management
+    shutdown: false
+    vrf: MGMT
+    ip_address: 192.168.202.105/24
+    gateway: 192.168.202.1
+    type: oob
+management_api_http:
+  enable_vrfs:
+    MGMT: {}
+  enable_https: true
+loopback_interfaces:
+  Loopback0:
+    description: EVPN_Overlay_Peering
+    shutdown: false
+    ip_address: 192.168.255.3/32
+  Loopback1:
+    description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
+    ip_address: 192.168.254.3/32
+prefix_lists:
+  PL-LOOPBACKS-EVPN-OVERLAY:
+    sequence_numbers:
+      10:
+        action: permit 192.168.255.0/24 eq 32
+      20:
+        action: permit 192.168.254.0/24 eq 32
+route_maps:
+  RM-CONN-2-BGP:
+    sequence_numbers:
+      10:
+        type: permit
+        match:
+        - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+router_bfd:
+  multihop:
+    interval: 300
+    min_rx: 300
+    multiplier: 3
+ip_igmp_snooping:
+  globally_enabled: true
+ip_virtual_router_mac_address: 00:dc:00:00:00:0a
+vxlan_interface:
+  Vxlan1:
+    description: AUTO_BGP_ASN_LEAF1A_VTEP
+    vxlan:
+      source_interface: Loopback1
+      udp_port: 4789

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF1B.yml
@@ -1,0 +1,100 @@
+router_bgp:
+  as: '65102'
+  router_id: 192.168.255.4
+  bgp_defaults:
+  - no bgp default ipv4-unicast
+  - distance bgp 20 200 200
+  - maximum-paths 4 ecmp 4
+  peer_groups:
+    IPv4-UNDERLAY-PEERS:
+      type: ipv4
+      maximum_routes: 12000
+      send_community: all
+    EVPN-OVERLAY-PEERS:
+      type: evpn
+      update_source: Loopback0
+      bfd: true
+      ebgp_multihop: '3'
+      send_community: all
+      maximum_routes: 0
+  address_family_ipv4:
+    peer_groups:
+      IPv4-UNDERLAY-PEERS:
+        activate: true
+      EVPN-OVERLAY-PEERS:
+        activate: false
+  redistribute_routes:
+    connected:
+      route_map: RM-CONN-2-BGP
+  address_family_evpn:
+    peer_groups:
+      EVPN-OVERLAY-PEERS:
+        activate: true
+static_routes:
+- vrf: MGMT
+  destination_address_prefix: 0.0.0.0/0
+  gateway: 192.168.202.1
+service_routing_protocols_model: multi-agent
+ip_routing: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+spanning_tree:
+  mode: mstp
+  mst_instances:
+    '0':
+      priority: 4096
+vrfs:
+  MGMT:
+    ip_routing: false
+management_interfaces:
+  Management1:
+    description: oob_management
+    shutdown: false
+    vrf: MGMT
+    ip_address: 192.168.202.106/24
+    gateway: 192.168.202.1
+    type: oob
+management_api_http:
+  enable_vrfs:
+    MGMT: {}
+  enable_https: true
+loopback_interfaces:
+  Loopback0:
+    description: EVPN_Overlay_Peering
+    shutdown: false
+    ip_address: 192.168.255.4/32
+  Loopback1:
+    description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
+    ip_address: 192.168.254.4/32
+prefix_lists:
+  PL-LOOPBACKS-EVPN-OVERLAY:
+    sequence_numbers:
+      10:
+        action: permit 192.168.255.0/24 eq 32
+      20:
+        action: permit 192.168.254.0/24 eq 32
+route_maps:
+  RM-CONN-2-BGP:
+    sequence_numbers:
+      10:
+        type: permit
+        match:
+        - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+router_bfd:
+  multihop:
+    interval: 300
+    min_rx: 300
+    multiplier: 3
+ip_igmp_snooping:
+  globally_enabled: true
+ip_virtual_router_mac_address: 00:dc:00:00:00:0a
+vxlan_interface:
+  Vxlan1:
+    description: AUTO_BGP_ASN_LEAF1B_VTEP
+    vxlan:
+      source_interface: Loopback1
+      udp_port: 4789

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF2.yml
@@ -1,0 +1,100 @@
+router_bgp:
+  as: '65103'
+  router_id: 192.168.255.5
+  bgp_defaults:
+  - no bgp default ipv4-unicast
+  - distance bgp 20 200 200
+  - maximum-paths 4 ecmp 4
+  peer_groups:
+    IPv4-UNDERLAY-PEERS:
+      type: ipv4
+      maximum_routes: 12000
+      send_community: all
+    EVPN-OVERLAY-PEERS:
+      type: evpn
+      update_source: Loopback0
+      bfd: true
+      ebgp_multihop: '3'
+      send_community: all
+      maximum_routes: 0
+  address_family_ipv4:
+    peer_groups:
+      IPv4-UNDERLAY-PEERS:
+        activate: true
+      EVPN-OVERLAY-PEERS:
+        activate: false
+  redistribute_routes:
+    connected:
+      route_map: RM-CONN-2-BGP
+  address_family_evpn:
+    peer_groups:
+      EVPN-OVERLAY-PEERS:
+        activate: true
+static_routes:
+- vrf: MGMT
+  destination_address_prefix: 0.0.0.0/0
+  gateway: 192.168.202.1
+service_routing_protocols_model: multi-agent
+ip_routing: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+spanning_tree:
+  mode: mstp
+  mst_instances:
+    '0':
+      priority: 4096
+vrfs:
+  MGMT:
+    ip_routing: false
+management_interfaces:
+  Management1:
+    description: oob_management
+    shutdown: false
+    vrf: MGMT
+    ip_address: 192.168.202.107/24
+    gateway: 192.168.202.1
+    type: oob
+management_api_http:
+  enable_vrfs:
+    MGMT: {}
+  enable_https: true
+loopback_interfaces:
+  Loopback0:
+    description: EVPN_Overlay_Peering
+    shutdown: false
+    ip_address: 192.168.255.5/32
+  Loopback1:
+    description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
+    ip_address: 192.168.254.5/32
+prefix_lists:
+  PL-LOOPBACKS-EVPN-OVERLAY:
+    sequence_numbers:
+      10:
+        action: permit 192.168.255.0/24 eq 32
+      20:
+        action: permit 192.168.254.0/24 eq 32
+route_maps:
+  RM-CONN-2-BGP:
+    sequence_numbers:
+      10:
+        type: permit
+        match:
+        - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+router_bfd:
+  multihop:
+    interval: 300
+    min_rx: 300
+    multiplier: 3
+ip_igmp_snooping:
+  globally_enabled: true
+ip_virtual_router_mac_address: 00:dc:00:00:00:0a
+vxlan_interface:
+  Vxlan1:
+    description: AUTO_BGP_ASN_LEAF2_VTEP
+    vxlan:
+      source_interface: Loopback1
+      udp_port: 4789

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF3A.yml
@@ -1,0 +1,184 @@
+router_bgp:
+  as: '65105'
+  router_id: 192.168.255.7
+  bgp_defaults:
+  - no bgp default ipv4-unicast
+  - distance bgp 20 200 200
+  - maximum-paths 4 ecmp 4
+  peer_groups:
+    MLAG-IPv4-UNDERLAY-PEER:
+      type: ipv4
+      remote_as: '65105'
+      next_hop_self: true
+      description: AUTO_BGP_ASN_LEAF3B
+      maximum_routes: 12000
+      send_community: all
+      route_map_in: RM-MLAG-PEER-IN
+    IPv4-UNDERLAY-PEERS:
+      type: ipv4
+      maximum_routes: 12000
+      send_community: all
+    EVPN-OVERLAY-PEERS:
+      type: evpn
+      update_source: Loopback0
+      bfd: true
+      ebgp_multihop: '3'
+      send_community: all
+      maximum_routes: 0
+  address_family_ipv4:
+    peer_groups:
+      MLAG-IPv4-UNDERLAY-PEER:
+        activate: true
+      IPv4-UNDERLAY-PEERS:
+        activate: true
+      EVPN-OVERLAY-PEERS:
+        activate: false
+  neighbors:
+    10.255.251.9:
+      peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: AUTO_BGP_ASN_LEAF3B
+  redistribute_routes:
+    connected:
+      route_map: RM-CONN-2-BGP
+  address_family_evpn:
+    peer_groups:
+      EVPN-OVERLAY-PEERS:
+        activate: true
+static_routes:
+- vrf: MGMT
+  destination_address_prefix: 0.0.0.0/0
+  gateway: 192.168.202.1
+service_routing_protocols_model: multi-agent
+ip_routing: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+spanning_tree:
+  mode: mstp
+  mst_instances:
+    '0':
+      priority: 4096
+  no_spanning_tree_vlan: 4093-4094
+vrfs:
+  MGMT:
+    ip_routing: false
+management_interfaces:
+  Management1:
+    description: oob_management
+    shutdown: false
+    vrf: MGMT
+    ip_address: 192.168.202.109/24
+    gateway: 192.168.202.1
+    type: oob
+management_api_http:
+  enable_vrfs:
+    MGMT: {}
+  enable_https: true
+vlans:
+  4093:
+    tenant: system
+    name: LEAF_PEER_L3
+    trunk_groups:
+    - LEAF_PEER_L3
+  4094:
+    tenant: system
+    name: MLAG_PEER
+    trunk_groups:
+    - MLAG
+vlan_interfaces:
+  Vlan4093:
+    description: MLAG_PEER_L3_PEERING
+    shutdown: false
+    ip_address: 10.255.251.8/31
+    mtu: 9000
+  Vlan4094:
+    description: MLAG_PEER
+    shutdown: false
+    ip_address: 10.255.252.8/31
+    no_autostate: true
+    mtu: 9000
+port_channel_interfaces:
+  Port-Channel3:
+    description: MLAG_PEER_AUTO_BGP_ASN_LEAF3B_Po3
+    type: switched
+    shutdown: false
+    vlans: 2-4094
+    mode: trunk
+    trunk_groups:
+    - LEAF_PEER_L3
+    - MLAG
+ethernet_interfaces:
+  Ethernet3:
+    peer: AUTO_BGP_ASN_LEAF3B
+    peer_interface: Ethernet3
+    peer_type: mlag_peer
+    description: MLAG_PEER_AUTO_BGP_ASN_LEAF3B_Ethernet3
+    type: switched
+    shutdown: false
+    channel_group:
+      id: 3
+      mode: active
+  Ethernet4:
+    peer: AUTO_BGP_ASN_LEAF3B
+    peer_interface: Ethernet4
+    peer_type: mlag_peer
+    description: MLAG_PEER_AUTO_BGP_ASN_LEAF3B_Ethernet4
+    type: switched
+    shutdown: false
+    channel_group:
+      id: 3
+      mode: active
+mlag_configuration:
+  domain_id: AUTO_BGP_ASN_LEAF3_MLAG
+  local_interface: Vlan4094
+  peer_address: 10.255.252.9
+  peer_link: Port-Channel3
+  reload_delay_mlag: 300
+  reload_delay_non_mlag: 330
+route_maps:
+  RM-MLAG-PEER-IN:
+    sequence_numbers:
+      10:
+        type: permit
+        set:
+        - origin incomplete
+        description: Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing
+  RM-CONN-2-BGP:
+    sequence_numbers:
+      10:
+        type: permit
+        match:
+        - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+loopback_interfaces:
+  Loopback0:
+    description: EVPN_Overlay_Peering
+    shutdown: false
+    ip_address: 192.168.255.7/32
+  Loopback1:
+    description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
+    ip_address: 192.168.254.7/32
+prefix_lists:
+  PL-LOOPBACKS-EVPN-OVERLAY:
+    sequence_numbers:
+      10:
+        action: permit 192.168.255.0/24 eq 32
+      20:
+        action: permit 192.168.254.0/24 eq 32
+router_bfd:
+  multihop:
+    interval: 300
+    min_rx: 300
+    multiplier: 3
+ip_igmp_snooping:
+  globally_enabled: true
+ip_virtual_router_mac_address: 00:dc:00:00:00:0a
+vxlan_interface:
+  Vxlan1:
+    description: AUTO_BGP_ASN_LEAF3A_VTEP
+    vxlan:
+      source_interface: Loopback1
+      virtual_router_encapsulation_mac_address: mlag-system-id
+      udp_port: 4789

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF3B.yml
@@ -1,0 +1,184 @@
+router_bgp:
+  as: '65105'
+  router_id: 192.168.255.8
+  bgp_defaults:
+  - no bgp default ipv4-unicast
+  - distance bgp 20 200 200
+  - maximum-paths 4 ecmp 4
+  peer_groups:
+    MLAG-IPv4-UNDERLAY-PEER:
+      type: ipv4
+      remote_as: '65105'
+      next_hop_self: true
+      description: AUTO_BGP_ASN_LEAF3A
+      maximum_routes: 12000
+      send_community: all
+      route_map_in: RM-MLAG-PEER-IN
+    IPv4-UNDERLAY-PEERS:
+      type: ipv4
+      maximum_routes: 12000
+      send_community: all
+    EVPN-OVERLAY-PEERS:
+      type: evpn
+      update_source: Loopback0
+      bfd: true
+      ebgp_multihop: '3'
+      send_community: all
+      maximum_routes: 0
+  address_family_ipv4:
+    peer_groups:
+      MLAG-IPv4-UNDERLAY-PEER:
+        activate: true
+      IPv4-UNDERLAY-PEERS:
+        activate: true
+      EVPN-OVERLAY-PEERS:
+        activate: false
+  neighbors:
+    10.255.251.8:
+      peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: AUTO_BGP_ASN_LEAF3A
+  redistribute_routes:
+    connected:
+      route_map: RM-CONN-2-BGP
+  address_family_evpn:
+    peer_groups:
+      EVPN-OVERLAY-PEERS:
+        activate: true
+static_routes:
+- vrf: MGMT
+  destination_address_prefix: 0.0.0.0/0
+  gateway: 192.168.202.1
+service_routing_protocols_model: multi-agent
+ip_routing: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+spanning_tree:
+  mode: mstp
+  mst_instances:
+    '0':
+      priority: 4096
+  no_spanning_tree_vlan: 4093-4094
+vrfs:
+  MGMT:
+    ip_routing: false
+management_interfaces:
+  Management1:
+    description: oob_management
+    shutdown: false
+    vrf: MGMT
+    ip_address: 192.168.202.110/24
+    gateway: 192.168.202.1
+    type: oob
+management_api_http:
+  enable_vrfs:
+    MGMT: {}
+  enable_https: true
+vlans:
+  4093:
+    tenant: system
+    name: LEAF_PEER_L3
+    trunk_groups:
+    - LEAF_PEER_L3
+  4094:
+    tenant: system
+    name: MLAG_PEER
+    trunk_groups:
+    - MLAG
+vlan_interfaces:
+  Vlan4093:
+    description: MLAG_PEER_L3_PEERING
+    shutdown: false
+    ip_address: 10.255.251.9/31
+    mtu: 9000
+  Vlan4094:
+    description: MLAG_PEER
+    shutdown: false
+    ip_address: 10.255.252.9/31
+    no_autostate: true
+    mtu: 9000
+port_channel_interfaces:
+  Port-Channel3:
+    description: MLAG_PEER_AUTO_BGP_ASN_LEAF3A_Po3
+    type: switched
+    shutdown: false
+    vlans: 2-4094
+    mode: trunk
+    trunk_groups:
+    - LEAF_PEER_L3
+    - MLAG
+ethernet_interfaces:
+  Ethernet3:
+    peer: AUTO_BGP_ASN_LEAF3A
+    peer_interface: Ethernet3
+    peer_type: mlag_peer
+    description: MLAG_PEER_AUTO_BGP_ASN_LEAF3A_Ethernet3
+    type: switched
+    shutdown: false
+    channel_group:
+      id: 3
+      mode: active
+  Ethernet4:
+    peer: AUTO_BGP_ASN_LEAF3A
+    peer_interface: Ethernet4
+    peer_type: mlag_peer
+    description: MLAG_PEER_AUTO_BGP_ASN_LEAF3A_Ethernet4
+    type: switched
+    shutdown: false
+    channel_group:
+      id: 3
+      mode: active
+mlag_configuration:
+  domain_id: AUTO_BGP_ASN_LEAF3_MLAG
+  local_interface: Vlan4094
+  peer_address: 10.255.252.8
+  peer_link: Port-Channel3
+  reload_delay_mlag: 300
+  reload_delay_non_mlag: 330
+route_maps:
+  RM-MLAG-PEER-IN:
+    sequence_numbers:
+      10:
+        type: permit
+        set:
+        - origin incomplete
+        description: Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing
+  RM-CONN-2-BGP:
+    sequence_numbers:
+      10:
+        type: permit
+        match:
+        - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+loopback_interfaces:
+  Loopback0:
+    description: EVPN_Overlay_Peering
+    shutdown: false
+    ip_address: 192.168.255.8/32
+  Loopback1:
+    description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
+    ip_address: 192.168.254.7/32
+prefix_lists:
+  PL-LOOPBACKS-EVPN-OVERLAY:
+    sequence_numbers:
+      10:
+        action: permit 192.168.255.0/24 eq 32
+      20:
+        action: permit 192.168.254.0/24 eq 32
+router_bfd:
+  multihop:
+    interval: 300
+    min_rx: 300
+    multiplier: 3
+ip_igmp_snooping:
+  globally_enabled: true
+ip_virtual_router_mac_address: 00:dc:00:00:00:0a
+vxlan_interface:
+  Vxlan1:
+    description: AUTO_BGP_ASN_LEAF3B_VTEP
+    vxlan:
+      source_interface: Loopback1
+      virtual_router_encapsulation_mac_address: mlag-system-id
+      udp_port: 4789

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF4A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF4A.yml
@@ -1,0 +1,184 @@
+router_bgp:
+  as: '65222'
+  router_id: 192.168.255.9
+  bgp_defaults:
+  - no bgp default ipv4-unicast
+  - distance bgp 20 200 200
+  - maximum-paths 4 ecmp 4
+  peer_groups:
+    MLAG-IPv4-UNDERLAY-PEER:
+      type: ipv4
+      remote_as: '65222'
+      next_hop_self: true
+      description: AUTO_BGP_ASN_LEAF4B
+      maximum_routes: 12000
+      send_community: all
+      route_map_in: RM-MLAG-PEER-IN
+    IPv4-UNDERLAY-PEERS:
+      type: ipv4
+      maximum_routes: 12000
+      send_community: all
+    EVPN-OVERLAY-PEERS:
+      type: evpn
+      update_source: Loopback0
+      bfd: true
+      ebgp_multihop: '3'
+      send_community: all
+      maximum_routes: 0
+  address_family_ipv4:
+    peer_groups:
+      MLAG-IPv4-UNDERLAY-PEER:
+        activate: true
+      IPv4-UNDERLAY-PEERS:
+        activate: true
+      EVPN-OVERLAY-PEERS:
+        activate: false
+  neighbors:
+    10.255.251.13:
+      peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: AUTO_BGP_ASN_LEAF4B
+  redistribute_routes:
+    connected:
+      route_map: RM-CONN-2-BGP
+  address_family_evpn:
+    peer_groups:
+      EVPN-OVERLAY-PEERS:
+        activate: true
+static_routes:
+- vrf: MGMT
+  destination_address_prefix: 0.0.0.0/0
+  gateway: 192.168.202.1
+service_routing_protocols_model: multi-agent
+ip_routing: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+spanning_tree:
+  mode: mstp
+  mst_instances:
+    '0':
+      priority: 4096
+  no_spanning_tree_vlan: 4093-4094
+vrfs:
+  MGMT:
+    ip_routing: false
+management_interfaces:
+  Management1:
+    description: oob_management
+    shutdown: false
+    vrf: MGMT
+    ip_address: 192.168.202.111/24
+    gateway: 192.168.202.1
+    type: oob
+management_api_http:
+  enable_vrfs:
+    MGMT: {}
+  enable_https: true
+vlans:
+  4093:
+    tenant: system
+    name: LEAF_PEER_L3
+    trunk_groups:
+    - LEAF_PEER_L3
+  4094:
+    tenant: system
+    name: MLAG_PEER
+    trunk_groups:
+    - MLAG
+vlan_interfaces:
+  Vlan4093:
+    description: MLAG_PEER_L3_PEERING
+    shutdown: false
+    ip_address: 10.255.251.12/31
+    mtu: 9000
+  Vlan4094:
+    description: MLAG_PEER
+    shutdown: false
+    ip_address: 10.255.252.12/31
+    no_autostate: true
+    mtu: 9000
+port_channel_interfaces:
+  Port-Channel3:
+    description: MLAG_PEER_AUTO_BGP_ASN_LEAF4B_Po3
+    type: switched
+    shutdown: false
+    vlans: 2-4094
+    mode: trunk
+    trunk_groups:
+    - LEAF_PEER_L3
+    - MLAG
+ethernet_interfaces:
+  Ethernet3:
+    peer: AUTO_BGP_ASN_LEAF4B
+    peer_interface: Ethernet3
+    peer_type: mlag_peer
+    description: MLAG_PEER_AUTO_BGP_ASN_LEAF4B_Ethernet3
+    type: switched
+    shutdown: false
+    channel_group:
+      id: 3
+      mode: active
+  Ethernet4:
+    peer: AUTO_BGP_ASN_LEAF4B
+    peer_interface: Ethernet4
+    peer_type: mlag_peer
+    description: MLAG_PEER_AUTO_BGP_ASN_LEAF4B_Ethernet4
+    type: switched
+    shutdown: false
+    channel_group:
+      id: 3
+      mode: active
+mlag_configuration:
+  domain_id: AUTO_BGP_ASN_LEAF4_MLAG_OVERRIDE
+  local_interface: Vlan4094
+  peer_address: 10.255.252.13
+  peer_link: Port-Channel3
+  reload_delay_mlag: 300
+  reload_delay_non_mlag: 330
+route_maps:
+  RM-MLAG-PEER-IN:
+    sequence_numbers:
+      10:
+        type: permit
+        set:
+        - origin incomplete
+        description: Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing
+  RM-CONN-2-BGP:
+    sequence_numbers:
+      10:
+        type: permit
+        match:
+        - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+loopback_interfaces:
+  Loopback0:
+    description: EVPN_Overlay_Peering
+    shutdown: false
+    ip_address: 192.168.255.9/32
+  Loopback1:
+    description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
+    ip_address: 192.168.254.9/32
+prefix_lists:
+  PL-LOOPBACKS-EVPN-OVERLAY:
+    sequence_numbers:
+      10:
+        action: permit 192.168.255.0/24 eq 32
+      20:
+        action: permit 192.168.254.0/24 eq 32
+router_bfd:
+  multihop:
+    interval: 300
+    min_rx: 300
+    multiplier: 3
+ip_igmp_snooping:
+  globally_enabled: true
+ip_virtual_router_mac_address: 00:dc:00:00:00:0a
+vxlan_interface:
+  Vxlan1:
+    description: AUTO_BGP_ASN_LEAF4A_VTEP
+    vxlan:
+      source_interface: Loopback1
+      virtual_router_encapsulation_mac_address: mlag-system-id
+      udp_port: 4789

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF4B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF4B.yml
@@ -1,0 +1,184 @@
+router_bgp:
+  as: '65222'
+  router_id: 192.168.255.10
+  bgp_defaults:
+  - no bgp default ipv4-unicast
+  - distance bgp 20 200 200
+  - maximum-paths 4 ecmp 4
+  peer_groups:
+    MLAG-IPv4-UNDERLAY-PEER:
+      type: ipv4
+      remote_as: '65222'
+      next_hop_self: true
+      description: AUTO_BGP_ASN_LEAF4A
+      maximum_routes: 12000
+      send_community: all
+      route_map_in: RM-MLAG-PEER-IN
+    IPv4-UNDERLAY-PEERS:
+      type: ipv4
+      maximum_routes: 12000
+      send_community: all
+    EVPN-OVERLAY-PEERS:
+      type: evpn
+      update_source: Loopback0
+      bfd: true
+      ebgp_multihop: '3'
+      send_community: all
+      maximum_routes: 0
+  address_family_ipv4:
+    peer_groups:
+      MLAG-IPv4-UNDERLAY-PEER:
+        activate: true
+      IPv4-UNDERLAY-PEERS:
+        activate: true
+      EVPN-OVERLAY-PEERS:
+        activate: false
+  neighbors:
+    10.255.251.12:
+      peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: AUTO_BGP_ASN_LEAF4A
+  redistribute_routes:
+    connected:
+      route_map: RM-CONN-2-BGP
+  address_family_evpn:
+    peer_groups:
+      EVPN-OVERLAY-PEERS:
+        activate: true
+static_routes:
+- vrf: MGMT
+  destination_address_prefix: 0.0.0.0/0
+  gateway: 192.168.202.1
+service_routing_protocols_model: multi-agent
+ip_routing: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+spanning_tree:
+  mode: mstp
+  mst_instances:
+    '0':
+      priority: 4096
+  no_spanning_tree_vlan: 4093-4094
+vrfs:
+  MGMT:
+    ip_routing: false
+management_interfaces:
+  Management1:
+    description: oob_management
+    shutdown: false
+    vrf: MGMT
+    ip_address: 192.168.202.112/24
+    gateway: 192.168.202.1
+    type: oob
+management_api_http:
+  enable_vrfs:
+    MGMT: {}
+  enable_https: true
+vlans:
+  4093:
+    tenant: system
+    name: LEAF_PEER_L3
+    trunk_groups:
+    - LEAF_PEER_L3
+  4094:
+    tenant: system
+    name: MLAG_PEER
+    trunk_groups:
+    - MLAG
+vlan_interfaces:
+  Vlan4093:
+    description: MLAG_PEER_L3_PEERING
+    shutdown: false
+    ip_address: 10.255.251.13/31
+    mtu: 9000
+  Vlan4094:
+    description: MLAG_PEER
+    shutdown: false
+    ip_address: 10.255.252.13/31
+    no_autostate: true
+    mtu: 9000
+port_channel_interfaces:
+  Port-Channel3:
+    description: MLAG_PEER_AUTO_BGP_ASN_LEAF4A_Po3
+    type: switched
+    shutdown: false
+    vlans: 2-4094
+    mode: trunk
+    trunk_groups:
+    - LEAF_PEER_L3
+    - MLAG
+ethernet_interfaces:
+  Ethernet3:
+    peer: AUTO_BGP_ASN_LEAF4A
+    peer_interface: Ethernet3
+    peer_type: mlag_peer
+    description: MLAG_PEER_AUTO_BGP_ASN_LEAF4A_Ethernet3
+    type: switched
+    shutdown: false
+    channel_group:
+      id: 3
+      mode: active
+  Ethernet4:
+    peer: AUTO_BGP_ASN_LEAF4A
+    peer_interface: Ethernet4
+    peer_type: mlag_peer
+    description: MLAG_PEER_AUTO_BGP_ASN_LEAF4A_Ethernet4
+    type: switched
+    shutdown: false
+    channel_group:
+      id: 3
+      mode: active
+mlag_configuration:
+  domain_id: AUTO_BGP_ASN_LEAF4_MLAG_OVERRIDE
+  local_interface: Vlan4094
+  peer_address: 10.255.252.12
+  peer_link: Port-Channel3
+  reload_delay_mlag: 300
+  reload_delay_non_mlag: 330
+route_maps:
+  RM-MLAG-PEER-IN:
+    sequence_numbers:
+      10:
+        type: permit
+        set:
+        - origin incomplete
+        description: Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing
+  RM-CONN-2-BGP:
+    sequence_numbers:
+      10:
+        type: permit
+        match:
+        - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+loopback_interfaces:
+  Loopback0:
+    description: EVPN_Overlay_Peering
+    shutdown: false
+    ip_address: 192.168.255.10/32
+  Loopback1:
+    description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
+    ip_address: 192.168.254.9/32
+prefix_lists:
+  PL-LOOPBACKS-EVPN-OVERLAY:
+    sequence_numbers:
+      10:
+        action: permit 192.168.255.0/24 eq 32
+      20:
+        action: permit 192.168.254.0/24 eq 32
+router_bfd:
+  multihop:
+    interval: 300
+    min_rx: 300
+    multiplier: 3
+ip_igmp_snooping:
+  globally_enabled: true
+ip_virtual_router_mac_address: 00:dc:00:00:00:0a
+vxlan_interface:
+  Vxlan1:
+    description: AUTO_BGP_ASN_LEAF4B_VTEP
+    vxlan:
+      source_interface: Loopback1
+      virtual_router_encapsulation_mac_address: mlag-system-id
+      udp_port: 4789

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF5A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF5A.yml
@@ -1,0 +1,100 @@
+router_bgp:
+  as: '65333'
+  router_id: 192.168.255.11
+  bgp_defaults:
+  - no bgp default ipv4-unicast
+  - distance bgp 20 200 200
+  - maximum-paths 4 ecmp 4
+  peer_groups:
+    IPv4-UNDERLAY-PEERS:
+      type: ipv4
+      maximum_routes: 12000
+      send_community: all
+    EVPN-OVERLAY-PEERS:
+      type: evpn
+      update_source: Loopback0
+      bfd: true
+      ebgp_multihop: '3'
+      send_community: all
+      maximum_routes: 0
+  address_family_ipv4:
+    peer_groups:
+      IPv4-UNDERLAY-PEERS:
+        activate: true
+      EVPN-OVERLAY-PEERS:
+        activate: false
+  redistribute_routes:
+    connected:
+      route_map: RM-CONN-2-BGP
+  address_family_evpn:
+    peer_groups:
+      EVPN-OVERLAY-PEERS:
+        activate: true
+static_routes:
+- vrf: MGMT
+  destination_address_prefix: 0.0.0.0/0
+  gateway: 192.168.202.1
+service_routing_protocols_model: multi-agent
+ip_routing: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+spanning_tree:
+  mode: mstp
+  mst_instances:
+    '0':
+      priority: 4096
+vrfs:
+  MGMT:
+    ip_routing: false
+management_interfaces:
+  Management1:
+    description: oob_management
+    shutdown: false
+    vrf: MGMT
+    ip_address: 192.168.202.113/24
+    gateway: 192.168.202.1
+    type: oob
+management_api_http:
+  enable_vrfs:
+    MGMT: {}
+  enable_https: true
+loopback_interfaces:
+  Loopback0:
+    description: EVPN_Overlay_Peering
+    shutdown: false
+    ip_address: 192.168.255.11/32
+  Loopback1:
+    description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
+    ip_address: 192.168.254.11/32
+prefix_lists:
+  PL-LOOPBACKS-EVPN-OVERLAY:
+    sequence_numbers:
+      10:
+        action: permit 192.168.255.0/24 eq 32
+      20:
+        action: permit 192.168.254.0/24 eq 32
+route_maps:
+  RM-CONN-2-BGP:
+    sequence_numbers:
+      10:
+        type: permit
+        match:
+        - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+router_bfd:
+  multihop:
+    interval: 300
+    min_rx: 300
+    multiplier: 3
+ip_igmp_snooping:
+  globally_enabled: true
+ip_virtual_router_mac_address: 00:dc:00:00:00:0a
+vxlan_interface:
+  Vxlan1:
+    description: AUTO_BGP_ASN_LEAF5A_VTEP
+    vxlan:
+      source_interface: Loopback1
+      udp_port: 4789

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_UNGROUPED_LEAF6.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_UNGROUPED_LEAF6.yml
@@ -1,0 +1,100 @@
+router_bgp:
+  as: '65110'
+  router_id: 192.168.255.12
+  bgp_defaults:
+  - no bgp default ipv4-unicast
+  - distance bgp 20 200 200
+  - maximum-paths 4 ecmp 4
+  peer_groups:
+    IPv4-UNDERLAY-PEERS:
+      type: ipv4
+      maximum_routes: 12000
+      send_community: all
+    EVPN-OVERLAY-PEERS:
+      type: evpn
+      update_source: Loopback0
+      bfd: true
+      ebgp_multihop: '3'
+      send_community: all
+      maximum_routes: 0
+  address_family_ipv4:
+    peer_groups:
+      IPv4-UNDERLAY-PEERS:
+        activate: true
+      EVPN-OVERLAY-PEERS:
+        activate: false
+  redistribute_routes:
+    connected:
+      route_map: RM-CONN-2-BGP
+  address_family_evpn:
+    peer_groups:
+      EVPN-OVERLAY-PEERS:
+        activate: true
+static_routes:
+- vrf: MGMT
+  destination_address_prefix: 0.0.0.0/0
+  gateway: 192.168.202.1
+service_routing_protocols_model: multi-agent
+ip_routing: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+spanning_tree:
+  mode: mstp
+  mst_instances:
+    '0':
+      priority: 4096
+vrfs:
+  MGMT:
+    ip_routing: false
+management_interfaces:
+  Management1:
+    description: oob_management
+    shutdown: false
+    vrf: MGMT
+    ip_address: 192.168.202.114/24
+    gateway: 192.168.202.1
+    type: oob
+management_api_http:
+  enable_vrfs:
+    MGMT: {}
+  enable_https: true
+loopback_interfaces:
+  Loopback0:
+    description: EVPN_Overlay_Peering
+    shutdown: false
+    ip_address: 192.168.255.12/32
+  Loopback1:
+    description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
+    ip_address: 192.168.254.12/32
+prefix_lists:
+  PL-LOOPBACKS-EVPN-OVERLAY:
+    sequence_numbers:
+      10:
+        action: permit 192.168.255.0/24 eq 32
+      20:
+        action: permit 192.168.254.0/24 eq 32
+route_maps:
+  RM-CONN-2-BGP:
+    sequence_numbers:
+      10:
+        type: permit
+        match:
+        - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+router_bfd:
+  multihop:
+    interval: 300
+    min_rx: 300
+    multiplier: 3
+ip_igmp_snooping:
+  globally_enabled: true
+ip_virtual_router_mac_address: 00:dc:00:00:00:0a
+vxlan_interface:
+  Vxlan1:
+    description: AUTO_BGP_UNGROUPED_LEAF6_VTEP
+    vxlan:
+      source_interface: Loopback1
+      udp_port: 4789

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/AUTO_BGP_ASN.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/AUTO_BGP_ASN.yml
@@ -41,3 +41,18 @@ l3leaf:
         AUTO_BGP_ASN_LEAF3B:
           id: 6
           mgmt_ip: 192.168.202.110/24
+    AUTO_BGP_ASN_LEAF4_MLAG_OVERRIDE:
+      bgp_as: 65222
+      nodes:
+        AUTO_BGP_ASN_LEAF4A:
+          id: 7
+          mgmt_ip: 192.168.202.111/24
+        AUTO_BGP_ASN_LEAF4B:
+          id: 8
+          mgmt_ip: 192.168.202.112/24
+    AUTO_BGP_ASN_LEAF5_NODE_OVERRIDE:
+      nodes:
+        AUTO_BGP_ASN_LEAF5A:
+          id: 9
+          bgp_as: 65333
+          mgmt_ip: 192.168.202.113/24

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/AUTO_BGP_ASN.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/AUTO_BGP_ASN.yml
@@ -1,0 +1,43 @@
+type: l3leaf
+mgmt_gateway: 192.168.202.1
+
+l3leaf:
+  defaults:
+    platform: vEOS-LAB
+    loopback_ipv4_pool: 192.168.255.0/24
+    loopback_ipv4_offset: 2
+    vtep_loopback_ipv4_pool: 192.168.254.0/24
+    uplink_interfaces: []
+    uplink_switches: []
+    uplink_ipv4_pool: 172.31.255.0/24
+    bgp_defaults: ['no bgp default ipv4-unicast', 'distance bgp 20 200 200']
+    mlag_interfaces: [ Ethernet3, Ethernet4 ]
+    virtual_router_mac_address: 00:dc:00:00:00:0a
+    mlag_peer_l3_ipv4_pool: 10.255.251.0/24
+    mlag_peer_ipv4_pool: 10.255.252.0/24
+    spanning_tree_mode: mstp
+    spanning_tree_priority: 4096
+    bgp_as: 65101-65110
+  node_groups:
+    AUTO_BGP_ASN_LEAF1_AA:
+      mlag: false
+      nodes:
+        AUTO_BGP_ASN_LEAF1A:
+          id: 1
+          mgmt_ip: 192.168.202.105/24
+        AUTO_BGP_ASN_LEAF1B:
+          id: 2
+          mgmt_ip: 192.168.202.106/24
+    AUTO_BGP_ASN_LEAF2_STANDALONE:
+      nodes:
+        AUTO_BGP_ASN_LEAF2:
+          id: 3
+          mgmt_ip: 192.168.202.107/24
+    AUTO_BGP_ASN_LEAF3_MLAG:
+      nodes:
+        AUTO_BGP_ASN_LEAF3A:
+          id: 5
+          mgmt_ip: 192.168.202.109/24
+        AUTO_BGP_ASN_LEAF3B:
+          id: 6
+          mgmt_ip: 192.168.202.110/24

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/AUTO_BGP_ASN.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/AUTO_BGP_ASN.yml
@@ -56,3 +56,7 @@ l3leaf:
           id: 9
           bgp_as: 65333
           mgmt_ip: 192.168.202.113/24
+  nodes:
+    AUTO_BGP_UNGROUPED_LEAF6:
+      id: 10
+      mgmt_ip: 192.168.202.114/24

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
@@ -122,6 +122,13 @@ all:
               hosts:
                 AUTO_BGP_ASN_LEAF3A:
                 AUTO_BGP_ASN_LEAF3B:
+            AUTO_BGP_ASN_LEAF4_MLAG_OVERRIDE:
+              hosts:
+                AUTO_BGP_ASN_LEAF4A:
+                AUTO_BGP_ASN_LEAF4B:
+            BGP_ASN_LEAF5_NODE_OVERRIDE:
+              hosts:
+                AUTO_BGP_ASN_LEAF5A:
         AVD_LAB:
           children:
             DC1_FABRIC:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
@@ -129,6 +129,9 @@ all:
             BGP_ASN_LEAF5_NODE_OVERRIDE:
               hosts:
                 AUTO_BGP_ASN_LEAF5A:
+          hosts:
+            AUTO_BGP_UNGROUPED_LEAF6:
+
         AVD_LAB:
           children:
             DC1_FABRIC:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
@@ -109,6 +109,19 @@ all:
               hosts:
                 CUSTOM-TEMPLATES-L3LEAF1A:
                 CUSTOM-TEMPLATES-L3LEAF1B:
+        AUTO_BGP_ASN:
+          children:
+            AUTO_BGP_ASN_LEAF1_AA:
+              hosts:
+                AUTO_BGP_ASN_LEAF1A:
+                AUTO_BGP_ASN_LEAF1B:
+            AUTO_BGP_ASN_LEAF2_STANDALONE:
+              hosts:
+                AUTO_BGP_ASN_LEAF2:
+            AUTO_BGP_ASN_LEAF3_MLAG:
+              hosts:
+                AUTO_BGP_ASN_LEAF3A:
+                AUTO_BGP_ASN_LEAF3B:
         AVD_LAB:
           children:
             DC1_FABRIC:

--- a/ansible_collections/arista/avd/plugins/module_utils/eos_designs_facts.py
+++ b/ansible_collections/arista/avd/plugins/module_utils/eos_designs_facts.py
@@ -1141,11 +1141,13 @@ class EosDesignsFacts:
                         if len(bgp_as_range_expanded) == 1:
                             return bgp_as_range_expanded[0]
                         elif self.mlag:
-                            return bgp_as_range_expanded[self._switch_data_node_group_nodes[0]["id"] - 1]
+                            return bgp_as_range_expanded[self.mlag_switch_ids["primary"] - 1]
                         else:
                             return bgp_as_range_expanded[self.id - 1]
                     except IndexError as exc:
-                        raise AristaAvdError("Unable to allocate bgp as: bgp_as range is too small for number of devices") from exc
+                        raise AristaAvdError(
+                            "Unable to allocate BGP AS: bgp_as range is too small "
+                            f"({len(bgp_as_range_expanded)}) for the id of the device") from exc
 
             # Hack to make mpls PR non-breaking, adds empty bgp to igp topology spines
             # TODO: Remove this as part of AVD4.0

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-topology.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-topology.md
@@ -333,7 +333,18 @@ default_interfaces:
 < node_type_key >:
 
   defaults:
-    # node BGP AS | Required.
+    # Node BGP AS | Required.
+    # For eBGP topologies, bgp_as can be defined as a range of ASNs under defaults.  This range will be expanded and ASNs allocated
+    # according to the following rules:
+    #  - Standalone nodes and Non-MLAG (i.e. EVPN A/A multi-homing) node groups will be allocated unique ASNs from the range based on
+    #    the node's ID.
+    #  - Switches in MLAG pairs will be allocated a single ASN, based on the node ID of the first node in the node group.
+    # Examples:
+    # bgp_as: 65101-65110                 Contiguous range of ASNs.
+    # bgp_as: 65001,65010,65020,65030     Non-contiguous range of ASNs.
+    # bgp_as: 65000.101-125               Contiguous range of 4-byte ASNs, increment in the last 2 bytes.
+    # bgp_as: 64512                       Single AS, no range.
+    # Commas and hyphens can be combined in more-or-less any combination.
     bgp_as: < bgp_as >
 
     # List of EOS command to apply to BGP daemon | Optional

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-topology.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-topology.md
@@ -334,7 +334,7 @@ default_interfaces:
 
   defaults:
     # Node BGP AS | Required.
-    # For eBGP topologies, bgp_as can be defined as a range of ASNs under defaults.  This range will be expanded and ASNs allocated
+    # For eBGP topologies, bgp_as can be defined as a range of ASNs.  This range will be expanded and ASNs allocated
     # according to the following rules:
     #  - Standalone nodes and Non-MLAG (i.e. EVPN A/A multi-homing) node groups will be allocated unique ASNs from the range based on
     #    the node's ID.

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-topology.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-topology.md
@@ -338,13 +338,13 @@ default_interfaces:
     # according to the following rules:
     #  - Standalone nodes and Non-MLAG (i.e. EVPN A/A multi-homing) node groups will be allocated unique ASNs from the range based on
     #    the node's ID.
-    #  - Switches in MLAG pairs will be allocated a single ASN, based on the node ID of the first node in the node group.
+    #  - Switches in MLAG pairs will be allocated a single ASN for both, based on the node ID of the first node in the node group.
     # Examples:
     # bgp_as: 65101-65110                 Contiguous range of ASNs.
     # bgp_as: 65001,65010,65020,65030     Non-contiguous range of ASNs.
     # bgp_as: 65000.101-125               Contiguous range of 4-byte ASNs, increment in the last 2 bytes.
     # bgp_as: 64512                       Single AS, no range.
-    # Commas and hyphens can be combined in more-or-less any combination.
+    # Commas and hyphens can be combined in more or less any combination.
     bgp_as: < bgp_as >
 
     # List of EOS command to apply to BGP daemon | Optional


### PR DESCRIPTION
## Change Summary

Automatically assign BGP ASNs to a node type from a range of ASNs

## Related Issue(s)

N/A

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Amends the existing eos_designs bgp_as variable to support ranges of ASNs.  This allows a `bgp_as` range to be defined under a node type's `defaults` clause so that ASNs can be allocated to (for example) l3leafs using the following mechanism:

The bgp_as range is expanded into a list of ASNs and ASNs allocated according to the following:

* Standalone nodes: device's `id` is used to index into that list.
* A/A EVPN MH nodes: device's `id` is used to index into that list.
* MLAG nodes: The device ID of the first node in the node group of the MLAG pair is used to index into the list.

Bare (non-range) ASN behaviour is unaffected.  Inheritance is also unaffected.
```
# Node BGP AS | Required.
# For eBGP topologies, bgp_as can be defined as a range of ASNs under defaults.  This range will be expanded and ASNs allocated
# according to the following rules:
#  - Standalone nodes and Non-MLAG (i.e. EVPN A/A multi-homing) node groups will be allocated unique ASNs from the range based on
#    the node's ID.
#  - Switches in MLAG pairs will be allocated a single ASN, based on the node ID of the first node in the node group.
# Examples:
# bgp_as: 65101-65110                 Contiguous range of ASNs.
# bgp_as: 65001,65010,65020,65030     Non-contiguous range of ASNs.
# bgp_as: 65000.101-125               Contiguous range of 4-byte ASNs, increment in the last 2 bytes.
# bgp_as: 64512                       Single AS, no range.
# Commas and hyphens can be combined in more-or-less any combination.
```
## How to test
New molecule test switches defined to test just this functionality.  Also tested against my standard demo repos.

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been rebased from devel before I start
- [X] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [X] My change requires a change to the documentation and documentation have been updated accordingly.
- [X] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
