### PR TITLE
Feat(eos_designs): Support static_routes for default vrf  under network-services

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/BGP-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/BGP-SPINE2.md
@@ -358,12 +358,14 @@ no ip routing vrf MGMT
 | VRF | Destination Prefix | Next Hop IP             | Exit interface      | Administrative Distance       | Tag               | Route Name                    | Metric         |
 | --- | ------------------ | ----------------------- | ------------------- | ----------------------------- | ----------------- | ----------------------------- | -------------- |
 | MGMT | 0.0.0.0/0 | 172.31.0.1 | - | 1 | - | - | - |
+| default | 10.0.0.0/8 | 10.1.100.100 | - | 1 | - | - | - |
 
 ### Static Routes Device Configuration
 
 ```eos
 !
 ip route vrf MGMT 0.0.0.0/0 172.31.0.1
+ip route 10.0.0.0/8 10.1.100.100
 ```
 
 ## Router BGP
@@ -428,6 +430,7 @@ router bgp 65001
    neighbor 192.168.254.0 peer group MLAG-IPv4-UNDERLAY-PEER
    neighbor 192.168.254.0 description BGP-SPINE1
    redistribute connected
+   redistribute static
    !
    address-family ipv4
       neighbor IPv4-UNDERLAY-PEERS activate

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/ISIS-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/ISIS-SPINE1.md
@@ -289,12 +289,14 @@ no ip routing vrf MGMT
 | VRF | Destination Prefix | Next Hop IP             | Exit interface      | Administrative Distance       | Tag               | Route Name                    | Metric         |
 | --- | ------------------ | ----------------------- | ------------------- | ----------------------------- | ----------------- | ----------------------------- | -------------- |
 | MGMT | 0.0.0.0/0 | 172.31.0.1 | - | 1 | - | - | - |
+| default | 10.1.0.0/16 | 10.1.100.100 | - | 1 | - | - | - |
 
 ### Static Routes Device Configuration
 
 ```eos
 !
 ip route vrf MGMT 0.0.0.0/0 172.31.0.1
+ip route 10.1.0.0/16 10.1.100.100
 ```
 
 ## Router ISIS
@@ -315,6 +317,7 @@ ip route vrf MGMT 0.0.0.0/0 172.31.0.1
 | Route Type | Route-Map | Include Leaked |
 | ---------- | --------- | -------------- |
 | connected | - | - |
+| static | - | - |
 
 ### ISIS Interfaces Summary
 
@@ -330,6 +333,7 @@ router isis EVPN_UNDERLAY
    net 49.0001.0001.0000.0001.00
    is-type level-2
    redistribute connected
+   redistribute static
    router-id ipv4 192.168.255.1
    log-adjacency-changes
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/OSPF-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/OSPF-SPINE2.md
@@ -362,12 +362,14 @@ no ip routing vrf MGMT
 | VRF | Destination Prefix | Next Hop IP             | Exit interface      | Administrative Distance       | Tag               | Route Name                    | Metric         |
 | --- | ------------------ | ----------------------- | ------------------- | ----------------------------- | ----------------- | ----------------------------- | -------------- |
 | MGMT | 0.0.0.0/0 | 172.31.0.1 | - | 1 | - | - | - |
+| default | 10.0.0.0/8 | 10.1.100.100 | - | 1 | - | - | - |
 
 ### Static Routes Device Configuration
 
 ```eos
 !
 ip route vrf MGMT 0.0.0.0/0 172.31.0.1
+ip route 10.0.0.0/8 10.1.100.100
 ```
 
 ## Router OSPF
@@ -383,6 +385,7 @@ ip route vrf MGMT 0.0.0.0/0 172.31.0.1
 | Process ID | Source Protocol | Route Map |
 | ---------- | --------------- | --------- |
 | 100 | connected | - |
+| 100 | static | - |
 
 ### OSPF Interfaces
 
@@ -402,6 +405,7 @@ router ospf 100
    no passive-interface Vlan4094
    no passive-interface Ethernet5
    max-lsa 12000
+   redistribute static
    redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/BGP-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/BGP-SPINE2.cfg
@@ -104,6 +104,7 @@ mlag configuration
    reload-delay non-mlag 330
 !
 ip route vrf MGMT 0.0.0.0/0 172.31.0.1
+ip route 10.0.0.0/8 10.1.100.100
 !
 route-map RM-MLAG-PEER-IN permit 10
    description Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing
@@ -128,6 +129,7 @@ router bgp 65001
    neighbor 192.168.254.0 peer group MLAG-IPv4-UNDERLAY-PEER
    neighbor 192.168.254.0 description BGP-SPINE1
    redistribute connected
+   redistribute static
    !
    address-family ipv4
       neighbor IPv4-UNDERLAY-PEERS activate

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/ISIS-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/ISIS-SPINE1.cfg
@@ -58,11 +58,13 @@ ip routing
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 172.31.0.1
+ip route 10.1.0.0/16 10.1.100.100
 !
 router isis EVPN_UNDERLAY
    net 49.0001.0001.0000.0001.00
    is-type level-2
    redistribute connected
+   redistribute static
    router-id ipv4 192.168.255.1
    log-adjacency-changes
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/OSPF-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/OSPF-SPINE2.cfg
@@ -109,6 +109,7 @@ mlag configuration
    reload-delay non-mlag 330
 !
 ip route vrf MGMT 0.0.0.0/0 172.31.0.1
+ip route 10.0.0.0/8 10.1.100.100
 !
 router ospf 100
    router-id 192.168.255.2
@@ -116,6 +117,7 @@ router ospf 100
    no passive-interface Vlan4094
    no passive-interface Ethernet5
    max-lsa 12000
+   redistribute static
    redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-SPINE2.yml
@@ -32,10 +32,14 @@ router_bgp:
       peer_group: IPv4-UNDERLAY-PEERS
   redistribute_routes:
     connected: {}
+    static: {}
 static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0
   gateway: 172.31.0.1
+- destination_address_prefix: 10.0.0.0/8
+  vrf: default
+  gateway: 10.1.100.100
 service_routing_protocols_model: multi-agent
 ip_routing: true
 vlan_internal_order:

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/ISIS-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/ISIS-SPINE1.yml
@@ -2,6 +2,9 @@ static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0
   gateway: 172.31.0.1
+- destination_address_prefix: 10.1.0.0/16
+  vrf: default
+  gateway: 10.1.100.100
 service_routing_protocols_model: multi-agent
 ip_routing: true
 vlan_internal_order:
@@ -68,6 +71,7 @@ router_isis:
   - maximum-paths 4
   redistribute_routes:
   - source_protocol: connected
+  - source_protocol: static
 vlans:
   110:
     tenant: L2LS_ISIS

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-SPINE2.yml
@@ -2,6 +2,9 @@ static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0
   gateway: 172.31.0.1
+- destination_address_prefix: 10.0.0.0/8
+  vrf: default
+  gateway: 10.1.100.100
 service_routing_protocols_model: multi-agent
 ip_routing: true
 vlan_internal_order:
@@ -140,6 +143,7 @@ router_ospf:
       max_lsa: 12000
       redistribute:
         connected: {}
+        static: {}
 ip_igmp_snooping:
   globally_enabled: true
 ip_virtual_router_mac_address: 00:1c:73:00:00:99

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/inventory/group_vars/ISIS_LEAFS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/inventory/group_vars/ISIS_LEAFS.yml
@@ -6,9 +6,12 @@ leaf:
   defaults:
     uplink_interfaces: ['Ethernet1']
     uplink_switches: ['ISIS-SPINE1']
+    isis_system_id_prefix: '0001.0001'
+    isis_maximum_paths: 4
     platform: vEOS-LAB
   node_groups:
     ISIS_LEAFS:
+      vtep_loopback: Loopback0
       nodes:
         ISIS-LEAF1:
           id: 1

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/inventory/group_vars/L2LS_BGP.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/inventory/group_vars/L2LS_BGP.yml
@@ -13,6 +13,10 @@ tenants:
             name: SVI_100
             ip_address_virtual: 10.1.100.1/24
             enabled: true
+        static_routes: # Testing creation of static route in default VRF including redistribute static under the underlay protocol
+          - destination_address_prefix: 10.0.0.0/8
+            gateway: 10.1.100.100
+            nodes: [ BGP-SPINE2 ]
 
 network_ports:
   - switches:

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/inventory/group_vars/L2LS_ISIS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/inventory/group_vars/L2LS_ISIS.yml
@@ -14,6 +14,10 @@ tenants:
             name: SVI_110
             ip_address_virtual: 10.0.110.1/24
             enabled: true
+        static_routes: # Testing creation of static route in default VRF including redistribute static under the underlay protocol
+          - destination_address_prefix: 10.1.0.0/16
+            gateway: 10.1.100.100
+            nodes: [ ISIS-SPINE1 ]
 
 network_ports:
   - switches:

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/inventory/group_vars/L2LS_OSPF.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/inventory/group_vars/L2LS_OSPF.yml
@@ -13,6 +13,10 @@ tenants:
             name: SVI_100
             ip_address_virtual: 10.0.100.1/24
             enabled: true
+        static_routes: # Testing creation of static route in default VRF including redistribute static under the underlay protocol
+          - destination_address_prefix: 10.0.0.0/8
+            gateway: 10.1.100.100
+            nodes: [ OSPF-SPINE2 ]
 
 network_ports:
   - switches:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MH-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MH-LEAF2A.cfg
@@ -126,13 +126,20 @@ ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.255.0/24 eq 32
    seq 20 permit 192.168.254.0/24 eq 32
 !
+ip prefix-list PL-STATIC-VRF-DEFAULT
+   seq 10 permit 10.0.0.0/8
+!
 ip prefix-list PL-SVI-VRF-DEFAULT
    seq 10 permit 10.2.10.0/24
 !
 ip route vrf MGMT 0.0.0.0/0 192.168.200.5
+ip route 10.0.0.0/8 10.2.10.100
 !
 route-map RM-BGP-UNDERLAY-PEERS-OUT deny 10
    match ip address prefix-list PL-SVI-VRF-DEFAULT
+!
+route-map RM-BGP-UNDERLAY-PEERS-OUT deny 15
+   match ip address prefix-list PL-STATIC-VRF-DEFAULT
 !
 route-map RM-BGP-UNDERLAY-PEERS-OUT permit 20
 !
@@ -144,6 +151,9 @@ route-map RM-CONN-2-BGP permit 30
 !
 route-map RM-EVPN-EXPORT-VRF-DEFAULT permit 10
    match ip address prefix-list PL-SVI-VRF-DEFAULT
+!
+route-map RM-EVPN-EXPORT-VRF-DEFAULT permit 20
+   match ip address prefix-list PL-STATIC-VRF-DEFAULT
 !
 router bfd
    multihop interval 1200 min-rx 1200 multiplier 3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF2A.yml
@@ -89,6 +89,9 @@ static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0
   gateway: 192.168.200.5
+- destination_address_prefix: 10.0.0.0/8
+  vrf: default
+  gateway: 10.2.10.100
 service_routing_protocols_model: multi-agent
 ip_routing: true
 daemon_terminattr:
@@ -220,6 +223,10 @@ prefix_lists:
     sequence_numbers:
       10:
         action: permit 10.2.10.0/24
+  PL-STATIC-VRF-DEFAULT:
+    sequence_numbers:
+      10:
+        action: permit 10.0.0.0/8
 route_maps:
   RM-CONN-2-BGP:
     sequence_numbers:
@@ -237,12 +244,20 @@ route_maps:
         type: permit
         match:
         - ip address prefix-list PL-SVI-VRF-DEFAULT
+      20:
+        type: permit
+        match:
+        - ip address prefix-list PL-STATIC-VRF-DEFAULT
   RM-BGP-UNDERLAY-PEERS-OUT:
     sequence_numbers:
       10:
         type: deny
         match:
         - ip address prefix-list PL-SVI-VRF-DEFAULT
+      15:
+        type: deny
+        match:
+        - ip address prefix-list PL-STATIC-VRF-DEFAULT
       20:
         type: permit
 router_bfd:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/MH_TENANT_NETWORKS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/MH_TENANT_NETWORKS.yml
@@ -24,3 +24,6 @@ tenants:
             tags: [default_vrf]
             enabled: true
             ip_address_virtual: 10.2.10.1/24
+        static_routes:
+          - destination_address_prefix: 10.0.0.0/8
+            gateway: 10.2.10.100

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/network-services.md
@@ -159,7 +159,7 @@ mac_address_table:
       # VRF name | Required
       # vrf "default" is supported under network-services. Currently the supported options for "default" vrf are route-target,
       # route-distinguisher settings, structured_config, raw_eos_cli in bgp and SVIs are the only supported interface type.
-      # Vlan-aware-bundles are supported as well inside default vrf. OSPF is not supported currently.
+      # Static-routes and vlan-aware-bundles are supported as well inside default vrf. OSPF is not supported currently.
       < tenant_a_vrf_1 >:
 
         # Optional

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/default-vrf-redistribute-static.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/default-vrf-redistribute-static.j2
@@ -1,0 +1,16 @@
+{# This only runs if bgp was not configured as part of evpn config #}
+{% if switch.underlay_routing_protocol == 'ebgp' %}
+router_bgp:
+  redistribute_routes:
+    static: {}
+{% elif switch.underlay_routing_protocol in ['isis', 'isis-ldp', 'isis-sr', 'isis-sr-ldp'] %}
+router_isis:
+  redistribute_routes:
+    source_protocol: static
+{% elif switch.underlay_routing_protocol in ['ospf', 'ospf-ldp'] %}
+router_ospf:
+  process_ids:
+    {{ underlay_ospf_process_id }}:
+      redistribute:
+        static: {}
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/default-vrf-redistribute-static.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/default-vrf-redistribute-static.j2
@@ -6,7 +6,7 @@ router_bgp:
 {% elif switch.underlay_routing_protocol in ['isis', 'isis-ldp', 'isis-sr', 'isis-sr-ldp'] %}
 router_isis:
   redistribute_routes:
-    source_protocol: static
+    - source_protocol: static
 {% elif switch.underlay_routing_protocol in ['ospf', 'ospf-ldp'] %}
 router_ospf:
   process_ids:

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/default-vrf-route-map.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/default-vrf-route-map.j2
@@ -1,26 +1,52 @@
 {# prefix_lists #}
 prefix_lists:
+{% if default_vrf.svi_subnets %}
   PL-SVI-VRF-DEFAULT:
     sequence_numbers:
-{% for svi_subnet in default_vrf.svi_subnets %}
+{%     for svi_subnet in default_vrf.svi_subnets %}
       {{ 10*loop.index }}:
         action: "permit {{ svi_subnet }}"
-{% endfor %}
+{%     endfor %}
+{% endif %}
+{% if default_vrf.static_routes %}
+  PL-STATIC-VRF-DEFAULT:
+    sequence_numbers:
+{%     for static_route in default_vrf.static_routes %}
+      {{ 10*loop.index }}:
+        action: "permit {{ static_route }}"
+{%     endfor %}
+{% endif %}
 
 {# route_maps #}
 route_maps:
   RM-EVPN-EXPORT-VRF-DEFAULT:
     sequence_numbers:
+{% if default_vrf.svi_subnets %}
       10:
         type: permit
         match:
         - ip address prefix-list PL-SVI-VRF-DEFAULT
+{% endif %}
+{% if default_vrf.static_routes %}
+      20:
+        type: permit
+        match:
+        - ip address prefix-list PL-STATIC-VRF-DEFAULT
+{% endif %}
   RM-BGP-UNDERLAY-PEERS-OUT:
     sequence_numbers:
+{% if default_vrf.svi_subnets %}
       10:
         type: deny
         match:
         - ip address prefix-list PL-SVI-VRF-DEFAULT
+{% endif %}
+{% if default_vrf.static_routes %}
+      15:
+        type: deny
+        match:
+        - ip address prefix-list PL-STATIC-VRF-DEFAULT
+{% endif %}
       20:
         type: permit
   RM-CONN-2-BGP:

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/main.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/main.j2
@@ -1,7 +1,7 @@
 {# Add one blank line after each included template #}
 {% if switch.network_services_l2 is arista.avd.defined(true) or switch.network_services_l3 is arista.avd.defined(true) or switch.network_services_l1 is arista.avd.defined(true) %}
 {%     set network_services_data = namespace(ipv6vrfs = {}) %}
-{%     set default_vrf = namespace(svi_subnets = []) %}
+{%     set default_vrf = namespace(svi_subnets = [], static_routes = []) %}
 {%     include 'network_services/logic.j2' %}
 
 {% endif %}
@@ -57,9 +57,10 @@
       switch.network_services_l1 is arista.avd.defined(true)) %}
 {%     include 'network_services/vtep-logic.j2' %}
 
-{%     if default_vrf.svi_subnets and switch.evpn_role in ["client", "server"] %}
+{%     if (default_vrf.svi_subnets or default_vrf.static_routes) and switch.evpn_role in ["client", "server"] %}
 {%         include 'network_services/default-vrf-route-map.j2' %}
 
+{%         set default_vrf.static_routes = [] %}
 {%     endif %}
 
 {%     include 'network_services/router-bgp.j2' %}
@@ -75,5 +76,12 @@
       switch.network_services_l2 is arista.avd.defined(true) and
       switch.network_services_l3 is arista.avd.defined(true) %}
 {%     include 'network_services/virtual-source-nat-vrfs.j2' %}
+
+{% endif %}
+
+{% if default_vrf.static_routes | arista.avd.default(false) %}
+{# since we cannot update BGP in multiple templates, the case for underlay BGP #}
+{# is handled inside router-bgp.j2 and redistribute_static is reset to false #}
+{%     include 'network_services/default-vrf-redistribute-static.j2' %}
 
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-default-vrf.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-default-vrf.j2
@@ -1,5 +1,11 @@
 {# router bgp default vrf configuration for evpn #}
+{% if default_vrf.svi_subnets %}
   peer_groups:
     {{ switch.bgp_peer_groups.ipv4_underlay_peers.name }}:
       type: ipv4
       route_map_out: RM-BGP-UNDERLAY-PEERS-OUT
+{% endif %}
+{% if default_vrf.static_routes %}
+  redistribute_routes:
+    static: {}
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp.j2
@@ -11,7 +11,7 @@ router_bgp:
 {%         include 'network_services/router-bgp-vlan-aware-bundles.j2' %}
 
 {%     endif %}
-{%     if default_vrf.svi_subnets and switch.evpn_role in ["client", "server"] %}
+{%     if (default_vrf.svi_subnets or default_vrf.static_routes) and switch.evpn_role in ["client", "server"] %}
 {%         include 'network_services/router-bgp-default-vrf.j2' %}
 
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp.j2
@@ -11,7 +11,7 @@ router_bgp:
 {%         include 'network_services/router-bgp-vlan-aware-bundles.j2' %}
 
 {%     endif %}
-{%     if (default_vrf.svi_subnets or default_vrf.static_routes) and switch.evpn_role in ["client", "server"] %}
+{%     if switch.evpn_role in ["client", "server"] %}
 {%         include 'network_services/router-bgp-default-vrf.j2' %}
 
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/static-routes.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/static-routes.j2
@@ -47,6 +47,9 @@ static_routes:
 {%         if vrf.static_routes is arista.avd.defined %}
 {%             for static_route in vrf.static_routes %}
 {%                 if inventory_hostname in static_route.nodes | arista.avd.default([inventory_hostname]) %}
+{%                     if vrf.name == "default" %}
+{%                         do default_vrf.static_routes.append(static_route.destination_address_prefix) %}
+{%                     endif %}
   - destination_address_prefix: {{ static_route.destination_address_prefix }}
     vrf: {{ vrf.name }}
 {%                     if static_route.gateway is arista.avd.defined %}


### PR DESCRIPTION
## Change Summary

Feat(eos_designs): Support static_routes for default vrf  under network-services
<!-- Enter short PR description -->

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->
Add static routes and redistribution of static routes in the case of VRF `default`.
For EVPN the `redistribute static` will be added under BGP and the static routes will be added to a prefix-list which is included under the EVPN default-vrf route-maps.

For non-evpn networks the `redistribute static` is added to the relevant underlay routing instance (if any)

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Added molecule coverage to existing default vrf scenarios for EVPN and non-EVPN.
## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
