### PR TITLE
Fix: Remove ansible-test enforced GPL3 header from modules

### DIFF
--- a/ansible_collections/arista/avd/plugins/module_utils/strip_empties.py
+++ b/ansible_collections/arista/avd/plugins/module_utils/strip_empties.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 # coding: utf-8 -*-
 #
-# GNU General Public License v3.0+
-#
-# Copyright 2019 Arista Networks AS-EMEA
+# Copyright 2019 Arista Networks
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ansible_collections/arista/avd/plugins/modules/configlet_build_config.py
+++ b/ansible_collections/arista/avd/plugins/modules/configlet_build_config.py
@@ -1,9 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-# GNU General Public License v3.0+
-#
-# Copyright 2019 Arista Networks AS-EMEA
+# Copyright 2019 Arista Networks
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ansible_collections/arista/avd/plugins/modules/eos_designs_facts.py
+++ b/ansible_collections/arista/avd/plugins/modules/eos_designs_facts.py
@@ -1,5 +1,3 @@
-# GNU General Public License v3.0+
-#
 # Copyright 2022 Arista Networks
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ansible_collections/arista/avd/plugins/modules/inventory_to_container.py
+++ b/ansible_collections/arista/avd/plugins/modules/inventory_to_container.py
@@ -1,9 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-# GNU General Public License v3.0+
-#
-# Copyright 2019 Arista Networks AS-EMEA
+# Copyright 2019 Arista Networks
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ansible_collections/arista/avd/plugins/modules/validate.py
+++ b/ansible_collections/arista/avd/plugins/modules/validate.py
@@ -1,5 +1,3 @@
-# GNU General Public License v3.0+
-#
 # Copyright 2022 Arista Networks
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/ansible_collections/arista/avd/plugins/modules/yaml_templates_to_facts.py
+++ b/ansible_collections/arista/avd/plugins/modules/yaml_templates_to_facts.py
@@ -1,6 +1,4 @@
-# GNU General Public License v3.0+
-#
-# Copyright 2021 Arista Networks AS-EMEA
+# Copyright 2021 Arista Networks
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ansible_collections/arista/avd/tests/sanity/ignore-2.11.txt
+++ b/ansible_collections/arista/avd/tests/sanity/ignore-2.11.txt
@@ -1,0 +1,5 @@
+plugins/modules/configlet_build_config.py validate-modules:missing-gplv3-license
+plugins/modules/eos_designs_facts.py validate-modules:missing-gplv3-license
+plugins/modules/inventory_to_container.py validate-modules:missing-gplv3-license
+plugins/modules/validate.py validate-modules:missing-gplv3-license
+plugins/modules/yaml_templates_to_facts.py validate-modules:missing-gplv3-license

--- a/ansible_collections/arista/avd/tests/sanity/ignore-2.12.txt
+++ b/ansible_collections/arista/avd/tests/sanity/ignore-2.12.txt
@@ -1,0 +1,5 @@
+plugins/modules/configlet_build_config.py validate-modules:missing-gplv3-license
+plugins/modules/eos_designs_facts.py validate-modules:missing-gplv3-license
+plugins/modules/inventory_to_container.py validate-modules:missing-gplv3-license
+plugins/modules/validate.py validate-modules:missing-gplv3-license
+plugins/modules/yaml_templates_to_facts.py validate-modules:missing-gplv3-license


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Remove ansible-test enforced GPL3 header from modules

Ansible-test sanity enforces a GPL3 license in all modules. This is not intended for collections, but only for Ansible Core, so we will add ignores for these rules and remove the GPL3 line.
The collection is licensed under Apache 2.0 as it is mentioned everywhere else.