### PR TITLE
Feat(eos_designs): Support for custom naming of trunk groups

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l2leaf1b.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l2leaf1b.cfg
@@ -15,51 +15,51 @@ no aaa root
 !
 vlan 100
    name svi100_with_trunk_groups
-   trunk group MLAG
-   trunk group UPLINK
+   trunk group CUSTOM_MLAG_TG_NAME
+   trunk group CUSTOM_UPLINK_TG_NAME
 !
 vlan 110
    name l2vlan110_with_trunk_groups
-   trunk group MLAG
-   trunk group UPLINK
+   trunk group CUSTOM_MLAG_TG_NAME
+   trunk group CUSTOM_UPLINK_TG_NAME
 !
 vlan 200
    name svi200_with_trunk_groups
-   trunk group MLAG
+   trunk group CUSTOM_MLAG_TG_NAME
+   trunk group CUSTOM_UPLINK_TG_NAME
    trunk group TG_200
-   trunk group UPLINK
 !
 vlan 210
    name l2vlan210_with_trunk_groups
-   trunk group MLAG
+   trunk group CUSTOM_MLAG_TG_NAME
+   trunk group CUSTOM_UPLINK_TG_NAME
    trunk group TG_200
-   trunk group UPLINK
 !
 vlan 300
    name svi300_with_trunk_groups
-   trunk group MLAG
+   trunk group CUSTOM_MLAG_TG_NAME
+   trunk group CUSTOM_UPLINK_TG_NAME
    trunk group TG_300
-   trunk group UPLINK
 !
 vlan 310
    name l2vlan310_with_trunk_groups
-   trunk group MLAG
+   trunk group CUSTOM_MLAG_TG_NAME
+   trunk group CUSTOM_UPLINK_TG_NAME
    trunk group TG_300
-   trunk group UPLINK
 !
 vlan 398
    name svi398_without_trunk_groups
-   trunk group MLAG
-   trunk group UPLINK
+   trunk group CUSTOM_MLAG_TG_NAME
+   trunk group CUSTOM_UPLINK_TG_NAME
 !
 vlan 399
    name l2vlan399_without_trunk_groups
-   trunk group MLAG
-   trunk group UPLINK
+   trunk group CUSTOM_MLAG_TG_NAME
+   trunk group CUSTOM_UPLINK_TG_NAME
 !
 vlan 4094
    name MLAG_PEER
-   trunk group MLAG
+   trunk group CUSTOM_MLAG_TG_NAME
 !
 vrf instance MGMT
 !
@@ -77,7 +77,7 @@ interface Port-Channel3
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
-   switchport trunk group MLAG
+   switchport trunk group CUSTOM_MLAG_TG_NAME
 !
 interface Port-Channel13
    description server_with_tg_300_portchannel

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l3leaf1b.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l3leaf1b.cfg
@@ -15,77 +15,77 @@ no aaa root
 !
 vlan 100
    name svi100_with_trunk_groups
-   trunk group MLAG
+   trunk group CUSTOM_MLAG_TG_NAME
    trunk group TRUNK_GROUP_TESTS_L2LEAF1
 !
 vlan 110
    name l2vlan110_with_trunk_groups
-   trunk group MLAG
+   trunk group CUSTOM_MLAG_TG_NAME
    trunk group TRUNK_GROUP_TESTS_L2LEAF1
 !
 vlan 200
    name svi200_with_trunk_groups
-   trunk group MLAG
+   trunk group CUSTOM_MLAG_TG_NAME
    trunk group trunk-group-tests-l2leaf3
    trunk group TRUNK_GROUP_TESTS_L2LEAF1
 !
 vlan 210
    name l2vlan210_with_trunk_groups
-   trunk group MLAG
+   trunk group CUSTOM_MLAG_TG_NAME
    trunk group trunk-group-tests-l2leaf3
    trunk group TRUNK_GROUP_TESTS_L2LEAF1
 !
 vlan 300
    name svi300_with_trunk_groups
-   trunk group MLAG
+   trunk group CUSTOM_MLAG_TG_NAME
    trunk group TG_300
    trunk group TRUNK_GROUP_TESTS_L2LEAF1
 !
 vlan 301
    name svi301_with_trunk_groups_only_l3leaf
-   trunk group MLAG
+   trunk group CUSTOM_MLAG_TG_NAME
    trunk group TG_300
 !
 vlan 310
    name l2vlan310_with_trunk_groups
-   trunk group MLAG
+   trunk group CUSTOM_MLAG_TG_NAME
    trunk group TG_300
    trunk group TRUNK_GROUP_TESTS_L2LEAF1
 !
 vlan 311
    name l2vlan310_with_trunk_groups_only_l3leaf
-   trunk group MLAG
+   trunk group CUSTOM_MLAG_TG_NAME
    trunk group TG_300
 !
 vlan 398
    name svi398_without_trunk_groups
-   trunk group MLAG
+   trunk group CUSTOM_MLAG_TG_NAME
    trunk group TRUNK_GROUP_TESTS_L2LEAF1
 !
 vlan 399
    name l2vlan399_without_trunk_groups
-   trunk group MLAG
+   trunk group CUSTOM_MLAG_TG_NAME
    trunk group TRUNK_GROUP_TESTS_L2LEAF1
 !
 vlan 3099
    name MLAG_iBGP_TG_100
-   trunk group LEAF_PEER_L3
+   trunk group CUSTOM_LEAF_PEER_L3_TG_NAME
 !
 vlan 3199
    name MLAG_iBGP_TG_200
-   trunk group LEAF_PEER_L3
+   trunk group CUSTOM_LEAF_PEER_L3_TG_NAME
 !
 vlan 3299
    name MLAG_iBGP_TG_300
-   trunk group LEAF_PEER_L3
+   trunk group CUSTOM_LEAF_PEER_L3_TG_NAME
 !
 vlan 4093
    name LEAF_PEER_L3
-   trunk group LEAF_PEER_L3
+   trunk group CUSTOM_LEAF_PEER_L3_TG_NAME
 !
 vlan 4094
    name MLAG_PEER
-   trunk group MLAG
+   trunk group CUSTOM_MLAG_TG_NAME
 !
 vrf instance MGMT
 !
@@ -109,8 +109,8 @@ interface Port-Channel3
    switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
-   switchport trunk group LEAF_PEER_L3
-   switchport trunk group MLAG
+   switchport trunk group CUSTOM_LEAF_PEER_L3_TG_NAME
+   switchport trunk group CUSTOM_MLAG_TG_NAME
 !
 interface Port-Channel5
    description TRUNK-GROUP-TESTS-L2LEAF3_Po1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l2leaf1b.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l2leaf1b.yml
@@ -23,59 +23,59 @@ vlans:
     tenant: system
     name: MLAG_PEER
     trunk_groups:
-    - MLAG
+    - CUSTOM_MLAG_TG_NAME
   100:
     tenant: TRUNK_GROUP_TESTS
     name: svi100_with_trunk_groups
     trunk_groups:
-    - MLAG
-    - UPLINK
+    - CUSTOM_MLAG_TG_NAME
+    - CUSTOM_UPLINK_TG_NAME
   200:
     tenant: TRUNK_GROUP_TESTS
     name: svi200_with_trunk_groups
     trunk_groups:
     - TG_200
-    - MLAG
-    - UPLINK
+    - CUSTOM_MLAG_TG_NAME
+    - CUSTOM_UPLINK_TG_NAME
   300:
     tenant: TRUNK_GROUP_TESTS
     name: svi300_with_trunk_groups
     trunk_groups:
     - TG_300
-    - MLAG
-    - UPLINK
+    - CUSTOM_MLAG_TG_NAME
+    - CUSTOM_UPLINK_TG_NAME
   398:
     tenant: TRUNK_GROUP_TESTS
     name: svi398_without_trunk_groups
     trunk_groups:
-    - MLAG
-    - UPLINK
+    - CUSTOM_MLAG_TG_NAME
+    - CUSTOM_UPLINK_TG_NAME
   110:
     tenant: TRUNK_GROUP_TESTS
     name: l2vlan110_with_trunk_groups
     trunk_groups:
-    - MLAG
-    - UPLINK
+    - CUSTOM_MLAG_TG_NAME
+    - CUSTOM_UPLINK_TG_NAME
   210:
     tenant: TRUNK_GROUP_TESTS
     name: l2vlan210_with_trunk_groups
     trunk_groups:
     - TG_200
-    - MLAG
-    - UPLINK
+    - CUSTOM_MLAG_TG_NAME
+    - CUSTOM_UPLINK_TG_NAME
   310:
     tenant: TRUNK_GROUP_TESTS
     name: l2vlan310_with_trunk_groups
     trunk_groups:
     - TG_300
-    - MLAG
-    - UPLINK
+    - CUSTOM_MLAG_TG_NAME
+    - CUSTOM_UPLINK_TG_NAME
   399:
     tenant: TRUNK_GROUP_TESTS
     name: l2vlan399_without_trunk_groups
     trunk_groups:
-    - MLAG
-    - UPLINK
+    - CUSTOM_MLAG_TG_NAME
+    - CUSTOM_UPLINK_TG_NAME
 vlan_interfaces:
   Vlan4094:
     description: MLAG_PEER
@@ -91,7 +91,7 @@ port_channel_interfaces:
     vlans: 2-4094
     mode: trunk
     trunk_groups:
-    - MLAG
+    - CUSTOM_MLAG_TG_NAME
   Port-Channel1:
     description: TRUNK_GROUP_TESTS_L3LEAF1_Po1
     type: switched

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf1b.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf1b.yml
@@ -203,91 +203,91 @@ vlans:
     tenant: system
     name: LEAF_PEER_L3
     trunk_groups:
-    - LEAF_PEER_L3
+    - CUSTOM_LEAF_PEER_L3_TG_NAME
   4094:
     tenant: system
     name: MLAG_PEER
     trunk_groups:
-    - MLAG
+    - CUSTOM_MLAG_TG_NAME
   100:
     trunk_groups:
     - TRUNK_GROUP_TESTS_L2LEAF1
-    - MLAG
+    - CUSTOM_MLAG_TG_NAME
     tenant: TRUNK_GROUP_TESTS
     name: svi100_with_trunk_groups
   110:
     trunk_groups:
     - TRUNK_GROUP_TESTS_L2LEAF1
-    - MLAG
+    - CUSTOM_MLAG_TG_NAME
     tenant: TRUNK_GROUP_TESTS
     name: l2vlan110_with_trunk_groups
   200:
     trunk_groups:
     - TRUNK_GROUP_TESTS_L2LEAF1
     - trunk-group-tests-l2leaf3
-    - MLAG
+    - CUSTOM_MLAG_TG_NAME
     tenant: TRUNK_GROUP_TESTS
     name: svi200_with_trunk_groups
   210:
     trunk_groups:
     - TRUNK_GROUP_TESTS_L2LEAF1
     - trunk-group-tests-l2leaf3
-    - MLAG
+    - CUSTOM_MLAG_TG_NAME
     tenant: TRUNK_GROUP_TESTS
     name: l2vlan210_with_trunk_groups
   300:
     trunk_groups:
     - TRUNK_GROUP_TESTS_L2LEAF1
     - TG_300
-    - MLAG
+    - CUSTOM_MLAG_TG_NAME
     tenant: TRUNK_GROUP_TESTS
     name: svi300_with_trunk_groups
   310:
     trunk_groups:
     - TRUNK_GROUP_TESTS_L2LEAF1
     - TG_300
-    - MLAG
+    - CUSTOM_MLAG_TG_NAME
     tenant: TRUNK_GROUP_TESTS
     name: l2vlan310_with_trunk_groups
   398:
     trunk_groups:
     - TRUNK_GROUP_TESTS_L2LEAF1
-    - MLAG
+    - CUSTOM_MLAG_TG_NAME
     tenant: TRUNK_GROUP_TESTS
     name: svi398_without_trunk_groups
   399:
     trunk_groups:
     - TRUNK_GROUP_TESTS_L2LEAF1
-    - MLAG
+    - CUSTOM_MLAG_TG_NAME
     tenant: TRUNK_GROUP_TESTS
     name: l2vlan399_without_trunk_groups
   3099:
     tenant: TRUNK_GROUP_TESTS
     name: MLAG_iBGP_TG_100
     trunk_groups:
-    - LEAF_PEER_L3
+    - CUSTOM_LEAF_PEER_L3_TG_NAME
   3199:
     tenant: TRUNK_GROUP_TESTS
     name: MLAG_iBGP_TG_200
     trunk_groups:
-    - LEAF_PEER_L3
+    - CUSTOM_LEAF_PEER_L3_TG_NAME
   301:
     tenant: TRUNK_GROUP_TESTS
     name: svi301_with_trunk_groups_only_l3leaf
     trunk_groups:
     - TG_300
-    - MLAG
+    - CUSTOM_MLAG_TG_NAME
   3299:
     tenant: TRUNK_GROUP_TESTS
     name: MLAG_iBGP_TG_300
     trunk_groups:
-    - LEAF_PEER_L3
+    - CUSTOM_LEAF_PEER_L3_TG_NAME
   311:
     tenant: TRUNK_GROUP_TESTS
     name: l2vlan310_with_trunk_groups_only_l3leaf
     trunk_groups:
     - TG_300
-    - MLAG
+    - CUSTOM_MLAG_TG_NAME
 vlan_interfaces:
   Vlan4093:
     description: MLAG_PEER_L3_PEERING
@@ -376,8 +376,8 @@ port_channel_interfaces:
     vlans: 2-4094
     mode: trunk
     trunk_groups:
-    - LEAF_PEER_L3
-    - MLAG
+    - CUSTOM_LEAF_PEER_L3_TG_NAME
+    - CUSTOM_MLAG_TG_NAME
   Port-Channel1:
     description: TRUNK_GROUP_TESTS_L2LEAF1_Po1
     type: switched

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/trunk-group-tests-l2leaf1b.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/trunk-group-tests-l2leaf1b.yml
@@ -2,3 +2,12 @@
 # Testing "only_local_vlan_trunk_groups: true" set in hostvars to see that only
 # locally used trunk-groups are set on vlans even without "filter.only_vlans_in_use: true"
 only_local_vlan_trunk_groups: true
+
+# Testing custom Trunk Group names on l2leaf1b and l3leaf1b.
+trunk_groups:
+  mlag:
+    name: "CUSTOM_MLAG_TG_NAME"
+  mlag_l3:
+    name: "CUSTOM_LEAF_PEER_L3_TG_NAME"
+  uplink:
+    name: "CUSTOM_UPLINK_TG_NAME"

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/trunk-group-tests-l3leaf1b.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/trunk-group-tests-l3leaf1b.yml
@@ -2,3 +2,12 @@
 # Testing "only_local_vlan_trunk_groups: true" set in hostvars to see that only
 # locally used trunk-groups are set on vlans even without "filter.only_vlans_in_use: true"
 only_local_vlan_trunk_groups: true
+
+# Testing custom Trunk Group names on l2leaf1b and l3leaf1b.
+trunk_groups:
+  mlag:
+    name: "CUSTOM_MLAG_TG_NAME"
+  mlag_l3:
+    name: "CUSTOM_LEAF_PEER_L3_TG_NAME"
+  uplink:
+    name: "CUSTOM_UPLINK_TG_NAME"

--- a/ansible_collections/arista/avd/plugins/module_utils/eos_designs_facts.py
+++ b/ansible_collections/arista/avd/plugins/module_utils/eos_designs_facts.py
@@ -666,6 +666,23 @@ class EosDesignsFacts:
         return None
 
     @cached_property
+    def trunk_groups(self):
+        if not self._any_network_services:
+            return None
+
+        return {
+            'mlag': {
+                'name': get(self._hostvars, "trunk_groups.mlag.name", default="MLAG")
+            },
+            'mlag_l3': {
+                'name': get(self._hostvars, "trunk_groups.mlag_l3.name", default="LEAF_PEER_L3")
+            },
+            'uplink': {
+                'name': get(self._hostvars, "trunk_groups.uplink.name", default="UPLINK")
+            }
+        }
+
+    @cached_property
     def enable_trunk_groups(self):
         if self._any_network_services:
             return get(self._hostvars, "enable_trunk_groups", default=False)

--- a/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-variables.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/doc/fabric-variables.md
@@ -257,6 +257,19 @@ enable_trunk_groups: < true | false | default -> false >
 # See "Details on only_local_vlan_trunk_groups" below.
 # Requires "enable_trunk_groups: true"
 only_local_vlan_trunk_groups: < true | false | default -> false >
+
+# Trunk Group Names | Optional
+trunk_groups:
+  # "mlag" is the Trunk Group used for MLAG VLAN (Typically VLAN 4094).
+  mlag:
+    name: < trunk_group_name | default -> "MLAG" >
+  # "mlag_l3" is the Trunk Group used for MLAG L3 peering VLAN (Typically VLAN 4093).
+  # "mlag_l3" is also the Trunk Group used for VRF L3 peering VLANs
+  mlag_l3:
+    name: < trunk_group_name | default -> "LEAF_PEER_L3" >
+  # "uplink" is the Trunk Group used on L2 Leaf switches when "enable_trunk_groups" is set.
+  uplink:
+    name: < trunk_group_name | default -> "UPLINK" >
 ```
 
 ## Details on `enable_trunk_groups`

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/mlag/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/mlag/port-channel-interfaces.j2
@@ -13,9 +13,9 @@ port_channel_interfaces:
 {% if switch.mlag_l3 is arista.avd.defined %}
 {#     Add LEAF_PEER_L3 even if we reuse the MLAG trunk group for underlay peering #}
 {#     since this trunk group is also used for overlay iBGP peerings #}
-      - LEAF_PEER_L3
+      - {{ switch.trunk_groups.mlag_l3.name }}
 {% endif %}
-      - MLAG
+      - {{ switch.trunk_groups.mlag.name }}
 {% if switch.mlag_port_channel_structured_config is arista.avd.defined %}
     struct_cfg: {{ switch.mlag_port_channel_structured_config }}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/mlag/vlans.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/mlag/vlans.j2
@@ -4,10 +4,10 @@ vlans:
     tenant: system
     name: LEAF_PEER_L3
     trunk_groups:
-      - LEAF_PEER_L3
+      - {{ switch.trunk_groups.mlag_l3.name }}
 {% endif %}
   {{ switch.mlag_peer_vlan }}:
     tenant: system
     name: MLAG_PEER
     trunk_groups:
-      - MLAG
+      - {{ switch.trunk_groups.mlag.name }}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vlans.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vlans.j2
@@ -13,10 +13,10 @@ vlans:
 {%                     set trunk_groups = trunk_groups | intersect(switch.endpoint_trunk_groups) %}
 {%                 endif %}
 {%                 if switch.mlag is arista.avd.defined(true) %}
-{%                     do trunk_groups.append('MLAG') %}
+{%                     do trunk_groups.append(switch.trunk_groups.mlag.name) %}
 {%                 endif %}
 {%                 if switch.uplink_type == "port-channel" %}
-{%                     do trunk_groups.append('UPLINK') %}
+{%                     do trunk_groups.append(switch.trunk_groups.uplink.name) %}
 {%                 endif %}
     trunk_groups: {{ trunk_groups | unique }}
 {%             endif %}
@@ -32,7 +32,7 @@ vlans:
     tenant: {{ tenant.name }}
     name: MLAG_iBGP_{{ vrf.name }}
     trunk_groups:
-      - LEAF_PEER_L3
+      - {{ switch.trunk_groups.mlag_l3.name }}
 {%             endif %}
 {%         endif %}
 {%     endfor %}
@@ -47,10 +47,10 @@ vlans:
 {%                 set trunk_groups = trunk_groups | intersect(switch.endpoint_trunk_groups) %}
 {%             endif %}
 {%             if switch.mlag is arista.avd.defined(true) %}
-{%                 do trunk_groups.append('MLAG') %}
+{%                 do trunk_groups.append(switch.trunk_groups.mlag.name) %}
 {%             endif %}
 {%             if switch.uplink_type == "port-channel" %}
-{%                 do trunk_groups.append('UPLINK') %}
+{%                 do trunk_groups.append(switch.trunk_groups.uplink.name) %}
 {%             endif %}
     trunk_groups: {{ trunk_groups | unique }}
 {%         endif %}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Support for custom naming of trunk groups

## Related Issue(s)

Fixes #2003

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

```yaml
# Trunk Group Names | Optional
trunk_groups:
  # "mlag" is the Trunk Group used for MLAG VLAN (Typically VLAN 4094).
  mlag:
    name: < trunk_group_name | default -> "MLAG" >
  # "mlag_l3" is the Trunk Group used for MLAG L3 peering VLAN (Typically VLAN 4093).
  # "mlag_l3" is also the Trunk Group used for VRF L3 peering VLANs
  mlag_l3:
    name: < trunk_group_name | default -> "LEAF_PEER_L3" >
  # "uplink" is the Trunk Group used on L2 Leaf switches when "enable_trunk_groups" is set.
  uplink:
    name: < trunk_group_name | default -> "UPLINK" >
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Added molecule coverage in existing trunk group test only on some devices 
- No changes to devices using defaults
- Correctly updated trunk group names on leafs with custom names.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
