### PR TITLE
Fix(eos_designs): Only configure EVPN filtering on EVPN nodes

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/main.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/main.j2
@@ -57,8 +57,7 @@
       switch.network_services_l1 is arista.avd.defined(true)) %}
 {%     include 'network_services/vtep-logic.j2' %}
 
-{%     if default_vrf.svi_subnets %}
-
+{%     if default_vrf.svi_subnets and switch.evpn_role in ["client", "server"] %}
 {%         include 'network_services/default-vrf-route-map.j2' %}
 
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-vrfs.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-vrfs.j2
@@ -37,7 +37,7 @@
 {%                 endfor %}
     {{ vrf.name }}:
 {%                 if vrf.name == 'default' %}
-{%                     if default_vrf.svi_subnets %}
+{%                     if default_vrf.svi_subnets and switch.evpn_role in ["client", "server"] %}
 {%                         do route_targets.export.evpn.append('route-map RM-EVPN-EXPORT-VRF-DEFAULT') %}
       rd: "{{ switch.overlay_rd_type_admin_subfield }}:{{ bgp_vrf_id }}"
       route_targets:

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp.j2
@@ -11,7 +11,7 @@ router_bgp:
 {%         include 'network_services/router-bgp-vlan-aware-bundles.j2' %}
 
 {%     endif %}
-{%     if default_vrf.svi_subnets %}
+{%     if default_vrf.svi_subnets and switch.evpn_role in ["client", "server"] %}
 {%         include 'network_services/router-bgp-default-vrf.j2' %}
 
 {%     endif %}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Only configure EVPN filtering on EVPN nodes

## Related Issue(s)

When deploying services in vrf default in a BGP network without EVPN, the EVPN related filtering config is still created on the switches (see #1499).

Fixes aristanetworks/avd-internal#44

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->
Add condition for `evpn_role` on the code logic added in #1499 

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
No changes to molecule. Should be covered in future L3LS scenario.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
