### PR TITLE
Feat(eos_cli_config_gen): router bgp link-bandwidth

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
@@ -110,6 +110,18 @@ interface Management1
 | 12.10.10.0/24 | True | my-peer-group3 | - | 65444 | default |
 | 13.10.10.0/24 | - | my-peer-group4 | my-peer-filter | - | default |
 
+### Router BGP Peer Groups
+
+#### test-link-bandwidth1
+
+| Settings | Value |
+| -------- | ----- |
+
+#### test-link-bandwidth2
+
+| Settings | Value |
+| -------- | ----- |
+
 ### BGP Neighbors
 
 | Neighbor | Remote AS | VRF | Shutdown | Send-community | Maximum-routes | Allowas-in | BFD | RIB Pre-Policy Retain |
@@ -154,17 +166,23 @@ router bgp 65101
    bgp listen range 10.10.10.0/24 peer-group my-peer-group1 peer-filter my-peer-filter
    bgp listen range 12.10.10.0/24 peer-id include router-id peer-group my-peer-group3 remote-as 65444
    bgp listen range 13.10.10.0/24 peer-group my-peer-group4 peer-filter my-peer-filter
+   neighbor test-link-bandwidth1 peer group
+   neighbor test-link-bandwidth1 link-bandwidth default 100G
+   neighbor test-link-bandwidth2 peer group
+   neighbor test-link-bandwidth2 link-bandwidth
    neighbor interface Ethernet2 peer-group PG-FOO-v4 remote-as 65102
    neighbor interface Ethernet3 peer-group PG-FOO-v4 peer-filter PF-BAR-v4
    neighbor 192.0.3.1 remote-as 65432
    neighbor 192.0.3.1 rib-in pre-policy retain
    neighbor 192.0.3.1 default-originate always
    neighbor 192.0.3.1 send-community
+   neighbor 192.0.3.1 link-bandwidth default 100G
    neighbor 192.0.3.2 remote-as 65433
    neighbor 192.0.3.2 rib-in pre-policy retain all
    neighbor 192.0.3.2 default-originate route-map RM-FOO-MATCH3
    neighbor 192.0.3.2 send-community extended
    neighbor 192.0.3.2 maximum-routes 10000
+   neighbor 192.0.3.2 link-bandwidth
    neighbor 192.0.3.3 remote-as 65434
    neighbor 192.0.3.3 rib-in pre-policy retain
    neighbor 192.0.3.3 send-community standard

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
@@ -116,11 +116,13 @@ interface Management1
 
 | Settings | Value |
 | -------- | ----- |
+| Link-Bandwidth | default 100G |
 
 #### test-link-bandwidth2
 
 | Settings | Value |
 | -------- | ----- |
+| Link-Bandwidth | enabled |
 
 ### BGP Neighbors
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-base.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-base.cfg
@@ -25,17 +25,23 @@ router bgp 65101
    bgp listen range 10.10.10.0/24 peer-group my-peer-group1 peer-filter my-peer-filter
    bgp listen range 12.10.10.0/24 peer-id include router-id peer-group my-peer-group3 remote-as 65444
    bgp listen range 13.10.10.0/24 peer-group my-peer-group4 peer-filter my-peer-filter
+   neighbor test-link-bandwidth1 peer group
+   neighbor test-link-bandwidth1 link-bandwidth default 100G
+   neighbor test-link-bandwidth2 peer group
+   neighbor test-link-bandwidth2 link-bandwidth
    neighbor interface Ethernet2 peer-group PG-FOO-v4 remote-as 65102
    neighbor interface Ethernet3 peer-group PG-FOO-v4 peer-filter PF-BAR-v4
    neighbor 192.0.3.1 remote-as 65432
    neighbor 192.0.3.1 rib-in pre-policy retain
    neighbor 192.0.3.1 default-originate always
    neighbor 192.0.3.1 send-community
+   neighbor 192.0.3.1 link-bandwidth default 100G
    neighbor 192.0.3.2 remote-as 65433
    neighbor 192.0.3.2 rib-in pre-policy retain all
    neighbor 192.0.3.2 default-originate route-map RM-FOO-MATCH3
    neighbor 192.0.3.2 send-community extended
    neighbor 192.0.3.2 maximum-routes 10000
+   neighbor 192.0.3.2 link-bandwidth
    neighbor 192.0.3.3 remote-as 65434
    neighbor 192.0.3.3 rib-in pre-policy retain
    neighbor 192.0.3.3 send-community standard

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-base.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-base.yml
@@ -36,6 +36,14 @@ router_bgp:
       peer_group: my-peer-group4
       peer_filter: my-peer-filter
       remote_as: 65444
+  peer_groups:
+    test-link-bandwidth1:
+      link_bandwidth:
+        enabled: true
+        default: 100G
+    test-link-bandwidth2:
+      link_bandwidth:
+        enabled: true
   aggregate_addresses:
     1.1.1.0/24:
       advertise_only: true
@@ -83,6 +91,9 @@ router_bgp:
     192.0.3.1:
       remote_as: 65432
       send_community: all
+      link_bandwidth:
+        enabled: true
+        default: 100G
       default_originate:
         enabled: true
         always: true
@@ -92,6 +103,8 @@ router_bgp:
       remote_as: 65433
       send_community: extended
       maximum_routes: 10000
+      link_bandwidth:
+        enabled: true
       default_originate:
         enabled: true
         route_map: RM-FOO-MATCH3

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -2931,6 +2931,9 @@ router_bgp:
       maximum_routes: < integer >
       maximum_routes_warning_limit: < "<integer>" | "<0-100> percent" >
       maximum_routes_warning_only: < true | false >
+      link_bandwidth:
+        enabled: < true | false >
+        default: < nn.nn(K|M|G)  Link speed in bits/second >
       allowas_in:
         enabled: < true | false >
         times: < 1-10 >
@@ -2982,6 +2985,9 @@ router_bgp:
       maximum_routes: < integer >
       maximum_routes_warning_limit: < "<integer>" | "<0-100> percent" >
       maximum_routes_warning_only: < true | false >
+      link_bandwidth:
+        enabled: < true | false >
+        default: < nn.nn(K|M|G)  Link speed in bits/second >
       allowas_in:
         enabled: < true | false >
         times: < 1-10 >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-bgp.j2
@@ -185,6 +185,13 @@
 {%                 endif %}
 | Maximum routes | {{ value }} |
 {%             endif %}
+{%             if peer_group.link_bandwidth.enabled is arista.avd.defined(true) %}
+{%                 set value = "enabled" %}
+{%                 if peer_group.link_bandwidth.default is arista.avd.defined %}
+{%                     set value = "default " ~ peer_group.link_bandwidth.default %}
+{%                 endif %}
+| Link-Bandwidth | {{ value }} |
+{%             endif %}
 {%         endfor %}
 {%     endif %}
 {%     set temp = namespace() %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -153,6 +153,13 @@ router bgp {{ router_bgp.as }}
 {%             endif %}
    {{ maximum_routes_cli }}
 {%         endif %}
+{%         if peer_group.link_bandwidth.enabled is arista.avd.defined(true) %}
+{%             set link_bandwidth_cli = "neighbor " ~ peer_group.name ~ " link-bandwidth" %}
+{%             if peer_group.link_bandwidth.default is arista.avd.defined %}
+{%                 set link_bandwidth_cli = link_bandwidth_cli ~ " default " ~ peer_group.link_bandwidth.default %}
+{%             endif %}
+   {{ link_bandwidth_cli }}
+{%         endif %}
 {%         if peer_group.weight is arista.avd.defined %}
    neighbor {{ peer_group.name }} weight {{ peer_group.weight }}
 {%         endif %}
@@ -278,6 +285,13 @@ router bgp {{ router_bgp.as }}
 {%                 set maximum_routes_cli = maximum_routes_cli ~ " warning-only" %}
 {%             endif %}
    {{ maximum_routes_cli }}
+{%         endif %}
+{%         if neighbor.link_bandwidth.enabled is arista.avd.defined(true) %}
+{%             set link_bandwidth_cli = "neighbor " ~ neighbor.ip_address ~ " link-bandwidth" %}
+{%             if neighbor.link_bandwidth.default is arista.avd.defined %}
+{%                 set link_bandwidth_cli = link_bandwidth_cli ~ " default " ~ neighbor.link_bandwidth.default %}
+{%             endif %}
+   {{ link_bandwidth_cli }}
 {%         endif %}
 {%     endfor %}
 {%     for aggregate_address in router_bgp.aggregate_addresses | arista.avd.convert_dicts('prefix') | arista.avd.natural_sort('prefix') %}


### PR DESCRIPTION
## Change Summary

Added the link-bandwidth command for both peer group and neighbor under router bgp to allow the bandwidth of a link to influence a route

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Allow the link-bandwidth command to be enabled and the default bandwidth for a link to be set on a per peer group or per neighbor basis under router bgp

```yaml
router_bgp:
  peer_groups:
    < peer_group_name_1>:
      link_bandwidth:
        enabled: < true | false >
        default: < nn.nn(K|M|G)  Link speed in bits/second >
  neighbors:
    < IPv4_address_1 >:
      link_bandwidth:
        enabled: < true | false >
        default: < nn.nn(K|M|G)  Link speed in bits/second >
```

## How to test
See molecule results

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
