### PR TITLE
Doc(eos_designs): specify that id must be unique within a node_type

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-topology-v4.0.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-topology-v4.0.md
@@ -127,7 +127,7 @@ defaults <- node_group <- node_group.node <- node
     - name: <node inventory hostname>
       # Vars defined per node
 
-      # Unique identifier | Required.
+      # Unique identifier per node_type | Required.
       id: < integer >
 
       # Node management IP address | Optional.

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-topology.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-topology.md
@@ -127,7 +127,7 @@ defaults <- node_group <- node_group.node <- node
     <node inventory hostname>:
       # Vars defined per node
 
-      # Unique identifier | Required.
+      # Unique identifier per node_type | Required.
       id: < integer >
 
       # Node management IP address | Optional.


### PR DESCRIPTION
## Change Summary

Indicate that the `id` in the fabric-variables must be unique within a node_type and not globally.

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

Documentation change

## How to test

No test

## Checklist

### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
