### PR TITLE
Feat(eos_cli_config_gen): Add schema for access_lists

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/schema_eos_cli_config_gen.md
+++ b/.github/PULL_REQUEST_TEMPLATE/schema_eos_cli_config_gen.md
@@ -9,7 +9,7 @@
 - [ ] Create schema fragment matching data model described in README.md and README_v4.0.md
   - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
   - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
-  - Copy line 1-6 from another schema (comments and global schema).
+  - Copy line 1-5 from another schema (comments and outer type:dict).
   - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
   - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
 - [ ] If the data model has been converted from wildcard dicts:

--- a/.github/PULL_REQUEST_TEMPLATE/schema_eos_cli_config_gen.md
+++ b/.github/PULL_REQUEST_TEMPLATE/schema_eos_cli_config_gen.md
@@ -1,0 +1,33 @@
+## Add schema for data model
+
+<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->
+
+## Checklist
+
+### Contributor Checklist
+
+- [ ] Create schema fragment matching data model described in README.md and README_v4.0.md
+  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
+  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
+  - Copy line 1-6 from another schema (comments and global schema).
+  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
+  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
+- [ ] If the data model has been converted from wildcard dicts:
+  - Add `convert_types: ['dict']` to the schema.
+  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
+- [ ] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
+- [ ] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.
+
+### Reviewer Checklist
+
+- Reviewer 1:
+  - [ ] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
+  - [ ] Verify that `convert_dicts` has been removed from templates as applicable.
+  - [ ] Verify no changes to configs/docs on any molecule scenario
+  - [ ] Verify that CI pass
+
+- Reviewer 2:
+  - [ ] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
+  - [ ] Verify that `convert_dicts` has been removed from templates as applicable.
+  - [ ] Verify no changes to configs/docs on any molecule scenario
+  - [ ] Verify that CI pass

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -1,2 +1,26 @@
 !!! warning
     This document describes the data model for AVD 4.x. It may or may not work in previous versions.
+
+## IP Extended Access-Lists
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>access_lists</samp>](## "access_lists") | List, items: Dictionary |  |  |  | IP Extended Access-Lists |
+| [<samp>&nbsp;&nbsp;- name</samp>](## "access_lists.[].name") | String | Required, Unique |  |  | access_list_name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;counters_per_entry</samp>](## "access_lists.[].counters_per_entry") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;sequence_numbers</samp>](## "access_lists.[].sequence_numbers") | List, items: Dictionary | Required |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- sequence</samp>](## "access_lists.[].sequence_numbers.[].sequence") | Integer | Required, Unique |  |  | sequence_id |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;action</samp>](## "access_lists.[].sequence_numbers.[].action") | String | Required |  |  | action as string |
+
+### YAML
+
+```yaml
+access_lists:
+  - name: <str>
+    counters_per_entry: <bool>
+    sequence_numbers:
+      - sequence: <int>
+        action: <str>
+```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -15,7 +15,6 @@ Access list names must be unique.
 
 The legacy data model supports simplified ACL definition with `sequence` to `action` mapping:
 
-
 ### Variables
 
 | Variable | Type | Required | Default | Value Restrictions | Description |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -1,18 +1,31 @@
 !!! warning
     This document describes the data model for AVD 4.x. It may or may not work in previous versions.
 
-## IP Extended Access-Lists
+## IP Extended Access-Lists (legacy model)
+
+### Description
+
+AVD currently supports 2 different data models for extended ACLs:
+
+- The legacy `access_lists` data model, for compatibility with existing deployments
+- The improved `ip_access_lists` data model, for access to more EOS features
+
+Both data models can coexists without conflicts, as different keys are used: `access_lists` vs `ip_access_lists`.
+Access list names must be unique.
+
+The legacy data model supports simplified ACL definition with `sequence` to `action` mapping:
+
 
 ### Variables
 
 | Variable | Type | Required | Default | Value Restrictions | Description |
 | -------- | ---- | -------- | ------- | ------------------ | ----------- |
-| [<samp>access_lists</samp>](## "access_lists") | List, items: Dictionary |  |  |  | IP Extended Access-Lists |
-| [<samp>&nbsp;&nbsp;- name</samp>](## "access_lists.[].name") | String | Required, Unique |  |  | access_list_name |
+| [<samp>access_lists</samp>](## "access_lists") | List, items: Dictionary |  |  |  | IP Extended Access-Lists (legacy model) |
+| [<samp>&nbsp;&nbsp;- name</samp>](## "access_lists.[].name") | String | Required, Unique |  |  | Access-list Name |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;counters_per_entry</samp>](## "access_lists.[].counters_per_entry") | Boolean |  |  |  |  |
 | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;sequence_numbers</samp>](## "access_lists.[].sequence_numbers") | List, items: Dictionary | Required |  |  |  |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- sequence</samp>](## "access_lists.[].sequence_numbers.[].sequence") | Integer | Required, Unique |  |  | sequence_id |
-| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;action</samp>](## "access_lists.[].sequence_numbers.[].action") | String | Required |  |  | action as string |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- sequence</samp>](## "access_lists.[].sequence_numbers.[].sequence") | Integer | Required, Unique |  |  | Sequence ID |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;action</samp>](## "access_lists.[].sequence_numbers.[].action") | String | Required |  |  | Action as string<br>Example: "deny ip any any" |
 
 ### YAML
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -6,7 +6,7 @@ keys:
     primary_key: name
     convert_types:
     - dict
-    display_name: IP Extended Access-Lists
+    display_name: IP Extended Access-Lists (legacy model)
     description: 'AVD currently supports 2 different data models for extended ACLs:
 
 
@@ -21,8 +21,8 @@ keys:
       Access list names must be unique.
 
 
-      The legacy data model supports simplified ACL definition with `sequence_number`
-      to `action_string` mapping:
+      The legacy data model supports simplified ACL definition with `sequence` to
+      `action` mapping:
 
       '
     items:
@@ -31,7 +31,7 @@ keys:
         name:
           type: str
           required: true
-          display_name: access_list_name
+          display_name: Access-list Name
         counters_per_entry:
           type: bool
         sequence_numbers:
@@ -46,10 +46,12 @@ keys:
               sequence:
                 type: int
                 required: true
-                display_name: sequence_id
+                display_name: Sequence ID
                 convert_types:
                 - str
               action:
                 type: str
                 required: true
-                display_name: action as string
+                description: 'Action as string
+
+                  Example: "deny ip any any"'

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/_defaults.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/_defaults.schema.yml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+allow_other_keys: true

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/access_lists.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/access_lists.schema.yml
@@ -2,14 +2,13 @@
 # Line above is used by RedHat's YAML Schema vscode extension
 # Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
 type: dict
-allow_other_keys: true
 keys:
   access_lists:
     type: list
     primary_key: name
     convert_types:
       - dict
-    display_name: IP Extended Access-Lists
+    display_name: IP Extended Access-Lists (legacy model)
     description: |
       AVD currently supports 2 different data models for extended ACLs:
 
@@ -19,14 +18,14 @@ keys:
       Both data models can coexists without conflicts, as different keys are used: `access_lists` vs `ip_access_lists`.
       Access list names must be unique.
 
-      The legacy data model supports simplified ACL definition with `sequence_number` to `action_string` mapping:
+      The legacy data model supports simplified ACL definition with `sequence` to `action` mapping:
     items:
       type: dict
       keys:
         name:
           type: str
           required: true
-          display_name: access_list_name
+          display_name: Access-list Name
         counters_per_entry:
           type: bool
         sequence_numbers:
@@ -41,10 +40,12 @@ keys:
               sequence:
                 type: int
                 required: true
-                display_name: sequence_id
+                display_name: Sequence ID
                 convert_types:
                   - str
               action:
                 type: str
                 required: true
-                display_name: action as string
+                description: |
+                  Action as string
+                  Example: "deny ip any any"

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/access_lists.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/access_lists.schema.yml
@@ -1,3 +1,6 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
 type: dict
 allow_other_keys: true
 keys:
@@ -5,26 +8,18 @@ keys:
     type: list
     primary_key: name
     convert_types:
-    - dict
+      - dict
     display_name: IP Extended Access-Lists
-    description: 'AVD currently supports 2 different data models for extended ACLs:
-
+    description: |
+      AVD currently supports 2 different data models for extended ACLs:
 
       - The legacy `access_lists` data model, for compatibility with existing deployments
-
       - The improved `ip_access_lists` data model, for access to more EOS features
 
-
-      Both data models can coexists without conflicts, as different keys are used:
-      `access_lists` vs `ip_access_lists`.
-
+      Both data models can coexists without conflicts, as different keys are used: `access_lists` vs `ip_access_lists`.
       Access list names must be unique.
 
-
-      The legacy data model supports simplified ACL definition with `sequence_number`
-      to `action_string` mapping:
-
-      '
+      The legacy data model supports simplified ACL definition with `sequence_number` to `action_string` mapping:
     items:
       type: dict
       keys:
@@ -39,7 +34,7 @@ keys:
           required: true
           primary_key: sequence
           convert_types:
-          - dict
+            - dict
           items:
             type: dict
             keys:
@@ -48,7 +43,7 @@ keys:
                 required: true
                 display_name: sequence_id
                 convert_types:
-                - str
+                  - str
               action:
                 type: str
                 required: true

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/avd_schema_documentation.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/avd_schema_documentation.j2
@@ -7,7 +7,7 @@
 
 ### Description
 
-{{ table.description }}
+{{ table.description -}}
 {%     endif %}
 
 ### Variables

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/access-lists.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/access-lists.j2
@@ -4,7 +4,7 @@
 
 ### Extended Access-lists Summary
 
-{%     for access_list in access_lists | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%     for access_list in access_lists | arista.avd.natural_sort('name') %}
 #### {{ access_list.name }}
 {%         if access_list.counters_per_entry is arista.avd.defined(true) %}
 
@@ -13,7 +13,7 @@ ACL has counting mode `counters per-entry` enabled!
 
 | Sequence | Action |
 | -------- | ------ |
-{%         for sequence in access_list.sequence_numbers | arista.avd.convert_dicts('sequence') | arista.avd.natural_sort('sequence') %}
+{%         for sequence in access_list.sequence_numbers | arista.avd.natural_sort('sequence') %}
 | {{ sequence.sequence }} | {{ sequence.action }} |
 {%         endfor %}
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/access-lists.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/access-lists.j2
@@ -1,11 +1,11 @@
 {# eos - extended access-lists #}
-{% for access_list in access_lists | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{% for access_list in access_lists | arista.avd.natural_sort('name') %}
 !
 ip access-list {{ access_list.name }}
 {%     if access_list.counters_per_entry is arista.avd.defined(true) %}
    counters per-entry
 {%     endif %}
-{%     for sequence in access_list.sequence_numbers | arista.avd.convert_dicts('sequence') | arista.avd.natural_sort('sequence') %}
+{%     for sequence in access_list.sequence_numbers | arista.avd.natural_sort('sequence') %}
 {%         if sequence.action is arista.avd.defined %}
    {{ sequence.sequence }} {{ sequence.action }}
 {%         endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/avd_schema_documentation.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/avd_schema_documentation.j2
@@ -7,7 +7,7 @@
 
 ### Description
 
-{{ table.description }}
+{{ table.description -}}
 {%     endif %}
 
 ### Variables


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-6 from another schema (comments and global schema).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1:
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2:
  - [ ] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [ ] Verify that `convert_dicts` has been removed from templates as applicable.
  - [ ] Verify no changes to configs/docs on any molecule scenario
  - [ ] Verify that CI pass
