### PR TITLE
Feat(eos_designs): support switch_id and offset in rd admin subfield

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF1.cfg
@@ -1,0 +1,124 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname RD-RT-ADMIN-SUBFIELD-L3LEAF1
+!
+no enable password
+no aaa root
+!
+vlan 1
+   name VLAN_1
+!
+vlan 2
+   name VLAN_2
+!
+vrf instance MGMT
+!
+vrf instance TEST1
+   description TEST1
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 192.168.255.1/32
+!
+interface Loopback1
+   description VTEP_VXLAN_Tunnel_Source
+   no shutdown
+   ip address 192.168.254.1/32
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.200.101/24
+!
+interface Vlan1
+   description VLAN_1
+   no shutdown
+   vrf TEST1
+   ip address virtual 10.0.1.1/24
+!
+interface Vlan2
+   description VLAN_2
+   no shutdown
+   vrf TEST1
+   ip address virtual 10.0.2.1/24
+!
+interface Vxlan1
+   description RD-RT-ADMIN-SUBFIELD-L3LEAF1_VTEP
+   vxlan source-interface Loopback1
+   vxlan udp-port 4789
+   vxlan vlan 1 vni 10001
+   vxlan vlan 2 vni 10002
+   vxlan vrf TEST1 vni 11
+!
+ip virtual-router mac-address 00:dc:00:00:00:0a
+!
+ip routing
+no ip routing vrf MGMT
+ip routing vrf TEST1
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+   seq 20 permit 192.168.254.0/24 eq 32
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.200.1
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 65001
+   router-id 192.168.255.1
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   vlan 1
+      rd 192.168.255.1:10001
+      route-target both 10001:10001
+      redistribute learned
+   !
+   vlan 2
+      rd 192.168.255.1:10002
+      route-target both 10002:10002
+      redistribute learned
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor IPv4-UNDERLAY-PEERS activate
+   !
+   vrf TEST1
+      rd 192.168.255.1:11
+      route-target import evpn 11:11
+      route-target export evpn 11:11
+      router-id 192.168.255.1
+      redistribute connected
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF2.cfg
@@ -91,13 +91,13 @@ router bgp 65002
    redistribute connected route-map RM-CONN-2-BGP
    !
    vlan 1
-      rd 192.168.255.2:10001
-      route-target both 10001:10001
+      rd 192.168.254.2:10001
+      route-target both 65002:10001
       redistribute learned
    !
    vlan 2
-      rd 192.168.255.2:10002
-      route-target both 10002:10002
+      rd 192.168.254.2:10002
+      route-target both 65002:10002
       redistribute learned
    !
    address-family evpn
@@ -108,9 +108,9 @@ router bgp 65002
       neighbor IPv4-UNDERLAY-PEERS activate
    !
    vrf TEST1
-      rd 192.168.255.2:11
-      route-target import evpn 11:11
-      route-target export evpn 11:11
+      rd 192.168.254.2:11
+      route-target import evpn 65002:11
+      route-target export evpn 65002:11
       router-id 192.168.255.2
       redistribute connected
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF2.cfg
@@ -1,0 +1,124 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname RD-RT-ADMIN-SUBFIELD-L3LEAF2
+!
+no enable password
+no aaa root
+!
+vlan 1
+   name VLAN_1
+!
+vlan 2
+   name VLAN_2
+!
+vrf instance MGMT
+!
+vrf instance TEST1
+   description TEST1
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 192.168.255.2/32
+!
+interface Loopback1
+   description VTEP_VXLAN_Tunnel_Source
+   no shutdown
+   ip address 192.168.254.2/32
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.200.102/24
+!
+interface Vlan1
+   description VLAN_1
+   no shutdown
+   vrf TEST1
+   ip address virtual 10.0.1.1/24
+!
+interface Vlan2
+   description VLAN_2
+   no shutdown
+   vrf TEST1
+   ip address virtual 10.0.2.1/24
+!
+interface Vxlan1
+   description RD-RT-ADMIN-SUBFIELD-L3LEAF2_VTEP
+   vxlan source-interface Loopback1
+   vxlan udp-port 4789
+   vxlan vlan 1 vni 10001
+   vxlan vlan 2 vni 10002
+   vxlan vrf TEST1 vni 11
+!
+ip virtual-router mac-address 00:dc:00:00:00:0a
+!
+ip routing
+no ip routing vrf MGMT
+ip routing vrf TEST1
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+   seq 20 permit 192.168.254.0/24 eq 32
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.200.1
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 65002
+   router-id 192.168.255.2
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   vlan 1
+      rd 192.168.255.2:10001
+      route-target both 10001:10001
+      redistribute learned
+   !
+   vlan 2
+      rd 192.168.255.2:10002
+      route-target both 10002:10002
+      redistribute learned
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor IPv4-UNDERLAY-PEERS activate
+   !
+   vrf TEST1
+      rd 192.168.255.2:11
+      route-target import evpn 11:11
+      route-target export evpn 11:11
+      router-id 192.168.255.2
+      redistribute connected
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF3.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF3.cfg
@@ -1,0 +1,124 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname RD-RT-ADMIN-SUBFIELD-L3LEAF3
+!
+no enable password
+no aaa root
+!
+vlan 1
+   name VLAN_1
+!
+vlan 2
+   name VLAN_2
+!
+vrf instance MGMT
+!
+vrf instance TEST1
+   description TEST1
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 192.168.255.3/32
+!
+interface Loopback1
+   description VTEP_VXLAN_Tunnel_Source
+   no shutdown
+   ip address 192.168.254.3/32
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.200.103/24
+!
+interface Vlan1
+   description VLAN_1
+   no shutdown
+   vrf TEST1
+   ip address virtual 10.0.1.1/24
+!
+interface Vlan2
+   description VLAN_2
+   no shutdown
+   vrf TEST1
+   ip address virtual 10.0.2.1/24
+!
+interface Vxlan1
+   description RD-RT-ADMIN-SUBFIELD-L3LEAF3_VTEP
+   vxlan source-interface Loopback1
+   vxlan udp-port 4789
+   vxlan vlan 1 vni 10001
+   vxlan vlan 2 vni 10002
+   vxlan vrf TEST1 vni 11
+!
+ip virtual-router mac-address 00:dc:00:00:00:0a
+!
+ip routing
+no ip routing vrf MGMT
+ip routing vrf TEST1
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+   seq 20 permit 192.168.254.0/24 eq 32
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.200.1
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 65003
+   router-id 192.168.255.3
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   vlan 1
+      rd 192.168.255.3:10001
+      route-target both 10001:10001
+      redistribute learned
+   !
+   vlan 2
+      rd 192.168.255.3:10002
+      route-target both 10002:10002
+      redistribute learned
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor IPv4-UNDERLAY-PEERS activate
+   !
+   vrf TEST1
+      rd 192.168.255.3:11
+      route-target import evpn 11:11
+      route-target export evpn 11:11
+      router-id 192.168.255.3
+      redistribute connected
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF3.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF3.cfg
@@ -91,13 +91,13 @@ router bgp 65003
    redistribute connected route-map RM-CONN-2-BGP
    !
    vlan 1
-      rd 192.168.255.3:10001
-      route-target both 10001:10001
+      rd 65003:10001
+      route-target both 15:10001
       redistribute learned
    !
    vlan 2
-      rd 192.168.255.3:10002
-      route-target both 10002:10002
+      rd 65003:10002
+      route-target both 15:10002
       redistribute learned
    !
    address-family evpn
@@ -108,9 +108,9 @@ router bgp 65003
       neighbor IPv4-UNDERLAY-PEERS activate
    !
    vrf TEST1
-      rd 192.168.255.3:11
-      route-target import evpn 11:11
-      route-target export evpn 11:11
+      rd 65003:11
+      route-target import evpn 15:11
+      route-target export evpn 15:11
       router-id 192.168.255.3
       redistribute connected
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF4.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF4.cfg
@@ -91,13 +91,13 @@ router bgp 65004
    redistribute connected route-map RM-CONN-2-BGP
    !
    vlan 1
-      rd 192.168.255.4:10001
-      route-target both 10001:10001
+      rd 5004:10001
+      route-target both 4294967295:10001
       redistribute learned
    !
    vlan 2
-      rd 192.168.255.4:10002
-      route-target both 10002:10002
+      rd 5004:10002
+      route-target both 4294967295:10002
       redistribute learned
    !
    address-family evpn
@@ -108,9 +108,9 @@ router bgp 65004
       neighbor IPv4-UNDERLAY-PEERS activate
    !
    vrf TEST1
-      rd 192.168.255.4:11
-      route-target import evpn 11:11
-      route-target export evpn 11:11
+      rd 5004:11
+      route-target import evpn 4294967295:11
+      route-target export evpn 4294967295:11
       router-id 192.168.255.4
       redistribute connected
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF4.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF4.cfg
@@ -1,0 +1,124 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname RD-RT-ADMIN-SUBFIELD-L3LEAF4
+!
+no enable password
+no aaa root
+!
+vlan 1
+   name VLAN_1
+!
+vlan 2
+   name VLAN_2
+!
+vrf instance MGMT
+!
+vrf instance TEST1
+   description TEST1
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 192.168.255.4/32
+!
+interface Loopback1
+   description VTEP_VXLAN_Tunnel_Source
+   no shutdown
+   ip address 192.168.254.4/32
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.200.104/24
+!
+interface Vlan1
+   description VLAN_1
+   no shutdown
+   vrf TEST1
+   ip address virtual 10.0.1.1/24
+!
+interface Vlan2
+   description VLAN_2
+   no shutdown
+   vrf TEST1
+   ip address virtual 10.0.2.1/24
+!
+interface Vxlan1
+   description RD-RT-ADMIN-SUBFIELD-L3LEAF4_VTEP
+   vxlan source-interface Loopback1
+   vxlan udp-port 4789
+   vxlan vlan 1 vni 10001
+   vxlan vlan 2 vni 10002
+   vxlan vrf TEST1 vni 11
+!
+ip virtual-router mac-address 00:dc:00:00:00:0a
+!
+ip routing
+no ip routing vrf MGMT
+ip routing vrf TEST1
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+   seq 20 permit 192.168.254.0/24 eq 32
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.200.1
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 65004
+   router-id 192.168.255.4
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   vlan 1
+      rd 192.168.255.4:10001
+      route-target both 10001:10001
+      redistribute learned
+   !
+   vlan 2
+      rd 192.168.255.4:10002
+      route-target both 10002:10002
+      redistribute learned
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor IPv4-UNDERLAY-PEERS activate
+   !
+   vrf TEST1
+      rd 192.168.255.4:11
+      route-target import evpn 11:11
+      route-target export evpn 11:11
+      router-id 192.168.255.4
+      redistribute connected
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF5.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF5.cfg
@@ -1,0 +1,124 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname RD-RT-ADMIN-SUBFIELD-L3LEAF5
+!
+no enable password
+no aaa root
+!
+vlan 1
+   name VLAN_1
+!
+vlan 2
+   name VLAN_2
+!
+vrf instance MGMT
+!
+vrf instance TEST1
+   description TEST1
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 192.168.255.5/32
+!
+interface Loopback1
+   description VTEP_VXLAN_Tunnel_Source
+   no shutdown
+   ip address 192.168.254.5/32
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.200.105/24
+!
+interface Vlan1
+   description VLAN_1
+   no shutdown
+   vrf TEST1
+   ip address virtual 10.0.1.1/24
+!
+interface Vlan2
+   description VLAN_2
+   no shutdown
+   vrf TEST1
+   ip address virtual 10.0.2.1/24
+!
+interface Vxlan1
+   description RD-RT-ADMIN-SUBFIELD-L3LEAF5_VTEP
+   vxlan source-interface Loopback1
+   vxlan udp-port 4789
+   vxlan vlan 1 vni 10001
+   vxlan vlan 2 vni 10002
+   vxlan vrf TEST1 vni 11
+!
+ip virtual-router mac-address 00:dc:00:00:00:0a
+!
+ip routing
+no ip routing vrf MGMT
+ip routing vrf TEST1
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+   seq 20 permit 192.168.254.0/24 eq 32
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.200.1
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 65005
+   router-id 192.168.255.5
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   vlan 1
+      rd 192.168.255.5:10001
+      route-target both 10001:10001
+      redistribute learned
+   !
+   vlan 2
+      rd 192.168.255.5:10002
+      route-target both 10002:10002
+      redistribute learned
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor IPv4-UNDERLAY-PEERS activate
+   !
+   vrf TEST1
+      rd 192.168.255.5:11
+      route-target import evpn 11:11
+      route-target export evpn 11:11
+      router-id 192.168.255.5
+      redistribute connected
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF5.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF5.cfg
@@ -91,12 +91,12 @@ router bgp 65005
    redistribute connected route-map RM-CONN-2-BGP
    !
    vlan 1
-      rd 192.168.255.5:10001
+      rd 1.1.1.1:10001
       route-target both 10001:10001
       redistribute learned
    !
    vlan 2
-      rd 192.168.255.5:10002
+      rd 1.1.1.1:10002
       route-target both 10002:10002
       redistribute learned
    !
@@ -108,7 +108,7 @@ router bgp 65005
       neighbor IPv4-UNDERLAY-PEERS activate
    !
    vrf TEST1
-      rd 192.168.255.5:11
+      rd 1.1.1.1:11
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.5

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF6.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF6.cfg
@@ -1,0 +1,124 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname RD-RT-ADMIN-SUBFIELD-L3LEAF6
+!
+no enable password
+no aaa root
+!
+vlan 1
+   name VLAN_1
+!
+vlan 2
+   name VLAN_2
+!
+vrf instance MGMT
+!
+vrf instance TEST1
+   description TEST1
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 192.168.255.6/32
+!
+interface Loopback1
+   description VTEP_VXLAN_Tunnel_Source
+   no shutdown
+   ip address 192.168.254.6/32
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.200.106/24
+!
+interface Vlan1
+   description VLAN_1
+   no shutdown
+   vrf TEST1
+   ip address virtual 10.0.1.1/24
+!
+interface Vlan2
+   description VLAN_2
+   no shutdown
+   vrf TEST1
+   ip address virtual 10.0.2.1/24
+!
+interface Vxlan1
+   description RD-RT-ADMIN-SUBFIELD-L3LEAF6_VTEP
+   vxlan source-interface Loopback1
+   vxlan udp-port 4789
+   vxlan vlan 1 vni 10001
+   vxlan vlan 2 vni 10002
+   vxlan vrf TEST1 vni 11
+!
+ip virtual-router mac-address 00:dc:00:00:00:0a
+!
+ip routing
+no ip routing vrf MGMT
+ip routing vrf TEST1
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+   seq 20 permit 192.168.254.0/24 eq 32
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.200.1
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 65006
+   router-id 192.168.255.6
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   vlan 1
+      rd 192.168.255.6:10001
+      route-target both 10001:10001
+      redistribute learned
+   !
+   vlan 2
+      rd 192.168.255.6:10002
+      route-target both 10002:10002
+      redistribute learned
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor IPv4-UNDERLAY-PEERS activate
+   !
+   vrf TEST1
+      rd 192.168.255.6:11
+      route-target import evpn 11:11
+      route-target export evpn 11:11
+      router-id 192.168.255.6
+      redistribute connected
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF6.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF6.cfg
@@ -91,12 +91,12 @@ router bgp 65006
    redistribute connected route-map RM-CONN-2-BGP
    !
    vlan 1
-      rd 192.168.255.6:10001
+      rd 65535:10001
       route-target both 10001:10001
       redistribute learned
    !
    vlan 2
-      rd 192.168.255.6:10002
+      rd 65535:10002
       route-target both 10002:10002
       redistribute learned
    !
@@ -108,7 +108,7 @@ router bgp 65006
       neighbor IPv4-UNDERLAY-PEERS activate
    !
    vrf TEST1
-      rd 192.168.255.6:11
+      rd 65535:11
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.6

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF7.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF7.cfg
@@ -91,12 +91,12 @@ router bgp 65007
    redistribute connected route-map RM-CONN-2-BGP
    !
    vlan 1
-      rd 192.168.255.7:10001
+      rd 4294967295:10001
       route-target both 10001:10001
       redistribute learned
    !
    vlan 2
-      rd 192.168.255.7:10002
+      rd 4294967295:10002
       route-target both 10002:10002
       redistribute learned
    !
@@ -108,7 +108,7 @@ router bgp 65007
       neighbor IPv4-UNDERLAY-PEERS activate
    !
    vrf TEST1
-      rd 192.168.255.7:11
+      rd 4294967295:11
       route-target import evpn 11:11
       route-target export evpn 11:11
       router-id 192.168.255.7

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF7.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF7.cfg
@@ -1,0 +1,124 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname RD-RT-ADMIN-SUBFIELD-L3LEAF7
+!
+no enable password
+no aaa root
+!
+vlan 1
+   name VLAN_1
+!
+vlan 2
+   name VLAN_2
+!
+vrf instance MGMT
+!
+vrf instance TEST1
+   description TEST1
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 192.168.255.7/32
+!
+interface Loopback1
+   description VTEP_VXLAN_Tunnel_Source
+   no shutdown
+   ip address 192.168.254.7/32
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.200.107/24
+!
+interface Vlan1
+   description VLAN_1
+   no shutdown
+   vrf TEST1
+   ip address virtual 10.0.1.1/24
+!
+interface Vlan2
+   description VLAN_2
+   no shutdown
+   vrf TEST1
+   ip address virtual 10.0.2.1/24
+!
+interface Vxlan1
+   description RD-RT-ADMIN-SUBFIELD-L3LEAF7_VTEP
+   vxlan source-interface Loopback1
+   vxlan udp-port 4789
+   vxlan vlan 1 vni 10001
+   vxlan vlan 2 vni 10002
+   vxlan vrf TEST1 vni 11
+!
+ip virtual-router mac-address 00:dc:00:00:00:0a
+!
+ip routing
+no ip routing vrf MGMT
+ip routing vrf TEST1
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+   seq 20 permit 192.168.254.0/24 eq 32
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.200.1
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 65007
+   router-id 192.168.255.7
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   vlan 1
+      rd 192.168.255.7:10001
+      route-target both 10001:10001
+      redistribute learned
+   !
+   vlan 2
+      rd 192.168.255.7:10002
+      route-target both 10002:10002
+      redistribute learned
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor IPv4-UNDERLAY-PEERS activate
+   !
+   vrf TEST1
+      rd 192.168.255.7:11
+      route-target import evpn 11:11
+      route-target export evpn 11:11
+      router-id 192.168.255.7
+      redistribute connected
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF1.yml
@@ -1,0 +1,159 @@
+router_bgp:
+  as: '65001'
+  router_id: 192.168.255.1
+  bgp_defaults:
+  - maximum-paths 4 ecmp 4
+  peer_groups:
+    IPv4-UNDERLAY-PEERS:
+      type: ipv4
+      maximum_routes: 12000
+      send_community: all
+    EVPN-OVERLAY-PEERS:
+      type: evpn
+      update_source: Loopback0
+      bfd: true
+      ebgp_multihop: '3'
+      send_community: all
+      maximum_routes: 0
+  address_family_ipv4:
+    peer_groups:
+      IPv4-UNDERLAY-PEERS:
+        activate: true
+      EVPN-OVERLAY-PEERS:
+        activate: false
+  redistribute_routes:
+    connected:
+      route_map: RM-CONN-2-BGP
+  address_family_evpn:
+    peer_groups:
+      EVPN-OVERLAY-PEERS:
+        activate: true
+  vrfs:
+    TEST1:
+      router_id: 192.168.255.1
+      rd: 192.168.255.1:11
+      route_targets:
+        import:
+          evpn:
+          - '11:11'
+        export:
+          evpn:
+          - '11:11'
+      redistribute_routes:
+      - connected
+  vlans:
+    1:
+      tenant: Tenant_A
+      rd: 192.168.255.1:10001
+      route_targets:
+        both:
+        - 10001:10001
+      redistribute_routes:
+      - learned
+    2:
+      tenant: Tenant_A
+      rd: 192.168.255.1:10002
+      route_targets:
+        both:
+        - 10002:10002
+      redistribute_routes:
+      - learned
+static_routes:
+- vrf: MGMT
+  destination_address_prefix: 0.0.0.0/0
+  gateway: 192.168.200.1
+service_routing_protocols_model: multi-agent
+ip_routing: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+vrfs:
+  MGMT:
+    ip_routing: false
+  TEST1:
+    tenant: Tenant_A
+    ip_routing: true
+    description: TEST1
+management_interfaces:
+  Management1:
+    description: oob_management
+    shutdown: false
+    vrf: MGMT
+    ip_address: 192.168.200.101/24
+    gateway: 192.168.200.1
+    type: oob
+management_api_http:
+  enable_vrfs:
+    MGMT: {}
+  enable_https: true
+loopback_interfaces:
+  Loopback0:
+    description: EVPN_Overlay_Peering
+    shutdown: false
+    ip_address: 192.168.255.1/32
+  Loopback1:
+    description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
+    ip_address: 192.168.254.1/32
+prefix_lists:
+  PL-LOOPBACKS-EVPN-OVERLAY:
+    sequence_numbers:
+      10:
+        action: permit 192.168.255.0/24 eq 32
+      20:
+        action: permit 192.168.254.0/24 eq 32
+route_maps:
+  RM-CONN-2-BGP:
+    sequence_numbers:
+      10:
+        type: permit
+        match:
+        - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+router_bfd:
+  multihop:
+    interval: 300
+    min_rx: 300
+    multiplier: 3
+vlans:
+  1:
+    tenant: Tenant_A
+    name: VLAN_1
+  2:
+    tenant: Tenant_A
+    name: VLAN_2
+ip_igmp_snooping:
+  globally_enabled: true
+ip_virtual_router_mac_address: 00:dc:00:00:00:0a
+vlan_interfaces:
+  Vlan1:
+    tenant: Tenant_A
+    tags:
+    - test_l3
+    description: VLAN_1
+    shutdown: false
+    vrf: TEST1
+    ip_address_virtual: 10.0.1.1/24
+  Vlan2:
+    tenant: Tenant_A
+    tags:
+    - test_l3
+    description: VLAN_2
+    shutdown: false
+    vrf: TEST1
+    ip_address_virtual: 10.0.2.1/24
+vxlan_interface:
+  Vxlan1:
+    description: RD-RT-ADMIN-SUBFIELD-L3LEAF1_VTEP
+    vxlan:
+      source_interface: Loopback1
+      udp_port: 4789
+      vlans:
+        1:
+          vni: 10001
+        2:
+          vni: 10002
+      vrfs:
+        TEST1:
+          vni: 11

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF2.yml
@@ -1,0 +1,159 @@
+router_bgp:
+  as: '65002'
+  router_id: 192.168.255.2
+  bgp_defaults:
+  - maximum-paths 4 ecmp 4
+  peer_groups:
+    IPv4-UNDERLAY-PEERS:
+      type: ipv4
+      maximum_routes: 12000
+      send_community: all
+    EVPN-OVERLAY-PEERS:
+      type: evpn
+      update_source: Loopback0
+      bfd: true
+      ebgp_multihop: '3'
+      send_community: all
+      maximum_routes: 0
+  address_family_ipv4:
+    peer_groups:
+      IPv4-UNDERLAY-PEERS:
+        activate: true
+      EVPN-OVERLAY-PEERS:
+        activate: false
+  redistribute_routes:
+    connected:
+      route_map: RM-CONN-2-BGP
+  address_family_evpn:
+    peer_groups:
+      EVPN-OVERLAY-PEERS:
+        activate: true
+  vrfs:
+    TEST1:
+      router_id: 192.168.255.2
+      rd: 192.168.255.2:11
+      route_targets:
+        import:
+          evpn:
+          - '11:11'
+        export:
+          evpn:
+          - '11:11'
+      redistribute_routes:
+      - connected
+  vlans:
+    1:
+      tenant: Tenant_A
+      rd: 192.168.255.2:10001
+      route_targets:
+        both:
+        - 10001:10001
+      redistribute_routes:
+      - learned
+    2:
+      tenant: Tenant_A
+      rd: 192.168.255.2:10002
+      route_targets:
+        both:
+        - 10002:10002
+      redistribute_routes:
+      - learned
+static_routes:
+- vrf: MGMT
+  destination_address_prefix: 0.0.0.0/0
+  gateway: 192.168.200.1
+service_routing_protocols_model: multi-agent
+ip_routing: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+vrfs:
+  MGMT:
+    ip_routing: false
+  TEST1:
+    tenant: Tenant_A
+    ip_routing: true
+    description: TEST1
+management_interfaces:
+  Management1:
+    description: oob_management
+    shutdown: false
+    vrf: MGMT
+    ip_address: 192.168.200.102/24
+    gateway: 192.168.200.1
+    type: oob
+management_api_http:
+  enable_vrfs:
+    MGMT: {}
+  enable_https: true
+loopback_interfaces:
+  Loopback0:
+    description: EVPN_Overlay_Peering
+    shutdown: false
+    ip_address: 192.168.255.2/32
+  Loopback1:
+    description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
+    ip_address: 192.168.254.2/32
+prefix_lists:
+  PL-LOOPBACKS-EVPN-OVERLAY:
+    sequence_numbers:
+      10:
+        action: permit 192.168.255.0/24 eq 32
+      20:
+        action: permit 192.168.254.0/24 eq 32
+route_maps:
+  RM-CONN-2-BGP:
+    sequence_numbers:
+      10:
+        type: permit
+        match:
+        - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+router_bfd:
+  multihop:
+    interval: 300
+    min_rx: 300
+    multiplier: 3
+vlans:
+  1:
+    tenant: Tenant_A
+    name: VLAN_1
+  2:
+    tenant: Tenant_A
+    name: VLAN_2
+ip_igmp_snooping:
+  globally_enabled: true
+ip_virtual_router_mac_address: 00:dc:00:00:00:0a
+vlan_interfaces:
+  Vlan1:
+    tenant: Tenant_A
+    tags:
+    - test_l3
+    description: VLAN_1
+    shutdown: false
+    vrf: TEST1
+    ip_address_virtual: 10.0.1.1/24
+  Vlan2:
+    tenant: Tenant_A
+    tags:
+    - test_l3
+    description: VLAN_2
+    shutdown: false
+    vrf: TEST1
+    ip_address_virtual: 10.0.2.1/24
+vxlan_interface:
+  Vxlan1:
+    description: RD-RT-ADMIN-SUBFIELD-L3LEAF2_VTEP
+    vxlan:
+      source_interface: Loopback1
+      udp_port: 4789
+      vlans:
+        1:
+          vni: 10001
+        2:
+          vni: 10002
+      vrfs:
+        TEST1:
+          vni: 11

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF2.yml
@@ -31,31 +31,31 @@ router_bgp:
   vrfs:
     TEST1:
       router_id: 192.168.255.2
-      rd: 192.168.255.2:11
+      rd: 192.168.254.2:11
       route_targets:
         import:
           evpn:
-          - '11:11'
+          - '65002:11'
         export:
           evpn:
-          - '11:11'
+          - '65002:11'
       redistribute_routes:
       - connected
   vlans:
     1:
       tenant: Tenant_A
-      rd: 192.168.255.2:10001
+      rd: 192.168.254.2:10001
       route_targets:
         both:
-        - 10001:10001
+        - 65002:10001
       redistribute_routes:
       - learned
     2:
       tenant: Tenant_A
-      rd: 192.168.255.2:10002
+      rd: 192.168.254.2:10002
       route_targets:
         both:
-        - 10002:10002
+        - 65002:10002
       redistribute_routes:
       - learned
 static_routes:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF3.yml
@@ -1,0 +1,159 @@
+router_bgp:
+  as: '65003'
+  router_id: 192.168.255.3
+  bgp_defaults:
+  - maximum-paths 4 ecmp 4
+  peer_groups:
+    IPv4-UNDERLAY-PEERS:
+      type: ipv4
+      maximum_routes: 12000
+      send_community: all
+    EVPN-OVERLAY-PEERS:
+      type: evpn
+      update_source: Loopback0
+      bfd: true
+      ebgp_multihop: '3'
+      send_community: all
+      maximum_routes: 0
+  address_family_ipv4:
+    peer_groups:
+      IPv4-UNDERLAY-PEERS:
+        activate: true
+      EVPN-OVERLAY-PEERS:
+        activate: false
+  redistribute_routes:
+    connected:
+      route_map: RM-CONN-2-BGP
+  address_family_evpn:
+    peer_groups:
+      EVPN-OVERLAY-PEERS:
+        activate: true
+  vrfs:
+    TEST1:
+      router_id: 192.168.255.3
+      rd: 192.168.255.3:11
+      route_targets:
+        import:
+          evpn:
+          - '11:11'
+        export:
+          evpn:
+          - '11:11'
+      redistribute_routes:
+      - connected
+  vlans:
+    1:
+      tenant: Tenant_A
+      rd: 192.168.255.3:10001
+      route_targets:
+        both:
+        - 10001:10001
+      redistribute_routes:
+      - learned
+    2:
+      tenant: Tenant_A
+      rd: 192.168.255.3:10002
+      route_targets:
+        both:
+        - 10002:10002
+      redistribute_routes:
+      - learned
+static_routes:
+- vrf: MGMT
+  destination_address_prefix: 0.0.0.0/0
+  gateway: 192.168.200.1
+service_routing_protocols_model: multi-agent
+ip_routing: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+vrfs:
+  MGMT:
+    ip_routing: false
+  TEST1:
+    tenant: Tenant_A
+    ip_routing: true
+    description: TEST1
+management_interfaces:
+  Management1:
+    description: oob_management
+    shutdown: false
+    vrf: MGMT
+    ip_address: 192.168.200.103/24
+    gateway: 192.168.200.1
+    type: oob
+management_api_http:
+  enable_vrfs:
+    MGMT: {}
+  enable_https: true
+loopback_interfaces:
+  Loopback0:
+    description: EVPN_Overlay_Peering
+    shutdown: false
+    ip_address: 192.168.255.3/32
+  Loopback1:
+    description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
+    ip_address: 192.168.254.3/32
+prefix_lists:
+  PL-LOOPBACKS-EVPN-OVERLAY:
+    sequence_numbers:
+      10:
+        action: permit 192.168.255.0/24 eq 32
+      20:
+        action: permit 192.168.254.0/24 eq 32
+route_maps:
+  RM-CONN-2-BGP:
+    sequence_numbers:
+      10:
+        type: permit
+        match:
+        - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+router_bfd:
+  multihop:
+    interval: 300
+    min_rx: 300
+    multiplier: 3
+vlans:
+  1:
+    tenant: Tenant_A
+    name: VLAN_1
+  2:
+    tenant: Tenant_A
+    name: VLAN_2
+ip_igmp_snooping:
+  globally_enabled: true
+ip_virtual_router_mac_address: 00:dc:00:00:00:0a
+vlan_interfaces:
+  Vlan1:
+    tenant: Tenant_A
+    tags:
+    - test_l3
+    description: VLAN_1
+    shutdown: false
+    vrf: TEST1
+    ip_address_virtual: 10.0.1.1/24
+  Vlan2:
+    tenant: Tenant_A
+    tags:
+    - test_l3
+    description: VLAN_2
+    shutdown: false
+    vrf: TEST1
+    ip_address_virtual: 10.0.2.1/24
+vxlan_interface:
+  Vxlan1:
+    description: RD-RT-ADMIN-SUBFIELD-L3LEAF3_VTEP
+    vxlan:
+      source_interface: Loopback1
+      udp_port: 4789
+      vlans:
+        1:
+          vni: 10001
+        2:
+          vni: 10002
+      vrfs:
+        TEST1:
+          vni: 11

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF3.yml
@@ -31,31 +31,31 @@ router_bgp:
   vrfs:
     TEST1:
       router_id: 192.168.255.3
-      rd: 192.168.255.3:11
+      rd: '65003:11'
       route_targets:
         import:
           evpn:
-          - '11:11'
+          - '15:11'
         export:
           evpn:
-          - '11:11'
+          - '15:11'
       redistribute_routes:
       - connected
   vlans:
     1:
       tenant: Tenant_A
-      rd: 192.168.255.3:10001
+      rd: 65003:10001
       route_targets:
         both:
-        - 10001:10001
+        - 15:10001
       redistribute_routes:
       - learned
     2:
       tenant: Tenant_A
-      rd: 192.168.255.3:10002
+      rd: 65003:10002
       route_targets:
         both:
-        - 10002:10002
+        - 15:10002
       redistribute_routes:
       - learned
 static_routes:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF4.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF4.yml
@@ -1,0 +1,159 @@
+router_bgp:
+  as: '65004'
+  router_id: 192.168.255.4
+  bgp_defaults:
+  - maximum-paths 4 ecmp 4
+  peer_groups:
+    IPv4-UNDERLAY-PEERS:
+      type: ipv4
+      maximum_routes: 12000
+      send_community: all
+    EVPN-OVERLAY-PEERS:
+      type: evpn
+      update_source: Loopback0
+      bfd: true
+      ebgp_multihop: '3'
+      send_community: all
+      maximum_routes: 0
+  address_family_ipv4:
+    peer_groups:
+      IPv4-UNDERLAY-PEERS:
+        activate: true
+      EVPN-OVERLAY-PEERS:
+        activate: false
+  redistribute_routes:
+    connected:
+      route_map: RM-CONN-2-BGP
+  address_family_evpn:
+    peer_groups:
+      EVPN-OVERLAY-PEERS:
+        activate: true
+  vrfs:
+    TEST1:
+      router_id: 192.168.255.4
+      rd: 192.168.255.4:11
+      route_targets:
+        import:
+          evpn:
+          - '11:11'
+        export:
+          evpn:
+          - '11:11'
+      redistribute_routes:
+      - connected
+  vlans:
+    1:
+      tenant: Tenant_A
+      rd: 192.168.255.4:10001
+      route_targets:
+        both:
+        - 10001:10001
+      redistribute_routes:
+      - learned
+    2:
+      tenant: Tenant_A
+      rd: 192.168.255.4:10002
+      route_targets:
+        both:
+        - 10002:10002
+      redistribute_routes:
+      - learned
+static_routes:
+- vrf: MGMT
+  destination_address_prefix: 0.0.0.0/0
+  gateway: 192.168.200.1
+service_routing_protocols_model: multi-agent
+ip_routing: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+vrfs:
+  MGMT:
+    ip_routing: false
+  TEST1:
+    tenant: Tenant_A
+    ip_routing: true
+    description: TEST1
+management_interfaces:
+  Management1:
+    description: oob_management
+    shutdown: false
+    vrf: MGMT
+    ip_address: 192.168.200.104/24
+    gateway: 192.168.200.1
+    type: oob
+management_api_http:
+  enable_vrfs:
+    MGMT: {}
+  enable_https: true
+loopback_interfaces:
+  Loopback0:
+    description: EVPN_Overlay_Peering
+    shutdown: false
+    ip_address: 192.168.255.4/32
+  Loopback1:
+    description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
+    ip_address: 192.168.254.4/32
+prefix_lists:
+  PL-LOOPBACKS-EVPN-OVERLAY:
+    sequence_numbers:
+      10:
+        action: permit 192.168.255.0/24 eq 32
+      20:
+        action: permit 192.168.254.0/24 eq 32
+route_maps:
+  RM-CONN-2-BGP:
+    sequence_numbers:
+      10:
+        type: permit
+        match:
+        - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+router_bfd:
+  multihop:
+    interval: 300
+    min_rx: 300
+    multiplier: 3
+vlans:
+  1:
+    tenant: Tenant_A
+    name: VLAN_1
+  2:
+    tenant: Tenant_A
+    name: VLAN_2
+ip_igmp_snooping:
+  globally_enabled: true
+ip_virtual_router_mac_address: 00:dc:00:00:00:0a
+vlan_interfaces:
+  Vlan1:
+    tenant: Tenant_A
+    tags:
+    - test_l3
+    description: VLAN_1
+    shutdown: false
+    vrf: TEST1
+    ip_address_virtual: 10.0.1.1/24
+  Vlan2:
+    tenant: Tenant_A
+    tags:
+    - test_l3
+    description: VLAN_2
+    shutdown: false
+    vrf: TEST1
+    ip_address_virtual: 10.0.2.1/24
+vxlan_interface:
+  Vxlan1:
+    description: RD-RT-ADMIN-SUBFIELD-L3LEAF4_VTEP
+    vxlan:
+      source_interface: Loopback1
+      udp_port: 4789
+      vlans:
+        1:
+          vni: 10001
+        2:
+          vni: 10002
+      vrfs:
+        TEST1:
+          vni: 11

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF4.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF4.yml
@@ -31,31 +31,31 @@ router_bgp:
   vrfs:
     TEST1:
       router_id: 192.168.255.4
-      rd: 192.168.255.4:11
+      rd: '5004:11'
       route_targets:
         import:
           evpn:
-          - '11:11'
+          - '4294967295:11'
         export:
           evpn:
-          - '11:11'
+          - '4294967295:11'
       redistribute_routes:
       - connected
   vlans:
     1:
       tenant: Tenant_A
-      rd: 192.168.255.4:10001
+      rd: 5004:10001
       route_targets:
         both:
-        - 10001:10001
+        - 4294967295:10001
       redistribute_routes:
       - learned
     2:
       tenant: Tenant_A
-      rd: 192.168.255.4:10002
+      rd: 5004:10002
       route_targets:
         both:
-        - 10002:10002
+        - 4294967295:10002
       redistribute_routes:
       - learned
 static_routes:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF5.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF5.yml
@@ -1,0 +1,159 @@
+router_bgp:
+  as: '65005'
+  router_id: 192.168.255.5
+  bgp_defaults:
+  - maximum-paths 4 ecmp 4
+  peer_groups:
+    IPv4-UNDERLAY-PEERS:
+      type: ipv4
+      maximum_routes: 12000
+      send_community: all
+    EVPN-OVERLAY-PEERS:
+      type: evpn
+      update_source: Loopback0
+      bfd: true
+      ebgp_multihop: '3'
+      send_community: all
+      maximum_routes: 0
+  address_family_ipv4:
+    peer_groups:
+      IPv4-UNDERLAY-PEERS:
+        activate: true
+      EVPN-OVERLAY-PEERS:
+        activate: false
+  redistribute_routes:
+    connected:
+      route_map: RM-CONN-2-BGP
+  address_family_evpn:
+    peer_groups:
+      EVPN-OVERLAY-PEERS:
+        activate: true
+  vrfs:
+    TEST1:
+      router_id: 192.168.255.5
+      rd: 192.168.255.5:11
+      route_targets:
+        import:
+          evpn:
+          - '11:11'
+        export:
+          evpn:
+          - '11:11'
+      redistribute_routes:
+      - connected
+  vlans:
+    1:
+      tenant: Tenant_A
+      rd: 192.168.255.5:10001
+      route_targets:
+        both:
+        - 10001:10001
+      redistribute_routes:
+      - learned
+    2:
+      tenant: Tenant_A
+      rd: 192.168.255.5:10002
+      route_targets:
+        both:
+        - 10002:10002
+      redistribute_routes:
+      - learned
+static_routes:
+- vrf: MGMT
+  destination_address_prefix: 0.0.0.0/0
+  gateway: 192.168.200.1
+service_routing_protocols_model: multi-agent
+ip_routing: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+vrfs:
+  MGMT:
+    ip_routing: false
+  TEST1:
+    tenant: Tenant_A
+    ip_routing: true
+    description: TEST1
+management_interfaces:
+  Management1:
+    description: oob_management
+    shutdown: false
+    vrf: MGMT
+    ip_address: 192.168.200.105/24
+    gateway: 192.168.200.1
+    type: oob
+management_api_http:
+  enable_vrfs:
+    MGMT: {}
+  enable_https: true
+loopback_interfaces:
+  Loopback0:
+    description: EVPN_Overlay_Peering
+    shutdown: false
+    ip_address: 192.168.255.5/32
+  Loopback1:
+    description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
+    ip_address: 192.168.254.5/32
+prefix_lists:
+  PL-LOOPBACKS-EVPN-OVERLAY:
+    sequence_numbers:
+      10:
+        action: permit 192.168.255.0/24 eq 32
+      20:
+        action: permit 192.168.254.0/24 eq 32
+route_maps:
+  RM-CONN-2-BGP:
+    sequence_numbers:
+      10:
+        type: permit
+        match:
+        - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+router_bfd:
+  multihop:
+    interval: 300
+    min_rx: 300
+    multiplier: 3
+vlans:
+  1:
+    tenant: Tenant_A
+    name: VLAN_1
+  2:
+    tenant: Tenant_A
+    name: VLAN_2
+ip_igmp_snooping:
+  globally_enabled: true
+ip_virtual_router_mac_address: 00:dc:00:00:00:0a
+vlan_interfaces:
+  Vlan1:
+    tenant: Tenant_A
+    tags:
+    - test_l3
+    description: VLAN_1
+    shutdown: false
+    vrf: TEST1
+    ip_address_virtual: 10.0.1.1/24
+  Vlan2:
+    tenant: Tenant_A
+    tags:
+    - test_l3
+    description: VLAN_2
+    shutdown: false
+    vrf: TEST1
+    ip_address_virtual: 10.0.2.1/24
+vxlan_interface:
+  Vxlan1:
+    description: RD-RT-ADMIN-SUBFIELD-L3LEAF5_VTEP
+    vxlan:
+      source_interface: Loopback1
+      udp_port: 4789
+      vlans:
+        1:
+          vni: 10001
+        2:
+          vni: 10002
+      vrfs:
+        TEST1:
+          vni: 11

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF5.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF5.yml
@@ -31,7 +31,7 @@ router_bgp:
   vrfs:
     TEST1:
       router_id: 192.168.255.5
-      rd: 192.168.255.5:11
+      rd: 1.1.1.1:11
       route_targets:
         import:
           evpn:
@@ -44,7 +44,7 @@ router_bgp:
   vlans:
     1:
       tenant: Tenant_A
-      rd: 192.168.255.5:10001
+      rd: 1.1.1.1:10001
       route_targets:
         both:
         - 10001:10001
@@ -52,7 +52,7 @@ router_bgp:
       - learned
     2:
       tenant: Tenant_A
-      rd: 192.168.255.5:10002
+      rd: 1.1.1.1:10002
       route_targets:
         both:
         - 10002:10002

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF6.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF6.yml
@@ -31,7 +31,7 @@ router_bgp:
   vrfs:
     TEST1:
       router_id: 192.168.255.6
-      rd: 192.168.255.6:11
+      rd: '65535:11'
       route_targets:
         import:
           evpn:
@@ -44,7 +44,7 @@ router_bgp:
   vlans:
     1:
       tenant: Tenant_A
-      rd: 192.168.255.6:10001
+      rd: 65535:10001
       route_targets:
         both:
         - 10001:10001
@@ -52,7 +52,7 @@ router_bgp:
       - learned
     2:
       tenant: Tenant_A
-      rd: 192.168.255.6:10002
+      rd: 65535:10002
       route_targets:
         both:
         - 10002:10002

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF6.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF6.yml
@@ -1,0 +1,159 @@
+router_bgp:
+  as: '65006'
+  router_id: 192.168.255.6
+  bgp_defaults:
+  - maximum-paths 4 ecmp 4
+  peer_groups:
+    IPv4-UNDERLAY-PEERS:
+      type: ipv4
+      maximum_routes: 12000
+      send_community: all
+    EVPN-OVERLAY-PEERS:
+      type: evpn
+      update_source: Loopback0
+      bfd: true
+      ebgp_multihop: '3'
+      send_community: all
+      maximum_routes: 0
+  address_family_ipv4:
+    peer_groups:
+      IPv4-UNDERLAY-PEERS:
+        activate: true
+      EVPN-OVERLAY-PEERS:
+        activate: false
+  redistribute_routes:
+    connected:
+      route_map: RM-CONN-2-BGP
+  address_family_evpn:
+    peer_groups:
+      EVPN-OVERLAY-PEERS:
+        activate: true
+  vrfs:
+    TEST1:
+      router_id: 192.168.255.6
+      rd: 192.168.255.6:11
+      route_targets:
+        import:
+          evpn:
+          - '11:11'
+        export:
+          evpn:
+          - '11:11'
+      redistribute_routes:
+      - connected
+  vlans:
+    1:
+      tenant: Tenant_A
+      rd: 192.168.255.6:10001
+      route_targets:
+        both:
+        - 10001:10001
+      redistribute_routes:
+      - learned
+    2:
+      tenant: Tenant_A
+      rd: 192.168.255.6:10002
+      route_targets:
+        both:
+        - 10002:10002
+      redistribute_routes:
+      - learned
+static_routes:
+- vrf: MGMT
+  destination_address_prefix: 0.0.0.0/0
+  gateway: 192.168.200.1
+service_routing_protocols_model: multi-agent
+ip_routing: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+vrfs:
+  MGMT:
+    ip_routing: false
+  TEST1:
+    tenant: Tenant_A
+    ip_routing: true
+    description: TEST1
+management_interfaces:
+  Management1:
+    description: oob_management
+    shutdown: false
+    vrf: MGMT
+    ip_address: 192.168.200.106/24
+    gateway: 192.168.200.1
+    type: oob
+management_api_http:
+  enable_vrfs:
+    MGMT: {}
+  enable_https: true
+loopback_interfaces:
+  Loopback0:
+    description: EVPN_Overlay_Peering
+    shutdown: false
+    ip_address: 192.168.255.6/32
+  Loopback1:
+    description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
+    ip_address: 192.168.254.6/32
+prefix_lists:
+  PL-LOOPBACKS-EVPN-OVERLAY:
+    sequence_numbers:
+      10:
+        action: permit 192.168.255.0/24 eq 32
+      20:
+        action: permit 192.168.254.0/24 eq 32
+route_maps:
+  RM-CONN-2-BGP:
+    sequence_numbers:
+      10:
+        type: permit
+        match:
+        - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+router_bfd:
+  multihop:
+    interval: 300
+    min_rx: 300
+    multiplier: 3
+vlans:
+  1:
+    tenant: Tenant_A
+    name: VLAN_1
+  2:
+    tenant: Tenant_A
+    name: VLAN_2
+ip_igmp_snooping:
+  globally_enabled: true
+ip_virtual_router_mac_address: 00:dc:00:00:00:0a
+vlan_interfaces:
+  Vlan1:
+    tenant: Tenant_A
+    tags:
+    - test_l3
+    description: VLAN_1
+    shutdown: false
+    vrf: TEST1
+    ip_address_virtual: 10.0.1.1/24
+  Vlan2:
+    tenant: Tenant_A
+    tags:
+    - test_l3
+    description: VLAN_2
+    shutdown: false
+    vrf: TEST1
+    ip_address_virtual: 10.0.2.1/24
+vxlan_interface:
+  Vxlan1:
+    description: RD-RT-ADMIN-SUBFIELD-L3LEAF6_VTEP
+    vxlan:
+      source_interface: Loopback1
+      udp_port: 4789
+      vlans:
+        1:
+          vni: 10001
+        2:
+          vni: 10002
+      vrfs:
+        TEST1:
+          vni: 11

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF7.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF7.yml
@@ -31,7 +31,7 @@ router_bgp:
   vrfs:
     TEST1:
       router_id: 192.168.255.7
-      rd: 192.168.255.7:11
+      rd: '4294967295:11'
       route_targets:
         import:
           evpn:
@@ -44,7 +44,7 @@ router_bgp:
   vlans:
     1:
       tenant: Tenant_A
-      rd: 192.168.255.7:10001
+      rd: 4294967295:10001
       route_targets:
         both:
         - 10001:10001
@@ -52,7 +52,7 @@ router_bgp:
       - learned
     2:
       tenant: Tenant_A
-      rd: 192.168.255.7:10002
+      rd: 4294967295:10002
       route_targets:
         both:
         - 10002:10002

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF7.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF7.yml
@@ -1,0 +1,159 @@
+router_bgp:
+  as: '65007'
+  router_id: 192.168.255.7
+  bgp_defaults:
+  - maximum-paths 4 ecmp 4
+  peer_groups:
+    IPv4-UNDERLAY-PEERS:
+      type: ipv4
+      maximum_routes: 12000
+      send_community: all
+    EVPN-OVERLAY-PEERS:
+      type: evpn
+      update_source: Loopback0
+      bfd: true
+      ebgp_multihop: '3'
+      send_community: all
+      maximum_routes: 0
+  address_family_ipv4:
+    peer_groups:
+      IPv4-UNDERLAY-PEERS:
+        activate: true
+      EVPN-OVERLAY-PEERS:
+        activate: false
+  redistribute_routes:
+    connected:
+      route_map: RM-CONN-2-BGP
+  address_family_evpn:
+    peer_groups:
+      EVPN-OVERLAY-PEERS:
+        activate: true
+  vrfs:
+    TEST1:
+      router_id: 192.168.255.7
+      rd: 192.168.255.7:11
+      route_targets:
+        import:
+          evpn:
+          - '11:11'
+        export:
+          evpn:
+          - '11:11'
+      redistribute_routes:
+      - connected
+  vlans:
+    1:
+      tenant: Tenant_A
+      rd: 192.168.255.7:10001
+      route_targets:
+        both:
+        - 10001:10001
+      redistribute_routes:
+      - learned
+    2:
+      tenant: Tenant_A
+      rd: 192.168.255.7:10002
+      route_targets:
+        both:
+        - 10002:10002
+      redistribute_routes:
+      - learned
+static_routes:
+- vrf: MGMT
+  destination_address_prefix: 0.0.0.0/0
+  gateway: 192.168.200.1
+service_routing_protocols_model: multi-agent
+ip_routing: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+vrfs:
+  MGMT:
+    ip_routing: false
+  TEST1:
+    tenant: Tenant_A
+    ip_routing: true
+    description: TEST1
+management_interfaces:
+  Management1:
+    description: oob_management
+    shutdown: false
+    vrf: MGMT
+    ip_address: 192.168.200.107/24
+    gateway: 192.168.200.1
+    type: oob
+management_api_http:
+  enable_vrfs:
+    MGMT: {}
+  enable_https: true
+loopback_interfaces:
+  Loopback0:
+    description: EVPN_Overlay_Peering
+    shutdown: false
+    ip_address: 192.168.255.7/32
+  Loopback1:
+    description: VTEP_VXLAN_Tunnel_Source
+    shutdown: false
+    ip_address: 192.168.254.7/32
+prefix_lists:
+  PL-LOOPBACKS-EVPN-OVERLAY:
+    sequence_numbers:
+      10:
+        action: permit 192.168.255.0/24 eq 32
+      20:
+        action: permit 192.168.254.0/24 eq 32
+route_maps:
+  RM-CONN-2-BGP:
+    sequence_numbers:
+      10:
+        type: permit
+        match:
+        - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+router_bfd:
+  multihop:
+    interval: 300
+    min_rx: 300
+    multiplier: 3
+vlans:
+  1:
+    tenant: Tenant_A
+    name: VLAN_1
+  2:
+    tenant: Tenant_A
+    name: VLAN_2
+ip_igmp_snooping:
+  globally_enabled: true
+ip_virtual_router_mac_address: 00:dc:00:00:00:0a
+vlan_interfaces:
+  Vlan1:
+    tenant: Tenant_A
+    tags:
+    - test_l3
+    description: VLAN_1
+    shutdown: false
+    vrf: TEST1
+    ip_address_virtual: 10.0.1.1/24
+  Vlan2:
+    tenant: Tenant_A
+    tags:
+    - test_l3
+    description: VLAN_2
+    shutdown: false
+    vrf: TEST1
+    ip_address_virtual: 10.0.2.1/24
+vxlan_interface:
+  Vxlan1:
+    description: RD-RT-ADMIN-SUBFIELD-L3LEAF7_VTEP
+    vxlan:
+      source_interface: Loopback1
+      udp_port: 4789
+      vlans:
+        1:
+          vni: 10001
+        2:
+          vni: 10002
+      vrfs:
+        TEST1:
+          vni: 11

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/RD_RT_ADMIN_SUBFIELD_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/RD_RT_ADMIN_SUBFIELD_TESTS.yml
@@ -1,0 +1,63 @@
+# RD RT ADMIN SUBFIELD TESTS
+
+# Test overlay_rd and overlay_rt values.
+type: l3leaf
+
+mgmt_gateway: 192.168.200.1
+
+
+l3leaf:
+  defaults:
+    platform: vEOS-LAB
+    loopback_ipv4_pool: 192.168.255.0/24
+    vtep_loopback_ipv4_pool: 192.168.254.0/24
+    virtual_router_mac_address: 00:dc:00:00:00:0a
+  nodes:
+    RD-RT-ADMIN-SUBFIELD-L3LEAF1:
+      bgp_as: 65001
+      id: 1
+      mgmt_ip: 192.168.200.101/24
+    RD-RT-ADMIN-SUBFIELD-L3LEAF2:
+      bgp_as: 65002
+      id: 2
+      mgmt_ip: 192.168.200.102/24
+    RD-RT-ADMIN-SUBFIELD-L3LEAF3:
+      bgp_as: 65003
+      id: 3
+      mgmt_ip: 192.168.200.103/24
+    RD-RT-ADMIN-SUBFIELD-L3LEAF4:
+      bgp_as: 65004
+      id: 4
+      mgmt_ip: 192.168.200.104/24
+    RD-RT-ADMIN-SUBFIELD-L3LEAF5:
+      bgp_as: 65005
+      id: 5
+      mgmt_ip: 192.168.200.105/24
+    RD-RT-ADMIN-SUBFIELD-L3LEAF6:
+      bgp_as: 65006
+      id: 6
+      mgmt_ip: 192.168.200.106/24
+    RD-RT-ADMIN-SUBFIELD-L3LEAF7:
+      bgp_as: 65007
+      id: 7
+      mgmt_ip: 192.168.200.107/24
+
+tenants:
+# igmp_snooping_querier enable on Tenant
+  Tenant_A:
+    mac_vrf_vni_base: 10000
+    vrfs:
+      TEST1:
+        description: "TEST1"
+        vrf_vni: 11
+        svis:
+          1:
+            name: "VLAN_1"
+            tags: ['test_l3']
+            enabled: True
+            ip_address_virtual: 10.0.1.1/24
+          2:
+            name: "VLAN_2"
+            tags: ['test_l3']
+            enabled: True
+            ip_address_virtual: 10.0.2.1/24

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/RD-RT-ADMIN-SUBFIELD-L3LEAF1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/RD-RT-ADMIN-SUBFIELD-L3LEAF1.yml
@@ -1,0 +1,13 @@
+---
+
+# Test with default values
+
+#Expected result: rd 192.168.255.1:*
+# overlay_rd_type:
+#   admin_subfield: overlay_loopback_ip
+
+# Expected results:
+# - vlan1: rt 10001:10001
+# - vlan2: rt 10002:10002
+# overlay_rt_type:
+#   admin_subfield: mac_vrf_id

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/RD-RT-ADMIN-SUBFIELD-L3LEAF2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/RD-RT-ADMIN-SUBFIELD-L3LEAF2.yml
@@ -1,0 +1,9 @@
+---
+
+# Expected result: rd 192.168.254.2:*
+overlay_rd_type:
+  admin_subfield: vtep_loopback
+
+# Expected result: rt 65002:*
+overlay_rt_type:
+  admin_subfield: bgp_as

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/RD-RT-ADMIN-SUBFIELD-L3LEAF3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/RD-RT-ADMIN-SUBFIELD-L3LEAF3.yml
@@ -1,0 +1,9 @@
+---
+
+# Expected result: rd 65003:*
+overlay_rd_type:
+  admin_subfield: bgp_as
+
+# Expected result: rt 15:*
+overlay_rt_type:
+  admin_subfield: 15

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/RD-RT-ADMIN-SUBFIELD-L3LEAF4.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/RD-RT-ADMIN-SUBFIELD-L3LEAF4.yml
@@ -1,0 +1,10 @@
+---
+
+# Expected result: rd 5004:*
+overlay_rd_type:
+  admin_subfield: switch_id
+  admin_subfield_offset: 5000
+
+# Expected result: rt 4294967295:*
+overlay_rt_type:
+  admin_subfield: 4294967295

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/RD-RT-ADMIN-SUBFIELD-L3LEAF5.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/RD-RT-ADMIN-SUBFIELD-L3LEAF5.yml
@@ -1,0 +1,5 @@
+---
+
+# Expected result: rd 1.1.1.1:*
+overlay_rd_type:
+  admin_subfield: 1.1.1.1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/RD-RT-ADMIN-SUBFIELD-L3LEAF6.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/RD-RT-ADMIN-SUBFIELD-L3LEAF6.yml
@@ -1,0 +1,6 @@
+---
+
+overlay_rd_type:
+# Expected result: rd 65535:*
+  admin_subfield: 65525
+  admin_subfield_offset: 10

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/RD-RT-ADMIN-SUBFIELD-L3LEAF7.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/RD-RT-ADMIN-SUBFIELD-L3LEAF7.yml
@@ -1,0 +1,5 @@
+---
+
+overlay_rd_type:
+# Expected result: rd 4294967295:*
+  admin_subfield: 4294967295

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
@@ -71,7 +71,15 @@ all:
           hosts:
             SVI_PROFILE_NODE_1:
             SVI_PROFILE_NODE_2:
-
+        RD_RT_ADMIN_SUBFIELD_TESTS:
+          hosts:
+            RD-RT-ADMIN-SUBFIELD-L3LEAF1:
+            RD-RT-ADMIN-SUBFIELD-L3LEAF2:
+            RD-RT-ADMIN-SUBFIELD-L3LEAF3:
+            RD-RT-ADMIN-SUBFIELD-L3LEAF4:
+            RD-RT-ADMIN-SUBFIELD-L3LEAF5:
+            RD-RT-ADMIN-SUBFIELD-L3LEAF6:
+            RD-RT-ADMIN-SUBFIELD-L3LEAF7:
         AVD_LAB:
           children:
             DC1_FABRIC:

--- a/ansible_collections/arista/avd/plugins/module_utils/eos_designs_facts.py
+++ b/ansible_collections/arista/avd/plugins/module_utils/eos_designs_facts.py
@@ -742,14 +742,21 @@ class EosDesignsFacts:
             get(self._hostvars, "evpn_rd_type.admin_subfield"),
             get(self._hostvars, "overlay_rd_type.admin_subfield")
         )
+        tmp_overlay_rd_type_admin_subfield_offset = default(
+            get(self._hostvars, "evpn_rd_type.admin_subfield_offset"),
+            get(self._hostvars, "overlay_rd_type.admin_subfield_offset"),
+            0
+        )
         if tmp_overlay_rd_type_admin_subfield is None:
             return self.router_id
         if tmp_overlay_rd_type_admin_subfield == "vtep_loopback":
             return self.vtep_ip
         if tmp_overlay_rd_type_admin_subfield == "bgp_as":
             return self.bgp_as
-        if isinstance(tmp_overlay_rd_type_admin_subfield, int) and tmp_overlay_rd_type_admin_subfield > 0 and tmp_overlay_rd_type_admin_subfield < 4294967295:
-            return tmp_overlay_rd_type_admin_subfield
+        if tmp_overlay_rd_type_admin_subfield == "switch_id":
+            return self.id + tmp_overlay_rd_type_admin_subfield_offset
+        if isinstance(tmp_overlay_rd_type_admin_subfield, int) and tmp_overlay_rd_type_admin_subfield > 0 and tmp_overlay_rd_type_admin_subfield <= 4294967295:
+            return tmp_overlay_rd_type_admin_subfield + tmp_overlay_rd_type_admin_subfield_offset
         if isinstance(tmp_overlay_rd_type_admin_subfield, str):
             try:
                 ipaddress.ip_address(tmp_overlay_rd_type_admin_subfield)

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
@@ -45,7 +45,7 @@ mlag_ibgp_peering_vrfs:
 # For 16-bit ASN/number the VNI can be a 32-bit number.
 # Old variable name "evpn_rd_type", supported for backward-compatibility.
 overlay_rd_type:
-  admin_subfield: < "vtep_loopback" | "bgp_as" | "switch_id" | < IPv4 Address > | <0-65535> | <0-4294967295> | default -> <overlay_loopback_ip> >
+  admin_subfield: < "vtep_loopback" | "bgp_as" | "switch_id" | < IPv4_address > | <0-65535> | <0-4294967295> | default -> <overlay_loopback_ip> >
   # Offset can only be used if admin_subfield is an interger between <0-4294967295> or "switch_id".
   admin_subfield_offset: <0-4294967295> | default -> 0 >
 

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
@@ -47,7 +47,8 @@ mlag_ibgp_peering_vrfs:
 overlay_rd_type:
   admin_subfield: < "vtep_loopback" | "bgp_as" | "switch_id" | < IPv4 Address > | <0-65535> | <0-4294967295> | default -> <overlay_loopback_ip> >
   # Offset can only be used if admin_subfield is an interger between <0-4294967295> or "switch_id".
-  admin_subfield_offset: <0-4294967295> | default -> 0 >
+  # Total value of admin_subfield + admin_subfield_offsett must be <= 4294967295.
+  admin_subfield_offset: < int > | default -> 0 >
 
 # Specify RT type | Optional
 # Route Target (RT) for L2 / L3 services is set to <vni>:<vni> per default

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
@@ -45,7 +45,9 @@ mlag_ibgp_peering_vrfs:
 # For 16-bit ASN/number the VNI can be a 32-bit number.
 # Old variable name "evpn_rd_type", supported for backward-compatibility.
 overlay_rd_type:
-  admin_subfield: < "vtep_loopback" | "bgp_as" | < IPv4 Address > | <0-65535> | <0-4294967295> | default -> <overlay_loopback_ip> >
+  admin_subfield: < "vtep_loopback" | "bgp_as" | "switch_id" | < IPv4 Address > | <0-65535> | <0-4294967295> | default -> <overlay_loopback_ip> >
+  # Offset can only be used if admin_subfield is an interger between <0-4294967295> or "switch_id".
+  admin_subfield_offset: <0-4294967295> | default -> 0 >
 
 # Specify RT type | Optional
 # Route Target (RT) for L2 / L3 services is set to <vni>:<vni> per default

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
@@ -47,7 +47,7 @@ mlag_ibgp_peering_vrfs:
 overlay_rd_type:
   admin_subfield: < "vtep_loopback" | "bgp_as" | "switch_id" | < IPv4_address > | <0-65535> | <0-4294967295> | default -> <overlay_loopback_ip> >
   # Offset can only be used if admin_subfield is an interger between <0-4294967295> or "switch_id".
-  # Total value of admin_subfield + admin_subfield_offsett must be <= 4294967295.
+  # Total value of admin_subfield + admin_subfield_offset must be <= 4294967295.
   admin_subfield_offset: < int > | default -> 0 >
 
 # Specify RT type | Optional


### PR DESCRIPTION
## Change Summary

- Support switch_id and offset in rd admin subfield
- Fix to support the maximum value of 4294967295
- Increase molecule unit test coverage for `overlay_rd_type` and `overlay_rt_type`
## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

```yaml
overlay_rd_type:
 # New "switch_id" option in admin_subfield
  admin_subfield: < "vtep_loopback" | "bgp_as" | "switch_id" | < IPv4 Address > | <0-65535> | <0-4294967295> | default -> <overlay_loopback_ip> >
  # New key ->
  # Offset can only be used if admin_subfield is an interger between <0-4294967295> or "switch_id".
  admin_subfield_offset: <0-4294967295> | default -> 0 >
```

## How to test
See Molecule tests

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
