### PR TITLE
Feat(eos_cli_config_gen): Support for MCS client commands

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mcs-client.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mcs-client.md
@@ -1,0 +1,118 @@
+# mcs-client
+# Table of Contents
+
+- [Management](#management)
+  - [Management Interfaces](#management-interfaces)
+- [Authentication](#authentication)
+- [Monitoring](#monitoring)
+  - [MCS client Summary](#mcs-client-summary)
+- [Internal VLAN Allocation Policy](#internal-vlan-allocation-policy)
+  - [Internal VLAN Allocation Policy Summary](#internal-vlan-allocation-policy-summary)
+- [Interfaces](#interfaces)
+- [Routing](#routing)
+  - [IP Routing](#ip-routing)
+  - [IPv6 Routing](#ipv6-routing)
+- [Multicast](#multicast)
+- [Filters](#filters)
+- [ACL](#acl)
+- [Quality Of Service](#quality-of-service)
+
+# Management
+
+## Management Interfaces
+
+### Management Interfaces Summary
+
+#### IPv4
+
+| Management Interface | description | Type | VRF | IP Address | Gateway |
+| -------------------- | ----------- | ---- | --- | ---------- | ------- |
+| Management1 | oob_management | oob | MGMT | 10.73.255.122/24 | 10.73.255.2 |
+
+#### IPv6
+
+| Management Interface | description | Type | VRF | IPv6 Address | IPv6 Gateway |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ |
+| Management1 | oob_management | oob | MGMT | -  | - |
+
+### Management Interfaces Device Configuration
+
+```eos
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+```
+
+# Authentication
+
+# Monitoring
+
+## MCS client Summary
+MCS client is running
+
+| Secondary CVX cluster | Server Hosts |
+| --------------------- | ------------ |
+| blue | 10.90.224.188,10.90.224.189,leaf2.atd.lab |
+| purple | 10.90.224.200,10.90.224.201,leaf1.atd.lab |
+
+### MCS client configuration
+
+```eos
+!
+mcs client
+    no shutdown
+    !
+    cvx secondary blue
+        server host 10.90.224.188
+        server host 10.90.224.189
+        server host leaf2.atd.lab
+    !
+    cvx secondary purple
+        server host 10.90.224.200
+        server host 10.90.224.201
+        server host leaf1.atd.lab
+```
+
+# Internal VLAN Allocation Policy
+
+## Internal VLAN Allocation Policy Summary
+
+**Default Allocation Policy**
+
+| Policy Allocation | Range Beginning | Range Ending |
+| ------------------| --------------- | ------------ |
+| ascending | 1006 | 4094 |
+
+# Interfaces
+
+# Routing
+
+## IP Routing
+
+### IP Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | false |
+
+### IP Routing Device Configuration
+
+```eos
+```
+## IPv6 Routing
+
+### IPv6 Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | false |
+
+# Multicast
+
+# Filters
+
+# ACL
+
+# Quality Of Service

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mcs-client.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mcs-client.md
@@ -54,9 +54,8 @@ MCS client is running
 
 | Secondary CVX cluster | Server Hosts |
 | --------------------- | ------------ |
-| blue | 10.90.224.188,10.90.224.189,leaf2.atd.lab |
-| purple | 10.90.224.200,10.90.224.201,leaf1.atd.lab |
-
+| default | 10.90.224.188,10.90.224.189,leaf2.atd.lab |
+-
 ### MCS client configuration
 
 ```eos
@@ -64,15 +63,10 @@ MCS client is running
 mcs client
     no shutdown
     !
-    cvx secondary blue
+    cvx secondary default
         server host 10.90.224.188
         server host 10.90.224.189
         server host leaf2.atd.lab
-    !
-    cvx secondary purple
-        server host 10.90.224.200
-        server host 10.90.224.201
-        server host leaf1.atd.lab
 ```
 
 # Internal VLAN Allocation Policy

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mcs-client.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mcs-client.md
@@ -50,11 +50,12 @@ interface Management1
 # Monitoring
 
 ## MCS client Summary
+
 MCS client is running
 
 | Secondary CVX cluster | Server Hosts |
 | --------------------- | ------------ |
-| default | 10.90.224.188,10.90.224.189,leaf2.atd.lab |
+| default | 10.90.224.188, 10.90.224.189, leaf2.atd.lab |
 -
 ### MCS client configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mcs-client.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mcs-client.md
@@ -90,7 +90,7 @@ mcs client
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | false |
+| default | False |
 
 ### IP Routing Device Configuration
 
@@ -102,7 +102,7 @@ mcs client
 
 | VRF | Routing Enabled |
 | --- | --------------- |
-| default | false |
+| default | False |
 
 # Multicast
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mcs-client.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mcs-client.md
@@ -62,12 +62,12 @@ MCS client is enabled
 ```eos
 !
 mcs client
-    no shutdown
-    !
-    cvx secondary default
-        server host 10.90.224.188
-        server host 10.90.224.189
-        server host leaf2.atd.lab
+   no shutdown
+   !
+   cvx secondary default
+      server host 10.90.224.188
+      server host 10.90.224.189
+      server host leaf2.atd.lab
 ```
 
 # Internal VLAN Allocation Policy

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mcs-client.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mcs-client.md
@@ -51,12 +51,12 @@ interface Management1
 
 ## MCS client Summary
 
-MCS client is running
+MCS client is enabled
 
 | Secondary CVX cluster | Server Hosts |
 | --------------------- | ------------ |
 | default | 10.90.224.188, 10.90.224.189, leaf2.atd.lab |
--
+
 ### MCS client configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/mcs-client.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/mcs-client.cfg
@@ -5,15 +5,10 @@ transceiver qsfp default-mode 4x10G
 mcs client
     no shutdown
     !
-    cvx secondary blue
+    cvx secondary default
         server host 10.90.224.188
         server host 10.90.224.189
         server host leaf2.atd.lab
-    !
-    cvx secondary purple
-        server host 10.90.224.200
-        server host 10.90.224.201
-        server host leaf1.atd.lab
 !
 hostname mcs-client
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/mcs-client.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/mcs-client.cfg
@@ -1,0 +1,28 @@
+!RANCID-CONTENT-TYPE: arista
+!
+transceiver qsfp default-mode 4x10G
+!
+mcs client
+    no shutdown
+    !
+    cvx secondary blue
+        server host 10.90.224.188
+        server host 10.90.224.189
+        server host leaf2.atd.lab
+    !
+    cvx secondary purple
+        server host 10.90.224.200
+        server host 10.90.224.201
+        server host leaf1.atd.lab
+!
+hostname mcs-client
+!
+no enable password
+no aaa root
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/mcs-client.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/mcs-client.cfg
@@ -3,12 +3,12 @@
 transceiver qsfp default-mode 4x10G
 !
 mcs client
-    no shutdown
-    !
-    cvx secondary default
-        server host 10.90.224.188
-        server host 10.90.224.189
-        server host leaf2.atd.lab
+   no shutdown
+   !
+   cvx secondary default
+      server host 10.90.224.188
+      server host 10.90.224.189
+      server host leaf2.atd.lab
 !
 hostname mcs-client
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/mcs-client.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/mcs-client.yml
@@ -1,0 +1,14 @@
+### MCS Client ###
+mcs_client:
+  shutdown: false
+  cvx_secondary:
+    - name: blue
+      server_hosts:
+        - 10.90.224.188
+        - 10.90.224.189
+        - leaf2.atd.lab
+    - name: purple
+      server_hosts:
+        - 10.90.224.200
+        - 10.90.224.201
+        - leaf1.atd.lab

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/mcs-client.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/mcs-client.yml
@@ -2,13 +2,8 @@
 mcs_client:
   shutdown: false
   cvx_secondary:
-    - name: blue
-      server_hosts:
-        - 10.90.224.188
-        - 10.90.224.189
-        - leaf2.atd.lab
-    - name: purple
-      server_hosts:
-        - 10.90.224.200
-        - 10.90.224.201
-        - leaf1.atd.lab
+    name: default
+    server_hosts:
+      - 10.90.224.188
+      - 10.90.224.189
+      - leaf2.atd.lab

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
@@ -50,6 +50,7 @@ load-interval
 logging-match-list
 logging-minimal
 logging
+mcs-client
 loopbacks-interfaces
 mac-address-table
 maintenance

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1626,13 +1626,12 @@ lldp:
 
 ```yaml
 mcs_client:
-  shutdown: false
+  shutdown: < true | false >
   cvx_secondary:
-      name: default
+      name: < name >
       server_hosts:
-        - 10.90.224.188
-        - 10.90.224.189
-        - leaf2.atd.lab
+        - < IP | hostname >
+        - < IP | hostname >
 ```
 
 ### MACsec

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1622,6 +1622,24 @@ lldp:
   run: < true | false >
 ```
 
+### MCS client
+
+```yaml
+mcs_client:
+  shutdown: false
+  cvx_secondary:
+    - name: blue
+      server_hosts:
+        - 10.90.224.188
+        - 10.90.224.189
+        - leaf2.atd.lab
+    - name: purple
+      server_hosts:
+        - 10.90.224.200
+        - 10.90.224.201
+        - leaf1.atd.lab
+```
+
 ### MACsec
 
 ```yaml

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1628,10 +1628,10 @@ lldp:
 mcs_client:
   shutdown: < true | false >
   cvx_secondary:
-      name: < name >
-      server_hosts:
-        - < IP | hostname >
-        - < IP | hostname >
+    name: < name >
+    server_hosts:
+      - < IP | hostname >
+      - < IP | hostname >
 ```
 
 ### MACsec

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1628,16 +1628,11 @@ lldp:
 mcs_client:
   shutdown: false
   cvx_secondary:
-    - name: blue
+      name: blue
       server_hosts:
         - 10.90.224.188
         - 10.90.224.189
         - leaf2.atd.lab
-    - name: purple
-      server_hosts:
-        - 10.90.224.200
-        - 10.90.224.201
-        - leaf1.atd.lab
 ```
 
 ### MACsec

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1628,7 +1628,7 @@ lldp:
 mcs_client:
   shutdown: false
   cvx_secondary:
-      name: blue
+      name: default
       server_hosts:
         - 10.90.224.188
         - 10.90.224.189

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/mcs-client.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/mcs-client.j2
@@ -2,17 +2,19 @@
 {% if mcs_client is arista.avd.defined %}
 
 ## MCS client Summary
-{%     if shut is arista.avd.defined(true) %}
+{%     if mcs_client.shutdown is arista.avd.defined(true) %}
+
 MCS client is shutdown
-{%     elif shut is arista.avd.defined(false) %}
+{%     elif mcs_client.shutdown is arista.avd.defined(false) %}
 {%     endif %}
+
 MCS client is running
 {%     if mcs_client.cvx_secondary is arista.avd.defined %}
 
 | Secondary CVX cluster | Server Hosts |
 | --------------------- | ------------ |
 {%         set secondary = mcs_client.cvx_secondary.name %}
-{%         set servers = mcs_client.cvx_secondary.server_hosts | arista.avd.default('-') | join(',') %}
+{%         set servers = mcs_client.cvx_secondary.server_hosts | arista.avd.default('-') | join(', ') %}
 | {{ secondary }} | {{ servers }} |
 {%     endif %}
 -

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/mcs-client.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/mcs-client.j2
@@ -11,13 +11,11 @@ MCS client is running
 
 | Secondary CVX cluster | Server Hosts |
 | --------------------- | ------------ |
-{%         for name in mcs_client.cvx_secondary | arista.avd.natural_sort %}
-{%             set secondary = name.name %}
-{%             set servers = name.server_hosts | arista.avd.default('-') | join(',') %}
+{%         set secondary = mcs_client.cvx_secondary.name %}
+{%         set servers = mcs_client.cvx_secondary.server_hosts | arista.avd.default('-') | join(',') %}
 | {{ secondary }} | {{ servers }} |
-{%         endfor %}
 {%     endif %}
-
+-
 ### MCS client configuration
 
 ```eos

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/mcs-client.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/mcs-client.j2
@@ -6,9 +6,9 @@
 
 MCS client is shutdown
 {%     elif mcs_client.shutdown is arista.avd.defined(false) %}
-{%     endif %}
 
 MCS client is enabled
+{%     endif %}
 {%     if mcs_client.cvx_secondary is arista.avd.defined %}
 
 | Secondary CVX cluster | Server Hosts |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/mcs-client.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/mcs-client.j2
@@ -1,0 +1,26 @@
+{# MCS Client #}
+{% if mcs_client is arista.avd.defined %}
+
+## MCS client Summary
+{%     if shut is arista.avd.defined(true) %}
+MCS client is shutdown
+{%     elif shut is arista.avd.defined(false) %}
+{%     endif %}
+MCS client is running
+{%     if mcs_client.cvx_secondary is arista.avd.defined %}
+
+| Secondary CVX cluster | Server Hosts |
+| --------------------- | ------------ |
+{%         for name in mcs_client.cvx_secondary | arista.avd.natural_sort %}
+{%             set secondary = name.name %}
+{%             set servers = name.server_hosts | arista.avd.default('-') | join(',') %}
+| {{ secondary }} | {{ servers }} |
+{%         endfor %}
+{%     endif %}
+
+### MCS client configuration
+
+```eos
+{%     include 'eos/mcs-client.j2' %}
+```
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/mcs-client.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/mcs-client.j2
@@ -8,7 +8,7 @@ MCS client is shutdown
 {%     elif mcs_client.shutdown is arista.avd.defined(false) %}
 {%     endif %}
 
-MCS client is running
+MCS client is enabled
 {%     if mcs_client.cvx_secondary is arista.avd.defined %}
 
 | Secondary CVX cluster | Server Hosts |
@@ -17,7 +17,7 @@ MCS client is running
 {%         set servers = mcs_client.cvx_secondary.server_hosts | arista.avd.default('-') | join(', ') %}
 | {{ secondary }} | {{ servers }} |
 {%     endif %}
--
+
 ### MCS client configuration
 
 ```eos

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-device-documentation.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-device-documentation.j2
@@ -86,6 +86,8 @@
 {% include 'documentation/daemons.j2' %}
 {## Logging #}
 {% include 'documentation/logging.j2' %}
+{## Mcs client #}
+{% include 'documentation/mcs-client.j2' %}
 {## SNMP #}
 {% include 'documentation/snmp-settings.j2' %}
 {## Monitor Sessions #}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
@@ -48,6 +48,8 @@
 {% include 'eos/lacp.j2' %}
 {# logging #}
 {% include 'eos/logging.j2' %}
+{# mcs client #}
+{% include 'eos/mcs-client.j2' %}
 {# match-list #}
 {% include 'eos/match-lists.j2' %}
 {# as-paths #}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/mcs-client.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/mcs-client.j2
@@ -1,0 +1,19 @@
+{# MCS client #}
+{% if mcs_client is arista.avd.defined %}
+!
+mcs client
+{%     if mcs_client.shutdown is arista.avd.defined(true) %}
+    shutdown
+{%     elif mcs_client.shutdown is arista.avd.defined(false) %}
+    no shutdown
+{%     endif %}
+{%     if mcs_client.cvx_secondary is arista.avd.defined %}
+{%         for name in mcs_client.cvx_secondary | arista.avd.natural_sort %}
+    !
+    cvx secondary {{ name.name }}
+{%             for server_host in name.server_hosts | arista.avd.natural_sort %}
+        server host {{ server_host }}
+{%             endfor %}
+{%         endfor %}
+{%     endif %}
+{% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/mcs-client.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/mcs-client.j2
@@ -7,14 +7,12 @@ mcs client
 {%     elif mcs_client.shutdown is arista.avd.defined(false) %}
     no shutdown
 {%     endif %}
-{%     if mcs_client.cvx_secondary is arista.avd.defined %}
-{%         if mcs_client.cvx_secondary.name is arista.avd.defined %}
-{%             set name = mcs_client.cvx_secondary.name %}
+{%     if mcs_client.cvx_secondary.name is arista.avd.defined %}
+{%         set name = mcs_client.cvx_secondary.name %}
     !
     cvx secondary {{ name }}
-{%             for server_host in mcs_client.cvx_secondary.server_hosts | arista.avd.natural_sort %}
+{%         for server_host in mcs_client.cvx_secondary.server_hosts | arista.avd.natural_sort %}
         server host {{ server_host }}
-{%             endfor %}
-{%         endif %}
+{%         endfor %}
 {%     endif %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/mcs-client.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/mcs-client.j2
@@ -3,16 +3,15 @@
 !
 mcs client
 {%     if mcs_client.shutdown is arista.avd.defined(true) %}
-    shutdown
+   shutdown
 {%     elif mcs_client.shutdown is arista.avd.defined(false) %}
-    no shutdown
+   no shutdown
 {%     endif %}
 {%     if mcs_client.cvx_secondary.name is arista.avd.defined %}
-{%         set name = mcs_client.cvx_secondary.name %}
-    !
-    cvx secondary {{ name }}
+   !
+   cvx secondary {{ mcs_client.cvx_secondary.name }}
 {%         for server_host in mcs_client.cvx_secondary.server_hosts | arista.avd.natural_sort %}
-        server host {{ server_host }}
+      server host {{ server_host }}
 {%         endfor %}
 {%     endif %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/mcs-client.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/mcs-client.j2
@@ -8,12 +8,13 @@ mcs client
     no shutdown
 {%     endif %}
 {%     if mcs_client.cvx_secondary is arista.avd.defined %}
-{%         for name in mcs_client.cvx_secondary | arista.avd.natural_sort %}
+{%         if mcs_client.cvx_secondary.name is arista.avd.defined %}
+{%             set name = mcs_client.cvx_secondary.name %}
     !
-    cvx secondary {{ name.name }}
-{%             for server_host in name.server_hosts | arista.avd.natural_sort %}
+    cvx secondary {{ name }}
+{%             for server_host in mcs_client.cvx_secondary.server_hosts | arista.avd.natural_sort %}
         server host {{ server_host }}
 {%             endfor %}
-{%         endfor %}
+{%         endif %}
 {%     endif %}
 {% endif %}


### PR DESCRIPTION
## Change Summary

Add support for MCS client on CVX

```
mcs client
   no shutdown
   !
   cvx secondary blue
      server host 172.24.86.56
```

## Related Issue(s)

Fixes #1963

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Data Model:

```
mcs_client:
  shutdown: < true|false >
  cvx_secondary:
    name: blue
    server_host:
       - < IPv4_address >
       - < IPv4_address >
```

Eg:
```
mcs_client:
  shutdown: true
  cvx_secondary:
    name: blue
    server_host:
       - 172.24.86.56
```
## How to test
`molecule converge --scenario-name eos_cli_config_gen -- --limit mcs-client`

## Checklist

### User Checklist

### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
