### PR TITLE
Doc: mkdoc updates with layouts, font, material theme, and syntax highlighting

### DIFF
--- a/ansible_collections/arista/avd/docs/requirements.txt
+++ b/ansible_collections/arista/avd/docs/requirements.txt
@@ -1,6 +1,6 @@
 mkdocs
 mkdocs-bootswatch
-mkdocs-material==7.2.0
+mkdocs-material==8.3.9
 mkdocs-material-extensions
 fontawesome-markdown
 pymdown-extensions

--- a/ansible_collections/arista/avd/docs/stylesheets/extra.material.css
+++ b/ansible_collections/arista/avd/docs/stylesheets/extra.material.css
@@ -37,7 +37,7 @@
   --block-code-bg-color:               #e4e4e4;
   /* --md-code-fg-color:                  ...; */
 
-  font-size: 1rem;
+  /* font-size: 1rem; */
   /* min-height: 100%;
   position: relative;
   width: 100%; */

--- a/ansible_collections/arista/avd/docs/stylesheets/extra.material.css
+++ b/ansible_collections/arista/avd/docs/stylesheets/extra.material.css
@@ -4,15 +4,6 @@
 
 :root {
   /* Color schema based on Arista Color Schema */
-  /* Default color shades */
-  --md-default-fg-color:               #000000;
-  --md-default-fg-color--light:        #a1a0a0;
-  --md-default-fg-color--lighter:      #FFFFFF;
-  --md-default-fg-color--lightest:     #FFFFFF;
-  --md-default-bg-color:               #FFFFFF;
-  --md-default-bg-color--light:        #FFFFFF;
-  --md-default-bg-color--lighter:      #FFFFFF;
-  --md-default-bg-color--lightest:     #FFFFFF;
 
   /* Primary color shades */
   --md-primary-fg-color:               #27569B;
@@ -58,6 +49,30 @@
   /* --md-code-bg-color:                  #E6E6E6; */
   --md-code-border-color:              #aec6db4f;
   /* --block-code-bg-color:               #e4e4e4; */
+}
+
+[data-md-color-scheme="default"] {
+  /* Primary color shades */
+  --md-primary-fg-color:               #27569B;
+  --md-primary-fg-color--light:        #FFFFFF;
+  --md-primary-fg-color--dark:         #27569B;
+  --md-primary-bg-color:               #FFFFFF;
+  --md-primary-bg-color--light:        #FFFFFF;
+
+  /* Accent color shades */
+  --md-accent-fg-color:                #27569B;
+  --md-accent-bg-color:                #27569B;
+  --md-accent-bg-color--light:         #27569B;
+
+  /* Link color */
+  --md-typeset-a-color:                #27569B;
+  --md-typeset-a-color-fg:             #FFFFFF;
+  --md-typeset-a-color-bg:             #27569B;
+
+  /* Code block color shades */
+  --md-code-bg-color:                  #E6E6E6;
+  --md-code-border-color:              #0000004f;
+  --block-code-bg-color:               #e4e4e4;
 }
 
 @media only screen and (min-width: 76.25em) {

--- a/ansible_collections/arista/avd/docs/stylesheets/highlight.js
+++ b/ansible_collections/arista/avd/docs/stylesheets/highlight.js
@@ -1,3 +1,0 @@
-document$.subscribe(() => {
-  hljs.highlightAll()
-})

--- a/ansible_collections/arista/avd/docs/stylesheets/tables.js
+++ b/ansible_collections/arista/avd/docs/stylesheets/tables.js
@@ -1,5 +1,6 @@
+// Source: https://squidfunk.github.io/mkdocs-material/reference/data-tables/#sortable-tables
 document$.subscribe(function() {
-  var tables = document.querySelectorAll("article table")
+  var tables = document.querySelectorAll("article table:not([class])")
   tables.forEach(function(table) {
     new Tablesort(table)
   })

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@
 site_name: Arista AVD collection
 site_author: Arista Ansible Team
 site_description: Arista Validated Design collection's documentation
-copyright: Copyright &copy; 2019 - 2021 Arista Networks
+copyright: Copyright &copy; 2019 - 2022 Arista Networks
 
 # Repository information
 repo_name: AVD on Github
@@ -10,17 +10,17 @@ repo_url: https://github.com/aristanetworks/ansible-avd
 
 # Configuration
 use_directory_urls: false
+edit_uri: ""
 theme:
   name: material
   # custom_dir: ansible_collections/arista/avd/docs/_overrides
   features:
     - navigation.instant
     - navigation.top
+    - search.highlight
+    - header.autohide
+    - content.code.annotate
   highlightjs: true
-  hljs_languages:
-    - yaml
-    - python
-    - shell
   icon:
     repo: fontawesome/brands/github
     logo: fontawesome/solid/book
@@ -42,14 +42,21 @@ theme:
         icon: material/weather-night
         name: Switch to light mode
 
+extra:
+  social:
+  - icon: fontawesome/brands/github-alt
+    link: https://github.com/aristanetworks/ansible-avd
+  - icon: fontawesome/brands/twitter
+    link: https://twitter.com/AristaNetworks
+  - icon: fontawesome/solid/globe
+    link: https://www.arista.com
+
 extra_css:
   - docs/stylesheets/extra.material.css
 
 extra_javascript:
-  - https://cdnjs.cloudflare.com/ajax/libs/tablesort/5.2.1/tablesort.min.js
+  - https://unpkg.com/tablesort@5.3.0/dist/tablesort.min.js
   - docs/stylesheets/tables.js
-  - https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.7.2/highlight.min.js
-  - docs/stylesheets/highlight.js
 
 plugins:
   - search:
@@ -63,6 +70,8 @@ plugins:
   #     minify_js: true
 
 markdown_extensions:
+  - admonition
+  - fontawesome_markdown
   - mdx_truly_sane_lists
   - smarty
   - pymdownx.arithmatex
@@ -71,37 +80,35 @@ markdown_extensions:
   - pymdownx.caret
   - pymdownx.critic
   - pymdownx.details
+  - pymdownx.highlight:
+      anchor_linenums: true
   - pymdownx.inlinehilite
   - pymdownx.magiclink
   - pymdownx.mark
   - pymdownx.smartsymbols
-  - pymdownx.superfences
+  - pymdownx.snippets:
+      base_path: 'ansible_collections/arista/avd/'
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:
+      alternate_style: true 
   - pymdownx.tasklist:
       custom_checkbox: true
   - pymdownx.tilde
-  - fontawesome_markdown
-  - admonition
-  - codehilite:
-      guess_lang: true
+  - tables
   - toc:
       separator: "-"
       # permalink: "#"
       permalink: true
       baselevel: 3
-  - pymdownx.highlight
-  - pymdownx.superfences
-  - pymdownx.snippets:
-      base_path: 'ansible_collections/arista/avd/'
 
 # TOC
 docs_dir: ansible_collections/arista/avd/
 nav:
   - Home: README.md
-  - Release Notes:
-      - 3.x.x: docs/release-notes/3.x.x.md
-      - 2.x.x: docs/release-notes/2.x.x.md
-      - 1.1.x: docs/release-notes/1.1.x.md
-      - 1.0.x: docs/release-notes/1.0.x.md
   - Getting Started:
       - Introduction to Ansible and AVD: docs/getting-started/intro-to-ansible-and-avd.md
       - Example for Single DC L3LS: examples/single-dc-l3ls/README.md
@@ -145,7 +152,7 @@ nav:
       - Module Inventory to containers: docs/modules/inventory_to_container.rst.md
       - Module Configlet Build configuration: docs/modules/configlet_build_config.rst.md
       - AVD Plugins & Filters: plugins/README.md
-      - Cloudvision Module documentation: https://cvp.avd.sh/
+      - CloudVision Module documentation: https://cvp.avd.sh/
   - Contributing to AVD:
       - Overview: docs/contribution/overview.md
       - Setup environment: docs/contribution/setup-environment.md
@@ -156,8 +163,13 @@ nav:
   - External resources:
       - Ansible collection user guide: https://docs.ansible.com/ansible/latest/user_guide/collections_using.html
       - Ansible User guide: https://docs.ansible.com/ansible/latest/user_guide/index.html
+  - Release Notes:
+      - 3.x.x: docs/release-notes/3.x.x.md
+      - 2.x.x: docs/release-notes/2.x.x.md
+      - 1.1.x: docs/release-notes/1.1.x.md
+      - 1.0.x: docs/release-notes/1.0.x.md
   - About:
       - Ansible Galaxy page: https://galaxy.ansible.com/arista/avd
       - Arista CVP Collection: https://cvp.avd.sh/en/latest/
       - Arista Installation Script: https://github.com/arista-netdevops-community/avd-install
-      - Arista Netdevops Community: https://aristanetworks.github.io/netdevops-examples/
+      - Arista NetDevOps Community: https://aristanetworks.github.io/netdevops-examples/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,12 +44,12 @@ theme:
 
 extra:
   social:
-  - icon: fontawesome/brands/github-alt
-    link: https://github.com/aristanetworks/ansible-avd
-  - icon: fontawesome/brands/twitter
-    link: https://twitter.com/AristaNetworks
-  - icon: fontawesome/solid/globe
-    link: https://www.arista.com
+    - icon: fontawesome/brands/github-alt
+      link: https://github.com/aristanetworks/ansible-avd
+    - icon: fontawesome/brands/twitter
+      link: https://twitter.com/AristaNetworks
+    - icon: fontawesome/solid/globe
+      link: https://www.arista.com
 
 extra_css:
   - docs/stylesheets/extra.material.css
@@ -94,7 +94,7 @@ markdown_extensions:
           class: mermaid
           format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.tabbed:
-      alternate_style: true 
+      alternate_style: true
   - pymdownx.tasklist:
       custom_checkbox: true
   - pymdownx.tilde

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,8 +46,8 @@ extra:
   social:
     - icon: fontawesome/brands/github-alt
       link: https://github.com/aristanetworks/ansible-avd
-    - icon: fontawesome/brands/twitter
-      link: https://twitter.com/AristaNetworks
+    # - icon: fontawesome/brands/twitter
+    #   link: https://twitter.com/AristaNetworks
     - icon: fontawesome/solid/globe
       link: https://www.arista.com
 


### PR DESCRIPTION
## Change Summary

This PR updates the material theme used for the site to the latest stable. This also includes enabling new features that have been added with the most recent releases. In addition, code highlighting has been updated to use the built-in system. Please see the list of proposed changes for a full breakdown.

## Related Issue(s)

Fixes aristanetworks/avd-internal#39

## Proposed changes

The following updates have been implemented  as part of this PR:

- Bump material theme in use from `7.2.0` to `8.3.9`
  - Please see official documentation for release [notes](https://github.com/squidfunk/mkdocs-material/releases)
- Update font size (easier to read) to use default provided by mkdocs
- Update copyright dates
- Update tables.js from material theme documentation
    ```js
    // Source: https://squidfunk.github.io/mkdocs-material/reference/data-tables/#sortable-tables
    document$.subscribe(function() {
      var tables = document.querySelectorAll("article table:not([class])")
      tables.forEach(function(table) {
        new Tablesort(table)
      })
    ```  
- Removed edit option in documentation (leads to broken link), users can always submit changes through standard PR
- Removed highlight js and CodeHilite - now using built-in [Highlight](https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/#highlight), including updates to `mkdocs.yml`.
- Enabled built-in [mermaid](https://squidfunk.github.io/mkdocs-material/reference/diagrams/?h=mermaid) diagram support (experimental but awesome)
- Enabled the following markdown extensions for current and future documentation:
  - [search.highlight](https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-search/?h=search#search-highlighting)
  - [header.autohide](https://squidfunk.github.io/mkdocs-material/setup/setting-up-the-header/?h=autohide#automatic-hiding)
  - [content.code.annotate](https://squidfunk.github.io/mkdocs-material/reference/code-blocks/?h=code+anno#code-annotations) added in version `8.0.0`
- Enabled the following social icons
  - GitHub
  - Arista global site
- Enabled markdown extensions to enabled features mentioned above
- Moved release notes lower in the navigation pane

## How to test

Reviews can install the requirements listed in the `doc` directory and then run `mkdocs serve` from the root of the project. Another option is to visit this [build](https://ansible-avd-juliopdx.readthedocs.io/en/mkdocs-refactor/index.html) that references the latest changes being introduced in this PR

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
