### PR TITLE
Feat(eos_cli_config_gen): add support for SSL profile cipher-list

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mac-security-eth-po-entropy.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mac-security-eth-po-entropy.md
@@ -66,9 +66,9 @@ interface Management1
 
 ## Management Security SSL Profiles
 
-| SSL Profile Name | TLS protocol accepted | Certificate filename | Key filename |
-| ---------------- | --------------------- | -------------------- | ------------ |
-| SSL_PROFILE | 1.1 1.2 | SSL_CERT | SSL_KEY |
+| SSL Profile Name | TLS protocol accepted | Certificate filename | Key filename | Cipher List |
+| ---------------- | --------------------- | -------------------- | ------------ | ----------- |
+| SSL_PROFILE | 1.1 1.2 | SSL_CERT | SSL_KEY | - |
 
 ## Management Security Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-security.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-security.md
@@ -6,6 +6,7 @@
 - [Authentication](#authentication)
 - [Management Security](#management-security)
   - [Management Security Summary](#management-security-summary)
+  - [Management Security SSL Profiles](#management-security-ssl-profiles)
   - [Management Security Configuration](#management-security-configuration)
 - [Monitoring](#monitoring)
 - [Internal VLAN Allocation Policy](#internal-vlan-allocation-policy)
@@ -60,6 +61,14 @@ interface Management1
 | Reversible password encryption | aes-256-gcm |
 | Minimum password length | 17 |
 
+## Management Security SSL Profiles
+
+| SSL Profile Name | TLS protocol accepted | Certificate filename | Key filename | Cipher List |
+| ---------------- | --------------------- | -------------------- | ------------ | ----------- |
+| certificate-profile | - | eAPI.crt | eAPI.key | - |
+| cipher-list-profile | - | - | - | ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384 |
+| tls-versions-profile | 1.0 1.1 | - | - | - |
+
 ## Management Security Configuration
 
 ```eos
@@ -69,6 +78,12 @@ management security
    password encryption-key common
    password encryption reversible aes-256-gcm
    password minimum length 17
+   ssl profile certificate-profile
+      certificate eAPI.crt key eAPI.key
+   ssl profile cipher-list-profile
+      cipher-list ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384
+   ssl profile tls-versions-profile
+      tls versions 1.0 1.1
 ```
 
 # Monitoring

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-security.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-security.cfg
@@ -17,5 +17,11 @@ management security
    password encryption-key common
    password encryption reversible aes-256-gcm
    password minimum length 17
+   ssl profile certificate-profile
+      certificate eAPI.crt key eAPI.key
+   ssl profile cipher-list-profile
+      cipher-list ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384
+   ssl profile tls-versions-profile
+      tls versions 1.0 1.1
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/management-security.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/management-security.yml
@@ -5,3 +5,12 @@ management_security:
     minimum_length: 17
     encryption_key_common: true
     encryption_reversible: aes-256-gcm
+  ssl_profiles:
+    - name: tls-versions-profile
+      tls_versions: "1.0 1.1"
+    - name: cipher-list-profile
+      cipher_list: ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384
+    - name: certificate-profile
+      certificate:
+        file: eAPI.crt
+        key: eAPI.key

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/mac-security-eth-po-entropy.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/mac-security-eth-po-entropy.md
@@ -66,9 +66,9 @@ interface Management1
 
 ## Management Security SSL Profiles
 
-| SSL Profile Name | TLS protocol accepted | Certificate filename | Key filename |
-| ---------------- | --------------------- | -------------------- | ------------ |
-| SSL_PROFILE | 1.1 1.2 | SSL_CERT | SSL_KEY |
+| SSL Profile Name | TLS protocol accepted | Certificate filename | Key filename | Cipher List |
+| ---------------- | --------------------- | -------------------- | ------------ | ----------- |
+| SSL_PROFILE | 1.1 1.2 | SSL_CERT | SSL_KEY | - |
 
 ## Management Security Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/management-security.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/documentation/devices/management-security.md
@@ -6,6 +6,7 @@
 - [Authentication](#authentication)
 - [Management Security](#management-security)
   - [Management Security Summary](#management-security-summary)
+  - [Management Security SSL Profiles](#management-security-ssl-profiles)
   - [Management Security Configuration](#management-security-configuration)
 - [Monitoring](#monitoring)
 - [Internal VLAN Allocation Policy](#internal-vlan-allocation-policy)
@@ -60,6 +61,14 @@ interface Management1
 | Reversible password encryption | aes-256-gcm |
 | Minimum password length | 17 |
 
+## Management Security SSL Profiles
+
+| SSL Profile Name | TLS protocol accepted | Certificate filename | Key filename | Cipher List |
+| ---------------- | --------------------- | -------------------- | ------------ | ----------- |
+| certificate-profile | - | eAPI.crt | eAPI.key | - |
+| cipher-list-profile | - | - | - | ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384 |
+| tls-versions-profile | 1.0 1.1 | - | - | - |
+
 ## Management Security Configuration
 
 ```eos
@@ -69,6 +78,12 @@ management security
    password encryption-key common
    password encryption reversible aes-256-gcm
    password minimum length 17
+   ssl profile certificate-profile
+      certificate eAPI.crt key eAPI.key
+   ssl profile cipher-list-profile
+      cipher-list ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384
+   ssl profile tls-versions-profile
+      tls versions 1.0 1.1
 ```
 
 # Monitoring

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/management-security.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/intended/configs/management-security.cfg
@@ -17,5 +17,11 @@ management security
    password encryption-key common
    password encryption reversible aes-256-gcm
    password minimum length 17
+   ssl profile certificate-profile
+      certificate eAPI.crt key eAPI.key
+   ssl profile cipher-list-profile
+      cipher-list ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384
+   ssl profile tls-versions-profile
+      tls versions 1.0 1.1
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/management-security.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_v4.0/inventory/host_vars/management-security.yml
@@ -5,3 +5,12 @@ management_security:
     minimum_length: 17
     encryption_key_common: true
     encryption_reversible: aes-256-gcm
+  ssl_profiles:
+    - name: tls-versions-profile
+      tls_versions: "1.0 1.1"
+    - name: cipher-list-profile
+      cipher_list: ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384
+    - name: certificate-profile
+      certificate:
+        file: eAPI.crt
+        key: eAPI.key

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1860,6 +1860,8 @@ management_security:
   ssl_profiles:
     - name: <ssl_profile_1>
       tls_versions: < list of allowed tls versions as string >
+      # cipher_list syntax follows the openssl cipher strings format
+      cipher_list: < column separated list of allowed ciphers as a string >
       certificate:
         file: < certificate filename >
         key: < key filename >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README_v4.0.md
@@ -1742,6 +1742,8 @@ management_security:
   ssl_profiles:
     - name: <ssl_profile_1>
       tls_versions: < list of allowed tls versions as string >
+      # cipher_list syntax follows the openssl cipher strings format
+      cipher_list: < column separated list of allowed ciphers as a string >
       certificate:
         file: < certificate filename >
         key: < key filename >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-security.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-security.j2
@@ -22,10 +22,10 @@
 
 ## Management Security SSL Profiles
 
-| SSL Profile Name | TLS protocol accepted | Certificate filename | Key filename |
-| ---------------- | --------------------- | -------------------- | ------------ |
+| SSL Profile Name | TLS protocol accepted | Certificate filename | Key filename | Cipher List |
+| ---------------- | --------------------- | -------------------- | ------------ | ----------- |
 {%         for ssl_profile in management_security.ssl_profiles | arista.avd.natural_sort %}
-| {{ ssl_profile.name | arista.avd.default('-') }} | {{ ssl_profile.tls_versions | arista.avd.default('-') }} | {{ ssl_profile.certificate.file | arista.avd.default('-') }} | {{ ssl_profile.certificate.key | arista.avd.default('-') }} |
+| {{ ssl_profile.name | arista.avd.default('-') }} | {{ ssl_profile.tls_versions | arista.avd.default('-') }} | {{ ssl_profile.certificate.file | arista.avd.default('-') }} | {{ ssl_profile.certificate.key | arista.avd.default('-') }} | {{ ssl_profile.cipher_list | arista.avd.default('-') }} |
 {%         endfor %}
 {%     endif %}
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-security.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-security.j2
@@ -19,6 +19,9 @@ management security
 {%         if ssl_profile.tls_versions is arista.avd.defined %}
       tls versions {{ ssl_profile.tls_versions }}
 {%         endif  %}
+{%         if ssl_profile.cipher_list is arista.avd.defined %}
+      cipher-list {{ ssl_profile.cipher_list }}
+{%         endif  %}
 {%         if ssl_profile.certificate is arista.avd.defined %}
       certificate {{ ssl_profile.certificate.file }} key {{ ssl_profile.certificate.key }}
 {%         endif  %}


### PR DESCRIPTION
## Change Summary

Add support for cipher-list

## Related Issue(s)

Fixes #1973 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Added `cipher_list` parameter for `ssl_profiles`

```yaml
  management_security:
    entropy_source: < entropy_source >
    password:
      minimum_length: < 1-32 >
      encryption_key_common: < true | false >
      encryption_reversible: < aes-256-gcm >
    ssl_profiles:
      - name: <ssl_profile_1>
        tls_versions: < list of allowed tls versions as string >
        # cipher_list syntax follows the openssl cipher strings format
        cipher_list: < column separated list of allowed ciphers as a string >
        certificate:
          file: < certificate filename >
          key: < key filename >
      - name: <ssl_profile_2>
        tls_versions: < list of allowed tls versions as string >
```

## How to test

molecule

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
