### PR TITLE
Feat(eos_cli_config_gen): Support for setting queue-monitor length cpu thresholds

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/queue_monitor_length.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/queue_monitor_length.md
@@ -1,0 +1,91 @@
+# queue_monitor_length
+# Table of Contents
+
+- [Management](#management)
+  - [Management Interfaces](#management-interfaces)
+- [Authentication](#authentication)
+- [Monitoring](#monitoring)
+- [Internal VLAN Allocation Policy](#internal-vlan-allocation-policy)
+  - [Internal VLAN Allocation Policy Summary](#internal-vlan-allocation-policy-summary)
+- [Interfaces](#interfaces)
+- [Routing](#routing)
+  - [IP Routing](#ip-routing)
+  - [IPv6 Routing](#ipv6-routing)
+- [Multicast](#multicast)
+- [Filters](#filters)
+- [ACL](#acl)
+- [Quality Of Service](#quality-of-service)
+
+# Management
+
+## Management Interfaces
+
+### Management Interfaces Summary
+
+#### IPv4
+
+| Management Interface | description | Type | VRF | IP Address | Gateway |
+| -------------------- | ----------- | ---- | --- | ---------- | ------- |
+| Management1 | oob_management | oob | MGMT | 10.73.255.122/24 | 10.73.255.2 |
+
+#### IPv6
+
+| Management Interface | description | Type | VRF | IPv6 Address | IPv6 Gateway |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ |
+| Management1 | oob_management | oob | MGMT | -  | - |
+
+### Management Interfaces Device Configuration
+
+```eos
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+```
+
+# Authentication
+
+# Monitoring
+
+# Internal VLAN Allocation Policy
+
+## Internal VLAN Allocation Policy Summary
+
+**Default Allocation Policy**
+
+| Policy Allocation | Range Beginning | Range Ending |
+| ------------------| --------------- | ------------ |
+| ascending | 1006 | 4094 |
+
+# Interfaces
+
+# Routing
+
+## IP Routing
+
+### IP Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | False |
+
+### IP Routing Device Configuration
+
+```eos
+```
+## IPv6 Routing
+
+### IPv6 Routing Summary
+
+| VRF | Routing Enabled |
+| --- | --------------- |
+| default | False |
+
+# Multicast
+
+# Filters
+
+# ACL
+
+# Quality Of Service

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/queue_monitor_length.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/queue_monitor_length.cfg
@@ -1,0 +1,20 @@
+!RANCID-CONTENT-TYPE: arista
+!
+transceiver qsfp default-mode 4x10G
+!
+queue-monitor length
+queue-monitor length log 100
+queue-monitor length notifying
+queue-monitor length cpu thresholds 200000 100000
+!
+hostname queue_monitor_length
+!
+no enable password
+no aaa root
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/queue_monitor_length.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/queue_monitor_length.yml
@@ -1,0 +1,10 @@
+queue_monitor_length:
+  # "enabled: true" will be required in AVD4.0. In AVD3.x default is true as long as queue_monitor_length is defined and not None
+  enabled: true
+  log: 100
+  notifying: true
+  cpu:
+    thresholds:
+      # "high" threshold is mandatory
+      high: 200000
+      low: 100000

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
@@ -86,6 +86,7 @@ prefix-lists
 prompt
 ptp
 qos
+queue_monitor_length
 queue_monitor_streaming
 redundancy
 roles

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/README.md
@@ -2716,8 +2716,15 @@ qos_profiles:
 
 ```yaml
 queue_monitor_length:
+  # "enabled: true" will be required in AVD4.0. In AVD3.x default is true as long as queue_monitor_length is defined and not None
+  enabled: < true | false >
   log: < seconds >
   notifying: < true | false - should only be used for platforms supporting the "queue-monitor length notifying" CLI >
+  cpu:
+    thresholds:
+      # "high" threshold is mandatory
+      high: < integer >
+      low: < integer >
 ```
 
 #### Queue Monitor Streaming

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/queue-monitor-length.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/queue-monitor-length.j2
@@ -1,4 +1,4 @@
-{% if queue_monitor_length is arista.avd.defined %}
+{% if queue_monitor_length is arista.avd.defined and queue_monitor_length.enabled is not arista.avd.defined(false) %}
 !
 queue-monitor length
 {%     if queue_monitor_length.log is arista.avd.defined %}
@@ -6,5 +6,12 @@ queue-monitor length log {{ queue_monitor_length.log }}
 {%     endif %}
 {%     if queue_monitor_length.notifying is arista.avd.defined(true) %}
 queue-monitor length notifying
+{%     endif %}
+{%     if queue_monitor_length.cpu.thresholds.high is arista.avd.defined %}
+{%         if queue_monitor_length.cpu.thresholds.low is arista.avd.defined %}
+queue-monitor length cpu thresholds {{ queue_monitor_length.cpu.thresholds.high }} {{ queue_monitor_length.cpu.thresholds.low }}
+{%         else %}
+queue-monitor length cpu threshold {{ queue_monitor_length.cpu.thresholds.high }}
+{%         endif %}
 {%     endif %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/base/queue-monitor-length.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/base/queue-monitor-length.j2
@@ -1,11 +1,14 @@
 {% if queue_monitor_length is defined %}
 queue_monitor_length:
-  enabled: true
+  enabled: {{ queue_monitor_length.enabled | arista.avd.default(true) }}
 {%     if queue_monitor_length.notifying is arista.avd.defined and
          switch.platform_settings.feature_support.queue_monitor_length_notify is not arista.avd.defined(false) %}
   notifying: {{ queue_monitor_length.notifying }}
 {%     endif %}
 {%     if queue_monitor_length.log is defined %}
   log: {{ queue_monitor_length.log }}
+{%     endif %}
+{%     if queue_monitor_length.cpu is defined %}
+  cpu: {{ queue_monitor_length.cpu }}
 {%     endif %}
 {% endif %}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Support for setting queue-monitor length cpu thresholds

## Related Issue(s)

Fixes #2002 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->
- Added documentation of `queue_monitor_length.enabled` to avoid empty dict data models.
- Added molecule coverage for everything `queue_monitor_length`
- Updated `eos_designs` wrapper template
- Data model changes:

```yaml
queue_monitor_length:
  # "enabled: true" will be required in AVD4.0. In AVD3.x default is true as long as queue_monitor_length is defined and not None
  enabled: < true | false >
  <...>
  cpu:
    thresholds:
      # "high" threshold is mandatory
      high: < integer >
      low: < integer >
```

Notice there is no documentation template for this feature.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Molecule coverage added.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
