### PR TITLE
Fix(eos_designs): return the missing node_type in error

### DIFF
--- a/ansible_collections/arista/avd/plugins/module_utils/eos_designs_facts.py
+++ b/ansible_collections/arista/avd/plugins/module_utils/eos_designs_facts.py
@@ -142,7 +142,7 @@ class EosDesignsFacts:
                 return node_type
 
         # Not found
-        raise AristaAvdMissingVariableError(f"node_type_keys.<>.type=={type}")
+        raise AristaAvdMissingVariableError(f"node_type_keys.<>.type=={self.type}")
 
     @cached_property
     def connected_endpoints(self):


### PR DESCRIPTION
## Change Summary

Provide the node type detail in the error

## Related Issue(s)

Fixes #1979

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been rebased from devel before I start
- [X] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [X] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
