### PR TITLE
Fix: Create MLAG port-channels with network_ports data model

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/network-ports-tests-2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/network-ports-tests-2.cfg
@@ -8,8 +8,14 @@ service routing protocols model multi-agent
 !
 hostname network-ports-tests-2
 !
+no spanning-tree vlan-id 4094
+!
 no enable password
 no aaa root
+!
+vlan 4094
+   name MLAG_PEER
+   trunk group MLAG
 !
 vrf instance MGMT
 !
@@ -18,6 +24,7 @@ interface Port-Channel1
    no shutdown
    switchport
    switchport access vlan 101
+   mlag 1
    spanning-tree portfast
    spanning-tree bpdufilter enable
 !
@@ -26,8 +33,17 @@ interface Port-Channel2
    no shutdown
    switchport
    switchport access vlan 101
+   mlag 2
    spanning-tree portfast
    spanning-tree bpdufilter enable
+!
+interface Port-Channel101
+   description MLAG_PEER_network-ports-tests.1_Po101
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 2-4094
+   switchport mode trunk
+   switchport trunk group MLAG
 !
 interface Ethernet1
    description AP1 with port_channel
@@ -489,8 +505,28 @@ interface Ethernet4
    spanning-tree portfast
    spanning-tree bpdufilter enable
 !
+interface Ethernet10/1
+   description MLAG_PEER_network-ports-tests.1_Ethernet10/1
+   no shutdown
+   channel-group 101 mode active
+!
+interface Vlan4094
+   description MLAG_PEER
+   no shutdown
+   mtu 9000
+   no autostate
+   ip address 10.255.252.1/31
+!
 ip routing
 no ip routing vrf MGMT
+!
+mlag configuration
+   domain-id mlag
+   local-interface Vlan4094
+   peer-address 10.255.252.0
+   peer-link Port-Channel101
+   reload-delay mlag 300
+   reload-delay non-mlag 330
 !
 ip route vrf MGMT 0.0.0.0/0 192.168.0.1
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/network-ports-tests.1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/network-ports-tests.1.cfg
@@ -8,10 +8,24 @@ service routing protocols model multi-agent
 !
 hostname network-ports-tests.1
 !
+no spanning-tree vlan-id 4094
+!
 no enable password
 no aaa root
 !
+vlan 4094
+   name MLAG_PEER
+   trunk group MLAG
+!
 vrf instance MGMT
+!
+interface Port-Channel101
+   description MLAG_PEER_network-ports-tests-2_Po101
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 2-4094
+   switchport mode trunk
+   switchport trunk group MLAG
 !
 interface Ethernet1
    description PCs
@@ -481,8 +495,28 @@ interface Ethernet4
    spanning-tree portfast
    spanning-tree bpdufilter enable
 !
+interface Ethernet10/1
+   description MLAG_PEER_network-ports-tests-2_Ethernet10/1
+   no shutdown
+   channel-group 101 mode active
+!
+interface Vlan4094
+   description MLAG_PEER
+   no shutdown
+   mtu 9000
+   no autostate
+   ip address 10.255.252.0/31
+!
 ip routing
 no ip routing vrf MGMT
+!
+mlag configuration
+   domain-id mlag
+   local-interface Vlan4094
+   peer-address 10.255.252.1
+   peer-link Port-Channel101
+   reload-delay mlag 300
+   reload-delay non-mlag 330
 !
 ip route vrf MGMT 0.0.0.0/0 192.168.0.1
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests-2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests-2.yml
@@ -16,9 +16,59 @@ management_api_http:
   enable_vrfs:
     MGMT: {}
   enable_https: true
-ip_igmp_snooping:
-  globally_enabled: true
+spanning_tree:
+  no_spanning_tree_vlan: 4094
+vlans:
+  4094:
+    tenant: system
+    name: MLAG_PEER
+    trunk_groups:
+    - MLAG
+vlan_interfaces:
+  Vlan4094:
+    description: MLAG_PEER
+    shutdown: false
+    ip_address: 10.255.252.1/31
+    no_autostate: true
+    mtu: 9000
+port_channel_interfaces:
+  Port-Channel101:
+    description: MLAG_PEER_network-ports-tests.1_Po101
+    type: switched
+    shutdown: false
+    vlans: 2-4094
+    mode: trunk
+    trunk_groups:
+    - MLAG
+  Port-Channel1:
+    description: AP1 with port_channel
+    type: switched
+    shutdown: false
+    mode: access
+    vlans: 101
+    spanning_tree_portfast: edge
+    spanning_tree_bpdufilter: enabled
+    mlag: 1
+  Port-Channel2:
+    description: AP1 with port_channel
+    type: switched
+    shutdown: false
+    mode: access
+    vlans: 101
+    spanning_tree_portfast: edge
+    spanning_tree_bpdufilter: enabled
+    mlag: 2
 ethernet_interfaces:
+  Ethernet10/1:
+    peer: network-ports-tests.1
+    peer_interface: Ethernet10/1
+    peer_type: mlag_peer
+    description: MLAG_PEER_network-ports-tests.1_Ethernet10/1
+    type: switched
+    shutdown: false
+    channel_group:
+      id: 101
+      mode: active
   Ethernet1:
     peer: AP1 with port_channel
     peer_type: network_port
@@ -545,20 +595,12 @@ ethernet_interfaces:
     vlans: 100
     spanning_tree_portfast: edge
     spanning_tree_bpdufilter: enabled
-port_channel_interfaces:
-  Port-Channel1:
-    description: AP1 with port_channel
-    type: switched
-    shutdown: false
-    mode: access
-    vlans: 101
-    spanning_tree_portfast: edge
-    spanning_tree_bpdufilter: enabled
-  Port-Channel2:
-    description: AP1 with port_channel
-    type: switched
-    shutdown: false
-    mode: access
-    vlans: 101
-    spanning_tree_portfast: edge
-    spanning_tree_bpdufilter: enabled
+mlag_configuration:
+  domain_id: mlag
+  local_interface: Vlan4094
+  peer_address: 10.255.252.0
+  peer_link: Port-Channel101
+  reload_delay_mlag: 300
+  reload_delay_non_mlag: 330
+ip_igmp_snooping:
+  globally_enabled: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests.1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests.1.yml
@@ -16,9 +16,41 @@ management_api_http:
   enable_vrfs:
     MGMT: {}
   enable_https: true
-ip_igmp_snooping:
-  globally_enabled: true
+spanning_tree:
+  no_spanning_tree_vlan: 4094
+vlans:
+  4094:
+    tenant: system
+    name: MLAG_PEER
+    trunk_groups:
+    - MLAG
+vlan_interfaces:
+  Vlan4094:
+    description: MLAG_PEER
+    shutdown: false
+    ip_address: 10.255.252.0/31
+    no_autostate: true
+    mtu: 9000
+port_channel_interfaces:
+  Port-Channel101:
+    description: MLAG_PEER_network-ports-tests-2_Po101
+    type: switched
+    shutdown: false
+    vlans: 2-4094
+    mode: trunk
+    trunk_groups:
+    - MLAG
 ethernet_interfaces:
+  Ethernet10/1:
+    peer: network-ports-tests-2
+    peer_interface: Ethernet10/1
+    peer_type: mlag_peer
+    description: MLAG_PEER_network-ports-tests-2_Ethernet10/1
+    type: switched
+    shutdown: false
+    channel_group:
+      id: 101
+      mode: active
   Ethernet1:
     peer: PCs
     peer_type: network_port
@@ -539,3 +571,12 @@ ethernet_interfaces:
     vlans: 100
     spanning_tree_portfast: edge
     spanning_tree_bpdufilter: enabled
+mlag_configuration:
+  domain_id: mlag
+  local_interface: Vlan4094
+  peer_address: 10.255.252.1
+  peer_link: Port-Channel101
+  reload_delay_mlag: 300
+  reload_delay_non_mlag: 330
+ip_igmp_snooping:
+  globally_enabled: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/NETWORK_PORTS_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/NETWORK_PORTS_TESTS.yml
@@ -42,8 +42,12 @@ network_ports:
     description: PCs
 
 l2leaf:
-  nodes:
-    network-ports-tests.1:
-      id: 1
-    network-ports-tests-2:
-      id: 2
+  node_groups:
+    mlag:
+      mlag_peer_ipv4_pool: 10.255.252.0/24
+      mlag_interfaces: ["Ethernet10/1"]
+      nodes:
+        network-ports-tests.1:
+          id: 1
+        network-ports-tests-2:
+          id: 2

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/logic.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/logic.j2
@@ -18,7 +18,8 @@
 {#                 Create list of inventory_hostname once per interface to be compatible with existing adapters style #}
 {%                 set adapters = [] %}
 {%                 for switch_port in switch_ports %}
-{%                     set adapter_overrides = {"switch_ports": [switch_port], "switches": [inventory_hostname]} %}
+{#                     Inserting a blank in switches to always trigger the check for mlag/esi for network_ports data model #}
+{%                     set adapter_overrides = {"switch_ports": [switch_port], "switches": [inventory_hostname, ""]} %}
 {%                     set adapter = network_port_item | ansible.builtin.combine(adapter_overrides) %}
 {%                     do adapters.append(adapter) %}
 {%                 endfor %}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Create MLAG port-channels with network_ports data model.

## Related Issue(s)

Fixes #2005 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- Insert an extra blank switch name in the dataset created by network_ports, to force the existing logic for connected_endpoints to configure MLAG / ESI as applicable.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Added test coverage for MLAG to existing molecule scenario.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
