### PR TITLE
Fix(eos_designs): Remove unneeded mlag ibgp vlan for vrf default

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/BGP-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/BGP-SPINE1.md
@@ -134,7 +134,6 @@ vlan internal order ascending range 1006 1199
 | VLAN ID | Name | Trunk Groups |
 | ------- | ---- | ------------ |
 | 100 | SVI_100 | - |
-| 2999 | MLAG_iBGP_default | LEAF_PEER_L3 |
 | 4094 | MLAG_PEER | MLAG |
 
 ## VLANs Device Configuration
@@ -143,10 +142,6 @@ vlan internal order ascending range 1006 1199
 !
 vlan 100
    name SVI_100
-!
-vlan 2999
-   name MLAG_iBGP_default
-   trunk group LEAF_PEER_L3
 !
 vlan 4094
    name MLAG_PEER

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/BGP-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/BGP-SPINE2.md
@@ -134,7 +134,6 @@ vlan internal order ascending range 1006 1199
 | VLAN ID | Name | Trunk Groups |
 | ------- | ---- | ------------ |
 | 100 | SVI_100 | - |
-| 2999 | MLAG_iBGP_default | LEAF_PEER_L3 |
 | 4094 | MLAG_PEER | MLAG |
 
 ## VLANs Device Configuration
@@ -143,10 +142,6 @@ vlan internal order ascending range 1006 1199
 !
 vlan 100
    name SVI_100
-!
-vlan 2999
-   name MLAG_iBGP_default
-   trunk group LEAF_PEER_L3
 !
 vlan 4094
    name MLAG_PEER

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/OSPF-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/OSPF-SPINE1.md
@@ -132,7 +132,6 @@ vlan internal order ascending range 1006 1199
 | VLAN ID | Name | Trunk Groups |
 | ------- | ---- | ------------ |
 | 100 | SVI_100 | - |
-| 2999 | MLAG_iBGP_default | LEAF_PEER_L3 |
 | 4094 | MLAG_PEER | MLAG |
 
 ## VLANs Device Configuration
@@ -141,10 +140,6 @@ vlan internal order ascending range 1006 1199
 !
 vlan 100
    name SVI_100
-!
-vlan 2999
-   name MLAG_iBGP_default
-   trunk group LEAF_PEER_L3
 !
 vlan 4094
    name MLAG_PEER

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/OSPF-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/OSPF-SPINE2.md
@@ -132,7 +132,6 @@ vlan internal order ascending range 1006 1199
 | VLAN ID | Name | Trunk Groups |
 | ------- | ---- | ------------ |
 | 100 | SVI_100 | - |
-| 2999 | MLAG_iBGP_default | LEAF_PEER_L3 |
 | 4094 | MLAG_PEER | MLAG |
 
 ## VLANs Device Configuration
@@ -141,10 +140,6 @@ vlan internal order ascending range 1006 1199
 !
 vlan 100
    name SVI_100
-!
-vlan 2999
-   name MLAG_iBGP_default
-   trunk group LEAF_PEER_L3
 !
 vlan 4094
    name MLAG_PEER

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/BGP-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/BGP-SPINE1.cfg
@@ -16,10 +16,6 @@ no aaa root
 vlan 100
    name SVI_100
 !
-vlan 2999
-   name MLAG_iBGP_default
-   trunk group LEAF_PEER_L3
-!
 vlan 4094
    name MLAG_PEER
    trunk group MLAG

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/BGP-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/BGP-SPINE2.cfg
@@ -16,10 +16,6 @@ no aaa root
 vlan 100
    name SVI_100
 !
-vlan 2999
-   name MLAG_iBGP_default
-   trunk group LEAF_PEER_L3
-!
 vlan 4094
    name MLAG_PEER
    trunk group MLAG

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/OSPF-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/OSPF-SPINE1.cfg
@@ -16,10 +16,6 @@ no aaa root
 vlan 100
    name SVI_100
 !
-vlan 2999
-   name MLAG_iBGP_default
-   trunk group LEAF_PEER_L3
-!
 vlan 4094
    name MLAG_PEER
    trunk group MLAG

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/OSPF-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/OSPF-SPINE2.cfg
@@ -16,10 +16,6 @@ no aaa root
 vlan 100
    name SVI_100
 !
-vlan 2999
-   name MLAG_iBGP_default
-   trunk group LEAF_PEER_L3
-!
 vlan 4094
    name MLAG_PEER
    trunk group MLAG

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-SPINE1.yml
@@ -61,11 +61,6 @@ vlans:
   100:
     tenant: L2LS_BGP
     name: SVI_100
-  2999:
-    tenant: L2LS_BGP
-    name: MLAG_iBGP_default
-    trunk_groups:
-    - LEAF_PEER_L3
 vlan_interfaces:
   Vlan4094:
     description: MLAG_PEER

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-SPINE2.yml
@@ -61,11 +61,6 @@ vlans:
   100:
     tenant: L2LS_BGP
     name: SVI_100
-  2999:
-    tenant: L2LS_BGP
-    name: MLAG_iBGP_default
-    trunk_groups:
-    - LEAF_PEER_L3
 vlan_interfaces:
   Vlan4094:
     description: MLAG_PEER

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-SPINE1.yml
@@ -26,11 +26,6 @@ vlans:
   100:
     tenant: L2LS_OSPF
     name: SVI_100
-  2999:
-    tenant: L2LS_OSPF
-    name: MLAG_iBGP_default
-    trunk_groups:
-    - LEAF_PEER_L3
 vlan_interfaces:
   Vlan4094:
     description: MLAG_PEER

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-SPINE2.yml
@@ -26,11 +26,6 @@ vlans:
   100:
     tenant: L2LS_OSPF
     name: SVI_100
-  2999:
-    tenant: L2LS_OSPF
-    name: MLAG_iBGP_default
-    trunk_groups:
-    - LEAF_PEER_L3
 vlan_interfaces:
   Vlan4094:
     description: MLAG_PEER

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vlan-interfaces.j2
@@ -104,28 +104,26 @@ vlan_interfaces:
 {%             set configure_mlag_ibgp_peering = vrf.enable_mlag_ibgp_peering_vrfs | arista.avd.default(
                                                  tenant.enable_mlag_ibgp_peering_vrfs,
                                                  true) %}
-{%             if configure_mlag_ibgp_peering %}
+{%             if configure_mlag_ibgp_peering and vrf.name != 'default' %}
 {%                 set vrf_id_int = vrf.vrf_id | arista.avd.default(vrf.vrf_vni) | int %}
-{%                 if vrf.name != 'default' %}
   Vlan{{ vrf.mlag_ibgp_peering_vlan | arista.avd.default(mlag_ibgp_peering_vrfs.base_vlan + (vrf_id_int - 1)) }}:
     tenant: {{ tenant.name }}
     type: underlay_peering
     shutdown: false
     description: "MLAG_PEER_L3_iBGP: vrf {{ vrf.name }}"
     vrf: {{ vrf.name }}
-{%                     if underlay_rfc5549 is arista.avd.defined(true) and overlay_mlag_rfc5549 is arista.avd.defined(true) %}
+{%                 if underlay_rfc5549 is arista.avd.defined(true) and overlay_mlag_rfc5549 is arista.avd.defined(true) %}
     ipv6_enable: true
-{%                     elif vrf.mlag_ibgp_peering_ipv4_pool is arista.avd.defined %}
-{%                         if switch.mlag_role == 'primary' %}
+{%                 elif vrf.mlag_ibgp_peering_ipv4_pool is arista.avd.defined %}
+{%                     if switch.mlag_role == 'primary' %}
     ip_address: "{% include switch.ip_addressing.mlag_ibgp_peering_ip_primary %}/31"
-{%                         else %}
-    ip_address: "{% include switch.ip_addressing.mlag_ibgp_peering_ip_secondary %}/31"
-{%                         endif %}
 {%                     else %}
-    ip_address: {{ switch.mlag_l3_ip | arista.avd.default(switch.mlag_ip) }}/31
+    ip_address: "{% include switch.ip_addressing.mlag_ibgp_peering_ip_secondary %}/31"
 {%                     endif %}
-    mtu: {{ p2p_uplinks_mtu }}
+{%                 else %}
+    ip_address: {{ switch.mlag_l3_ip | arista.avd.default(switch.mlag_ip) }}/31
 {%                 endif %}
+    mtu: {{ p2p_uplinks_mtu }}
 {%             endif %}
 {%         endif %}
 {%     endfor %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vlans.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vlans.j2
@@ -23,7 +23,7 @@ vlans:
 {%             set configure_mlag_ibgp_peering = vrf.enable_mlag_ibgp_peering_vrfs | arista.avd.default(
                                                  tenant.enable_mlag_ibgp_peering_vrfs,
                                                  true) %}
-{%             if configure_mlag_ibgp_peering %}
+{%             if configure_mlag_ibgp_peering and vrf.name != 'default' %}
 {%                 set vrf_id_int = vrf.vrf_id | arista.avd.default(vrf.vrf_vni) | int %}
   {{ vrf.mlag_ibgp_peering_vlan | arista.avd.default(mlag_ibgp_peering_vrfs.base_vlan + (vrf_id_int - 1)) }}:
     tenant: {{ tenant.name }}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Remove unneeded mlag ibgp vlan for vrf default

## Related Issue(s)

This was implemented partially in #1499 covering SVI and BGP, but the vlan itself was forgotten. This PR fixes that.

Fixes aristanetworks/avd-internal#41

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

Under Network Services we create a vlan for MLAG iBGP per VRF. This should not happen for vrf `default`. This PR removes the vlan. SVI and iBGP was already removed in a previous PR #1499.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
No change to molecule. We will cover this in future L2LS molecule scenario

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
