### PR TITLE
Doc: (eos_snapshot): fix var name in input example

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_snapshot/README.md
+++ b/ansible_collections/arista/avd/roles/eos_snapshot/README.md
@@ -141,7 +141,7 @@ output_format:
  # - json
  # - yaml
 
-commands_to_collect:
+commands_list:
   - show lldp neighbors
   - show ip interface brief
   - show interfaces description


### PR DESCRIPTION
## Change Summary

Docs for eos_snapshot include an example with variable `commands_to_collect` (used earlier in development), which should be `commands_list`.  

## Component(s) name

`arista.avd.eos_snapshot`

## Proposed changes
Update example in docs.

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
