### PR TITLE
Fix(eos_designs): Fix the router_isis redistribute_routes connected

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/ISIS-LEAF1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/ISIS-LEAF1.md
@@ -1,0 +1,252 @@
+# ISIS-LEAF1
+# Table of Contents
+
+- [Management](#management)
+  - [Management Interfaces](#management-interfaces)
+  - [Management API HTTP](#management-api-http)
+- [Authentication](#authentication)
+- [Monitoring](#monitoring)
+- [Internal VLAN Allocation Policy](#internal-vlan-allocation-policy)
+  - [Internal VLAN Allocation Policy Summary](#internal-vlan-allocation-policy-summary)
+  - [Internal VLAN Allocation Policy Configuration](#internal-vlan-allocation-policy-configuration)
+- [VLANs](#vlans)
+  - [VLANs Summary](#vlans-summary)
+  - [VLANs Device Configuration](#vlans-device-configuration)
+- [Interfaces](#interfaces)
+  - [Ethernet Interfaces](#ethernet-interfaces)
+  - [Port-Channel Interfaces](#port-channel-interfaces)
+- [Routing](#routing)
+  - [Service Routing Protocols Model](#service-routing-protocols-model)
+  - [IP Routing](#ip-routing)
+  - [IPv6 Routing](#ipv6-routing)
+  - [Static Routes](#static-routes)
+- [Multicast](#multicast)
+  - [IP IGMP Snooping](#ip-igmp-snooping)
+- [Filters](#filters)
+- [ACL](#acl)
+- [VRF Instances](#vrf-instances)
+  - [VRF Instances Summary](#vrf-instances-summary)
+  - [VRF Instances Device Configuration](#vrf-instances-device-configuration)
+- [Quality Of Service](#quality-of-service)
+
+# Management
+
+## Management Interfaces
+
+### Management Interfaces Summary
+
+#### IPv4
+
+| Management Interface | description | Type | VRF | IP Address | Gateway |
+| -------------------- | ----------- | ---- | --- | ---------- | ------- |
+| Management1 | oob_management | oob | MGMT | 192.168.200.105/24 | 172.31.0.1 |
+
+#### IPv6
+
+| Management Interface | description | Type | VRF | IPv6 Address | IPv6 Gateway |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ |
+| Management1 | oob_management | oob | MGMT | -  | - |
+
+### Management Interfaces Device Configuration
+
+```eos
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.200.105/24
+```
+
+## Management API HTTP
+
+### Management API HTTP Summary
+
+| HTTP | HTTPS | Default Services |
+| ---- | ----- | ---------------- |
+| False | True | - |
+
+### Management API VRF Access
+
+| VRF Name | IPv4 ACL | IPv6 ACL |
+| -------- | -------- | -------- |
+| MGMT | - | - |
+
+### Management API HTTP Configuration
+
+```eos
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+```
+
+# Authentication
+
+# Monitoring
+
+# Internal VLAN Allocation Policy
+
+## Internal VLAN Allocation Policy Summary
+
+| Policy Allocation | Range Beginning | Range Ending |
+| ------------------| --------------- | ------------ |
+| ascending | 1006 | 1199 |
+
+## Internal VLAN Allocation Policy Configuration
+
+```eos
+!
+vlan internal order ascending range 1006 1199
+```
+
+# VLANs
+
+## VLANs Summary
+
+| VLAN ID | Name | Trunk Groups |
+| ------- | ---- | ------------ |
+| 110 | SVI_110 | - |
+
+## VLANs Device Configuration
+
+```eos
+!
+vlan 110
+   name SVI_110
+```
+
+# Interfaces
+
+## Ethernet Interfaces
+
+### Ethernet Interfaces Summary
+
+#### L2
+
+| Interface | Description | Mode | VLANs | Native VLAN | Trunk Group | Channel-Group |
+| --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
+| Ethernet1 | ISIS-SPINE1_Ethernet1 | *trunk | *110 | *- | *- | 1 |
+
+*Inherited from Port-Channel Interface
+
+### Ethernet Interfaces Device Configuration
+
+```eos
+!
+interface Ethernet1
+   description ISIS-SPINE1_Ethernet1
+   no shutdown
+   channel-group 1 mode active
+```
+
+## Port-Channel Interfaces
+
+### Port-Channel Interfaces Summary
+
+#### L2
+
+| Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
+| --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
+| Port-Channel1 | ISIS-SPINE1_Po1 | switched | trunk | 110 | - | - | - | - | - | - |
+
+### Port-Channel Interfaces Device Configuration
+
+```eos
+!
+interface Port-Channel1
+   description ISIS-SPINE1_Po1
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 110
+   switchport mode trunk
+```
+
+# Routing
+## Service Routing Protocols Model
+
+Multi agent routing protocol model enabled
+
+```eos
+!
+service routing protocols model multi-agent
+```
+
+## IP Routing
+
+### IP Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | true |
+| MGMT | false |
+
+### IP Routing Device Configuration
+
+```eos
+!
+ip routing
+no ip routing vrf MGMT
+```
+## IPv6 Routing
+
+### IPv6 Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | false |
+| MGMT | false |
+
+## Static Routes
+
+### Static Routes Summary
+
+| VRF | Destination Prefix | Next Hop IP             | Exit interface      | Administrative Distance       | Tag               | Route Name                    | Metric         |
+| --- | ------------------ | ----------------------- | ------------------- | ----------------------------- | ----------------- | ----------------------------- | -------------- |
+| MGMT | 0.0.0.0/0 | 172.31.0.1 | - | 1 | - | - | - |
+
+### Static Routes Device Configuration
+
+```eos
+!
+ip route vrf MGMT 0.0.0.0/0 172.31.0.1
+```
+
+# Multicast
+
+## IP IGMP Snooping
+
+### IP IGMP Snooping Summary
+
+| IGMP Snooping | Fast Leave | Interface Restart Query | Proxy | Restart Query Interval | Robustness Variable |
+| ------------- | ---------- | ----------------------- | ----- | ---------------------- | ------------------- |
+| Enabled | - | - | - | - | - |
+
+### IP IGMP Snooping Device Configuration
+
+```eos
+```
+
+# Filters
+
+# ACL
+
+# VRF Instances
+
+## VRF Instances Summary
+
+| VRF Name | IP Routing |
+| -------- | ---------- |
+| MGMT | disabled |
+
+## VRF Instances Device Configuration
+
+```eos
+!
+vrf instance MGMT
+```
+
+# Quality Of Service

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/ISIS-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/ISIS-SPINE1.md
@@ -1,0 +1,375 @@
+# ISIS-SPINE1
+# Table of Contents
+
+- [Management](#management)
+  - [Management Interfaces](#management-interfaces)
+  - [Management API HTTP](#management-api-http)
+- [Authentication](#authentication)
+- [Monitoring](#monitoring)
+- [Internal VLAN Allocation Policy](#internal-vlan-allocation-policy)
+  - [Internal VLAN Allocation Policy Summary](#internal-vlan-allocation-policy-summary)
+  - [Internal VLAN Allocation Policy Configuration](#internal-vlan-allocation-policy-configuration)
+- [VLANs](#vlans)
+  - [VLANs Summary](#vlans-summary)
+  - [VLANs Device Configuration](#vlans-device-configuration)
+- [Interfaces](#interfaces)
+  - [Ethernet Interfaces](#ethernet-interfaces)
+  - [Port-Channel Interfaces](#port-channel-interfaces)
+  - [Loopback Interfaces](#loopback-interfaces)
+  - [VLAN Interfaces](#vlan-interfaces)
+- [Routing](#routing)
+  - [Service Routing Protocols Model](#service-routing-protocols-model)
+  - [Virtual Router MAC Address](#virtual-router-mac-address)
+  - [IP Routing](#ip-routing)
+  - [IPv6 Routing](#ipv6-routing)
+  - [Static Routes](#static-routes)
+  - [Router ISIS](#router-isis)
+- [Multicast](#multicast)
+  - [IP IGMP Snooping](#ip-igmp-snooping)
+- [Filters](#filters)
+- [ACL](#acl)
+- [VRF Instances](#vrf-instances)
+  - [VRF Instances Summary](#vrf-instances-summary)
+  - [VRF Instances Device Configuration](#vrf-instances-device-configuration)
+- [Quality Of Service](#quality-of-service)
+
+# Management
+
+## Management Interfaces
+
+### Management Interfaces Summary
+
+#### IPv4
+
+| Management Interface | description | Type | VRF | IP Address | Gateway |
+| -------------------- | ----------- | ---- | --- | ---------- | ------- |
+| Management1 | oob_management | oob | MGMT | 192.168.200.101/24 | 172.31.0.1 |
+
+#### IPv6
+
+| Management Interface | description | Type | VRF | IPv6 Address | IPv6 Gateway |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ |
+| Management1 | oob_management | oob | MGMT | -  | - |
+
+### Management Interfaces Device Configuration
+
+```eos
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.200.101/24
+```
+
+## Management API HTTP
+
+### Management API HTTP Summary
+
+| HTTP | HTTPS | Default Services |
+| ---- | ----- | ---------------- |
+| False | True | - |
+
+### Management API VRF Access
+
+| VRF Name | IPv4 ACL | IPv6 ACL |
+| -------- | -------- | -------- |
+| MGMT | - | - |
+
+### Management API HTTP Configuration
+
+```eos
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+```
+
+# Authentication
+
+# Monitoring
+
+# Internal VLAN Allocation Policy
+
+## Internal VLAN Allocation Policy Summary
+
+| Policy Allocation | Range Beginning | Range Ending |
+| ------------------| --------------- | ------------ |
+| ascending | 1006 | 1199 |
+
+## Internal VLAN Allocation Policy Configuration
+
+```eos
+!
+vlan internal order ascending range 1006 1199
+```
+
+# VLANs
+
+## VLANs Summary
+
+| VLAN ID | Name | Trunk Groups |
+| ------- | ---- | ------------ |
+| 110 | SVI_110 | - |
+
+## VLANs Device Configuration
+
+```eos
+!
+vlan 110
+   name SVI_110
+```
+
+# Interfaces
+
+## Ethernet Interfaces
+
+### Ethernet Interfaces Summary
+
+#### L2
+
+| Interface | Description | Mode | VLANs | Native VLAN | Trunk Group | Channel-Group |
+| --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
+| Ethernet1 | ISIS-LEAF1_Ethernet1 | *trunk | *110 | *- | *- | 1 |
+| Ethernet10 |  Endpoint | access | 110 | - | - | - |
+
+*Inherited from Port-Channel Interface
+
+### Ethernet Interfaces Device Configuration
+
+```eos
+!
+interface Ethernet1
+   description ISIS-LEAF1_Ethernet1
+   no shutdown
+   channel-group 1 mode active
+!
+interface Ethernet10
+   description Endpoint
+   no shutdown
+   switchport access vlan 110
+   switchport mode access
+   switchport
+```
+
+## Port-Channel Interfaces
+
+### Port-Channel Interfaces Summary
+
+#### L2
+
+| Interface | Description | Type | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
+| --------- | ----------- | ---- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
+| Port-Channel1 | ISIS-LEAF1_Po1 | switched | trunk | 110 | - | - | - | - | - | - |
+
+### Port-Channel Interfaces Device Configuration
+
+```eos
+!
+interface Port-Channel1
+   description ISIS-LEAF1_Po1
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 110
+   switchport mode trunk
+```
+
+## Loopback Interfaces
+
+### Loopback Interfaces Summary
+
+#### IPv4
+
+| Interface | Description | VRF | IP Address |
+| --------- | ----------- | --- | ---------- |
+| Loopback0 | - | default | 192.168.255.1/32 |
+
+#### IPv6
+
+| Interface | Description | VRF | IPv6 Address |
+| --------- | ----------- | --- | ------------ |
+| Loopback0 | - | default | - |
+
+#### ISIS
+
+| Interface | ISIS instance | ISIS metric | Interface mode |
+| --------- | ------------- | ----------- | -------------- |
+| Loopback0 | EVPN_UNDERLAY | - | passive |
+
+### Loopback Interfaces Device Configuration
+
+```eos
+!
+interface Loopback0
+   no shutdown
+   ip address 192.168.255.1/32
+   isis enable EVPN_UNDERLAY
+   isis passive
+```
+
+## VLAN Interfaces
+
+### VLAN Interfaces Summary
+
+| Interface | Description | VRF |  MTU | Shutdown |
+| --------- | ----------- | --- | ---- | -------- |
+| Vlan110 | SVI_110 | default | - | false |
+
+#### IPv4
+
+| Interface | VRF | IP Address | IP Address Virtual | IP Router Virtual Address | VRRP | ACL In | ACL Out |
+| --------- | --- | ---------- | ------------------ | ------------------------- | ---- | ------ | ------- |
+| Vlan110 |  default  |  -  |  10.0.110.1/24  |  -  |  -  |  -  |  -  |
+
+### VLAN Interfaces Device Configuration
+
+```eos
+!
+interface Vlan110
+   description SVI_110
+   no shutdown
+   ip address virtual 10.0.110.1/24
+```
+
+# Routing
+## Service Routing Protocols Model
+
+Multi agent routing protocol model enabled
+
+```eos
+!
+service routing protocols model multi-agent
+```
+
+## Virtual Router MAC Address
+
+### Virtual Router MAC Address Summary
+
+#### Virtual Router MAC Address: 00:1c:73:00:00:9a
+
+### Virtual Router MAC Address Configuration
+
+```eos
+!
+ip virtual-router mac-address 00:1c:73:00:00:9a
+```
+
+## IP Routing
+
+### IP Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | true |
+| MGMT | false |
+
+### IP Routing Device Configuration
+
+```eos
+!
+ip routing
+no ip routing vrf MGMT
+```
+## IPv6 Routing
+
+### IPv6 Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | false |
+| MGMT | false |
+
+## Static Routes
+
+### Static Routes Summary
+
+| VRF | Destination Prefix | Next Hop IP             | Exit interface      | Administrative Distance       | Tag               | Route Name                    | Metric         |
+| --- | ------------------ | ----------------------- | ------------------- | ----------------------------- | ----------------- | ----------------------------- | -------------- |
+| MGMT | 0.0.0.0/0 | 172.31.0.1 | - | 1 | - | - | - |
+
+### Static Routes Device Configuration
+
+```eos
+!
+ip route vrf MGMT 0.0.0.0/0 172.31.0.1
+```
+
+## Router ISIS
+
+### Router ISIS Summary
+
+| Settings | Value |
+| -------- | ----- |
+| Instance | EVPN_UNDERLAY |
+| Net-ID | 49.0001.0001.0000.0001.00 |
+| Type | level-2 |
+| Address Family | ipv4 unicast |
+| Router-ID | 192.168.255.1 |
+| Log Adjacency Changes | True |
+
+### ISIS Route Redistribution
+
+| Route Type | Route-Map | Include Leaked |
+| ---------- | --------- | -------------- |
+| connected | - | - |
+
+### ISIS Interfaces Summary
+
+| Interface | ISIS Instance | ISIS Metric | Interface Mode |
+| --------- | ------------- | ----------- | -------------- |
+| Loopback0 | EVPN_UNDERLAY | - | passive |
+
+### Router ISIS Device Configuration
+
+```eos
+!
+router isis EVPN_UNDERLAY
+   net 49.0001.0001.0000.0001.00
+   is-type level-2
+   redistribute connected
+   router-id ipv4 192.168.255.1
+   log-adjacency-changes
+   !
+   address-family ipv4 unicast
+      maximum-paths 4
+   !
+```
+
+# Multicast
+
+## IP IGMP Snooping
+
+### IP IGMP Snooping Summary
+
+| IGMP Snooping | Fast Leave | Interface Restart Query | Proxy | Restart Query Interval | Robustness Variable |
+| ------------- | ---------- | ----------------------- | ----- | ---------------------- | ------------------- |
+| Enabled | - | - | - | - | - |
+
+### IP IGMP Snooping Device Configuration
+
+```eos
+```
+
+# Filters
+
+# ACL
+
+# VRF Instances
+
+## VRF Instances Summary
+
+| VRF Name | IP Routing |
+| -------- | ---------- |
+| MGMT | disabled |
+
+## VRF Instances Device Configuration
+
+```eos
+!
+vrf instance MGMT
+```
+
+# Quality Of Service

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/fabric/L2LS-documentation.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/fabric/L2LS-documentation.md
@@ -21,6 +21,8 @@
 | L2LS_BGP | leaf | BGP-LEAF2 | - | - | Provisioned |
 | L2LS_BGP | l3spine | BGP-SPINE1 | - | - | Provisioned |
 | L2LS_BGP | l3spine | BGP-SPINE2 | - | - | Provisioned |
+| L2LS_ISIS | leaf | ISIS-LEAF1 | 192.168.200.105/24 | vEOS-LAB | Provisioned |
+| L2LS_ISIS | l3spine | ISIS-SPINE1 | 192.168.200.101/24 | vEOS-LAB | Provisioned |
 | L2LS_L2ONLY | leaf | L2ONLY-LEAF1 | - | - | Provisioned |
 | L2LS_L2ONLY | leaf | L2ONLY-LEAF2 | - | - | Provisioned |
 | L2LS_L2ONLY | spine | L2ONLY-SPINE1 | - | - | Provisioned |
@@ -46,6 +48,7 @@
 | leaf | BGP-LEAF2 | Ethernet2 | l3spine | BGP-SPINE2 | Ethernet2 |
 | l3spine | BGP-SPINE1 | Ethernet3 | mlag_peer | BGP-SPINE2 | Ethernet3 |
 | l3spine | BGP-SPINE1 | Ethernet4 | mlag_peer | BGP-SPINE2 | Ethernet4 |
+| leaf | ISIS-LEAF1 | Ethernet1 | l3spine | ISIS-SPINE1 | Ethernet1 |
 | leaf | L2ONLY-LEAF1 | Ethernet1 | spine | L2ONLY-SPINE1 | Ethernet1 |
 | leaf | L2ONLY-LEAF1 | Ethernet2 | spine | L2ONLY-SPINE2 | Ethernet1 |
 | leaf | L2ONLY-LEAF2 | Ethernet1 | spine | L2ONLY-SPINE1 | Ethernet2 |
@@ -75,7 +78,7 @@
 
 | Loopback Pool | Available Addresses | Assigned addresses | Assigned Address % |
 | ------------- | ------------------- | ------------------ | ------------------ |
-| 192.168.255.0/24 | 256 | 4 | 1.57 % |
+| 192.168.255.0/24 | 256 | 5 | 1.96 % |
 
 ## Loopback0 Interfaces Node Allocation
 
@@ -83,6 +86,7 @@
 | --- | ---- | --------- |
 | L2LS_BGP | BGP-SPINE1 | 192.168.255.1/32 |
 | L2LS_BGP | BGP-SPINE2 | 192.168.255.2/32 |
+| L2LS_ISIS | ISIS-SPINE1 | 192.168.255.1/32 |
 | L2LS_OSPF | OSPF-SPINE1 | 192.168.255.1/32 |
 | L2LS_OSPF | OSPF-SPINE2 | 192.168.255.2/32 |
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/fabric/L2LS-topology.csv
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/fabric/L2LS-topology.csv
@@ -17,6 +17,9 @@ l3spine,BGP-SPINE2,Ethernet2,leaf,BGP-LEAF2,Ethernet2,True
 l3spine,BGP-SPINE2,Ethernet3,mlag_peer,BGP-SPINE1,Ethernet3,True
 l3spine,BGP-SPINE2,Ethernet4,mlag_peer,BGP-SPINE1,Ethernet4,True
 l3spine,BGP-SPINE2,Ethernet5,other,DUMMY-CORE,Ethernet1/4,True
+leaf,ISIS-LEAF1,Ethernet1,l3spine,ISIS-SPINE1,Ethernet1,True
+l3spine,ISIS-SPINE1,Ethernet1,leaf,ISIS-LEAF1,Ethernet1,True
+l3spine,ISIS-SPINE1,Ethernet10,network_port,Endpoint,,True
 leaf,L2ONLY-LEAF1,Ethernet1,spine,L2ONLY-SPINE1,Ethernet1,True
 leaf,L2ONLY-LEAF1,Ethernet2,spine,L2ONLY-SPINE2,Ethernet1,True
 leaf,L2ONLY-LEAF1,Ethernet10,network_port,Endpoint,,True

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/ISIS-LEAF1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/ISIS-LEAF1.cfg
@@ -1,0 +1,49 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname ISIS-LEAF1
+!
+no enable password
+no aaa root
+!
+vlan 110
+   name SVI_110
+!
+vrf instance MGMT
+!
+interface Port-Channel1
+   description ISIS-SPINE1_Po1
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 110
+   switchport mode trunk
+!
+interface Ethernet1
+   description ISIS-SPINE1_Ethernet1
+   no shutdown
+   channel-group 1 mode active
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.200.105/24
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip route vrf MGMT 0.0.0.0/0 172.31.0.1
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/ISIS-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/ISIS-SPINE1.cfg
@@ -1,0 +1,80 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname ISIS-SPINE1
+!
+no enable password
+no aaa root
+!
+vlan 110
+   name SVI_110
+!
+vrf instance MGMT
+!
+interface Port-Channel1
+   description ISIS-LEAF1_Po1
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 110
+   switchport mode trunk
+!
+interface Ethernet1
+   description ISIS-LEAF1_Ethernet1
+   no shutdown
+   channel-group 1 mode active
+!
+interface Ethernet10
+   description Endpoint
+   no shutdown
+   switchport access vlan 110
+   switchport mode access
+   switchport
+!
+interface Loopback0
+   no shutdown
+   ip address 192.168.255.1/32
+   isis enable EVPN_UNDERLAY
+   isis passive
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.200.101/24
+!
+interface Vlan110
+   description SVI_110
+   no shutdown
+   ip address virtual 10.0.110.1/24
+!
+ip virtual-router mac-address 00:1c:73:00:00:9a
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip route vrf MGMT 0.0.0.0/0 172.31.0.1
+!
+router isis EVPN_UNDERLAY
+   net 49.0001.0001.0000.0001.00
+   is-type level-2
+   redistribute connected
+   router-id ipv4 192.168.255.1
+   log-adjacency-changes
+   !
+   address-family ipv4 unicast
+      maximum-paths 4
+   !
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/ISIS-LEAF1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/ISIS-LEAF1.yml
@@ -1,0 +1,50 @@
+static_routes:
+- vrf: MGMT
+  destination_address_prefix: 0.0.0.0/0
+  gateway: 172.31.0.1
+service_routing_protocols_model: multi-agent
+ip_routing: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+vrfs:
+  MGMT:
+    ip_routing: false
+management_interfaces:
+  Management1:
+    description: oob_management
+    shutdown: false
+    vrf: MGMT
+    ip_address: 192.168.200.105/24
+    gateway: 172.31.0.1
+    type: oob
+management_api_http:
+  enable_vrfs:
+    MGMT: {}
+  enable_https: true
+ethernet_interfaces:
+  Ethernet1:
+    peer: ISIS-SPINE1
+    peer_interface: Ethernet1
+    peer_type: l3spine
+    description: ISIS-SPINE1_Ethernet1
+    type: switched
+    shutdown: false
+    channel_group:
+      id: 1
+      mode: active
+port_channel_interfaces:
+  Port-Channel1:
+    description: ISIS-SPINE1_Po1
+    type: switched
+    shutdown: false
+    vlans: 110
+    mode: trunk
+vlans:
+  110:
+    tenant: L2LS_ISIS
+    name: SVI_110
+ip_igmp_snooping:
+  globally_enabled: true

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/ISIS-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/ISIS-SPINE1.yml
@@ -1,0 +1,83 @@
+static_routes:
+- vrf: MGMT
+  destination_address_prefix: 0.0.0.0/0
+  gateway: 172.31.0.1
+service_routing_protocols_model: multi-agent
+ip_routing: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+vrfs:
+  MGMT:
+    ip_routing: false
+management_interfaces:
+  Management1:
+    description: oob_management
+    shutdown: false
+    vrf: MGMT
+    ip_address: 192.168.200.101/24
+    gateway: 172.31.0.1
+    type: oob
+management_api_http:
+  enable_vrfs:
+    MGMT: {}
+  enable_https: true
+ethernet_interfaces:
+  Ethernet1:
+    peer: ISIS-LEAF1
+    peer_interface: Ethernet1
+    peer_type: leaf
+    description: ISIS-LEAF1_Ethernet1
+    type: switched
+    shutdown: false
+    channel_group:
+      id: 1
+      mode: active
+  Ethernet10:
+    peer: Endpoint
+    peer_type: network_port
+    description: Endpoint
+    type: switched
+    shutdown: false
+    mode: access
+    vlans: 110
+port_channel_interfaces:
+  Port-Channel1:
+    description: ISIS-LEAF1_Po1
+    type: switched
+    shutdown: false
+    vlans: 110
+    mode: trunk
+loopback_interfaces:
+  Loopback0:
+    shutdown: false
+    ip_address: 192.168.255.1/32
+    isis_enable: EVPN_UNDERLAY
+    isis_passive: true
+router_isis:
+  instance: EVPN_UNDERLAY
+  log_adjacency_changes: true
+  net: 49.0001.0001.0000.0001.00
+  router_id: 192.168.255.1
+  is_type: level-2
+  address_family:
+  - ipv4 unicast
+  isis_af_defaults:
+  - maximum-paths 4
+  redistribute_routes:
+  - source_protocol: connected
+vlans:
+  110:
+    tenant: L2LS_ISIS
+    name: SVI_110
+ip_igmp_snooping:
+  globally_enabled: true
+ip_virtual_router_mac_address: 00:1c:73:00:00:9a
+vlan_interfaces:
+  Vlan110:
+    tenant: L2LS_ISIS
+    description: SVI_110
+    shutdown: false
+    ip_address_virtual: 10.0.110.1/24

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/inventory/group_vars/ISIS_LEAFS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/inventory/group_vars/ISIS_LEAFS.yml
@@ -1,0 +1,16 @@
+---
+
+type: leaf
+
+leaf:
+  defaults:
+    uplink_interfaces: ['Ethernet1']
+    uplink_switches: ['ISIS-SPINE1']
+    platform: vEOS-LAB
+  node_groups:
+    ISIS_LEAFS:
+      nodes:
+        ISIS-LEAF1:
+          id: 1
+          mgmt_ip: 192.168.200.105/24
+          uplink_switch_interfaces: ['Ethernet1']

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/inventory/group_vars/ISIS_SPINES.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/inventory/group_vars/ISIS_SPINES.yml
@@ -1,0 +1,14 @@
+---
+type: l3spine
+
+l3spine:
+  defaults:
+    platform: vEOS-LAB
+    loopback_ipv4_pool: 192.168.255.0/24
+    isis_system_id_prefix: '0001.0000'
+    isis_maximum_paths: 4
+    virtual_router_mac_address: 00:1c:73:00:00:9A
+  nodes:
+    ISIS-SPINE1:
+      id: 1
+      mgmt_ip: 192.168.200.101/24

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/inventory/group_vars/L2LS_ISIS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/inventory/group_vars/L2LS_ISIS.yml
@@ -1,0 +1,25 @@
+---
+
+pod_name: L2LS_ISIS
+
+underlay_routing_protocol: isis
+isis_area_id: "49.0001"
+
+tenants:
+  L2LS_ISIS:
+    vrfs:
+      default:
+        svis:
+          110:
+            name: SVI_110
+            ip_address_virtual: 10.0.110.1/24
+            enabled: true
+
+network_ports:
+  - switches:
+      - "ISIS-SPINE[1]"
+    switch_ports:
+      - "Ethernet10"
+    vlans: 110
+    mode: access
+    description: Endpoint

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/inventory/hosts.yml
@@ -23,6 +23,14 @@ all:
               hosts:
                 BGP-LEAF1:
                 BGP-LEAF2:
+        L2LS_ISIS:
+          children:
+            ISIS_SPINES:
+              hosts:
+                ISIS-SPINE1:
+            ISIS_LEAFS:
+              hosts:
+                ISIS-LEAF1:
         L2LS_L2ONLY:
           children:
             L2ONLY_SPINES:

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/underlay/isis-sr/router-isis.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/underlay/isis-sr/router-isis.j2
@@ -47,5 +47,5 @@ router_isis:
     enabled: true
 {% if switch.overlay_routing_protocol == "none" %}
   redistribute_routes:
-    source_protocol: connected
+    - source_protocol: connected
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/underlay/isis/router-isis.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/underlay/isis/router-isis.j2
@@ -38,5 +38,5 @@ router_isis:
 {% endif %}
 {% if switch.overlay_routing_protocol == "none" %}
   redistribute_routes:
-    source_protocol: connected
+    - source_protocol: connected
 {% endif %}


### PR DESCRIPTION
## Change Summary

The redistribute_routes on router_isis should be a list of dictionaries. Currently it is a dictionary, which is fixed.

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
