### PR TITLE
Test(eos_designs): Add molecule scenario for L2LS

### DIFF
--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -229,6 +229,7 @@ jobs:
           - 'evpn_underlay_isis_overlay_ibgp'
           - 'eos_designs-twodc-5stage-clos'
           - 'evpn_underlay_rfc5549_overlay_ebgp'
+          - 'eos_designs-l2ls'
           - 'eos_designs-mpls-isis-sr-ldp'
           - 'upgrade_v2.x_to_v3.0_evpn_underlay_ebgp_overlay_ebgp'
           - 'upgrade_v2.x_to_v3.0_evpn_underlay_ospf_overlay_ebgp'

--- a/ansible_collections/arista/avd/molecule/MOLECULE_SCENARIOS.txt
+++ b/ansible_collections/arista/avd/molecule/MOLECULE_SCENARIOS.txt
@@ -4,6 +4,7 @@ eos_config_deploy_cvp
 eos_designs_unit_tests
 eos_designs_unit_tests_v4.0
 eos_designs-twodc-5stage-clos
+eos_designs-l2ls
 eos_designs-mpls-isis-sr-ldp
 evpn_underlay_ebgp_overlay_ebgp
 evpn_underlay_isis_overlay_ibgp

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/converge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/converge.yml
@@ -1,0 +1,10 @@
+---
+- name: Converge
+  hosts: all
+  gather_facts: false
+  connection: local
+  tasks:
+    - name: generate intended variables
+      delegate_to: 127.0.0.1
+      import_role:
+        name: arista.avd.eos_designs

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/create.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/create.yml
@@ -1,0 +1,13 @@
+---
+- name: Configure local folders
+  hosts: all
+  gather_facts: false
+  connection: local
+  vars:
+    root_dir: '{{playbook_dir}}'
+  tasks:
+    - name: create local output folders
+      delegate_to: 127.0.0.1
+      import_role:
+        name: arista.avd.build_output_folders
+      run_once: true

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/destroy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/destroy.yml
@@ -1,0 +1,17 @@
+---
+- name: Remove output folders
+  hosts: all
+  gather_facts: false
+  connection: local
+  tasks:
+    - name: delete local folders
+      delegate_to: 127.0.0.1
+      run_once: true
+      file:
+        path: "{{root_dir}}/{{ item }}"
+        state: absent
+      with_items:
+        - documentation
+        - intended
+        - config_backup
+        - reports

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/BGP-LEAF1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/BGP-LEAF1.md
@@ -1,0 +1,246 @@
+# BGP-LEAF1
+# Table of Contents
+
+- [Management](#management)
+  - [Management API HTTP](#management-api-http)
+- [Authentication](#authentication)
+- [Monitoring](#monitoring)
+- [Internal VLAN Allocation Policy](#internal-vlan-allocation-policy)
+  - [Internal VLAN Allocation Policy Summary](#internal-vlan-allocation-policy-summary)
+  - [Internal VLAN Allocation Policy Configuration](#internal-vlan-allocation-policy-configuration)
+- [VLANs](#vlans)
+  - [VLANs Summary](#vlans-summary)
+  - [VLANs Device Configuration](#vlans-device-configuration)
+- [Interfaces](#interfaces)
+  - [Ethernet Interfaces](#ethernet-interfaces)
+  - [Port-Channel Interfaces](#port-channel-interfaces)
+- [Routing](#routing)
+  - [Service Routing Protocols Model](#service-routing-protocols-model)
+  - [IP Routing](#ip-routing)
+  - [IPv6 Routing](#ipv6-routing)
+  - [Static Routes](#static-routes)
+- [Multicast](#multicast)
+  - [IP IGMP Snooping](#ip-igmp-snooping)
+- [Filters](#filters)
+- [ACL](#acl)
+- [VRF Instances](#vrf-instances)
+  - [VRF Instances Summary](#vrf-instances-summary)
+  - [VRF Instances Device Configuration](#vrf-instances-device-configuration)
+- [Quality Of Service](#quality-of-service)
+
+# Management
+
+## Management API HTTP
+
+### Management API HTTP Summary
+
+| HTTP | HTTPS | Default Services |
+| ---- | ----- | ---------------- |
+| False | True | - |
+
+### Management API VRF Access
+
+| VRF Name | IPv4 ACL | IPv6 ACL |
+| -------- | -------- | -------- |
+| MGMT | - | - |
+
+### Management API HTTP Configuration
+
+```eos
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+```
+
+# Authentication
+
+# Monitoring
+
+# Internal VLAN Allocation Policy
+
+## Internal VLAN Allocation Policy Summary
+
+| Policy Allocation | Range Beginning | Range Ending |
+| ------------------| --------------- | ------------ |
+| ascending | 1006 | 1199 |
+
+## Internal VLAN Allocation Policy Configuration
+
+```eos
+!
+vlan internal order ascending range 1006 1199
+```
+
+# VLANs
+
+## VLANs Summary
+
+| VLAN ID | Name | Trunk Groups |
+| ------- | ---- | ------------ |
+| 100 | SVI_100 | - |
+
+## VLANs Device Configuration
+
+```eos
+!
+vlan 100
+   name SVI_100
+```
+
+# Interfaces
+
+## Ethernet Interfaces
+
+### Ethernet Interfaces Summary
+
+#### L2
+
+| Interface | Description | Mode | VLANs | Native VLAN | Trunk Group | Channel-Group |
+| --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
+| Ethernet1 | BGP-SPINE1_Ethernet1 | *trunk | *100 | *- | *- | 1 |
+| Ethernet2 | BGP-SPINE2_Ethernet1 | *trunk | *100 | *- | *- | 1 |
+| Ethernet10 |  Endpoint | access | 100 | - | - | - |
+| Ethernet11 |  Endpoint | access | 100 | - | - | - |
+
+*Inherited from Port-Channel Interface
+
+### Ethernet Interfaces Device Configuration
+
+```eos
+!
+interface Ethernet1
+   description BGP-SPINE1_Ethernet1
+   no shutdown
+   channel-group 1 mode active
+!
+interface Ethernet2
+   description BGP-SPINE2_Ethernet1
+   no shutdown
+   channel-group 1 mode active
+!
+interface Ethernet10
+   description Endpoint
+   no shutdown
+   switchport access vlan 100
+   switchport mode access
+   switchport
+!
+interface Ethernet11
+   description Endpoint
+   no shutdown
+   switchport access vlan 100
+   switchport mode access
+   switchport
+```
+
+## Port-Channel Interfaces
+
+### Port-Channel Interfaces Summary
+
+#### L2
+
+| Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
+| --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
+| Port-Channel1 | BGP_SPINES_Po1 | switched | trunk | 100 | - | - | - | - | - | - |
+
+### Port-Channel Interfaces Device Configuration
+
+```eos
+!
+interface Port-Channel1
+   description BGP_SPINES_Po1
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 100
+   switchport mode trunk
+```
+
+# Routing
+## Service Routing Protocols Model
+
+Multi agent routing protocol model enabled
+
+```eos
+!
+service routing protocols model multi-agent
+```
+
+## IP Routing
+
+### IP Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | true |
+| MGMT | false |
+
+### IP Routing Device Configuration
+
+```eos
+!
+ip routing
+no ip routing vrf MGMT
+```
+## IPv6 Routing
+
+### IPv6 Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | false |
+| MGMT | false |
+
+## Static Routes
+
+### Static Routes Summary
+
+| VRF | Destination Prefix | Next Hop IP             | Exit interface      | Administrative Distance       | Tag               | Route Name                    | Metric         |
+| --- | ------------------ | ----------------------- | ------------------- | ----------------------------- | ----------------- | ----------------------------- | -------------- |
+| MGMT | 0.0.0.0/0 | - | - | 1 | - | - | - |
+
+### Static Routes Device Configuration
+
+```eos
+!
+ip route vrf MGMT 0.0.0.0/0
+```
+
+# Multicast
+
+## IP IGMP Snooping
+
+### IP IGMP Snooping Summary
+
+| IGMP Snooping | Fast Leave | Interface Restart Query | Proxy | Restart Query Interval | Robustness Variable |
+| ------------- | ---------- | ----------------------- | ----- | ---------------------- | ------------------- |
+| Enabled | - | - | - | - | - |
+
+### IP IGMP Snooping Device Configuration
+
+```eos
+```
+
+# Filters
+
+# ACL
+
+# VRF Instances
+
+## VRF Instances Summary
+
+| VRF Name | IP Routing |
+| -------- | ---------- |
+| MGMT | disabled |
+
+## VRF Instances Device Configuration
+
+```eos
+!
+vrf instance MGMT
+```
+
+# Quality Of Service

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/BGP-LEAF2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/BGP-LEAF2.md
@@ -1,0 +1,246 @@
+# BGP-LEAF2
+# Table of Contents
+
+- [Management](#management)
+  - [Management API HTTP](#management-api-http)
+- [Authentication](#authentication)
+- [Monitoring](#monitoring)
+- [Internal VLAN Allocation Policy](#internal-vlan-allocation-policy)
+  - [Internal VLAN Allocation Policy Summary](#internal-vlan-allocation-policy-summary)
+  - [Internal VLAN Allocation Policy Configuration](#internal-vlan-allocation-policy-configuration)
+- [VLANs](#vlans)
+  - [VLANs Summary](#vlans-summary)
+  - [VLANs Device Configuration](#vlans-device-configuration)
+- [Interfaces](#interfaces)
+  - [Ethernet Interfaces](#ethernet-interfaces)
+  - [Port-Channel Interfaces](#port-channel-interfaces)
+- [Routing](#routing)
+  - [Service Routing Protocols Model](#service-routing-protocols-model)
+  - [IP Routing](#ip-routing)
+  - [IPv6 Routing](#ipv6-routing)
+  - [Static Routes](#static-routes)
+- [Multicast](#multicast)
+  - [IP IGMP Snooping](#ip-igmp-snooping)
+- [Filters](#filters)
+- [ACL](#acl)
+- [VRF Instances](#vrf-instances)
+  - [VRF Instances Summary](#vrf-instances-summary)
+  - [VRF Instances Device Configuration](#vrf-instances-device-configuration)
+- [Quality Of Service](#quality-of-service)
+
+# Management
+
+## Management API HTTP
+
+### Management API HTTP Summary
+
+| HTTP | HTTPS | Default Services |
+| ---- | ----- | ---------------- |
+| False | True | - |
+
+### Management API VRF Access
+
+| VRF Name | IPv4 ACL | IPv6 ACL |
+| -------- | -------- | -------- |
+| MGMT | - | - |
+
+### Management API HTTP Configuration
+
+```eos
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+```
+
+# Authentication
+
+# Monitoring
+
+# Internal VLAN Allocation Policy
+
+## Internal VLAN Allocation Policy Summary
+
+| Policy Allocation | Range Beginning | Range Ending |
+| ------------------| --------------- | ------------ |
+| ascending | 1006 | 1199 |
+
+## Internal VLAN Allocation Policy Configuration
+
+```eos
+!
+vlan internal order ascending range 1006 1199
+```
+
+# VLANs
+
+## VLANs Summary
+
+| VLAN ID | Name | Trunk Groups |
+| ------- | ---- | ------------ |
+| 100 | SVI_100 | - |
+
+## VLANs Device Configuration
+
+```eos
+!
+vlan 100
+   name SVI_100
+```
+
+# Interfaces
+
+## Ethernet Interfaces
+
+### Ethernet Interfaces Summary
+
+#### L2
+
+| Interface | Description | Mode | VLANs | Native VLAN | Trunk Group | Channel-Group |
+| --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
+| Ethernet1 | BGP-SPINE1_Ethernet2 | *trunk | *100 | *- | *- | 1 |
+| Ethernet2 | BGP-SPINE2_Ethernet2 | *trunk | *100 | *- | *- | 1 |
+| Ethernet10 |  Endpoint | access | 100 | - | - | - |
+| Ethernet11 |  Endpoint | access | 100 | - | - | - |
+
+*Inherited from Port-Channel Interface
+
+### Ethernet Interfaces Device Configuration
+
+```eos
+!
+interface Ethernet1
+   description BGP-SPINE1_Ethernet2
+   no shutdown
+   channel-group 1 mode active
+!
+interface Ethernet2
+   description BGP-SPINE2_Ethernet2
+   no shutdown
+   channel-group 1 mode active
+!
+interface Ethernet10
+   description Endpoint
+   no shutdown
+   switchport access vlan 100
+   switchport mode access
+   switchport
+!
+interface Ethernet11
+   description Endpoint
+   no shutdown
+   switchport access vlan 100
+   switchport mode access
+   switchport
+```
+
+## Port-Channel Interfaces
+
+### Port-Channel Interfaces Summary
+
+#### L2
+
+| Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
+| --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
+| Port-Channel1 | BGP_SPINES_Po2 | switched | trunk | 100 | - | - | - | - | - | - |
+
+### Port-Channel Interfaces Device Configuration
+
+```eos
+!
+interface Port-Channel1
+   description BGP_SPINES_Po2
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 100
+   switchport mode trunk
+```
+
+# Routing
+## Service Routing Protocols Model
+
+Multi agent routing protocol model enabled
+
+```eos
+!
+service routing protocols model multi-agent
+```
+
+## IP Routing
+
+### IP Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | true |
+| MGMT | false |
+
+### IP Routing Device Configuration
+
+```eos
+!
+ip routing
+no ip routing vrf MGMT
+```
+## IPv6 Routing
+
+### IPv6 Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | false |
+| MGMT | false |
+
+## Static Routes
+
+### Static Routes Summary
+
+| VRF | Destination Prefix | Next Hop IP             | Exit interface      | Administrative Distance       | Tag               | Route Name                    | Metric         |
+| --- | ------------------ | ----------------------- | ------------------- | ----------------------------- | ----------------- | ----------------------------- | -------------- |
+| MGMT | 0.0.0.0/0 | - | - | 1 | - | - | - |
+
+### Static Routes Device Configuration
+
+```eos
+!
+ip route vrf MGMT 0.0.0.0/0
+```
+
+# Multicast
+
+## IP IGMP Snooping
+
+### IP IGMP Snooping Summary
+
+| IGMP Snooping | Fast Leave | Interface Restart Query | Proxy | Restart Query Interval | Robustness Variable |
+| ------------- | ---------- | ----------------------- | ----- | ---------------------- | ------------------- |
+| Enabled | - | - | - | - | - |
+
+### IP IGMP Snooping Device Configuration
+
+```eos
+```
+
+# Filters
+
+# ACL
+
+# VRF Instances
+
+## VRF Instances Summary
+
+| VRF Name | IP Routing |
+| -------- | ---------- |
+| MGMT | disabled |
+
+## VRF Instances Device Configuration
+
+```eos
+!
+vrf instance MGMT
+```
+
+# Quality Of Service

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/BGP-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/BGP-SPINE1.md
@@ -1,4 +1,4 @@
-# OSPF-SPINE1
+# BGP-SPINE1
 # Table of Contents
 
 - [Management](#management)
@@ -28,10 +28,12 @@
   - [IP Routing](#ip-routing)
   - [IPv6 Routing](#ipv6-routing)
   - [Static Routes](#static-routes)
-  - [Router OSPF](#router-ospf)
+  - [Router BGP](#router-bgp)
 - [Multicast](#multicast)
   - [IP IGMP Snooping](#ip-igmp-snooping)
 - [Filters](#filters)
+  - [Prefix-lists](#prefix-lists)
+  - [Route-maps](#route-maps)
 - [ACL](#acl)
 - [VRF Instances](#vrf-instances)
   - [VRF Instances Summary](#vrf-instances-summary)
@@ -76,7 +78,7 @@ management api http-commands
 
 | Domain-id | Local-interface | Peer-address | Peer-link |
 | --------- | --------------- | ------------ | --------- |
-| OSPF_SPINES | Vlan4094 | 192.168.254.1 | Port-Channel3 |
+| BGP_SPINES | Vlan4094 | 192.168.254.1 | Port-Channel3 |
 
 Dual primary detection is disabled.
 
@@ -85,7 +87,7 @@ Dual primary detection is disabled.
 ```eos
 !
 mlag configuration
-   domain-id OSPF_SPINES
+   domain-id BGP_SPINES
    local-interface Vlan4094
    peer-address 192.168.254.1
    peer-link Port-Channel3
@@ -161,10 +163,10 @@ vlan 4094
 
 | Interface | Description | Mode | VLANs | Native VLAN | Trunk Group | Channel-Group |
 | --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
-| Ethernet1 | OSPF-LEAF1_Ethernet1 | *trunk | *100 | *- | *- | 1 |
-| Ethernet2 | OSPF-LEAF2_Ethernet1 | *trunk | *100 | *- | *- | 2 |
-| Ethernet3 | MLAG_PEER_OSPF-SPINE2_Ethernet3 | *trunk | *2-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 3 |
-| Ethernet4 | MLAG_PEER_OSPF-SPINE2_Ethernet4 | *trunk | *2-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 3 |
+| Ethernet1 | BGP-LEAF1_Ethernet1 | *trunk | *100 | *- | *- | 1 |
+| Ethernet2 | BGP-LEAF2_Ethernet1 | *trunk | *100 | *- | *- | 2 |
+| Ethernet3 | MLAG_PEER_BGP-SPINE2_Ethernet3 | *trunk | *2-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 3 |
+| Ethernet4 | MLAG_PEER_BGP-SPINE2_Ethernet4 | *trunk | *2-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 3 |
 
 *Inherited from Port-Channel Interface
 
@@ -172,40 +174,38 @@ vlan 4094
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet5 | P2P_LINK_TO_DUMMY-CORE_Ethernet1/1 | routed | - | 192.168.253.0/31 | default | 9000 | false | - | - |
+| Ethernet5 | P2P_LINK_TO_DUMMY-CORE_Ethernet1/3 | routed | - | 192.168.253.4/31 | default | 9000 | false | - | - |
 
 ### Ethernet Interfaces Device Configuration
 
 ```eos
 !
 interface Ethernet1
-   description OSPF-LEAF1_Ethernet1
+   description BGP-LEAF1_Ethernet1
    no shutdown
    channel-group 1 mode active
 !
 interface Ethernet2
-   description OSPF-LEAF2_Ethernet1
+   description BGP-LEAF2_Ethernet1
    no shutdown
    channel-group 2 mode active
 !
 interface Ethernet3
-   description MLAG_PEER_OSPF-SPINE2_Ethernet3
+   description MLAG_PEER_BGP-SPINE2_Ethernet3
    no shutdown
    channel-group 3 mode active
 !
 interface Ethernet4
-   description MLAG_PEER_OSPF-SPINE2_Ethernet4
+   description MLAG_PEER_BGP-SPINE2_Ethernet4
    no shutdown
    channel-group 3 mode active
 !
 interface Ethernet5
-   description P2P_LINK_TO_DUMMY-CORE_Ethernet1/1
+   description P2P_LINK_TO_DUMMY-CORE_Ethernet1/3
    no shutdown
    mtu 9000
    no switchport
-   ip address 192.168.253.0/31
-   ip ospf network point-to-point
-   ip ospf area 0.0.0.0
+   ip address 192.168.253.4/31
 ```
 
 ## Port-Channel Interfaces
@@ -216,16 +216,16 @@ interface Ethernet5
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel1 | OSPF-LEAF1_Po1 | switched | trunk | 100 | - | - | - | - | 1 | - |
-| Port-Channel2 | OSPF-LEAF2_Po1 | switched | trunk | 100 | - | - | - | - | 2 | - |
-| Port-Channel3 | MLAG_PEER_OSPF-SPINE2_Po3 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
+| Port-Channel1 | BGP-LEAF1_Po1 | switched | trunk | 100 | - | - | - | - | 1 | - |
+| Port-Channel2 | BGP-LEAF2_Po1 | switched | trunk | 100 | - | - | - | - | 2 | - |
+| Port-Channel3 | MLAG_PEER_BGP-SPINE2_Po3 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
 
 ```eos
 !
 interface Port-Channel1
-   description OSPF-LEAF1_Po1
+   description BGP-LEAF1_Po1
    no shutdown
    switchport
    switchport trunk allowed vlan 100
@@ -233,7 +233,7 @@ interface Port-Channel1
    mlag 1
 !
 interface Port-Channel2
-   description OSPF-LEAF2_Po1
+   description BGP-LEAF2_Po1
    no shutdown
    switchport
    switchport trunk allowed vlan 100
@@ -241,7 +241,7 @@ interface Port-Channel2
    mlag 2
 !
 interface Port-Channel3
-   description MLAG_PEER_OSPF-SPINE2_Po3
+   description MLAG_PEER_BGP-SPINE2_Po3
    no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
@@ -274,7 +274,6 @@ interface Port-Channel3
 interface Loopback0
    no shutdown
    ip address 192.168.255.1/32
-   ip ospf area 0.0.0.0
 ```
 
 ## VLAN Interfaces
@@ -290,7 +289,7 @@ interface Loopback0
 
 | Interface | VRF | IP Address | IP Address Virtual | IP Router Virtual Address | VRRP | ACL In | ACL Out |
 | --------- | --- | ---------- | ------------------ | ------------------------- | ---- | ------ | ------- |
-| Vlan100 |  default  |  -  |  10.0.100.1/24  |  -  |  -  |  -  |  -  |
+| Vlan100 |  default  |  -  |  10.1.100.1/24  |  -  |  -  |  -  |  -  |
 | Vlan4094 |  default  |  192.168.254.0/31  |  -  |  -  |  -  |  -  |  -  |
 
 ### VLAN Interfaces Device Configuration
@@ -300,7 +299,7 @@ interface Loopback0
 interface Vlan100
    description SVI_100
    no shutdown
-   ip address virtual 10.0.100.1/24
+   ip address virtual 10.1.100.1/24
 !
 interface Vlan4094
    description MLAG_PEER
@@ -308,8 +307,6 @@ interface Vlan4094
    mtu 9000
    no autostate
    ip address 192.168.254.0/31
-   ip ospf network point-to-point
-   ip ospf area 0.0.0.0
 ```
 
 # Routing
@@ -375,31 +372,72 @@ no ip routing vrf MGMT
 ip route vrf MGMT 0.0.0.0/0
 ```
 
-## Router OSPF
+## Router BGP
 
-### Router OSPF Summary
+### Router BGP Summary
 
-| Process ID | Router ID | Default Passive Interface | No Passive Interface | BFD | Max LSA | Default Information Originate | Log Adjacency Changes Detail | Auto Cost Reference Bandwidth | Maximum Paths | MPLS LDP Sync Default | Distribute List In |
-| ---------- | --------- | ------------------------- | -------------------- | --- | ------- | ----------------------------- | ---------------------------- | ----------------------------- | ------------- | --------------------- | ------------------ |
-| 100 | 192.168.255.1 | enabled | Ethernet5 <br> | disabled | 12000 | disabled | disabled | - | - | - | - |
+| BGP AS | Router ID |
+| ------ | --------- |
+| 65001|  192.168.255.1 |
 
-### OSPF Interfaces
+| BGP Tuning |
+| ---------- |
+| maximum-paths 4 ecmp 4 |
 
-| Interface | Area | Cost | Point To Point |
-| -------- | -------- | -------- | -------- |
-| Ethernet5 | 0.0.0.0 | - | True |
-| Vlan4094 | 0.0.0.0 | - | True |
-| Loopback0 | 0.0.0.0 | - | - |
+### Router BGP Peer Groups
 
-### Router OSPF Device Configuration
+#### IPv4-UNDERLAY-PEERS
+
+| Settings | Value |
+| -------- | ----- |
+| Address Family | ipv4 |
+| Send community | all |
+| Maximum routes | 12000 |
+
+#### MLAG-IPv4-UNDERLAY-PEER
+
+| Settings | Value |
+| -------- | ----- |
+| Address Family | ipv4 |
+| Remote AS | 65001 |
+| Next-hop self | True |
+| Send community | all |
+| Maximum routes | 12000 |
+
+### BGP Neighbors
+
+| Neighbor | Remote AS | VRF | Shutdown | Send-community | Maximum-routes | Allowas-in | BFD | RIB Pre-Policy Retain |
+| -------- | --------- | --- | -------- | -------------- | -------------- | ---------- | --- | --------------------- |
+| 192.168.253.5 | 65000 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - |
+| 192.168.254.1 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | default | - | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | - | - | - |
+
+### Router BGP Device Configuration
 
 ```eos
 !
-router ospf 100
+router bgp 65001
    router-id 192.168.255.1
-   passive-interface default
-   no passive-interface Ethernet5
-   max-lsa 12000
+   maximum-paths 4 ecmp 4
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   neighbor MLAG-IPv4-UNDERLAY-PEER peer group
+   neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65001
+   neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
+   neighbor MLAG-IPv4-UNDERLAY-PEER description BGP-SPINE2
+   neighbor MLAG-IPv4-UNDERLAY-PEER send-community
+   neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000
+   neighbor MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN in
+   neighbor 192.168.253.5 peer group IPv4-UNDERLAY-PEERS
+   neighbor 192.168.253.5 remote-as 65000
+   neighbor 192.168.253.5 description DUMMY-CORE
+   neighbor 192.168.254.1 peer group MLAG-IPv4-UNDERLAY-PEER
+   neighbor 192.168.254.1 description BGP-SPINE2
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   address-family ipv4
+      neighbor IPv4-UNDERLAY-PEERS activate
+      neighbor MLAG-IPv4-UNDERLAY-PEER activate
 ```
 
 # Multicast
@@ -418,6 +456,52 @@ router ospf 100
 ```
 
 # Filters
+
+## Prefix-lists
+
+### Prefix-lists Summary
+
+#### PL-LOOPBACKS-EVPN-OVERLAY
+
+| Sequence | Action |
+| -------- | ------ |
+| 10 | permit 192.168.255.0/24 eq 32 |
+
+### Prefix-lists Device Configuration
+
+```eos
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+```
+
+## Route-maps
+
+### Route-maps Summary
+
+#### RM-CONN-2-BGP
+
+| Sequence | Type | Match and/or Set |
+| -------- | ---- | ---------------- |
+| 10 | permit | match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY |
+
+#### RM-MLAG-PEER-IN
+
+| Sequence | Type | Match and/or Set |
+| -------- | ---- | ---------------- |
+| 10 | permit | set origin incomplete |
+
+### Route-maps Device Configuration
+
+```eos
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+route-map RM-MLAG-PEER-IN permit 10
+   description Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing
+   set origin incomplete
+```
 
 # ACL
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/BGP-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/BGP-SPINE2.md
@@ -1,4 +1,4 @@
-# OSPF-SPINE1
+# BGP-SPINE2
 # Table of Contents
 
 - [Management](#management)
@@ -28,10 +28,12 @@
   - [IP Routing](#ip-routing)
   - [IPv6 Routing](#ipv6-routing)
   - [Static Routes](#static-routes)
-  - [Router OSPF](#router-ospf)
+  - [Router BGP](#router-bgp)
 - [Multicast](#multicast)
   - [IP IGMP Snooping](#ip-igmp-snooping)
 - [Filters](#filters)
+  - [Prefix-lists](#prefix-lists)
+  - [Route-maps](#route-maps)
 - [ACL](#acl)
 - [VRF Instances](#vrf-instances)
   - [VRF Instances Summary](#vrf-instances-summary)
@@ -76,7 +78,7 @@ management api http-commands
 
 | Domain-id | Local-interface | Peer-address | Peer-link |
 | --------- | --------------- | ------------ | --------- |
-| OSPF_SPINES | Vlan4094 | 192.168.254.1 | Port-Channel3 |
+| BGP_SPINES | Vlan4094 | 192.168.254.0 | Port-Channel3 |
 
 Dual primary detection is disabled.
 
@@ -85,9 +87,9 @@ Dual primary detection is disabled.
 ```eos
 !
 mlag configuration
-   domain-id OSPF_SPINES
+   domain-id BGP_SPINES
    local-interface Vlan4094
-   peer-address 192.168.254.1
+   peer-address 192.168.254.0
    peer-link Port-Channel3
    reload-delay mlag 300
    reload-delay non-mlag 330
@@ -161,10 +163,10 @@ vlan 4094
 
 | Interface | Description | Mode | VLANs | Native VLAN | Trunk Group | Channel-Group |
 | --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
-| Ethernet1 | OSPF-LEAF1_Ethernet1 | *trunk | *100 | *- | *- | 1 |
-| Ethernet2 | OSPF-LEAF2_Ethernet1 | *trunk | *100 | *- | *- | 2 |
-| Ethernet3 | MLAG_PEER_OSPF-SPINE2_Ethernet3 | *trunk | *2-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 3 |
-| Ethernet4 | MLAG_PEER_OSPF-SPINE2_Ethernet4 | *trunk | *2-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 3 |
+| Ethernet1 | BGP-LEAF1_Ethernet2 | *trunk | *100 | *- | *- | 1 |
+| Ethernet2 | BGP-LEAF2_Ethernet2 | *trunk | *100 | *- | *- | 2 |
+| Ethernet3 | MLAG_PEER_BGP-SPINE1_Ethernet3 | *trunk | *2-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 3 |
+| Ethernet4 | MLAG_PEER_BGP-SPINE1_Ethernet4 | *trunk | *2-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 3 |
 
 *Inherited from Port-Channel Interface
 
@@ -172,40 +174,38 @@ vlan 4094
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet5 | P2P_LINK_TO_DUMMY-CORE_Ethernet1/1 | routed | - | 192.168.253.0/31 | default | 9000 | false | - | - |
+| Ethernet5 | P2P_LINK_TO_DUMMY-CORE_Ethernet1/4 | routed | - | 192.168.253.6/31 | default | 9000 | false | - | - |
 
 ### Ethernet Interfaces Device Configuration
 
 ```eos
 !
 interface Ethernet1
-   description OSPF-LEAF1_Ethernet1
+   description BGP-LEAF1_Ethernet2
    no shutdown
    channel-group 1 mode active
 !
 interface Ethernet2
-   description OSPF-LEAF2_Ethernet1
+   description BGP-LEAF2_Ethernet2
    no shutdown
    channel-group 2 mode active
 !
 interface Ethernet3
-   description MLAG_PEER_OSPF-SPINE2_Ethernet3
+   description MLAG_PEER_BGP-SPINE1_Ethernet3
    no shutdown
    channel-group 3 mode active
 !
 interface Ethernet4
-   description MLAG_PEER_OSPF-SPINE2_Ethernet4
+   description MLAG_PEER_BGP-SPINE1_Ethernet4
    no shutdown
    channel-group 3 mode active
 !
 interface Ethernet5
-   description P2P_LINK_TO_DUMMY-CORE_Ethernet1/1
+   description P2P_LINK_TO_DUMMY-CORE_Ethernet1/4
    no shutdown
    mtu 9000
    no switchport
-   ip address 192.168.253.0/31
-   ip ospf network point-to-point
-   ip ospf area 0.0.0.0
+   ip address 192.168.253.6/31
 ```
 
 ## Port-Channel Interfaces
@@ -216,16 +216,16 @@ interface Ethernet5
 
 | Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
 | --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel1 | OSPF-LEAF1_Po1 | switched | trunk | 100 | - | - | - | - | 1 | - |
-| Port-Channel2 | OSPF-LEAF2_Po1 | switched | trunk | 100 | - | - | - | - | 2 | - |
-| Port-Channel3 | MLAG_PEER_OSPF-SPINE2_Po3 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
+| Port-Channel1 | BGP-LEAF1_Po1 | switched | trunk | 100 | - | - | - | - | 1 | - |
+| Port-Channel2 | BGP-LEAF2_Po1 | switched | trunk | 100 | - | - | - | - | 2 | - |
+| Port-Channel3 | MLAG_PEER_BGP-SPINE1_Po3 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
 
 ### Port-Channel Interfaces Device Configuration
 
 ```eos
 !
 interface Port-Channel1
-   description OSPF-LEAF1_Po1
+   description BGP-LEAF1_Po1
    no shutdown
    switchport
    switchport trunk allowed vlan 100
@@ -233,7 +233,7 @@ interface Port-Channel1
    mlag 1
 !
 interface Port-Channel2
-   description OSPF-LEAF2_Po1
+   description BGP-LEAF2_Po1
    no shutdown
    switchport
    switchport trunk allowed vlan 100
@@ -241,7 +241,7 @@ interface Port-Channel2
    mlag 2
 !
 interface Port-Channel3
-   description MLAG_PEER_OSPF-SPINE2_Po3
+   description MLAG_PEER_BGP-SPINE1_Po3
    no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
@@ -258,7 +258,7 @@ interface Port-Channel3
 
 | Interface | Description | VRF | IP Address |
 | --------- | ----------- | --- | ---------- |
-| Loopback0 | - | default | 192.168.255.1/32 |
+| Loopback0 | - | default | 192.168.255.2/32 |
 
 #### IPv6
 
@@ -273,8 +273,7 @@ interface Port-Channel3
 !
 interface Loopback0
    no shutdown
-   ip address 192.168.255.1/32
-   ip ospf area 0.0.0.0
+   ip address 192.168.255.2/32
 ```
 
 ## VLAN Interfaces
@@ -290,8 +289,8 @@ interface Loopback0
 
 | Interface | VRF | IP Address | IP Address Virtual | IP Router Virtual Address | VRRP | ACL In | ACL Out |
 | --------- | --- | ---------- | ------------------ | ------------------------- | ---- | ------ | ------- |
-| Vlan100 |  default  |  -  |  10.0.100.1/24  |  -  |  -  |  -  |  -  |
-| Vlan4094 |  default  |  192.168.254.0/31  |  -  |  -  |  -  |  -  |  -  |
+| Vlan100 |  default  |  -  |  10.1.100.1/24  |  -  |  -  |  -  |  -  |
+| Vlan4094 |  default  |  192.168.254.1/31  |  -  |  -  |  -  |  -  |  -  |
 
 ### VLAN Interfaces Device Configuration
 
@@ -300,16 +299,14 @@ interface Loopback0
 interface Vlan100
    description SVI_100
    no shutdown
-   ip address virtual 10.0.100.1/24
+   ip address virtual 10.1.100.1/24
 !
 interface Vlan4094
    description MLAG_PEER
    no shutdown
    mtu 9000
    no autostate
-   ip address 192.168.254.0/31
-   ip ospf network point-to-point
-   ip ospf area 0.0.0.0
+   ip address 192.168.254.1/31
 ```
 
 # Routing
@@ -375,31 +372,72 @@ no ip routing vrf MGMT
 ip route vrf MGMT 0.0.0.0/0
 ```
 
-## Router OSPF
+## Router BGP
 
-### Router OSPF Summary
+### Router BGP Summary
 
-| Process ID | Router ID | Default Passive Interface | No Passive Interface | BFD | Max LSA | Default Information Originate | Log Adjacency Changes Detail | Auto Cost Reference Bandwidth | Maximum Paths | MPLS LDP Sync Default | Distribute List In |
-| ---------- | --------- | ------------------------- | -------------------- | --- | ------- | ----------------------------- | ---------------------------- | ----------------------------- | ------------- | --------------------- | ------------------ |
-| 100 | 192.168.255.1 | enabled | Ethernet5 <br> | disabled | 12000 | disabled | disabled | - | - | - | - |
+| BGP AS | Router ID |
+| ------ | --------- |
+| 65001|  192.168.255.2 |
 
-### OSPF Interfaces
+| BGP Tuning |
+| ---------- |
+| maximum-paths 4 ecmp 4 |
 
-| Interface | Area | Cost | Point To Point |
-| -------- | -------- | -------- | -------- |
-| Ethernet5 | 0.0.0.0 | - | True |
-| Vlan4094 | 0.0.0.0 | - | True |
-| Loopback0 | 0.0.0.0 | - | - |
+### Router BGP Peer Groups
 
-### Router OSPF Device Configuration
+#### IPv4-UNDERLAY-PEERS
+
+| Settings | Value |
+| -------- | ----- |
+| Address Family | ipv4 |
+| Send community | all |
+| Maximum routes | 12000 |
+
+#### MLAG-IPv4-UNDERLAY-PEER
+
+| Settings | Value |
+| -------- | ----- |
+| Address Family | ipv4 |
+| Remote AS | 65001 |
+| Next-hop self | True |
+| Send community | all |
+| Maximum routes | 12000 |
+
+### BGP Neighbors
+
+| Neighbor | Remote AS | VRF | Shutdown | Send-community | Maximum-routes | Allowas-in | BFD | RIB Pre-Policy Retain |
+| -------- | --------- | --- | -------- | -------------- | -------------- | ---------- | --- | --------------------- |
+| 192.168.253.7 | 65000 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - |
+| 192.168.254.0 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | default | - | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | - | - | - |
+
+### Router BGP Device Configuration
 
 ```eos
 !
-router ospf 100
-   router-id 192.168.255.1
-   passive-interface default
-   no passive-interface Ethernet5
-   max-lsa 12000
+router bgp 65001
+   router-id 192.168.255.2
+   maximum-paths 4 ecmp 4
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   neighbor MLAG-IPv4-UNDERLAY-PEER peer group
+   neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65001
+   neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
+   neighbor MLAG-IPv4-UNDERLAY-PEER description BGP-SPINE1
+   neighbor MLAG-IPv4-UNDERLAY-PEER send-community
+   neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000
+   neighbor MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN in
+   neighbor 192.168.253.7 peer group IPv4-UNDERLAY-PEERS
+   neighbor 192.168.253.7 remote-as 65000
+   neighbor 192.168.253.7 description DUMMY-CORE
+   neighbor 192.168.254.0 peer group MLAG-IPv4-UNDERLAY-PEER
+   neighbor 192.168.254.0 description BGP-SPINE1
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   address-family ipv4
+      neighbor IPv4-UNDERLAY-PEERS activate
+      neighbor MLAG-IPv4-UNDERLAY-PEER activate
 ```
 
 # Multicast
@@ -418,6 +456,52 @@ router ospf 100
 ```
 
 # Filters
+
+## Prefix-lists
+
+### Prefix-lists Summary
+
+#### PL-LOOPBACKS-EVPN-OVERLAY
+
+| Sequence | Action |
+| -------- | ------ |
+| 10 | permit 192.168.255.0/24 eq 32 |
+
+### Prefix-lists Device Configuration
+
+```eos
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+```
+
+## Route-maps
+
+### Route-maps Summary
+
+#### RM-CONN-2-BGP
+
+| Sequence | Type | Match and/or Set |
+| -------- | ---- | ---------------- |
+| 10 | permit | match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY |
+
+#### RM-MLAG-PEER-IN
+
+| Sequence | Type | Match and/or Set |
+| -------- | ---- | ---------------- |
+| 10 | permit | set origin incomplete |
+
+### Route-maps Device Configuration
+
+```eos
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+route-map RM-MLAG-PEER-IN permit 10
+   description Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing
+   set origin incomplete
+```
 
 # ACL
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/OSPF-LEAF1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/OSPF-LEAF1.md
@@ -1,0 +1,246 @@
+# OSPF-LEAF1
+# Table of Contents
+
+- [Management](#management)
+  - [Management API HTTP](#management-api-http)
+- [Authentication](#authentication)
+- [Monitoring](#monitoring)
+- [Internal VLAN Allocation Policy](#internal-vlan-allocation-policy)
+  - [Internal VLAN Allocation Policy Summary](#internal-vlan-allocation-policy-summary)
+  - [Internal VLAN Allocation Policy Configuration](#internal-vlan-allocation-policy-configuration)
+- [VLANs](#vlans)
+  - [VLANs Summary](#vlans-summary)
+  - [VLANs Device Configuration](#vlans-device-configuration)
+- [Interfaces](#interfaces)
+  - [Ethernet Interfaces](#ethernet-interfaces)
+  - [Port-Channel Interfaces](#port-channel-interfaces)
+- [Routing](#routing)
+  - [Service Routing Protocols Model](#service-routing-protocols-model)
+  - [IP Routing](#ip-routing)
+  - [IPv6 Routing](#ipv6-routing)
+  - [Static Routes](#static-routes)
+- [Multicast](#multicast)
+  - [IP IGMP Snooping](#ip-igmp-snooping)
+- [Filters](#filters)
+- [ACL](#acl)
+- [VRF Instances](#vrf-instances)
+  - [VRF Instances Summary](#vrf-instances-summary)
+  - [VRF Instances Device Configuration](#vrf-instances-device-configuration)
+- [Quality Of Service](#quality-of-service)
+
+# Management
+
+## Management API HTTP
+
+### Management API HTTP Summary
+
+| HTTP | HTTPS | Default Services |
+| ---- | ----- | ---------------- |
+| False | True | - |
+
+### Management API VRF Access
+
+| VRF Name | IPv4 ACL | IPv6 ACL |
+| -------- | -------- | -------- |
+| MGMT | - | - |
+
+### Management API HTTP Configuration
+
+```eos
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+```
+
+# Authentication
+
+# Monitoring
+
+# Internal VLAN Allocation Policy
+
+## Internal VLAN Allocation Policy Summary
+
+| Policy Allocation | Range Beginning | Range Ending |
+| ------------------| --------------- | ------------ |
+| ascending | 1006 | 1199 |
+
+## Internal VLAN Allocation Policy Configuration
+
+```eos
+!
+vlan internal order ascending range 1006 1199
+```
+
+# VLANs
+
+## VLANs Summary
+
+| VLAN ID | Name | Trunk Groups |
+| ------- | ---- | ------------ |
+| 100 | SVI_100 | - |
+
+## VLANs Device Configuration
+
+```eos
+!
+vlan 100
+   name SVI_100
+```
+
+# Interfaces
+
+## Ethernet Interfaces
+
+### Ethernet Interfaces Summary
+
+#### L2
+
+| Interface | Description | Mode | VLANs | Native VLAN | Trunk Group | Channel-Group |
+| --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
+| Ethernet1 | OSPF-SPINE1_Ethernet1 | *trunk | *100 | *- | *- | 1 |
+| Ethernet2 | OSPF-SPINE2_Ethernet1 | *trunk | *100 | *- | *- | 1 |
+| Ethernet10 |  Endpoint | access | 100 | - | - | - |
+| Ethernet11 |  Endpoint | access | 100 | - | - | - |
+
+*Inherited from Port-Channel Interface
+
+### Ethernet Interfaces Device Configuration
+
+```eos
+!
+interface Ethernet1
+   description OSPF-SPINE1_Ethernet1
+   no shutdown
+   channel-group 1 mode active
+!
+interface Ethernet2
+   description OSPF-SPINE2_Ethernet1
+   no shutdown
+   channel-group 1 mode active
+!
+interface Ethernet10
+   description Endpoint
+   no shutdown
+   switchport access vlan 100
+   switchport mode access
+   switchport
+!
+interface Ethernet11
+   description Endpoint
+   no shutdown
+   switchport access vlan 100
+   switchport mode access
+   switchport
+```
+
+## Port-Channel Interfaces
+
+### Port-Channel Interfaces Summary
+
+#### L2
+
+| Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
+| --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
+| Port-Channel1 | OSPF_SPINES_Po1 | switched | trunk | 100 | - | - | - | - | - | - |
+
+### Port-Channel Interfaces Device Configuration
+
+```eos
+!
+interface Port-Channel1
+   description OSPF_SPINES_Po1
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 100
+   switchport mode trunk
+```
+
+# Routing
+## Service Routing Protocols Model
+
+Multi agent routing protocol model enabled
+
+```eos
+!
+service routing protocols model multi-agent
+```
+
+## IP Routing
+
+### IP Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | true |
+| MGMT | false |
+
+### IP Routing Device Configuration
+
+```eos
+!
+ip routing
+no ip routing vrf MGMT
+```
+## IPv6 Routing
+
+### IPv6 Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | false |
+| MGMT | false |
+
+## Static Routes
+
+### Static Routes Summary
+
+| VRF | Destination Prefix | Next Hop IP             | Exit interface      | Administrative Distance       | Tag               | Route Name                    | Metric         |
+| --- | ------------------ | ----------------------- | ------------------- | ----------------------------- | ----------------- | ----------------------------- | -------------- |
+| MGMT | 0.0.0.0/0 | - | - | 1 | - | - | - |
+
+### Static Routes Device Configuration
+
+```eos
+!
+ip route vrf MGMT 0.0.0.0/0
+```
+
+# Multicast
+
+## IP IGMP Snooping
+
+### IP IGMP Snooping Summary
+
+| IGMP Snooping | Fast Leave | Interface Restart Query | Proxy | Restart Query Interval | Robustness Variable |
+| ------------- | ---------- | ----------------------- | ----- | ---------------------- | ------------------- |
+| Enabled | - | - | - | - | - |
+
+### IP IGMP Snooping Device Configuration
+
+```eos
+```
+
+# Filters
+
+# ACL
+
+# VRF Instances
+
+## VRF Instances Summary
+
+| VRF Name | IP Routing |
+| -------- | ---------- |
+| MGMT | disabled |
+
+## VRF Instances Device Configuration
+
+```eos
+!
+vrf instance MGMT
+```
+
+# Quality Of Service

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/OSPF-LEAF2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/OSPF-LEAF2.md
@@ -1,0 +1,246 @@
+# OSPF-LEAF2
+# Table of Contents
+
+- [Management](#management)
+  - [Management API HTTP](#management-api-http)
+- [Authentication](#authentication)
+- [Monitoring](#monitoring)
+- [Internal VLAN Allocation Policy](#internal-vlan-allocation-policy)
+  - [Internal VLAN Allocation Policy Summary](#internal-vlan-allocation-policy-summary)
+  - [Internal VLAN Allocation Policy Configuration](#internal-vlan-allocation-policy-configuration)
+- [VLANs](#vlans)
+  - [VLANs Summary](#vlans-summary)
+  - [VLANs Device Configuration](#vlans-device-configuration)
+- [Interfaces](#interfaces)
+  - [Ethernet Interfaces](#ethernet-interfaces)
+  - [Port-Channel Interfaces](#port-channel-interfaces)
+- [Routing](#routing)
+  - [Service Routing Protocols Model](#service-routing-protocols-model)
+  - [IP Routing](#ip-routing)
+  - [IPv6 Routing](#ipv6-routing)
+  - [Static Routes](#static-routes)
+- [Multicast](#multicast)
+  - [IP IGMP Snooping](#ip-igmp-snooping)
+- [Filters](#filters)
+- [ACL](#acl)
+- [VRF Instances](#vrf-instances)
+  - [VRF Instances Summary](#vrf-instances-summary)
+  - [VRF Instances Device Configuration](#vrf-instances-device-configuration)
+- [Quality Of Service](#quality-of-service)
+
+# Management
+
+## Management API HTTP
+
+### Management API HTTP Summary
+
+| HTTP | HTTPS | Default Services |
+| ---- | ----- | ---------------- |
+| False | True | - |
+
+### Management API VRF Access
+
+| VRF Name | IPv4 ACL | IPv6 ACL |
+| -------- | -------- | -------- |
+| MGMT | - | - |
+
+### Management API HTTP Configuration
+
+```eos
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+```
+
+# Authentication
+
+# Monitoring
+
+# Internal VLAN Allocation Policy
+
+## Internal VLAN Allocation Policy Summary
+
+| Policy Allocation | Range Beginning | Range Ending |
+| ------------------| --------------- | ------------ |
+| ascending | 1006 | 1199 |
+
+## Internal VLAN Allocation Policy Configuration
+
+```eos
+!
+vlan internal order ascending range 1006 1199
+```
+
+# VLANs
+
+## VLANs Summary
+
+| VLAN ID | Name | Trunk Groups |
+| ------- | ---- | ------------ |
+| 100 | SVI_100 | - |
+
+## VLANs Device Configuration
+
+```eos
+!
+vlan 100
+   name SVI_100
+```
+
+# Interfaces
+
+## Ethernet Interfaces
+
+### Ethernet Interfaces Summary
+
+#### L2
+
+| Interface | Description | Mode | VLANs | Native VLAN | Trunk Group | Channel-Group |
+| --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
+| Ethernet1 | OSPF-SPINE1_Ethernet2 | *trunk | *100 | *- | *- | 1 |
+| Ethernet2 | OSPF-SPINE2_Ethernet2 | *trunk | *100 | *- | *- | 1 |
+| Ethernet10 |  Endpoint | access | 100 | - | - | - |
+| Ethernet11 |  Endpoint | access | 100 | - | - | - |
+
+*Inherited from Port-Channel Interface
+
+### Ethernet Interfaces Device Configuration
+
+```eos
+!
+interface Ethernet1
+   description OSPF-SPINE1_Ethernet2
+   no shutdown
+   channel-group 1 mode active
+!
+interface Ethernet2
+   description OSPF-SPINE2_Ethernet2
+   no shutdown
+   channel-group 1 mode active
+!
+interface Ethernet10
+   description Endpoint
+   no shutdown
+   switchport access vlan 100
+   switchport mode access
+   switchport
+!
+interface Ethernet11
+   description Endpoint
+   no shutdown
+   switchport access vlan 100
+   switchport mode access
+   switchport
+```
+
+## Port-Channel Interfaces
+
+### Port-Channel Interfaces Summary
+
+#### L2
+
+| Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
+| --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
+| Port-Channel1 | OSPF_SPINES_Po2 | switched | trunk | 100 | - | - | - | - | - | - |
+
+### Port-Channel Interfaces Device Configuration
+
+```eos
+!
+interface Port-Channel1
+   description OSPF_SPINES_Po2
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 100
+   switchport mode trunk
+```
+
+# Routing
+## Service Routing Protocols Model
+
+Multi agent routing protocol model enabled
+
+```eos
+!
+service routing protocols model multi-agent
+```
+
+## IP Routing
+
+### IP Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | true |
+| MGMT | false |
+
+### IP Routing Device Configuration
+
+```eos
+!
+ip routing
+no ip routing vrf MGMT
+```
+## IPv6 Routing
+
+### IPv6 Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | false |
+| MGMT | false |
+
+## Static Routes
+
+### Static Routes Summary
+
+| VRF | Destination Prefix | Next Hop IP             | Exit interface      | Administrative Distance       | Tag               | Route Name                    | Metric         |
+| --- | ------------------ | ----------------------- | ------------------- | ----------------------------- | ----------------- | ----------------------------- | -------------- |
+| MGMT | 0.0.0.0/0 | - | - | 1 | - | - | - |
+
+### Static Routes Device Configuration
+
+```eos
+!
+ip route vrf MGMT 0.0.0.0/0
+```
+
+# Multicast
+
+## IP IGMP Snooping
+
+### IP IGMP Snooping Summary
+
+| IGMP Snooping | Fast Leave | Interface Restart Query | Proxy | Restart Query Interval | Robustness Variable |
+| ------------- | ---------- | ----------------------- | ----- | ---------------------- | ------------------- |
+| Enabled | - | - | - | - | - |
+
+### IP IGMP Snooping Device Configuration
+
+```eos
+```
+
+# Filters
+
+# ACL
+
+# VRF Instances
+
+## VRF Instances Summary
+
+| VRF Name | IP Routing |
+| -------- | ---------- |
+| MGMT | disabled |
+
+## VRF Instances Device Configuration
+
+```eos
+!
+vrf instance MGMT
+```
+
+# Quality Of Service

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/OSPF-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/OSPF-SPINE1.md
@@ -1,0 +1,422 @@
+# OSPF-SPINE1
+# Table of Contents
+
+- [Management](#management)
+  - [Management API HTTP](#management-api-http)
+- [Authentication](#authentication)
+- [Monitoring](#monitoring)
+- [MLAG](#mlag)
+  - [MLAG Summary](#mlag-summary)
+  - [MLAG Device Configuration](#mlag-device-configuration)
+- [Spanning Tree](#spanning-tree)
+  - [Spanning Tree Summary](#spanning-tree-summary)
+  - [Spanning Tree Device Configuration](#spanning-tree-device-configuration)
+- [Internal VLAN Allocation Policy](#internal-vlan-allocation-policy)
+  - [Internal VLAN Allocation Policy Summary](#internal-vlan-allocation-policy-summary)
+  - [Internal VLAN Allocation Policy Configuration](#internal-vlan-allocation-policy-configuration)
+- [VLANs](#vlans)
+  - [VLANs Summary](#vlans-summary)
+  - [VLANs Device Configuration](#vlans-device-configuration)
+- [Interfaces](#interfaces)
+  - [Ethernet Interfaces](#ethernet-interfaces)
+  - [Port-Channel Interfaces](#port-channel-interfaces)
+  - [Loopback Interfaces](#loopback-interfaces)
+  - [VLAN Interfaces](#vlan-interfaces)
+- [Routing](#routing)
+  - [Service Routing Protocols Model](#service-routing-protocols-model)
+  - [Virtual Router MAC Address](#virtual-router-mac-address)
+  - [IP Routing](#ip-routing)
+  - [IPv6 Routing](#ipv6-routing)
+  - [Static Routes](#static-routes)
+  - [Router OSPF](#router-ospf)
+- [Multicast](#multicast)
+  - [IP IGMP Snooping](#ip-igmp-snooping)
+- [Filters](#filters)
+- [ACL](#acl)
+- [VRF Instances](#vrf-instances)
+  - [VRF Instances Summary](#vrf-instances-summary)
+  - [VRF Instances Device Configuration](#vrf-instances-device-configuration)
+- [Quality Of Service](#quality-of-service)
+
+# Management
+
+## Management API HTTP
+
+### Management API HTTP Summary
+
+| HTTP | HTTPS | Default Services |
+| ---- | ----- | ---------------- |
+| False | True | - |
+
+### Management API VRF Access
+
+| VRF Name | IPv4 ACL | IPv6 ACL |
+| -------- | -------- | -------- |
+| MGMT | - | - |
+
+### Management API HTTP Configuration
+
+```eos
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+```
+
+# Authentication
+
+# Monitoring
+
+# MLAG
+
+## MLAG Summary
+
+| Domain-id | Local-interface | Peer-address | Peer-link |
+| --------- | --------------- | ------------ | --------- |
+| OSPF_SPINES | Vlan4094 | 192.168.254.1 | Port-Channel3 |
+
+Dual primary detection is disabled.
+
+## MLAG Device Configuration
+
+```eos
+!
+mlag configuration
+   domain-id OSPF_SPINES
+   local-interface Vlan4094
+   peer-address 192.168.254.1
+   peer-link Port-Channel3
+   reload-delay mlag 300
+   reload-delay non-mlag 330
+```
+
+# Spanning Tree
+
+## Spanning Tree Summary
+
+STP mode: **mstp**
+
+### Global Spanning-Tree Settings
+
+- Spanning Tree disabled for VLANs: **4094**
+
+## Spanning Tree Device Configuration
+
+```eos
+!
+no spanning-tree vlan-id 4094
+```
+
+# Internal VLAN Allocation Policy
+
+## Internal VLAN Allocation Policy Summary
+
+| Policy Allocation | Range Beginning | Range Ending |
+| ------------------| --------------- | ------------ |
+| ascending | 1006 | 1199 |
+
+## Internal VLAN Allocation Policy Configuration
+
+```eos
+!
+vlan internal order ascending range 1006 1199
+```
+
+# VLANs
+
+## VLANs Summary
+
+| VLAN ID | Name | Trunk Groups |
+| ------- | ---- | ------------ |
+| 100 | SVI_100 | - |
+| 2999 | MLAG_iBGP_default | LEAF_PEER_L3 |
+| 4094 | MLAG_PEER | MLAG |
+
+## VLANs Device Configuration
+
+```eos
+!
+vlan 100
+   name SVI_100
+!
+vlan 2999
+   name MLAG_iBGP_default
+   trunk group LEAF_PEER_L3
+!
+vlan 4094
+   name MLAG_PEER
+   trunk group MLAG
+```
+
+# Interfaces
+
+## Ethernet Interfaces
+
+### Ethernet Interfaces Summary
+
+#### L2
+
+| Interface | Description | Mode | VLANs | Native VLAN | Trunk Group | Channel-Group |
+| --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
+| Ethernet1 | OSPF-LEAF1_Ethernet1 | *trunk | *100 | *- | *- | 1 |
+| Ethernet2 | OSPF-LEAF2_Ethernet1 | *trunk | *100 | *- | *- | 2 |
+| Ethernet3 | MLAG_PEER_OSPF-SPINE2_Ethernet3 | *trunk | *2-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 3 |
+| Ethernet4 | MLAG_PEER_OSPF-SPINE2_Ethernet4 | *trunk | *2-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 3 |
+
+*Inherited from Port-Channel Interface
+
+### Ethernet Interfaces Device Configuration
+
+```eos
+!
+interface Ethernet1
+   description OSPF-LEAF1_Ethernet1
+   no shutdown
+   channel-group 1 mode active
+!
+interface Ethernet2
+   description OSPF-LEAF2_Ethernet1
+   no shutdown
+   channel-group 2 mode active
+!
+interface Ethernet3
+   description MLAG_PEER_OSPF-SPINE2_Ethernet3
+   no shutdown
+   channel-group 3 mode active
+!
+interface Ethernet4
+   description MLAG_PEER_OSPF-SPINE2_Ethernet4
+   no shutdown
+   channel-group 3 mode active
+```
+
+## Port-Channel Interfaces
+
+### Port-Channel Interfaces Summary
+
+#### L2
+
+| Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
+| --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
+| Port-Channel1 | OSPF-LEAF1_Po1 | switched | trunk | 100 | - | - | - | - | 1 | - |
+| Port-Channel2 | OSPF-LEAF2_Po1 | switched | trunk | 100 | - | - | - | - | 2 | - |
+| Port-Channel3 | MLAG_PEER_OSPF-SPINE2_Po3 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
+
+### Port-Channel Interfaces Device Configuration
+
+```eos
+!
+interface Port-Channel1
+   description OSPF-LEAF1_Po1
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 100
+   switchport mode trunk
+   mlag 1
+!
+interface Port-Channel2
+   description OSPF-LEAF2_Po1
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 100
+   switchport mode trunk
+   mlag 2
+!
+interface Port-Channel3
+   description MLAG_PEER_OSPF-SPINE2_Po3
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 2-4094
+   switchport mode trunk
+   switchport trunk group LEAF_PEER_L3
+   switchport trunk group MLAG
+```
+
+## Loopback Interfaces
+
+### Loopback Interfaces Summary
+
+#### IPv4
+
+| Interface | Description | VRF | IP Address |
+| --------- | ----------- | --- | ---------- |
+| Loopback0 | - | default | 192.168.255.1/32 |
+
+#### IPv6
+
+| Interface | Description | VRF | IPv6 Address |
+| --------- | ----------- | --- | ------------ |
+| Loopback0 | - | default | - |
+
+
+### Loopback Interfaces Device Configuration
+
+```eos
+!
+interface Loopback0
+   no shutdown
+   ip address 192.168.255.1/32
+   ip ospf area 0.0.0.0
+```
+
+## VLAN Interfaces
+
+### VLAN Interfaces Summary
+
+| Interface | Description | VRF |  MTU | Shutdown |
+| --------- | ----------- | --- | ---- | -------- |
+| Vlan100 | SVI_100 | default | - | false |
+| Vlan4094 | MLAG_PEER | default | 9000 | false |
+
+#### IPv4
+
+| Interface | VRF | IP Address | IP Address Virtual | IP Router Virtual Address | VRRP | ACL In | ACL Out |
+| --------- | --- | ---------- | ------------------ | ------------------------- | ---- | ------ | ------- |
+| Vlan100 |  default  |  -  |  10.0.100.1/24  |  -  |  -  |  -  |  -  |
+| Vlan4094 |  default  |  192.168.254.0/31  |  -  |  -  |  -  |  -  |  -  |
+
+### VLAN Interfaces Device Configuration
+
+```eos
+!
+interface Vlan100
+   description SVI_100
+   no shutdown
+   ip address virtual 10.0.100.1/24
+!
+interface Vlan4094
+   description MLAG_PEER
+   no shutdown
+   mtu 9000
+   no autostate
+   ip address 192.168.254.0/31
+   ip ospf network point-to-point
+   ip ospf area 0.0.0.0
+```
+
+# Routing
+## Service Routing Protocols Model
+
+Multi agent routing protocol model enabled
+
+```eos
+!
+service routing protocols model multi-agent
+```
+
+## Virtual Router MAC Address
+
+### Virtual Router MAC Address Summary
+
+#### Virtual Router MAC Address: 00:1c:73:00:00:99
+
+### Virtual Router MAC Address Configuration
+
+```eos
+!
+ip virtual-router mac-address 00:1c:73:00:00:99
+```
+
+## IP Routing
+
+### IP Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | true |
+| MGMT | false |
+
+### IP Routing Device Configuration
+
+```eos
+!
+ip routing
+no ip routing vrf MGMT
+```
+## IPv6 Routing
+
+### IPv6 Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | false |
+| MGMT | false |
+
+## Static Routes
+
+### Static Routes Summary
+
+| VRF | Destination Prefix | Next Hop IP             | Exit interface      | Administrative Distance       | Tag               | Route Name                    | Metric         |
+| --- | ------------------ | ----------------------- | ------------------- | ----------------------------- | ----------------- | ----------------------------- | -------------- |
+| MGMT | 0.0.0.0/0 | - | - | 1 | - | - | - |
+
+### Static Routes Device Configuration
+
+```eos
+!
+ip route vrf MGMT 0.0.0.0/0
+```
+
+## Router OSPF
+
+### Router OSPF Summary
+
+| Process ID | Router ID | Default Passive Interface | No Passive Interface | BFD | Max LSA | Default Information Originate | Log Adjacency Changes Detail | Auto Cost Reference Bandwidth | Maximum Paths | MPLS LDP Sync Default | Distribute List In |
+| ---------- | --------- | ------------------------- | -------------------- | --- | ------- | ----------------------------- | ---------------------------- | ----------------------------- | ------------- | --------------------- | ------------------ |
+| 100 | 192.168.255.1 | enabled |- | disabled | 12000 | disabled | disabled | - | - | - | - |
+
+### OSPF Interfaces
+
+| Interface | Area | Cost | Point To Point |
+| -------- | -------- | -------- | -------- |
+| Vlan4094 | 0.0.0.0 | - | True |
+| Loopback0 | 0.0.0.0 | - | - |
+
+### Router OSPF Device Configuration
+
+```eos
+!
+router ospf 100
+   router-id 192.168.255.1
+   passive-interface default
+   max-lsa 12000
+```
+
+# Multicast
+
+## IP IGMP Snooping
+
+### IP IGMP Snooping Summary
+
+| IGMP Snooping | Fast Leave | Interface Restart Query | Proxy | Restart Query Interval | Robustness Variable |
+| ------------- | ---------- | ----------------------- | ----- | ---------------------- | ------------------- |
+| Enabled | - | - | - | - | - |
+
+### IP IGMP Snooping Device Configuration
+
+```eos
+```
+
+# Filters
+
+# ACL
+
+# VRF Instances
+
+## VRF Instances Summary
+
+| VRF Name | IP Routing |
+| -------- | ---------- |
+| MGMT | disabled |
+
+## VRF Instances Device Configuration
+
+```eos
+!
+vrf instance MGMT
+```
+
+# Quality Of Service

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/OSPF-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/OSPF-SPINE2.md
@@ -1,0 +1,422 @@
+# OSPF-SPINE2
+# Table of Contents
+
+- [Management](#management)
+  - [Management API HTTP](#management-api-http)
+- [Authentication](#authentication)
+- [Monitoring](#monitoring)
+- [MLAG](#mlag)
+  - [MLAG Summary](#mlag-summary)
+  - [MLAG Device Configuration](#mlag-device-configuration)
+- [Spanning Tree](#spanning-tree)
+  - [Spanning Tree Summary](#spanning-tree-summary)
+  - [Spanning Tree Device Configuration](#spanning-tree-device-configuration)
+- [Internal VLAN Allocation Policy](#internal-vlan-allocation-policy)
+  - [Internal VLAN Allocation Policy Summary](#internal-vlan-allocation-policy-summary)
+  - [Internal VLAN Allocation Policy Configuration](#internal-vlan-allocation-policy-configuration)
+- [VLANs](#vlans)
+  - [VLANs Summary](#vlans-summary)
+  - [VLANs Device Configuration](#vlans-device-configuration)
+- [Interfaces](#interfaces)
+  - [Ethernet Interfaces](#ethernet-interfaces)
+  - [Port-Channel Interfaces](#port-channel-interfaces)
+  - [Loopback Interfaces](#loopback-interfaces)
+  - [VLAN Interfaces](#vlan-interfaces)
+- [Routing](#routing)
+  - [Service Routing Protocols Model](#service-routing-protocols-model)
+  - [Virtual Router MAC Address](#virtual-router-mac-address)
+  - [IP Routing](#ip-routing)
+  - [IPv6 Routing](#ipv6-routing)
+  - [Static Routes](#static-routes)
+  - [Router OSPF](#router-ospf)
+- [Multicast](#multicast)
+  - [IP IGMP Snooping](#ip-igmp-snooping)
+- [Filters](#filters)
+- [ACL](#acl)
+- [VRF Instances](#vrf-instances)
+  - [VRF Instances Summary](#vrf-instances-summary)
+  - [VRF Instances Device Configuration](#vrf-instances-device-configuration)
+- [Quality Of Service](#quality-of-service)
+
+# Management
+
+## Management API HTTP
+
+### Management API HTTP Summary
+
+| HTTP | HTTPS | Default Services |
+| ---- | ----- | ---------------- |
+| False | True | - |
+
+### Management API VRF Access
+
+| VRF Name | IPv4 ACL | IPv6 ACL |
+| -------- | -------- | -------- |
+| MGMT | - | - |
+
+### Management API HTTP Configuration
+
+```eos
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+```
+
+# Authentication
+
+# Monitoring
+
+# MLAG
+
+## MLAG Summary
+
+| Domain-id | Local-interface | Peer-address | Peer-link |
+| --------- | --------------- | ------------ | --------- |
+| OSPF_SPINES | Vlan4094 | 192.168.254.0 | Port-Channel3 |
+
+Dual primary detection is disabled.
+
+## MLAG Device Configuration
+
+```eos
+!
+mlag configuration
+   domain-id OSPF_SPINES
+   local-interface Vlan4094
+   peer-address 192.168.254.0
+   peer-link Port-Channel3
+   reload-delay mlag 300
+   reload-delay non-mlag 330
+```
+
+# Spanning Tree
+
+## Spanning Tree Summary
+
+STP mode: **mstp**
+
+### Global Spanning-Tree Settings
+
+- Spanning Tree disabled for VLANs: **4094**
+
+## Spanning Tree Device Configuration
+
+```eos
+!
+no spanning-tree vlan-id 4094
+```
+
+# Internal VLAN Allocation Policy
+
+## Internal VLAN Allocation Policy Summary
+
+| Policy Allocation | Range Beginning | Range Ending |
+| ------------------| --------------- | ------------ |
+| ascending | 1006 | 1199 |
+
+## Internal VLAN Allocation Policy Configuration
+
+```eos
+!
+vlan internal order ascending range 1006 1199
+```
+
+# VLANs
+
+## VLANs Summary
+
+| VLAN ID | Name | Trunk Groups |
+| ------- | ---- | ------------ |
+| 100 | SVI_100 | - |
+| 2999 | MLAG_iBGP_default | LEAF_PEER_L3 |
+| 4094 | MLAG_PEER | MLAG |
+
+## VLANs Device Configuration
+
+```eos
+!
+vlan 100
+   name SVI_100
+!
+vlan 2999
+   name MLAG_iBGP_default
+   trunk group LEAF_PEER_L3
+!
+vlan 4094
+   name MLAG_PEER
+   trunk group MLAG
+```
+
+# Interfaces
+
+## Ethernet Interfaces
+
+### Ethernet Interfaces Summary
+
+#### L2
+
+| Interface | Description | Mode | VLANs | Native VLAN | Trunk Group | Channel-Group |
+| --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
+| Ethernet1 | OSPF-LEAF1_Ethernet2 | *trunk | *100 | *- | *- | 1 |
+| Ethernet2 | OSPF-LEAF2_Ethernet2 | *trunk | *100 | *- | *- | 2 |
+| Ethernet3 | MLAG_PEER_OSPF-SPINE1_Ethernet3 | *trunk | *2-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 3 |
+| Ethernet4 | MLAG_PEER_OSPF-SPINE1_Ethernet4 | *trunk | *2-4094 | *- | *['LEAF_PEER_L3', 'MLAG'] | 3 |
+
+*Inherited from Port-Channel Interface
+
+### Ethernet Interfaces Device Configuration
+
+```eos
+!
+interface Ethernet1
+   description OSPF-LEAF1_Ethernet2
+   no shutdown
+   channel-group 1 mode active
+!
+interface Ethernet2
+   description OSPF-LEAF2_Ethernet2
+   no shutdown
+   channel-group 2 mode active
+!
+interface Ethernet3
+   description MLAG_PEER_OSPF-SPINE1_Ethernet3
+   no shutdown
+   channel-group 3 mode active
+!
+interface Ethernet4
+   description MLAG_PEER_OSPF-SPINE1_Ethernet4
+   no shutdown
+   channel-group 3 mode active
+```
+
+## Port-Channel Interfaces
+
+### Port-Channel Interfaces Summary
+
+#### L2
+
+| Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
+| --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
+| Port-Channel1 | OSPF-LEAF1_Po1 | switched | trunk | 100 | - | - | - | - | 1 | - |
+| Port-Channel2 | OSPF-LEAF2_Po1 | switched | trunk | 100 | - | - | - | - | 2 | - |
+| Port-Channel3 | MLAG_PEER_OSPF-SPINE1_Po3 | switched | trunk | 2-4094 | - | ['LEAF_PEER_L3', 'MLAG'] | - | - | - | - |
+
+### Port-Channel Interfaces Device Configuration
+
+```eos
+!
+interface Port-Channel1
+   description OSPF-LEAF1_Po1
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 100
+   switchport mode trunk
+   mlag 1
+!
+interface Port-Channel2
+   description OSPF-LEAF2_Po1
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 100
+   switchport mode trunk
+   mlag 2
+!
+interface Port-Channel3
+   description MLAG_PEER_OSPF-SPINE1_Po3
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 2-4094
+   switchport mode trunk
+   switchport trunk group LEAF_PEER_L3
+   switchport trunk group MLAG
+```
+
+## Loopback Interfaces
+
+### Loopback Interfaces Summary
+
+#### IPv4
+
+| Interface | Description | VRF | IP Address |
+| --------- | ----------- | --- | ---------- |
+| Loopback0 | - | default | 192.168.255.2/32 |
+
+#### IPv6
+
+| Interface | Description | VRF | IPv6 Address |
+| --------- | ----------- | --- | ------------ |
+| Loopback0 | - | default | - |
+
+
+### Loopback Interfaces Device Configuration
+
+```eos
+!
+interface Loopback0
+   no shutdown
+   ip address 192.168.255.2/32
+   ip ospf area 0.0.0.0
+```
+
+## VLAN Interfaces
+
+### VLAN Interfaces Summary
+
+| Interface | Description | VRF |  MTU | Shutdown |
+| --------- | ----------- | --- | ---- | -------- |
+| Vlan100 | SVI_100 | default | - | false |
+| Vlan4094 | MLAG_PEER | default | 9000 | false |
+
+#### IPv4
+
+| Interface | VRF | IP Address | IP Address Virtual | IP Router Virtual Address | VRRP | ACL In | ACL Out |
+| --------- | --- | ---------- | ------------------ | ------------------------- | ---- | ------ | ------- |
+| Vlan100 |  default  |  -  |  10.0.100.1/24  |  -  |  -  |  -  |  -  |
+| Vlan4094 |  default  |  192.168.254.1/31  |  -  |  -  |  -  |  -  |  -  |
+
+### VLAN Interfaces Device Configuration
+
+```eos
+!
+interface Vlan100
+   description SVI_100
+   no shutdown
+   ip address virtual 10.0.100.1/24
+!
+interface Vlan4094
+   description MLAG_PEER
+   no shutdown
+   mtu 9000
+   no autostate
+   ip address 192.168.254.1/31
+   ip ospf network point-to-point
+   ip ospf area 0.0.0.0
+```
+
+# Routing
+## Service Routing Protocols Model
+
+Multi agent routing protocol model enabled
+
+```eos
+!
+service routing protocols model multi-agent
+```
+
+## Virtual Router MAC Address
+
+### Virtual Router MAC Address Summary
+
+#### Virtual Router MAC Address: 00:1c:73:00:00:99
+
+### Virtual Router MAC Address Configuration
+
+```eos
+!
+ip virtual-router mac-address 00:1c:73:00:00:99
+```
+
+## IP Routing
+
+### IP Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | true |
+| MGMT | false |
+
+### IP Routing Device Configuration
+
+```eos
+!
+ip routing
+no ip routing vrf MGMT
+```
+## IPv6 Routing
+
+### IPv6 Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | false |
+| MGMT | false |
+
+## Static Routes
+
+### Static Routes Summary
+
+| VRF | Destination Prefix | Next Hop IP             | Exit interface      | Administrative Distance       | Tag               | Route Name                    | Metric         |
+| --- | ------------------ | ----------------------- | ------------------- | ----------------------------- | ----------------- | ----------------------------- | -------------- |
+| MGMT | 0.0.0.0/0 | - | - | 1 | - | - | - |
+
+### Static Routes Device Configuration
+
+```eos
+!
+ip route vrf MGMT 0.0.0.0/0
+```
+
+## Router OSPF
+
+### Router OSPF Summary
+
+| Process ID | Router ID | Default Passive Interface | No Passive Interface | BFD | Max LSA | Default Information Originate | Log Adjacency Changes Detail | Auto Cost Reference Bandwidth | Maximum Paths | MPLS LDP Sync Default | Distribute List In |
+| ---------- | --------- | ------------------------- | -------------------- | --- | ------- | ----------------------------- | ---------------------------- | ----------------------------- | ------------- | --------------------- | ------------------ |
+| 100 | 192.168.255.2 | enabled |- | disabled | 12000 | disabled | disabled | - | - | - | - |
+
+### OSPF Interfaces
+
+| Interface | Area | Cost | Point To Point |
+| -------- | -------- | -------- | -------- |
+| Vlan4094 | 0.0.0.0 | - | True |
+| Loopback0 | 0.0.0.0 | - | - |
+
+### Router OSPF Device Configuration
+
+```eos
+!
+router ospf 100
+   router-id 192.168.255.2
+   passive-interface default
+   max-lsa 12000
+```
+
+# Multicast
+
+## IP IGMP Snooping
+
+### IP IGMP Snooping Summary
+
+| IGMP Snooping | Fast Leave | Interface Restart Query | Proxy | Restart Query Interval | Robustness Variable |
+| ------------- | ---------- | ----------------------- | ----- | ---------------------- | ------------------- |
+| Enabled | - | - | - | - | - |
+
+### IP IGMP Snooping Device Configuration
+
+```eos
+```
+
+# Filters
+
+# ACL
+
+# VRF Instances
+
+## VRF Instances Summary
+
+| VRF Name | IP Routing |
+| -------- | ---------- |
+| MGMT | disabled |
+
+## VRF Instances Device Configuration
+
+```eos
+!
+vrf instance MGMT
+```
+
+# Quality Of Service

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/OSPF-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/OSPF-SPINE2.md
@@ -168,6 +168,12 @@ vlan 4094
 
 *Inherited from Port-Channel Interface
 
+#### IPv4
+
+| Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
+| --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
+| Ethernet5 | P2P_LINK_TO_DUMMY-CORE_Ethernet1/2 | routed | - | 192.168.253.2/31 | default | 9000 | false | - | - |
+
 ### Ethernet Interfaces Device Configuration
 
 ```eos
@@ -191,6 +197,15 @@ interface Ethernet4
    description MLAG_PEER_OSPF-SPINE1_Ethernet4
    no shutdown
    channel-group 3 mode active
+!
+interface Ethernet5
+   description P2P_LINK_TO_DUMMY-CORE_Ethernet1/2
+   no shutdown
+   mtu 9000
+   no switchport
+   ip address 192.168.253.2/31
+   ip ospf network point-to-point
+   ip ospf area 0.0.0.0
 ```
 
 ## Port-Channel Interfaces
@@ -366,12 +381,13 @@ ip route vrf MGMT 0.0.0.0/0
 
 | Process ID | Router ID | Default Passive Interface | No Passive Interface | BFD | Max LSA | Default Information Originate | Log Adjacency Changes Detail | Auto Cost Reference Bandwidth | Maximum Paths | MPLS LDP Sync Default | Distribute List In |
 | ---------- | --------- | ------------------------- | -------------------- | --- | ------- | ----------------------------- | ---------------------------- | ----------------------------- | ------------- | --------------------- | ------------------ |
-| 100 | 192.168.255.2 | enabled |- | disabled | 12000 | disabled | disabled | - | - | - | - |
+| 100 | 192.168.255.2 | enabled | Ethernet5 <br> | disabled | 12000 | disabled | disabled | - | - | - | - |
 
 ### OSPF Interfaces
 
 | Interface | Area | Cost | Point To Point |
 | -------- | -------- | -------- | -------- |
+| Ethernet5 | 0.0.0.0 | - | True |
 | Vlan4094 | 0.0.0.0 | - | True |
 | Loopback0 | 0.0.0.0 | - | - |
 
@@ -382,6 +398,7 @@ ip route vrf MGMT 0.0.0.0/0
 router ospf 100
    router-id 192.168.255.2
    passive-interface default
+   no passive-interface Ethernet5
    max-lsa 12000
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/fabric/L2LS-documentation.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/fabric/L2LS-documentation.md
@@ -1,0 +1,75 @@
+# L2LS
+
+# Table of Contents
+
+- [Fabric Switches and Management IP](#fabric-switches-and-management-ip)
+  - [Fabric Switches with inband Management IP](#fabric-switches-with-inband-management-ip)
+- [Fabric Topology](#fabric-topology)
+- [Fabric IP Allocation](#fabric-ip-allocation)
+  - [Fabric Point-To-Point Links](#fabric-point-to-point-links)
+  - [Point-To-Point Links Node Allocation](#point-to-point-links-node-allocation)
+  - [Loopback Interfaces (BGP EVPN Peering)](#loopback-interfaces-bgp-evpn-peering)
+  - [Loopback0 Interfaces Node Allocation](#loopback0-interfaces-node-allocation)
+  - [VTEP Loopback VXLAN Tunnel Source Interfaces (VTEPs Only)](#vtep-loopback-vxlan-tunnel-source-interfaces-vteps-only)
+  - [VTEP Loopback Node allocation](#vtep-loopback-node-allocation)
+
+# Fabric Switches and Management IP
+
+| POD | Type | Node | Management IP | Platform | Provisioned in CloudVision |
+| --- | ---- | ---- | ------------- | -------- | -------------------------- |
+| L2LS_OSPF | leaf | OSPF-LEAF1 | - | - | Provisioned |
+| L2LS_OSPF | leaf | OSPF-LEAF2 | - | - | Provisioned |
+| L2LS_OSPF | spine | OSPF-SPINE1 | - | - | Provisioned |
+| L2LS_OSPF | spine | OSPF-SPINE2 | - | - | Provisioned |
+
+> Provision status is based on Ansible inventory declaration and do not represent real status from CloudVision.
+
+## Fabric Switches with inband Management IP
+| POD | Type | Node | Management IP | Inband Interface |
+| --- | ---- | ---- | ------------- | ---------------- |
+
+# Fabric Topology
+
+| Type | Node | Node Interface | Peer Type | Peer Node | Peer Interface |
+| ---- | ---- | -------------- | --------- | ----------| -------------- |
+| leaf | OSPF-LEAF1 | Ethernet1 | spine | OSPF-SPINE1 | Ethernet1 |
+| leaf | OSPF-LEAF1 | Ethernet2 | spine | OSPF-SPINE2 | Ethernet1 |
+| leaf | OSPF-LEAF2 | Ethernet1 | spine | OSPF-SPINE1 | Ethernet2 |
+| leaf | OSPF-LEAF2 | Ethernet2 | spine | OSPF-SPINE2 | Ethernet2 |
+| spine | OSPF-SPINE1 | Ethernet3 | mlag_peer | OSPF-SPINE2 | Ethernet3 |
+| spine | OSPF-SPINE1 | Ethernet4 | mlag_peer | OSPF-SPINE2 | Ethernet4 |
+
+# Fabric IP Allocation
+
+## Fabric Point-To-Point Links
+
+| Uplink IPv4 Pool | Available Addresses | Assigned addresses | Assigned Address % |
+| ---------------- | ------------------- | ------------------ | ------------------ |
+
+## Point-To-Point Links Node Allocation
+
+| Node | Node Interface | Node IP Address | Peer Node | Peer Interface | Peer IP Address |
+| ---- | -------------- | --------------- | --------- | -------------- | --------------- |
+
+## Loopback Interfaces (BGP EVPN Peering)
+
+| Loopback Pool | Available Addresses | Assigned addresses | Assigned Address % |
+| ------------- | ------------------- | ------------------ | ------------------ |
+| 192.168.255.0/24 | 256 | 2 | 0.79 % |
+
+## Loopback0 Interfaces Node Allocation
+
+| POD | Node | Loopback0 |
+| --- | ---- | --------- |
+| L2LS_OSPF | OSPF-SPINE1 | 192.168.255.1/32 |
+| L2LS_OSPF | OSPF-SPINE2 | 192.168.255.2/32 |
+
+## VTEP Loopback VXLAN Tunnel Source Interfaces (VTEPs Only)
+
+| VTEP Loopback Pool | Available Addresses | Assigned addresses | Assigned Address % |
+| --------------------- | ------------------- | ------------------ | ------------------ |
+
+## VTEP Loopback Node allocation
+
+| POD | Node | Loopback1 |
+| --- | ---- | --------- |

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/fabric/L2LS-documentation.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/fabric/L2LS-documentation.md
@@ -17,6 +17,10 @@
 
 | POD | Type | Node | Management IP | Platform | Provisioned in CloudVision |
 | --- | ---- | ---- | ------------- | -------- | -------------------------- |
+| L2LS_BGP | leaf | BGP-LEAF1 | - | - | Provisioned |
+| L2LS_BGP | leaf | BGP-LEAF2 | - | - | Provisioned |
+| L2LS_BGP | spine | BGP-SPINE1 | - | - | Provisioned |
+| L2LS_BGP | spine | BGP-SPINE2 | - | - | Provisioned |
 | L2LS_OSPF | leaf | OSPF-LEAF1 | - | - | Provisioned |
 | L2LS_OSPF | leaf | OSPF-LEAF2 | - | - | Provisioned |
 | L2LS_OSPF | spine | OSPF-SPINE1 | - | - | Provisioned |
@@ -32,6 +36,12 @@
 
 | Type | Node | Node Interface | Peer Type | Peer Node | Peer Interface |
 | ---- | ---- | -------------- | --------- | ----------| -------------- |
+| leaf | BGP-LEAF1 | Ethernet1 | spine | BGP-SPINE1 | Ethernet1 |
+| leaf | BGP-LEAF1 | Ethernet2 | spine | BGP-SPINE2 | Ethernet1 |
+| leaf | BGP-LEAF2 | Ethernet1 | spine | BGP-SPINE1 | Ethernet2 |
+| leaf | BGP-LEAF2 | Ethernet2 | spine | BGP-SPINE2 | Ethernet2 |
+| spine | BGP-SPINE1 | Ethernet3 | mlag_peer | BGP-SPINE2 | Ethernet3 |
+| spine | BGP-SPINE1 | Ethernet4 | mlag_peer | BGP-SPINE2 | Ethernet4 |
 | leaf | OSPF-LEAF1 | Ethernet1 | spine | OSPF-SPINE1 | Ethernet1 |
 | leaf | OSPF-LEAF1 | Ethernet2 | spine | OSPF-SPINE2 | Ethernet1 |
 | leaf | OSPF-LEAF2 | Ethernet1 | spine | OSPF-SPINE1 | Ethernet2 |
@@ -55,12 +65,14 @@
 
 | Loopback Pool | Available Addresses | Assigned addresses | Assigned Address % |
 | ------------- | ------------------- | ------------------ | ------------------ |
-| 192.168.255.0/24 | 256 | 2 | 0.79 % |
+| 192.168.255.0/24 | 256 | 4 | 1.57 % |
 
 ## Loopback0 Interfaces Node Allocation
 
 | POD | Node | Loopback0 |
 | --- | ---- | --------- |
+| L2LS_BGP | BGP-SPINE1 | 192.168.255.1/32 |
+| L2LS_BGP | BGP-SPINE2 | 192.168.255.2/32 |
 | L2LS_OSPF | OSPF-SPINE1 | 192.168.255.1/32 |
 | L2LS_OSPF | OSPF-SPINE2 | 192.168.255.2/32 |
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/fabric/L2LS-p2p-links.csv
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/fabric/L2LS-p2p-links.csv
@@ -1,0 +1,1 @@
+Type,Node,Node Interface,Leaf IP Address,Peer Type,Peer Node,Peer Interface,Peer IP Address

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/fabric/L2LS-topology.csv
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/fabric/L2LS-topology.csv
@@ -1,4 +1,22 @@
 Node Type,Node,Node Interface,Peer Type,Peer Node,Peer Interface,Node Interface Enabled
+leaf,BGP-LEAF1,Ethernet1,spine,BGP-SPINE1,Ethernet1,True
+leaf,BGP-LEAF1,Ethernet2,spine,BGP-SPINE2,Ethernet1,True
+leaf,BGP-LEAF1,Ethernet10,network_port,Endpoint,,True
+leaf,BGP-LEAF1,Ethernet11,network_port,Endpoint,,True
+leaf,BGP-LEAF2,Ethernet1,spine,BGP-SPINE1,Ethernet2,True
+leaf,BGP-LEAF2,Ethernet2,spine,BGP-SPINE2,Ethernet2,True
+leaf,BGP-LEAF2,Ethernet10,network_port,Endpoint,,True
+leaf,BGP-LEAF2,Ethernet11,network_port,Endpoint,,True
+spine,BGP-SPINE1,Ethernet1,leaf,BGP-LEAF1,Ethernet1,True
+spine,BGP-SPINE1,Ethernet2,leaf,BGP-LEAF2,Ethernet1,True
+spine,BGP-SPINE1,Ethernet3,mlag_peer,BGP-SPINE2,Ethernet3,True
+spine,BGP-SPINE1,Ethernet4,mlag_peer,BGP-SPINE2,Ethernet4,True
+spine,BGP-SPINE1,Ethernet5,other,DUMMY-CORE,Ethernet1/3,True
+spine,BGP-SPINE2,Ethernet1,leaf,BGP-LEAF1,Ethernet2,True
+spine,BGP-SPINE2,Ethernet2,leaf,BGP-LEAF2,Ethernet2,True
+spine,BGP-SPINE2,Ethernet3,mlag_peer,BGP-SPINE1,Ethernet3,True
+spine,BGP-SPINE2,Ethernet4,mlag_peer,BGP-SPINE1,Ethernet4,True
+spine,BGP-SPINE2,Ethernet5,other,DUMMY-CORE,Ethernet1/4,True
 leaf,OSPF-LEAF1,Ethernet1,spine,OSPF-SPINE1,Ethernet1,True
 leaf,OSPF-LEAF1,Ethernet2,spine,OSPF-SPINE2,Ethernet1,True
 leaf,OSPF-LEAF1,Ethernet10,network_port,Endpoint,,True
@@ -11,7 +29,9 @@ spine,OSPF-SPINE1,Ethernet1,leaf,OSPF-LEAF1,Ethernet1,True
 spine,OSPF-SPINE1,Ethernet2,leaf,OSPF-LEAF2,Ethernet1,True
 spine,OSPF-SPINE1,Ethernet3,mlag_peer,OSPF-SPINE2,Ethernet3,True
 spine,OSPF-SPINE1,Ethernet4,mlag_peer,OSPF-SPINE2,Ethernet4,True
+spine,OSPF-SPINE1,Ethernet5,other,DUMMY-CORE,Ethernet1/1,True
 spine,OSPF-SPINE2,Ethernet1,leaf,OSPF-LEAF1,Ethernet2,True
 spine,OSPF-SPINE2,Ethernet2,leaf,OSPF-LEAF2,Ethernet2,True
 spine,OSPF-SPINE2,Ethernet3,mlag_peer,OSPF-SPINE1,Ethernet3,True
 spine,OSPF-SPINE2,Ethernet4,mlag_peer,OSPF-SPINE1,Ethernet4,True
+spine,OSPF-SPINE2,Ethernet5,other,DUMMY-CORE,Ethernet1/2,True

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/fabric/L2LS-topology.csv
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/fabric/L2LS-topology.csv
@@ -1,0 +1,17 @@
+Node Type,Node,Node Interface,Peer Type,Peer Node,Peer Interface,Node Interface Enabled
+leaf,OSPF-LEAF1,Ethernet1,spine,OSPF-SPINE1,Ethernet1,True
+leaf,OSPF-LEAF1,Ethernet2,spine,OSPF-SPINE2,Ethernet1,True
+leaf,OSPF-LEAF1,Ethernet10,network_port,Endpoint,,True
+leaf,OSPF-LEAF1,Ethernet11,network_port,Endpoint,,True
+leaf,OSPF-LEAF2,Ethernet1,spine,OSPF-SPINE1,Ethernet2,True
+leaf,OSPF-LEAF2,Ethernet2,spine,OSPF-SPINE2,Ethernet2,True
+leaf,OSPF-LEAF2,Ethernet10,network_port,Endpoint,,True
+leaf,OSPF-LEAF2,Ethernet11,network_port,Endpoint,,True
+spine,OSPF-SPINE1,Ethernet1,leaf,OSPF-LEAF1,Ethernet1,True
+spine,OSPF-SPINE1,Ethernet2,leaf,OSPF-LEAF2,Ethernet1,True
+spine,OSPF-SPINE1,Ethernet3,mlag_peer,OSPF-SPINE2,Ethernet3,True
+spine,OSPF-SPINE1,Ethernet4,mlag_peer,OSPF-SPINE2,Ethernet4,True
+spine,OSPF-SPINE2,Ethernet1,leaf,OSPF-LEAF1,Ethernet2,True
+spine,OSPF-SPINE2,Ethernet2,leaf,OSPF-LEAF2,Ethernet2,True
+spine,OSPF-SPINE2,Ethernet3,mlag_peer,OSPF-SPINE1,Ethernet3,True
+spine,OSPF-SPINE2,Ethernet4,mlag_peer,OSPF-SPINE1,Ethernet4,True

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/BGP-LEAF1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/BGP-LEAF1.cfg
@@ -1,0 +1,62 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname BGP-LEAF1
+!
+no enable password
+no aaa root
+!
+vlan 100
+   name SVI_100
+!
+vrf instance MGMT
+!
+interface Port-Channel1
+   description BGP_SPINES_Po1
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 100
+   switchport mode trunk
+!
+interface Ethernet1
+   description BGP-SPINE1_Ethernet1
+   no shutdown
+   channel-group 1 mode active
+!
+interface Ethernet2
+   description BGP-SPINE2_Ethernet1
+   no shutdown
+   channel-group 1 mode active
+!
+interface Ethernet10
+   description Endpoint
+   no shutdown
+   switchport access vlan 100
+   switchport mode access
+   switchport
+!
+interface Ethernet11
+   description Endpoint
+   no shutdown
+   switchport access vlan 100
+   switchport mode access
+   switchport
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip route vrf MGMT 0.0.0.0/0
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/BGP-LEAF2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/BGP-LEAF2.cfg
@@ -1,0 +1,62 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname BGP-LEAF2
+!
+no enable password
+no aaa root
+!
+vlan 100
+   name SVI_100
+!
+vrf instance MGMT
+!
+interface Port-Channel1
+   description BGP_SPINES_Po2
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 100
+   switchport mode trunk
+!
+interface Ethernet1
+   description BGP-SPINE1_Ethernet2
+   no shutdown
+   channel-group 1 mode active
+!
+interface Ethernet2
+   description BGP-SPINE2_Ethernet2
+   no shutdown
+   channel-group 1 mode active
+!
+interface Ethernet10
+   description Endpoint
+   no shutdown
+   switchport access vlan 100
+   switchport mode access
+   switchport
+!
+interface Ethernet11
+   description Endpoint
+   no shutdown
+   switchport access vlan 100
+   switchport mode access
+   switchport
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip route vrf MGMT 0.0.0.0/0
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/BGP-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/BGP-SPINE1.cfg
@@ -6,7 +6,7 @@ transceiver qsfp default-mode 4x10G
 !
 service routing protocols model multi-agent
 !
-hostname OSPF-SPINE1
+hostname BGP-SPINE1
 !
 no spanning-tree vlan-id 4094
 !
@@ -27,7 +27,7 @@ vlan 4094
 vrf instance MGMT
 !
 interface Port-Channel1
-   description OSPF-LEAF1_Po1
+   description BGP-LEAF1_Po1
    no shutdown
    switchport
    switchport trunk allowed vlan 100
@@ -35,7 +35,7 @@ interface Port-Channel1
    mlag 1
 !
 interface Port-Channel2
-   description OSPF-LEAF2_Po1
+   description BGP-LEAF2_Po1
    no shutdown
    switchport
    switchport trunk allowed vlan 100
@@ -43,7 +43,7 @@ interface Port-Channel2
    mlag 2
 !
 interface Port-Channel3
-   description MLAG_PEER_OSPF-SPINE2_Po3
+   description MLAG_PEER_BGP-SPINE2_Po3
    no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
@@ -52,43 +52,40 @@ interface Port-Channel3
    switchport trunk group MLAG
 !
 interface Ethernet1
-   description OSPF-LEAF1_Ethernet1
+   description BGP-LEAF1_Ethernet1
    no shutdown
    channel-group 1 mode active
 !
 interface Ethernet2
-   description OSPF-LEAF2_Ethernet1
+   description BGP-LEAF2_Ethernet1
    no shutdown
    channel-group 2 mode active
 !
 interface Ethernet3
-   description MLAG_PEER_OSPF-SPINE2_Ethernet3
+   description MLAG_PEER_BGP-SPINE2_Ethernet3
    no shutdown
    channel-group 3 mode active
 !
 interface Ethernet4
-   description MLAG_PEER_OSPF-SPINE2_Ethernet4
+   description MLAG_PEER_BGP-SPINE2_Ethernet4
    no shutdown
    channel-group 3 mode active
 !
 interface Ethernet5
-   description P2P_LINK_TO_DUMMY-CORE_Ethernet1/1
+   description P2P_LINK_TO_DUMMY-CORE_Ethernet1/3
    no shutdown
    mtu 9000
    no switchport
-   ip address 192.168.253.0/31
-   ip ospf network point-to-point
-   ip ospf area 0.0.0.0
+   ip address 192.168.253.4/31
 !
 interface Loopback0
    no shutdown
    ip address 192.168.255.1/32
-   ip ospf area 0.0.0.0
 !
 interface Vlan100
    description SVI_100
    no shutdown
-   ip address virtual 10.0.100.1/24
+   ip address virtual 10.1.100.1/24
 !
 interface Vlan4094
    description MLAG_PEER
@@ -96,16 +93,17 @@ interface Vlan4094
    mtu 9000
    no autostate
    ip address 192.168.254.0/31
-   ip ospf network point-to-point
-   ip ospf area 0.0.0.0
 !
 ip virtual-router mac-address 00:1c:73:00:00:99
 !
 ip routing
 no ip routing vrf MGMT
 !
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+!
 mlag configuration
-   domain-id OSPF_SPINES
+   domain-id BGP_SPINES
    local-interface Vlan4094
    peer-address 192.168.254.1
    peer-link Port-Channel3
@@ -114,11 +112,36 @@ mlag configuration
 !
 ip route vrf MGMT 0.0.0.0/0
 !
-router ospf 100
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+route-map RM-MLAG-PEER-IN permit 10
+   description Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing
+   set origin incomplete
+!
+router bgp 65001
    router-id 192.168.255.1
-   passive-interface default
-   no passive-interface Ethernet5
-   max-lsa 12000
+   maximum-paths 4 ecmp 4
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   neighbor MLAG-IPv4-UNDERLAY-PEER peer group
+   neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65001
+   neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
+   neighbor MLAG-IPv4-UNDERLAY-PEER description BGP-SPINE2
+   neighbor MLAG-IPv4-UNDERLAY-PEER send-community
+   neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000
+   neighbor MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN in
+   neighbor 192.168.253.5 peer group IPv4-UNDERLAY-PEERS
+   neighbor 192.168.253.5 remote-as 65000
+   neighbor 192.168.253.5 description DUMMY-CORE
+   neighbor 192.168.254.1 peer group MLAG-IPv4-UNDERLAY-PEER
+   neighbor 192.168.254.1 description BGP-SPINE2
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   address-family ipv4
+      neighbor IPv4-UNDERLAY-PEERS activate
+      neighbor MLAG-IPv4-UNDERLAY-PEER activate
 !
 management api http-commands
    protocol https

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/BGP-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/BGP-SPINE2.cfg
@@ -6,7 +6,7 @@ transceiver qsfp default-mode 4x10G
 !
 service routing protocols model multi-agent
 !
-hostname OSPF-SPINE2
+hostname BGP-SPINE2
 !
 no spanning-tree vlan-id 4094
 !
@@ -27,7 +27,7 @@ vlan 4094
 vrf instance MGMT
 !
 interface Port-Channel1
-   description OSPF-LEAF1_Po1
+   description BGP-LEAF1_Po1
    no shutdown
    switchport
    switchport trunk allowed vlan 100
@@ -35,7 +35,7 @@ interface Port-Channel1
    mlag 1
 !
 interface Port-Channel2
-   description OSPF-LEAF2_Po1
+   description BGP-LEAF2_Po1
    no shutdown
    switchport
    switchport trunk allowed vlan 100
@@ -43,7 +43,7 @@ interface Port-Channel2
    mlag 2
 !
 interface Port-Channel3
-   description MLAG_PEER_OSPF-SPINE1_Po3
+   description MLAG_PEER_BGP-SPINE1_Po3
    no shutdown
    switchport
    switchport trunk allowed vlan 2-4094
@@ -52,43 +52,40 @@ interface Port-Channel3
    switchport trunk group MLAG
 !
 interface Ethernet1
-   description OSPF-LEAF1_Ethernet2
+   description BGP-LEAF1_Ethernet2
    no shutdown
    channel-group 1 mode active
 !
 interface Ethernet2
-   description OSPF-LEAF2_Ethernet2
+   description BGP-LEAF2_Ethernet2
    no shutdown
    channel-group 2 mode active
 !
 interface Ethernet3
-   description MLAG_PEER_OSPF-SPINE1_Ethernet3
+   description MLAG_PEER_BGP-SPINE1_Ethernet3
    no shutdown
    channel-group 3 mode active
 !
 interface Ethernet4
-   description MLAG_PEER_OSPF-SPINE1_Ethernet4
+   description MLAG_PEER_BGP-SPINE1_Ethernet4
    no shutdown
    channel-group 3 mode active
 !
 interface Ethernet5
-   description P2P_LINK_TO_DUMMY-CORE_Ethernet1/2
+   description P2P_LINK_TO_DUMMY-CORE_Ethernet1/4
    no shutdown
    mtu 9000
    no switchport
-   ip address 192.168.253.2/31
-   ip ospf network point-to-point
-   ip ospf area 0.0.0.0
+   ip address 192.168.253.6/31
 !
 interface Loopback0
    no shutdown
    ip address 192.168.255.2/32
-   ip ospf area 0.0.0.0
 !
 interface Vlan100
    description SVI_100
    no shutdown
-   ip address virtual 10.0.100.1/24
+   ip address virtual 10.1.100.1/24
 !
 interface Vlan4094
    description MLAG_PEER
@@ -96,16 +93,17 @@ interface Vlan4094
    mtu 9000
    no autostate
    ip address 192.168.254.1/31
-   ip ospf network point-to-point
-   ip ospf area 0.0.0.0
 !
 ip virtual-router mac-address 00:1c:73:00:00:99
 !
 ip routing
 no ip routing vrf MGMT
 !
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+!
 mlag configuration
-   domain-id OSPF_SPINES
+   domain-id BGP_SPINES
    local-interface Vlan4094
    peer-address 192.168.254.0
    peer-link Port-Channel3
@@ -114,11 +112,36 @@ mlag configuration
 !
 ip route vrf MGMT 0.0.0.0/0
 !
-router ospf 100
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+route-map RM-MLAG-PEER-IN permit 10
+   description Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing
+   set origin incomplete
+!
+router bgp 65001
    router-id 192.168.255.2
-   passive-interface default
-   no passive-interface Ethernet5
-   max-lsa 12000
+   maximum-paths 4 ecmp 4
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   neighbor MLAG-IPv4-UNDERLAY-PEER peer group
+   neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65001
+   neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
+   neighbor MLAG-IPv4-UNDERLAY-PEER description BGP-SPINE1
+   neighbor MLAG-IPv4-UNDERLAY-PEER send-community
+   neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000
+   neighbor MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN in
+   neighbor 192.168.253.7 peer group IPv4-UNDERLAY-PEERS
+   neighbor 192.168.253.7 remote-as 65000
+   neighbor 192.168.253.7 description DUMMY-CORE
+   neighbor 192.168.254.0 peer group MLAG-IPv4-UNDERLAY-PEER
+   neighbor 192.168.254.0 description BGP-SPINE1
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   address-family ipv4
+      neighbor IPv4-UNDERLAY-PEERS activate
+      neighbor MLAG-IPv4-UNDERLAY-PEER activate
 !
 management api http-commands
    protocol https

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/OSPF-LEAF1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/OSPF-LEAF1.cfg
@@ -1,0 +1,62 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname OSPF-LEAF1
+!
+no enable password
+no aaa root
+!
+vlan 100
+   name SVI_100
+!
+vrf instance MGMT
+!
+interface Port-Channel1
+   description OSPF_SPINES_Po1
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 100
+   switchport mode trunk
+!
+interface Ethernet1
+   description OSPF-SPINE1_Ethernet1
+   no shutdown
+   channel-group 1 mode active
+!
+interface Ethernet2
+   description OSPF-SPINE2_Ethernet1
+   no shutdown
+   channel-group 1 mode active
+!
+interface Ethernet10
+   description Endpoint
+   no shutdown
+   switchport access vlan 100
+   switchport mode access
+   switchport
+!
+interface Ethernet11
+   description Endpoint
+   no shutdown
+   switchport access vlan 100
+   switchport mode access
+   switchport
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip route vrf MGMT 0.0.0.0/0
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/OSPF-LEAF2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/OSPF-LEAF2.cfg
@@ -1,0 +1,62 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname OSPF-LEAF2
+!
+no enable password
+no aaa root
+!
+vlan 100
+   name SVI_100
+!
+vrf instance MGMT
+!
+interface Port-Channel1
+   description OSPF_SPINES_Po2
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 100
+   switchport mode trunk
+!
+interface Ethernet1
+   description OSPF-SPINE1_Ethernet2
+   no shutdown
+   channel-group 1 mode active
+!
+interface Ethernet2
+   description OSPF-SPINE2_Ethernet2
+   no shutdown
+   channel-group 1 mode active
+!
+interface Ethernet10
+   description Endpoint
+   no shutdown
+   switchport access vlan 100
+   switchport mode access
+   switchport
+!
+interface Ethernet11
+   description Endpoint
+   no shutdown
+   switchport access vlan 100
+   switchport mode access
+   switchport
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip route vrf MGMT 0.0.0.0/0
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/OSPF-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/OSPF-SPINE1.cfg
@@ -1,0 +1,120 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname OSPF-SPINE1
+!
+no spanning-tree vlan-id 4094
+!
+no enable password
+no aaa root
+!
+vlan 100
+   name SVI_100
+!
+vlan 2999
+   name MLAG_iBGP_default
+   trunk group LEAF_PEER_L3
+!
+vlan 4094
+   name MLAG_PEER
+   trunk group MLAG
+!
+vrf instance MGMT
+!
+interface Port-Channel1
+   description OSPF-LEAF1_Po1
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 100
+   switchport mode trunk
+   mlag 1
+!
+interface Port-Channel2
+   description OSPF-LEAF2_Po1
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 100
+   switchport mode trunk
+   mlag 2
+!
+interface Port-Channel3
+   description MLAG_PEER_OSPF-SPINE2_Po3
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 2-4094
+   switchport mode trunk
+   switchport trunk group LEAF_PEER_L3
+   switchport trunk group MLAG
+!
+interface Ethernet1
+   description OSPF-LEAF1_Ethernet1
+   no shutdown
+   channel-group 1 mode active
+!
+interface Ethernet2
+   description OSPF-LEAF2_Ethernet1
+   no shutdown
+   channel-group 2 mode active
+!
+interface Ethernet3
+   description MLAG_PEER_OSPF-SPINE2_Ethernet3
+   no shutdown
+   channel-group 3 mode active
+!
+interface Ethernet4
+   description MLAG_PEER_OSPF-SPINE2_Ethernet4
+   no shutdown
+   channel-group 3 mode active
+!
+interface Loopback0
+   no shutdown
+   ip address 192.168.255.1/32
+   ip ospf area 0.0.0.0
+!
+interface Vlan100
+   description SVI_100
+   no shutdown
+   ip address virtual 10.0.100.1/24
+!
+interface Vlan4094
+   description MLAG_PEER
+   no shutdown
+   mtu 9000
+   no autostate
+   ip address 192.168.254.0/31
+   ip ospf network point-to-point
+   ip ospf area 0.0.0.0
+!
+ip virtual-router mac-address 00:1c:73:00:00:99
+!
+ip routing
+no ip routing vrf MGMT
+!
+mlag configuration
+   domain-id OSPF_SPINES
+   local-interface Vlan4094
+   peer-address 192.168.254.1
+   peer-link Port-Channel3
+   reload-delay mlag 300
+   reload-delay non-mlag 330
+!
+ip route vrf MGMT 0.0.0.0/0
+!
+router ospf 100
+   router-id 192.168.255.1
+   passive-interface default
+   max-lsa 12000
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/OSPF-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/OSPF-SPINE2.cfg
@@ -1,0 +1,120 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname OSPF-SPINE2
+!
+no spanning-tree vlan-id 4094
+!
+no enable password
+no aaa root
+!
+vlan 100
+   name SVI_100
+!
+vlan 2999
+   name MLAG_iBGP_default
+   trunk group LEAF_PEER_L3
+!
+vlan 4094
+   name MLAG_PEER
+   trunk group MLAG
+!
+vrf instance MGMT
+!
+interface Port-Channel1
+   description OSPF-LEAF1_Po1
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 100
+   switchport mode trunk
+   mlag 1
+!
+interface Port-Channel2
+   description OSPF-LEAF2_Po1
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 100
+   switchport mode trunk
+   mlag 2
+!
+interface Port-Channel3
+   description MLAG_PEER_OSPF-SPINE1_Po3
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 2-4094
+   switchport mode trunk
+   switchport trunk group LEAF_PEER_L3
+   switchport trunk group MLAG
+!
+interface Ethernet1
+   description OSPF-LEAF1_Ethernet2
+   no shutdown
+   channel-group 1 mode active
+!
+interface Ethernet2
+   description OSPF-LEAF2_Ethernet2
+   no shutdown
+   channel-group 2 mode active
+!
+interface Ethernet3
+   description MLAG_PEER_OSPF-SPINE1_Ethernet3
+   no shutdown
+   channel-group 3 mode active
+!
+interface Ethernet4
+   description MLAG_PEER_OSPF-SPINE1_Ethernet4
+   no shutdown
+   channel-group 3 mode active
+!
+interface Loopback0
+   no shutdown
+   ip address 192.168.255.2/32
+   ip ospf area 0.0.0.0
+!
+interface Vlan100
+   description SVI_100
+   no shutdown
+   ip address virtual 10.0.100.1/24
+!
+interface Vlan4094
+   description MLAG_PEER
+   no shutdown
+   mtu 9000
+   no autostate
+   ip address 192.168.254.1/31
+   ip ospf network point-to-point
+   ip ospf area 0.0.0.0
+!
+ip virtual-router mac-address 00:1c:73:00:00:99
+!
+ip routing
+no ip routing vrf MGMT
+!
+mlag configuration
+   domain-id OSPF_SPINES
+   local-interface Vlan4094
+   peer-address 192.168.254.0
+   peer-link Port-Channel3
+   reload-delay mlag 300
+   reload-delay non-mlag 330
+!
+ip route vrf MGMT 0.0.0.0/0
+!
+router ospf 100
+   router-id 192.168.255.2
+   passive-interface default
+   max-lsa 12000
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-LEAF1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-LEAF1.yml
@@ -1,0 +1,67 @@
+static_routes:
+- vrf: MGMT
+  destination_address_prefix: 0.0.0.0/0
+service_routing_protocols_model: multi-agent
+ip_routing: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+vrfs:
+  MGMT:
+    ip_routing: false
+management_api_http:
+  enable_vrfs:
+    MGMT: {}
+  enable_https: true
+ethernet_interfaces:
+  Ethernet1:
+    peer: BGP-SPINE1
+    peer_interface: Ethernet1
+    peer_type: spine
+    description: BGP-SPINE1_Ethernet1
+    type: switched
+    shutdown: false
+    channel_group:
+      id: 1
+      mode: active
+  Ethernet2:
+    peer: BGP-SPINE2
+    peer_interface: Ethernet1
+    peer_type: spine
+    description: BGP-SPINE2_Ethernet1
+    type: switched
+    shutdown: false
+    channel_group:
+      id: 1
+      mode: active
+  Ethernet10:
+    peer: Endpoint
+    peer_type: network_port
+    description: Endpoint
+    type: switched
+    shutdown: false
+    mode: access
+    vlans: 100
+  Ethernet11:
+    peer: Endpoint
+    peer_type: network_port
+    description: Endpoint
+    type: switched
+    shutdown: false
+    mode: access
+    vlans: 100
+port_channel_interfaces:
+  Port-Channel1:
+    description: BGP_SPINES_Po1
+    type: switched
+    shutdown: false
+    vlans: 100
+    mode: trunk
+vlans:
+  100:
+    tenant: L2LS_BGP
+    name: SVI_100
+ip_igmp_snooping:
+  globally_enabled: true

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-LEAF2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-LEAF2.yml
@@ -1,0 +1,67 @@
+static_routes:
+- vrf: MGMT
+  destination_address_prefix: 0.0.0.0/0
+service_routing_protocols_model: multi-agent
+ip_routing: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+vrfs:
+  MGMT:
+    ip_routing: false
+management_api_http:
+  enable_vrfs:
+    MGMT: {}
+  enable_https: true
+ethernet_interfaces:
+  Ethernet1:
+    peer: BGP-SPINE1
+    peer_interface: Ethernet2
+    peer_type: spine
+    description: BGP-SPINE1_Ethernet2
+    type: switched
+    shutdown: false
+    channel_group:
+      id: 1
+      mode: active
+  Ethernet2:
+    peer: BGP-SPINE2
+    peer_interface: Ethernet2
+    peer_type: spine
+    description: BGP-SPINE2_Ethernet2
+    type: switched
+    shutdown: false
+    channel_group:
+      id: 1
+      mode: active
+  Ethernet10:
+    peer: Endpoint
+    peer_type: network_port
+    description: Endpoint
+    type: switched
+    shutdown: false
+    mode: access
+    vlans: 100
+  Ethernet11:
+    peer: Endpoint
+    peer_type: network_port
+    description: Endpoint
+    type: switched
+    shutdown: false
+    mode: access
+    vlans: 100
+port_channel_interfaces:
+  Port-Channel1:
+    description: BGP_SPINES_Po2
+    type: switched
+    shutdown: false
+    vlans: 100
+    mode: trunk
+vlans:
+  100:
+    tenant: L2LS_BGP
+    name: SVI_100
+ip_igmp_snooping:
+  globally_enabled: true

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-SPINE1.yml
@@ -1,3 +1,38 @@
+router_bgp:
+  as: '65001'
+  router_id: 192.168.255.1
+  bgp_defaults:
+  - maximum-paths 4 ecmp 4
+  peer_groups:
+    MLAG-IPv4-UNDERLAY-PEER:
+      type: ipv4
+      remote_as: '65001'
+      next_hop_self: true
+      description: BGP-SPINE2
+      maximum_routes: 12000
+      send_community: all
+      route_map_in: RM-MLAG-PEER-IN
+    IPv4-UNDERLAY-PEERS:
+      type: ipv4
+      maximum_routes: 12000
+      send_community: all
+  address_family_ipv4:
+    peer_groups:
+      MLAG-IPv4-UNDERLAY-PEER:
+        activate: true
+      IPv4-UNDERLAY-PEERS:
+        activate: true
+  neighbors:
+    192.168.254.1:
+      peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: BGP-SPINE2
+    192.168.253.5:
+      remote_as: '65000'
+      description: DUMMY-CORE
+      peer_group: IPv4-UNDERLAY-PEERS
+  redistribute_routes:
+    connected:
+      route_map: RM-CONN-2-BGP
 static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0
@@ -24,10 +59,10 @@ vlans:
     trunk_groups:
     - MLAG
   100:
-    tenant: L2LS_OSPF
+    tenant: L2LS_BGP
     name: SVI_100
   2999:
-    tenant: L2LS_OSPF
+    tenant: L2LS_BGP
     name: MLAG_iBGP_default
     trunk_groups:
     - LEAF_PEER_L3
@@ -38,16 +73,14 @@ vlan_interfaces:
     ip_address: 192.168.254.0/31
     no_autostate: true
     mtu: 9000
-    ospf_network_point_to_point: true
-    ospf_area: 0.0.0.0
   Vlan100:
-    tenant: L2LS_OSPF
+    tenant: L2LS_BGP
     description: SVI_100
     shutdown: false
-    ip_address_virtual: 10.0.100.1/24
+    ip_address_virtual: 10.1.100.1/24
 port_channel_interfaces:
   Port-Channel3:
-    description: MLAG_PEER_OSPF-SPINE2_Po3
+    description: MLAG_PEER_BGP-SPINE2_Po3
     type: switched
     shutdown: false
     vlans: 2-4094
@@ -56,14 +89,14 @@ port_channel_interfaces:
     - LEAF_PEER_L3
     - MLAG
   Port-Channel1:
-    description: OSPF-LEAF1_Po1
+    description: BGP-LEAF1_Po1
     type: switched
     shutdown: false
     vlans: 100
     mode: trunk
     mlag: 1
   Port-Channel2:
-    description: OSPF-LEAF2_Po1
+    description: BGP-LEAF2_Po1
     type: switched
     shutdown: false
     vlans: 100
@@ -71,40 +104,40 @@ port_channel_interfaces:
     mlag: 2
 ethernet_interfaces:
   Ethernet3:
-    peer: OSPF-SPINE2
+    peer: BGP-SPINE2
     peer_interface: Ethernet3
     peer_type: mlag_peer
-    description: MLAG_PEER_OSPF-SPINE2_Ethernet3
+    description: MLAG_PEER_BGP-SPINE2_Ethernet3
     type: switched
     shutdown: false
     channel_group:
       id: 3
       mode: active
   Ethernet4:
-    peer: OSPF-SPINE2
+    peer: BGP-SPINE2
     peer_interface: Ethernet4
     peer_type: mlag_peer
-    description: MLAG_PEER_OSPF-SPINE2_Ethernet4
+    description: MLAG_PEER_BGP-SPINE2_Ethernet4
     type: switched
     shutdown: false
     channel_group:
       id: 3
       mode: active
   Ethernet1:
-    peer: OSPF-LEAF1
+    peer: BGP-LEAF1
     peer_interface: Ethernet1
     peer_type: leaf
-    description: OSPF-LEAF1_Ethernet1
+    description: BGP-LEAF1_Ethernet1
     type: switched
     shutdown: false
     channel_group:
       id: 1
       mode: active
   Ethernet2:
-    peer: OSPF-LEAF2
+    peer: BGP-LEAF2
     peer_interface: Ethernet1
     peer_type: leaf
-    description: OSPF-LEAF2_Ethernet1
+    description: BGP-LEAF2_Ethernet1
     type: switched
     shutdown: false
     channel_group:
@@ -112,35 +145,43 @@ ethernet_interfaces:
       mode: active
   Ethernet5:
     peer: DUMMY-CORE
-    peer_interface: Ethernet1/1
+    peer_interface: Ethernet1/3
     peer_type: other
-    description: P2P_LINK_TO_DUMMY-CORE_Ethernet1/1
+    description: P2P_LINK_TO_DUMMY-CORE_Ethernet1/3
     type: routed
     shutdown: false
     mtu: 9000
-    ip_address: 192.168.253.0/31
-    ospf_network_point_to_point: true
-    ospf_area: 0.0.0.0
+    ip_address: 192.168.253.4/31
 mlag_configuration:
-  domain_id: OSPF_SPINES
+  domain_id: BGP_SPINES
   local_interface: Vlan4094
   peer_address: 192.168.254.1
   peer_link: Port-Channel3
   reload_delay_mlag: 300
   reload_delay_non_mlag: 330
+route_maps:
+  RM-MLAG-PEER-IN:
+    sequence_numbers:
+      10:
+        type: permit
+        set:
+        - origin incomplete
+        description: Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing
+  RM-CONN-2-BGP:
+    sequence_numbers:
+      10:
+        type: permit
+        match:
+        - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
 loopback_interfaces:
   Loopback0:
     shutdown: false
     ip_address: 192.168.255.1/32
-    ospf_area: 0.0.0.0
-router_ospf:
-  process_ids:
-    100:
-      passive_interface_default: true
-      router_id: 192.168.255.1
-      max_lsa: 12000
-      no_passive_interfaces:
-      - Ethernet5
+prefix_lists:
+  PL-LOOPBACKS-EVPN-OVERLAY:
+    sequence_numbers:
+      10:
+        action: permit 192.168.255.0/24 eq 32
 ip_igmp_snooping:
   globally_enabled: true
 ip_virtual_router_mac_address: 00:1c:73:00:00:99

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-SPINE2.yml
@@ -1,3 +1,38 @@
+router_bgp:
+  as: '65001'
+  router_id: 192.168.255.2
+  bgp_defaults:
+  - maximum-paths 4 ecmp 4
+  peer_groups:
+    MLAG-IPv4-UNDERLAY-PEER:
+      type: ipv4
+      remote_as: '65001'
+      next_hop_self: true
+      description: BGP-SPINE1
+      maximum_routes: 12000
+      send_community: all
+      route_map_in: RM-MLAG-PEER-IN
+    IPv4-UNDERLAY-PEERS:
+      type: ipv4
+      maximum_routes: 12000
+      send_community: all
+  address_family_ipv4:
+    peer_groups:
+      MLAG-IPv4-UNDERLAY-PEER:
+        activate: true
+      IPv4-UNDERLAY-PEERS:
+        activate: true
+  neighbors:
+    192.168.254.0:
+      peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: BGP-SPINE1
+    192.168.253.7:
+      remote_as: '65000'
+      description: DUMMY-CORE
+      peer_group: IPv4-UNDERLAY-PEERS
+  redistribute_routes:
+    connected:
+      route_map: RM-CONN-2-BGP
 static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0
@@ -24,10 +59,10 @@ vlans:
     trunk_groups:
     - MLAG
   100:
-    tenant: L2LS_OSPF
+    tenant: L2LS_BGP
     name: SVI_100
   2999:
-    tenant: L2LS_OSPF
+    tenant: L2LS_BGP
     name: MLAG_iBGP_default
     trunk_groups:
     - LEAF_PEER_L3
@@ -38,16 +73,14 @@ vlan_interfaces:
     ip_address: 192.168.254.1/31
     no_autostate: true
     mtu: 9000
-    ospf_network_point_to_point: true
-    ospf_area: 0.0.0.0
   Vlan100:
-    tenant: L2LS_OSPF
+    tenant: L2LS_BGP
     description: SVI_100
     shutdown: false
-    ip_address_virtual: 10.0.100.1/24
+    ip_address_virtual: 10.1.100.1/24
 port_channel_interfaces:
   Port-Channel3:
-    description: MLAG_PEER_OSPF-SPINE1_Po3
+    description: MLAG_PEER_BGP-SPINE1_Po3
     type: switched
     shutdown: false
     vlans: 2-4094
@@ -56,14 +89,14 @@ port_channel_interfaces:
     - LEAF_PEER_L3
     - MLAG
   Port-Channel1:
-    description: OSPF-LEAF1_Po1
+    description: BGP-LEAF1_Po1
     type: switched
     shutdown: false
     vlans: 100
     mode: trunk
     mlag: 1
   Port-Channel2:
-    description: OSPF-LEAF2_Po1
+    description: BGP-LEAF2_Po1
     type: switched
     shutdown: false
     vlans: 100
@@ -71,40 +104,40 @@ port_channel_interfaces:
     mlag: 2
 ethernet_interfaces:
   Ethernet3:
-    peer: OSPF-SPINE1
+    peer: BGP-SPINE1
     peer_interface: Ethernet3
     peer_type: mlag_peer
-    description: MLAG_PEER_OSPF-SPINE1_Ethernet3
+    description: MLAG_PEER_BGP-SPINE1_Ethernet3
     type: switched
     shutdown: false
     channel_group:
       id: 3
       mode: active
   Ethernet4:
-    peer: OSPF-SPINE1
+    peer: BGP-SPINE1
     peer_interface: Ethernet4
     peer_type: mlag_peer
-    description: MLAG_PEER_OSPF-SPINE1_Ethernet4
+    description: MLAG_PEER_BGP-SPINE1_Ethernet4
     type: switched
     shutdown: false
     channel_group:
       id: 3
       mode: active
   Ethernet1:
-    peer: OSPF-LEAF1
+    peer: BGP-LEAF1
     peer_interface: Ethernet2
     peer_type: leaf
-    description: OSPF-LEAF1_Ethernet2
+    description: BGP-LEAF1_Ethernet2
     type: switched
     shutdown: false
     channel_group:
       id: 1
       mode: active
   Ethernet2:
-    peer: OSPF-LEAF2
+    peer: BGP-LEAF2
     peer_interface: Ethernet2
     peer_type: leaf
-    description: OSPF-LEAF2_Ethernet2
+    description: BGP-LEAF2_Ethernet2
     type: switched
     shutdown: false
     channel_group:
@@ -112,35 +145,43 @@ ethernet_interfaces:
       mode: active
   Ethernet5:
     peer: DUMMY-CORE
-    peer_interface: Ethernet1/2
+    peer_interface: Ethernet1/4
     peer_type: other
-    description: P2P_LINK_TO_DUMMY-CORE_Ethernet1/2
+    description: P2P_LINK_TO_DUMMY-CORE_Ethernet1/4
     type: routed
     shutdown: false
     mtu: 9000
-    ip_address: 192.168.253.2/31
-    ospf_network_point_to_point: true
-    ospf_area: 0.0.0.0
+    ip_address: 192.168.253.6/31
 mlag_configuration:
-  domain_id: OSPF_SPINES
+  domain_id: BGP_SPINES
   local_interface: Vlan4094
   peer_address: 192.168.254.0
   peer_link: Port-Channel3
   reload_delay_mlag: 300
   reload_delay_non_mlag: 330
+route_maps:
+  RM-MLAG-PEER-IN:
+    sequence_numbers:
+      10:
+        type: permit
+        set:
+        - origin incomplete
+        description: Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing
+  RM-CONN-2-BGP:
+    sequence_numbers:
+      10:
+        type: permit
+        match:
+        - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
 loopback_interfaces:
   Loopback0:
     shutdown: false
     ip_address: 192.168.255.2/32
-    ospf_area: 0.0.0.0
-router_ospf:
-  process_ids:
-    100:
-      passive_interface_default: true
-      router_id: 192.168.255.2
-      max_lsa: 12000
-      no_passive_interfaces:
-      - Ethernet5
+prefix_lists:
+  PL-LOOPBACKS-EVPN-OVERLAY:
+    sequence_numbers:
+      10:
+        action: permit 192.168.255.0/24 eq 32
 ip_igmp_snooping:
   globally_enabled: true
 ip_virtual_router_mac_address: 00:1c:73:00:00:99

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-LEAF1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-LEAF1.yml
@@ -1,0 +1,67 @@
+static_routes:
+- vrf: MGMT
+  destination_address_prefix: 0.0.0.0/0
+service_routing_protocols_model: multi-agent
+ip_routing: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+vrfs:
+  MGMT:
+    ip_routing: false
+management_api_http:
+  enable_vrfs:
+    MGMT: {}
+  enable_https: true
+ethernet_interfaces:
+  Ethernet1:
+    peer: OSPF-SPINE1
+    peer_interface: Ethernet1
+    peer_type: spine
+    description: OSPF-SPINE1_Ethernet1
+    type: switched
+    shutdown: false
+    channel_group:
+      id: 1
+      mode: active
+  Ethernet2:
+    peer: OSPF-SPINE2
+    peer_interface: Ethernet1
+    peer_type: spine
+    description: OSPF-SPINE2_Ethernet1
+    type: switched
+    shutdown: false
+    channel_group:
+      id: 1
+      mode: active
+  Ethernet10:
+    peer: Endpoint
+    peer_type: network_port
+    description: Endpoint
+    type: switched
+    shutdown: false
+    mode: access
+    vlans: 100
+  Ethernet11:
+    peer: Endpoint
+    peer_type: network_port
+    description: Endpoint
+    type: switched
+    shutdown: false
+    mode: access
+    vlans: 100
+port_channel_interfaces:
+  Port-Channel1:
+    description: OSPF_SPINES_Po1
+    type: switched
+    shutdown: false
+    vlans: 100
+    mode: trunk
+vlans:
+  100:
+    tenant: L2LS_OSPF
+    name: SVI_100
+ip_igmp_snooping:
+  globally_enabled: true

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-LEAF2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-LEAF2.yml
@@ -1,0 +1,67 @@
+static_routes:
+- vrf: MGMT
+  destination_address_prefix: 0.0.0.0/0
+service_routing_protocols_model: multi-agent
+ip_routing: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+vrfs:
+  MGMT:
+    ip_routing: false
+management_api_http:
+  enable_vrfs:
+    MGMT: {}
+  enable_https: true
+ethernet_interfaces:
+  Ethernet1:
+    peer: OSPF-SPINE1
+    peer_interface: Ethernet2
+    peer_type: spine
+    description: OSPF-SPINE1_Ethernet2
+    type: switched
+    shutdown: false
+    channel_group:
+      id: 1
+      mode: active
+  Ethernet2:
+    peer: OSPF-SPINE2
+    peer_interface: Ethernet2
+    peer_type: spine
+    description: OSPF-SPINE2_Ethernet2
+    type: switched
+    shutdown: false
+    channel_group:
+      id: 1
+      mode: active
+  Ethernet10:
+    peer: Endpoint
+    peer_type: network_port
+    description: Endpoint
+    type: switched
+    shutdown: false
+    mode: access
+    vlans: 100
+  Ethernet11:
+    peer: Endpoint
+    peer_type: network_port
+    description: Endpoint
+    type: switched
+    shutdown: false
+    mode: access
+    vlans: 100
+port_channel_interfaces:
+  Port-Channel1:
+    description: OSPF_SPINES_Po2
+    type: switched
+    shutdown: false
+    vlans: 100
+    mode: trunk
+vlans:
+  100:
+    tenant: L2LS_OSPF
+    name: SVI_100
+ip_igmp_snooping:
+  globally_enabled: true

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-SPINE1.yml
@@ -1,0 +1,133 @@
+static_routes:
+- vrf: MGMT
+  destination_address_prefix: 0.0.0.0/0
+service_routing_protocols_model: multi-agent
+ip_routing: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+vrfs:
+  MGMT:
+    ip_routing: false
+management_api_http:
+  enable_vrfs:
+    MGMT: {}
+  enable_https: true
+spanning_tree:
+  no_spanning_tree_vlan: 4094
+vlans:
+  4094:
+    tenant: system
+    name: MLAG_PEER
+    trunk_groups:
+    - MLAG
+  100:
+    tenant: L2LS_OSPF
+    name: SVI_100
+  2999:
+    tenant: L2LS_OSPF
+    name: MLAG_iBGP_default
+    trunk_groups:
+    - LEAF_PEER_L3
+vlan_interfaces:
+  Vlan4094:
+    description: MLAG_PEER
+    shutdown: false
+    ip_address: 192.168.254.0/31
+    no_autostate: true
+    mtu: 9000
+    ospf_network_point_to_point: true
+    ospf_area: 0.0.0.0
+  Vlan100:
+    tenant: L2LS_OSPF
+    description: SVI_100
+    shutdown: false
+    ip_address_virtual: 10.0.100.1/24
+port_channel_interfaces:
+  Port-Channel3:
+    description: MLAG_PEER_OSPF-SPINE2_Po3
+    type: switched
+    shutdown: false
+    vlans: 2-4094
+    mode: trunk
+    trunk_groups:
+    - LEAF_PEER_L3
+    - MLAG
+  Port-Channel1:
+    description: OSPF-LEAF1_Po1
+    type: switched
+    shutdown: false
+    vlans: 100
+    mode: trunk
+    mlag: 1
+  Port-Channel2:
+    description: OSPF-LEAF2_Po1
+    type: switched
+    shutdown: false
+    vlans: 100
+    mode: trunk
+    mlag: 2
+ethernet_interfaces:
+  Ethernet3:
+    peer: OSPF-SPINE2
+    peer_interface: Ethernet3
+    peer_type: mlag_peer
+    description: MLAG_PEER_OSPF-SPINE2_Ethernet3
+    type: switched
+    shutdown: false
+    channel_group:
+      id: 3
+      mode: active
+  Ethernet4:
+    peer: OSPF-SPINE2
+    peer_interface: Ethernet4
+    peer_type: mlag_peer
+    description: MLAG_PEER_OSPF-SPINE2_Ethernet4
+    type: switched
+    shutdown: false
+    channel_group:
+      id: 3
+      mode: active
+  Ethernet1:
+    peer: OSPF-LEAF1
+    peer_interface: Ethernet1
+    peer_type: leaf
+    description: OSPF-LEAF1_Ethernet1
+    type: switched
+    shutdown: false
+    channel_group:
+      id: 1
+      mode: active
+  Ethernet2:
+    peer: OSPF-LEAF2
+    peer_interface: Ethernet1
+    peer_type: leaf
+    description: OSPF-LEAF2_Ethernet1
+    type: switched
+    shutdown: false
+    channel_group:
+      id: 2
+      mode: active
+mlag_configuration:
+  domain_id: OSPF_SPINES
+  local_interface: Vlan4094
+  peer_address: 192.168.254.1
+  peer_link: Port-Channel3
+  reload_delay_mlag: 300
+  reload_delay_non_mlag: 330
+loopback_interfaces:
+  Loopback0:
+    shutdown: false
+    ip_address: 192.168.255.1/32
+    ospf_area: 0.0.0.0
+router_ospf:
+  process_ids:
+    100:
+      passive_interface_default: true
+      router_id: 192.168.255.1
+      max_lsa: 12000
+ip_igmp_snooping:
+  globally_enabled: true
+ip_virtual_router_mac_address: 00:1c:73:00:00:99

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-SPINE2.yml
@@ -1,0 +1,133 @@
+static_routes:
+- vrf: MGMT
+  destination_address_prefix: 0.0.0.0/0
+service_routing_protocols_model: multi-agent
+ip_routing: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+vrfs:
+  MGMT:
+    ip_routing: false
+management_api_http:
+  enable_vrfs:
+    MGMT: {}
+  enable_https: true
+spanning_tree:
+  no_spanning_tree_vlan: 4094
+vlans:
+  4094:
+    tenant: system
+    name: MLAG_PEER
+    trunk_groups:
+    - MLAG
+  100:
+    tenant: L2LS_OSPF
+    name: SVI_100
+  2999:
+    tenant: L2LS_OSPF
+    name: MLAG_iBGP_default
+    trunk_groups:
+    - LEAF_PEER_L3
+vlan_interfaces:
+  Vlan4094:
+    description: MLAG_PEER
+    shutdown: false
+    ip_address: 192.168.254.1/31
+    no_autostate: true
+    mtu: 9000
+    ospf_network_point_to_point: true
+    ospf_area: 0.0.0.0
+  Vlan100:
+    tenant: L2LS_OSPF
+    description: SVI_100
+    shutdown: false
+    ip_address_virtual: 10.0.100.1/24
+port_channel_interfaces:
+  Port-Channel3:
+    description: MLAG_PEER_OSPF-SPINE1_Po3
+    type: switched
+    shutdown: false
+    vlans: 2-4094
+    mode: trunk
+    trunk_groups:
+    - LEAF_PEER_L3
+    - MLAG
+  Port-Channel1:
+    description: OSPF-LEAF1_Po1
+    type: switched
+    shutdown: false
+    vlans: 100
+    mode: trunk
+    mlag: 1
+  Port-Channel2:
+    description: OSPF-LEAF2_Po1
+    type: switched
+    shutdown: false
+    vlans: 100
+    mode: trunk
+    mlag: 2
+ethernet_interfaces:
+  Ethernet3:
+    peer: OSPF-SPINE1
+    peer_interface: Ethernet3
+    peer_type: mlag_peer
+    description: MLAG_PEER_OSPF-SPINE1_Ethernet3
+    type: switched
+    shutdown: false
+    channel_group:
+      id: 3
+      mode: active
+  Ethernet4:
+    peer: OSPF-SPINE1
+    peer_interface: Ethernet4
+    peer_type: mlag_peer
+    description: MLAG_PEER_OSPF-SPINE1_Ethernet4
+    type: switched
+    shutdown: false
+    channel_group:
+      id: 3
+      mode: active
+  Ethernet1:
+    peer: OSPF-LEAF1
+    peer_interface: Ethernet2
+    peer_type: leaf
+    description: OSPF-LEAF1_Ethernet2
+    type: switched
+    shutdown: false
+    channel_group:
+      id: 1
+      mode: active
+  Ethernet2:
+    peer: OSPF-LEAF2
+    peer_interface: Ethernet2
+    peer_type: leaf
+    description: OSPF-LEAF2_Ethernet2
+    type: switched
+    shutdown: false
+    channel_group:
+      id: 2
+      mode: active
+mlag_configuration:
+  domain_id: OSPF_SPINES
+  local_interface: Vlan4094
+  peer_address: 192.168.254.0
+  peer_link: Port-Channel3
+  reload_delay_mlag: 300
+  reload_delay_non_mlag: 330
+loopback_interfaces:
+  Loopback0:
+    shutdown: false
+    ip_address: 192.168.255.2/32
+    ospf_area: 0.0.0.0
+router_ospf:
+  process_ids:
+    100:
+      passive_interface_default: true
+      router_id: 192.168.255.2
+      max_lsa: 12000
+ip_igmp_snooping:
+  globally_enabled: true
+ip_virtual_router_mac_address: 00:1c:73:00:00:99

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/inventory/group_vars/BGP_LEAFS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/inventory/group_vars/BGP_LEAFS.yml
@@ -1,0 +1,14 @@
+---
+type: leaf
+
+leaf:
+  defaults:
+    uplink_switches: [ BGP-SPINE1, BGP-SPINE2 ]
+    uplink_interfaces: [ Ethernet1, Ethernet2 ]
+  nodes:
+    BGP-LEAF1:
+      id: 1
+      uplink_switch_interfaces: [ Ethernet1, Ethernet1 ]
+    BGP-LEAF2:
+      id: 2
+      uplink_switch_interfaces: [ Ethernet2, Ethernet2 ]

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/inventory/group_vars/BGP_SPINES.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/inventory/group_vars/BGP_SPINES.yml
@@ -1,0 +1,19 @@
+---
+type: spine
+
+spine:
+  defaults:
+    loopback_ipv4_pool: 192.168.255.0/24
+    mlag_peer_ipv4_pool: 192.168.254.0/24
+    mlag_peer_l3_vlan: 4094
+    mlag_interfaces: [ Ethernet3, Ethernet4 ]
+    virtual_router_mac_address: 00:1c:73:00:00:99
+    spanning_tree_priority: 4096
+  node_groups:
+    BGP_SPINES:
+      bgp_as: 65001
+      nodes:
+        BGP-SPINE1:
+          id: 1
+        BGP-SPINE2:
+          id: 2

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/inventory/group_vars/L2LS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/inventory/group_vars/L2LS.yml
@@ -1,0 +1,7 @@
+---
+design:
+  type: l2ls
+
+fabric_name: L2LS
+
+mgmt_gateway: null

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/inventory/group_vars/L2LS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/inventory/group_vars/L2LS.yml
@@ -1,4 +1,12 @@
 ---
+# Basic test scenarios for L2LS design.
+
+# One POD with OSPF and one POD with BGP underlay routing
+# No overlay or VRFs
+# SVIs only in default VRF
+# Two spine and two leaf switches per POD
+# Core interfaces to non-existing core switch. (to test the underlay routing)
+
 design:
   type: l2ls
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/inventory/group_vars/L2LS_BGP.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/inventory/group_vars/L2LS_BGP.yml
@@ -1,0 +1,35 @@
+---
+
+pod_name: L2LS_BGP
+
+underlay_routing_protocol: ebgp
+
+tenants:
+  L2LS_BGP:
+    vrfs:
+      default:
+        svis:
+          100:
+            name: SVI_100
+            ip_address_virtual: 10.1.100.1/24
+            enabled: true
+
+network_ports:
+  - switches:
+      - "BGP-LEAF[1-2]"
+    switch_ports:
+      - "Ethernet10-11"
+    vlans: 100
+    mode: access
+    description: Endpoint
+
+core_interfaces:
+  p2p_links:
+    - subnet: 192.168.253.4/31
+      nodes: [ BGP-SPINE1, DUMMY-CORE ]
+      interfaces: [ Ethernet5, Ethernet1/3 ]
+      as: [ 65001, 65000 ]
+    - subnet: 192.168.253.6/31
+      nodes: [ BGP-SPINE2, DUMMY-CORE ]
+      interfaces: [ Ethernet5, Ethernet1/4 ]
+      as: [ 65001, 65000 ]

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/inventory/group_vars/L2LS_OSPF.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/inventory/group_vars/L2LS_OSPF.yml
@@ -1,0 +1,24 @@
+---
+
+pod_name: L2LS_OSPF
+
+underlay_routing_protocol: ospf
+
+tenants:
+  L2LS_OSPF:
+    vrfs:
+      default:
+        svis:
+          100:
+            name: SVI_100
+            ip_address_virtual: 10.0.100.1/24
+            enabled: true
+
+network_ports:
+  - switches:
+      - "OSPF-LEAF[1-2]"
+    switch_ports:
+      - "Ethernet10-11"
+    vlans: 100
+    mode: access
+    description: Endpoint

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/inventory/group_vars/L2LS_OSPF.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/inventory/group_vars/L2LS_OSPF.yml
@@ -22,3 +22,12 @@ network_ports:
     vlans: 100
     mode: access
     description: Endpoint
+
+core_interfaces:
+  p2p_links:
+    - subnet: 192.168.253.0/31
+      nodes: [ OSPF-SPINE1, DUMMY-CORE ]
+      interfaces: [ Ethernet5, Ethernet1/1 ]
+    - subnet: 192.168.253.2/31
+      nodes: [ OSPF-SPINE2, DUMMY-CORE ]
+      interfaces: [ Ethernet5, Ethernet1/2 ]

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/inventory/group_vars/OSPF_LEAFS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/inventory/group_vars/OSPF_LEAFS.yml
@@ -1,0 +1,14 @@
+---
+type: leaf
+
+leaf:
+  defaults:
+    uplink_switches: [ OSPF-SPINE1, OSPF-SPINE2 ]
+    uplink_interfaces: [ Ethernet1, Ethernet2 ]
+  nodes:
+    OSPF-LEAF1:
+      id: 1
+      uplink_switch_interfaces: [ Ethernet1, Ethernet1 ]
+    OSPF-LEAF2:
+      id: 2
+      uplink_switch_interfaces: [ Ethernet2, Ethernet2 ]

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/inventory/group_vars/OSPF_SPINES.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/inventory/group_vars/OSPF_SPINES.yml
@@ -1,0 +1,18 @@
+---
+type: spine
+
+spine:
+  defaults:
+    loopback_ipv4_pool: 192.168.255.0/24
+    mlag_peer_ipv4_pool: 192.168.254.0/24
+    mlag_peer_l3_vlan: 4094
+    mlag_interfaces: [ Ethernet3, Ethernet4 ]
+    virtual_router_mac_address: 00:1c:73:00:00:99
+    spanning_tree_priority: 4096
+  node_groups:
+    OSPF_SPINES:
+      nodes:
+        OSPF-SPINE1:
+          id: 1
+        OSPF-SPINE2:
+          id: 2

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/inventory/group_vars/all.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/inventory/group_vars/all.yml
@@ -1,0 +1,2 @@
+---
+root_dir: '{{playbook_dir}}'

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/inventory/host_vars/all.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/inventory/host_vars/all.yml
@@ -1,0 +1,2 @@
+---
+root_dir: '{{playbook_dir}}'

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/inventory/hosts.yml
@@ -1,0 +1,15 @@
+---
+all:
+  children:
+    L2LS:
+      children:
+        L2LS_OSPF:
+          children:
+            OSPF_SPINES:
+              hosts:
+                OSPF-SPINE1:
+                OSPF-SPINE2:
+            OSPF_LEAFS:
+              hosts:
+                OSPF-LEAF1:
+                OSPF-LEAF2:

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/inventory/hosts.yml
@@ -13,3 +13,13 @@ all:
               hosts:
                 OSPF-LEAF1:
                 OSPF-LEAF2:
+        L2LS_BGP:
+          children:
+            BGP_SPINES:
+              hosts:
+                BGP-SPINE1:
+                BGP-SPINE2:
+            BGP_LEAFS:
+              hosts:
+                BGP-LEAF1:
+                BGP-LEAF2:

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/molecule.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/molecule.yml
@@ -1,0 +1,55 @@
+---
+scenario:
+  converge_sequence:
+    - syntax
+    - create
+    - converge
+    - verify
+  test_sequence:
+    - syntax
+    - create
+    - converge
+    - idempotence
+    - verify
+  cleanup_sequence:
+    - destroy
+dependency:
+  name: galaxy
+driver:
+  name: delegated
+platforms:
+  - name: OSPF-SPINE1
+    image: avdteam/base:3.8-v2.0
+    pre_build_image: true
+    managed: false
+    groups:
+      - OSPF_SPINES
+      - L2LS_OSPF
+      - L2LS
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      jinja2_extensions: 'jinja2.ext.loopcontrols,jinja2.ext.do,jinja2.ext.i18n'
+      gathering: explicit
+
+  inventory:
+    links:
+      hosts: 'inventory/hosts.yml'
+      group_vars: 'inventory/group_vars/'
+      host_vars: 'inventory/host_vars/'
+  # ansible_args:
+  #   - --inventory=inventory/hosts.yml
+verifier:
+  name: ansible
+  inventory:
+    links:
+      hosts: 'inventory/hosts.yml'
+      group_vars: 'inventory/group_vars/'
+      host_vars: 'inventory/host_vars/'
+  # ansible_args:
+  #   - --inventory=inventory/hosts.yml
+  config_options:
+    defaults:
+      jinja2_extensions: 'jinja2.ext.loopcontrols,jinja2.ext.do,jinja2.ext.i18n'
+      gathering: explicit

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/verify.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/verify.yml
@@ -1,0 +1,10 @@
+---
+- name: Converge
+  hosts: all
+  gather_facts: false
+  connection: local
+  tasks:
+    - name: generate device intended config and documentation
+      delegate_to: 127.0.0.1
+      import_role:
+        name: arista.avd.eos_cli_config_gen


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Add molecule scenario for L2LS

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

Add basic test scenarios for L2LS design.
- On POD with OSPF and one POD with BGP underlay routing
- No overlay or VRFs
- A single SVI in default VRF
- Two spine and two leaf switches per POD
- Core interfaces to non-existing core switch. (to test the underlay routing)

This should be merged before the fixes for L2LS design issues. This will make it visible what the fixes do.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
