### PR TITLE
CI: Limit runtime by only testing older Ansible on a few scenarios

### DIFF
--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -151,8 +151,16 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        avd_scenario: ['eos_cli_config_gen', 'upgrade_eos_cli_config_gen', 'eos_cli_config_gen_v4.0']
-        ansible_version: ['ansible-core==2.11.3', 'ansible-core>=2.11.3,<2.13.0']
+        avd_scenario:
+          - 'eos_cli_config_gen'
+          - 'upgrade_eos_cli_config_gen'
+          - 'eos_cli_config_gen_v4.0'
+        ansible_version:
+          - 'ansible-core>=2.11.3,<2.13.0'
+        # Also test minimum ansible version for one scenario.
+        include:
+          - avd_scenario: 'eos_cli_config_gen'
+            ansible_version: 'ansible-core==2.11.3'
     needs: [ pre_commit ]
     if: needs.file-changes.outputs.config_gen == 'true'
     steps:
@@ -187,7 +195,7 @@ jobs:
       fail-fast: true
       matrix:
         avd_scenario: ['dhcp_configuration', 'dhcp_provisionning']
-        ansible_version: ['ansible-core==2.11.3', 'ansible-core>=2.11.3,<2.13.0']
+        ansible_version: ['ansible-core>=2.11.3,<2.13.0']
     needs: [ pre_commit ]
     if: needs.file-changes.outputs.dhcp == 'true'
     steps:
@@ -235,7 +243,12 @@ jobs:
           - 'upgrade_v2.x_to_v3.0_evpn_underlay_isis_overlay_ibgp'
           - 'upgrade_v2.x_to_v3.0_eos_designs-twodc-5stage-clos'
           - 'upgrade_v2.x_to_v3.0_evpn_underlay_rfc5549_overlay_ebgp'
-        ansible_version: ['ansible-core==2.11.3', 'ansible-core>=2.11.3,<2.13.0']
+        ansible_version:
+          - 'ansible-core>=2.11.3,<2.13.0'
+        # Also test minimum ansible version for one scenario.
+        include:
+          - avd_scenario: 'eos_designs_unit_tests'
+            ansible_version: 'ansible-core==2.11.3'
     needs: [ pre_commit ]
     if: needs.file-changes.outputs.eos_design == 'true' || needs.file-changes.outputs.config_gen == 'true'
     steps:


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Limit runtime by only testing older Ansible on a few scenarios

Limit test of minimum Ansible version to molecule scenarios `eos_cli_config_gen`, `eos_designs_unit_tests` and `eos_config_deploy_cvp`

