### PR TITLE
Feat(eos_cli_config_gen): Support multicast routing under ethernet and vlan interfaces

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -155,11 +155,13 @@ interface Management1
 
 #### Multicast Routing
 
-| Interface | IP Version | Static Routes Allowed | Boundary ACL |
-| --------- | ---------- | --------------------- | ------------ |
+| Interface | IP Version | Static Routes Allowed | Multicast Boundaries |
+| --------- | ---------- | --------------------- | -------------------- |
 | Ethernet2 | IPv4 | True | ACL_MULTICAST |
-| Ethernet2 | IPv6 | - | ACL_V6_MULTICAST out |
-| Ethernet9 | IPv4 | - | ACL_MULTICAST out |
+| Ethernet2 | IPv6 | - | ACL_V6_MULTICAST |
+| Ethernet4 | IPv4 | True | 224.0.1.0/24, 224.0.2.0/24 |
+| Ethernet4 | IPv6 | - | ff00::/16, ff01::/16 |
+| Ethernet9 | IPv4 | - | ACL_MULTICAST |
 | Ethernet9 | IPv6 | True | - |
 
 #### IPv4
@@ -287,6 +289,11 @@ interface Ethernet4
    ipv6 nd managed-config-flag
    ipv6 access-group IPv6_ACL_IN in
    ipv6 access-group IPv6_ACL_OUT out
+   multicast ipv4 boundary 224.0.1.0/24 out
+   multicast ipv4 boundary 224.0.2.0/24
+   multicast ipv6 boundary ff00::/16 out
+   multicast ipv6 boundary ff01::/16 out
+   multicast ipv4 static
    priority-flow-control on
    spanning-tree guard none
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -153,6 +153,15 @@ interface Management1
 | Ethernet1 | EVPN_MH_ES1 | upstream |
 | Ethernet3 | EVPN_MH_ES2 | downstream |
 
+#### Multicast Routing
+
+| Interface | IP Version | Static Routes Allowed | Boundary ACL |
+| --------- | ---------- | --------------------- | ------------ |
+| Ethernet2 | IPv4 | True | ACL_MULTICAST |
+| Ethernet2 | IPv6 | - | ACL_V6_MULTICAST out |
+| Ethernet9 | IPv4 | - | ACL_MULTICAST out |
+| Ethernet9 | IPv6 | True | - |
+
 #### IPv4
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
@@ -239,6 +248,9 @@ interface Ethernet2
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
    switchport
+   multicast ipv4 boundary ACL_MULTICAST
+   multicast ipv6 boundary ACL_V6_MULTICAST out
+   multicast ipv4 static
    priority-flow-control on
    priority-flow-control priority 5 no-drop
    storm-control all level 10
@@ -355,6 +367,8 @@ interface Ethernet9
    no switchport
    ip address 172.31.128.9/31
    mpls ldp interface
+   multicast ipv4 boundary ACL_MULTICAST out
+   multicast ipv6 static
    mpls ip
 !
 interface Ethernet10

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
@@ -159,8 +159,8 @@ interface Management1
 
 #### Multicast Routing
 
-| Interface | IP Version | Static Routes Allowed | Multicast Boundaries | Export Routes From Source Traffic |
-| --------- | ---------- | --------------------- | -------------------- | --------------------------------- |
+| Interface | IP Version | Static Routes Allowed | Multicast Boundaries | Export Host Routes For Multicast Sources |
+| --------- | ---------- | --------------------- | -------------------- | ---------------------------------------- |
 | Vlan75 | IPv4 | True | 224.0.1.0/24, 224.0.2.0/24 | - |
 | Vlan75 | IPv6 | - | ff00::/16, ff01::/16 | - |
 | Vlan89 | IPv4 | - | ACL_MULTICAST | True |

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
@@ -157,6 +157,15 @@ interface Management1
 | Vlan667 | 1 | 105 | 2 | Enabled | - | - | 192.0.2.1 | 2 | - |
 | Vlan667 | 2 | - | - | Enabled | - | - | - | 2 | 2001:db8::1 |
 
+#### Multicast Routing
+
+| Interface | IP Version | Static Routes Allowed | Boundary | Export Routes From Source Traffic |
+| --------- | ---------- | --------------------- | -------- | --------------------------------- |
+| Vlan89 | IPv4 | - | ACL_MULTICAST | True |
+| Vlan89 | IPv6 | True | ACL_V6_MULTICAST_WITH_OUT out | - |
+| Vlan110 | IPv4 | True | ACL_MULTICAST out | - |
+| Vlan110 | IPv6 | - | - | True |
+
 ### VLAN Interfaces Device Configuration
 
 ```eos
@@ -259,7 +268,10 @@ interface Vlan89
    ipv6 address 1b11:3a00:22b0:5200::15/64
    ipv6 nd managed-config-flag
    ipv6 nd prefix 1b11:3a00:22b0:5200::/64 infinite infinite no-autoconfig
+   multicast ipv4 boundary ACL_MULTICAST
+   multicast ipv6 boundary ACL_V6_MULTICAST_WITH_OUT out
    multicast ipv4 source route export
+   multicast ipv6 static
    pim ipv4 sparse-mode
    pim ipv4 local-interface Loopback0
    ipv6 virtual-router address 1b11:3a00:22b0:5200::3
@@ -286,6 +298,9 @@ interface Vlan110
    no shutdown
    vrf Tenant_A
    ip address 10.0.101.1/24
+   multicast ipv4 boundary ACL_MULTICAST out
+   multicast ipv6 source route export 20
+   multicast ipv4 static
    pvlan mapping 111-112
 !
 interface Vlan333

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
@@ -159,11 +159,13 @@ interface Management1
 
 #### Multicast Routing
 
-| Interface | IP Version | Static Routes Allowed | Boundary | Export Routes From Source Traffic |
-| --------- | ---------- | --------------------- | -------- | --------------------------------- |
+| Interface | IP Version | Static Routes Allowed | Multicast Boundaries | Export Routes From Source Traffic |
+| --------- | ---------- | --------------------- | -------------------- | --------------------------------- |
+| Vlan75 | IPv4 | True | 224.0.1.0/24, 224.0.2.0/24 | - |
+| Vlan75 | IPv6 | - | ff00::/16, ff01::/16 | - |
 | Vlan89 | IPv4 | - | ACL_MULTICAST | True |
-| Vlan89 | IPv6 | True | ACL_V6_MULTICAST_WITH_OUT out | - |
-| Vlan110 | IPv4 | True | ACL_MULTICAST out | - |
+| Vlan89 | IPv6 | True | ACL_V6_MULTICAST_WITH_OUT | - |
+| Vlan110 | IPv4 | True | ACL_MULTICAST | - |
 | Vlan110 | IPv6 | - | - | True |
 
 ### VLAN Interfaces Device Configuration
@@ -208,6 +210,11 @@ interface Vlan75
    ipv6 address 1b11:3a00:22b0:1000::15/64
    ipv6 nd managed-config-flag
    ipv6 nd prefix 1b11:3a00:22b0:1000::/64 infinite infinite no-autoconfig
+   multicast ipv4 boundary 224.0.1.0/24 out
+   multicast ipv4 boundary 224.0.2.0/24
+   multicast ipv6 boundary ff00::/16 out
+   multicast ipv6 boundary ff01::/16 out
+   multicast ipv4 static
    ipv6 virtual-router address 1b11:3a00:22b0:1000::1
    ip address virtual 10.10.75.1/24
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
@@ -66,6 +66,11 @@ interface Ethernet4
    ipv6 nd managed-config-flag
    ipv6 access-group IPv6_ACL_IN in
    ipv6 access-group IPv6_ACL_OUT out
+   multicast ipv4 boundary 224.0.1.0/24 out
+   multicast ipv4 boundary 224.0.2.0/24
+   multicast ipv6 boundary ff00::/16 out
+   multicast ipv6 boundary ff01::/16 out
+   multicast ipv4 static
    priority-flow-control on
    spanning-tree guard none
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
@@ -27,6 +27,9 @@ interface Ethernet2
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
    switchport
+   multicast ipv4 boundary ACL_MULTICAST
+   multicast ipv6 boundary ACL_V6_MULTICAST out
+   multicast ipv4 static
    priority-flow-control on
    priority-flow-control priority 5 no-drop
    storm-control all level 10
@@ -143,6 +146,8 @@ interface Ethernet9
    no switchport
    ip address 172.31.128.9/31
    mpls ldp interface
+   multicast ipv4 boundary ACL_MULTICAST out
+   multicast ipv6 static
    mpls ip
 !
 interface Ethernet10

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
@@ -110,7 +110,10 @@ interface Vlan89
    ipv6 address 1b11:3a00:22b0:5200::15/64
    ipv6 nd managed-config-flag
    ipv6 nd prefix 1b11:3a00:22b0:5200::/64 infinite infinite no-autoconfig
+   multicast ipv4 boundary ACL_MULTICAST
+   multicast ipv6 boundary ACL_V6_MULTICAST_WITH_OUT out
    multicast ipv4 source route export
+   multicast ipv6 static
    pim ipv4 sparse-mode
    pim ipv4 local-interface Loopback0
    ipv6 virtual-router address 1b11:3a00:22b0:5200::3
@@ -137,6 +140,9 @@ interface Vlan110
    no shutdown
    vrf Tenant_A
    ip address 10.0.101.1/24
+   multicast ipv4 boundary ACL_MULTICAST out
+   multicast ipv6 source route export 20
+   multicast ipv4 static
    pvlan mapping 111-112
 !
 interface Vlan333

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
@@ -50,6 +50,11 @@ interface Vlan75
    ipv6 address 1b11:3a00:22b0:1000::15/64
    ipv6 nd managed-config-flag
    ipv6 nd prefix 1b11:3a00:22b0:1000::/64 infinite infinite no-autoconfig
+   multicast ipv4 boundary 224.0.1.0/24 out
+   multicast ipv4 boundary 224.0.2.0/24
+   multicast ipv6 boundary ff00::/16 out
+   multicast ipv6 boundary ff01::/16 out
+   multicast ipv4 static
    ipv6 virtual-router address 1b11:3a00:22b0:1000::1
    ip address virtual 10.10.75.1/24
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
@@ -39,10 +39,10 @@ ethernet_interfaces:
       ipv4:
         static: true
         boundaries:
-          - name: ACL_MULTICAST
+          - boundary: ACL_MULTICAST
       ipv6:
         boundaries:
-          - ACL_V6_MULTICAST
+          - boundary: ACL_V6_MULTICAST
     storm_control:
       all:
         level: 10
@@ -110,13 +110,13 @@ ethernet_interfaces:
       ipv4:
         static: true
         boundaries:
-          - name: 224.0.1.0/24
+          - boundary: 224.0.1.0/24
             out: true
-          - name: 224.0.2.0/24
+          - boundary: 224.0.2.0/24
       ipv6:
         boundaries:
-          - ff00::/16
-          - ff01::/16
+          - boundary: ff00::/16
+          - boundary: ff01::/16
 
   Ethernet5:
     description: Molecule Routing
@@ -223,7 +223,7 @@ ethernet_interfaces:
     multicast:
       ipv4:
         boundaries:
-          - name: ACL_MULTICAST
+          - boundary: ACL_MULTICAST
             out: true
       ipv6:
         static: true

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
@@ -35,6 +35,12 @@ ethernet_interfaces:
     description: SRV-POD02_Eth1
     mode: trunk
     vlans: 110-111,210-211
+    multicast:
+      ipv4:
+        static: true
+        boundary: ACL_MULTICAST
+      ipv6:
+        boundary: ACL_V6_MULTICAST
     storm_control:
       all:
         level: 10
@@ -201,6 +207,11 @@ ethernet_interfaces:
     description: interface_with_mpls_enabled
     type: routed
     ip_address: 172.31.128.9/31
+    multicast:
+      ipv4:
+        boundary: ACL_MULTICAST out
+      ipv6:
+        static: true
     mpls:
       ip: true
       ldp:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
@@ -38,9 +38,11 @@ ethernet_interfaces:
     multicast:
       ipv4:
         static: true
-        boundary: ACL_MULTICAST
+        boundaries:
+          - name: ACL_MULTICAST
       ipv6:
-        boundary: ACL_V6_MULTICAST
+        boundaries:
+          - ACL_V6_MULTICAST
     storm_control:
       all:
         level: 10
@@ -104,6 +106,17 @@ ethernet_interfaces:
     priority_flow_control:
       enabled: true
     spanning_tree_guard: disabled
+    multicast:
+      ipv4:
+        static: true
+        boundaries:
+          - name: 224.0.1.0/24
+            out: true
+          - name: 224.0.2.0/24
+      ipv6:
+        boundaries:
+          - ff00::/16
+          - ff01::/16
 
   Ethernet5:
     description: Molecule Routing
@@ -209,7 +222,9 @@ ethernet_interfaces:
     ip_address: 172.31.128.9/31
     multicast:
       ipv4:
-        boundary: ACL_MULTICAST out
+        boundaries:
+          - name: ACL_MULTICAST
+            out: true
       ipv6:
         static: true
     mpls:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
@@ -199,13 +199,13 @@ vlan_interfaces:
       ipv4:
         static: true
         boundaries:
-          - name: 224.0.1.0/24
+          - boundary: 224.0.1.0/24
             out: true
-          - name: 224.0.2.0/24
+          - boundary: 224.0.2.0/24
       ipv6:
         boundaries:
-          - ff00::/16
-          - ff01::/16
+          - boundary: ff00::/16
+          - boundary: ff01::/16
 
 # IPv6 + helpers + Mcast
 
@@ -236,11 +236,11 @@ vlan_interfaces:
         source_route_export:
           enabled: true
         boundaries:
-          - name: ACL_MULTICAST
+          - boundary: ACL_MULTICAST
       ipv6:
         static: true
         boundaries:
-          - ACL_V6_MULTICAST_WITH_OUT
+          - boundary: ACL_V6_MULTICAST_WITH_OUT
     pim:
       ipv4:
         sparse_mode: true
@@ -256,7 +256,7 @@ vlan_interfaces:
       ipv4:
         static: true
         boundaries:
-          - name: ACL_MULTICAST
+          - boundary: ACL_MULTICAST
             out: true
       ipv6:
         source_route_export:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
@@ -195,6 +195,17 @@ vlan_interfaces:
         preferred_lifetime: infinite
         no_autoconfig_flag: true
     ipv6_virtual_router_address: 1b11:3a00:22b0:1000::1
+    multicast:
+      ipv4:
+        static: true
+        boundaries:
+          - name: 224.0.1.0/24
+            out: true
+          - name: 224.0.2.0/24
+      ipv6:
+        boundaries:
+          - ff00::/16
+          - ff01::/16
 
 # IPv6 + helpers + Mcast
 
@@ -224,10 +235,12 @@ vlan_interfaces:
       ipv4:
         source_route_export:
           enabled: true
-        boundary: ACL_MULTICAST
+        boundaries:
+          - name: ACL_MULTICAST
       ipv6:
         static: true
-        boundary: ACL_V6_MULTICAST_WITH_OUT
+        boundaries:
+          - ACL_V6_MULTICAST_WITH_OUT
     pim:
       ipv4:
         sparse_mode: true
@@ -242,7 +255,9 @@ vlan_interfaces:
     multicast:
       ipv4:
         static: true
-        boundary: ACL_MULTICAST out
+        boundaries:
+          - name: ACL_MULTICAST
+            out: true
       ipv6:
         source_route_export:
           enabled: true

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
@@ -224,6 +224,10 @@ vlan_interfaces:
       ipv4:
         source_route_export:
           enabled: true
+        boundary: ACL_MULTICAST
+      ipv6:
+        static: true
+        boundary: ACL_V6_MULTICAST_WITH_OUT
     pim:
       ipv4:
         sparse_mode: true
@@ -235,6 +239,14 @@ vlan_interfaces:
     vrf: Tenant_A
     ip_address: 10.0.101.1/24
     pvlan_mapping: 111-112
+    multicast:
+      ipv4:
+        static: true
+        boundary: ACL_MULTICAST out
+      ipv6:
+        source_route_export:
+          enabled: true
+          administrative_distance: 20
 
 # VRRP
   Vlan667:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/vlan-interfaces.md
@@ -138,8 +138,8 @@ interface Management1
 
 #### Multicast Routing
 
-| Interface | IP Version | Static Routes Allowed | Boundary | Export Routes From Source Traffic |
-| --------- | ---------- | --------------------- | -------- | --------------------------------- |
+| Interface | IP Version | Static Routes Allowed | Multicast Boundaries | Export Routes From Source Traffic |
+| --------- | ---------- | --------------------- | -------------------- | --------------------------------- |
 | Vlan89 | IPv4 | - | - | True |
 
 ### VLAN Interfaces Device Configuration

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/vlan-interfaces.md
@@ -138,8 +138,8 @@ interface Management1
 
 #### Multicast Routing
 
-| Interface | IP Version | Static Routes Allowed | Multicast Boundaries | Export Routes From Source Traffic |
-| --------- | ---------- | --------------------- | -------------------- | --------------------------------- |
+| Interface | IP Version | Static Routes Allowed | Multicast Boundaries | Export Host Routes For Multicast Sources |
+| --------- | ---------- | --------------------- | -------------------- | ---------------------------------------- |
 | Vlan89 | IPv4 | - | - | True |
 
 ### VLAN Interfaces Device Configuration

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/vlan-interfaces.md
@@ -136,6 +136,12 @@ interface Management1
 | Vlan1001 | Tenant_A | a1::1/64 | - | - | - | - | true | - | - |
 | Vlan1002 | Tenant_A | a2::1/64 | - | - | - | true | true | - | - |
 
+#### Multicast Routing
+
+| Interface | IP Version | Static Routes Allowed | Boundary | Export Routes From Source Traffic |
+| --------- | ---------- | --------------------- | -------- | --------------------------------- |
+| Vlan89 | IPv4 | - | - | True |
+
 ### VLAN Interfaces Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -995,11 +995,16 @@ ethernet_interfaces:
     mac_access_group_in: < mac_access_list_name >
     mac_access_group_out: < mac_access_list_name >
     multicast:
+      # boundaries can be either 1 ACL or a list of multicast IP address_range(s)/prefix but not combination of both
       ipv4:
-        boundary: < < acl_name > | < acl_name > out >
+        boundaries:
+          - name: < acl_name | multicast_ip_subnet >
+            out: < true | false >
         static: < true | false >
       ipv6:
-        boundary: < acl_name >
+        # By default the rule is applied on the outgoing traffic
+        boundaries:
+          - < acl_name | multicast_ip_subnet >
         static: < true | false >
     ospf_network_point_to_point: < true | false >
     ospf_area: < ospf_area >
@@ -1527,14 +1532,19 @@ vlan_interfaces:
     ipv6_access_group_in: < ipv6_access_list_name >
     ipv6_access_group_out: < ipv6_access_list_name >
     multicast:
+      # boundaries can be either 1 ACL or a list of multicast IP address_range(s)/prefix but not combination of both
       ipv4:
-        boundary: < < acl_name > | < acl_name > out >
+        boundaries:
+          - name: < acl_name | multicast_ip_subnet >
+            out: < true | false >
         source_route_export:
           enabled: < true | false >
           administrative_distance: < 1-255 >
         static: < true | false >
       ipv6:
-        boundary: < acl_name >
+        # By default the rule is applied on the outgoing traffic
+        boundaries:
+          - < acl_name | multicast_ip_subnet >
         source_route_export:
           enabled: < true | false >
           administrative_distance: < 1-255 >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -998,13 +998,12 @@ ethernet_interfaces:
       # boundaries can be either 1 ACL or a list of multicast IP address_range(s)/prefix but not combination of both
       ipv4:
         boundaries:
-          - name: < acl_name | multicast_ip_subnet >
+          - boundary: < acl_name | multicast_ip_subnet >
             out: < true | false >
         static: < true | false >
       ipv6:
-        # By default the rule is applied on the outgoing traffic
         boundaries:
-          - < acl_name | multicast_ip_subnet >
+          - boundary: < acl_name | multicast_ip_subnet >
         static: < true | false >
     ospf_network_point_to_point: < true | false >
     ospf_area: < ospf_area >
@@ -1535,16 +1534,15 @@ vlan_interfaces:
       # boundaries can be either 1 ACL or a list of multicast IP address_range(s)/prefix but not combination of both
       ipv4:
         boundaries:
-          - name: < acl_name | multicast_ip_subnet >
+          - boundary: < acl_name | multicast_ip_subnet >
             out: < true | false >
         source_route_export:
           enabled: < true | false >
           administrative_distance: < 1-255 >
         static: < true | false >
       ipv6:
-        # By default the rule is applied on the outgoing traffic
         boundaries:
-          - < acl_name | multicast_ip_subnet >
+          - boundary: < acl_name | multicast_ip_subnet >
         source_route_export:
           enabled: < true | false >
           administrative_distance: < 1-255 >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -994,6 +994,13 @@ ethernet_interfaces:
     ipv6_access_group_out: < ipv6_access_list_name >
     mac_access_group_in: < mac_access_list_name >
     mac_access_group_out: < mac_access_list_name >
+    multicast:
+      ipv4:
+        boundary: < < acl_name > | < acl_name > out >
+        static: < true | false >
+      ipv6:
+        boundary: < acl_name >
+        static: < true | false >
     ospf_network_point_to_point: < true | false >
     ospf_area: < ospf_area >
     ospf_cost: < ospf_cost >
@@ -1521,9 +1528,17 @@ vlan_interfaces:
     ipv6_access_group_out: < ipv6_access_list_name >
     multicast:
       ipv4:
+        boundary: < < acl_name > | < acl_name > out >
         source_route_export:
           enabled: < true | false >
           administrative_distance: < 1-255 >
+        static: < true | false >
+      ipv6:
+        boundary: < acl_name >
+        source_route_export:
+          enabled: < true | false >
+          administrative_distance: < 1-255 >
+        static: < true | false >
     ospf_network_point_to_point: < true | false >
     ospf_area: < ospf_area >
     ospf_cost: < ospf_cost >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ethernet-interfaces.j2
@@ -159,11 +159,15 @@
 {%             endif %}
 {%         endfor %}
 {%     endif %}
-{# Link Tracking Groups #}
+{# Link Tracking Groups and multicast #}
 {%     set link_tracking_interfaces = [] %}
+{%     set multicast_interfaces = [] %}
 {%     for ethernet_interface in ethernet_interfaces | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
 {%         if ethernet_interface.link_tracking_groups is arista.avd.defined %}
 {%             do link_tracking_interfaces.append(ethernet_interface) %}
+{%         endif %}
+{%         if ethernet_interface.multicast is arista.avd.defined %}
+{%             do multicast_interfaces.append(ethernet_interface) %}
 {%         endif %}
 {%     endfor %}
 {%     if link_tracking_interfaces | length > 0 %}
@@ -178,6 +182,35 @@
 | {{ link_tracking_interface.name }} | {{ link_tracking_group.name }} | {{ link_tracking_group.direction }} |
 {%                 endif %}
 {%             endfor %}
+{%         endfor %}
+{%     endif %}
+{%     if multicast_interfaces | length > 0 %}
+
+#### Multicast Routing
+
+| Interface | IP Version | Static Routes Allowed | Boundary ACL |
+| --------- | ---------- | --------------------- | ------------ |
+{%         for multicast_interface in multicast_interfaces %}
+{%             if multicast_interface.multicast.ipv4 is arista.avd.defined %}
+{%                 set version = 'IPv4' %}
+{%                 set static = multicast_interface.multicast.ipv4.static | arista.avd.default('-') %}
+{%                 set boundary = multicast_interface.multicast.ipv4.boundary | arista.avd.default('-') %}
+{%             endif %}
+{%             if version is arista.avd.defined('IPv4') %}
+| {{ multicast_interface.name }} | {{ version }} | {{ static }} | {{ boundary }} |
+{%             endif %}
+{%             if multicast_interface.multicast.ipv6 is arista.avd.defined %}
+{%                 set version = 'IPv6' %}
+{%                 set static = multicast_interface.multicast.ipv6.static | arista.avd.default('-') %}
+{%                 if multicast_interface.multicast.ipv6.boundary is arista.avd.defined %}
+{%                     set boundary = multicast_interface.multicast.ipv6.boundary ~ ' out' %}
+{%                 else %}
+{%                     set boundary = '-' %}
+{%                 endif %}
+{%             endif %}
+{%             if version is arista.avd.defined('IPv6') %}
+| {{ multicast_interface.name }} | {{ version }} | {{ static }} | {{ boundary }} |
+{%             endif %}
 {%         endfor %}
 {%     endif %}
 {# IPv4 #}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ethernet-interfaces.j2
@@ -188,22 +188,28 @@
 
 #### Multicast Routing
 
-| Interface | IP Version | Static Routes Allowed | Boundary ACL |
-| --------- | ---------- | --------------------- | ------------ |
+| Interface | IP Version | Static Routes Allowed | Multicast Boundaries |
+| --------- | ---------- | --------------------- | -------------------- |
 {%         for multicast_interface in multicast_interfaces %}
 {%             if multicast_interface.multicast.ipv4 is arista.avd.defined %}
 {%                 set static = multicast_interface.multicast.ipv4.static | arista.avd.default('-') %}
-{%                 set boundary = multicast_interface.multicast.ipv4.boundary | arista.avd.default('-') %}
-| {{ multicast_interface.name }} | IPv4 | {{ static }} | {{ boundary }} |
+{%                 if multicast_interface.multicast.ipv4.boundaries is arista.avd.defined %}
+{%                     set boundaries = multicast_interface.multicast.ipv4.boundaries | selectattr('name', 'arista.avd.defined') |
+                                                                                        map(attribute='name') |
+                                                                                        join(', ') %}
+{%                 else %}
+{%                     set boundaries = '-' %}
+{%                 endif %}
+| {{ multicast_interface.name }} | IPv4 | {{ static }} | {{ boundaries }} |
 {%             endif %}
 {%             if multicast_interface.multicast.ipv6 is arista.avd.defined %}
 {%                 set static = multicast_interface.multicast.ipv6.static | arista.avd.default('-') %}
-{%                 if multicast_interface.multicast.ipv6.boundary is arista.avd.defined %}
-{%                     set boundary = multicast_interface.multicast.ipv6.boundary ~ ' out' %}
+{%                 if multicast_interface.multicast.ipv6.boundaries is arista.avd.defined %}
+{%                     set boundaries = multicast_interface.multicast.ipv6.boundaries | join(', ') %}
 {%                 else %}
-{%                     set boundary = '-' %}
+{%                     set boundaries = '-' %}
 {%                 endif %}
-| {{ multicast_interface.name }} | IPv6 | {{ static }} | {{ boundary }} |
+| {{ multicast_interface.name }} | IPv6 | {{ static }} | {{ boundaries }} |
 {%             endif %}
 {%         endfor %}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ethernet-interfaces.j2
@@ -192,24 +192,18 @@
 | --------- | ---------- | --------------------- | ------------ |
 {%         for multicast_interface in multicast_interfaces %}
 {%             if multicast_interface.multicast.ipv4 is arista.avd.defined %}
-{%                 set version = 'IPv4' %}
 {%                 set static = multicast_interface.multicast.ipv4.static | arista.avd.default('-') %}
 {%                 set boundary = multicast_interface.multicast.ipv4.boundary | arista.avd.default('-') %}
-{%             endif %}
-{%             if version is arista.avd.defined('IPv4') %}
-| {{ multicast_interface.name }} | {{ version }} | {{ static }} | {{ boundary }} |
+| {{ multicast_interface.name }} | IPv4 | {{ static }} | {{ boundary }} |
 {%             endif %}
 {%             if multicast_interface.multicast.ipv6 is arista.avd.defined %}
-{%                 set version = 'IPv6' %}
 {%                 set static = multicast_interface.multicast.ipv6.static | arista.avd.default('-') %}
 {%                 if multicast_interface.multicast.ipv6.boundary is arista.avd.defined %}
 {%                     set boundary = multicast_interface.multicast.ipv6.boundary ~ ' out' %}
 {%                 else %}
 {%                     set boundary = '-' %}
 {%                 endif %}
-{%             endif %}
-{%             if version is arista.avd.defined('IPv6') %}
-| {{ multicast_interface.name }} | {{ version }} | {{ static }} | {{ boundary }} |
+| {{ multicast_interface.name }} | IPv6 | {{ static }} | {{ boundary }} |
 {%             endif %}
 {%         endfor %}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ethernet-interfaces.j2
@@ -159,15 +159,11 @@
 {%             endif %}
 {%         endfor %}
 {%     endif %}
-{# Link Tracking Groups and multicast #}
+{# Link Tracking Groups #}
 {%     set link_tracking_interfaces = [] %}
-{%     set multicast_interfaces = [] %}
 {%     for ethernet_interface in ethernet_interfaces | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
 {%         if ethernet_interface.link_tracking_groups is arista.avd.defined %}
 {%             do link_tracking_interfaces.append(ethernet_interface) %}
-{%         endif %}
-{%         if ethernet_interface.multicast is arista.avd.defined %}
-{%             do multicast_interfaces.append(ethernet_interface) %}
 {%         endif %}
 {%     endfor %}
 {%     if link_tracking_interfaces | length > 0 %}
@@ -184,6 +180,13 @@
 {%             endfor %}
 {%         endfor %}
 {%     endif %}
+{# Multicast Routing #}
+{%     set multicast_interfaces = [] %}
+{%     for ethernet_interface in ethernet_interfaces | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%         if ethernet_interface.multicast is arista.avd.defined %}
+{%             do multicast_interfaces.append(ethernet_interface) %}
+{%         endif %}
+{%     endfor %}
 {%     if multicast_interfaces | length > 0 %}
 
 #### Multicast Routing
@@ -194,8 +197,8 @@
 {%             if multicast_interface.multicast.ipv4 is arista.avd.defined %}
 {%                 set static = multicast_interface.multicast.ipv4.static | arista.avd.default('-') %}
 {%                 if multicast_interface.multicast.ipv4.boundaries is arista.avd.defined %}
-{%                     set boundaries = multicast_interface.multicast.ipv4.boundaries | selectattr('name', 'arista.avd.defined') |
-                                                                                        map(attribute='name') |
+{%                     set boundaries = multicast_interface.multicast.ipv4.boundaries | selectattr('boundary', 'arista.avd.defined') |
+                                                                                        map(attribute='boundary') |
                                                                                         join(', ') %}
 {%                 else %}
 {%                     set boundaries = '-' %}
@@ -205,7 +208,9 @@
 {%             if multicast_interface.multicast.ipv6 is arista.avd.defined %}
 {%                 set static = multicast_interface.multicast.ipv6.static | arista.avd.default('-') %}
 {%                 if multicast_interface.multicast.ipv6.boundaries is arista.avd.defined %}
-{%                     set boundaries = multicast_interface.multicast.ipv6.boundaries | join(', ') %}
+{%                     set boundaries = multicast_interface.multicast.ipv6.boundaries | selectattr('boundary', 'arista.avd.defined') |
+                                                                                        map(attribute='boundary') |
+                                                                                        join(', ') %}
 {%                 else %}
 {%                     set boundaries = '-' %}
 {%                 endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vlan-interfaces.j2
@@ -127,12 +127,16 @@
 {%             endfor %}
 {%         endfor %}
 {%     endif %}
-{# ISIS #}
+{# ISIS and multicast #}
 {%     set vlan_interface_isis = namespace() %}
+{%     set multicast_interfaces = [] %}
 {%     set vlan_interface_isis.configured = false %}
 {%     for vlan_interface in vlan_interfaces | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
 {%         if vlan_interface.isis_enable is defined %}
 {%             set vlan_interface_isis.configured = true %}
+{%         endif %}
+{%         if vlan_interface.multicast is arista.avd.defined %}
+{%             do multicast_interfaces.append(vlan_interface) %}
 {%         endif %}
 {%     endfor %}
 {%     if vlan_interface_isis.configured == true %}
@@ -150,6 +154,37 @@
 {%                     set mode = 'passive' | arista.avd.default('-') %}
 {%                 endif %}
 | {{ vlan_interface.name }} | {{ vlan_interface.isis_enable }} | {{ isis_metric }} | {{ mode }} |
+{%             endif %}
+{%         endfor %}
+{%     endif %}
+{%     if multicast_interfaces | length > 0 %}
+
+#### Multicast Routing
+
+| Interface | IP Version | Static Routes Allowed | Boundary | Export Routes From Source Traffic |
+| --------- | ---------- | --------------------- | -------- | --------------------------------- |
+{%         for multicast_interface in multicast_interfaces %}
+{%             if multicast_interface.multicast.ipv4 is arista.avd.defined %}
+{%                 set version = 'IPv4' %}
+{%                 set static = multicast_interface.multicast.ipv4.static | arista.avd.default('-') %}
+{%                 set boundary = multicast_interface.multicast.ipv4.boundary | arista.avd.default('-') %}
+{%                 set source_route_export = multicast_interface.multicast.ipv4.source_route_export.enabled | arista.avd.default('-') %}
+{%             endif %}
+{%             if version is arista.avd.defined('IPv4') %}
+| {{ multicast_interface.name }} | {{ version }} | {{ static }} | {{ boundary }} | {{ source_route_export }} |
+{%             endif %}
+{%             if multicast_interface.multicast.ipv6 is arista.avd.defined %}
+{%                 set version = 'IPv6' %}
+{%                 set static = multicast_interface.multicast.ipv6.static | arista.avd.default('-') %}
+{%                 if multicast_interface.multicast.ipv6.boundary is arista.avd.defined %}
+{%                     set boundary = multicast_interface.multicast.ipv6.boundary ~ ' out' %}
+{%                 else %}
+{%                     set boundary = '-' %}
+{%                 endif %}
+{%                 set source_route_export = multicast_interface.multicast.ipv6.source_route_export.enabled | arista.avd.default('-') %}
+{%             endif %}
+{%             if version is arista.avd.defined('IPv6') %}
+| {{ multicast_interface.name }} | {{ version }} | {{ static }} | {{ boundary }} | {{ source_route_export }} |
 {%             endif %}
 {%         endfor %}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vlan-interfaces.j2
@@ -127,16 +127,13 @@
 {%             endfor %}
 {%         endfor %}
 {%     endif %}
-{# ISIS and multicast #}
+{# ISIS #}
 {%     set vlan_interface_isis = namespace() %}
-{%     set multicast_interfaces = [] %}
 {%     set vlan_interface_isis.configured = false %}
 {%     for vlan_interface in vlan_interfaces | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
 {%         if vlan_interface.isis_enable is defined %}
 {%             set vlan_interface_isis.configured = true %}
-{%         endif %}
-{%         if vlan_interface.multicast is arista.avd.defined %}
-{%             do multicast_interfaces.append(vlan_interface) %}
+{%             break %}
 {%         endif %}
 {%     endfor %}
 {%     if vlan_interface_isis.configured == true %}
@@ -157,40 +154,43 @@
 {%             endif %}
 {%         endfor %}
 {%     endif %}
+{# Multicast Routing #}
+{%     set multicast_interfaces = [] %}
+{%     for vlan_interface in vlan_interfaces | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%         if vlan_interface.multicast is arista.avd.defined %}
+{%             do multicast_interfaces.append(vlan_interface) %}
+{%         endif %}
+{%     endfor %}
 {%     if multicast_interfaces | length > 0 %}
 
 #### Multicast Routing
 
-| Interface | IP Version | Static Routes Allowed | Multicast Boundaries | Export Routes From Source Traffic |
-| --------- | ---------- | --------------------- | -------------------- | --------------------------------- |
+| Interface | IP Version | Static Routes Allowed | Multicast Boundaries | Export Host Routes For Multicast Sources |
+| --------- | ---------- | --------------------- | -------------------- | ---------------------------------------- |
 {%         for multicast_interface in multicast_interfaces %}
 {%             if multicast_interface.multicast.ipv4 is arista.avd.defined %}
-{%                 set version = 'IPv4' %}
 {%                 set static = multicast_interface.multicast.ipv4.static | arista.avd.default('-') %}
 {%                 if multicast_interface.multicast.ipv4.boundaries is arista.avd.defined %}
-{%                     set boundaries = multicast_interface.multicast.ipv4.boundaries | selectattr('name', 'arista.avd.defined') |
-                                                                                        map(attribute='name') |
+{%                     set boundaries = multicast_interface.multicast.ipv4.boundaries | selectattr('boundary', 'arista.avd.defined') |
+                                                                                        map(attribute='boundary') |
                                                                                         join(', ') %}
 {%                 else %}
 {%                     set boundaries = '-' %}
 {%                 endif %}
 {%                 set source_route_export = multicast_interface.multicast.ipv4.source_route_export.enabled | arista.avd.default('-') %}
-{%             endif %}
-{%             if version is arista.avd.defined('IPv4') %}
-| {{ multicast_interface.name }} | {{ version }} | {{ static }} | {{ boundaries }} | {{ source_route_export }} |
+| {{ multicast_interface.name }} | IPv4 | {{ static }} | {{ boundaries }} | {{ source_route_export }} |
 {%             endif %}
 {%             if multicast_interface.multicast.ipv6 is arista.avd.defined %}
-{%                 set version = 'IPv6' %}
 {%                 set static = multicast_interface.multicast.ipv6.static | arista.avd.default('-') %}
 {%                 if multicast_interface.multicast.ipv6.boundaries is arista.avd.defined %}
-{%                     set boundaries = multicast_interface.multicast.ipv6.boundaries | join(', ') %}
+{%                     set boundaries = multicast_interface.multicast.ipv6.boundaries | selectattr('boundary', 'arista.avd.defined') |
+                                                                                        map(attribute='boundary') |
+                                                                                        join(', ') %}
 {%                 else %}
 {%                     set boundaries = '-' %}
 {%                 endif %}
 {%                 set source_route_export = multicast_interface.multicast.ipv6.source_route_export.enabled | arista.avd.default('-') %}
-{%             endif %}
-{%             if version is arista.avd.defined('IPv6') %}
-| {{ multicast_interface.name }} | {{ version }} | {{ static }} | {{ boundaries }} | {{ source_route_export }} |
+| {{ multicast_interface.name }} | IPv6 | {{ static }} | {{ boundaries }} | {{ source_route_export }} |
 {%             endif %}
 {%         endfor %}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vlan-interfaces.j2
@@ -161,30 +161,36 @@
 
 #### Multicast Routing
 
-| Interface | IP Version | Static Routes Allowed | Boundary | Export Routes From Source Traffic |
-| --------- | ---------- | --------------------- | -------- | --------------------------------- |
+| Interface | IP Version | Static Routes Allowed | Multicast Boundaries | Export Routes From Source Traffic |
+| --------- | ---------- | --------------------- | -------------------- | --------------------------------- |
 {%         for multicast_interface in multicast_interfaces %}
 {%             if multicast_interface.multicast.ipv4 is arista.avd.defined %}
 {%                 set version = 'IPv4' %}
 {%                 set static = multicast_interface.multicast.ipv4.static | arista.avd.default('-') %}
-{%                 set boundary = multicast_interface.multicast.ipv4.boundary | arista.avd.default('-') %}
+{%                 if multicast_interface.multicast.ipv4.boundaries is arista.avd.defined %}
+{%                     set boundaries = multicast_interface.multicast.ipv4.boundaries | selectattr('name', 'arista.avd.defined') |
+                                                                                        map(attribute='name') |
+                                                                                        join(', ') %}
+{%                 else %}
+{%                     set boundaries = '-' %}
+{%                 endif %}
 {%                 set source_route_export = multicast_interface.multicast.ipv4.source_route_export.enabled | arista.avd.default('-') %}
 {%             endif %}
 {%             if version is arista.avd.defined('IPv4') %}
-| {{ multicast_interface.name }} | {{ version }} | {{ static }} | {{ boundary }} | {{ source_route_export }} |
+| {{ multicast_interface.name }} | {{ version }} | {{ static }} | {{ boundaries }} | {{ source_route_export }} |
 {%             endif %}
 {%             if multicast_interface.multicast.ipv6 is arista.avd.defined %}
 {%                 set version = 'IPv6' %}
 {%                 set static = multicast_interface.multicast.ipv6.static | arista.avd.default('-') %}
-{%                 if multicast_interface.multicast.ipv6.boundary is arista.avd.defined %}
-{%                     set boundary = multicast_interface.multicast.ipv6.boundary ~ ' out' %}
+{%                 if multicast_interface.multicast.ipv6.boundaries is arista.avd.defined %}
+{%                     set boundaries = multicast_interface.multicast.ipv6.boundaries | join(', ') %}
 {%                 else %}
-{%                     set boundary = '-' %}
+{%                     set boundaries = '-' %}
 {%                 endif %}
 {%                 set source_route_export = multicast_interface.multicast.ipv6.source_route_export.enabled | arista.avd.default('-') %}
 {%             endif %}
 {%             if version is arista.avd.defined('IPv6') %}
-| {{ multicast_interface.name }} | {{ version }} | {{ static }} | {{ boundary }} | {{ source_route_export }} |
+| {{ multicast_interface.name }} | {{ version }} | {{ static }} | {{ boundaries }} | {{ source_route_export }} |
 {%             endif %}
 {%         endfor %}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -387,6 +387,20 @@ interface {{ ethernet_interface.name }}
 {%         if ethernet_interface.mac_access_group_out is arista.avd.defined %}
    mac access-group {{ ethernet_interface.mac_access_group_out }} out
 {%         endif %}
+{%         if ethernet_interface.multicast is arista.avd.defined %}
+{%             if ethernet_interface.multicast.ipv4.boundary is arista.avd.defined %}
+   multicast ipv4 boundary {{ ethernet_interface.multicast.ipv4.boundary }}
+{%             endif %}
+{%             if ethernet_interface.multicast.ipv6.boundary is arista.avd.defined %}
+   multicast ipv6 boundary {{ ethernet_interface.multicast.ipv6.boundary }} out
+{%             endif %}
+{%             if ethernet_interface.multicast.ipv4.static is arista.avd.defined(true) %}
+   multicast ipv4 static
+{%             endif %}
+{%             if ethernet_interface.multicast.ipv6.static is arista.avd.defined(true) %}
+   multicast ipv6 static
+{%             endif %}
+{%         endif %}
 {%         if ethernet_interface.mpls.ip is arista.avd.defined(true) %}
    mpls ip
 {%         elif ethernet_interface.mpls.ip is arista.avd.defined(false) %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -390,7 +390,7 @@ interface {{ ethernet_interface.name }}
 {%         if ethernet_interface.multicast is arista.avd.defined %}
 {%             if ethernet_interface.multicast.ipv4.boundaries is arista.avd.defined %}
 {%                 for boundary in ethernet_interface.multicast.ipv4.boundaries %}
-{%                     set boundary_cli = "multicast ipv4 boundary " ~ boundary.name %}
+{%                     set boundary_cli = "multicast ipv4 boundary " ~ boundary.boundary %}
 {%                     if boundary.out is arista.avd.defined(true) %}
 {%                         set boundary_cli = boundary_cli ~ " out" %}
 {%                     endif %}
@@ -399,7 +399,7 @@ interface {{ ethernet_interface.name }}
 {%             endif %}
 {%             if ethernet_interface.multicast.ipv6.boundaries is arista.avd.defined %}
 {%                 for boundary in ethernet_interface.multicast.ipv6.boundaries %}
-   multicast ipv6 boundary {{ boundary }} out
+   multicast ipv6 boundary {{ boundary.boundary }} out
 {%                 endfor %}
 {%             endif %}
 {%             if ethernet_interface.multicast.ipv4.static is arista.avd.defined(true) %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -388,11 +388,19 @@ interface {{ ethernet_interface.name }}
    mac access-group {{ ethernet_interface.mac_access_group_out }} out
 {%         endif %}
 {%         if ethernet_interface.multicast is arista.avd.defined %}
-{%             if ethernet_interface.multicast.ipv4.boundary is arista.avd.defined %}
-   multicast ipv4 boundary {{ ethernet_interface.multicast.ipv4.boundary }}
+{%             if ethernet_interface.multicast.ipv4.boundaries is arista.avd.defined %}
+{%                 for boundary in ethernet_interface.multicast.ipv4.boundaries %}
+{%                     set boundary_cli = "multicast ipv4 boundary " ~ boundary.name %}
+{%                     if boundary.out is arista.avd.defined(true) %}
+{%                         set boundary_cli = boundary_cli ~ " out" %}
+{%                     endif %}
+   {{ boundary_cli }}
+{%                 endfor %}
 {%             endif %}
-{%             if ethernet_interface.multicast.ipv6.boundary is arista.avd.defined %}
-   multicast ipv6 boundary {{ ethernet_interface.multicast.ipv6.boundary }} out
+{%             if ethernet_interface.multicast.ipv6.boundaries is arista.avd.defined %}
+{%                 for boundary in ethernet_interface.multicast.ipv6.boundaries %}
+   multicast ipv6 boundary {{ boundary }} out
+{%                 endfor %}
 {%             endif %}
 {%             if ethernet_interface.multicast.ipv4.static is arista.avd.defined(true) %}
    multicast ipv4 static

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
@@ -94,7 +94,7 @@ interface {{ vlan_interface.name }}
 {%     if vlan_interface.multicast is arista.avd.defined %}
 {%         if vlan_interface.multicast.ipv4.boundaries is arista.avd.defined %}
 {%             for boundary in vlan_interface.multicast.ipv4.boundaries %}
-{%                 set boundary_cli = "multicast ipv4 boundary " ~ boundary.name %}
+{%                 set boundary_cli = "multicast ipv4 boundary " ~ boundary.boundary %}
 {%                 if boundary.out is arista.avd.defined(true) %}
 {%                     set boundary_cli = boundary_cli ~ " out" %}
 {%                 endif %}
@@ -103,7 +103,7 @@ interface {{ vlan_interface.name }}
 {%         endif %}
 {%         if vlan_interface.multicast.ipv6.boundaries is arista.avd.defined %}
 {%             for boundary in vlan_interface.multicast.ipv6.boundaries %}
-   multicast ipv6 boundary {{ boundary }} out
+   multicast ipv6 boundary {{ boundary.boundary }} out
 {%             endfor %}
 {%         endif %}
 {%         if vlan_interface.multicast.ipv4.source_route_export.enabled is arista.avd.defined(true) %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
@@ -91,11 +91,32 @@ interface {{ vlan_interface.name }}
    {{ ipv6_nd_prefix_cli }}
 {%         endfor %}
 {%     endif %}
-{%     if vlan_interface.multicast.ipv4.source_route_export.enabled is arista.avd.defined(true) %}
-{%         if vlan_interface.multicast.ipv4.source_route_export.administrative_distance is arista.avd.defined %}
+{%     if vlan_interface.multicast is arista.avd.defined %}
+{%         if vlan_interface.multicast.ipv4.boundary is arista.avd.defined %}
+   multicast ipv4 boundary {{ vlan_interface.multicast.ipv4.boundary }}
+{%         endif %}
+{%         if vlan_interface.multicast.ipv6.boundary is arista.avd.defined %}
+   multicast ipv6 boundary {{ vlan_interface.multicast.ipv6.boundary }} out
+{%         endif %}
+{%         if vlan_interface.multicast.ipv4.source_route_export.enabled is arista.avd.defined(true) %}
+{%             if vlan_interface.multicast.ipv4.source_route_export.administrative_distance is arista.avd.defined %}
    multicast ipv4 source route export {{ vlan_interface.multicast.ipv4.source_route_export.administrative_distance }}
-{%         else %}
+{%             else %}
    multicast ipv4 source route export
+{%             endif %}
+{%         endif %}
+{%         if vlan_interface.multicast.ipv6.source_route_export.enabled is arista.avd.defined(true) %}
+{%             if vlan_interface.multicast.ipv6.source_route_export.administrative_distance is arista.avd.defined %}
+   multicast ipv6 source route export {{ vlan_interface.multicast.ipv6.source_route_export.administrative_distance }}
+{%             else %}
+   multicast ipv6 source route export
+{%             endif %}
+{%         endif %}
+{%         if vlan_interface.multicast.ipv4.static is arista.avd.defined(true) %}
+   multicast ipv4 static
+{%         endif %}
+{%         if vlan_interface.multicast.ipv6.static is arista.avd.defined(true) %}
+   multicast ipv6 static
 {%         endif %}
 {%     endif %}
 {%     if vlan_interface.access_group_in is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
@@ -92,11 +92,19 @@ interface {{ vlan_interface.name }}
 {%         endfor %}
 {%     endif %}
 {%     if vlan_interface.multicast is arista.avd.defined %}
-{%         if vlan_interface.multicast.ipv4.boundary is arista.avd.defined %}
-   multicast ipv4 boundary {{ vlan_interface.multicast.ipv4.boundary }}
+{%         if vlan_interface.multicast.ipv4.boundaries is arista.avd.defined %}
+{%             for boundary in vlan_interface.multicast.ipv4.boundaries %}
+{%                 set boundary_cli = "multicast ipv4 boundary " ~ boundary.name %}
+{%                 if boundary.out is arista.avd.defined(true) %}
+{%                     set boundary_cli = boundary_cli ~ " out" %}
+{%                 endif %}
+   {{ boundary_cli }}
+{%             endfor %}
 {%         endif %}
-{%         if vlan_interface.multicast.ipv6.boundary is arista.avd.defined %}
-   multicast ipv6 boundary {{ vlan_interface.multicast.ipv6.boundary }} out
+{%         if vlan_interface.multicast.ipv6.boundaries is arista.avd.defined %}
+{%             for boundary in vlan_interface.multicast.ipv6.boundaries %}
+   multicast ipv6 boundary {{ boundary }} out
+{%             endfor %}
 {%         endif %}
 {%         if vlan_interface.multicast.ipv4.source_route_export.enabled is arista.avd.defined(true) %}
 {%             if vlan_interface.multicast.ipv4.source_route_export.administrative_distance is arista.avd.defined %}


### PR DESCRIPTION
## Change Summary

Support multicast routing commands under ethernet and vlan interfaces

## Related Issue(s)

Related Issues #1708 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

```yaml
ethernet_interfaces:
  < ethernet_interface >:
    multicast:
      # boundaries can be either 1 ACL or a list of multicast IP address_range(s)/prefix but not combination of both
      ipv4:
        boundaries:
          - boundary: < acl_name | multicast_ip_subnet >
            out: < true | false >
        static: < true | false >
      ipv6:
        boundaries:
          - boundary: < acl_name | multicast_ip_subnet >
        static: < true | false >

vlan_interfaces:
  < vlan_interface >:
    multicast:
      ipv4:
        boundaries:
          - boundary: < acl_name | multicast_ip_subnet >
            out: < true | false >
        source_route_export:
          enabled: < true | false >
          administrative_distance: < 1-255 >
        static: < true | false >
      ipv6:
        boundaries:
          - boundary: < acl_name | multicast_ip_subnet >
        source_route_export:
          enabled: < true | false >
          administrative_distance: < 1-255 >
        static: < true | false >
```

## How to test

`cd ansible_collections/arista/avd`
`molecule converge -s eos_cli_config_gen`
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
