### PR TITLE
Fix(eos_designs): Missing IGP no-passive for single MLAG VLAN

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/OSPF-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/OSPF-SPINE1.md
@@ -376,7 +376,7 @@ ip route vrf MGMT 0.0.0.0/0
 
 | Process ID | Router ID | Default Passive Interface | No Passive Interface | BFD | Max LSA | Default Information Originate | Log Adjacency Changes Detail | Auto Cost Reference Bandwidth | Maximum Paths | MPLS LDP Sync Default | Distribute List In |
 | ---------- | --------- | ------------------------- | -------------------- | --- | ------- | ----------------------------- | ---------------------------- | ----------------------------- | ------------- | --------------------- | ------------------ |
-| 100 | 192.168.255.1 | enabled | Ethernet5 <br> | disabled | 12000 | disabled | disabled | - | - | - | - |
+| 100 | 192.168.255.1 | enabled | Vlan4094 <br> Ethernet5 <br> | disabled | 12000 | disabled | disabled | - | - | - | - |
 
 ### Router OSPF Router Redistribution
 
@@ -399,6 +399,7 @@ ip route vrf MGMT 0.0.0.0/0
 router ospf 100
    router-id 192.168.255.1
    passive-interface default
+   no passive-interface Vlan4094
    no passive-interface Ethernet5
    max-lsa 12000
    redistribute connected

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/OSPF-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/OSPF-SPINE2.md
@@ -376,7 +376,7 @@ ip route vrf MGMT 0.0.0.0/0
 
 | Process ID | Router ID | Default Passive Interface | No Passive Interface | BFD | Max LSA | Default Information Originate | Log Adjacency Changes Detail | Auto Cost Reference Bandwidth | Maximum Paths | MPLS LDP Sync Default | Distribute List In |
 | ---------- | --------- | ------------------------- | -------------------- | --- | ------- | ----------------------------- | ---------------------------- | ----------------------------- | ------------- | --------------------- | ------------------ |
-| 100 | 192.168.255.2 | enabled | Ethernet5 <br> | disabled | 12000 | disabled | disabled | - | - | - | - |
+| 100 | 192.168.255.2 | enabled | Vlan4094 <br> Ethernet5 <br> | disabled | 12000 | disabled | disabled | - | - | - | - |
 
 ### Router OSPF Router Redistribution
 
@@ -399,6 +399,7 @@ ip route vrf MGMT 0.0.0.0/0
 router ospf 100
    router-id 192.168.255.2
    passive-interface default
+   no passive-interface Vlan4094
    no passive-interface Ethernet5
    max-lsa 12000
    redistribute connected

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/OSPF-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/OSPF-SPINE1.cfg
@@ -113,6 +113,7 @@ ip route vrf MGMT 0.0.0.0/0
 router ospf 100
    router-id 192.168.255.1
    passive-interface default
+   no passive-interface Vlan4094
    no passive-interface Ethernet5
    max-lsa 12000
    redistribute connected

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/OSPF-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/OSPF-SPINE2.cfg
@@ -113,6 +113,7 @@ ip route vrf MGMT 0.0.0.0/0
 router ospf 100
    router-id 192.168.255.2
    passive-interface default
+   no passive-interface Vlan4094
    no passive-interface Ethernet5
    max-lsa 12000
    redistribute connected

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-SPINE1.yml
@@ -133,11 +133,12 @@ router_ospf:
     100:
       passive_interface_default: true
       router_id: 192.168.255.1
+      no_passive_interfaces:
+      - Vlan4094
+      - Ethernet5
       max_lsa: 12000
       redistribute:
         connected: {}
-      no_passive_interfaces:
-      - Ethernet5
 ip_igmp_snooping:
   globally_enabled: true
 ip_virtual_router_mac_address: 00:1c:73:00:00:99

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-SPINE2.yml
@@ -133,11 +133,12 @@ router_ospf:
     100:
       passive_interface_default: true
       router_id: 192.168.255.2
+      no_passive_interfaces:
+      - Vlan4094
+      - Ethernet5
       max_lsa: 12000
       redistribute:
         connected: {}
-      no_passive_interfaces:
-      - Ethernet5
 ip_igmp_snooping:
   globally_enabled: true
 ip_virtual_router_mac_address: 00:1c:73:00:00:99

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG-OSPF-L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG-OSPF-L3LEAF1A.cfg
@@ -141,6 +141,7 @@ router ospf 100
    router-id 192.168.255.36
    passive-interface default
    no passive-interface Ethernet1
+   no passive-interface Vlan4094
    max-lsa 12000
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG-OSPF-L3LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG-OSPF-L3LEAF1B.cfg
@@ -141,6 +141,7 @@ router ospf 100
    router-id 192.168.255.37
    passive-interface default
    no passive-interface Ethernet1
+   no passive-interface Vlan4094
    max-lsa 12000
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG-OSPF-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG-OSPF-L3LEAF1A.yml
@@ -171,6 +171,7 @@ router_ospf:
       router_id: 192.168.255.36
       no_passive_interfaces:
       - Ethernet1
+      - Vlan4094
       max_lsa: 12000
 router_bfd:
   multihop:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG-OSPF-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG-OSPF-L3LEAF1B.yml
@@ -171,6 +171,7 @@ router_ospf:
       router_id: 192.168.255.37
       no_passive_interfaces:
       - Ethernet1
+      - Vlan4094
       max_lsa: 12000
 router_bfd:
   multihop:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3A.md
@@ -219,14 +219,14 @@ STP mode: **mstp**
 
 ### Global Spanning-Tree Settings
 
-- Spanning Tree disabled for VLANs: **4093-4094**
+- Spanning Tree disabled for VLANs: **4094**
 
 ## Spanning Tree Device Configuration
 
 ```eos
 !
 spanning-tree mode mstp
-no spanning-tree vlan-id 4093-4094
+no spanning-tree vlan-id 4094
 spanning-tree mst 0 priority 4096
 ```
 
@@ -251,16 +251,11 @@ vlan internal order ascending range 1006 1199
 
 | VLAN ID | Name | Trunk Groups |
 | ------- | ---- | ------------ |
-| 4093 | LEAF_PEER_L3 | LEAF_PEER_L3 |
 | 4094 | MLAG_PEER | MLAG |
 
 ## VLANs Device Configuration
 
 ```eos
-!
-vlan 4093
-   name LEAF_PEER_L3
-   trunk group LEAF_PEER_L3
 !
 vlan 4094
    name MLAG_PEER
@@ -450,34 +445,23 @@ interface Loopback1
 
 | Interface | Description | VRF |  MTU | Shutdown |
 | --------- | ----------- | --- | ---- | -------- |
-| Vlan4093 | MLAG_PEER_L3_PEERING | default | 1500 | false |
 | Vlan4094 | MLAG_PEER | default | 1500 | false |
 
 #### IPv4
 
 | Interface | VRF | IP Address | IP Address Virtual | IP Router Virtual Address | VRRP | ACL In | ACL Out |
 | --------- | --- | ---------- | ------------------ | ------------------------- | ---- | ------ | ------- |
-| Vlan4093 |  default  |  10.255.251.6/31  |  -  |  -  |  -  |  -  |  -  |
 | Vlan4094 |  default  |  10.255.252.6/31  |  -  |  -  |  -  |  -  |  -  |
 
 #### ISIS
 
 | Interface | ISIS Instance | ISIS Metric | Mode |
 | --------- | ------------- | ----------- | ---- |
-| Vlan4093 | EVPN_UNDERLAY | 50 | point-to-point |
+| Vlan4094 | EVPN_UNDERLAY | 50 | point-to-point |
 
 ### VLAN Interfaces Device Configuration
 
 ```eos
-!
-interface Vlan4093
-   description MLAG_PEER_L3_PEERING
-   no shutdown
-   mtu 1500
-   ip address 10.255.251.6/31
-   isis enable EVPN_UNDERLAY
-   isis metric 50
-   isis network point-to-point
 !
 interface Vlan4094
    description MLAG_PEER
@@ -485,6 +469,9 @@ interface Vlan4094
    mtu 1500
    no autostate
    ip address 10.255.252.6/31
+   isis enable EVPN_UNDERLAY
+   isis metric 50
+   isis network point-to-point
 ```
 
 ## VXLAN Interface
@@ -592,7 +579,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | Ethernet2 | EVPN_UNDERLAY | 50 | point-to-point |
 | Ethernet3 | EVPN_UNDERLAY | 50 | point-to-point |
 | Ethernet4 | EVPN_UNDERLAY | 50 | point-to-point |
-| Vlan4093 | EVPN_UNDERLAY | 50 | point-to-point |
+| Vlan4094 | EVPN_UNDERLAY | 50 | point-to-point |
 | Loopback0 | EVPN_UNDERLAY | - | passive |
 | Loopback1 | EVPN_UNDERLAY | - | passive |
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3B.md
@@ -219,14 +219,14 @@ STP mode: **mstp**
 
 ### Global Spanning-Tree Settings
 
-- Spanning Tree disabled for VLANs: **4093-4094**
+- Spanning Tree disabled for VLANs: **4094**
 
 ## Spanning Tree Device Configuration
 
 ```eos
 !
 spanning-tree mode mstp
-no spanning-tree vlan-id 4093-4094
+no spanning-tree vlan-id 4094
 spanning-tree mst 0 priority 4096
 ```
 
@@ -251,16 +251,11 @@ vlan internal order ascending range 1006 1199
 
 | VLAN ID | Name | Trunk Groups |
 | ------- | ---- | ------------ |
-| 4093 | LEAF_PEER_L3 | LEAF_PEER_L3 |
 | 4094 | MLAG_PEER | MLAG |
 
 ## VLANs Device Configuration
 
 ```eos
-!
-vlan 4093
-   name LEAF_PEER_L3
-   trunk group LEAF_PEER_L3
 !
 vlan 4094
    name MLAG_PEER
@@ -450,34 +445,23 @@ interface Loopback1
 
 | Interface | Description | VRF |  MTU | Shutdown |
 | --------- | ----------- | --- | ---- | -------- |
-| Vlan4093 | MLAG_PEER_L3_PEERING | default | 1500 | false |
 | Vlan4094 | MLAG_PEER | default | 1500 | false |
 
 #### IPv4
 
 | Interface | VRF | IP Address | IP Address Virtual | IP Router Virtual Address | VRRP | ACL In | ACL Out |
 | --------- | --- | ---------- | ------------------ | ------------------------- | ---- | ------ | ------- |
-| Vlan4093 |  default  |  10.255.251.7/31  |  -  |  -  |  -  |  -  |  -  |
 | Vlan4094 |  default  |  10.255.252.7/31  |  -  |  -  |  -  |  -  |  -  |
 
 #### ISIS
 
 | Interface | ISIS Instance | ISIS Metric | Mode |
 | --------- | ------------- | ----------- | ---- |
-| Vlan4093 | EVPN_UNDERLAY | 50 | point-to-point |
+| Vlan4094 | EVPN_UNDERLAY | 50 | point-to-point |
 
 ### VLAN Interfaces Device Configuration
 
 ```eos
-!
-interface Vlan4093
-   description MLAG_PEER_L3_PEERING
-   no shutdown
-   mtu 1500
-   ip address 10.255.251.7/31
-   isis enable EVPN_UNDERLAY
-   isis metric 50
-   isis network point-to-point
 !
 interface Vlan4094
    description MLAG_PEER
@@ -485,6 +469,9 @@ interface Vlan4094
    mtu 1500
    no autostate
    ip address 10.255.252.7/31
+   isis enable EVPN_UNDERLAY
+   isis metric 50
+   isis network point-to-point
 ```
 
 ## VXLAN Interface
@@ -592,7 +579,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | Ethernet2 | EVPN_UNDERLAY | 50 | point-to-point |
 | Ethernet3 | EVPN_UNDERLAY | 50 | point-to-point |
 | Ethernet4 | EVPN_UNDERLAY | 50 | point-to-point |
-| Vlan4093 | EVPN_UNDERLAY | 50 | point-to-point |
+| Vlan4094 | EVPN_UNDERLAY | 50 | point-to-point |
 | Loopback0 | EVPN_UNDERLAY | - | passive |
 | Loopback1 | EVPN_UNDERLAY | - | passive |
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SVC3A.cfg
@@ -18,7 +18,7 @@ ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 !
 spanning-tree mode mstp
-no spanning-tree vlan-id 4093-4094
+no spanning-tree vlan-id 4094
 spanning-tree mst 0 priority 4096
 !
 no enable password
@@ -26,10 +26,6 @@ no aaa root
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
-!
-vlan 4093
-   name LEAF_PEER_L3
-   trunk group LEAF_PEER_L3
 !
 vlan 4094
    name MLAG_PEER
@@ -134,21 +130,15 @@ interface Management1
    vrf MGMT
    ip address 192.168.200.108/24
 !
-interface Vlan4093
-   description MLAG_PEER_L3_PEERING
-   no shutdown
-   mtu 1500
-   ip address 10.255.251.6/31
-   isis enable EVPN_UNDERLAY
-   isis metric 50
-   isis network point-to-point
-!
 interface Vlan4094
    description MLAG_PEER
    no shutdown
    mtu 1500
    no autostate
    ip address 10.255.252.6/31
+   isis enable EVPN_UNDERLAY
+   isis metric 50
+   isis network point-to-point
 !
 interface Vxlan1
    description DC1-SVC3A_VTEP

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SVC3B.cfg
@@ -18,7 +18,7 @@ ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 !
 spanning-tree mode mstp
-no spanning-tree vlan-id 4093-4094
+no spanning-tree vlan-id 4094
 spanning-tree mst 0 priority 4096
 !
 no enable password
@@ -26,10 +26,6 @@ no aaa root
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
-!
-vlan 4093
-   name LEAF_PEER_L3
-   trunk group LEAF_PEER_L3
 !
 vlan 4094
    name MLAG_PEER
@@ -134,21 +130,15 @@ interface Management1
    vrf MGMT
    ip address 192.168.200.109/24
 !
-interface Vlan4093
-   description MLAG_PEER_L3_PEERING
-   no shutdown
-   mtu 1500
-   ip address 10.255.251.7/31
-   isis enable EVPN_UNDERLAY
-   isis metric 50
-   isis network point-to-point
-!
 interface Vlan4094
    description MLAG_PEER
    no shutdown
    mtu 1500
    no autostate
    ip address 10.255.252.7/31
+   isis enable EVPN_UNDERLAY
+   isis metric 50
+   isis network point-to-point
 !
 interface Vxlan1
    description DC1-SVC3B_VTEP

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SVC3A.yml
@@ -63,7 +63,7 @@ spanning_tree:
   mst_instances:
     '0':
       priority: 4096
-  no_spanning_tree_vlan: 4093-4094
+  no_spanning_tree_vlan: 4094
 local_users:
   admin:
     privilege: 15
@@ -89,31 +89,21 @@ management_api_http:
     MGMT: {}
   enable_https: true
 vlans:
-  4093:
-    tenant: system
-    name: LEAF_PEER_L3
-    trunk_groups:
-    - LEAF_PEER_L3
   4094:
     tenant: system
     name: MLAG_PEER
     trunk_groups:
     - MLAG
 vlan_interfaces:
-  Vlan4093:
-    description: MLAG_PEER_L3_PEERING
-    shutdown: false
-    ip_address: 10.255.251.6/31
-    mtu: 1500
-    isis_enable: EVPN_UNDERLAY
-    isis_metric: 50
-    isis_network_point_to_point: true
   Vlan4094:
     description: MLAG_PEER
     shutdown: false
     ip_address: 10.255.252.6/31
     no_autostate: true
     mtu: 1500
+    isis_enable: EVPN_UNDERLAY
+    isis_metric: 50
+    isis_network_point_to_point: true
 port_channel_interfaces:
   Port-Channel5:
     description: MLAG_PEER_DC1-SVC3B_Po5
@@ -250,7 +240,7 @@ router_isis:
   - Ethernet2
   - Ethernet3
   - Ethernet4
-  - Vlan4093
+  - Vlan4094
   - Loopback1
   is_type: level-2
   address_family:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SVC3B.yml
@@ -63,7 +63,7 @@ spanning_tree:
   mst_instances:
     '0':
       priority: 4096
-  no_spanning_tree_vlan: 4093-4094
+  no_spanning_tree_vlan: 4094
 local_users:
   admin:
     privilege: 15
@@ -89,31 +89,21 @@ management_api_http:
     MGMT: {}
   enable_https: true
 vlans:
-  4093:
-    tenant: system
-    name: LEAF_PEER_L3
-    trunk_groups:
-    - LEAF_PEER_L3
   4094:
     tenant: system
     name: MLAG_PEER
     trunk_groups:
     - MLAG
 vlan_interfaces:
-  Vlan4093:
-    description: MLAG_PEER_L3_PEERING
-    shutdown: false
-    ip_address: 10.255.251.7/31
-    mtu: 1500
-    isis_enable: EVPN_UNDERLAY
-    isis_metric: 50
-    isis_network_point_to_point: true
   Vlan4094:
     description: MLAG_PEER
     shutdown: false
     ip_address: 10.255.252.7/31
     no_autostate: true
     mtu: 1500
+    isis_enable: EVPN_UNDERLAY
+    isis_metric: 50
+    isis_network_point_to_point: true
 port_channel_interfaces:
   Port-Channel5:
     description: MLAG_PEER_DC1-SVC3A_Po5
@@ -250,7 +240,7 @@ router_isis:
   - Ethernet2
   - Ethernet3
   - Ethernet4
-  - Vlan4093
+  - Vlan4094
   - Loopback1
   is_type: level-2
   address_family:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/inventory/group_vars/DC1_FABRIC.yml
@@ -106,6 +106,7 @@ l3leaf:
       filter:
         tenants: [ Tenant_A, Tenant_B, Tenant_C ]
         tags: [ opzone, web, app, db, vmotion, nfs, wan ]
+      mlag_peer_l3_vlan: 4094 # Testing reuse of the same vlan for mlag and mlag l3 peering. Observe that isis is configured correctly for the vlan. (interface and no passive)
       nodes:
         DC1-SVC3A:
           id: 4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -217,14 +217,14 @@ STP mode: **mstp**
 
 ### Global Spanning-Tree Settings
 
-- Spanning Tree disabled for VLANs: **4093-4094**
+- Spanning Tree disabled for VLANs: **4094**
 
 ## Spanning Tree Device Configuration
 
 ```eos
 !
 spanning-tree mode mstp
-no spanning-tree vlan-id 4093-4094
+no spanning-tree vlan-id 4094
 spanning-tree mst 0 priority 4096
 ```
 
@@ -249,16 +249,11 @@ vlan internal order ascending range 1006 1199
 
 | VLAN ID | Name | Trunk Groups |
 | ------- | ---- | ------------ |
-| 4093 | LEAF_PEER_L3 | LEAF_PEER_L3 |
 | 4094 | MLAG_PEER | MLAG |
 
 ## VLANs Device Configuration
 
 ```eos
-!
-vlan 4093
-   name LEAF_PEER_L3
-   trunk group LEAF_PEER_L3
 !
 vlan 4094
    name MLAG_PEER
@@ -427,27 +422,17 @@ interface Loopback1
 
 | Interface | Description | VRF |  MTU | Shutdown |
 | --------- | ----------- | --- | ---- | -------- |
-| Vlan4093 | MLAG_PEER_L3_PEERING | default | 1500 | false |
 | Vlan4094 | MLAG_PEER | default | 1500 | false |
 
 #### IPv4
 
 | Interface | VRF | IP Address | IP Address Virtual | IP Router Virtual Address | VRRP | ACL In | ACL Out |
 | --------- | --- | ---------- | ------------------ | ------------------------- | ---- | ------ | ------- |
-| Vlan4093 |  default  |  10.255.251.6/31  |  -  |  -  |  -  |  -  |  -  |
 | Vlan4094 |  default  |  10.255.252.6/31  |  -  |  -  |  -  |  -  |  -  |
 
 ### VLAN Interfaces Device Configuration
 
 ```eos
-!
-interface Vlan4093
-   description MLAG_PEER_L3_PEERING
-   no shutdown
-   mtu 1500
-   ip address 10.255.251.6/31
-   ip ospf network point-to-point
-   ip ospf area 0.0.0.0
 !
 interface Vlan4094
    description MLAG_PEER
@@ -455,6 +440,8 @@ interface Vlan4094
    mtu 1500
    no autostate
    ip address 10.255.252.6/31
+   ip ospf network point-to-point
+   ip ospf area 0.0.0.0
 ```
 
 ## VXLAN Interface
@@ -547,7 +534,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | Process ID | Router ID | Default Passive Interface | No Passive Interface | BFD | Max LSA | Default Information Originate | Log Adjacency Changes Detail | Auto Cost Reference Bandwidth | Maximum Paths | MPLS LDP Sync Default | Distribute List In |
 | ---------- | --------- | ------------------------- | -------------------- | --- | ------- | ----------------------------- | ---------------------------- | ----------------------------- | ------------- | --------------------- | ------------------ |
-| 101 | 192.168.255.8 | enabled | Ethernet1 <br> Ethernet2 <br> Ethernet3 <br> Ethernet4 <br> Vlan4093 <br> | enabled | 12000 | disabled | disabled | - | - | - | - |
+| 101 | 192.168.255.8 | enabled | Ethernet1 <br> Ethernet2 <br> Ethernet3 <br> Ethernet4 <br> Vlan4094 <br> | enabled | 12000 | disabled | disabled | - | - | - | - |
 
 ### OSPF Interfaces
 
@@ -557,7 +544,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | Ethernet2 | 0.0.0.0 | - | True |
 | Ethernet3 | 0.0.0.0 | - | True |
 | Ethernet4 | 0.0.0.0 | - | True |
-| Vlan4093 | 0.0.0.0 | - | True |
+| Vlan4094 | 0.0.0.0 | - | True |
 | Loopback0 | 0.0.0.0 | - | - |
 | Loopback1 | 0.0.0.0 | - | - |
 
@@ -572,7 +559,7 @@ router ospf 101
    no passive-interface Ethernet2
    no passive-interface Ethernet3
    no passive-interface Ethernet4
-   no passive-interface Vlan4093
+   no passive-interface Vlan4094
    bfd default
    max-lsa 12000
 ```

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -217,14 +217,14 @@ STP mode: **mstp**
 
 ### Global Spanning-Tree Settings
 
-- Spanning Tree disabled for VLANs: **4093-4094**
+- Spanning Tree disabled for VLANs: **4094**
 
 ## Spanning Tree Device Configuration
 
 ```eos
 !
 spanning-tree mode mstp
-no spanning-tree vlan-id 4093-4094
+no spanning-tree vlan-id 4094
 spanning-tree mst 0 priority 4096
 ```
 
@@ -249,16 +249,11 @@ vlan internal order ascending range 1006 1199
 
 | VLAN ID | Name | Trunk Groups |
 | ------- | ---- | ------------ |
-| 4093 | LEAF_PEER_L3 | LEAF_PEER_L3 |
 | 4094 | MLAG_PEER | MLAG |
 
 ## VLANs Device Configuration
 
 ```eos
-!
-vlan 4093
-   name LEAF_PEER_L3
-   trunk group LEAF_PEER_L3
 !
 vlan 4094
    name MLAG_PEER
@@ -427,27 +422,17 @@ interface Loopback1
 
 | Interface | Description | VRF |  MTU | Shutdown |
 | --------- | ----------- | --- | ---- | -------- |
-| Vlan4093 | MLAG_PEER_L3_PEERING | default | 1500 | false |
 | Vlan4094 | MLAG_PEER | default | 1500 | false |
 
 #### IPv4
 
 | Interface | VRF | IP Address | IP Address Virtual | IP Router Virtual Address | VRRP | ACL In | ACL Out |
 | --------- | --- | ---------- | ------------------ | ------------------------- | ---- | ------ | ------- |
-| Vlan4093 |  default  |  10.255.251.7/31  |  -  |  -  |  -  |  -  |  -  |
 | Vlan4094 |  default  |  10.255.252.7/31  |  -  |  -  |  -  |  -  |  -  |
 
 ### VLAN Interfaces Device Configuration
 
 ```eos
-!
-interface Vlan4093
-   description MLAG_PEER_L3_PEERING
-   no shutdown
-   mtu 1500
-   ip address 10.255.251.7/31
-   ip ospf network point-to-point
-   ip ospf area 0.0.0.0
 !
 interface Vlan4094
    description MLAG_PEER
@@ -455,6 +440,8 @@ interface Vlan4094
    mtu 1500
    no autostate
    ip address 10.255.252.7/31
+   ip ospf network point-to-point
+   ip ospf area 0.0.0.0
 ```
 
 ## VXLAN Interface
@@ -547,7 +534,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 
 | Process ID | Router ID | Default Passive Interface | No Passive Interface | BFD | Max LSA | Default Information Originate | Log Adjacency Changes Detail | Auto Cost Reference Bandwidth | Maximum Paths | MPLS LDP Sync Default | Distribute List In |
 | ---------- | --------- | ------------------------- | -------------------- | --- | ------- | ----------------------------- | ---------------------------- | ----------------------------- | ------------- | --------------------- | ------------------ |
-| 101 | 192.168.255.9 | enabled | Ethernet1 <br> Ethernet2 <br> Ethernet3 <br> Ethernet4 <br> Vlan4093 <br> | enabled | 12000 | disabled | disabled | - | - | - | - |
+| 101 | 192.168.255.9 | enabled | Ethernet1 <br> Ethernet2 <br> Ethernet3 <br> Ethernet4 <br> Vlan4094 <br> | enabled | 12000 | disabled | disabled | - | - | - | - |
 
 ### OSPF Interfaces
 
@@ -557,7 +544,7 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 | Ethernet2 | 0.0.0.0 | - | True |
 | Ethernet3 | 0.0.0.0 | - | True |
 | Ethernet4 | 0.0.0.0 | - | True |
-| Vlan4093 | 0.0.0.0 | - | True |
+| Vlan4094 | 0.0.0.0 | - | True |
 | Loopback0 | 0.0.0.0 | - | - |
 | Loopback1 | 0.0.0.0 | - | - |
 
@@ -572,7 +559,7 @@ router ospf 101
    no passive-interface Ethernet2
    no passive-interface Ethernet3
    no passive-interface Ethernet4
-   no passive-interface Vlan4093
+   no passive-interface Vlan4094
    bfd default
    max-lsa 12000
 ```

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
@@ -18,7 +18,7 @@ ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 !
 spanning-tree mode mstp
-no spanning-tree vlan-id 4093-4094
+no spanning-tree vlan-id 4094
 spanning-tree mst 0 priority 4096
 !
 no enable password
@@ -26,10 +26,6 @@ no aaa root
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
-!
-vlan 4093
-   name LEAF_PEER_L3
-   trunk group LEAF_PEER_L3
 !
 vlan 4094
    name MLAG_PEER
@@ -128,20 +124,14 @@ interface Management1
    vrf MGMT
    ip address 192.168.200.108/24
 !
-interface Vlan4093
-   description MLAG_PEER_L3_PEERING
-   no shutdown
-   mtu 1500
-   ip address 10.255.251.6/31
-   ip ospf network point-to-point
-   ip ospf area 0.0.0.0
-!
 interface Vlan4094
    description MLAG_PEER
    no shutdown
    mtu 1500
    no autostate
    ip address 10.255.252.6/31
+   ip ospf network point-to-point
+   ip ospf area 0.0.0.0
 !
 interface Vxlan1
    description DC1-SVC3A_VTEP
@@ -206,7 +196,7 @@ router ospf 101
    no passive-interface Ethernet2
    no passive-interface Ethernet3
    no passive-interface Ethernet4
-   no passive-interface Vlan4093
+   no passive-interface Vlan4094
    bfd default
    max-lsa 12000
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
@@ -18,7 +18,7 @@ ntp local-interface vrf MGMT Management1
 ntp server vrf MGMT 192.168.200.5 prefer
 !
 spanning-tree mode mstp
-no spanning-tree vlan-id 4093-4094
+no spanning-tree vlan-id 4094
 spanning-tree mst 0 priority 4096
 !
 no enable password
@@ -26,10 +26,6 @@ no aaa root
 !
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
-!
-vlan 4093
-   name LEAF_PEER_L3
-   trunk group LEAF_PEER_L3
 !
 vlan 4094
    name MLAG_PEER
@@ -128,20 +124,14 @@ interface Management1
    vrf MGMT
    ip address 192.168.200.109/24
 !
-interface Vlan4093
-   description MLAG_PEER_L3_PEERING
-   no shutdown
-   mtu 1500
-   ip address 10.255.251.7/31
-   ip ospf network point-to-point
-   ip ospf area 0.0.0.0
-!
 interface Vlan4094
    description MLAG_PEER
    no shutdown
    mtu 1500
    no autostate
    ip address 10.255.252.7/31
+   ip ospf network point-to-point
+   ip ospf area 0.0.0.0
 !
 interface Vxlan1
    description DC1-SVC3B_VTEP
@@ -206,7 +196,7 @@ router ospf 101
    no passive-interface Ethernet2
    no passive-interface Ethernet3
    no passive-interface Ethernet4
-   no passive-interface Vlan4093
+   no passive-interface Vlan4094
    bfd default
    max-lsa 12000
 !

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -75,7 +75,7 @@ spanning_tree:
   mst_instances:
     '0':
       priority: 4096
-  no_spanning_tree_vlan: 4093-4094
+  no_spanning_tree_vlan: 4094
 local_users:
   admin:
     privilege: 15
@@ -101,30 +101,20 @@ management_api_http:
     MGMT: {}
   enable_https: true
 vlans:
-  4093:
-    tenant: system
-    name: LEAF_PEER_L3
-    trunk_groups:
-    - LEAF_PEER_L3
   4094:
     tenant: system
     name: MLAG_PEER
     trunk_groups:
     - MLAG
 vlan_interfaces:
-  Vlan4093:
-    description: MLAG_PEER_L3_PEERING
-    shutdown: false
-    ip_address: 10.255.251.6/31
-    mtu: 1500
-    ospf_network_point_to_point: true
-    ospf_area: 0.0.0.0
   Vlan4094:
     description: MLAG_PEER
     shutdown: false
     ip_address: 10.255.252.6/31
     no_autostate: true
     mtu: 1500
+    ospf_network_point_to_point: true
+    ospf_area: 0.0.0.0
 port_channel_interfaces:
   Port-Channel5:
     description: MLAG_PEER_DC1-SVC3B_Po5
@@ -255,7 +245,7 @@ router_ospf:
       - Ethernet2
       - Ethernet3
       - Ethernet4
-      - Vlan4093
+      - Vlan4094
       bfd_enable: true
       max_lsa: 12000
 router_bfd:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -75,7 +75,7 @@ spanning_tree:
   mst_instances:
     '0':
       priority: 4096
-  no_spanning_tree_vlan: 4093-4094
+  no_spanning_tree_vlan: 4094
 local_users:
   admin:
     privilege: 15
@@ -101,30 +101,20 @@ management_api_http:
     MGMT: {}
   enable_https: true
 vlans:
-  4093:
-    tenant: system
-    name: LEAF_PEER_L3
-    trunk_groups:
-    - LEAF_PEER_L3
   4094:
     tenant: system
     name: MLAG_PEER
     trunk_groups:
     - MLAG
 vlan_interfaces:
-  Vlan4093:
-    description: MLAG_PEER_L3_PEERING
-    shutdown: false
-    ip_address: 10.255.251.7/31
-    mtu: 1500
-    ospf_network_point_to_point: true
-    ospf_area: 0.0.0.0
   Vlan4094:
     description: MLAG_PEER
     shutdown: false
     ip_address: 10.255.252.7/31
     no_autostate: true
     mtu: 1500
+    ospf_network_point_to_point: true
+    ospf_area: 0.0.0.0
 port_channel_interfaces:
   Port-Channel5:
     description: MLAG_PEER_DC1-SVC3A_Po5
@@ -255,7 +245,7 @@ router_ospf:
       - Ethernet2
       - Ethernet3
       - Ethernet4
-      - Vlan4093
+      - Vlan4094
       bfd_enable: true
       max_lsa: 12000
 router_bfd:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
@@ -102,6 +102,7 @@ l3leaf:
           uplink_switch_interfaces: [ Ethernet3, Ethernet3, Ethernet3, Ethernet3 ]
     DC1_SVC3:
       bgp_as: 65103
+      mlag_peer_l3_vlan: 4094 # Testing reuse of the same vlan for mlag and mlag l3 peering. Observe that ospf is configured correctly for the vlan. (area and no passive)
       filter:
         tenants: [ Tenant_A, Tenant_B, Tenant_C ]
         tags: [ opzone, web, app, db, vmotion, nfs, wan ]

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/underlay/isis-sr/router-isis.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/underlay/isis-sr/router-isis.j2
@@ -11,7 +11,7 @@ router_isis:
 {%     endif %}
 {% endfor %}
 {% if switch.mlag_l3 is arista.avd.defined(true) %}
-    - Vlan{{ switch.mlag_peer_l3_vlan }}
+    - Vlan{{ switch.mlag_peer_l3_vlan | arista.avd.default(switch.mlag_peer_vlan) }}
 {% endif %}
 {% if switch.vtep is arista.avd.defined(true) %}
     - {{ switch.vtep_loopback }}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/underlay/isis/router-isis.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/underlay/isis/router-isis.j2
@@ -11,7 +11,7 @@ router_isis:
 {%     endif %}
 {% endfor %}
 {% if switch.mlag_l3 is arista.avd.defined(true) %}
-    - Vlan{{ switch.mlag_peer_l3_vlan }}
+    - Vlan{{ switch.mlag_peer_l3_vlan | arista.avd.default(switch.mlag_peer_vlan) }}
 {% endif %}
 {% if switch.vtep is arista.avd.defined(true) %}
     - {{ switch.vtep_loopback }}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/underlay/ospf/router-ospf.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/underlay/ospf/router-ospf.j2
@@ -10,8 +10,8 @@ router_ospf:
         - {{ link.interface }}
 {%     endif %}
 {% endfor %}
-{% if switch.mlag_peer_l3_vlan is arista.avd.defined %}
-        - Vlan{{ switch.mlag_peer_l3_vlan }}
+{% if switch.mlag_l3 is arista.avd.defined(true) %}
+        - Vlan{{ switch.mlag_peer_l3_vlan | arista.avd.default(switch.mlag_peer_vlan) }}
 {% endif %}
 {% if underlay_ospf_bfd_enable is arista.avd.defined(true) %}
       bfd_enable: true


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Fix missing no-passive in OSPF/ISIS when reusing the MLAG peer vlan for L3 peering

## Related Issue(s)

When reusing the MLAG peer vlan for L3 peering, the OSPF and ISIS processes was missing no-passive.

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- Implement logic to look for mlag_l3 and then fallback to mlag_peer_vlan if mlag_l3_vlan is not set.
- Modified molecule scenarios to cover this case for both OSPF and ISIS.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Modified OSPF and ISIS molecule scenarios to trigger the issue. Implemented fix and verified.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
