### PR TITLE
Refactor(eos_designs): Wildcard dict to list for tenants.vrfs.svis.nodes

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/inventory/group_vars/DC1_TENANTS_NETWORKS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests_v4.0/inventory/group_vars/DC1_TENANTS_NETWORKS.yml
@@ -108,7 +108,7 @@ tenants:
             tags: ['erp2']
             enabled: True
             nodes:
-              DC1-LEAF1A:
+              - name: DC1-LEAF1A
                 ip_address: 10.1.32.1/24
             ip_virtual_router_addresses:
               - 10.1.32.254

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/network-services-v4.0.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/network-services-v4.0.md
@@ -265,7 +265,7 @@ svi_profiles:
 
             # Define node specific configuration, such as unique IP addresses.
             nodes:
-              < l3_leaf_inventory_hostname_1 >:
+              - name: < l3_leaf_inventory_hostname_1 >
                 # device unique IP address for node.
                 ip_address: < IPv4_address/Mask >
 
@@ -278,7 +278,7 @@ svi_profiles:
                 # Overrides the setting on SVI level.
                 structured_config: < dictionary >
 
-              < l3_leaf_inventory_hostname_2 >:
+              - name: < l3_leaf_inventory_hostname_2 >
                 ip_address: < IPv4_address/Mask >
 
             # Defined interface MTU
@@ -562,18 +562,18 @@ dc1_tenants:
               - 10.1.12.1
               - 10.2.12.1/24
             nodes:
-              DC1-LEAF2A:
+              - name: DC1-LEAF2A
                 ip_address: 10.1.12.2/24
-              DC1-LEAF2B:
+              - name: DC1-LEAF2B
                 ip_address: 10.1.12.3/24
           - id: 113
             name: Tenant_A_OP_Zone_WAN
             tags: [ DC1_BL1 ]
             enabled: true
             nodes:
-              DC1-BL1A:
+              - name: DC1-BL1A
                 ip_address: 10.1.13.1/24
-              DC1-BL1B:
+              - name: DC1-BL1B
                 ip_address: 10.1.13.2/24
       - name: Tenant_A_WEB_Zone
         vrf_vni: 11

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/logic.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/logic.j2
@@ -55,9 +55,24 @@
 {%                                 endif %}
 {%                                 set tmp_svi = tmp_svi | ansible.builtin.combine(svi, recursive=true, list_merge='replace') %}
 {#                                 Structured config should not be merged recursively, but will be taken directly from the most specific level #}
-{%                                 do tmp_svi.update({"structured_config": svi.nodes[inventory_hostname].structured_config | arista.avd.default(
-                                                                           svi_profile.nodes[inventory_hostname].structured_config,
-                                                                           svi_parent_profile.nodes[inventory_hostname].structured_config,
+{%                                 set tmp_svi_struct_cfg = svi.nodes | arista.avd.default({}) |
+                                                                        arista.avd.convert_dicts('name') |
+                                                                        selectattr('name', 'arista.avd.defined', inventory_hostname) |
+                                                                        map(attribute='structured_config',) |
+                                                                        first %}
+{%                                 set tmp_svi_profile_struct_cfg = svi_profile.nodes | arista.avd.default({}) |
+                                                                        arista.avd.convert_dicts('name') |
+                                                                        selectattr('name', 'arista.avd.defined', inventory_hostname) |
+                                                                        map(attribute='structured_config',) |
+                                                                        first %}
+{%                                 set tmp_svi_parent_profile_struct_cfg = svi_parent_profile.nodes | arista.avd.default({}) |
+                                                                        arista.avd.convert_dicts('name') |
+                                                                        selectattr('name', 'arista.avd.defined', inventory_hostname) |
+                                                                        map(attribute='structured_config',) |
+                                                                        first %}
+{%                                 do tmp_svi.update({"structured_config": tmp_svi_struct_cfg | arista.avd.default(
+                                                                           tmp_svi_profile_struct_cfg,
+                                                                           tmp_svi_parent_profile_struct_cfg,
                                                                            svi.structured_config,
                                                                            svi_profile.structured_config,
                                                                            svi_parent_profile.structured_config)}) %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/logic.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/logic.j2
@@ -58,17 +58,17 @@
 {%                                 set tmp_svi_struct_cfg = svi.nodes | arista.avd.default({}) |
                                                                         arista.avd.convert_dicts('name') |
                                                                         selectattr('name', 'arista.avd.defined', inventory_hostname) |
-                                                                        map(attribute='structured_config',) |
+                                                                        map(attribute='structured_config') |
                                                                         first %}
 {%                                 set tmp_svi_profile_struct_cfg = svi_profile.nodes | arista.avd.default({}) |
                                                                         arista.avd.convert_dicts('name') |
                                                                         selectattr('name', 'arista.avd.defined', inventory_hostname) |
-                                                                        map(attribute='structured_config',) |
+                                                                        map(attribute='structured_config') |
                                                                         first %}
 {%                                 set tmp_svi_parent_profile_struct_cfg = svi_parent_profile.nodes | arista.avd.default({}) |
                                                                         arista.avd.convert_dicts('name') |
                                                                         selectattr('name', 'arista.avd.defined', inventory_hostname) |
-                                                                        map(attribute='structured_config',) |
+                                                                        map(attribute='structured_config') |
                                                                         first %}
 {%                                 do tmp_svi.update({"structured_config": tmp_svi_struct_cfg | arista.avd.default(
                                                                            tmp_svi_profile_struct_cfg,

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/logic.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/logic.j2
@@ -39,40 +39,41 @@
 {%                         if svi.id | int in whitelist.vlans %}
 {%                             if "all" in match_tags or svi.tags | arista.avd.default(['all']) is arista.avd.contains(match_tags) %}
 {%                                 set tmp_svi = {} %}
+{%                                 set tmp_svi_struct_cfg = svi.nodes | arista.avd.default({}) |
+                                                                        arista.avd.convert_dicts('name') |
+                                                                        selectattr('name', 'arista.avd.defined', inventory_hostname) |
+                                                                        map(attribute='structured_config') |
+                                                                        first %}
 {%                                 if svi.profile is arista.avd.defined %}
 {%                                     set svi_profile = svi_profiles | arista.avd.default({}) |
                                                                         arista.avd.convert_dicts('profile') |
                                                                         selectattr('profile', 'arista.avd.defined', svi.profile) |
                                                                         first %}
+{%                                     if tmp_svi_struct_cfg is not arista.avd.defined and svi_profile.nodes is arista.avd.defined %}
+{%                                         set tmp_svi_struct_cfg = svi_profile.nodes | arista.avd.convert_dicts('name') |
+                                                                                        selectattr('name', 'arista.avd.defined', inventory_hostname) |
+                                                                                        map(attribute='structured_config') |
+                                                                                        first %}
+{%                                     endif %}
 {%                                     if svi_profile.parent_profile is arista.avd.defined %}
 {%                                         set svi_parent_profile = svi_profiles | arista.avd.default({}) |
                                                                                    arista.avd.convert_dicts('profile') |
                                                                                    selectattr('profile', 'arista.avd.defined', svi_profile.parent_profile) |
                                                                                    first %}
+{%                                         if tmp_svi_struct_cfg is not arista.avd.defined and svi_parent_profile.nodes is arista.avd.defined %}
+{%                                             set tmp_svi_struct_cfg = svi_parent_profile.nodes | arista.avd.convert_dicts('name') |
+                                                                                                   selectattr('name', 'arista.avd.defined', inventory_hostname) |
+                                                                                                   map(attribute='structured_config') |
+                                                                                                   first %}
+{%                                         endif %}
 {%                                         set tmp_svi = svi_parent_profile %}
 {%                                     endif %}
 {%                                     set tmp_svi = tmp_svi | ansible.builtin.combine(svi_profile, recursive=true, list_merge='replace') %}
 {%                                 endif %}
 {%                                 set tmp_svi = tmp_svi | ansible.builtin.combine(svi, recursive=true, list_merge='replace') %}
 {#                                 Structured config should not be merged recursively, but will be taken directly from the most specific level #}
-{%                                 set tmp_svi_struct_cfg = svi.nodes | arista.avd.default({}) |
-                                                                        arista.avd.convert_dicts('name') |
-                                                                        selectattr('name', 'arista.avd.defined', inventory_hostname) |
-                                                                        map(attribute='structured_config') |
-                                                                        first %}
-{%                                 set tmp_svi_profile_struct_cfg = svi_profile.nodes | arista.avd.default({}) |
-                                                                        arista.avd.convert_dicts('name') |
-                                                                        selectattr('name', 'arista.avd.defined', inventory_hostname) |
-                                                                        map(attribute='structured_config') |
-                                                                        first %}
-{%                                 set tmp_svi_parent_profile_struct_cfg = svi_parent_profile.nodes | arista.avd.default({}) |
-                                                                        arista.avd.convert_dicts('name') |
-                                                                        selectattr('name', 'arista.avd.defined', inventory_hostname) |
-                                                                        map(attribute='structured_config') |
-                                                                        first %}
+
 {%                                 do tmp_svi.update({"structured_config": tmp_svi_struct_cfg | arista.avd.default(
-                                                                           tmp_svi_profile_struct_cfg,
-                                                                           tmp_svi_parent_profile_struct_cfg,
                                                                            svi.structured_config,
                                                                            svi_profile.structured_config,
                                                                            svi_parent_profile.structured_config)}) %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vlan-interfaces.j2
@@ -3,7 +3,11 @@ vlan_interfaces:
 {% for tenant in network_services_data.tenants %}
 {%     for vrf in tenant.vrfs %}
 {%         for svi in vrf.svis %}
-{%             set svi_raw_eos_cli = svi.nodes[inventory_hostname].raw_eos_cli | arista.avd.default(
+{%             set svi_node = svi.nodes | arista.avd.default({}) |
+                                          arista.avd.convert_dicts('name') |
+                                          selectattr('name', 'arista.avd.defined', inventory_hostname) |
+                                          first %}
+{%             set svi_raw_eos_cli = svi_node.raw_eos_cli | arista.avd.default(
                                      svi.raw_eos_cli) %}
 {%             set svi_ip_helpers = svi.ip_helpers | arista.avd.default(vrf.ip_helpers) %}
   Vlan{{ svi.id | int }}:
@@ -18,19 +22,19 @@ vlan_interfaces:
 {%             if vrf.name != 'default' %}
     vrf: {{ vrf.name }}
 {%             else %}
-{%                 set svi_subnet = svi.nodes[inventory_hostname].ip_address | arista.avd.default(svi.ip_address_virtual) | ansible.netcommon.ipaddr('subnet') %}
+{%                 set svi_subnet = svi_node.ip_address | arista.avd.default(svi.ip_address_virtual) | ansible.netcommon.ipaddr('subnet') %}
 {%                 if svi_subnet is arista.avd.defined and svi_subnet %}
 {%                     do default_vrf.svi_subnets.append(svi_subnet) %}
 {%                 endif %}
 {%             endif %}
 {# IP address configuration #}
-{%             if svi.nodes[inventory_hostname].ip_address is arista.avd.defined %}
-    ip_address: {{ svi.nodes[inventory_hostname].ip_address }}
+{%             if svi_node.ip_address is arista.avd.defined %}
+    ip_address: {{ svi_node.ip_address }}
 {%             endif %}
 {# IPv6 address configuration #}
-{%             if svi.nodes[inventory_hostname].ipv6_address is arista.avd.defined %}
+{%             if svi_node.ipv6_address is arista.avd.defined %}
 {%                 do network_services_data.ipv6vrfs.update({vrf.name: True}) %}
-    ipv6_address: {{ svi.nodes[inventory_hostname].ipv6_address }}
+    ipv6_address: {{ svi_node.ipv6_address }}
 {%             endif %}
 {# Virtual Router IP Address #}
 {%             if svi.ip_virtual_router_addresses is arista.avd.defined %}


### PR DESCRIPTION
## "Wildcard Keyed Dict" to "List of Dicts" Data model migration

<!-- Use this PR Title: Refactor(eos_cli_config_gen): Wildcard dict to list for `< data_model_key >` -->

## Data model key

`tenants.vrfs.svis.nodes`

## Checklist

### Contributor Checklist

- [x] Update `README_v4.0.md` with new data model
- [x] Update all `host_vars` under molecule scenario `eos_designs_unit_tests_v4.0` with new data model
- [x] Update templates:
  - [x] Add `arista.avd.convert_dicts('<primary key>')` filter for loops previously using wildcard keys
  - [x] Update `arista.avd.natural_sort('<primary key>')` to sort on the primary key (if applicable)
- [x] Run molecule `cd ansible_collections/arista/avd/molecule ; make cli-4.0-schema`
  - [x] Verify no changes to generated configs/docs

### Reviewer Checklist

- Reviewer 1 (Tony):
  - [x] Verify data model changes
  - [x] Verify that all molecule `host_vars` under `eos_designs_unit_tests_v4.0` has been updated to the new data model
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2 (Carl):
  - [x] Verify data model changes
  - [x] Verify that all molecule `host_vars` under `eos_designs_unit_tests_v4.0` has been updated to the new data model
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
