### PR TITLE
Fix(eos_designs): Correct underlay routing for overlay_routing_protocol: "none"

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/BGP-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/BGP-SPINE1.md
@@ -32,7 +32,6 @@
 - [Multicast](#multicast)
   - [IP IGMP Snooping](#ip-igmp-snooping)
 - [Filters](#filters)
-  - [Prefix-lists](#prefix-lists)
   - [Route-maps](#route-maps)
 - [ACL](#acl)
 - [VRF Instances](#vrf-instances)
@@ -433,7 +432,7 @@ router bgp 65001
    neighbor 192.168.253.5 description DUMMY-CORE
    neighbor 192.168.254.1 peer group MLAG-IPv4-UNDERLAY-PEER
    neighbor 192.168.254.1 description BGP-SPINE2
-   redistribute connected route-map RM-CONN-2-BGP
+   redistribute connected
    !
    address-family ipv4
       neighbor IPv4-UNDERLAY-PEERS activate
@@ -457,33 +456,9 @@ router bgp 65001
 
 # Filters
 
-## Prefix-lists
-
-### Prefix-lists Summary
-
-#### PL-LOOPBACKS-EVPN-OVERLAY
-
-| Sequence | Action |
-| -------- | ------ |
-| 10 | permit 192.168.255.0/24 eq 32 |
-
-### Prefix-lists Device Configuration
-
-```eos
-!
-ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
-   seq 10 permit 192.168.255.0/24 eq 32
-```
-
 ## Route-maps
 
 ### Route-maps Summary
-
-#### RM-CONN-2-BGP
-
-| Sequence | Type | Match and/or Set |
-| -------- | ---- | ---------------- |
-| 10 | permit | match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY |
 
 #### RM-MLAG-PEER-IN
 
@@ -494,9 +469,6 @@ ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
 ### Route-maps Device Configuration
 
 ```eos
-!
-route-map RM-CONN-2-BGP permit 10
-   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
 !
 route-map RM-MLAG-PEER-IN permit 10
    description Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/BGP-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/BGP-SPINE2.md
@@ -32,7 +32,6 @@
 - [Multicast](#multicast)
   - [IP IGMP Snooping](#ip-igmp-snooping)
 - [Filters](#filters)
-  - [Prefix-lists](#prefix-lists)
   - [Route-maps](#route-maps)
 - [ACL](#acl)
 - [VRF Instances](#vrf-instances)
@@ -433,7 +432,7 @@ router bgp 65001
    neighbor 192.168.253.7 description DUMMY-CORE
    neighbor 192.168.254.0 peer group MLAG-IPv4-UNDERLAY-PEER
    neighbor 192.168.254.0 description BGP-SPINE1
-   redistribute connected route-map RM-CONN-2-BGP
+   redistribute connected
    !
    address-family ipv4
       neighbor IPv4-UNDERLAY-PEERS activate
@@ -457,33 +456,9 @@ router bgp 65001
 
 # Filters
 
-## Prefix-lists
-
-### Prefix-lists Summary
-
-#### PL-LOOPBACKS-EVPN-OVERLAY
-
-| Sequence | Action |
-| -------- | ------ |
-| 10 | permit 192.168.255.0/24 eq 32 |
-
-### Prefix-lists Device Configuration
-
-```eos
-!
-ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
-   seq 10 permit 192.168.255.0/24 eq 32
-```
-
 ## Route-maps
 
 ### Route-maps Summary
-
-#### RM-CONN-2-BGP
-
-| Sequence | Type | Match and/or Set |
-| -------- | ---- | ---------------- |
-| 10 | permit | match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY |
 
 #### RM-MLAG-PEER-IN
 
@@ -494,9 +469,6 @@ ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
 ### Route-maps Device Configuration
 
 ```eos
-!
-route-map RM-CONN-2-BGP permit 10
-   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
 !
 route-map RM-MLAG-PEER-IN permit 10
    description Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/OSPF-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/OSPF-SPINE1.md
@@ -383,6 +383,12 @@ ip route vrf MGMT 0.0.0.0/0
 | ---------- | --------- | ------------------------- | -------------------- | --- | ------- | ----------------------------- | ---------------------------- | ----------------------------- | ------------- | --------------------- | ------------------ |
 | 100 | 192.168.255.1 | enabled | Ethernet5 <br> | disabled | 12000 | disabled | disabled | - | - | - | - |
 
+### Router OSPF Router Redistribution
+
+| Process ID | Source Protocol | Route Map |
+| ---------- | --------------- | --------- |
+| 100 | connected | - |
+
 ### OSPF Interfaces
 
 | Interface | Area | Cost | Point To Point |
@@ -400,6 +406,7 @@ router ospf 100
    passive-interface default
    no passive-interface Ethernet5
    max-lsa 12000
+   redistribute connected
 ```
 
 # Multicast

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/OSPF-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/OSPF-SPINE2.md
@@ -383,6 +383,12 @@ ip route vrf MGMT 0.0.0.0/0
 | ---------- | --------- | ------------------------- | -------------------- | --- | ------- | ----------------------------- | ---------------------------- | ----------------------------- | ------------- | --------------------- | ------------------ |
 | 100 | 192.168.255.2 | enabled | Ethernet5 <br> | disabled | 12000 | disabled | disabled | - | - | - | - |
 
+### Router OSPF Router Redistribution
+
+| Process ID | Source Protocol | Route Map |
+| ---------- | --------------- | --------- |
+| 100 | connected | - |
+
 ### OSPF Interfaces
 
 | Interface | Area | Cost | Point To Point |
@@ -400,6 +406,7 @@ router ospf 100
    passive-interface default
    no passive-interface Ethernet5
    max-lsa 12000
+   redistribute connected
 ```
 
 # Multicast

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/BGP-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/BGP-SPINE1.cfg
@@ -99,9 +99,6 @@ ip virtual-router mac-address 00:1c:73:00:00:99
 ip routing
 no ip routing vrf MGMT
 !
-ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
-   seq 10 permit 192.168.255.0/24 eq 32
-!
 mlag configuration
    domain-id BGP_SPINES
    local-interface Vlan4094
@@ -111,9 +108,6 @@ mlag configuration
    reload-delay non-mlag 330
 !
 ip route vrf MGMT 0.0.0.0/0
-!
-route-map RM-CONN-2-BGP permit 10
-   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
 !
 route-map RM-MLAG-PEER-IN permit 10
    description Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing
@@ -137,7 +131,7 @@ router bgp 65001
    neighbor 192.168.253.5 description DUMMY-CORE
    neighbor 192.168.254.1 peer group MLAG-IPv4-UNDERLAY-PEER
    neighbor 192.168.254.1 description BGP-SPINE2
-   redistribute connected route-map RM-CONN-2-BGP
+   redistribute connected
    !
    address-family ipv4
       neighbor IPv4-UNDERLAY-PEERS activate

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/BGP-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/BGP-SPINE2.cfg
@@ -99,9 +99,6 @@ ip virtual-router mac-address 00:1c:73:00:00:99
 ip routing
 no ip routing vrf MGMT
 !
-ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
-   seq 10 permit 192.168.255.0/24 eq 32
-!
 mlag configuration
    domain-id BGP_SPINES
    local-interface Vlan4094
@@ -111,9 +108,6 @@ mlag configuration
    reload-delay non-mlag 330
 !
 ip route vrf MGMT 0.0.0.0/0
-!
-route-map RM-CONN-2-BGP permit 10
-   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
 !
 route-map RM-MLAG-PEER-IN permit 10
    description Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing
@@ -137,7 +131,7 @@ router bgp 65001
    neighbor 192.168.253.7 description DUMMY-CORE
    neighbor 192.168.254.0 peer group MLAG-IPv4-UNDERLAY-PEER
    neighbor 192.168.254.0 description BGP-SPINE1
-   redistribute connected route-map RM-CONN-2-BGP
+   redistribute connected
    !
    address-family ipv4
       neighbor IPv4-UNDERLAY-PEERS activate

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/OSPF-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/OSPF-SPINE1.cfg
@@ -119,6 +119,7 @@ router ospf 100
    passive-interface default
    no passive-interface Ethernet5
    max-lsa 12000
+   redistribute connected
 !
 management api http-commands
    protocol https

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/OSPF-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/OSPF-SPINE2.cfg
@@ -119,6 +119,7 @@ router ospf 100
    passive-interface default
    no passive-interface Ethernet5
    max-lsa 12000
+   redistribute connected
 !
 management api http-commands
    protocol https

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-SPINE1.yml
@@ -31,8 +31,7 @@ router_bgp:
       description: DUMMY-CORE
       peer_group: IPv4-UNDERLAY-PEERS
   redistribute_routes:
-    connected:
-      route_map: RM-CONN-2-BGP
+    connected: {}
 static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0
@@ -167,21 +166,10 @@ route_maps:
         set:
         - origin incomplete
         description: Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing
-  RM-CONN-2-BGP:
-    sequence_numbers:
-      10:
-        type: permit
-        match:
-        - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
 loopback_interfaces:
   Loopback0:
     shutdown: false
     ip_address: 192.168.255.1/32
-prefix_lists:
-  PL-LOOPBACKS-EVPN-OVERLAY:
-    sequence_numbers:
-      10:
-        action: permit 192.168.255.0/24 eq 32
 ip_igmp_snooping:
   globally_enabled: true
 ip_virtual_router_mac_address: 00:1c:73:00:00:99

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-SPINE2.yml
@@ -31,8 +31,7 @@ router_bgp:
       description: DUMMY-CORE
       peer_group: IPv4-UNDERLAY-PEERS
   redistribute_routes:
-    connected:
-      route_map: RM-CONN-2-BGP
+    connected: {}
 static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0
@@ -167,21 +166,10 @@ route_maps:
         set:
         - origin incomplete
         description: Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing
-  RM-CONN-2-BGP:
-    sequence_numbers:
-      10:
-        type: permit
-        match:
-        - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
 loopback_interfaces:
   Loopback0:
     shutdown: false
     ip_address: 192.168.255.2/32
-prefix_lists:
-  PL-LOOPBACKS-EVPN-OVERLAY:
-    sequence_numbers:
-      10:
-        action: permit 192.168.255.0/24 eq 32
 ip_igmp_snooping:
   globally_enabled: true
 ip_virtual_router_mac_address: 00:1c:73:00:00:99

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-SPINE1.yml
@@ -139,6 +139,8 @@ router_ospf:
       passive_interface_default: true
       router_id: 192.168.255.1
       max_lsa: 12000
+      redistribute:
+        connected: {}
       no_passive_interfaces:
       - Ethernet5
 ip_igmp_snooping:

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-SPINE2.yml
@@ -139,6 +139,8 @@ router_ospf:
       passive_interface_default: true
       router_id: 192.168.255.2
       max_lsa: 12000
+      redistribute:
+        connected: {}
       no_passive_interfaces:
       - Ethernet5
 ip_igmp_snooping:

--- a/ansible_collections/arista/avd/roles/eos_designs/defaults/main/default-node-type-keys.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/defaults/main/default-node-type-keys.yml
@@ -62,6 +62,8 @@ default_node_type_keys:
       network_services:
         l2: true
         l3: true
+      default_overlay_routing_protocol: none
+      default_underlay_routing_protocol: none
     leaf:
       type: leaf
       connected_endpoints: true

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/underlay/ebgp/ipv6-prefix-lists.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/underlay/ebgp/ipv6-prefix-lists.j2
@@ -1,6 +1,8 @@
 {# IPv6 prefix-lists #}
+{% if switch.overlay_routing_protocol != "none" %}
 ipv6_prefix_lists:
   PL-LOOPBACKS-EVPN-OVERLAY-V6:
     sequence_numbers:
       10:
         action: "permit {{ switch.loopback_ipv6_pool }} eq 128"
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/underlay/ebgp/prefix-lists.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/underlay/ebgp/prefix-lists.j2
@@ -1,14 +1,16 @@
 {# prefix-lists #}
+{% if switch.overlay_routing_protocol != "none" %}
 prefix_lists:
   PL-LOOPBACKS-EVPN-OVERLAY:
     sequence_numbers:
       10:
         action: "permit {{ switch.loopback_ipv4_pool }} eq 32"
-{% if switch.vtep_ip is arista.avd.defined and switch.vtep_loopback | lower != 'loopback0' %}
+{%     if switch.vtep_ip is arista.avd.defined and switch.vtep_loopback | lower != 'loopback0' %}
       20:
         action: "permit {{ switch.vtep_loopback_ipv4_pool }} eq 32"
-{%     if vtep_vvtep_ip is arista.avd.defined and switch.network_services_l3 is arista.avd.defined(true) %}
+{%         if vtep_vvtep_ip is arista.avd.defined and switch.network_services_l3 is arista.avd.defined(true) %}
       30:
         action: "permit {{ vtep_vvtep_ip }}"
+{%         endif %}
 {%     endif %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/underlay/ebgp/route-maps.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/underlay/ebgp/route-maps.j2
@@ -1,4 +1,5 @@
 {# Leaf and Spine route-maps for the underlay#}
+{% if switch.overlay_routing_protocol != "none" %}
 route_maps:
   RM-CONN-2-BGP:
     sequence_numbers:
@@ -7,9 +8,10 @@ route_maps:
         match:
           - "ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY"
 {# SEQ 20 is set by inband management if applicable, so avoid setting that here #}
-{% if switch.underlay_ipv6 is arista.avd.defined(true) %}
+{%     if switch.underlay_ipv6 is arista.avd.defined(true) %}
       30:
         type: permit
         match:
           - "ipv6 address prefix-list PL-LOOPBACKS-EVPN-OVERLAY-V6"
+{%     endif %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/underlay/ebgp/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/underlay/ebgp/router-bgp.j2
@@ -25,8 +25,12 @@ router_bgp:
         activate: true
 {% endif %}
   redistribute_routes:
+{% if switch.overlay_routing_protocol == "none" %}
+    connected: {}
+{% else %}
     connected:
       route_map: RM-CONN-2-BGP
+{% endif %}
 
 {% if underlay_rfc5549 is arista.avd.defined(true) %}
 {# RFC5549 EBGP peerings #}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/underlay/isis-sr/router-isis.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/underlay/isis-sr/router-isis.j2
@@ -45,3 +45,7 @@ router_isis:
   segment_routing_mpls:
     router_id: {{ switch.router_id }}
     enabled: true
+{% if switch.overlay_routing_protocol == "none" %}
+  redistribute_routes:
+    source_protocol: connected
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/underlay/isis/router-isis.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/underlay/isis/router-isis.j2
@@ -36,3 +36,7 @@ router_isis:
 {% elif isis_ti_lfa.protection is arista.avd.defined("node") %}
     - fast-reroute ti-lfa mode node-protection
 {% endif %}
+{% if switch.overlay_routing_protocol == "none" %}
+  redistribute_routes:
+    source_protocol: connected
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/underlay/ospf/router-ospf.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/underlay/ospf/router-ospf.j2
@@ -17,3 +17,7 @@ router_ospf:
       bfd_enable: true
 {% endif %}
       max_lsa: {{ underlay_ospf_max_lsa }}
+{% if switch.overlay_routing_protocol == "none" %}
+      redistribute:
+        connected: {}
+{% endif %}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Correct underlay routing for overlay_routing_protocol: "none"

## Related Issue(s)

Recently we added support for `overlay_routing_protocol: "none"`. The PR did not include changes to underlay routing so the eos_designs behavior was to only redistribute the loopback IP into the underlay. This is wrong when not using an overlay, so instead we should redistribute all connected routes in default VRF to the underlay.

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->
When `overlay_routing_protocol: "none"` redistribute all routes in default VRF to underlay routing protocol.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Will be covered in future L2LS / L3LS molecule scenarios.

No changes to current molecule scenarios.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
