### PR TITLE
Fix(eos_designs): Resolve inline jinja in fabric_name

### DIFF
--- a/ansible_collections/arista/avd/plugins/action/eos_designs_facts.py
+++ b/ansible_collections/arista/avd/plugins/action/eos_designs_facts.py
@@ -32,7 +32,7 @@ class ActionModule(ActionBase):
         set_avd_switch_facts = self._task.args.get('avd_switch_facts', False)
 
         groups = task_vars.get('groups', {})
-        fabric_name = task_vars.get('fabric_name', '')
+        fabric_name = self._templar.template(task_vars.get('fabric_name', ''))
         fabric_hosts = groups.get(fabric_name, [])
         ansible_play_hosts_all = task_vars.get('ansible_play_hosts_all', [])
 


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Resolve inline jinja in fabric_name

## Related Issue(s)

Fixes issue where AVD would fail if `fabric_name` contained inline jinja:
```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: NoneType: None
fatal: [DC1-SUPER-SPINE1]: FAILED! => {"changed": false, "msg": "Invalid/missing 'fabric_name' variable.All hosts in the play must have the same 'fabric_name' valuewhich must point to an Ansible Group containing the hosts."}
```

## Component(s) name

`arista.avd.eos_designs_facts`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->
Added templating of the `fabric_name` variable.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Recreated issue in molecule scenario - verified failure. Applied patch. Verified solution.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
