### PR TITLE
Feat(eos_cli_config_gen): Add schema for ipv6_standard_access_lists

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/Input Variables.md
@@ -293,6 +293,30 @@ ipv6_prefix_lists:
         action: <str>
 ```
 
+## IPv6 Standard Access-Lists
+
+### Variables
+
+| Variable | Type | Required | Default | Value Restrictions | Description |
+| -------- | ---- | -------- | ------- | ------------------ | ----------- |
+| [<samp>ipv6_standard_access_lists</samp>](## "ipv6_standard_access_lists") | List, items: Dictionary |  |  |  | IPv6 Standard Access-Lists |
+| [<samp>&nbsp;&nbsp;- name</samp>](## "ipv6_standard_access_lists.[].name") | String | Required, Unique |  |  | Access-list Name |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;counters_per_entry</samp>](## "ipv6_standard_access_lists.[].counters_per_entry") | Boolean |  |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;sequence_numbers</samp>](## "ipv6_standard_access_lists.[].sequence_numbers") | List, items: Dictionary | Required |  |  |  |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- sequence</samp>](## "ipv6_standard_access_lists.[].sequence_numbers.[].sequence") | Integer | Required, Unique |  |  | Sequence ID |
+| [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;action</samp>](## "ipv6_standard_access_lists.[].sequence_numbers.[].action") | String | Required |  |  | Action as string<br>Example: "deny ipv6 any any" |
+
+### YAML
+
+```yaml
+ipv6_standard_access_lists:
+  - name: <str>
+    counters_per_entry: <bool>
+    sequence_numbers:
+      - sequence: <int>
+        action: <str>
+```
+
 ## Local Users
 
 ### Variables

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -360,6 +360,42 @@ keys:
                 description: 'Action as string
 
                   Example: "permit 1b11:3a00:22b0:0082::/64 eq 128"'
+  ipv6_standard_access_lists:
+    type: list
+    primary_key: name
+    convert_types:
+    - dict
+    display_name: IPv6 Standard Access-Lists
+    items:
+      type: dict
+      keys:
+        name:
+          type: str
+          required: true
+          display_name: Access-list Name
+        counters_per_entry:
+          type: bool
+        sequence_numbers:
+          type: list
+          required: true
+          primary_key: sequence
+          convert_types:
+          - dict
+          items:
+            type: dict
+            keys:
+              sequence:
+                type: int
+                required: true
+                display_name: Sequence ID
+                convert_types:
+                - str
+              action:
+                type: str
+                required: true
+                description: 'Action as string
+
+                  Example: "deny ipv6 any any"'
   local_users:
     type: list
     primary_key: name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ipv6_standard_access_lists.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ipv6_standard_access_lists.schema.yml
@@ -1,0 +1,42 @@
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+allow_other_keys: true
+keys:
+  ipv6_standard_access_lists:
+    type: list
+    primary_key: name
+    convert_types:
+      - dict
+    display_name: IPv6 Standard Access-Lists
+    items:
+      type: dict
+      keys:
+        name:
+          type: str
+          required: true
+          display_name: Access-list Name
+        counters_per_entry:
+          type: bool
+        sequence_numbers:
+          type: list
+          required: true
+          primary_key: sequence
+          convert_types:
+            - dict
+          items:
+            type: dict
+            keys:
+              sequence:
+                type: int
+                required: true
+                display_name: Sequence ID
+                convert_types:
+                  - str
+              action:
+                type: str
+                required: true
+                description: |
+                  Action as string
+                  Example: "deny ipv6 any any"

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ipv6-standard-access-lists.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ipv6-standard-access-lists.j2
@@ -4,7 +4,7 @@
 
 ### IPv6 Standard Access-lists Summary
 
-{%     for ipv6_standard_access_list in ipv6_standard_access_lists | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{%     for ipv6_standard_access_list in ipv6_standard_access_lists | arista.avd.natural_sort('name') %}
 #### {{ ipv6_standard_access_list.name }}
 {%         if ipv6_standard_access_list.counters_per_entry is arista.avd.defined(true) %}
 
@@ -13,7 +13,7 @@ ACL has counting mode `counters per-entry` enabled!
 
 | Sequence | Action |
 | -------- | ------ |
-{%         for sequence in ipv6_standard_access_list.sequence_numbers | arista.avd.convert_dicts('sequence') | arista.avd.natural_sort('sequence') %}
+{%         for sequence in ipv6_standard_access_list.sequence_numbers | arista.avd.natural_sort('sequence') %}
 | {{ sequence.sequence }} | {{ sequence.action }} |
 {%         endfor %}
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ipv6-standard-access-lists.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ipv6-standard-access-lists.j2
@@ -1,11 +1,11 @@
 {# eos - IPv6 standard access-lists #}
-{% for ipv6_standard_access_list in ipv6_standard_access_lists | arista.avd.convert_dicts('name') | arista.avd.natural_sort('name') %}
+{% for ipv6_standard_access_list in ipv6_standard_access_lists | arista.avd.natural_sort('name') %}
 !
 ipv6 access-list standard {{ ipv6_standard_access_list.name }}
 {%     if ipv6_standard_access_list.counters_per_entry is arista.avd.defined(true) %}
    counters per-entry
 {%     endif %}
-{%     for sequence in ipv6_standard_access_list.sequence_numbers | arista.avd.convert_dicts('sequence') | arista.avd.natural_sort('sequence') %}
+{%     for sequence in ipv6_standard_access_list.sequence_numbers | arista.avd.natural_sort('sequence') %}
 {%         if sequence.action is arista.avd.defined %}
    {{ sequence.sequence }} {{ sequence.action }}
 {%         endif %}


### PR DESCRIPTION
## Add schema for data model

<!-- Use this PR Title: Feat(eos_cli_config_gen): Add schema for < data_model_key > -->

## Checklist

### Contributor Checklist

- [x] Create schema fragment matching data model described in README.md and README_v4.0.md
  - README.md is most complete with all keys. README_v4.0 includes partial data models after conversion to lists.
  - Schema fragment path is `roles/eos_cli_config_gen/schemas/schema_fragments/<data_model_key>.schema.yml`.
  - Copy line 1-6 from another schema (comments and global schema).
  - Refer to [schema documentation](https://avd.sh/en/devel/docs/input-variable-validation-BETA.html) for syntax and/or use YAML Lint plugin from Redhat in VSCode.
  - Use `convert_types` on value that could be mixed type or misinterpreted like integers and numeric strings.
- [x] If the data model has been converted from wildcard dicts:
  - Add `convert_types: ['dict']` to the schema.
  - Remove `convert_dicts` from the `templates/eos/<>.j2` and `templates/documentation/<>.j2` templates.
- [x] Run `molecule converge -s build_schemas_and_docs` to update schema and documentation.
- [x] Test by running `molecule converge -s eos_cli_config_gen` and verify no errors or changes to generated configs/docs.

### Reviewer Checklist

- Reviewer 1: (Emil)
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass

- Reviewer 2 (Carl):
  - [x] Verify that data model is fully covered in the described schema. Easiest by looking at the generated documentation.
  - [x] Verify that `convert_dicts` has been removed from templates as applicable.
  - [x] Verify no changes to configs/docs on any molecule scenario
  - [x] Verify that CI pass
