### PR TITLE
Feat(plugins): Automatic requirements check

### DIFF
--- a/ansible_collections/arista/avd/plugins/README.md
+++ b/ansible_collections/arista/avd/plugins/README.md
@@ -699,8 +699,13 @@ Example:
 
 ### Verify Requirements
 
-The `arista.avd.verify_requirements` module is an Ansible Action Plugin providing the following capabilities - Display the current running version of the collection - Given a list of python requirements, verify if the installed libraries match these requirements - Validate the
-ansible version against collection requirements - Validate the collection requirements against the collection requirements - Validate the running python version
+The `arista.avd.verify_requirements` module is an Ansible Action Plugin providing the following capabilities:
+
+- Display the current running version of the collection.
+- Given a list of python requirements, verify if the installed libraries match these requirements.
+- Validate the ansible version against collection requirements.
+- Validate the collection requirements against the collection requirements.
+- Validate the running python version.
 
 A task is added to every `eos_*` role in the collection but the Verify Requirement task will run only once per playbook when multiple roles are used.
 

--- a/ansible_collections/arista/avd/plugins/README.md
+++ b/ansible_collections/arista/avd/plugins/README.md
@@ -176,7 +176,7 @@ To use this filter:
 !!! note
     This isn't using the same range syntax as EOS for modular or break-out ports. For example, on EOS `et1/1-2/4` gives you `et1/1, et1/2, et1/3, et1/4, et2/1, et2/2, et2/3, et2/4` on a fixed switch, but a different result on a modular switch depending on the module types. In AVD, the same range would be `et1-2/1-4`.
 
-#### Password filters
+### Password filters
 
 The `arista.avd.encrypt` and `arista.avd.decrypt` filters are used to encrypt or decrypt supported passwords.
 
@@ -191,7 +191,7 @@ Supported types:
 
 - bgp
 
-##### BGP passwords
+#### BGP passwords
 
 BGP password are encrypted/decrypted based on the Neighbor IP or the BGP Peer Group Name in EOS.
 
@@ -695,4 +695,143 @@ Example:
     md_toc_skip_lines: 3
   delegate_to: localhost
   when: generate_device_documentation | arista.avd.default(true)
+```
+
+### Verify Requirements
+
+The `arista.avd.verify_requirements` module is an Ansible Action Plugin providing the following capabilities - Display the current running version of the collection - Given a list of python requirements, verify if the installed libraries match these requirements - Validate the
+ansible version against collection requirements - Validate the collection requirements against the collection requirements - Validate the running python version
+
+A task is added to every `eos_*` role in the collection but the Verify Requirement task will run only once per playbook when multiple roles are used.
+
+Added in: version 4.0.0 of arista.avd
+
+Module options (= is mandatory):
+
+```yaml
+# Boolean, if set to True, the play does not stop if any requirement error is detected | Optional
+avd_ignore_requirements: <bool | default false>
+
+# List of strings of python requirements with pip file syntax | Required
+requirements: <list of str>
+```
+
+Example:
+
+```yaml
+- name: Verify collection requirements
+  arista.avd.verify_requirements:
+    requirements:
+      - Jinja2 >= 2.9
+      - paramiko == 2.7.1
+  check_mode: false
+  run_once: true
+```
+
+Example output (with debug):
+
+```text
+TASK [arista.avd.eos_designs : Verify Requirements] ********************************************************************************************************************************
+AVD version v4.0.0-dev5-25-g0233492b5
+{
+    "ansible": {
+        "collection": {
+            "name": "arista.avd",
+            "path": "/tmp/ansible-avd/ansible_collections",
+            "version": "v4.0.0-dev5-25-g0233492b5"
+        },
+        "ansible_version": "2.14.2",
+        "requires_ansible": "!=2.13.0,<2.15.0,>=2.12.6",
+        "collection_requirements": {
+            "not_found": {},
+            "valid": {
+                "arista.cvp": {
+                    "installed": "3.3.1",
+                    "required_version": null
+                },
+                "arista.eos": {
+                    "installed": "4.1.1",
+                    "required_version": null
+                },
+                "ansible.netcommon": {
+                    "installed": "3.0.1",
+                    "required_version": "!=2.6.0,>=2.4.0"
+                }
+            },
+            "mismatched": {},
+            "parsing_failed": []
+        }
+    },
+    "python": {
+        "python_version_info": {
+            "major": 3,
+            "minor": 10,
+            "micro": 3,
+            "releaselevel": "final",
+            "serial": 0
+        },
+        "python_path": [
+            "/Users/guillaumemulocher/.pyenv/versions/3.10.3/envs/ansible-avd/bin",
+            "/Users/guillaumemulocher/.pyenv/versions/3.10.3/lib/python310.zip",
+            "/Users/guillaumemulocher/.pyenv/versions/3.10.3/lib/python3.10",
+            "/Users/guillaumemulocher/.pyenv/versions/3.10.3/lib/python3.10/lib-dynload",
+            "/Users/guillaumemulocher/.pyenv/versions/3.10.3/envs/ansible-avd/lib/python3.10/site-packages"
+        ],
+        "python_requirements": {
+            "not_found": {},
+            "valid": {
+                "netaddr": {
+                    "installed": "0.8.0",
+                    "required_version": ">=0.7.19"
+                },
+                "Jinja2": {
+                    "installed": "3.1.2",
+                    "required_version": ">=2.11.3"
+                },
+                "treelib": {
+                    "installed": "1.6.1",
+                    "required_version": ">=1.5.5"
+                },
+                "cvprac": {
+                    "installed": "1.2.2",
+                    "required_version": ">=1.0.7"
+                },
+                "paramiko": {
+                    "installed": "3.0.0",
+                    "required_version": ">=2.7.1"
+                },
+                "jsonschema": {
+                    "installed": "4.17.3",
+                    "required_version": ">=4.5.1"
+                },
+                "requests": {
+                    "installed": "2.28.2",
+                    "required_version": ">=2.25.1"
+                },
+                "PyYAML": {
+                    "installed": "5.4.1",
+                    "required_version": ">=5.4.1"
+                },
+                "md-toc": {
+                    "installed": "8.1.8",
+                    "required_version": ">=7.1.0"
+                },
+                "deepmerge": {
+                    "installed": "1.1.0",
+                    "required_version": ">=1.1.0"
+                },
+                "cryptography": {
+                    "installed": "39.0.0",
+                    "required_version": ">=38.0.4"
+                },
+                "packaging": {
+                    "installed": "23.0",
+                    "required_version": ">=21.3"
+                }
+            },
+            "mismatched": {},
+            "parsing_failed": []
+        }
+    }
+}
 ```

--- a/ansible_collections/arista/avd/plugins/README.md
+++ b/ansible_collections/arista/avd/plugins/README.md
@@ -771,11 +771,11 @@ AVD version v4.0.0-dev5-25-g0233492b5
             "serial": 0
         },
         "python_path": [
-            "/Users/guillaumemulocher/.pyenv/versions/3.10.3/envs/ansible-avd/bin",
-            "/Users/guillaumemulocher/.pyenv/versions/3.10.3/lib/python310.zip",
-            "/Users/guillaumemulocher/.pyenv/versions/3.10.3/lib/python3.10",
-            "/Users/guillaumemulocher/.pyenv/versions/3.10.3/lib/python3.10/lib-dynload",
-            "/Users/guillaumemulocher/.pyenv/versions/3.10.3/envs/ansible-avd/lib/python3.10/site-packages"
+            "/tmp/.pyenv/versions/3.10.3/envs/ansible-avd/bin",
+            "/tmp/.pyenv/versions/3.10.3/lib/python310.zip",
+            "/tmp/.pyenv/versions/3.10.3/lib/python3.10",
+            "/tmp/.pyenv/versions/3.10.3/lib/python3.10/lib-dynload",
+            "/tmp/.pyenv/versions/3.10.3/envs/ansible-avd/lib/python3.10/site-packages"
         ],
         "python_requirements": {
             "not_found": {},

--- a/ansible_collections/arista/avd/plugins/action/verify_requirements.py
+++ b/ansible_collections/arista/avd/plugins/action/verify_requirements.py
@@ -1,0 +1,81 @@
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import importlib.metadata
+import re
+import sys
+
+from pip._vendor.packaging.specifiers import SpecifierSet
+
+from ansible.plugins.action import ActionBase
+from ansible.errors import AnsibleActionFail
+from ansible.utils.display import Display
+
+python_version_info = dict(
+    major=sys.version_info[0],
+    minor=sys.version_info[1],
+    micro=sys.version_info[2],
+    releaselevel=sys.version_info[3],
+    serial=sys.version_info[4],
+)
+
+
+class ActionModule(ActionBase):
+    def run(self, tmp=None, task_vars=None):
+        if task_vars is None:
+            task_vars = {}
+
+        result = super().run(tmp, task_vars)
+        del tmp  # tmp no longer has any effect
+        dependencies_dict = {"not_found": {}, "valid": {}, "mismatched": {}}
+
+        if not (self._task.args and "dependencies" in self._task.args):
+            raise AnsibleActionFail("The argument 'dependencies' must be set")
+
+        dependencies = self._task.args.get("dependencies")
+
+        if not isinstance(dependencies, list):
+            raise AnsibleActionFail("The argument 'dependencies' is not a list")
+
+        # Can match this format
+        # requests [security] >=2.8.1, == 2.8.* ; python_version < "2.7"
+        req_re = re.compile(
+            r"(^[a-zA-Z][a-zA-Z0-9_-]+) ?((?:\[[a-zA-Z0-9]+\])?) ?((?:(?:==|[!><~]=?) ?(?:[0-9.*]+),? ?)*)(?: ?; ?(.*))?$"
+        )
+
+        for dep in dependencies:
+            match = req_re.match(dep)
+            if not match:
+                raise AnsibleActionFail(f"Failed to parse {dep}")
+            pkg, label, specifiers_str, extra = match.groups()
+            specifiers_set = SpecifierSet(specifiers_str)
+
+            try:
+                installed_version = importlib.metadata.version(pkg)
+                Display().vvvv(f"Found {pkg} {installed_version} installed!", False)
+            except importlib.metadata.PackageNotFoundError:
+                dependencies_dict["not_found"][pkg] = {
+                    "installed": None,
+                    "desired": str(specifiers_set) if len(specifiers_set) > 0 else None,
+                }
+                result["failed"] = True
+                continue
+
+            if specifiers_set.contains(installed_version):
+                dependencies_dict["valid"][pkg] = {
+                    "installed": installed_version,
+                    "desired": str(specifiers_set) if len(specifiers_set) > 0 else None,
+                }
+            else:
+                dependencies_dict["mismatched"][pkg] = {
+                    "installed": installed_version,
+                    "desired": str(specifiers_set) if len(specifiers_set) > 0 else None,
+                }
+                result["failed"] = True
+
+        result["python_version_info"] = python_version_info
+        result["python_path"] = sys.path
+        result["dependencies"] = dependencies_dict
+
+        return result

--- a/ansible_collections/arista/avd/plugins/action/verify_requirements.py
+++ b/ansible_collections/arista/avd/plugins/action/verify_requirements.py
@@ -112,7 +112,7 @@ def _validate_ansible_version(collection_name, running_version, result) -> bool:
     if len(specifiers_set) > 0:
         result["requires_ansible"] = str(specifiers_set)
     if not specifiers_set.contains(running_version):
-        ActionModule.display.error(
+        display.error(
             f"Ansible Version running {running_version} - Requirement is {str(specifiers_set)}",
             False,
         )
@@ -161,9 +161,9 @@ def _validate_ansible_collections(running_collection_name, result) -> bool:
                 "desired": str(specifiers_set) if len(specifiers_set) > 0 else None,
             }
             if specifiers_set:
-                ActionModule.display.error(f"{collection_name} required but not found - required version is {str(specifiers_set)}", False)
+                display.error(f"{collection_name} required but not found - required version is {str(specifiers_set)}", False)
             else:
-                ActionModule.display.error(f"{collection_name} required but not found", False)
+                display.error(f"{collection_name} required but not found", False)
             failed = True
             continue
 
@@ -175,7 +175,7 @@ def _validate_ansible_collections(running_collection_name, result) -> bool:
                 "desired": str(specifiers_set) if len(specifiers_set) > 0 else None,
             }
         else:
-            ActionModule.display.error(f"{collection_name} version running {installed_version} - required version is {str(specifiers_set)}", False)
+            display.error(f"{collection_name} version running {installed_version} - required version is {str(specifiers_set)}", False)
             dependencies_dict["mismatched"][collection_name] = {
                 "installed": installed_version,
                 "desired": str(specifiers_set) if len(specifiers_set) > 0 else None,
@@ -194,7 +194,7 @@ def _get_collection_path(collection_name) -> str:
     return os.path.dirname(collection.__file__)
 
 
-def _get_collection_version(self, collection_path) -> str:
+def _get_collection_version(collection_path) -> str:
     """
     TODO
     """
@@ -208,7 +208,7 @@ def _get_collection_version(self, collection_path) -> str:
         with open(manifest_file, "rb") as fd:
             metadata = json.load(fd)["collection_info"]
 
-    ActionModule.display.vvv(str(metadata))
+    display.vvv(str(metadata))
 
     return metadata["version"]
 
@@ -219,12 +219,12 @@ def _get_running_collection_version(running_collection_name, result) -> None:
 
     # Try to detect a git tag
     # Using subprocess for now
-    with Popen(["git", "describe", "--tags"], stdout=PIPE, stderr=PIPE) as process:
+    with Popen(["git", "describe", "--tags"], stdout=PIPE, stderr=PIPE, cwd=collection_path) as process:
         output, err = process.communicate()
         if err:
-            ActionModule.display.vvv("Not a git repository")
+            display.vvv("Not a git repository")
         else:
-            ActionModule.display.vvv("This is a git repository, overwriting version with 'git describe --tags output'")
+            display.vvv("This is a git repository, overwriting version with 'git describe --tags output'")
             version = output.decode("UTF-8").strip()
 
     result["collection"] = {
@@ -271,4 +271,5 @@ class ActionModule(ActionBase):
         if _validate_ansible_collections(running_collection_name, result["ansible"]) is True:
             result["failed"] = True
 
+        del result["failed"]
         return result

--- a/ansible_collections/arista/avd/plugins/action/verify_requirements.py
+++ b/ansible_collections/arista/avd/plugins/action/verify_requirements.py
@@ -3,11 +3,14 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 import importlib.metadata
+import os
 import re
 import sys
 
-from ansible.plugins.action import ActionBase
+import yaml
 from ansible.errors import AnsibleActionFail
+from ansible.module_utils.compat.importlib import import_module
+from ansible.plugins.action import ActionBase
 from ansible.utils.display import Display
 
 HAS_PIP = True
@@ -15,6 +18,12 @@ try:
     from pip._vendor.packaging.specifiers import SpecifierSet
 except ImportError:
     HAS_PIP = False
+
+# Python >= 3.8
+MIN_PYTHON_SUPPORTED_VERSION = (3, 8)
+# Ansible >=2.11.3
+# TODO check if we can use meta/runtimes.yml
+ANSIBLE_SPECIFIERS = ">=2.11.3,<2.13.0"
 
 python_version_info = dict(
     major=sys.version_info[0],
@@ -26,16 +35,25 @@ python_version_info = dict(
 
 
 class ActionModule(ActionBase):
-    def run(self, tmp=None, task_vars=None):
-        if task_vars is None:
-            task_vars = {}
+    def _validate_python_version(self, result):
+        """
+        TODO - avoid hardcoding this
+        """
+        if sys.version_info < MIN_PYTHON_SUPPORTED_VERSION:
+            running_version = ".".join(str(v) for v in sys.version_info[:3])
+            min_version = ".".join(str(v) for v in MIN_PYTHON_SUPPORTED_VERSION)
+            Display().error(
+                f"Python Version running {running_version} - Minimum Version required is {min_version}",
+                False,
+            )
+            result["failed"] = True
+        result["python_version_info"] = python_version_info
+        result["python_path"] = sys.path
 
-        result = super().run(tmp, task_vars)
-        del tmp  # tmp no longer has any effect
-
-        if not HAS_PIP:
-            raise AnsibleActionFail("pip is required to run this plugin")
-
+    def _validate_python_dependencies(self, dependencies, result):
+        """
+        Validate python lib versions
+        """
         dependencies_dict = {
             "not_found": {},
             "valid": {},
@@ -43,19 +61,9 @@ class ActionModule(ActionBase):
             "parsing_failed": [],
         }
 
-        if not (self._task.args and "dependencies" in self._task.args):
-            raise AnsibleActionFail("The argument 'dependencies' must be set")
-
-        dependencies = self._task.args.get("dependencies")
-
-        if not isinstance(dependencies, list):
-            raise AnsibleActionFail("The argument 'dependencies' is not a list")
-
         # Can match this format
         # requests [security] >=2.8.1, == 2.8.* ; python_version < "2.7"
-        req_re = re.compile(
-            r"(^[a-zA-Z][a-zA-Z0-9_-]+) ?((?:\[[a-zA-Z0-9]+\])?) ?((?:(?:==|[!><~]=?) ?(?:[0-9.*]+),? ?)*)(?: ?; ?(.*))?$"
-        )
+        req_re = re.compile(r"(^[a-zA-Z][a-zA-Z0-9_-]+) ?((?:\[[a-zA-Z0-9]+\])?) ?((?:(?:==|[!><~]=?) ?(?:[0-9.*]+),? ?)*)(?: ?; ?(.*))?$")
 
         for dep in dependencies:
             match = req_re.match(dep)
@@ -88,8 +96,112 @@ class ActionModule(ActionBase):
                 }
                 result["failed"] = True
 
-        result["python_version_info"] = python_version_info
-        result["python_path"] = sys.path
         result["dependencies"] = dependencies_dict
+
+    def _validate_ansible_version(self, running_version, result):
+        """
+        Validate ansible version
+
+        TODO - avoid hardcoding this
+        """
+        specifiers_set = SpecifierSet(ANSIBLE_SPECIFIERS)
+        if not specifiers_set.contains(running_version):
+            Display().error(
+                f"Ansible Version running {running_version} - Requirement is {ANSIBLE_SPECIFIERS}",
+                False,
+            )
+            result["failed"] = True
+
+        result["ansible_version"] = running_version
+
+    def _validate_ansible_collections(self, result):
+        """ """
+        # TODO
+        pass
+
+    def __maybe_get_git_commit(self, collection_path):
+        def is_sha1(maybe_sha1):
+            try:
+                assert len(maybe_sha1) == 40
+                int(maybe_sha1, 16)
+                return True
+            except Exception:
+                return False
+
+        maybe_git_root = os.path.dirname(os.path.dirname(os.path.dirname(collection_path)))
+        maybe_git_dir = os.path.join(maybe_git_root, ".git")
+        if os.path.exists(maybe_git_dir):
+            # it is a git repo
+            with open(os.path.join(maybe_git_dir, "HEAD"), "r") as fd:
+                data = fd.read().strip()
+            if is_sha1(data):
+                return data[:9]
+
+            # HEAD is probably a ref
+            head = yaml.safe_load(data)
+            ref = head["ref"]
+            with open(os.path.join(maybe_git_dir, ref), "r") as fd:
+                data = fd.read().strip()
+            if is_sha1(data):
+                return data[:9]
+
+            # TODO - we failed parsing
+
+        return None
+
+    def _get_running_collection_version(self, running_collection_name, result):
+        """
+        TODO
+        """
+        collection = import_module(f"ansible_collections.{running_collection_name}")
+        collection_path = os.path.dirname(collection.__file__)
+        galaxy_file = os.path.join(collection_path, "galaxy.yml")
+        with open(galaxy_file, "rb") as fd:
+            metadata = yaml.safe_load(fd)
+
+        version = metadata["version"]
+
+        # Try to detect a git tag
+        # if it was cloned from git the git root will be two levels above
+        git_commit = self.__maybe_get_git_commit(collection_path)
+        # Not in theory `BLAH` should be the number of commits between version and the
+        # commit id but it is hard to compute without git API and the goal is to
+        # not add any additional dependencies
+        # TODO - decide if we want to keep this
+        if git_commit:
+            version = f"v{version}-BLAH-d{git_commit}"
+
+        result["collection"] = {
+            "name": running_collection_name,
+            "path": os.path.dirname(os.path.dirname(collection_path)),
+            "version": version,
+        }
+
+    def run(self, tmp=None, task_vars=None):
+        if task_vars is None:
+            task_vars = {}
+
+        result = super().run(tmp, task_vars)
+        del tmp  # tmp no longer has any effect
+
+        if not HAS_PIP:
+            raise AnsibleActionFail("pip is required to run this plugin")
+
+        if not (self._task.args and "dependencies" in self._task.args):
+            raise AnsibleActionFail("The argument 'dependencies' must be set")
+
+        dependencies = self._task.args.get("dependencies")
+
+        if not isinstance(dependencies, list):
+            raise AnsibleActionFail("The argument 'dependencies' is not a list")
+
+        running_ansible_version = task_vars["ansible_version"]["string"]
+        running_collection_name = task_vars["ansible_collection_name"]
+        self._get_running_collection_version(running_collection_name, result)
+
+        self._validate_python_version(result)
+        self._validate_python_dependencies(dependencies, result)
+        self._validate_ansible_version(running_ansible_version, result)
+        self._validate_ansible_collections(result)
 
         return result

--- a/ansible_collections/arista/avd/plugins/modules/verify_requirements.py
+++ b/ansible_collections/arista/avd/plugins/modules/verify_requirements.py
@@ -23,18 +23,18 @@ description:
   - Display the current running version of the collection
   - Given a list of python requirements, verify if the installed libraries match these requirements
   - Validate the ansible version against collection requirements
-  - Validate the collection dependencies against the collection requirements
+  - Validate the collection requirements against the collection requirements
   - Validate the running python version
 options:
-  dependencies:
+  requirements:
     description: |
-      - List of strings of python dependencies with pip file syntax
+      - List of strings of python requirements with pip file syntax.
     required: true
     type: list
     elements: str
-  avd_debug:
+  avd_ignore_requirements:
     description: |
-      - Boolean, if set to True, prints the output of the module
+      - Boolean, if set to True, the play does not stop if any requirement error is detected.
     required: false
     default: false
     type: bool
@@ -43,7 +43,7 @@ options:
 EXAMPLES = r"""
 - name: Verify collection requirements
   arista.avd.verify_requirements:
-    dependencies:
+    requirements:
       - Jinja2 >= 2.9
       - paramiko == 2.7.1
   check_mode: false

--- a/ansible_collections/arista/avd/plugins/modules/verify_requirements.py
+++ b/ansible_collections/arista/avd/plugins/modules/verify_requirements.py
@@ -34,8 +34,8 @@ EXAMPLES = r"""
 - name: Verify python requirements
   arista.avd.verify_requirements:
     dependencies:
-      - jinja2 >= 2.9
-      - ansible == 2.13
+      - Jinja2 >= 2.9
+      - paramiko == 2.7.1
   check_mode: False
   run_once: True
 """

--- a/ansible_collections/arista/avd/plugins/modules/verify_requirements.py
+++ b/ansible_collections/arista/avd/plugins/modules/verify_requirements.py
@@ -1,0 +1,41 @@
+# Copyright 2022 Arista Networks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+DOCUMENTATION = r"""
+---
+module: verify_requirements
+version_added: "3.8.0"
+author: Arista Ansible Team (@aristanetworks)
+short_description: Verify Python requirements when running AVD
+description:
+  - The `arista.avd.verify_requirements` module is an Ansible Action Plugin providing the following capabilities
+  - Given a list of python requirements, verify if the installed libraries match these requirements
+options:
+  dependencies:
+    description: |
+      - List of strings of dependencies with pip file syntax
+    required: True
+    type: list
+"""
+
+EXAMPLES = r"""
+- name: Verify python requirements
+  arista.avd.verify_requirements:
+    dependencies:
+      - jinja2 >= 2.9
+      - ansible == 2.13
+  check_mode: False
+  run_once: True
+"""

--- a/ansible_collections/arista/avd/plugins/modules/verify_requirements.py
+++ b/ansible_collections/arista/avd/plugins/modules/verify_requirements.py
@@ -20,6 +20,7 @@ author: Arista Ansible Team (@aristanetworks)
 short_description: Verify Python requirements when running AVD
 description:
   The `arista.avd.verify_requirements` module is an Ansible Action Plugin providing the following capabilities
+  - Display the current running version of the collection
   - Given a list of python requirements, verify if the installed libraries match these requirements
   - Validate the ansible version against collection requirements
   - Validate the collection dependencies against the collection requirements
@@ -28,17 +29,23 @@ options:
   dependencies:
     description: |
       - List of strings of python dependencies with pip file syntax
-    required: True
+    required: true
     type: list
-    elements: strings
+    elements: str
+  avd_debug:
+    description: |
+      - Boolean, if set to True, prints the output of the module
+    required: false
+    default: false
+    type: bool
 """
 
 EXAMPLES = r"""
-- name: Verify python requirements
+- name: Verify collection requirements
   arista.avd.verify_requirements:
     dependencies:
       - Jinja2 >= 2.9
       - paramiko == 2.7.1
-  check_mode: False
-  run_once: True
+  check_mode: false
+  run_once: true
 """

--- a/ansible_collections/arista/avd/plugins/modules/verify_requirements.py
+++ b/ansible_collections/arista/avd/plugins/modules/verify_requirements.py
@@ -11,23 +11,26 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
 DOCUMENTATION = r"""
 ---
 module: verify_requirements
-version_added: "3.8.0"
+version_added: "4.0.0"
 author: Arista Ansible Team (@aristanetworks)
 short_description: Verify Python requirements when running AVD
 description:
-  - The `arista.avd.verify_requirements` module is an Ansible Action Plugin providing the following capabilities
+  The `arista.avd.verify_requirements` module is an Ansible Action Plugin providing the following capabilities
   - Given a list of python requirements, verify if the installed libraries match these requirements
+  - Validate the ansible version against collection requirements
+  - Validate the collection dependencies against the collection requirements
+  - Validate the running python version
 options:
   dependencies:
     description: |
-      - List of strings of dependencies with pip file syntax
+      - List of strings of python dependencies with pip file syntax
     required: True
     type: list
+    elements: strings
 """
 
 EXAMPLES = r"""

--- a/ansible_collections/arista/avd/requirements.txt
+++ b/ansible_collections/arista/avd/requirements.txt
@@ -9,4 +9,4 @@ PyYAML>=5.4.1
 md-toc>=7.1.0
 deepmerge>=1.1.0
 cryptography>=38.0.4
-packaging==21.3
+packaging>=21.3

--- a/ansible_collections/arista/avd/requirements.txt
+++ b/ansible_collections/arista/avd/requirements.txt
@@ -9,3 +9,4 @@ PyYAML>=5.4.1
 md-toc>=7.1.0
 deepmerge>=1.1.0
 cryptography>=38.0.4
+pip>=21.3

--- a/ansible_collections/arista/avd/requirements.txt
+++ b/ansible_collections/arista/avd/requirements.txt
@@ -9,4 +9,4 @@ PyYAML>=5.4.1
 md-toc>=7.1.0
 deepmerge>=1.1.0
 cryptography>=38.0.4
-pip>=21.3
+packaging==21.3

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/tasks/main.yml
@@ -1,26 +1,15 @@
 ---
 - name: Verify Requirements
   tags: [always, avd_req]
+  delegate_to: localhost
   when: avd_requirements is not defined
-  block:
-    - name: Run requirements check module
-      arista.avd.verify_requirements:
-        dependencies: "{{ lookup('file', requirements_path ~ '/requirements.txt').splitlines() }}"
-      vars:
-        requirements_path: "{{ (role_path | split('/'))[0:-2] | join('/') }}"
-      run_once: true
-      register: avd_requirements
-
-    - name: Print requirements
-      tags: [debug, avd_req, never]
-      ansible.builtin.debug:
-        msg: "{{ avd_requirements }}"
-      run_once: true
-  rescue:
-    - name: Print requirements when error
-      ansible.builtin.debug:
-        msg: "{{ avd_requirements }}"
-      run_once: true
+  arista.avd.verify_requirements:
+    dependencies: "{{ lookup('file', requirements_path ~ '/requirements.txt').splitlines() }}"
+    avd_debug: "{{ avd_debug | default(false) }}"
+  vars:
+    requirements_path: "{{ (role_path | split('/'))[0:-2] | join('/') }}"
+  run_once: true
+  register: avd_requirements
 
 - name: Create required output directories if not present
   tags: [build, provision]

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/tasks/main.yml
@@ -4,8 +4,8 @@
   delegate_to: localhost
   when: avd_requirements is not defined
   arista.avd.verify_requirements:
-    dependencies: "{{ lookup('file', requirements_path ~ '/requirements.txt').splitlines() }}"
-    avd_debug: "{{ avd_debug | default(false) }}"
+    requirements: "{{ lookup('file', requirements_path ~ '/requirements.txt').splitlines() }}"
+    avd_ignore_requirements: "{{ avd_ignore_requirements | default(false) }}"
   vars:
     requirements_path: "{{ (role_path | split('/'))[0:-2] | join('/') }}"
   run_once: true

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/tasks/main.yml
@@ -1,30 +1,26 @@
 ---
-- name: "Collection {{ ansible_collection_name }} version {{ version }}{{ ('(git ' ~ git_tag ~ ')') if git_tag }} loaded from {{ collection_path }}"
-  tags: [always, avd_version]
-  ansible.builtin.set_fact:
-    avd_collection_version: version
-  vars:
-    versions: "{{ lookup('pipe', 'ansible-galaxy collection list -p ' ~ collection_path ~ ' --format yaml ' ~ ansible_collection_name) | from_yaml }}"
-    collection_path: "{{ (role_path | split('/'))[0:-4] | join('/') }}"
-    version: "{{ versions[collection_path][ansible_collection_name].version | default('Unknown') }}"
-    git_tag: "{{ lookup('pipe', 'git -C ' ~ collection_path ~ ' describe --tags --always 2>/dev/null', errors='ignore') }}"
-  run_once: true
-  failed_when: false
-
-- name: "Verify Requirements"
+- name: Verify Requirements
   tags: [always, avd_req]
-  arista.avd.verify_requirements:
-    dependencies: "{{ lookup('file', requirements_path ~ '/requirements.txt').splitlines() }}"
-  vars:
-    requirements_path: "{{ (role_path | split('/'))[0:-2] | join('/') }}"
-  run_once: true
-  register: requirements
+  when: avd_requirements is not defined
+  block:
+    - name: Run requirements check module
+      arista.avd.verify_requirements:
+        dependencies: "{{ lookup('file', requirements_path ~ '/requirements.txt').splitlines() }}"
+      vars:
+        requirements_path: "{{ (role_path | split('/'))[0:-2] | join('/') }}"
+      run_once: true
+      register: avd_requirements
 
-- name: "Print requirements"
-  tags: [debug, avd_req, never]
-  ansible.builtin.debug:
-    msg: "{{ requirements }}"
-  run_once: true
+    - name: Print requirements
+      tags: [debug, avd_req, never]
+      ansible.builtin.debug:
+        msg: "{{ avd_requirements }}"
+      run_once: true
+  rescue:
+    - name: Print requirements when error
+      ansible.builtin.debug:
+        msg: "{{ avd_requirements }}"
+      run_once: true
 
 - name: Create required output directories if not present
   tags: [build, provision]

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/tasks/main.yml
@@ -11,6 +11,21 @@
   run_once: true
   failed_when: false
 
+- name: "Verify Requirements"
+  tags: [always, avd_req]
+  arista.avd.verify_requirements:
+    dependencies: "{{ lookup('file', requirements_path ~ '/requirements.txt').splitlines() }}"
+  vars:
+    requirements_path: "{{ (role_path | split('/'))[0:-2] | join('/') }}"
+  run_once: true
+  register: requirements
+
+- name: "Print requirements"
+  tags: [debug, avd_req, never]
+  ansible.builtin.debug:
+    msg: "{{ requirements }}"
+  run_once: true
+
 - name: Create required output directories if not present
   tags: [build, provision]
   ansible.builtin.file:

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/main.yml
@@ -15,8 +15,8 @@
   delegate_to: localhost
   when: avd_requirements is not defined
   arista.avd.verify_requirements:
-    dependencies: "{{ lookup('file', requirements_path ~ '/requirements.txt').splitlines() }}"
-    avd_debug: "{{ avd_debug | default(false) }}"
+    requirements: "{{ lookup('file', requirements_path ~ '/requirements.txt').splitlines() }}"
+    avd_ignore_requirements: "{{ avd_ignore_requirements | default(false) }}"
   vars:
     requirements_path: "{{ (role_path | split('/'))[0:-2] | join('/') }}"
   run_once: true

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/main.yml
@@ -10,6 +10,29 @@
   delegate_to: localhost
   run_once: true
 
+- name: Verify Requirements
+  tags: [always, avd_req]
+  when: avd_requirements is not defined
+  block:
+    - name: Run requirements check module
+      arista.avd.verify_requirements:
+        dependencies: "{{ lookup('file', requirements_path ~ '/requirements.txt').splitlines() }}"
+      vars:
+        requirements_path: "{{ (role_path | split('/'))[0:-2] | join('/') }}"
+      run_once: true
+      register: avd_requirements
+
+    - name: Print requirements
+      tags: [debug, avd_req, never]
+      ansible.builtin.debug:
+        msg: "{{ avd_requirements }}"
+      run_once: true
+  rescue:
+    - name: Print requirements when error
+      ansible.builtin.debug:
+        msg: "{{ avd_requirements }}"
+      run_once: true
+
 - name: Start creation/update process.
   tags: [always]
   ansible.builtin.include_tasks: "{{ cv_collection }}/main.yml"

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/main.yml
@@ -12,26 +12,15 @@
 
 - name: Verify Requirements
   tags: [always, avd_req]
+  delegate_to: localhost
   when: avd_requirements is not defined
-  block:
-    - name: Run requirements check module
-      arista.avd.verify_requirements:
-        dependencies: "{{ lookup('file', requirements_path ~ '/requirements.txt').splitlines() }}"
-      vars:
-        requirements_path: "{{ (role_path | split('/'))[0:-2] | join('/') }}"
-      run_once: true
-      register: avd_requirements
-
-    - name: Print requirements
-      tags: [debug, avd_req, never]
-      ansible.builtin.debug:
-        msg: "{{ avd_requirements }}"
-      run_once: true
-  rescue:
-    - name: Print requirements when error
-      ansible.builtin.debug:
-        msg: "{{ avd_requirements }}"
-      run_once: true
+  arista.avd.verify_requirements:
+    dependencies: "{{ lookup('file', requirements_path ~ '/requirements.txt').splitlines() }}"
+    avd_debug: "{{ avd_debug | default(false) }}"
+  vars:
+    requirements_path: "{{ (role_path | split('/'))[0:-2] | join('/') }}"
+  run_once: true
+  register: avd_requirements
 
 - name: Start creation/update process.
   tags: [always]

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v1/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v1/main.yml
@@ -1,18 +1,5 @@
 ---
 # Common action for all states.
-
-- name: "Collection {{ ansible_collection_name }} version {{ version }}{{ ('(git ' ~ git_tag ~ ')') if git_tag }} loaded from {{ collection_path }}"
-  tags: [always, avd_version]
-  ansible.builtin.set_fact:
-    avd_collection_version: version
-  vars:
-    versions: "{{ lookup('pipe', 'ansible-galaxy collection list -p ' ~ collection_path ~ ' --format yaml ' ~ ansible_collection_name) | from_yaml }}"
-    collection_path: "{{ (role_path | split('/'))[0:-4] | join('/') }}"
-    version: "{{ versions[collection_path][ansible_collection_name].version | default('Unknown') }}"
-    git_tag: "{{ lookup('pipe', 'git -C ' ~ collection_path ~ ' describe --tags --always 2>/dev/null', errors='ignore') }}"
-  run_once: true
-  failed_when: false
-
 # Load tasks when device_filter is string
 - name: Generate CVP information using device_filter as string.
   tags: [always]

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v3/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/tasks/v3/main.yml
@@ -1,16 +1,4 @@
 ---
-- name: "Collection {{ ansible_collection_name }} version {{ version }}{{ ('(git ' ~ git_tag ~ ')') if git_tag }} loaded from {{ collection_path }}"
-  tags: [always, avd_version]
-  ansible.builtin.set_fact:
-    avd_collection_version: version
-  vars:
-    versions: "{{ lookup('pipe', 'ansible-galaxy collection list -p ' ~ collection_path ~ ' --format yaml ' ~ ansible_collection_name) | from_yaml }}"
-    collection_path: "{{ (role_path | split('/'))[0:-4] | join('/') }}"
-    version: "{{ versions[collection_path][ansible_collection_name].version | default('Unknown') }}"
-    git_tag: "{{ lookup('pipe', 'git -C ' ~ collection_path ~ ' describe --tags --always 2>/dev/null', errors='ignore') }}"
-  run_once: true
-  failed_when: false
-
 - name: "Generate intended variables"
   tags: [always]
   arista.avd.inventory_to_container:

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_eapi/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_eapi/tasks/main.yml
@@ -1,26 +1,15 @@
 ---
 - name: Verify Requirements
   tags: [always, avd_req]
+  delegate_to: localhost
   when: avd_requirements is not defined
-  block:
-    - name: Run requirements check module
-      arista.avd.verify_requirements:
-        dependencies: "{{ lookup('file', requirements_path ~ '/requirements.txt').splitlines() }}"
-      vars:
-        requirements_path: "{{ (role_path | split('/'))[0:-2] | join('/') }}"
-      run_once: true
-      register: avd_requirements
-
-    - name: Print requirements
-      tags: [debug, avd_req, never]
-      ansible.builtin.debug:
-        msg: "{{ avd_requirements }}"
-      run_once: true
-  rescue:
-    - name: Print requirements when error
-      ansible.builtin.debug:
-        msg: "{{ avd_requirements }}"
-      run_once: true
+  arista.avd.verify_requirements:
+    dependencies: "{{ lookup('file', requirements_path ~ '/requirements.txt').splitlines() }}"
+    avd_debug: "{{ avd_debug | default(false) }}"
+  vars:
+    requirements_path: "{{ (role_path | split('/'))[0:-2] | join('/') }}"
+  run_once: true
+  register: avd_requirements
 
 - name: Create required output directories if not present
   ansible.builtin.file:

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_eapi/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_eapi/tasks/main.yml
@@ -4,8 +4,8 @@
   delegate_to: localhost
   when: avd_requirements is not defined
   arista.avd.verify_requirements:
-    dependencies: "{{ lookup('file', requirements_path ~ '/requirements.txt').splitlines() }}"
-    avd_debug: "{{ avd_debug | default(false) }}"
+    requirements: "{{ lookup('file', requirements_path ~ '/requirements.txt').splitlines() }}"
+    avd_ignore_requirements: "{{ avd_ignore_requirements | default(false) }}"
   vars:
     requirements_path: "{{ (role_path | split('/'))[0:-2] | join('/') }}"
   run_once: true

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_eapi/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_eapi/tasks/main.yml
@@ -1,15 +1,26 @@
 ---
-- name: "Collection {{ ansible_collection_name }} version {{ version }}{{ ('(git ' ~ git_tag ~ ')') if git_tag }} loaded from {{ collection_path }}"
-  tags: [always, avd_version]
-  ansible.builtin.set_fact:
-    avd_collection_version: version
-  vars:
-    versions: "{{ lookup('pipe', 'ansible-galaxy collection list -p ' ~ collection_path ~ ' --format yaml ' ~ ansible_collection_name) | from_yaml }}"
-    collection_path: "{{ (role_path | split('/'))[0:-4] | join('/') }}"
-    version: "{{ versions[collection_path][ansible_collection_name].version | default('Unknown') }}"
-    git_tag: "{{ lookup('pipe', 'git -C ' ~ collection_path ~ ' describe --tags --always 2>/dev/null', errors='ignore') }}"
-  run_once: true
-  failed_when: false
+- name: Verify Requirements
+  tags: [always, avd_req]
+  when: avd_requirements is not defined
+  block:
+    - name: Run requirements check module
+      arista.avd.verify_requirements:
+        dependencies: "{{ lookup('file', requirements_path ~ '/requirements.txt').splitlines() }}"
+      vars:
+        requirements_path: "{{ (role_path | split('/'))[0:-2] | join('/') }}"
+      run_once: true
+      register: avd_requirements
+
+    - name: Print requirements
+      tags: [debug, avd_req, never]
+      ansible.builtin.debug:
+        msg: "{{ avd_requirements }}"
+      run_once: true
+  rescue:
+    - name: Print requirements when error
+      ansible.builtin.debug:
+        msg: "{{ avd_requirements }}"
+      run_once: true
 
 - name: Create required output directories if not present
   ansible.builtin.file:

--- a/ansible_collections/arista/avd/roles/eos_designs/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/tasks/main.yml
@@ -12,7 +12,7 @@
   failed_when: false
 
 - name: "Verify Requirements"
-  tags: [debug, avd_req]
+  tags: [debug, avd_req, never]
   arista.avd.verify_requirements:
     dependencies: "{{ lookup('file', requirements_path ~ '/requirements.txt').splitlines() }}"
   vars:
@@ -21,7 +21,7 @@
   register: requirements
 
 - name: "Print requirements"
-  tags: [debug, avd_req]
+  tags: [debug, avd_req, never]
   debug: msg="{{ requirements }}"
   run_once: true
 

--- a/ansible_collections/arista/avd/roles/eos_designs/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/tasks/main.yml
@@ -1,42 +1,15 @@
 ---
-- name: "Collection {{ ansible_collection_name }} version {{ version }}{{ ('(git ' ~ git_tag ~ ')') if git_tag }} loaded from {{ collection_path }}"
-  tags: [always, avd_version]
-  ansible.builtin.set_fact:
-    avd_collection_version: version
-  vars:
-    versions: "{{ lookup('pipe', 'ansible-galaxy collection list -p ' ~ collection_path ~ ' --format yaml ' ~ ansible_collection_name) | from_yaml }}"
-    collection_path: "{{ (role_path | split('/'))[0:-4] | join('/') }}"
-    version: "{{ versions[collection_path][ansible_collection_name].version | default('Unknown') }}"
-    git_tag: "{{ lookup('pipe', 'git -C ' ~ collection_path ~ ' describe --tags --always 2>/dev/null', errors='ignore') }}"
+- name: Verify Requirements
+  tags: [always, avd_req]
   run_once: true
+  delegate_to: localhost
+  when: avd_requirements is not defined
   failed_when: false
-
-- name: "Verify Requirements"
-  tags: [debug, avd_req, never]
   arista.avd.verify_requirements:
     dependencies: "{{ lookup('file', requirements_path ~ '/requirements.txt').splitlines() }}"
+    avd_debug: false  #TODO make it a variable
   vars:
     requirements_path: "{{ (role_path | split('/'))[0:-2] | join('/') }}"
-  run_once: true
-  register: requirements
-
-- name: "Print requirements"
-  tags: [debug, avd_req, never]
-  ansible.builtin.debug:
-    msg: "{{ requirements }}"
-  run_once: true
-
-- name: Create required output directories if not present
-  tags: [build, provision]
-  ansible.builtin.file:
-    path: "{{ item }}"
-    state: directory
-    mode: 0775
-  loop:
-    - "{{ structured_dir }}"
-    - "{{ fabric_dir }}"
-  delegate_to: localhost
-  run_once: true
 
 - name: Set eos_designs facts
   tags: [build, provision, facts]

--- a/ansible_collections/arista/avd/roles/eos_designs/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/tasks/main.yml
@@ -4,8 +4,8 @@
   delegate_to: localhost
   when: avd_requirements is not defined
   arista.avd.verify_requirements:
-    dependencies: "{{ lookup('file', requirements_path ~ '/requirements.txt').splitlines() }}"
-    avd_debug: "{{ avd_debug | default(false) }}"
+    requirements: "{{ lookup('file', requirements_path ~ '/requirements.txt').splitlines() }}"
+    avd_ignore_requirements: "{{ avd_ignore_requirements | default(false) }}"
   vars:
     requirements_path: "{{ (role_path | split('/'))[0:-2] | join('/') }}"
   run_once: true

--- a/ansible_collections/arista/avd/roles/eos_designs/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/tasks/main.yml
@@ -22,7 +22,8 @@
 
 - name: "Print requirements"
   tags: [debug, avd_req, never]
-  debug: msg="{{ requirements }}"
+  ansible.builtin.debug:
+    msg: "{{ requirements }}"
   run_once: true
 
 - name: Create required output directories if not present

--- a/ansible_collections/arista/avd/roles/eos_designs/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/tasks/main.yml
@@ -11,6 +11,20 @@
   run_once: true
   failed_when: false
 
+- name: "Verify Requirements"
+  tags: [debug, avd_req]
+  arista.avd.verify_requirements:
+    dependencies: "{{ lookup('file', requirements_path ~ '/requirements.txt').splitlines() }}"
+  vars:
+    requirements_path: "{{ (role_path | split('/'))[0:-2] | join('/') }}"
+  run_once: true
+  register: requirements
+
+- name: "Print requirements"
+  tags: [debug, avd_req]
+  debug: msg="{{ requirements }}"
+  run_once: true
+
 - name: Create required output directories if not present
   tags: [build, provision]
   ansible.builtin.file:

--- a/ansible_collections/arista/avd/roles/eos_designs/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/tasks/main.yml
@@ -1,15 +1,15 @@
 ---
 - name: Verify Requirements
   tags: [always, avd_req]
-  run_once: true
   delegate_to: localhost
   when: avd_requirements is not defined
-  failed_when: false
   arista.avd.verify_requirements:
     dependencies: "{{ lookup('file', requirements_path ~ '/requirements.txt').splitlines() }}"
-    avd_debug: false  #TODO make it a variable
+    avd_debug: "{{ avd_debug | default(false) }}"
   vars:
     requirements_path: "{{ (role_path | split('/'))[0:-2] | join('/') }}"
+  run_once: true
+  register: avd_requirements
 
 - name: Set eos_designs facts
   tags: [build, provision, facts]

--- a/ansible_collections/arista/avd/roles/eos_snapshot/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_snapshot/tasks/main.yml
@@ -4,8 +4,8 @@
   delegate_to: localhost
   when: avd_requirements is not defined
   arista.avd.verify_requirements:
-    dependencies: "{{ lookup('file', requirements_path ~ '/requirements.txt').splitlines() }}"
-    avd_debug: "{{ avd_debug | default(false) }}"
+    requirements: "{{ lookup('file', requirements_path ~ '/requirements.txt').splitlines() }}"
+    avd_ignore_requirements: "{{ avd_ignore_requirements | default(false) }}"
   vars:
     requirements_path: "{{ (role_path | split('/'))[0:-2] | join('/') }}"
   run_once: true

--- a/ansible_collections/arista/avd/roles/eos_snapshot/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_snapshot/tasks/main.yml
@@ -1,17 +1,26 @@
 ---
-# tasks file for eos_snapshot
-- name: "Collection {{ ansible_collection_name }} version {{ version }}{{ ('(git ' ~ git_tag ~ ')') if git_tag }} loaded from {{ collection_path }}"
-  delegate_to: localhost
-  tags: [always, avd_version]
-  ansible.builtin.set_fact:
-    avd_collection_version: version
-  vars:
-    versions: "{{ lookup('pipe', 'ansible-galaxy collection list -p ' ~ collection_path ~ ' --format yaml ' ~ ansible_collection_name) | from_yaml }}"
-    collection_path: "{{ (role_path | split('/'))[0:-4] | join('/') }}"
-    version: "{{ versions[collection_path][ansible_collection_name].version | default('Unknown') }}"
-    git_tag: "{{ lookup('pipe', 'git -C ' ~ collection_path ~ ' describe --tags --always 2>/dev/null', errors='ignore') }}"
-  run_once: true
-  failed_when: false
+- name: Verify Requirements
+  tags: [always, avd_req]
+  when: avd_requirements is not defined
+  block:
+    - name: Run requirements check module
+      arista.avd.verify_requirements:
+        dependencies: "{{ lookup('file', requirements_path ~ '/requirements.txt').splitlines() }}"
+      vars:
+        requirements_path: "{{ (role_path | split('/'))[0:-2] | join('/') }}"
+      run_once: true
+      register: avd_requirements
+
+    - name: Print requirements
+      tags: [debug, avd_req, never]
+      ansible.builtin.debug:
+        msg: "{{ avd_requirements }}"
+      run_once: true
+  rescue:
+    - name: Print requirements when error
+      ansible.builtin.debug:
+        msg: "{{ avd_requirements }}"
+      run_once: true
 
 - name: Create required output directories if not present
   delegate_to: localhost

--- a/ansible_collections/arista/avd/roles/eos_snapshot/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_snapshot/tasks/main.yml
@@ -1,26 +1,15 @@
 ---
 - name: Verify Requirements
   tags: [always, avd_req]
+  delegate_to: localhost
   when: avd_requirements is not defined
-  block:
-    - name: Run requirements check module
-      arista.avd.verify_requirements:
-        dependencies: "{{ lookup('file', requirements_path ~ '/requirements.txt').splitlines() }}"
-      vars:
-        requirements_path: "{{ (role_path | split('/'))[0:-2] | join('/') }}"
-      run_once: true
-      register: avd_requirements
-
-    - name: Print requirements
-      tags: [debug, avd_req, never]
-      ansible.builtin.debug:
-        msg: "{{ avd_requirements }}"
-      run_once: true
-  rescue:
-    - name: Print requirements when error
-      ansible.builtin.debug:
-        msg: "{{ avd_requirements }}"
-      run_once: true
+  arista.avd.verify_requirements:
+    dependencies: "{{ lookup('file', requirements_path ~ '/requirements.txt').splitlines() }}"
+    avd_debug: "{{ avd_debug | default(false) }}"
+  vars:
+    requirements_path: "{{ (role_path | split('/'))[0:-2] | join('/') }}"
+  run_once: true
+  register: avd_requirements
 
 - name: Create required output directories if not present
   delegate_to: localhost

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/main.yml
@@ -1,26 +1,15 @@
 ---
 - name: Verify Requirements
   tags: [always, avd_req]
+  delegate_to: localhost
   when: avd_requirements is not defined
-  block:
-    - name: Run requirements check module
-      arista.avd.verify_requirements:
-        dependencies: "{{ lookup('file', requirements_path ~ '/requirements.txt').splitlines() }}"
-      vars:
-        requirements_path: "{{ (role_path | split('/'))[0:-2] | join('/') }}"
-      run_once: true
-      register: avd_requirements
-
-    - name: Print requirements
-      tags: [debug, avd_req, never]
-      ansible.builtin.debug:
-        msg: "{{ avd_requirements }}"
-      run_once: true
-  rescue:
-    - name: Print requirements when error
-      ansible.builtin.debug:
-        msg: "{{ avd_requirements }}"
-      run_once: true
+  arista.avd.verify_requirements:
+    dependencies: "{{ lookup('file', requirements_path ~ '/requirements.txt').splitlines() }}"
+    avd_debug: "{{ avd_debug | default(false) }}"
+  vars:
+    requirements_path: "{{ (role_path | split('/'))[0:-2] | join('/') }}"
+  run_once: true
+  register: avd_requirements
 
 - name: Create required output directories if not present
   ansible.builtin.file:

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/main.yml
@@ -1,16 +1,26 @@
 ---
-- name: "Collection {{ ansible_collection_name }} version {{ version }}{{ ('(git ' ~ git_tag ~ ')') if git_tag }} loaded from {{ collection_path }}"
-  delegate_to: localhost
-  tags: [always, avd_version]
-  ansible.builtin.set_fact:
-    avd_collection_version: version
-  vars:
-    versions: "{{ lookup('pipe', 'ansible-galaxy collection list -p ' ~ collection_path ~ ' --format yaml ' ~ ansible_collection_name) | from_yaml }}"
-    collection_path: "{{ (role_path | split('/'))[0:-4] | join('/') }}"
-    version: "{{ versions[collection_path][ansible_collection_name].version | default('Unknown') }}"
-    git_tag: "{{ lookup('pipe', 'git -C ' ~ collection_path ~ ' describe --tags --always 2>/dev/null', errors='ignore') }}"
-  run_once: true
-  failed_when: false
+- name: Verify Requirements
+  tags: [always, avd_req]
+  when: avd_requirements is not defined
+  block:
+    - name: Run requirements check module
+      arista.avd.verify_requirements:
+        dependencies: "{{ lookup('file', requirements_path ~ '/requirements.txt').splitlines() }}"
+      vars:
+        requirements_path: "{{ (role_path | split('/'))[0:-2] | join('/') }}"
+      run_once: true
+      register: avd_requirements
+
+    - name: Print requirements
+      tags: [debug, avd_req, never]
+      ansible.builtin.debug:
+        msg: "{{ avd_requirements }}"
+      run_once: true
+  rescue:
+    - name: Print requirements when error
+      ansible.builtin.debug:
+        msg: "{{ avd_requirements }}"
+      run_once: true
 
 - name: Create required output directories if not present
   ansible.builtin.file:

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/main.yml
@@ -4,8 +4,8 @@
   delegate_to: localhost
   when: avd_requirements is not defined
   arista.avd.verify_requirements:
-    dependencies: "{{ lookup('file', requirements_path ~ '/requirements.txt').splitlines() }}"
-    avd_debug: "{{ avd_debug | default(false) }}"
+    requirements: "{{ lookup('file', requirements_path ~ '/requirements.txt').splitlines() }}"
+    avd_ignore_requirements: "{{ avd_ignore_requirements | default(false) }}"
   vars:
     requirements_path: "{{ (role_path | split('/'))[0:-2] | join('/') }}"
   run_once: true

--- a/ansible_collections/arista/avd/tests/sanity/ignore-2.12.txt
+++ b/ansible_collections/arista/avd/tests/sanity/ignore-2.12.txt
@@ -2,5 +2,6 @@ plugins/modules/configlet_build_config.py validate-modules:missing-gplv3-license
 plugins/modules/eos_designs_facts.py validate-modules:missing-gplv3-license
 plugins/modules/inventory_to_container.py validate-modules:missing-gplv3-license
 plugins/modules/validate_and_template.py validate-modules:missing-gplv3-license
+plugins/modules/verify_requirements.py validate-modules:missing-gplv3-license
 plugins/modules/yaml_templates_to_facts.py validate-modules:missing-gplv3-license
 roles/eos_designs/python_modules/custom_structured_configuration/avdstructuredconfig.py pep8:E203 # Required for compatibility with black formatting (space before colon)

--- a/ansible_collections/arista/avd/tests/sanity/ignore-2.13.txt
+++ b/ansible_collections/arista/avd/tests/sanity/ignore-2.13.txt
@@ -2,5 +2,6 @@ plugins/modules/configlet_build_config.py validate-modules:missing-gplv3-license
 plugins/modules/eos_designs_facts.py validate-modules:missing-gplv3-license
 plugins/modules/inventory_to_container.py validate-modules:missing-gplv3-license
 plugins/modules/validate_and_template.py validate-modules:missing-gplv3-license
+plugins/modules/verify_requirements.py validate-modules:missing-gplv3-license
 plugins/modules/yaml_templates_to_facts.py validate-modules:missing-gplv3-license
 roles/eos_designs/python_modules/custom_structured_configuration/avdstructuredconfig.py pep8:E203 # Required for compatibility with black formatting (space before colon)

--- a/ansible_collections/arista/avd/tests/sanity/ignore-2.14.txt
+++ b/ansible_collections/arista/avd/tests/sanity/ignore-2.14.txt
@@ -2,5 +2,6 @@ plugins/modules/configlet_build_config.py validate-modules:missing-gplv3-license
 plugins/modules/eos_designs_facts.py validate-modules:missing-gplv3-license
 plugins/modules/inventory_to_container.py validate-modules:missing-gplv3-license
 plugins/modules/validate_and_template.py validate-modules:missing-gplv3-license
+plugins/modules/verify_requirements.py validate-modules:missing-gplv3-license
 plugins/modules/yaml_templates_to_facts.py validate-modules:missing-gplv3-license
 roles/eos_designs/python_modules/custom_structured_configuration/avdstructuredconfig.py pep8:E203 # Required for compatibility with black formatting (space before colon)

--- a/ansible_collections/arista/avd/tests/unit/action/test_verify_requirements.py
+++ b/ansible_collections/arista/avd/tests/unit/action/test_verify_requirements.py
@@ -1,0 +1,97 @@
+__metaclass__ = type
+
+import importlib
+from collections import namedtuple
+from unittest.mock import patch
+
+import pytest
+
+from ansible_collections.arista.avd.plugins.action.verify_requirements import (
+    MIN_PYTHON_SUPPORTED_VERSION,
+    _validate_python_dependencies,
+    _validate_python_version,
+)
+
+
+@pytest.mark.parametrize(
+    "mocked_version, expected_return",
+    [
+        (
+            (2, 2, 2, "final", 0),
+            False,
+        ),
+        (
+            (MIN_PYTHON_SUPPORTED_VERSION[0], MIN_PYTHON_SUPPORTED_VERSION[1], 42, "final", 0),
+            True,
+        ),
+    ],
+)
+def test__validate_python_version(mocked_version, expected_return):
+    """
+    TODO - could add the expected stderr
+    """
+    result = {}
+    version_info = namedtuple("version_info", "major minor micro releaselevel serial")
+    with patch("ansible_collections.arista.avd.plugins.action.verify_requirements.sys") as mocked_sys:
+        mocked_sys.version_info = version_info(*mocked_version)
+        ret = _validate_python_version(result)
+    assert ret == expected_return
+    assert result["python_version_info"] == {
+        "major": mocked_version[0],
+        "minor": mocked_version[1],
+        "micro": mocked_version[2],
+        "releaselevel": mocked_version[3],
+        "serial": mocked_version[4],
+    }
+    assert bool(result["python_path"])
+
+
+@pytest.mark.parametrize(
+    "n_deps, mocked_version, requirement_version, expected_return",
+    [
+        pytest.param(
+            1,
+            "4.3",
+            "4.2",
+            True,
+            id="valid version",
+        ),
+        pytest.param(
+            2,
+            "4.0",
+            "4.2",
+            False,
+            id="invalid version",
+        ),
+        pytest.param(
+            1,
+            None,
+            "4.2",
+            False,
+            id="missing dependency",
+        ),
+        pytest.param(
+            0,
+            None,
+            None,
+            True,
+            id="no dependency",
+        ),
+    ],
+)
+def test__validate_python_dependencies(n_deps, mocked_version, requirement_version, expected_return):
+    """
+    Running with n_deps dependencies
+
+    TODO - check the results
+         - not testing for wrongly formated dependencies
+    """
+    result = {}
+    dependencies = [f"test-dep>={requirement_version}" for _ in range(n_deps)]  # pylint: disable=disallowed-name
+    print(dependencies)
+    with patch("ansible_collections.arista.avd.plugins.action.verify_requirements.importlib.metadata.version") as patched_version:
+        patched_version.return_value = mocked_version
+        if mocked_version is None:
+            patched_version.side_effect = importlib.metadata.PackageNotFoundError()
+        ret = _validate_python_dependencies(dependencies, result)
+        assert ret == expected_return

--- a/ansible_collections/arista/avd/tests/unit/action/test_verify_requirements.py
+++ b/ansible_collections/arista/avd/tests/unit/action/test_verify_requirements.py
@@ -10,7 +10,7 @@ from ansible_collections.arista.avd.plugins.action.verify_requirements import (
     MIN_PYTHON_SUPPORTED_VERSION,
     _validate_ansible_collections,
     _validate_ansible_version,
-    _validate_python_dependencies,
+    _validate_python_requirements,
     _validate_python_version,
 )
 
@@ -49,7 +49,7 @@ def test__validate_python_version(mocked_version, expected_return):
 
 
 @pytest.mark.parametrize(
-    "n_deps, mocked_version, requirement_version, expected_return",
+    "n_reqs, mocked_version, requirement_version, expected_return",
     [
         pytest.param(
             1,
@@ -70,31 +70,31 @@ def test__validate_python_version(mocked_version, expected_return):
             None,
             "4.2",
             False,
-            id="missing dependency",
+            id="missing requirement",
         ),
         pytest.param(
             0,
             None,
             None,
             True,
-            id="no dependency",
+            id="no requirement",
         ),
     ],
 )
-def test__validate_python_dependencies(n_deps, mocked_version, requirement_version, expected_return):
+def test__validate_python_requirements(n_reqs, mocked_version, requirement_version, expected_return):
     """
-    Running with n_deps dependencies
+    Running with n_reqs requirements
 
     TODO - check the results
-         - not testing for wrongly formated dependencies
+         - not testing for wrongly formated requirements
     """
     result = {}
-    dependencies = [f"test-dep>={requirement_version}" for _ in range(n_deps)]  # pylint: disable=disallowed-name
+    requirements = [f"test-dep>={requirement_version}" for _ in range(n_reqs)]  # pylint: disable=disallowed-name
     with patch("ansible_collections.arista.avd.plugins.action.verify_requirements.importlib.metadata.version") as patched_version:
         patched_version.return_value = mocked_version
         if mocked_version is None:
             patched_version.side_effect = importlib.metadata.PackageNotFoundError()
-        ret = _validate_python_dependencies(dependencies, result)
+        ret = _validate_python_requirements(requirements, result)
         assert ret == expected_return
 
 
@@ -123,7 +123,7 @@ def test__validate_ansible_version(mocked_running_version, expected_return):
 
 
 @pytest.mark.parametrize(
-    "n_deps, mocked_version, requirement_version, expected_return",
+    "n_reqs, mocked_version, requirement_version, expected_return",
     [
         pytest.param(
             1,
@@ -151,20 +151,20 @@ def test__validate_ansible_version(mocked_running_version, expected_return):
             None,
             ">=4.2",
             False,
-            id="missing dependency",
+            id="missing requirement",
         ),
         pytest.param(
             0,
             None,
             None,
             True,
-            id="no dependency",
+            id="no requirement",
         ),
     ],
 )
-def test__validate_ansible_collections(n_deps, mocked_version, requirement_version, expected_return):
+def test__validate_ansible_collections(n_reqs, mocked_version, requirement_version, expected_return):
     """
-    Running with n_deps dependencies
+    Running with n_reqs requirements
 
     TODO - check the results
          - not testing for wrongly formated collection.yml file
@@ -173,8 +173,8 @@ def test__validate_ansible_collections(n_deps, mocked_version, requirement_versi
 
     # Create the metadata based on test input data
     metadata = {}
-    if n_deps > 0:
-        metadata["collections"] = [{"name": "test-collection"} for _ in range(n_deps)]  # pylint: disable=disallowed-name
+    if n_reqs > 0:
+        metadata["collections"] = [{"name": "test-collection"} for _ in range(n_reqs)]  # pylint: disable=disallowed-name
         if requirement_version is not None:
             for collection in metadata["collections"]:
                 collection["version"] = requirement_version

--- a/ansible_collections/arista/avd/tests/unit/action/test_verify_requirements.py
+++ b/ansible_collections/arista/avd/tests/unit/action/test_verify_requirements.py
@@ -179,11 +179,11 @@ def test__validate_ansible_collections(n_reqs, mocked_version, requirement_versi
             for collection in metadata["collections"]:
                 collection["version"] = requirement_version
 
-    with (
-        patch("ansible_collections.arista.avd.plugins.action.verify_requirements.yaml.safe_load") as patched_safe_load,
-        patch("ansible_collections.arista.avd.plugins.action.verify_requirements._get_collection_path") as patched__get_collection_path,
-        patch("ansible_collections.arista.avd.plugins.action.verify_requirements._get_collection_version") as patched__get_collection_version,
-    ):
+    with patch("ansible_collections.arista.avd.plugins.action.verify_requirements.yaml.safe_load") as patched_safe_load, patch(
+        "ansible_collections.arista.avd.plugins.action.verify_requirements._get_collection_path"
+    ) as patched__get_collection_path, patch(
+        "ansible_collections.arista.avd.plugins.action.verify_requirements._get_collection_version"
+    ) as patched__get_collection_version:
         patched_safe_load.return_value = metadata
         patched__get_collection_path.return_value = "dummy"
         if mocked_version is None:

--- a/ansible_collections/arista/avd/tests/unit/action/test_verify_requirements.py
+++ b/ansible_collections/arista/avd/tests/unit/action/test_verify_requirements.py
@@ -183,11 +183,14 @@ def test__validate_ansible_collections(n_reqs, mocked_version, requirement_versi
         "ansible_collections.arista.avd.plugins.action.verify_requirements._get_collection_path"
     ) as patched__get_collection_path, patch(
         "ansible_collections.arista.avd.plugins.action.verify_requirements._get_collection_version"
-    ) as patched__get_collection_version:
+    ) as patched__get_collection_version, patch(
+        "ansible_collections.arista.avd.plugins.action.verify_requirements.open"
+    ):
         patched_safe_load.return_value = metadata
         patched__get_collection_path.return_value = "dummy"
-        if mocked_version is None:
-            patched__get_collection_path.side_effect = ModuleNotFoundError()
+        if mocked_version is None and n_reqs > 0:
+            # First call is for arista.avd
+            patched__get_collection_path.side_effect = ["dummy", ModuleNotFoundError()]
         patched__get_collection_version.return_value = mocked_version
 
         ret = _validate_ansible_collections("arista.avd", result)

--- a/ansible_collections/arista/avd/tests/unit/action/test_verify_requirements.py
+++ b/ansible_collections/arista/avd/tests/unit/action/test_verify_requirements.py
@@ -1,7 +1,7 @@
 __metaclass__ = type
 
-import importlib
 from collections import namedtuple
+from importlib.metadata import PackageNotFoundError
 from unittest.mock import patch
 
 import pytest
@@ -90,10 +90,10 @@ def test__validate_python_requirements(n_reqs, mocked_version, requirement_versi
     """
     result = {}
     requirements = [f"test-dep>={requirement_version}" for _ in range(n_reqs)]  # pylint: disable=disallowed-name
-    with patch("ansible_collections.arista.avd.plugins.action.verify_requirements.importlib.metadata.version") as patched_version:
+    with patch("ansible_collections.arista.avd.plugins.action.verify_requirements.version") as patched_version:
         patched_version.return_value = mocked_version
         if mocked_version is None:
-            patched_version.side_effect = importlib.metadata.PackageNotFoundError()
+            patched_version.side_effect = PackageNotFoundError()
         ret = _validate_python_requirements(requirements, result)
         assert ret == expected_return
 


### PR DESCRIPTION
## Change Summary

This PR intends to implement a plugin to verify that the minimum requirements for AVD are met

## Component(s) name

`arista.avd.plugins`

## Proposed changes

* Creation of a plugin
* Addition of task in roles to verify the environment
 
## How to test

* The initial commit for this PR can be checked with any playbook importing the `eos_designs` role by running with the `debug` tags.

* some tests will need to be written for the python module.

## Checklist

### User Checklist

[ ] decide when / where to run the task

### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
