### PR TITLE
Feat(eos_cli_config_gen): Add shutdown knob to MCS client commands

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mcs-client.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mcs-client.md
@@ -54,8 +54,8 @@ interface Management1
 MCS client is enabled
 
 | Secondary CVX cluster | Server Hosts | Enabled |
-| --------------------- | ------------ | -------- |
-| default | 10.90.224.188, 10.90.224.189, leaf2.atd.lab | False |
+| --------------------- | ------------ | ------- |
+| default | 10.90.224.188, 10.90.224.189, leaf2.atd.lab | True |
 
 ### MCS client configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mcs-client.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mcs-client.md
@@ -53,9 +53,9 @@ interface Management1
 
 MCS client is enabled
 
-| Secondary CVX cluster | Server Hosts |
-| --------------------- | ------------ |
-| default | 10.90.224.188, 10.90.224.189, leaf2.atd.lab |
+| Secondary CVX cluster | Server Hosts | Enabled |
+| --------------------- | ------------ | -------- |
+| default | 10.90.224.188, 10.90.224.189, leaf2.atd.lab | False |
 
 ### MCS client configuration
 
@@ -65,6 +65,7 @@ mcs client
    no shutdown
    !
    cvx secondary default
+      no shutdown
       server host 10.90.224.188
       server host 10.90.224.189
       server host leaf2.atd.lab

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/mcs-client.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/mcs-client.cfg
@@ -6,6 +6,7 @@ mcs client
    no shutdown
    !
    cvx secondary default
+      no shutdown
       server host 10.90.224.188
       server host 10.90.224.189
       server host leaf2.atd.lab

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/mcs-client.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/mcs-client.yml
@@ -3,6 +3,7 @@ mcs_client:
   shutdown: false
   cvx_secondary:
     name: default
+    shutdown: false
     server_hosts:
       - 10.90.224.188
       - 10.90.224.189

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -1629,6 +1629,7 @@ mcs_client:
   shutdown: < true | false >
   cvx_secondary:
     name: < name >
+    shutdown: < true | false >
     server_hosts:
       - < IP | hostname >
       - < IP | hostname >

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/mcs-client.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/mcs-client.j2
@@ -12,7 +12,7 @@ MCS client is enabled
 {%     if mcs_client.cvx_secondary is arista.avd.defined %}
 
 | Secondary CVX cluster | Server Hosts | Enabled |
-| --------------------- | ------------ | -------- |
+| --------------------- | ------------ | ------- |
 {%         set secondary = mcs_client.cvx_secondary.name %}
 {%         set servers = mcs_client.cvx_secondary.server_hosts | arista.avd.default('-') | join(', ') %}
 {%         if mcs_client.cvx_secondary.shutdown is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/mcs-client.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/mcs-client.j2
@@ -11,11 +11,12 @@ MCS client is enabled
 {%     endif %}
 {%     if mcs_client.cvx_secondary is arista.avd.defined %}
 
-| Secondary CVX cluster | Server Hosts |
-| --------------------- | ------------ |
+| Secondary CVX cluster | Server Hosts | Enabled |
+| --------------------- | ------------ | -------- |
 {%         set secondary = mcs_client.cvx_secondary.name %}
 {%         set servers = mcs_client.cvx_secondary.server_hosts | arista.avd.default('-') | join(', ') %}
-| {{ secondary }} | {{ servers }} |
+{%         set enabled = mcs_client.cvx_secondary.shutdown | arista.avd.default('-') %}
+| {{ secondary }} | {{ servers }} | {{ enabled }} |
 {%     endif %}
 
 ### MCS client configuration

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/mcs-client.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/mcs-client.j2
@@ -15,7 +15,11 @@ MCS client is enabled
 | --------------------- | ------------ | -------- |
 {%         set secondary = mcs_client.cvx_secondary.name %}
 {%         set servers = mcs_client.cvx_secondary.server_hosts | arista.avd.default('-') | join(', ') %}
-{%         set enabled = mcs_client.cvx_secondary.shutdown | arista.avd.default('-') %}
+{%         if mcs_client.cvx_secondary.shutdown is arista.avd.defined %}
+{%             set enabled = not mcs_client.cvx_secondary.shutdown %}
+{%         else %}
+{%             set enabled = '-' %}
+{%         endif %}
 | {{ secondary }} | {{ servers }} | {{ enabled }} |
 {%     endif %}
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/mcs-client.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/mcs-client.j2
@@ -10,10 +10,10 @@ mcs client
 {%     if mcs_client.cvx_secondary.name is arista.avd.defined %}
    !
    cvx secondary {{ mcs_client.cvx_secondary.name }}
-{%         if mcs_client.cvx_secondary.shutdown is arista.avd.defined(true) %}
-      shutdown
-{%         elif mcs_client.cvx_secondary.shutdown is arista.avd.defined(false) %}
+{%         if mcs_client.cvx_secondary.shutdown is arista.avd.defined(false) %}
       no shutdown
+{%         elif mcs_client.cvx_secondary.shutdown is arista.avd.defined(true) %}
+      shutdown
 {%         endif %}
 {%         for server_host in mcs_client.cvx_secondary.server_hosts | arista.avd.natural_sort %}
       server host {{ server_host }}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/mcs-client.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/mcs-client.j2
@@ -10,6 +10,11 @@ mcs client
 {%     if mcs_client.cvx_secondary.name is arista.avd.defined %}
    !
    cvx secondary {{ mcs_client.cvx_secondary.name }}
+{%         if mcs_client.cvx_secondary.shutdown is arista.avd.defined(true) %}
+      shutdown
+{%         elif mcs_client.cvx_secondary.shutdown is arista.avd.defined(false) %}
+      no shutdown
+{%         endif %}
 {%         for server_host in mcs_client.cvx_secondary.server_hosts | arista.avd.natural_sort %}
       server host {{ server_host }}
 {%         endfor %}


### PR DESCRIPTION
Added `shutdown` option to MCS client commands

## Change Summary

<!-- Enter short PR description -->

## Related Issue(s)

Fixes #2008 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Use case example

```
mcs client
   no shutdown
   !
   cvx secondary blue
      no shutdown
      server host 172.24.86.56
```

Data Model:

```
mcs_client:
  shutdown: < true|false >
  cvx_secondary:
  - name: blue
    shutdown: < true | false >
    server_host:
       - < IPv4_address >
       - < IPv4_address >
```

## How to test
`molecule converge --scenario-name eos_cli_config_gen -- --limit mcs-client`

## Checklist

### User Checklist


### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
