### PR TITLE
Fix(eos_designs): fix the Loopback0 interface description

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_designs/templates/underlay/interfaces/loopback-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/underlay/interfaces/loopback-interfaces.j2
@@ -2,7 +2,9 @@ loopback_interfaces:
 {% if switch.router_id is arista.avd.defined %}
 {# BGP Loopback #}
   Loopback0:
+{%     if switch.interface_descriptions.overlay_loopback_interface is arista.avd.defined %}
     description: "{% include switch.interface_descriptions.overlay_loopback_interface %}"
+{%     endif %}
     shutdown: false
     ip_address: {{ switch.router_id }}/32
 {%     if switch.ipv6_router_id is arista.avd.defined %}


### PR DESCRIPTION
## Change Summary

In l2ls design there is no overlay. But when the template for overlay_loopback_interface description is not provided in the designs, it errors out as the Loopback0 interface description is dependent on `interface_descriptions.overlay_loopback_interface`, which is null for l2ls design. So this is fixed with a defined test.

## Related Issue(s)

Fixes #1954 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

Added a defined test before including the description template for loopback interface.

<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test

`make refresh-facts` -> should not generate any new facts or delete any. Also, there should be no error while running this.
The change was tested for a l2ls network locally.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
