### PR TITLE
Feat(eos_designs): igmp querier in network services

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/IGMP-QUERIER-L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/IGMP-QUERIER-L3LEAF1A.cfg
@@ -63,7 +63,7 @@ vlan 2
    name VLAN_2
 !
 vlan 3
-   name VLAN_2
+   name VLAN_3
 !
 vlan 11
    name VLAN_11
@@ -75,10 +75,10 @@ vlan 21
    name VLAN_21
 !
 vlan 22
-   name VLAN_23
+   name VLAN_22
 !
 vlan 23
-   name VLAN_12
+   name VLAN_23
 !
 vlan 101
    name VLAN_101
@@ -147,7 +147,7 @@ interface Vlan2
    ip address virtual 10.0.2.1/24
 !
 interface Vlan3
-   description VLAN_2
+   description VLAN_3
    no shutdown
    vrf IGMP_QUERIER_TEST_1
    ip address virtual 10.0.3.1/24
@@ -171,13 +171,13 @@ interface Vlan21
    ip address virtual 10.0.21.1/24
 !
 interface Vlan22
-   description VLAN_23
+   description VLAN_22
    no shutdown
    vrf IGMP_QUERIER_TEST_3
    ip address virtual 10.0.22.1/24
 !
 interface Vlan23
-   description VLAN_12
+   description VLAN_23
    no shutdown
    vrf IGMP_QUERIER_TEST_3
    ip address virtual 10.0.23.1/24

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/IGMP-QUERIER-L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/IGMP-QUERIER-L3LEAF1A.cfg
@@ -1,0 +1,288 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+ip igmp snooping vlan 1 querier
+ip igmp snooping vlan 1 querier address 192.168.255.1
+ip igmp snooping vlan 2 querier
+ip igmp snooping vlan 2 querier address 192.168.255.1
+ip igmp snooping vlan 2 querier version 3
+no ip igmp snooping vlan 3 querier
+ip igmp snooping vlan 3 querier address 192.168.255.1
+ip igmp snooping vlan 11 querier
+ip igmp snooping vlan 11 querier address 1.1.1.1
+ip igmp snooping vlan 11 querier version 3
+ip igmp snooping vlan 12 querier
+ip igmp snooping vlan 12 querier address 1.1.1.1
+ip igmp snooping vlan 12 querier version 3
+ip igmp snooping vlan 21 querier
+ip igmp snooping vlan 21 querier address 192.168.255.1
+ip igmp snooping vlan 22 querier
+ip igmp snooping vlan 22 querier address 1.1.1.1
+ip igmp snooping vlan 22 querier version 3
+ip igmp snooping vlan 101 querier
+ip igmp snooping vlan 101 querier address 192.168.255.1
+ip igmp snooping vlan 102 querier
+ip igmp snooping vlan 102 querier address 192.168.255.1
+ip igmp snooping vlan 111 querier
+ip igmp snooping vlan 111 querier address 1.1.1.1
+ip igmp snooping vlan 111 querier version 3
+ip igmp snooping vlan 112 querier
+ip igmp snooping vlan 112 querier address 1.1.1.1
+ip igmp snooping vlan 112 querier version 3
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname IGMP-QUERIER-L3LEAF1A
+!
+no enable password
+no aaa root
+!
+vlan 1
+   name VLAN_1
+!
+vlan 2
+   name VLAN_2
+!
+vlan 3
+   name VLAN_2
+!
+vlan 11
+   name VLAN_11
+!
+vlan 12
+   name VLAN_12
+!
+vlan 21
+   name VLAN_11
+!
+vlan 22
+   name VLAN_12
+!
+vlan 101
+   name VLAN_101
+!
+vlan 102
+   name VLAN_102
+!
+vlan 111
+   name VLAN_111
+!
+vlan 112
+   name VLAN_112
+!
+vrf instance IGMP_QUERIER_TEST_1
+   description IGMP_QUERIER_TEST_1
+!
+vrf instance IGMP_QUERIER_TEST_2
+   description IGMP_QUERIER_TEST_2
+!
+vrf instance IGMP_QUERIER_TEST_3
+   description IGMP_QUERIER_TEST_3
+!
+vrf instance MGMT
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 192.168.255.1/32
+!
+interface Loopback1
+   description VTEP_VXLAN_Tunnel_Source
+   no shutdown
+   ip address 192.168.254.1/32
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.200.101/24
+!
+interface Vlan1
+   description VLAN_1
+   no shutdown
+   vrf IGMP_QUERIER_TEST_1
+   ip address virtual 10.0.1.1/24
+!
+interface Vlan2
+   description VLAN_2
+   no shutdown
+   vrf IGMP_QUERIER_TEST_1
+   ip address virtual 10.0.2.1/24
+!
+interface Vlan3
+   description VLAN_2
+   no shutdown
+   vrf IGMP_QUERIER_TEST_1
+   ip address virtual 10.0.3.1/24
+!
+interface Vlan11
+   description VLAN_11
+   no shutdown
+   vrf IGMP_QUERIER_TEST_2
+   ip address virtual 10.0.11.1/24
+!
+interface Vlan12
+   description VLAN_12
+   no shutdown
+   vrf IGMP_QUERIER_TEST_2
+   ip address virtual 10.0.12.1/24
+!
+interface Vlan21
+   description VLAN_11
+   no shutdown
+   vrf IGMP_QUERIER_TEST_3
+   ip address virtual 10.0.21.1/24
+!
+interface Vlan22
+   description VLAN_12
+   no shutdown
+   vrf IGMP_QUERIER_TEST_3
+   ip address virtual 10.0.22.1/24
+!
+interface Vxlan1
+   description IGMP-QUERIER-L3LEAF1A_VTEP
+   vxlan source-interface Loopback1
+   vxlan udp-port 4789
+   vxlan vlan 1 vni 10001
+   vxlan vlan 2 vni 10002
+   vxlan vlan 3 vni 10003
+   vxlan vlan 11 vni 20011
+   vxlan vlan 12 vni 20012
+   vxlan vlan 21 vni 20021
+   vxlan vlan 22 vni 20022
+   vxlan vlan 101 vni 10101
+   vxlan vlan 102 vni 10102
+   vxlan vlan 111 vni 20111
+   vxlan vlan 112 vni 20112
+   vxlan vrf IGMP_QUERIER_TEST_1 vni 11
+   vxlan vrf IGMP_QUERIER_TEST_2 vni 21
+   vxlan vrf IGMP_QUERIER_TEST_3 vni 21
+!
+ip virtual-router mac-address 00:dc:00:00:00:0a
+!
+ip routing
+ip routing vrf IGMP_QUERIER_TEST_1
+ip routing vrf IGMP_QUERIER_TEST_2
+ip routing vrf IGMP_QUERIER_TEST_3
+no ip routing vrf MGMT
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+   seq 20 permit 192.168.254.0/24 eq 32
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.200.5
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 65101
+   router-id 192.168.255.1
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   vlan 1
+      rd 192.168.255.1:10001
+      route-target both 10001:10001
+      redistribute learned
+   !
+   vlan 101
+      rd 192.168.255.1:10101
+      route-target both 10101:10101
+      redistribute learned
+   !
+   vlan 102
+      rd 192.168.255.1:10102
+      route-target both 10102:10102
+      redistribute learned
+   !
+   vlan 11
+      rd 192.168.255.1:20011
+      route-target both 20011:20011
+      redistribute learned
+   !
+   vlan 111
+      rd 192.168.255.1:20111
+      route-target both 20111:20111
+      redistribute learned
+   !
+   vlan 112
+      rd 192.168.255.1:20112
+      route-target both 20112:20112
+      redistribute learned
+   !
+   vlan 12
+      rd 192.168.255.1:20012
+      route-target both 20012:20012
+      redistribute learned
+   !
+   vlan 2
+      rd 192.168.255.1:10002
+      route-target both 10002:10002
+      redistribute learned
+   !
+   vlan 21
+      rd 192.168.255.1:20021
+      route-target both 20021:20021
+      redistribute learned
+   !
+   vlan 22
+      rd 192.168.255.1:20022
+      route-target both 20022:20022
+      redistribute learned
+   !
+   vlan 3
+      rd 192.168.255.1:10003
+      route-target both 10003:10003
+      redistribute learned
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor IPv4-UNDERLAY-PEERS activate
+   !
+   vrf IGMP_QUERIER_TEST_1
+      rd 192.168.255.1:11
+      route-target import evpn 11:11
+      route-target export evpn 11:11
+      router-id 192.168.255.1
+      redistribute connected
+   !
+   vrf IGMP_QUERIER_TEST_2
+      rd 192.168.255.1:21
+      route-target import evpn 21:21
+      route-target export evpn 21:21
+      router-id 192.168.255.1
+      redistribute connected
+   !
+   vrf IGMP_QUERIER_TEST_3
+      rd 192.168.255.1:21
+      route-target import evpn 21:21
+      route-target export evpn 21:21
+      router-id 192.168.255.1
+      redistribute connected
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/IGMP-QUERIER-L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/IGMP-QUERIER-L3LEAF1A.cfg
@@ -14,22 +14,38 @@ ip igmp snooping vlan 11 querier address 1.1.1.1
 ip igmp snooping vlan 11 querier version 3
 ip igmp snooping vlan 12 querier
 ip igmp snooping vlan 12 querier address 1.1.1.1
-ip igmp snooping vlan 12 querier version 3
+ip igmp snooping vlan 12 querier version 2
 ip igmp snooping vlan 21 querier
 ip igmp snooping vlan 21 querier address 192.168.255.1
 ip igmp snooping vlan 22 querier
 ip igmp snooping vlan 22 querier address 1.1.1.1
 ip igmp snooping vlan 22 querier version 3
+ip igmp snooping vlan 23 querier
+ip igmp snooping vlan 23 querier address 2.2.2.2
+ip igmp snooping vlan 23 querier version 1
 ip igmp snooping vlan 101 querier
 ip igmp snooping vlan 101 querier address 192.168.255.1
 ip igmp snooping vlan 102 querier
 ip igmp snooping vlan 102 querier address 192.168.255.1
+ip igmp snooping vlan 102 querier version 3
+no ip igmp snooping vlan 103 querier
+ip igmp snooping vlan 103 querier address 192.168.255.1
 ip igmp snooping vlan 111 querier
 ip igmp snooping vlan 111 querier address 1.1.1.1
 ip igmp snooping vlan 111 querier version 3
 ip igmp snooping vlan 112 querier
 ip igmp snooping vlan 112 querier address 1.1.1.1
-ip igmp snooping vlan 112 querier version 3
+ip igmp snooping vlan 112 querier version 2
+no ip igmp snooping vlan 113 querier
+ip igmp snooping vlan 113 querier address 1.1.1.1
+ip igmp snooping vlan 113 querier version 3
+ip igmp snooping vlan 121 querier
+ip igmp snooping vlan 121 querier address 2.2.2.2
+ip igmp snooping vlan 121 querier version 1
+ip igmp snooping vlan 122 querier
+ip igmp snooping vlan 122 querier address 192.168.255.1
+no ip igmp snooping vlan 123 querier
+ip igmp snooping vlan 123 querier address 192.168.255.1
 !
 transceiver qsfp default-mode 4x10G
 !
@@ -56,9 +72,12 @@ vlan 12
    name VLAN_12
 !
 vlan 21
-   name VLAN_11
+   name VLAN_21
 !
 vlan 22
+   name VLAN_23
+!
+vlan 23
    name VLAN_12
 !
 vlan 101
@@ -67,11 +86,26 @@ vlan 101
 vlan 102
    name VLAN_102
 !
+vlan 103
+   name VLAN_103
+!
 vlan 111
    name VLAN_111
 !
 vlan 112
    name VLAN_112
+!
+vlan 113
+   name VLAN_113
+!
+vlan 121
+   name VLAN_121
+!
+vlan 122
+   name VLAN_122
+!
+vlan 123
+   name VLAN_123
 !
 vrf instance IGMP_QUERIER_TEST_1
    description IGMP_QUERIER_TEST_1
@@ -131,16 +165,22 @@ interface Vlan12
    ip address virtual 10.0.12.1/24
 !
 interface Vlan21
-   description VLAN_11
+   description VLAN_21
    no shutdown
    vrf IGMP_QUERIER_TEST_3
    ip address virtual 10.0.21.1/24
 !
 interface Vlan22
-   description VLAN_12
+   description VLAN_23
    no shutdown
    vrf IGMP_QUERIER_TEST_3
    ip address virtual 10.0.22.1/24
+!
+interface Vlan23
+   description VLAN_12
+   no shutdown
+   vrf IGMP_QUERIER_TEST_3
+   ip address virtual 10.0.23.1/24
 !
 interface Vxlan1
    description IGMP-QUERIER-L3LEAF1A_VTEP
@@ -151,12 +191,18 @@ interface Vxlan1
    vxlan vlan 3 vni 10003
    vxlan vlan 11 vni 20011
    vxlan vlan 12 vni 20012
-   vxlan vlan 21 vni 20021
-   vxlan vlan 22 vni 20022
+   vxlan vlan 21 vni 40021
+   vxlan vlan 22 vni 40022
+   vxlan vlan 23 vni 40023
    vxlan vlan 101 vni 10101
    vxlan vlan 102 vni 10102
+   vxlan vlan 103 vni 10103
    vxlan vlan 111 vni 20111
    vxlan vlan 112 vni 20112
+   vxlan vlan 113 vni 20113
+   vxlan vlan 121 vni 40121
+   vxlan vlan 122 vni 40122
+   vxlan vlan 123 vni 40123
    vxlan vrf IGMP_QUERIER_TEST_1 vni 11
    vxlan vrf IGMP_QUERIER_TEST_2 vni 21
    vxlan vrf IGMP_QUERIER_TEST_3 vni 21
@@ -210,6 +256,11 @@ router bgp 65101
       route-target both 10102:10102
       redistribute learned
    !
+   vlan 103
+      rd 192.168.255.1:10103
+      route-target both 10103:10103
+      redistribute learned
+   !
    vlan 11
       rd 192.168.255.1:20011
       route-target both 20011:20011
@@ -225,9 +276,29 @@ router bgp 65101
       route-target both 20112:20112
       redistribute learned
    !
+   vlan 113
+      rd 192.168.255.1:20113
+      route-target both 20113:20113
+      redistribute learned
+   !
    vlan 12
       rd 192.168.255.1:20012
       route-target both 20012:20012
+      redistribute learned
+   !
+   vlan 121
+      rd 192.168.255.1:40121
+      route-target both 40121:40121
+      redistribute learned
+   !
+   vlan 122
+      rd 192.168.255.1:40122
+      route-target both 40122:40122
+      redistribute learned
+   !
+   vlan 123
+      rd 192.168.255.1:40123
+      route-target both 40123:40123
       redistribute learned
    !
    vlan 2
@@ -236,13 +307,18 @@ router bgp 65101
       redistribute learned
    !
    vlan 21
-      rd 192.168.255.1:20021
-      route-target both 20021:20021
+      rd 192.168.255.1:40021
+      route-target both 40021:40021
       redistribute learned
    !
    vlan 22
-      rd 192.168.255.1:20022
-      route-target both 20022:20022
+      rd 192.168.255.1:40022
+      route-target both 40022:40022
+      redistribute learned
+   !
+   vlan 23
+      rd 192.168.255.1:40023
+      route-target both 40023:40023
       redistribute learned
    !
    vlan 3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/IGMP-QUERIER-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/IGMP-QUERIER-L3LEAF1A.yml
@@ -277,7 +277,7 @@ vlans:
     name: VLAN_2
   3:
     tenant: Tenant_A
-    name: VLAN_2
+    name: VLAN_3
   101:
     tenant: Tenant_A
     name: VLAN_101
@@ -307,10 +307,10 @@ vlans:
     name: VLAN_21
   22:
     tenant: Tenant_D
-    name: VLAN_23
+    name: VLAN_22
   23:
     tenant: Tenant_D
-    name: VLAN_12
+    name: VLAN_23
   121:
     tenant: Tenant_D
     name: VLAN_121
@@ -423,7 +423,7 @@ vlan_interfaces:
     tenant: Tenant_A
     tags:
     - test_l3
-    description: VLAN_2
+    description: VLAN_3
     shutdown: false
     vrf: IGMP_QUERIER_TEST_1
     ip_address_virtual: 10.0.3.1/24
@@ -455,7 +455,7 @@ vlan_interfaces:
     tenant: Tenant_D
     tags:
     - test_l3
-    description: VLAN_23
+    description: VLAN_22
     shutdown: false
     vrf: IGMP_QUERIER_TEST_3
     ip_address_virtual: 10.0.22.1/24
@@ -463,7 +463,7 @@ vlan_interfaces:
     tenant: Tenant_D
     tags:
     - test_l3
-    description: VLAN_12
+    description: VLAN_23
     shutdown: false
     vrf: IGMP_QUERIER_TEST_3
     ip_address_virtual: 10.0.23.1/24

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/IGMP-QUERIER-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/IGMP-QUERIER-L3LEAF1A.yml
@@ -1,0 +1,403 @@
+router_bgp:
+  as: '65101'
+  router_id: 192.168.255.1
+  bgp_defaults:
+  - maximum-paths 4 ecmp 4
+  peer_groups:
+    IPv4-UNDERLAY-PEERS:
+      type: ipv4
+      maximum_routes: 12000
+      send_community: all
+    EVPN-OVERLAY-PEERS:
+      type: evpn
+      update_source: Loopback0
+      bfd: true
+      ebgp_multihop: '3'
+      send_community: all
+      maximum_routes: 0
+  address_family_ipv4:
+    peer_groups:
+      IPv4-UNDERLAY-PEERS:
+        activate: true
+      EVPN-OVERLAY-PEERS:
+        activate: false
+  redistribute_routes:
+    connected:
+      route_map: RM-CONN-2-BGP
+  address_family_evpn:
+    peer_groups:
+      EVPN-OVERLAY-PEERS:
+        activate: true
+  vrfs:
+    IGMP_QUERIER_TEST_1:
+      router_id: 192.168.255.1
+      rd: 192.168.255.1:11
+      route_targets:
+        import:
+          evpn:
+          - '11:11'
+        export:
+          evpn:
+          - '11:11'
+      redistribute_routes:
+      - connected
+    IGMP_QUERIER_TEST_2:
+      router_id: 192.168.255.1
+      rd: 192.168.255.1:21
+      route_targets:
+        import:
+          evpn:
+          - '21:21'
+        export:
+          evpn:
+          - '21:21'
+      redistribute_routes:
+      - connected
+    IGMP_QUERIER_TEST_3:
+      router_id: 192.168.255.1
+      rd: 192.168.255.1:21
+      route_targets:
+        import:
+          evpn:
+          - '21:21'
+        export:
+          evpn:
+          - '21:21'
+      redistribute_routes:
+      - connected
+  vlans:
+    1:
+      tenant: Tenant_A
+      rd: 192.168.255.1:10001
+      route_targets:
+        both:
+        - 10001:10001
+      redistribute_routes:
+      - learned
+    2:
+      tenant: Tenant_A
+      rd: 192.168.255.1:10002
+      route_targets:
+        both:
+        - 10002:10002
+      redistribute_routes:
+      - learned
+    3:
+      tenant: Tenant_A
+      rd: 192.168.255.1:10003
+      route_targets:
+        both:
+        - 10003:10003
+      redistribute_routes:
+      - learned
+    101:
+      tenant: Tenant_A
+      rd: 192.168.255.1:10101
+      route_targets:
+        both:
+        - 10101:10101
+      redistribute_routes:
+      - learned
+    102:
+      tenant: Tenant_A
+      rd: 192.168.255.1:10102
+      route_targets:
+        both:
+        - 10102:10102
+      redistribute_routes:
+      - learned
+    11:
+      tenant: Tenant_B
+      rd: 192.168.255.1:20011
+      route_targets:
+        both:
+        - 20011:20011
+      redistribute_routes:
+      - learned
+    12:
+      tenant: Tenant_B
+      rd: 192.168.255.1:20012
+      route_targets:
+        both:
+        - 20012:20012
+      redistribute_routes:
+      - learned
+    111:
+      tenant: Tenant_B
+      rd: 192.168.255.1:20111
+      route_targets:
+        both:
+        - 20111:20111
+      redistribute_routes:
+      - learned
+    112:
+      tenant: Tenant_B
+      rd: 192.168.255.1:20112
+      route_targets:
+        both:
+        - 20112:20112
+      redistribute_routes:
+      - learned
+    21:
+      tenant: Tenant_C
+      rd: 192.168.255.1:20021
+      route_targets:
+        both:
+        - 20021:20021
+      redistribute_routes:
+      - learned
+    22:
+      tenant: Tenant_C
+      rd: 192.168.255.1:20022
+      route_targets:
+        both:
+        - 20022:20022
+      redistribute_routes:
+      - learned
+static_routes:
+- vrf: MGMT
+  destination_address_prefix: 0.0.0.0/0
+  gateway: 192.168.200.5
+service_routing_protocols_model: multi-agent
+ip_routing: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+vrfs:
+  MGMT:
+    ip_routing: false
+  IGMP_QUERIER_TEST_1:
+    tenant: Tenant_A
+    ip_routing: true
+    description: IGMP_QUERIER_TEST_1
+  IGMP_QUERIER_TEST_2:
+    tenant: Tenant_B
+    ip_routing: true
+    description: IGMP_QUERIER_TEST_2
+  IGMP_QUERIER_TEST_3:
+    tenant: Tenant_C
+    ip_routing: true
+    description: IGMP_QUERIER_TEST_3
+management_interfaces:
+  Management1:
+    description: oob_management
+    shutdown: false
+    vrf: MGMT
+    ip_address: 192.168.200.101/24
+    gateway: 192.168.200.5
+    type: oob
+management_api_http:
+  enable_vrfs:
+    MGMT: {}
+  enable_https: true
+loopback_interfaces:
+  Loopback0:
+    description: EVPN_Overlay_Peering
+    shutdown: false
+    ip_address: 192.168.255.1/32
+  Loopback1:
+    description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
+    ip_address: 192.168.254.1/32
+prefix_lists:
+  PL-LOOPBACKS-EVPN-OVERLAY:
+    sequence_numbers:
+      10:
+        action: permit 192.168.255.0/24 eq 32
+      20:
+        action: permit 192.168.254.0/24 eq 32
+route_maps:
+  RM-CONN-2-BGP:
+    sequence_numbers:
+      10:
+        type: permit
+        match:
+        - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+router_bfd:
+  multihop:
+    interval: 300
+    min_rx: 300
+    multiplier: 3
+vlans:
+  1:
+    tenant: Tenant_A
+    name: VLAN_1
+  2:
+    tenant: Tenant_A
+    name: VLAN_2
+  3:
+    tenant: Tenant_A
+    name: VLAN_2
+  101:
+    tenant: Tenant_A
+    name: VLAN_101
+  102:
+    tenant: Tenant_A
+    name: VLAN_102
+  11:
+    tenant: Tenant_B
+    name: VLAN_11
+  12:
+    tenant: Tenant_B
+    name: VLAN_12
+  111:
+    tenant: Tenant_B
+    name: VLAN_111
+  112:
+    tenant: Tenant_B
+    name: VLAN_112
+  21:
+    tenant: Tenant_C
+    name: VLAN_11
+  22:
+    tenant: Tenant_C
+    name: VLAN_12
+ip_igmp_snooping:
+  globally_enabled: true
+  vlans:
+    1:
+      querier:
+        enabled: true
+        address: 192.168.255.1
+    2:
+      querier:
+        enabled: true
+        address: 192.168.255.1
+        version: 3
+    3:
+      querier:
+        enabled: false
+        address: 192.168.255.1
+    101:
+      querier:
+        enabled: true
+        address: 192.168.255.1
+    102:
+      querier:
+        enabled: true
+        address: 192.168.255.1
+    11:
+      querier:
+        enabled: true
+        address: 1.1.1.1
+        version: 3
+    12:
+      querier:
+        enabled: true
+        address: 1.1.1.1
+        version: 3
+    111:
+      querier:
+        enabled: true
+        address: 1.1.1.1
+        version: 3
+    112:
+      querier:
+        enabled: true
+        address: 1.1.1.1
+        version: 3
+    21:
+      querier:
+        enabled: true
+        address: 192.168.255.1
+    22:
+      querier:
+        enabled: true
+        address: 1.1.1.1
+        version: 3
+ip_virtual_router_mac_address: 00:dc:00:00:00:0a
+vlan_interfaces:
+  Vlan1:
+    tenant: Tenant_A
+    tags:
+    - test_l3
+    description: VLAN_1
+    shutdown: false
+    vrf: IGMP_QUERIER_TEST_1
+    ip_address_virtual: 10.0.1.1/24
+  Vlan2:
+    tenant: Tenant_A
+    tags:
+    - test_l3
+    description: VLAN_2
+    shutdown: false
+    vrf: IGMP_QUERIER_TEST_1
+    ip_address_virtual: 10.0.2.1/24
+  Vlan3:
+    tenant: Tenant_A
+    tags:
+    - test_l3
+    description: VLAN_2
+    shutdown: false
+    vrf: IGMP_QUERIER_TEST_1
+    ip_address_virtual: 10.0.3.1/24
+  Vlan11:
+    tenant: Tenant_B
+    tags:
+    - test_l3
+    description: VLAN_11
+    shutdown: false
+    vrf: IGMP_QUERIER_TEST_2
+    ip_address_virtual: 10.0.11.1/24
+  Vlan12:
+    tenant: Tenant_B
+    tags:
+    - test_l3
+    description: VLAN_12
+    shutdown: false
+    vrf: IGMP_QUERIER_TEST_2
+    ip_address_virtual: 10.0.12.1/24
+  Vlan21:
+    tenant: Tenant_C
+    tags:
+    - test_l3
+    description: VLAN_11
+    shutdown: false
+    vrf: IGMP_QUERIER_TEST_3
+    ip_address_virtual: 10.0.21.1/24
+  Vlan22:
+    tenant: Tenant_C
+    tags:
+    - test_l3
+    description: VLAN_12
+    shutdown: false
+    vrf: IGMP_QUERIER_TEST_3
+    ip_address_virtual: 10.0.22.1/24
+vxlan_interface:
+  Vxlan1:
+    description: IGMP-QUERIER-L3LEAF1A_VTEP
+    vxlan:
+      source_interface: Loopback1
+      udp_port: 4789
+      vlans:
+        1:
+          vni: 10001
+        2:
+          vni: 10002
+        3:
+          vni: 10003
+        101:
+          vni: 10101
+        102:
+          vni: 10102
+        11:
+          vni: 20011
+        12:
+          vni: 20012
+        111:
+          vni: 20111
+        112:
+          vni: 20112
+        21:
+          vni: 20021
+        22:
+          vni: 20022
+      vrfs:
+        IGMP_QUERIER_TEST_1:
+          vni: 11
+        IGMP_QUERIER_TEST_2:
+          vni: 21
+        IGMP_QUERIER_TEST_3:
+          vni: 21

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/IGMP-QUERIER-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/IGMP-QUERIER-L3LEAF1A.yml
@@ -106,6 +106,14 @@ router_bgp:
         - 10102:10102
       redistribute_routes:
       - learned
+    103:
+      tenant: Tenant_A
+      rd: 192.168.255.1:10103
+      route_targets:
+        both:
+        - 10103:10103
+      redistribute_routes:
+      - learned
     11:
       tenant: Tenant_B
       rd: 192.168.255.1:20011
@@ -138,20 +146,60 @@ router_bgp:
         - 20112:20112
       redistribute_routes:
       - learned
-    21:
-      tenant: Tenant_C
-      rd: 192.168.255.1:20021
+    113:
+      tenant: Tenant_B
+      rd: 192.168.255.1:20113
       route_targets:
         both:
-        - 20021:20021
+        - 20113:20113
+      redistribute_routes:
+      - learned
+    21:
+      tenant: Tenant_D
+      rd: 192.168.255.1:40021
+      route_targets:
+        both:
+        - 40021:40021
       redistribute_routes:
       - learned
     22:
-      tenant: Tenant_C
-      rd: 192.168.255.1:20022
+      tenant: Tenant_D
+      rd: 192.168.255.1:40022
       route_targets:
         both:
-        - 20022:20022
+        - 40022:40022
+      redistribute_routes:
+      - learned
+    23:
+      tenant: Tenant_D
+      rd: 192.168.255.1:40023
+      route_targets:
+        both:
+        - 40023:40023
+      redistribute_routes:
+      - learned
+    121:
+      tenant: Tenant_D
+      rd: 192.168.255.1:40121
+      route_targets:
+        both:
+        - 40121:40121
+      redistribute_routes:
+      - learned
+    122:
+      tenant: Tenant_D
+      rd: 192.168.255.1:40122
+      route_targets:
+        both:
+        - 40122:40122
+      redistribute_routes:
+      - learned
+    123:
+      tenant: Tenant_D
+      rd: 192.168.255.1:40123
+      route_targets:
+        both:
+        - 40123:40123
       redistribute_routes:
       - learned
 static_routes:
@@ -177,7 +225,7 @@ vrfs:
     ip_routing: true
     description: IGMP_QUERIER_TEST_2
   IGMP_QUERIER_TEST_3:
-    tenant: Tenant_C
+    tenant: Tenant_D
     ip_routing: true
     description: IGMP_QUERIER_TEST_3
 management_interfaces:
@@ -236,6 +284,9 @@ vlans:
   102:
     tenant: Tenant_A
     name: VLAN_102
+  103:
+    tenant: Tenant_A
+    name: VLAN_103
   11:
     tenant: Tenant_B
     name: VLAN_11
@@ -248,12 +299,27 @@ vlans:
   112:
     tenant: Tenant_B
     name: VLAN_112
+  113:
+    tenant: Tenant_B
+    name: VLAN_113
   21:
-    tenant: Tenant_C
-    name: VLAN_11
+    tenant: Tenant_D
+    name: VLAN_21
   22:
-    tenant: Tenant_C
+    tenant: Tenant_D
+    name: VLAN_23
+  23:
+    tenant: Tenant_D
     name: VLAN_12
+  121:
+    tenant: Tenant_D
+    name: VLAN_121
+  122:
+    tenant: Tenant_D
+    name: VLAN_122
+  123:
+    tenant: Tenant_D
+    name: VLAN_123
 ip_igmp_snooping:
   globally_enabled: true
   vlans:
@@ -278,6 +344,11 @@ ip_igmp_snooping:
       querier:
         enabled: true
         address: 192.168.255.1
+        version: 3
+    103:
+      querier:
+        enabled: false
+        address: 192.168.255.1
     11:
       querier:
         enabled: true
@@ -287,7 +358,7 @@ ip_igmp_snooping:
       querier:
         enabled: true
         address: 1.1.1.1
-        version: 3
+        version: 2
     111:
       querier:
         enabled: true
@@ -296,6 +367,11 @@ ip_igmp_snooping:
     112:
       querier:
         enabled: true
+        address: 1.1.1.1
+        version: 2
+    113:
+      querier:
+        enabled: false
         address: 1.1.1.1
         version: 3
     21:
@@ -307,6 +383,24 @@ ip_igmp_snooping:
         enabled: true
         address: 1.1.1.1
         version: 3
+    23:
+      querier:
+        enabled: true
+        address: 2.2.2.2
+        version: 1
+    121:
+      querier:
+        enabled: true
+        address: 2.2.2.2
+        version: 1
+    122:
+      querier:
+        enabled: true
+        address: 192.168.255.1
+    123:
+      querier:
+        enabled: false
+        address: 192.168.255.1
 ip_virtual_router_mac_address: 00:dc:00:00:00:0a
 vlan_interfaces:
   Vlan1:
@@ -350,21 +444,29 @@ vlan_interfaces:
     vrf: IGMP_QUERIER_TEST_2
     ip_address_virtual: 10.0.12.1/24
   Vlan21:
-    tenant: Tenant_C
+    tenant: Tenant_D
     tags:
     - test_l3
-    description: VLAN_11
+    description: VLAN_21
     shutdown: false
     vrf: IGMP_QUERIER_TEST_3
     ip_address_virtual: 10.0.21.1/24
   Vlan22:
-    tenant: Tenant_C
+    tenant: Tenant_D
+    tags:
+    - test_l3
+    description: VLAN_23
+    shutdown: false
+    vrf: IGMP_QUERIER_TEST_3
+    ip_address_virtual: 10.0.22.1/24
+  Vlan23:
+    tenant: Tenant_D
     tags:
     - test_l3
     description: VLAN_12
     shutdown: false
     vrf: IGMP_QUERIER_TEST_3
-    ip_address_virtual: 10.0.22.1/24
+    ip_address_virtual: 10.0.23.1/24
 vxlan_interface:
   Vxlan1:
     description: IGMP-QUERIER-L3LEAF1A_VTEP
@@ -382,6 +484,8 @@ vxlan_interface:
           vni: 10101
         102:
           vni: 10102
+        103:
+          vni: 10103
         11:
           vni: 20011
         12:
@@ -390,10 +494,20 @@ vxlan_interface:
           vni: 20111
         112:
           vni: 20112
+        113:
+          vni: 20113
         21:
-          vni: 20021
+          vni: 40021
         22:
-          vni: 20022
+          vni: 40022
+        23:
+          vni: 40023
+        121:
+          vni: 40121
+        122:
+          vni: 40122
+        123:
+          vni: 40123
       vrfs:
         IGMP_QUERIER_TEST_1:
           vni: 11

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/IGMP_QUERIER_L3LEAFS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/IGMP_QUERIER_L3LEAFS.yml
@@ -30,6 +30,7 @@ svi_profiles:
       version: 3
 
 tenants:
+# igmp_snooping_querier enable on Tenant
   Tenant_A:
     mac_vrf_vni_base: 10000
     igmp_snooping_querier:
@@ -39,11 +40,15 @@ tenants:
         description: "IGMP_QUERIER_TEST_1"
         vrf_vni: 11
         svis:
+        # Expected results:
+        # igmp querier enable, querier address set to loopback 0 address 192.168.255.1, and version not set (would default to EOS default -> 2)
           1:
             name: "VLAN_1"
             tags: ['test_l3']
             enabled: True
             ip_address_virtual: 10.0.1.1/24
+        # Expected results:
+        # igmp querier enable, querier address set to loopback 0 address 192.168.255.1, and version not set to 3
           2:
             name: "VLAN_2"
             tags: ['test_l3']
@@ -51,6 +56,8 @@ tenants:
             ip_address_virtual: 10.0.2.1/24
             igmp_snooping_querier:
               version: 3
+        # Expected results:
+        # igmp querier disabled, querier address set to loopback 0 address 192.168.255.1, and version not set (would default to EOS default -> 2)
           3:
             name: "VLAN_2"
             tags: ['test_l3']
@@ -59,14 +66,27 @@ tenants:
             igmp_snooping_querier:
               enabled: false
     l2vlans:
+      # Expected results:
+      # igmp querier enabled, querier address set to loopback 0 address 192.168.255.1,
       101:
         name: "VLAN_101"
         tags: ['test_l2']
+      # Expected results:
+      # igmp querier enable, querier address set to loopback 0 address 192.168.255.1, and version not set to 3
       102:
         name: "VLAN_102"
         tags: ['test_l2']
+        igmp_snooping_querier:
+          version: 3
+      # Expected results:
+      # igmp querier disable querier address set to loopback 0 address 192.168.255.1, and version not set (would default to EOS default -> 2)
+      103:
+        name: "VLAN_103"
+        tags: ['test_l2']
+        igmp_snooping_querier:
+          enabled: false
 
-# Test version and source address
+# Test setting source address and version at tenant level
   Tenant_B:
     mac_vrf_vni_base: 20000
     igmp_snooping_querier:
@@ -78,41 +98,101 @@ tenants:
         description: "IGMP_QUERIER_TEST_2"
         vrf_vni: 21
         svis:
+        # Expected results:
+        # igmp querier enable, querier address set to 1.1.1.1, and version set to 3
           11:
             name: "VLAN_11"
             tags: ['test_l3']
             enabled: True
             ip_address_virtual: 10.0.11.1/24
+        # Expected results:
+        # igmp querier enable, querier address set to 1.1.1.1, and version set to 2
           12:
             name: "VLAN_12"
             tags: ['test_l3']
             enabled: True
             ip_address_virtual: 10.0.12.1/24
+            igmp_snooping_querier:
+              version: 2
     l2vlans:
+      # Expected results:
+      # igmp querier enable, querier address set to 1.1.1.1, and version set to 3
       111:
         name: "VLAN_111"
         tags: ['test_l2']
+      # Expected results:
+      # igmp querier enable, querier address set to 1.1.1.1, and version set to 2
       112:
         name: "VLAN_112"
         tags: ['test_l2']
+        igmp_snooping_querier:
+          version: 2
+      113:
+        name: "VLAN_113"
+        tags: ['test_l2']
+      # Expected results:
+      # igmp querier disabled, querier address set to 1.1.1.1, and version set to 3
+        igmp_snooping_querier:
+          enabled: false
 
-# Test with svi profile
-  Tenant_C:
-    mac_vrf_vni_base: 20000
+# Tests with setting igmp_snooping_querier at SVI level with profiles
+  Tenant_D:
+    mac_vrf_vni_base: 40000
     vrfs:
       IGMP_QUERIER_TEST_3:
         description: "IGMP_QUERIER_TEST_3"
         vrf_vni: 21
         svis:
+          # Expected results:
+          # igmp querier enabled, querier address set to loopback 0 address 192.168.255.1, and version not set (would default to EOS default -> 2)
           21:
-            name: "VLAN_11"
+            name: "VLAN_21"
             tags: ['test_l3']
             enabled: True
             ip_address_virtual: 10.0.21.1/24
             profile: IGMP_QUERIER_CHILD_1
+          # Expected results:
+          # igmp querier enable, querier address set to 1.1.1.1, and version set to 3
           22:
-            name: "VLAN_12"
+            name: "VLAN_23"
             tags: ['test_l3']
             enabled: True
             ip_address_virtual: 10.0.22.1/24
             profile: IGMP_QUERIER_CHILD_2
+          # Expected results:
+          # igmp querier enable, querier address set to 2.2.2.2, and version set to 1
+          23:
+            name: "VLAN_12"
+            tags: ['test_l3']
+            enabled: True
+            ip_address_virtual: 10.0.23.1/24
+            igmp_snooping_querier:
+              enabled: true
+              source_address: 2.2.2.2
+              version: 1
+            profile: IGMP_QUERIER_CHILD_2
+
+    l2vlans:
+      # Expected results:
+      # igmp querier enable, querier address set to 2.2.2.2, and version set to 1
+      121:
+        name: "VLAN_121"
+        tags: ['test_l2']
+        igmp_snooping_querier:
+          enabled: true
+          source_address: 2.2.2.2
+          version: 1
+      # Expected results:
+      # igmp querier enable, querier address set to loopback 0 address 192.168.255.1, and version not set (would default to EOS default -> 2)
+      122:
+        name: "VLAN_122"
+        tags: ['test_l2']
+        igmp_snooping_querier:
+          enabled: true
+      # Expected results:
+      # igmp querier disabled, querier address set to loopback 0 address 192.168.255.1, and version not set (would default to EOS default -> 2)
+      123:
+        name: "VLAN_123"
+        tags: ['test_l2']
+        igmp_snooping_querier:
+          enabled: false

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/IGMP_QUERIER_L3LEAFS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/IGMP_QUERIER_L3LEAFS.yml
@@ -59,7 +59,7 @@ tenants:
         # Expected results:
         # igmp querier disabled, querier address set to loopback 0 address 192.168.255.1, and version not set (would default to EOS default -> 2)
           3:
-            name: "VLAN_2"
+            name: "VLAN_3"
             tags: ['test_l3']
             enabled: True
             ip_address_virtual: 10.0.3.1/24
@@ -154,7 +154,7 @@ tenants:
           # Expected results:
           # igmp querier enable, querier address set to 1.1.1.1, and version set to 3
           22:
-            name: "VLAN_23"
+            name: "VLAN_22"
             tags: ['test_l3']
             enabled: True
             ip_address_virtual: 10.0.22.1/24
@@ -162,7 +162,7 @@ tenants:
           # Expected results:
           # igmp querier enable, querier address set to 2.2.2.2, and version set to 1
           23:
-            name: "VLAN_12"
+            name: "VLAN_23"
             tags: ['test_l3']
             enabled: True
             ip_address_virtual: 10.0.23.1/24

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/IGMP_QUERIER_L3LEAFS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/IGMP_QUERIER_L3LEAFS.yml
@@ -1,0 +1,118 @@
+type: l3leaf
+
+mgmt_gateway: 192.168.200.5
+
+l3leaf:
+  defaults:
+    platform: vEOS-LAB
+    loopback_ipv4_pool: 192.168.255.0/24
+    vtep_loopback_ipv4_pool: 192.168.254.0/24
+    virtual_router_mac_address: 00:dc:00:00:00:0a
+    mlag_peer_l3_ipv4_pool: 10.255.251.0/24
+    mlag_peer_ipv4_pool: 10.255.252.0/24
+  nodes:
+    IGMP-QUERIER-L3LEAF1A:
+      bgp_as: 65101
+      id: 1
+      mgmt_ip: 192.168.200.101/24
+
+svi_profiles:
+  IGMP_QUERIER_PARENT:
+    igmp_snooping_querier:
+      enabled: true
+  IGMP_QUERIER_CHILD_1:
+    parent_profile: "IGMP_QUERIER_PARENT"
+  IGMP_QUERIER_CHILD_2:
+    parent_profile: "IGMP_QUERIER_PARENT"
+    igmp_snooping_querier:
+      enabled: true
+      source_address: 1.1.1.1
+      version: 3
+
+tenants:
+  Tenant_A:
+    mac_vrf_vni_base: 10000
+    igmp_snooping_querier:
+      enabled: true
+    vrfs:
+      IGMP_QUERIER_TEST_1:
+        description: "IGMP_QUERIER_TEST_1"
+        vrf_vni: 11
+        svis:
+          1:
+            name: "VLAN_1"
+            tags: ['test_l3']
+            enabled: True
+            ip_address_virtual: 10.0.1.1/24
+          2:
+            name: "VLAN_2"
+            tags: ['test_l3']
+            enabled: True
+            ip_address_virtual: 10.0.2.1/24
+            igmp_snooping_querier:
+              version: 3
+          3:
+            name: "VLAN_2"
+            tags: ['test_l3']
+            enabled: True
+            ip_address_virtual: 10.0.3.1/24
+            igmp_snooping_querier:
+              enabled: false
+    l2vlans:
+      101:
+        name: "VLAN_101"
+        tags: ['test_l2']
+      102:
+        name: "VLAN_102"
+        tags: ['test_l2']
+
+# Test version and source address
+  Tenant_B:
+    mac_vrf_vni_base: 20000
+    igmp_snooping_querier:
+      enabled: true
+      source_address: 1.1.1.1
+      version: 3
+    vrfs:
+      IGMP_QUERIER_TEST_2:
+        description: "IGMP_QUERIER_TEST_2"
+        vrf_vni: 21
+        svis:
+          11:
+            name: "VLAN_11"
+            tags: ['test_l3']
+            enabled: True
+            ip_address_virtual: 10.0.11.1/24
+          12:
+            name: "VLAN_12"
+            tags: ['test_l3']
+            enabled: True
+            ip_address_virtual: 10.0.12.1/24
+    l2vlans:
+      111:
+        name: "VLAN_111"
+        tags: ['test_l2']
+      112:
+        name: "VLAN_112"
+        tags: ['test_l2']
+
+# Test with svi profile
+  Tenant_C:
+    mac_vrf_vni_base: 20000
+    vrfs:
+      IGMP_QUERIER_TEST_3:
+        description: "IGMP_QUERIER_TEST_3"
+        vrf_vni: 21
+        svis:
+          21:
+            name: "VLAN_11"
+            tags: ['test_l3']
+            enabled: True
+            ip_address_virtual: 10.0.21.1/24
+            profile: IGMP_QUERIER_CHILD_1
+          22:
+            name: "VLAN_12"
+            tags: ['test_l3']
+            enabled: True
+            ip_address_virtual: 10.0.22.1/24
+            profile: IGMP_QUERIER_CHILD_2

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
@@ -53,6 +53,11 @@ all:
             UNDERLAY_MULTICAST_L2LEAFS:
               hosts:
                 UNDERLAY-MULTICAST-L2LEAF1A:
+        IGMP_QUERIER_TESTS:
+          children:
+            IGMP_QUERIER_L3LEAFS:
+              hosts:
+                IGMP-QUERIER-L3LEAF1A:
         BGP_PEER_GROUPS_STRUCTURED_CONFIG:
           hosts:
             bgp-peer-groups-structured-config-1:
@@ -182,7 +187,6 @@ all:
                       hosts:
                         MLAG-OSPF-L3LEAF1A:
                         MLAG-OSPF-L3LEAF1B:
-
             DC1_TENANTS_NETWORKS:
               children:
                 DC1_LEAFS:

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
@@ -256,17 +256,11 @@ mac_address_table:
             # Requires "enable_trunk_groups: true"
             trunk_groups: [ < trunk_group_1 >, < trunk_group_2 > ]
 
-            # Explicitly enable or disable evpn_l2_multicast to overide setting of tenants.<tenant>.evpn_l2_multicast.enabled.
-            # When evpn_l2_multicast.enanble it set to true for a vlan or a tenant, "igmp snooping" and igmp snooping querier" will always be enabled - overriding those individual settings.
-            evpn_l2_multicast:
-              enabled: < true | false >
-
             # Enable IGMP Snooping
             igmp_snooping_enabled: < true | false | default true (eos) >
 
             # Enable igmp snooping querier, by default using IP address of Loopback 0.
             igmp_snooping_querier:
-              # Will be enabled automatically if "evpn_l2_multicast" is enabled.
               enabled: < true | false >
               source_address: < ipv4_address -> default ip address of Loopback0 >
               version: < 1, 2, 3 -> default 2 (EOS) >
@@ -553,17 +547,11 @@ mac_address_table:
         # Extend this L2VLAN over VXLAN
         vxlan: < true | false | default -> true >
 
-        # Explicitly enable or disable evpn_l2_multicast to overide setting of tenants.<tenant>.evpn_l2_multicast.enabled.
-        # When evpn_l2_multicast.enanble it set to true for a vlan or a tenant, "igmp snooping" and igmp snooping querier" will always be enabled - overriding those individual settings.
-        evpn_l2_multicast:
-          enabled: < true | false >
-
         # Activate or deactivate IGMP snooping | Optional, default is true
         igmp_snooping_enabled: < true | false >
 
         # Enable igmp snooping querier, by default using IP address of Loopback 0.
         igmp_snooping_querier:
-          # Will be enabled automatically if "evpn_l2_multicast" is enabled.
           enabled: < true | false >
           source_address: < ipv4_address -> default ip address of Loopback0 >
           version: < 1, 2, 3 -> default 2 (EOS) >

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
@@ -131,6 +131,12 @@ mac_address_table:
         route_map_in: < route-map name >
         local_as: < local BGP ASN >
 
+    # Enable igmp snooping querier for each SVI/l2vlan x within tenant, by default using IP address of Loopback 0.
+    igmp_snooping_querier:
+       enabled: < true | false >
+       source_address: < ipv4_address -> default ip address of Loopback0 >
+       version: < 1, 2, 3 -> default 2 (EOS) >
+
     # Define L3 network services organized by vrf.
     vrfs:
       # VRF name | Required
@@ -250,8 +256,20 @@ mac_address_table:
             # Requires "enable_trunk_groups: true"
             trunk_groups: [ < trunk_group_1 >, < trunk_group_2 > ]
 
+            # Explicitly enable or disable evpn_l2_multicast to overide setting of tenants.<tenant>.evpn_l2_multicast.enabled.
+            # When evpn_l2_multicast.enanble it set to true for a vlan or a tenant, "igmp snooping" and igmp snooping querier" will always be enabled - overriding those individual settings.
+            evpn_l2_multicast:
+              enabled: < true | false >
+
             # Enable IGMP Snooping
             igmp_snooping_enabled: < true | false | default true (eos) >
+
+            # Enable igmp snooping querier, by default using IP address of Loopback 0.
+            igmp_snooping_querier:
+              # Will be enabled automatically if "evpn_l2_multicast" is enabled.
+              enabled: < true | false >
+              source_address: < ipv4_address -> default ip address of Loopback0 >
+              version: < 1, 2, 3 -> default 2 (EOS) >
 
             # ip address virtual to configure VXLAN Anycast IP address
             # Conserves IP addresses in VXLAN deployments as it doesn't require unique IP addresses on each node.
@@ -535,11 +553,20 @@ mac_address_table:
         # Extend this L2VLAN over VXLAN
         vxlan: < true | false | default -> true >
 
-      < 1-4096 >:
-        name: < description >
-        tags: [ < tag_1 >, < tag_2 > ]
+        # Explicitly enable or disable evpn_l2_multicast to overide setting of tenants.<tenant>.evpn_l2_multicast.enabled.
+        # When evpn_l2_multicast.enanble it set to true for a vlan or a tenant, "igmp snooping" and igmp snooping querier" will always be enabled - overriding those individual settings.
+        evpn_l2_multicast:
+          enabled: < true | false >
+
         # Activate or deactivate IGMP snooping | Optional, default is true
         igmp_snooping_enabled: < true | false >
+
+        # Enable igmp snooping querier, by default using IP address of Loopback 0.
+        igmp_snooping_querier:
+          # Will be enabled automatically if "evpn_l2_multicast" is enabled.
+          enabled: < true | false >
+          source_address: < ipv4_address -> default ip address of Loopback0 >
+          version: < 1, 2, 3 -> default 2 (EOS) >
 
   < tenant_b >:
     mac_vrf_vni_base: < 10000-16770000 >

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/ip-igmp-snooping.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/ip-igmp-snooping.j2
@@ -29,9 +29,7 @@ ip_igmp_snooping:
       querier:
         enabled: {{ svi_igmp_snooping_querier_enabled }}
         address: "{{ svi_igmp_snooping_querier_source_address }}"
-{%                         if svi_igmp_snooping_querier_version is arista.avd.defined %}
         version: {{ svi_igmp_snooping_querier_version }}
-{%                         endif %}
 {%                     endif %}
 {%                 endif %}
 {%             endfor %}
@@ -55,9 +53,7 @@ ip_igmp_snooping:
       querier:
         enabled: {{ l2vlan_igmp_snooping_querier_enabled }}
         address: "{{ l2vlan_igmp_snooping_querier_source_address }}"
-{%                     if l2vlan_igmp_snooping_querier_version is arista.avd.defined %}
         version: {{ l2vlan_igmp_snooping_querier_version }}
-{%                     endif %}
 {%                 endif %}
 {%             endif %}
 {%         endfor %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/ip-igmp-snooping.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/ip-igmp-snooping.j2
@@ -24,9 +24,7 @@ ip_igmp_snooping:
 {%                 endif %}
 {%                 if svi_igmp_snooping_enabled is arista.avd.defined or svi_igmp_snooping_querier_enabled is arista.avd.defined %}
     {{ svi.id | int }}:
-{%                     if svi_igmp_snooping_enabled is arista.avd.defined %}
       enabled: {{ svi_igmp_snooping_enabled }}
-{%                     endif %}
 {%                     if svi_igmp_snooping_querier_enabled is arista.avd.defined %}
       querier:
         enabled: {{ svi_igmp_snooping_querier_enabled }}
@@ -52,9 +50,7 @@ ip_igmp_snooping:
                                                           tenant.igmp_snooping_querier.version) %}
 {%             if l2vlan_igmp_snooping_enabled is arista.avd.defined or l2vlan_igmp_snooping_querier_enabled is arista.avd.defined %}
     {{ l2vlan.id | int }}:
-{%                 if l2vlan_igmp_snooping_enabled is arista.avd.defined %}
       enabled: {{ l2vlan_igmp_snooping_enabled }}
-{%                 endif %}
 {%                 if l2vlan_igmp_snooping_querier_enabled is arista.avd.defined %}
       querier:
         enabled: {{ l2vlan_igmp_snooping_querier_enabled }}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/ip-igmp-snooping.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/ip-igmp-snooping.j2
@@ -15,11 +15,13 @@ ip_igmp_snooping:
 {%                     set svi_igmp_snooping_querier_enabled = svi.igmp_snooping_querier.enabled | arista.avd.default(
                                                                tenant.igmp_snooping_querier.enabled) %}
 {%                 endif %}
-{%                 set svi_igmp_snooping_querier_source_address = svi.igmp_snooping_querier.source_address | arista.avd.default(
-                                                                  tenant.igmp_snooping_querier.source_address,
-                                                                  switch.router_id) %}
-{%                 set svi_igmp_snooping_querier_version = svi.igmp_snooping_querier.version | arista.avd.default(
-                                                           tenant.igmp_snooping_querier.version) %}
+{%                 if svi_igmp_snooping_querier_enabled is arista.avd.defined %}
+{%                     set svi_igmp_snooping_querier_source_address = svi.igmp_snooping_querier.source_address | arista.avd.default(
+                                                                      tenant.igmp_snooping_querier.source_address,
+                                                                      switch.router_id) %}
+{%                     set svi_igmp_snooping_querier_version = svi.igmp_snooping_querier.version | arista.avd.default(
+                                                               tenant.igmp_snooping_querier.version) %}
+{%                 endif %}
 {%                 if svi_igmp_snooping_enabled is arista.avd.defined or svi_igmp_snooping_querier_enabled is arista.avd.defined %}
     {{ svi.id | int }}:
 {%                     if svi_igmp_snooping_enabled is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/ip-igmp-snooping.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/ip-igmp-snooping.j2
@@ -20,13 +20,6 @@ ip_igmp_snooping:
                                                                   switch.router_id) %}
 {%                 set svi_igmp_snooping_querier_version = svi.igmp_snooping_querier.version | arista.avd.default(
                                                            tenant.igmp_snooping_querier.version) %}
-{%                 set svi_evpn_l2_multicast_enabled = svi.evpn_l2_multicast.enabled | arista.avd.default(
-                                                       tenant.evpn_l2_multicast.enabled) %}
-{%                 if switch.vtep is arista.avd.defined and svi_evpn_l2_multicast_enabled is arista.avd.defined(true) %}
-{#                     Setting to none to avoid extra line of config as we already check and enforce global igmp snooping #}
-{%                     set svi_igmp_snooping_enabled = none %}
-{%                     set svi_igmp_snooping_querier_enabled = true %}
-{%                 endif %}
 {%                 if svi_igmp_snooping_enabled is arista.avd.defined or svi_igmp_snooping_querier_enabled is arista.avd.defined %}
     {{ svi.id | int }}:
 {%                     if svi_igmp_snooping_enabled is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/ip-igmp-snooping.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/ip-igmp-snooping.j2
@@ -10,9 +10,36 @@ ip_igmp_snooping:
 {%         for vrf in tenant.vrfs %}
 {# Tenant VLANs w/SVIs #}
 {%             for svi in vrf.svis %}
-{%                 if svi.igmp_snooping_enabled is arista.avd.defined %}
+{%                 set svi_igmp_snooping_enabled = svi.igmp_snooping_enabled | arista.avd.default %}
+{%                 if switch.network_services_l3 is arista.avd.defined(true) %}
+{%                     set svi_igmp_snooping_querier_enabled = svi.igmp_snooping_querier.enabled | arista.avd.default(
+                                                               tenant.igmp_snooping_querier.enabled) %}
+{%                 endif %}
+{%                 set svi_igmp_snooping_querier_source_address = svi.igmp_snooping_querier.source_address | arista.avd.default(
+                                                                  tenant.igmp_snooping_querier.source_address,
+                                                                  switch.router_id) %}
+{%                 set svi_igmp_snooping_querier_version = svi.igmp_snooping_querier.version | arista.avd.default(
+                                                           tenant.igmp_snooping_querier.version) %}
+{%                 set svi_evpn_l2_multicast_enabled = svi.evpn_l2_multicast.enabled | arista.avd.default(
+                                                       tenant.evpn_l2_multicast.enabled) %}
+{%                 if switch.vtep is arista.avd.defined and svi_evpn_l2_multicast_enabled is arista.avd.defined(true) %}
+{#                     Setting to none to avoid extra line of config as we already check and enforce global igmp snooping #}
+{%                     set svi_igmp_snooping_enabled = none %}
+{%                     set svi_igmp_snooping_querier_enabled = true %}
+{%                 endif %}
+{%                 if svi_igmp_snooping_enabled is arista.avd.defined or svi_igmp_snooping_querier_enabled is arista.avd.defined %}
     {{ svi.id | int }}:
-      enabled: {{ svi.igmp_snooping_enabled }}
+{%                     if svi_igmp_snooping_enabled is arista.avd.defined %}
+      enabled: {{ svi_igmp_snooping_enabled }}
+{%                     endif %}
+{%                     if svi_igmp_snooping_querier_enabled is arista.avd.defined %}
+      querier:
+        enabled: {{ svi_igmp_snooping_querier_enabled }}
+        address: "{{ svi_igmp_snooping_querier_source_address }}"
+{%                         if svi_igmp_snooping_querier_version is arista.avd.defined %}
+        version: {{ svi_igmp_snooping_querier_version }}
+{%                         endif %}
+{%                     endif %}
 {%                 endif %}
 {%             endfor %}
 {%         endfor %}
@@ -20,9 +47,27 @@ ip_igmp_snooping:
 {# L2VLANs services             #}
 {# ---------------------------- #}
 {%         for l2vlan in tenant.l2vlans %}
-{%             if l2vlan.igmp_snooping_enabled is arista.avd.defined %}
+{%             set l2vlan_igmp_snooping_enabled = l2vlan.igmp_snooping_enabled | arista.avd.default %}
+{%             set l2vlan_igmp_snooping_querier_enabled = l2vlan.igmp_snooping_querier.enabled | arista.avd.default(
+                                                          tenant.igmp_snooping_querier.enabled) %}
+{%             set l2vlan_igmp_snooping_querier_source_address = l2vlan.igmp_snooping_querier.source_address | arista.avd.default(
+                                                                 tenant.igmp_snooping_querier.source_address,
+                                                                 switch.router_id) %}
+{%             set l2vlan_igmp_snooping_querier_version = l2vlan.igmp_snooping_querier.version | arista.avd.default(
+                                                          tenant.igmp_snooping_querier.version) %}
+{%             if l2vlan_igmp_snooping_enabled is arista.avd.defined or l2vlan_igmp_snooping_querier_enabled is arista.avd.defined %}
     {{ l2vlan.id | int }}:
-      enabled: {{ l2vlan.igmp_snooping_enabled }}
+{%                 if l2vlan_igmp_snooping_enabled is arista.avd.defined %}
+      enabled: {{ l2vlan_igmp_snooping_enabled }}
+{%                 endif %}
+{%                 if l2vlan_igmp_snooping_querier_enabled is arista.avd.defined %}
+      querier:
+        enabled: {{ l2vlan_igmp_snooping_querier_enabled }}
+        address: "{{ l2vlan_igmp_snooping_querier_source_address }}"
+{%                     if l2vlan_igmp_snooping_querier_version is arista.avd.defined %}
+        version: {{ l2vlan_igmp_snooping_querier_version }}
+{%                     endif %}
+{%                 endif %}
 {%             endif %}
 {%         endfor %}
 {%     endfor %}


### PR DESCRIPTION
## Change Summary

Provide knob in networks services to configure igmp querier at tenant,SVI and l2vlan.

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

```yaml
< network_services_keys.key_1 >:
  < tenant_a >:
    # Enable igmp snooping querier for each SVI/l2vlan x within tenant, by default using IP address of Loopback 0.
    igmp_snooping_querier:
       enabled: < true | false >
       source_address: < ipv4_address -> default ip address of Loopback0 >
       version: < 1, 2, 3 -> default 2 (EOS) >
    vrfs:
      < vrf_name >:
        svis:
            # Enable igmp snooping querier, by default using IP address of Loopback 0.
            igmp_snooping_querier:
              enabled: < true | false >
              source_address: < ipv4_address -> default ip address of Loopback0 >
              version: < 1, 2, 3 -> default 2 (EOS) >
    l2vlans:
      < vlan_id >:
        # Enable igmp snooping querier, by default using IP address of Loopback 0.
        igmp_snooping_querier:
          enabled: < true | false >
          source_address: < ipv4_address -> default ip address of Loopback0 >
          version: < 1, 2, 3 -> default 2 (EOS) >
```

## How to test

See Molecule test case

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
